### PR TITLE
Handle the case of a pod IP being reused while the old Pod still exists

### DIFF
--- a/pkg/proxy/endpointschangetracker_test.go
+++ b/pkg/proxy/endpointschangetracker_test.go
@@ -1321,8 +1321,8 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// test additions to existing state with partially overlapping slices and ports
 		"add a slice that overlaps with existing state and partial ports": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
-				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
+				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker: NewEndpointsChangeTracker(v1.IPv4Protocol, "host1", nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
@@ -1336,14 +1336,14 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{ip: "10.0.1.3", port: 80, endpoint: "10.0.1.3:80", isLocal: true, ready: true, serving: true, terminating: false},
 					&BaseEndpointInfo{ip: "10.0.1.4", port: 80, endpoint: "10.0.1.4:80", isLocal: true, ready: true, serving: true, terminating: false},
 					&BaseEndpointInfo{ip: "10.0.1.5", port: 80, endpoint: "10.0.1.5:80", isLocal: true, ready: true, serving: true, terminating: false},
-					&BaseEndpointInfo{ip: "10.0.2.1", port: 80, endpoint: "10.0.2.1:80", isLocal: false, ready: true, serving: true, terminating: false},
+					&BaseEndpointInfo{ip: "10.0.2.1", port: 80, endpoint: "10.0.2.1:80", isLocal: true, ready: true, serving: true, terminating: false},
 					&BaseEndpointInfo{ip: "10.0.2.2", port: 80, endpoint: "10.0.2.2:80", isLocal: true, ready: true, serving: true, terminating: false},
 				},
 				makeServicePortName("ns1", "svc1", "port-1", v1.ProtocolTCP): {
-					&BaseEndpointInfo{ip: "10.0.1.1", port: 443, endpoint: "10.0.1.1:443", isLocal: false, ready: true, serving: true, terminating: false},
+					&BaseEndpointInfo{ip: "10.0.1.1", port: 443, endpoint: "10.0.1.1:443", isLocal: true, ready: true, serving: true, terminating: false},
 					&BaseEndpointInfo{ip: "10.0.1.2", port: 443, endpoint: "10.0.1.2:443", isLocal: true, ready: true, serving: true, terminating: false},
-					&BaseEndpointInfo{ip: "10.0.1.3", port: 443, endpoint: "10.0.1.3:443", isLocal: false, ready: true, serving: true, terminating: false},
-					&BaseEndpointInfo{ip: "10.0.2.1", port: 443, endpoint: "10.0.2.1:443", isLocal: false, ready: true, serving: true, terminating: false},
+					&BaseEndpointInfo{ip: "10.0.1.3", port: 443, endpoint: "10.0.1.3:443", isLocal: true, ready: true, serving: true, terminating: false},
+					&BaseEndpointInfo{ip: "10.0.2.1", port: 443, endpoint: "10.0.2.1:443", isLocal: true, ready: true, serving: true, terminating: false},
 					&BaseEndpointInfo{ip: "10.0.2.2", port: 443, endpoint: "10.0.2.2:443", isLocal: true, ready: true, serving: true, terminating: false},
 				},
 			},


### PR DESCRIPTION
#### What this PR does / why we need it:
1. Removes an incorrect special case that was trying to be clever about Endpoints being moved between EndpointSlices, but was actually wrong.
2. Adds a new special case to handle #135266

#### Which issue(s) this PR is related to:
Fixes #135266

#### Special notes for your reviewer:
There's a lot of discussion of this in #135334... To summarize what I think we agreed on:

- If there are two Endpoints in different slices pointing to the same Pod (i.e., same `targetRef`), then that means that the EndpointSlice controller is moving the Endpoint from one slice to another. _Ideally_ in this case, we would prefer the Endpoint from the more-recently-updated slice, since it may have more up-to-date `conditions` than the other one. (But we don't do that even with this PR.)
  - FWIW #135334 used both `endpoints.kubernetes.io/last-change-trigger-time` and a sequence counter to decide which slice to prefer, but the sequence counter is unnecessary (and possibly even wrong): any change to Pod status will result in `endpoints.kubernetes.io/last-change-trigger-time` being updated, so if the EndpointSlice controller updates a slice _without_ updating its trigger time, then that means it *didn't* update any of the `conditions`.
- If there are two Endpoints, in the same or different slices, pointing to *different* pods (different `targetRefs`), and one is `terminating` and the other isn't, then that means a pod IP got reused after a pod exited but before the `Pod` was fully deleted, which is valid.
  - (In #135334 we went back and forth on whether the important thing was `ready`, `serving`, or `terminating`, and I eventually decided on `terminating` here, because that's the only case we explicitly agreed was reasonable. e.g., if you have two non-terminating pods where one is serving and one is not, then sure, it's clear what the _intent_ is, but you shouldn't do that anyway. Right?)
- The way the endpointslicecache code is currently set up, we don't have access to the `last-change-trigger-time`s or the `targetRef`s at the point when we're trying to decide what to do about a duplicate IP, so we can't actually distinguish which case we're in when we find a duplicate. So I just made the code always assume the "different pods" case. This means that if an Endpoint gets moved from one slice to another just as its `conditions` change, then we may not pick up the `conditions` change until after we have received *both* EndpointSlice updates rather than just the first one. This is not really a big deal, since the two updates ought to arrive back-to-back anyway.
- (For completeness: if there are two Endpoints with the _same_ `targetRef` in the _same_ slice, then that's a bug in the EndpointSlice controller and all bets are off.)

It's possible a later refactoring of the code might make it possible to correctly track both situations, but doing that is not a priority.

#### Does this PR introduce a user-facing change?
```release-note
kube-proxy now correctly handles the case where a pod IP gets assigned to
a newly-created pod when the pod that previously had that IP has been
terminated but is not yet fully deleted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/kind bug
/sig network
/area kube-proxy
/priority important-soon
/triage accepted
/assign @aojea