### PR TITLE
Fix resource.MustParse fails to parse quantities near math.MaxInt64

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -302,6 +302,7 @@ func ParseQuantity(str string) (Quantity, error) {
 		precision = maxInt64Factors - int32(len(num)+len(denom))
 		// when maxInt64Factors (18) yields -1 (19 digits), parse num+denom to verify if it
 		// still fits in int64 (≤ MaxInt64). On success, enable the fast path (precision = 0).
+		// keep minInt64 still in Dec path because it's abs would overflow
 		if precision == -1 {
 			shifted := num + denom
 			_, err := strconv.ParseInt(shifted, 10, 64)

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -300,6 +300,15 @@ func ParseQuantity(str string) (Quantity, error) {
 	case DecimalExponent, DecimalSI:
 		scale = exponent
 		precision = maxInt64Factors - int32(len(num)+len(denom))
+		// when maxInt64Factors (18) yields -1 (19 digits), parse num+denom to verify if it
+		// still fits in int64 (≤ MaxInt64). On success, enable the fast path (precision = 0).
+		if precision == -1 {
+			shifted := num + denom
+			_, err := strconv.ParseInt(shifted, 10, 64)
+			if err == nil {
+				precision = 0 // enable the fast path
+			}
+		}
 	case BinarySI:
 		scale = 0
 		switch {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -557,9 +557,9 @@ func TestQuantityParse(t *testing.T) {
 // and that they can be represented as int64.
 func TestQuantityParseInt(t *testing.T) {
 	table := []struct {
-		input       string
-		expect      Quantity
-		expectError bool
+		input             string
+		expect            Quantity
+		expectToGoDecPath bool
 	}{
 		{"0", intQuantity(0, 0, DecimalSI), false},
 		{"2048", intQuantity(2048, 0, DecimalSI), false},
@@ -590,7 +590,7 @@ func TestQuantityParseInt(t *testing.T) {
 
 		j, ok := got.AsInt64()
 
-		if item.expectError {
+		if item.expectToGoDecPath {
 			if ok {
 				t.Errorf("%v: expected not to be able to convert to int64, got %d", item.input, j)
 			}
@@ -606,12 +606,7 @@ func TestQuantityParseInt(t *testing.T) {
 
 		i, ok := item.expect.AsInt64()
 		if !ok {
-			continue
-		}
-		if !ok {
-			if got.d.Dec == nil && got.i.scale >= 0 {
-				t.Errorf("%v: is an int64Amount, but can't return AsInt64: %v", item.input, got)
-			}
+			t.Errorf("%v: expected to be able to convert expected value to int64, got %d", item.input, i)
 			continue
 		}
 		if i != j {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -564,10 +564,15 @@ func TestQuantityParseInt(t *testing.T) {
 		{"2048", intQuantity(2048, 0, DecimalSI)},
 		{"1k", intQuantity(1000, 0, DecimalSI)},
 		{"1.3E+6", intQuantity(13, 5, DecimalExponent)},
-		// value larger than 1000000000000000000(1e18) previously failed because maxInt64Factors = 18, see issue#135487
+		{"922337203685477580", intQuantity(922337203685477580, 0, DecimalSI)},
+		{"-922337203685477580", intQuantity(-922337203685477580, 0, DecimalSI)},
+		// value larger than 1000000000000000000(1e18) would fail if skipping attempting
+		// to convert inf.Dec because maxInt64Factors = 18, see issue#135487
 		{"1000000000000000000", intQuantity(1000000000000000000, 0, DecimalSI)},
 		{"9223372036854775807", intQuantity(mostPositive, 0, DecimalSI)},
 		{"-9223372036854775807", intQuantity(mostNegative+1, 0, DecimalSI)},
+		{"9223372036854.775807M", intQuantity(9223372036854775807, 0, DecimalSI)},
+		{"92233720368.54775807E+8", intQuantity(9223372036854775807, 0, DecimalExponent)},
 	}
 
 	for _, item := range table {
@@ -603,7 +608,8 @@ func TestQuantityParseInt(t *testing.T) {
 	invalidInt := []string{
 		"1.0",
 		"9223372036854775808",  // mostPositive + 1
-		"-9223372036854775809", // mostNegative - 1
+		"-9223372036854775808", // mostNegative, intended to go dec path
+		"99999999999999999999",
 	}
 
 	for _, item := range invalidInt {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The current checks using `maxInt64Factors` are too coarse: they allow `999999999999999999 (has 18 nines)` to pass but block `1000000000000000000 (has 18 0)` 
```go
largestPass := "999999999999999999"
q := resource.MustParse(largestPass)
fmt.Println(q.AsInt64())

smallestBlock := "1000000000000000000"
q2 := resource.MustParse(smallestBlock)
fmt.Println(q2.AsInt64())
fmt.Println(q2.AsDec())
```
#### output
```
999999999999999999 true
0 false
1000000000000000000.000000000
```
 This pr added a precise boundary check so that up to `9223372036854775807` (maxInt64) can be accepted, while values above` 9223372036854775807` up to `999999999999999999 (has 19 nines)` are still correctly rejected. 
previous unit tests didn’t cover large int case before, this pr added some test cases for it as well.

#### Which issue(s) this PR is related to:
Fixes #135487
<https://github.com/kubernetes/kubernetes/issues/135487>

#### Special notes for your reviewer:

Compared to https://github.com/kubernetes/kubernetes/pull/135595, this PR explores a different approach to fixing the parsing behavior.

#### Does this PR introduce a user-facing change?
```release-note
Fix parsing of very large quantity values near `math.MaxInt64` in `resource.MustParse`, preventing incorrect parsing results and ensuring consistency with `resource.NewQuantity`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```