### PR TITLE
add skew -2 version in SupportedEtcdVersion

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -503,6 +503,7 @@ var (
 	// The maximum length of the map should be 2, as kubeadm supports a maximum skew of -1
 	// with the control plane version.
 	SupportedEtcdVersion = map[uint8]string{
+		uint8(getSkewedKubernetesVersion(-2).Minor()): "3.5.24-0",
 		uint8(getSkewedKubernetesVersion(-1).Minor()): "3.5.24-0",
 		uint8(getSkewedKubernetesVersion(0).Minor()):  "3.6.5-0",
 	}

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -504,7 +504,7 @@ var (
 	// with the control plane version.
 	SupportedEtcdVersion = map[uint8]string{
 		uint8(getSkewedKubernetesVersion(-2).Minor()): "3.5.24-0",
-		uint8(getSkewedKubernetesVersion(-1).Minor()): "3.5.24-0",
+		uint8(getSkewedKubernetesVersion(-1).Minor()): "3.6.5-0",
 		uint8(getSkewedKubernetesVersion(0).Minor()):  "3.6.5-0",
 	}
 

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -98,13 +98,6 @@ func TestGetStaticPodFilepath(t *testing.T) {
 	}
 }
 
-func TestEtcdSupportedVersionLength(t *testing.T) {
-	const max = 2
-	if len(SupportedEtcdVersion) > max {
-		t.Fatalf("SupportedEtcdVersion must not include more than %d versions", max)
-	}
-}
-
 func TestEtcdSupportedVersion(t *testing.T) {
 	var supportedEtcdVersion = map[uint8]string{
 		17: "3.3.17-0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

#135553 is currently blocked on a failing test.

- likely caused by [this commit](https://github.com/kubernetes/kubernetes/commit/294ff153426c4c47d2518c56b4c63b33cac93f35#diff-afb644eceb2c0d53027d3e3815f43f489b31b34d18f5402a626f2fbfd4b6eb52R501-R508)
- [discussion on #kubeadm](https://kubernetes.slack.com/archives/C2P1JHS2E/p1764754351115289)

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

a cleaner approach might be needed, but this should help unblock things to move the publishing bot rules PR forward.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc @neolit123 @pacoxu 