### PR TITLE
Support TopologyManager in Large NUMA System (NVIDIA GB200)

### DIFF
--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -833,7 +834,7 @@ func Test_Discover(t *testing.T) {
 				}
 				return
 			}
-			if diff := cmp.Diff(got, tt.want); diff != "" {
+			if diff := cmp.Diff(got, tt.want, cmpopts.IgnoreUnexported(cpuset.CPUSet{})); diff != "" {
 				t.Errorf("Discover() = %v, want %v diff=%s", got, tt.want, diff)
 			}
 		})


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Bug Fix 
/kind bug

#### What this PR does / why we need it:
Kubelet’s TopologyManager doesn’t scale well on systems with many NUMA nodes. On NVIDIA GB200, for example, there are 34 NUMA nodes but only 2 of them have CPUs suitable for scheduling pods. When a device plugin advertises all 34 NUMA nodes, TopologyManager’s generateDeviceTopologyHints ends up iterating over all subsets of that 34-bit mask (O(2^n)). With n=34, this becomes effectively unbounded, so kubelet never reaches the Allocate call. As a result, the virt-launcher pod stays in Pending and the VM remains stuck in Starting indefinitely.

This PR constrains the search space in two places:
- **Device-manager hints:** 
   Hint enumeration is limited to NUMA nodes that actually host available/reusable devices, and an “any-NUMA” fallback hint is added. This only reduces complexity when devices are located on a small subset of NUMA nodes. If a device plugin still reports devices spread across all N NUMA nodes, the candidate set remains size N and IterateBitMasks is still O(2^N). However, on realistic multi-NUMA systems (including GB200), GPUs are typically present only on a few CPU-bearing nodes, so the candidate set remains small and the search is tractable.
- **Memory-manager hints:** 
   NUMA nodes without CPUs are skipped (unless they already hold assignments), so hint enumeration is effectively limited to the 2 CPU nodes on GB200 and does not explode combinatorially.

#### Which issue(s) this PR is related to:

Fixes #135541
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.


Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)


If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
KEP: https://github.com/kubernetes/enhancements/issues/5726

Tested in GB200 (with KubeVirt)

1. Set topology manager policy with large NUMA nodes in kubelet config 
```yaml
topologyManagerPolicy: restricted
topologyManagerScope: pod
topologyManagerPolicyOptions:
  prefer-closest-numa-nodes: "true"
  max-allowable-numa-nodes: "34"
```

2. Deployed Device plugin, KubeVirt etc.

3. Create Pod (in this test example, it is KubeVirt VMI) with VFIO device passthrough

4. kubelet topology manager successfully passthrough admission and have the pod scheduled. Allocate was successfully.
```yaml
NAME                                      READY   STATUS    RESTARTS   AGE   IP           NODE           NOMINATED NODE   READINESS GATES
virt-launcher-vmi-gb200-4gpu-numa-xntbt   2/2     Running   0          68s   10.244.7.5   gb200-node-4   <none>           1/1

NAME                  AGE   PHASE     IP           NODENAME       READY   LIVE-MIGRATABLE   PAUSED
vmi-gb200-4gpu-numa   81s   Running   10.244.7.5   gb200-node-4   True    False
```
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
