### PR TITLE
Add index on ControllerRevision OwnerReference

### DIFF
--- a/pkg/controller/history/benchmark_test.go
+++ b/pkg/controller/history/benchmark_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package history
+
+import (
+	"fmt"
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/controller"
+)
+
+func BenchmarkListControllerRevisions(b *testing.B) {
+	parent := &apps.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-parent",
+			Namespace: "default",
+			UID:       types.UID("test-parent-uid"),
+		},
+	}
+	parentKind := schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "StatefulSet",
+	}
+
+	scenarios := []struct {
+		name             string
+		totalRevisions   int
+		ownedPercentage  float64 // percentage of totalRevisions that are owned
+		orphanPercentage float64 // percentage of totalRevisions that are orphans
+
+	}{
+		{
+			name:             "0.1pct_Owned_0pct_Orphan",
+			totalRevisions:   50000,
+			ownedPercentage:  0.1,
+			orphanPercentage: 0,
+		},
+		{
+			name:             "0.1pct_Owned_0.1pct_Orphan",
+			totalRevisions:   50000,
+			ownedPercentage:  0.1,
+			orphanPercentage: 0.1,
+		},
+		{
+			name:             "1pct_Owned_0pct_Orphan",
+			totalRevisions:   50000,
+			ownedPercentage:  1,
+			orphanPercentage: 0,
+		},
+		{
+			name:             "1pct_Owned_1pct_Orphan",
+			totalRevisions:   50000,
+			ownedPercentage:  1,
+			orphanPercentage: 1,
+		},
+		{
+			name:             "10pct_Owned_0pct_Orphan",
+			totalRevisions:   50000,
+			ownedPercentage:  10,
+			orphanPercentage: 0,
+		},
+		{
+			name:             "10pct_Owned_10pct_Orphan",
+			totalRevisions:   50000,
+			ownedPercentage:  10,
+			orphanPercentage: 10,
+		},
+		{
+			name:             "100pct_Owned_0pct_Orphan",
+			totalRevisions:   50000,
+			ownedPercentage:  100,
+			orphanPercentage: 0,
+		},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			ownedRevisions := int(float64(s.totalRevisions) * s.ownedPercentage / 100)
+			orphans := int(float64(s.totalRevisions) * s.orphanPercentage / 100)
+			otherOwned := s.totalRevisions - ownedRevisions - orphans
+
+			client := fake.NewClientset()
+			informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
+			revisionInformer := informerFactory.Apps().V1().ControllerRevisions()
+
+			if err := AddControllerRevisionControllerIndexer(revisionInformer.Informer()); err != nil {
+				b.Fatalf("failed to add indexer: %v", err)
+			}
+
+			revisions := make([]runtime.Object, 0, s.totalRevisions)
+			for i := 0; i < ownedRevisions; i++ {
+				revisions = append(revisions, createRevision(s.name, i, parent, parentKind))
+			}
+
+			// Create orphaned revisions (nil controller ref)
+			for i := 0; i < orphans; i++ {
+				rev := createRevision(s.name, ownedRevisions+i, nil, schema.GroupVersionKind{})
+				// Make sure it has no owner ref or at least no controller ref
+				rev.OwnerReferences = nil
+				revisions = append(revisions, rev)
+			}
+
+			// Create revisions owned by other controllers
+			otherParent := &apps.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-parent",
+					Namespace: "default",
+					UID:       types.UID("other-parent-uid"),
+				},
+			}
+			for i := 0; i < otherOwned; i++ {
+				revisions = append(revisions, createRevision(s.name, ownedRevisions+orphans+i, otherParent, parentKind))
+			}
+
+			indexer := revisionInformer.Informer().GetIndexer()
+			for _, obj := range revisions {
+				if err := indexer.Add(obj); err != nil {
+					b.Fatalf("failed to add object to indexer: %v", err)
+				}
+			}
+
+			history := NewHistory(client, revisionInformer.Lister(), indexer)
+			selector, _ := labels.Parse("name=" + s.name)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := history.ListControllerRevisions(parent, parentKind, selector)
+				if err != nil {
+					b.Fatalf("ListControllerRevisions failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func createRevision(scenarioName string, index int, owner metav1.Object, ownerKind schema.GroupVersionKind) *apps.ControllerRevision {
+	rev := &apps.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", scenarioName, index),
+			Namespace: "default",
+			Labels: map[string]string{
+				"name": scenarioName,
+			},
+			UID: types.UID(fmt.Sprintf("%s-%d", scenarioName, index)), // Ensure unique UID
+		},
+		Data:     runtime.RawExtension{Raw: []byte("{}")},
+		Revision: int64(index),
+	}
+
+	if owner != nil {
+		rev.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(owner, ownerKind)}
+	}
+
+	return rev
+}

