### PR TITLE
Fix TestTerminationOrderingSidecarStopAfterMain flake under stress

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go
@@ -55,9 +55,11 @@ func TestTerminationOrderingSidecarStopAfterMain(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	var sidecarWaitDelay int64
-	var mainWaitDelay int64
+	var sidecarWaitDelay, mainWaitDelay int64
+	syncChannel := make(chan struct{})
+
 	go func() {
+		close(syncChannel) // notifies other goroutine that this goroutine scheduled.
 		sidecarWaitDelay = int64(to.waitForTurn("init", 30))
 		to.containerTerminated("init")
 		wg.Done()
@@ -65,6 +67,7 @@ func TestTerminationOrderingSidecarStopAfterMain(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
+		<-syncChannel // make sure the other goroutine is scheduled.
 		mainWaitDelay = int64(to.waitForTurn("main", 0))
 		time.Sleep(1 * time.Second)
 		to.containerTerminated("main")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes the TestTerminationOrderingSidecarStopAfterMain test flake.

To summarize as a part of test, there are 2 go routines are being created one for main container and another for sidecar and there is sleep of 1 sec in the main container go routine. 
The expectation is that the side car go routine scheduled first and the timer is started, by the time main container go routines is finished the side car should record 1 sec time.

The hidden assumption here is that the sidecar go routine scheduled first which may not be the case as the main go routine can be scheduled when the system under load which may lead to flakes with below error message
```
    kuberuntime_termination_order_test.go:75: expected sidecar to wait for main container to exit, got delay of 0
```


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
