### PR TITLE
Embed proper interface in TransformingStore to ensure DeltaFIFO and RealFIFO are implementing it

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -270,7 +270,8 @@ func NewDeltaFIFOWithOptions(opts DeltaFIFOOptions) *DeltaFIFO {
 }
 
 var (
-	_ = Queue(&DeltaFIFO{}) // DeltaFIFO is a Queue
+	_ = Queue(&DeltaFIFO{})             // DeltaFIFO is a Queue
+	_ = TransformingStore(&DeltaFIFO{}) // DeltaFIFO implements TransformingStore to allow memory optimizations
 )
 
 var (

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -733,9 +733,11 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 		return false
 	}
 
+	var transformer TransformFunc
 	storeOpts := []StoreOption{}
 	if tr, ok := r.store.(TransformingStore); ok && tr.Transformer() != nil {
-		storeOpts = append(storeOpts, WithTransformer(tr.Transformer()))
+		transformer = tr.Transformer()
+		storeOpts = append(storeOpts, WithTransformer(transformer))
 	}
 
 	initTrace := trace.New("Reflector WatchList", trace.Field{Key: "name", Value: r.name})
@@ -795,7 +797,7 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 	// we utilize the temporaryStore to ensure independence from the current store implementation.
 	// as of today, the store is implemented as a queue and will be drained by the higher-level
 	// component as soon as it finishes replacing the content.
