### PR TITLE
kubectl create namespace: warn when name starts with kube-

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
@@ -19,10 +19,12 @@ package create
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -174,6 +176,9 @@ func (o *NamespaceOptions) createNamespace() *corev1.Namespace {
 func (o *NamespaceOptions) Validate() error {
 	if len(o.Name) == 0 {
 		return fmt.Errorf("name must be specified")
+	}
+	if strings.HasPrefix(o.Name, "kube-") {
+		klog.Warning("Avoid creating namespaces with the prefix kube-, since it is reserved for Kubernetes system namespaces.")
 	}
 	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -178,7 +177,7 @@ func (o *NamespaceOptions) Validate() error {
 		return fmt.Errorf("name must be specified")
 	}
 	if strings.HasPrefix(o.Name, "kube-") {
-		klog.Warning("Avoid creating namespaces with the prefix kube-, since it is reserved for Kubernetes system namespaces.")
+		fmt.Fprintf(o.ErrOut, "Warning: avoid creating namespaces with the prefix kube-, since it is reserved for Kubernetes system namespaces.\n")
 	}
 	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
@@ -19,7 +19,6 @@ package create
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -175,9 +174,6 @@ func (o *NamespaceOptions) createNamespace() *corev1.Namespace {
 func (o *NamespaceOptions) Validate() error {
 	if len(o.Name) == 0 {
 		return fmt.Errorf("name must be specified")
-	}
-	if strings.HasPrefix(o.Name, "kube-") {
-		fmt.Fprintf(o.ErrOut, "Warning: avoid creating namespaces with the prefix kube-, since it is reserved for Kubernetes system namespaces.\n")
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds a warning message when users create a namespace with a "kube-" prefix using `kubectl create namespace`.
Adding a warning would be great to help preventing potential conflicts, as the [Documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#working-with-namespaces) states:

> Avoid creating namespaces with the prefix kube-, since it is reserved for Kubernetes system namespaces.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added warning message when users create a namespace with a "kube-" prefix using `kubectl create namespace`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig cli