### PR TITLE
Automated cherry pick of #135568: add skew -2 version in SupportedEtcdVersion

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -503,6 +503,7 @@ var (
 	// The maximum length of the map should be 2, as kubeadm supports a maximum skew of -1
 	// with the control plane version.
 	SupportedEtcdVersion = map[uint8]string{
+		uint8(getSkewedKubernetesVersion(-2).Minor()): "3.5.24-0",
 		uint8(getSkewedKubernetesVersion(-1).Minor()): "3.5.24-0",
 		uint8(getSkewedKubernetesVersion(0).Minor()):  "3.6.5-0",
 	}

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -504,7 +504,7 @@ var (
 	// with the control plane version.
 	SupportedEtcdVersion = map[uint8]string{
 		uint8(getSkewedKubernetesVersion(-2).Minor()): "3.5.24-0",
-		uint8(getSkewedKubernetesVersion(-1).Minor()): "3.5.24-0",
+		uint8(getSkewedKubernetesVersion(-1).Minor()): "3.6.5-0",
 		uint8(getSkewedKubernetesVersion(0).Minor()):  "3.6.5-0",
 	}
 

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -98,13 +98,6 @@ func TestGetStaticPodFilepath(t *testing.T) {
 	}
 }
 
-func TestEtcdSupportedVersionLength(t *testing.T) {
-	const max = 2
-	if len(SupportedEtcdVersion) > max {
-		t.Fatalf("SupportedEtcdVersion must not include more than %d versions", max)
-	}
-}
-
 func TestEtcdSupportedVersion(t *testing.T) {
 	var supportedEtcdVersion = map[uint8]string{
 		17: "3.3.17-0",


### PR DESCRIPTION
Cherry pick of #135568 on release-1.35.

#135568: add skew -2 version in SupportedEtcdVersion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```