--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -48,6 +48,48 @@ import (
 // ControllerRevisionHashLabel is the label used to indicate the hash value of a ControllerRevision's Data.
 const ControllerRevisionHashLabel = "controller.kubernetes.io/hash"
 
+// ControllerRevisionControllerIndex is the index name for the ControllerRevision controller index.
+const ControllerRevisionControllerIndex = "controllerRevisionController"
+
+// ControllerRevisionControllerIndexKey returns the index key to locate ControllerRevisions with the specified controller ownerReference.
+// If the ownerReference is specified, the key is "namespace/kind/ownerReference.Name/ownerReference.UID".
+// If the ownerReference is nil, the key is just "namespace" for orphan revisions.
+func ControllerRevisionControllerIndexKey(namespace string, ownerReference *metav1.OwnerReference) string {
+	if ownerReference == nil {
+		return namespace
+	}
+	return namespace + "/" + ownerReference.Kind + "/" + ownerReference.Name + "/" + string(ownerReference.UID)
+}
+
+// AddControllerRevisionControllerIndexer adds an indexer for ControllerRevision's controllerRef.UID to the given Informer.
+// This indexer is used to efficiently look up ControllerRevisions by their ControllerRef.UID
+func AddControllerRevisionControllerIndexer(informer cache.SharedIndexInformer) error {
+	if _, exists := informer.GetIndexer().GetIndexers()[ControllerRevisionControllerIndex]; exists {
+		// indexer already exists, do nothing
+		return nil
+	}
+
+	err := informer.AddIndexers(cache.Indexers{
+		ControllerRevisionControllerIndex: func(obj interface{}) ([]string, error) {
+			cr, ok := obj.(*apps.ControllerRevision)
+			if !ok {
+				return nil, nil
+			}
+			// Get the ControllerRef of the ControllerRevision to check if it's managed by a controller.
+			// Index with a non-nil controller (indicating an owned revision) or a nil controller (indicating an orphan revision).
+			return []string{ControllerRevisionControllerIndexKey(cr.Namespace, metav1.GetControllerOfNoCopy(cr))}, nil
+		},
+	})
+	if err != nil {
+		// It's possible that the indexer was added by another controller between the check and the AddIndexers call.
+		// Check again if the indexer was added by another controller, otherwise return the error.
+		if _, exists := informer.GetIndexer().GetIndexers()[ControllerRevisionControllerIndex]; exists {
+			return nil
+		}
+	}
+	return err
+}
+
 // ControllerRevisionName returns the Name for a ControllerRevision in the form prefix-hash. If the length
 // of prefix is greater than 223 bytes, it is truncated to allow for a name that is no larger than 253 bytes.
 func ControllerRevisionName(prefix string, hash string) string {
@@ -158,7 +200,7 @@ type Interface interface {
 	// ListControllerRevisions lists all ControllerRevisions matching selector and owned by parent or no other
 	// controller. If the returned error is nil the returned slice of ControllerRevisions is valid. If the
 	// returned error is not nil, the returned slice is not valid.
-	ListControllerRevisions(parent metav1.Object, selector labels.Selector) ([]*apps.ControllerRevision, error)
+	ListControllerRevisions(parent metav1.Object, parentKind schema.GroupVersionKind, selector labels.Selector) ([]*apps.ControllerRevision, error)
 	// CreateControllerRevision attempts to create the revision as owned by parent via a ControllerRef. If name
 	// collision occurs, collisionCount (incremented each time collision occurs except for the first time) is
 	// added to the hash of the revision and it is renamed using ControllerRevisionName. Implementations may
@@ -186,8 +228,10 @@ type Interface interface {
 
 // NewHistory returns an instance of Interface that uses client to communicate with the API Server and lister to list
 // ControllerRevisions. This method should be used to create an Interface for all scenarios other than testing.
-func NewHistory(client clientset.Interface, lister appslisters.ControllerRevisionLister) Interface {
-	return &realHistory{client, lister}
+// If indexer is not nil, it will be used to optimize ListControllerRevisions and the indexer must have had
+// AddControllerRevisionControllerIndexer called on it.
+func NewHistory(client clientset.Interface, lister appslisters.ControllerRevisionLister, indexer cache.Indexer) Interface {
+	return &realHistory{client, lister, indexer}
 }
 
 // NewFakeHistory returns an instance of Interface that uses informer to create, update, list, and delete
@@ -197,16 +241,44 @@ func NewFakeHistory(informer appsinformers.ControllerRevisionInformer) Interface
 }
 
 type realHistory struct {
-	client clientset.Interface
-	lister appslisters.ControllerRevisionLister
+	client  clientset.Interface
+	lister  appslisters.ControllerRevisionLister
+	indexer cache.Indexer
 }
 
-func (rh *realHistory) ListControllerRevisions(parent metav1.Object, selector labels.Selector) ([]*apps.ControllerRevision, error) {
+func (rh *realHistory) ListControllerRevisions(parent metav1.Object, parentKind schema.GroupVersionKind, selector labels.Selector) ([]*apps.ControllerRevision, error) {
 	// List all revisions in the namespace that match the selector
-	history, err := rh.lister.ControllerRevisions(parent.GetNamespace()).List(selector)
-	if err != nil {
-		return nil, err
+	var history []*apps.ControllerRevision
+	var err error
+	if rh.indexer != nil {
+		keys := []string{
+			ControllerRevisionControllerIndexKey(parent.GetNamespace(), metav1.NewControllerRef(parent, parentKind)),
+			ControllerRevisionControllerIndexKey(parent.GetNamespace(), nil), // Include orphans
+		}
+
+		for _, key := range keys {
+			objs, err := rh.indexer.ByIndex(ControllerRevisionControllerIndex, key)
+			if err != nil {
+				return nil, err
+			}
+			for _, obj := range objs {
+				cr, ok := obj.(*apps.ControllerRevision)
+				if !ok {
+					continue
+				}
+				if selector.Matches(labels.Set(cr.Labels)) {
+					history = append(history, cr)
+				}
+			}
+		}
+	} else {
+		// Fallback to slow list if no indexer
+		history, err = rh.lister.ControllerRevisions(parent.GetNamespace()).List(selector)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	var owned []*apps.ControllerRevision
 	for i := range history {
 		ref := metav1.GetControllerOfNoCopy(history[i])
@@ -343,7 +415,7 @@ type fakeHistory struct {
 	lister  appslisters.ControllerRevisionLister
 }
 
-func (fh *fakeHistory) ListControllerRevisions(parent metav1.Object, selector labels.Selector) ([]*apps.ControllerRevision, error) {
+func (fh *fakeHistory) ListControllerRevisions(parent metav1.Object, parentKind schema.GroupVersionKind, selector labels.Selector) ([]*apps.ControllerRevision, error) {
 	history, err := fh.lister.ControllerRevisions(parent.GetNamespace()).List(selector)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/history/controller_history_test.go
+++ b/pkg/controller/history/controller_history_test.go
@@ -60,13 +60,16 @@ func TestRealHistory_ListControllerRevisions(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
 		for i := range test.revisions {
 			informer.Informer().GetIndexer().Add(test.revisions[i])
 		}
 
-		history := NewHistory(client, informer.Lister())
-		revisions, err := history.ListControllerRevisions(test.parent, test.selector)
+		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
+		revisions, err := history.ListControllerRevisions(test.parent, parentKind, test.selector)
 		if err != nil {
 			t.Errorf("%s: %s", test.name, err)
 		}
@@ -157,13 +160,16 @@ func TestFakeHistory_ListControllerRevisions(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
 		for i := range test.revisions {
 			informer.Informer().GetIndexer().Add(test.revisions[i])
 		}
 
 		history := NewFakeHistory(informer)
-		revisions, err := history.ListControllerRevisions(test.parent, test.selector)
+		revisions, err := history.ListControllerRevisions(test.parent, parentKind, test.selector)
 		if err != nil {
 			t.Errorf("%s: %s", test.name, err)
 		}
@@ -256,8 +262,11 @@ func TestRealHistory_CreateControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
-		history := NewHistory(client, informer.Lister())
+		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 
 		var collisionCount int32
 		for _, item := range test.existing {
@@ -388,6 +397,9 @@ func TestFakeHistory_CreateControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
 		history := NewFakeHistory(informer)
 
@@ -538,8 +550,11 @@ func TestRealHistory_UpdateControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
-		history := NewHistory(client, informer.Lister())
+		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
@@ -665,6 +680,9 @@ func TestFakeHistory_UpdateControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
@@ -753,8 +771,11 @@ func TestRealHistory_DeleteControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
-		history := NewHistory(client, informer.Lister())
+		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
@@ -856,6 +877,9 @@ func TestFakeHistory_DeleteControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
@@ -993,9 +1017,12 @@ func TestRealHistory_AdoptControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
 
-		history := NewHistory(client, informer.Lister())
+		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
@@ -1099,6 +1126,9 @@ func TestFakeHistory_AdoptControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
 
 		history := NewFakeHistory(informer)
@@ -1244,9 +1274,12 @@ func TestRealHistory_ReleaseControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
 
-		history := NewHistory(client, informer.Lister())
+		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
@@ -1366,6 +1399,9 @@ func TestFakeHistory_ReleaseControllerRevision(t *testing.T) {
 		defer close(stop)
 		informerFactory.Start(stop)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
+		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
+			t.Fatalf("failed to add indexer: %v", err)
+		}
 		informerFactory.WaitForCacheSync(stop)
 		history := NewFakeHistory(informer)
 		var collisionCount int32

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -101,6 +101,9 @@ func NewStatefulSetController(
 
 	// Register metrics
 	metrics.Register()
+	if err := history.AddControllerRevisionControllerIndexer(revInformer.Informer()); err != nil {
+		utilruntime.HandleError(fmt.Errorf("unable to add controller revision controller indexer: %w", err))
+	}
 	ssc := &StatefulSetController{
 		kubeClient: kubeClient,
 		control: NewDefaultStatefulSetControl(
@@ -110,7 +113,7 @@ func NewStatefulSetController(
 				pvcInformer.Lister(),
 				recorder),
 			NewRealStatefulSetStatusUpdater(kubeClient, setInformer.Lister()),
-			history.NewHistory(kubeClient, revInformer.Lister()),
+			history.NewHistory(kubeClient, revInformer.Lister(), revInformer.Informer().GetIndexer()),
 		),
 		pvcListerSynced: pvcInformer.Informer().HasSynced,
 		revListerSynced: revInformer.Informer().HasSynced,

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -155,7 +155,7 @@ func (ssc *defaultStatefulSetControl) ListRevisions(set *apps.StatefulSet) ([]*a
 	if err != nil {
 		return nil, err
 	}
-	return ssc.controllerHistory.ListControllerRevisions(set, selector)
+	return ssc.controllerHistory.ListControllerRevisions(set, controllerKind, selector)
 }
 
 func (ssc *defaultStatefulSetControl) AdoptOrphanRevisions(

--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -271,7 +271,7 @@ func TestStatefulSetControllerDeletionTimestampRace(t *testing.T) {
 	}
 
 	// It should not adopt revisions.
-	revisions, err := ssh.ListControllerRevisions(set, selector)
+	revisions, err := ssh.ListControllerRevisions(set, parentKind, selector)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add index on controller revision ownerReference UID. Similar things have been done for 
- https://github.com/kubernetes/kubernetes/pull/135551
- https://github.com/kubernetes/kubernetes/pull/130806

Benchmark:

Significant performs improvement on when owning a small percentage of all pods (which should mirror production cases).

```
jying@jefftree ~/g/s/k/kubernetes ❯❯❯ benchstat zzoldbench.txt zznewbench.txt 
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/controller/history
cpu: AMD EPYC 7B12
                                                      │ zzoldbench.txt  │           zznewbench.txt            │
                                                      │     sec/op      │    sec/op     vs base               │
ListControllerRevisions/0.1pct_Owned_0pct_Orphan-24     37049.844µ ± 4%   5.191µ ±  4%  -99.99% (p=0.002 n=6)
ListControllerRevisions/0.1pct_Owned_0.1pct_Orphan-24   36696.067µ ± 3%   9.623µ ±  1%  -99.97% (p=0.002 n=6)
ListControllerRevisions/1pct_Owned_0pct_Orphan-24        36670.42µ ± 2%   51.92µ ±  7%  -99.86% (p=0.002 n=6)
ListControllerRevisions/1pct_Owned_1pct_Orphan-24         36423.5µ ± 3%   111.7µ ±  1%  -99.69% (p=0.002 n=6)
ListControllerRevisions/10pct_Owned_0pct_Orphan-24        36395.6µ ± 6%   752.5µ ± 10%  -97.93% (p=0.002 n=6)
ListControllerRevisions/10pct_Owned_10pct_Orphan-24        36.329m ± 7%   2.119m ± 13%  -94.17% (p=0.002 n=6)
ListControllerRevisions/100pct_Owned_0pct_Orphan-24         38.44m ± 7%   32.21m ±  5%  -16.19% (p=0.002 n=6)
geomean                                                     36.85m        204.3µ        -99.45%

                                                      │ zzoldbench.txt  │           zznewbench.txt            │
                                                      │      B/op       │     B/op      vs base               │
ListControllerRevisions/0.1pct_Owned_0pct_Orphan-24     2904.423Ki ± 0%   2.939Ki ± 0%  -99.90% (p=0.002 n=6)
ListControllerRevisions/0.1pct_Owned_0.1pct_Orphan-24   2905.547Ki ± 0%   6.064Ki ± 0%  -99.79% (p=0.002 n=6)
ListControllerRevisions/1pct_Owned_0pct_Orphan-24        2912.55Ki ± 0%   26.31Ki ± 0%  -99.10% (p=0.002 n=6)
ListControllerRevisions/1pct_Owned_1pct_Orphan-24        2920.55Ki ± 0%   50.31Ki ± 0%  -98.28% (p=0.002 n=6)
ListControllerRevisions/10pct_Owned_0pct_Orphan-24        3054.5Ki ± 0%   382.3Ki ± 0%  -87.48% (p=0.002 n=6)
ListControllerRevisions/10pct_Owned_10pct_Orphan-24       3206.5Ki ± 0%   766.3Ki ± 0%  -76.10% (p=0.002 n=6)
ListControllerRevisions/100pct_Owned_0pct_Orphan-24        4.905Mi ± 0%   4.905Mi ± 0%   -0.00% (p=0.002 n=6)
geomean                                                    3.137Mi        85.98Ki       -97.32%

                                                      │ zzoldbench.txt │          zznewbench.txt           │
                                                      │   allocs/op    │ allocs/op   vs base               │
ListControllerRevisions/0.1pct_Owned_0pct_Orphan-24         36.00 ± 0%   17.00 ± 0%  -52.78% (p=0.002 n=6)
ListControllerRevisions/0.1pct_Owned_0.1pct_Orphan-24       37.00 ± 0%   20.00 ± 0%  -45.95% (p=0.002 n=6)
ListControllerRevisions/1pct_Owned_0pct_Orphan-24           39.00 ± 0%   23.00 ± 0%  -41.03% (p=0.002 n=6)
ListControllerRevisions/1pct_Owned_1pct_Orphan-24           40.00 ± 0%   26.00 ± 0%  -35.00% (p=0.002 n=6)
ListControllerRevisions/10pct_Owned_0pct_Orphan-24          45.00 ± 0%   35.00 ± 0%  -22.22% (p=0.002 n=6)
ListControllerRevisions/10pct_Owned_10pct_Orphan-24         47.00 ± 0%   40.00 ± 0%  -14.89% (p=0.002 n=6)
ListControllerRevisions/100pct_Owned_0pct_Orphan-24         54.00 ± 0%   53.00 ± 0%   -1.85% (p=0.002 n=6)
geomean                                                     42.17        28.45       -32.54%
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