-	checkWatchListDataConsistencyIfRequested(ctx, r.name, resourceVersion, r.listerWatcher.ListWithContext, temporaryStore.List)
+	checkWatchListDataConsistencyIfRequested(ctx, r.name, resourceVersion, r.listerWatcher.ListWithContext, transformer, temporaryStore.List)
 
 	if err := r.store.Replace(temporaryStore.List(), resourceVersion); err != nil {
 		return nil, fmt.Errorf("unable to sync watch-list result: %w", err)

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -79,7 +79,7 @@ type ReflectorStore interface {
 // TransformingStore is an optional interface that can be implemented by the provided store.
 // If implemented on the provided store reflector will use the same transformer in its internal stores.
 type TransformingStore interface {
-	Store
+	ReflectorStore
 	Transformer() TransformFunc
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector.go
@@ -33,11 +33,11 @@ import (
 //
 // Note that this function will panic when data inconsistency is detected.
 // This is intentional because we want to catch it in the CI.
-func checkWatchListDataConsistencyIfRequested[T runtime.Object, U any](ctx context.Context, identity string, lastSyncedResourceVersion string, listFn consistencydetector.ListFunc[T], retrieveItemsFn consistencydetector.RetrieveItemsFunc[U]) {
+func checkWatchListDataConsistencyIfRequested[T runtime.Object, U any](ctx context.Context, identity string, lastSyncedResourceVersion string, listFn consistencydetector.ListFunc[T], listItemTransformFunc func(interface{}) (interface{}, error), retrieveItemsFn consistencydetector.RetrieveItemsFunc[U]) {
 	if !consistencydetector.IsDataConsistencyDetectionForWatchListEnabled() {
 		return
 	}
 	// for informers we pass an empty ListOptions because
 	// listFn might be wrapped for filtering during informer construction.
-	consistencydetector.CheckDataConsistency(ctx, identity, lastSyncedResourceVersion, listFn, metav1.ListOptions{}, retrieveItemsFn)
+	consistencydetector.CheckDataConsistency(ctx, identity, lastSyncedResourceVersion, listFn, listItemTransformFunc, metav1.ListOptions{}, retrieveItemsFn)
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/client-go/util/consistencydetector"
+	"k8s.io/klog/v2/ktesting"
+)
+
+func TestReflectorDataConsistencyDetector(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
+	restore := consistencydetector.SetDataConsistencyDetectionForWatchListEnabledForTest(true)
+	defer restore()
+
+	markTransformed := func(obj interface{}) (interface{}, error) {
+		pod, ok := obj.(*v1.Pod)
+		if !ok {
+			return obj, nil
+		}
+		newPod := pod.DeepCopy()
+		if newPod.Labels == nil {
+			newPod.Labels = make(map[string]string)
+		}
+		newPod.Labels["transformed"] = "true"
+		return newPod, nil
+	}
+
+	for _, inOrder := range []bool{false, true} {
+		t.Run(fmt.Sprintf("InOrder=%v", inOrder), func(t *testing.T) {
+			clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.InOrderInformers, inOrder)
+			for _, transformerEnabled := range []bool{false, true} {
+				var transformer TransformFunc
+				if transformerEnabled {
+					transformer = markTransformed
+				}
+				t.Run(fmt.Sprintf("Transformer=%v", transformerEnabled), func(t *testing.T) {
+					runTestReflectorDataConsistencyDetector(t, transformer)
+				})
+			}
+		})
+	}
+}
+
+func runTestReflectorDataConsistencyDetector(t *testing.T, transformer TransformFunc) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	store := NewStore(MetaNamespaceKeyFunc)
+	fifo := newQueueFIFO(store, transformer)
+
+	lw := &ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return &v1.PodList{
+				ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+				Items: []v1.Pod{
+					{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", ResourceVersion: "1"}},
+				},
+			}, nil
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			w := watch.NewFake()
+			go func() {
+				w.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", ResourceVersion: "1"}})
+				w.Action(watch.Bookmark, &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Name:            "pod-1",
+					ResourceVersion: "1",
+					Annotations:     map[string]string{metav1.InitialEventsAnnotationKey: "true"},
+				}})
+			}()
+			return w, nil
+		},
+	}
+
+	r := NewReflector(lw, &v1.Pod{}, fifo, 0)
+
+	go func() {
+		_ = wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+			return r.LastSyncResourceVersion() != "", nil
+		})
+		cancel()
+	}()
+
+	err := r.ListAndWatchWithContext(ctx)
+	if err != nil {
+		t.Errorf("ListAndWatchWithContext returned error: %v", err)
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -539,20 +539,7 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 		s.startedLock.Lock()
 		defer s.startedLock.Unlock()
 
-		var fifo Queue
-		if clientgofeaturegate.FeatureGates().Enabled(clientgofeaturegate.InOrderInformers) {
-			fifo = NewRealFIFOWithOptions(RealFIFOOptions{
-				KeyFunction:  MetaNamespaceKeyFunc,
-				KnownObjects: s.indexer,
-				Transformer:  s.transform,
-			})
-		} else {
-			fifo = NewDeltaFIFOWithOptions(DeltaFIFOOptions{
-				KnownObjects:          s.indexer,
-				EmitDeltaTypeReplaced: true,
-				Transformer:           s.transform,
-			})
-		}
+		fifo := newQueueFIFO(s.indexer, s.transform)
 
 		cfg := &Config{
 			Queue:             fifo,

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
@@ -89,7 +89,8 @@ type RealFIFO struct {
 }
 
 var (
-	_ = Queue(&RealFIFO{}) // RealFIFO is a Queue
+	_ = Queue(&RealFIFO{})             // RealFIFO is a Queue
+	_ = TransformingStore(&RealFIFO{}) // RealFIFO implements TransformingStore to allow memory optimizations
 )
 
 // Close the queue.

--- a/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector.go
+++ b/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector.go
@@ -45,6 +45,16 @@ func IsDataConsistencyDetectionForWatchListEnabled() bool {
 	return dataConsistencyDetectionForWatchListEnabled
 }
 
+// SetDataConsistencyDetectionForWatchListEnabledForTest allows to enable/disable data consistency detection for testing purposes.
+// It returns a function that restores the original value.
+func SetDataConsistencyDetectionForWatchListEnabledForTest(enabled bool) func() {
+	original := dataConsistencyDetectionForWatchListEnabled
+	dataConsistencyDetectionForWatchListEnabled = enabled
+	return func() {
+		dataConsistencyDetectionForWatchListEnabled = original
+	}
+}
+
 type RetrieveItemsFunc[U any] func() []U
 
 type ListFunc[T runtime.Object] func(ctx context.Context, options metav1.ListOptions) (T, error)

--- a/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector.go
+++ b/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector.go
@@ -59,12 +59,14 @@ type RetrieveItemsFunc[U any] func() []U
 
 type ListFunc[T runtime.Object] func(ctx context.Context, options metav1.ListOptions) (T, error)
 
+type TransformFunc func(interface{}) (interface{}, error)
+
 // CheckDataConsistency exists solely for testing purposes.
 // we cannot use checkWatchListDataConsistencyIfRequested because
 // it is guarded by an environmental variable.
 // we cannot manipulate the environmental variable because
 // it will affect other tests in this package.
-func CheckDataConsistency[T runtime.Object, U any](ctx context.Context, identity string, lastSyncedResourceVersion string, listFn ListFunc[T], listOptions metav1.ListOptions, retrieveItemsFn RetrieveItemsFunc[U]) {
+func CheckDataConsistency[T runtime.Object, U any](ctx context.Context, identity string, lastSyncedResourceVersion string, listFn ListFunc[T], listItemTransformFunc TransformFunc, listOptions metav1.ListOptions, retrieveItemsFn RetrieveItemsFunc[U]) {
 	if !canFormAdditionalListCall(lastSyncedResourceVersion, listOptions) {
 		klog.V(4).Infof("data consistency check for %s is enabled but the parameters (RV, ListOptions) doesn't allow for creating a valid LIST request. Skipping the data consistency check.", identity)
 		return
@@ -93,6 +95,15 @@ func CheckDataConsistency[T runtime.Object, U any](ctx context.Context, identity
 	rawListItems, err := meta.ExtractListWithAlloc(list)
 	if err != nil {
 		panic(err) // this should never happen
+	}
+	if listItemTransformFunc != nil {
+		for i := range rawListItems {
+			obj, err := listItemTransformFunc(rawListItems[i])
+			if err != nil {
+				panic(err)
+			}
+			rawListItems[i] = obj.(runtime.Object)
+		}
 	}
 	listItems := toMetaObjectSliceOrDie(rawListItems)
 

--- a/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector_test.go
@@ -215,10 +215,10 @@ func TestDataConsistencyChecker(t *testing.T) {
 
 			if scenario.expectPanic {
 				require.Panics(t, func() {
-					CheckDataConsistency(ctx, "", scenario.lastSyncedResourceVersion, fakeLister.List, scenario.requestOptions, retrievedItemsFunc)
+					CheckDataConsistency(ctx, "", scenario.lastSyncedResourceVersion, fakeLister.List, nil, scenario.requestOptions, retrievedItemsFunc)
 				})
 			} else {
-				CheckDataConsistency(ctx, "", scenario.lastSyncedResourceVersion, fakeLister.List, scenario.requestOptions, retrievedItemsFunc)
+				CheckDataConsistency(ctx, "", scenario.lastSyncedResourceVersion, fakeLister.List, nil, scenario.requestOptions, retrievedItemsFunc)
 			}
 
 			require.Equal(t, scenario.expectedListRequests, fakeLister.counter)
@@ -235,7 +235,7 @@ func TestDataConsistencyCheckerRetry(t *testing.T) {
 	stopListErrorAfter := 5
 	fakeErrLister := &errorLister{stopErrorAfter: stopListErrorAfter}
 
-	CheckDataConsistency(ctx, "", "", fakeErrLister.List, metav1.ListOptions{}, retrievedItemsFunc)
+	CheckDataConsistency(ctx, "", "", fakeErrLister.List, nil, metav1.ListOptions{}, retrievedItemsFunc)
 	require.Equal(t, fakeErrLister.listCounter, fakeErrLister.stopErrorAfter)
 }
 


### PR DESCRIPTION
/kind bug

```release-note
k8s.io/client-go: Fixes a regression in 1.34+ which prevented informers from using configured Transformer functions
```

Draft to fix pull-kubernetes-e2e-gce test failures from https://github.com/kubernetes/kubernetes/pull/133263


Added a unit test for consistency detection. Without patch from @liggitt we get:
```
@ -2,7 +2,10 @@
  {
   "metadata": {
    "name": "pod-1",
-   "resourceVersion": "1"
+   "resourceVersion": "1",
+   "labels": {
+    "transformed": "true"
+   }
   },
   "spec": {
    "containers": null
--- FAIL: TestReflectorDataConsistencyDetector (0.01s)
    --- FAIL: TestReflectorDataConsistencyDetector/InOrder=false (0.01s)
        --- PASS: TestReflectorDataConsistencyDetector/InOrder=false/Transformer=false (0.01s)
        --- FAIL: TestReflectorDataConsistencyDetector/InOrder=false/Transformer=true (0.00s)
panic: data inconsistency detected for testing/testing.go:1934, panicking! [recovered, repanicked]

goroutine 18 [running]:
testing.tRunner.func1.2({0xcbda80, 0xc0004543e0})
        /pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
        /pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1875 +0x35b
panic({0xcbda80?, 0xc0004543e0?})
        /pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/panic.go:783 +0x132
k8s.io/client-go/util/consistencydetector.CheckDataConsistency[...]({0xf7c090, 0xc00039e050}, {0xc0003ba000, 0x17}, {0xf6e1d0, 0x1}, 0xc00019f840, {{{0x0, 0x0}, {0x0, ...}}, ...}, ...)
        /src/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector.go:105 +0x799
k8s.io/client-go/tools/cache.checkWatchListDataConsistencyIfRequested[...](...)
        /src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector.go:42
k8s.io/client-go/tools/cache.(*Reflector).watchList(0xc0003841e0, {0xf7c090, 0xc00039e050})
        /src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector.go:798 +0x8e5
k8s.io/client-go/tools/cache.(*Reflector).ListAndWatchWithContext(0xc0003841e0, {0xf7c090, 0xc00039e050})
        /src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector.go:423 +0x1ff
k8s.io/client-go/tools/cache.runTestReflectorDataConsistencyDetector(0xc0003a4000, 0xe802a0)
        /src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go:111 +0x1e5
k8s.io/client-go/tools/cache.TestReflectorDataConsistencyDetector.func2.1(0xc0003a4000?)
        /src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go:64 +0x17
testing.tRunner(0xc0003a4000, 0xc000380030)
        /pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 9
        /pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1997 +0x465
FAIL    k8s.io/client-go/tools/cache    0.035s
FAIL
```

With the fix we get
```
--- PASS: TestReflectorDataConsistencyDetector (0.04s)
    --- PASS: TestReflectorDataConsistencyDetector/InOrder=false (0.02s)
        --- PASS: TestReflectorDataConsistencyDetector/InOrder=false/Transformer=false (0.01s)
        --- PASS: TestReflectorDataConsistencyDetector/InOrder=false/Transformer=true (0.01s)
    --- PASS: TestReflectorDataConsistencyDetector/InOrder=true (0.02s)
        --- PASS: TestReflectorDataConsistencyDetector/InOrder=true/Transformer=false (0.01s)
        --- PASS: TestReflectorDataConsistencyDetector/InOrder=true/Transformer=true (0.01s)
```