### PR TITLE
Fix flaky TestApplyCRDuringCRDFinalization test

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -23,11 +23,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	testNamespace = "not-the-default"
+	testFinalizer = "noxu.example.com/finalizer"
 )
 
 func TestFinalization(t *testing.T) {
@@ -39,12 +45,12 @@ func TestFinalization(t *testing.T) {
 	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
-	ns := "not-the-default"
+	ns := testNamespace
 	name := "foo123"
 	noxuResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
 
 	instance := fixtures.NewNoxuInstance(ns, name)
-	instance.SetFinalizers([]string{"noxu.example.com/finalizer"})
+	instance.SetFinalizers([]string{testFinalizer})
 	createdNoxuInstance, err := instantiateCustomResource(t, instance, noxuResourceClient, noxuDefinition)
 	require.NoError(t, err)
 
@@ -104,12 +110,12 @@ func TestFinalizationAndDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a CR with a finalizer.
-	ns := "not-the-default"
+	ns := testNamespace
 	name := "foo123"
 	noxuResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
 
 	instance := fixtures.NewNoxuInstance(ns, name)
-	instance.SetFinalizers([]string{"noxu.example.com/finalizer"})
+	instance.SetFinalizers([]string{testFinalizer})
 	createdNoxuInstance, err := instantiateCustomResource(t, instance, noxuResourceClient, noxuDefinition)
 	require.NoError(t, err)
 
@@ -171,7 +177,7 @@ func TestApplyCRDuringCRDFinalization(t *testing.T) {
 
 	// Create a CRD with a finalizer which will stall deletion
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition.SetFinalizers([]string{"noxu.example.com/finalizer"})
+	noxuDefinition.SetFinalizers([]string{testFinalizer})
 	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
@@ -179,20 +185,27 @@ func TestApplyCRDuringCRDFinalization(t *testing.T) {
 	err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Delete(t.Context(), noxuDefinition.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 
+	// Wait for the CRD to have the Terminating condition set to True.
+	// The handler checks IsCRDConditionTrue(crd, apiextensionsv1.Terminating) to block
+	// CR creation, and this condition is set asynchronously by the CRD finalizer controller
+	// after it observes the DeletionTimestamp. Without this wait, the Apply could succeed
+	// if it races ahead of the controller setting the condition.
+	err = wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+		crd, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, noxuDefinition.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Terminating), nil
+	})
+	require.NoError(t, err, "timed out waiting for CRD Terminating condition to be set")
+
 	// Try to create a CR using SSA. This should fail due to the CRD validation
-	ns := "not-the-default"
+	ns := testNamespace
 	name := "foo123"
 	noxuResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
 
-	err = wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-		instance := fixtures.NewNoxuInstance(ns, name)
-		_, err := noxuResourceClient.Apply(ctx, name, instance, metav1.ApplyOptions{DryRun: []string{"All"}, FieldManager: "manager"})
-		if err == nil {
-			t.Log("apply was not blocked, retrying...")
-			return false, nil
-		}
-		return true, err
-	})
+	instance := fixtures.NewNoxuInstance(ns, name)
+	_, err = noxuResourceClient.Apply(t.Context(), name, instance, metav1.ApplyOptions{DryRun: []string{"All"}, FieldManager: "manager"})
 	wantErr := `create not allowed while custom resource definition is terminating`
 	require.ErrorContains(t, err, wantErr)
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
--> /kind flake

#### What this PR does / why we need it:
This PR fixes the flaky TestApplyCRDuringCRDFinalization test that was failing 
intermittently on slower systems (s390x architecture, race detector builds).

The root cause was a race condition where the test would attempt to apply a CR
immediately after requesting CRD deletion, without waiting for the CRD to
actually enter the terminating state. The fix explicitly waits for the CRD to
have a DeletionTimestamp set before attempting the apply operation.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
--> #135403 

#### Special notes for your reviewer:

The test was run multiple times (5x without race detector, 3x with race detector)
to verify the fix eliminates the flakiness. All related finalization tests
(TestFinalization, TestFinalizationAndDeletion, TestApplyCRDuringCRDFinalization)
pass consistently.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".


For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
--> 
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: NA

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
