### PR TITLE
Fix resource.MustParse fails to parse quantities near math.MaxInt64

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -300,6 +300,15 @@ func ParseQuantity(str string) (Quantity, error) {
 	case DecimalExponent, DecimalSI:
 		scale = exponent
 		precision = maxInt64Factors - int32(len(num)+len(denom))
+		// when maxInt64Factors (18) yields -1 (19 digits), parse num+denom to verify if it
+		// still fits in int64 (≤ MaxInt64). On success, enable the fast path (precision = 0).
+		if precision == -1 {
+			shifted := num + denom
+			_, err := strconv.ParseInt(shifted, 10, 64)
+			if err == nil {
+				precision = 0 // enable the fast path
+			}
+		}
 	case BinarySI:
 		scale = 0
 		switch {


### PR DESCRIPTION
# Summary
- Fix AsInt64() to properly convert inf.Dec values to int64 when representable.
- Add regression tests for parsing quantities near `math.MaxInt64`.

# Root Cause
When parsing quantities with 19 digits (e.g., `math.MaxInt64`), the parser falls back to `inf.Dec` because `maxInt64Factors = 18`. However, `AsInt64()` was returning `(0, false)` for all `inf.Dec` values without attempting conversion, misclassifying representable values.

# Solution
Enhance `AsInt64()` to convert `inf.Dec` to `int64` when the value is representable:
- `scale == 0`: return the unscaled value directly.
- `scale > 0`: divide by `10^scale` and require exact divisibility.
- `scale < 0`: multiply by `10^(-scale)` with overflow checks.

Additionally, refine the decimal fast-path heuristic:
- Keep the 18-digit quick check.
- If total digits are exactly 19, compare `num+denom` against `MaxInt64`; if it fits, allow the fast path.
