### PR TITLE
kubeadm: revert to using a static list of etcd versions

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -496,16 +496,27 @@ var (
 	// CurrentKubernetesVersion specifies current Kubernetes version supported by kubeadm
 	CurrentKubernetesVersion = getSkewedKubernetesVersion(0)
 
-	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
+	// SupportedEtcdVersion lists officially supported etcd versions with corresponding
+	// Kubernetes releases.
+	//
 	// If you are updating the versions in this map, make sure to also update:
 	// - MinExternalEtcdVersion: with the minimum etcd version from this map.
-	// - DefaultEtcdVersion: with etcd version used for the current k8s release (0).
-	// The maximum length of the map should be 2, as kubeadm supports a maximum skew of -1
-	// with the control plane version.
+	// - DefaultEtcdVersion: with etcd version used for the current k8s release.
+	//
+	// The maximum length of the map should be 3. kubeadm supports a maximum skew of -1
+	// with the control plane version, but before a release the oldest k8s version in this
+	// map will be the only stable version, thus one additional version is required
+	// to be unit tested.
+	//
+	// This map should not be used directly in kubeadm code. Instead, it should be used with
+	// EtcdSupportedVersion(), as it allows for returning a valid version even if the input
+	// k8s version key is not defined (out of bounds). This allows for kubeadm to assume
+	// an etcd version even if the map is not yet updated before a release. The user will
+	// get a warning in that case, so ideally the map should be updated for each release.
 	SupportedEtcdVersion = map[uint8]string{
-		uint8(getSkewedKubernetesVersion(-2).Minor()): "3.5.24-0",
-		uint8(getSkewedKubernetesVersion(-1).Minor()): "3.6.6-0",
-		uint8(getSkewedKubernetesVersion(0).Minor()):  "3.6.6-0",
+		34: "3.6.6-0",
+		35: "3.6.6-0",
+		36: "3.6.6-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -98,10 +98,18 @@ func TestGetStaticPodFilepath(t *testing.T) {
 	}
 }
 
+func TestEtcdSupportedVersionLength(t *testing.T) {
+	const max = 3
+	if len(SupportedEtcdVersion) != max {
+		t.Fatalf("SupportedEtcdVersion must include exactly %d versions", max)
+	}
+}
+
 func TestEtcdSupportedVersion(t *testing.T) {
 	var supportedEtcdVersion = map[uint8]string{
 		17: "3.3.17-0",
-		18: "3.4.3-0",
+		18: "3.4.2-0",
+		19: "3.4.3-0",
 	}
 	var tests = []struct {
 		kubernetesVersion string
@@ -135,7 +143,7 @@ func TestEtcdSupportedVersion(t *testing.T) {
 		},
 		{
 			kubernetesVersion: "1.18.1",
-			expectedVersion:   version.MustParseSemantic("3.4.3-0"),
+			expectedVersion:   version.MustParseSemantic("3.4.2-0"),
 			expectedWarning:   false,
 			expectedError:     false,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The introduction of dynamic keys in the etcd version map in constants.go introduced a couple of problems
(https://github.com/kubernetes/kubernetes/pull/134866):

1. The size of the map could no longer be unit tested because at UT runtime there was only one key "0".

2. Once a new k8s release branch is cut the version map has mismatched versions. The latest k8s version mapped to the future prerelease alpha (placeholder), the previous was the current WIP release version and the oldest version in the map is the current stable. This introduces undesired shift of versions where we are applying the wrong version to the current WIP release unless a contributor PRs it.

The old static approach on the other hand is safer because it hardcodes the versions, and the utility function EtcdSupportedVersion() ensures that we get a relevant etcd version even if the input k8s MINOR key is out of bonds for the map.

- Revert to using static version in the map.
- Revert the unit test TestEtcdSupportedVersionLength.
- Add additional comments over the map.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

NONE

#### Special notes for your reviewer:

slack discussion:
https://kubernetes.slack.com/archives/C2P1JHS2E/p1764754351115289

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
