### PR TITLE
Revert TerminalSize type duplication, use shared types

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/remotecommand/resize.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/remotecommand/resize.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2025 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,16 +16,19 @@ limitations under the License.
 
 package remotecommand
 
-import (
-	utilremotecommand "k8s.io/apimachinery/pkg/util/remotecommand"
-)
-
 // TerminalSize represents the width and height of a terminal.
-// This is an alias to the shared type in k8s.io/apimachinery/pkg/util/remotecommand
-// to maintain API compatibility while using a shared implementation.
-type TerminalSize = utilremotecommand.TerminalSize
+// This type is shared between k8s.io/kubectl/pkg/util/term and k8s.io/client-go/tools/remotecommand
+// to avoid dependency duplication while maintaining package decoupling.
+type TerminalSize struct {
+	Width  uint16
+	Height uint16
+}
 
 // TerminalSizeQueue is capable of returning terminal resize events as they occur.
-// This is an alias to the shared interface in k8s.io/apimachinery/pkg/util/remotecommand
-// to maintain API compatibility while using a shared implementation.
-type TerminalSizeQueue = utilremotecommand.TerminalSizeQueue
+// This interface is shared between k8s.io/kubectl/pkg/util/term and k8s.io/client-go/tools/remotecommand
+// to avoid dependency duplication while maintaining package decoupling.
+type TerminalSizeQueue interface {
+	// Next returns the new terminal size after the terminal has been resized. It returns nil when
+	// monitoring has been stopped.
+	Next() *TerminalSize
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/term/resize.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/term/resize.go
@@ -20,25 +20,19 @@ import (
 	"fmt"
 
 	"github.com/moby/term"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // TerminalSize represents the width and height of a terminal.
-// It is the same as staging/src/k8s.io/client-go/tools/remotecommand.TerminalSize.
-// Copied to decouple the packages. Terminal-related package should not depend on API client and vice versa.
-type TerminalSize struct {
-	Width  uint16
-	Height uint16
-}
+// This is an alias to the shared type in k8s.io/apimachinery/pkg/util/remotecommand
+// to maintain API compatibility while using a shared implementation.
+type TerminalSize = remotecommand.TerminalSize
 
 // TerminalSizeQueue is capable of returning terminal resize events as they occur.
-// It is the same as staging/src/k8s.io/client-go/tools/remotecommand.TerminalSizeQueue.
-// Copied to decouple the packages. Terminal-related package should not depend on API client and vice versa.
-type TerminalSizeQueue interface {
-	// Next returns the new terminal size after the terminal has been resized. It returns nil when
-	// monitoring has been stopped.
-	Next() *TerminalSize
-}
+// This is an alias to the shared interface in k8s.io/apimachinery/pkg/util/remotecommand
+// to maintain API compatibility while using a shared implementation.
+type TerminalSizeQueue = remotecommand.TerminalSizeQueue
 
 // GetSize returns the current size of the user's terminal. If it isn't a terminal,
 // nil is returned.


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
PR #133367 duplicated TerminalSize and TerminalSizeQueue types between kubectl/pkg/util/term and client-go/tools/remotecommand to avoid heavy dependencies. However, these types themselves have zero dependencies - only other files in the remotecommand package use websocket/spdystream.

This duplication broke downstream consumers that use both packages (e.g., cri-tools), requiring workarounds:
https://github.com/kubernetes-sigs/cri-tools/pull/1955/files#diff-c72419df07499621d9866069c71e99656016c3149f71040424b8bd1af4e7ec07L430-R452

This change moves the types to k8s.io/apimachinery/pkg/util/remotecommand (which already contains remotecommand protocol constants) and updates both kubectl and client-go to use type aliases. This eliminates duplication while achieving the original goal of package decoupling.
#### Which issue(s) this PR is related to:
Refers to https://github.com/kubernetes-sigs/cri-tools/pull/1955

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
