### PR TITLE
test/e2e: explicitly use new err variable inside parallelized code

### DIFF
--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -252,7 +252,8 @@ var _ = SIGDescribe("Job", func() {
 					Namespace: pod.Namespace,
 				},
 			}
-			err = f.ClientSet.CoreV1().Pods(pod.Namespace).EvictV1(ctx, evictTarget)
+			// use new variable explicitly here, to ensure it doesn't escape the scope of goroutines
+			err := f.ClientSet.CoreV1().Pods(pod.Namespace).EvictV1(ctx, evictTarget)
 			framework.ExpectNoError(err, "failed to evict the pod: %s/%s", pod.Name, pod.Namespace)
 
 			ginkgo.By(fmt.Sprintf("Awaiting for the pod: %s/%s to be deleted", pod.Name, pod.Namespace))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps
/sig testing

#### What this PR does / why we need it:
This was called out in https://github.com/kubernetes/kubernetes/pull/126169/files#r2582469185 as a potential race condition.

#### Which issue(s) this PR is related to:
None

#### Special notes for your reviewer:
/assign @mimowo @pohly 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
