### PR TITLE
DRA upgrade/downgrade: roll over only after -alpha.0

### DIFF
--- a/test/e2e_dra/upgradedowngrade_test.go
+++ b/test/e2e_dra/upgradedowngrade_test.go
@@ -123,6 +123,20 @@ var _ = ginkgo.Describe("DRA upgrade/downgrade", func() {
 		version, err := version.ParseGeneric(gitVersion)
 		tCtx.ExpectNoError(err, "parse version %s of repo root %q", gitVersion, repoRoot)
 		major, previousMinor := version.Major(), version.Minor()-1
+		if strings.Contains(gitVersion, "-alpha.0") {
+			// All version up to and including x.y.z-alpha.0 are treated as if we were
+			// still the previous minor version x.(y-1). There are two reason for this:
+			//
+			// - During code freeze around (at?) -rc.0, the master branch already
+			//   identfies itself as the next release with -alpha.0. Without this
+			//   special case, we would change the version skew testing from what
+			//   has been tested and been known to work to something else, which
+			//   can and at least once did break.
+			//
+			// - Early in the next cycle the differences compared to the previous
+			//   release are small, so it's more interesting to go back further.
+			previousMinor--
+		}
 		tCtx.Logf("got version: major: %d, minor: %d, previous minor: %d", major, version.Minor(), previousMinor)
 		tCtx = ktesting.End(tCtx)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

All version up to and including x.y.z-alpha.0 are treated as if we were still the previous minor version x.(y-1). There are two reason for this:

- During code freeze around (at?) -rc.0, the master branch already identfies itself as the next release with -alpha.0. Without this special case, we would change the version skew testing from what has been tested and been known to work to something else, which can and at least once did break.

- Early in the next cycle the differences compared to the previous release are small, so it's more interesting to go back further.

#### Which issue(s) this PR is related to:

Fixes this failure (from https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135395/pull-kubernetes-dra-integration/1996264876888035328):

```
          wait for kube-controller-manager: Expected
              <string>: W1203 17:33:14.336332   37613 feature_gate.go:410] Setting GA feature gate DynamicResourceAllocation=true. It will be removed in a future release.
...

              I1203 17:33:14.339246   37613 flags.go:64] FLAG: --lead...

          Gomega truncated this representation as it exceeds 'format.MaxLength'.
          Consider having the object provide a custom 'GomegaStringer' representation
          or adjust the parameters in Gomega's 'format' package.

          Learn more here: https://onsi.github.io/gomega/#adjusting-output

          to contain substring
              <string>: "Caches are synced" controller="resource_claim"
```

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/pull/135584 is another fix for the same problem. It'll be needed before we can start testing against 1.35. If we merge this PR (my preference), then https://github.com/kubernetes/kubernetes/pull/135584 can wait until after code thawn.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
