### PR TITLE
DRA testing: upgrade/downgrade preparation for 1.35

### DIFF
--- a/test/e2e_dra/upgradedowngrade_test.go
+++ b/test/e2e_dra/upgradedowngrade_test.go
@@ -266,15 +266,6 @@ var _ = ginkgo.Describe("DRA upgrade/downgrade", func() {
 		cluster.Modify(tCtx, restoreOptions)
 		tCtx = ktesting.End(tCtx)
 
-		// TODO: ensure that kube-controller-manager is up-and-running.
-		// This works around https://github.com/kubernetes/kubernetes/issues/132334 and can be removed
-		// once a fix for that is backported.
-		tCtx = ktesting.Begin(tCtx, "wait for kube-controller-manager")
-		ktesting.Eventually(tCtx, func(tCtx ktesting.TContext) string {
-			output, _ := cluster.GetSystemLogs(tCtx, localupcluster.KubeControllerManager)
-			return output
-		}).Should(gomega.ContainSubstring(`"Caches are synced" controller="resource_claim"`))
-		tCtx = ktesting.End(tCtx)
 		testResourceClaimDeviceStatusAfterDowngrade()
 
 		// We need to clean up explicitly because the normal


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135395/pull-kubernetes-dra-integration/1996264876888035328:

```
          wait for kube-controller-manager: Expected
              <string>: W1203 17:33:14.336332   37613 feature_gate.go:410] Setting GA feature gate DynamicResourceAllocation=true. It will be removed in a future release.
...

              I1203 17:33:14.339246   37613 flags.go:64] FLAG: --lead...

          Gomega truncated this representation as it exceeds 'format.MaxLength'.
          Consider having the object provide a custom 'GomegaStringer' representation
          or adjust the parameters in Gomega's 'format' package.

          Learn more here: https://onsi.github.io/gomega/#adjusting-output

          to contain substring
              <string>: "Caches are synced" controller="resource_claim"
```
#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This fixes version skew testing between 1.36 (current master!) and v1.35.0-rc.0 where the log output that the workaround looked for got removed. It is up for debate whether we should move to version skew testing against 1.34 and 1.35 already now. Other skew tests wait until v1.36.0-alpha.1 is out. EDIT: the script now also waits.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
