### PR TITLE
Fix external binding on a pod that is in scheduling does not wake up unschedulable pods

### DIFF
--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -973,6 +973,145 @@ func TestUpdatePod(t *testing.T) {
 	}
 }
 
+func TestUpdatePod_WakeUpPodsOnExternalScheduling(t *testing.T) {
+	highPriorityPod :=
+		st.MakePod().Name("hpp").Namespace("ns1").UID("hppns1").Priority(highPriority).SchedulerName(testSchedulerName).Obj()
+	medPriorityPod :=
+		st.MakePod().Name("smpp").Namespace("ns3").UID("mppns2").Priority(midPriority).SchedulerName(testSchedulerName).Obj()
+	lowPriorityPod :=
+		st.MakePod().Name("lpp").Namespace("ns4").UID("lppns1").Priority(lowPriority).SchedulerName(testSchedulerName).Obj()
+
+	pod := st.MakePod().Name("pod1").UID("pod1").SchedulerName(testSchedulerName).Obj()
+	assumedPodOnNodeA := pod.DeepCopy()
+	assumedPodOnNodeA.Spec.NodeName = "node-a"
+	boundPodOnNodeB := pod.DeepCopy()
+	boundPodOnNodeB.Spec.NodeName = "node-b"
+
+	medPriorityNominatedPodOnNodeA := pod.DeepCopy()
+	medPriorityNominatedPodOnNodeA.Status.NominatedNodeName = "node-a"
+	medPriorityNominatedPodOnNodeA.Spec.Priority = &midPriority
+
+	unschedulablePods := []*v1.Pod{highPriorityPod, medPriorityPod, lowPriorityPod}
+
+	// Make pods schedulable on Delete event when QHints are enabled
+	queueHintForPodDelete := func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+		return fwk.Queue, nil
+	}
+	queueingHintMap := internalqueue.QueueingHintMapPerProfile{
+		testSchedulerName: {
+			framework.EventAssignedPodDelete: {
+				{
+					PluginName:     "fooPlugin1",
+					QueueingHintFn: queueHintForPodDelete,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                  string
+		oldPod                *v1.Pod
+		newPod                *v1.Pod
+		assumedPod            *v1.Pod
+		wantInActiveOrBackoff sets.Set[string]
+	}{
+		{
+			name:                  "assumed pod externally bound to a different node should wake up other pods",
+			oldPod:                pod,
+			newPod:                boundPodOnNodeB,
+			assumedPod:            assumedPodOnNodeA,
+			wantInActiveOrBackoff: sets.New(lowPriorityPod.Name, medPriorityPod.Name, highPriorityPod.Name),
+		},
+		{
+			name:                  "nominated pod externally bound to a different node should wake up other pods with lower or equaL priority",
+			oldPod:                medPriorityNominatedPodOnNodeA,
+			newPod:                boundPodOnNodeB,
+			wantInActiveOrBackoff: sets.New(lowPriorityPod.Name, medPriorityPod.Name),
+		},
+	}
+
+	for _, tt := range tests {
+		for _, qHintEnabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s, with queuehint(%v)", tt.name, qHintEnabled), func(t *testing.T) {
+				if !qHintEnabled {
+					featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, false)
+				}
+
+				logger, ctx := ktesting.NewTestContext(t)
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+
+				var objs []runtime.Object
+				for _, pod := range unschedulablePods {
+					objs = append(objs, pod)
+				}
+				client := fake.NewClientset(objs...)
+				informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+				// apiDispatcher is unused in the test, but intializing it anyway.
+				apiDispatcher := apidispatcher.New(client, 16, apicalls.Relevances)
+				apiDispatcher.Run(logger)
+				defer apiDispatcher.Close()
+
+				recorder := metrics.NewMetricsAsyncRecorder(3, 20*time.Microsecond, ctx.Done())
+				queue := internalqueue.NewPriorityQueue(
+					newDefaultQueueSort(),
+					informerFactory,
+					internalqueue.WithMetricsRecorder(recorder),
+					internalqueue.WithQueueingHintMapPerProfile(queueingHintMap),
+					internalqueue.WithAPIDispatcher(apiDispatcher),
+					// disable backoff queue
+					internalqueue.WithPodInitialBackoffDuration(0),
+					internalqueue.WithPodMaxBackoffDuration(0))
+				schedulerCache := internalcache.New(ctx, 30*time.Second, nil)
+
+				// Put test pods into unschedulable queue
+				for _, pod := range unschedulablePods {
+					queue.Add(logger, pod)
+					poppedPod, err := queue.Pop(logger)
+					if err != nil {
+						t.Fatalf("Pop failed: %v", err)
+					}
+					poppedPod.UnschedulablePlugins = sets.New("fooPlugin1")
+					if err := queue.AddUnschedulableIfNotPresent(logger, poppedPod, queue.SchedulingCycle()); err != nil {
+						t.Errorf("Unexpected error from AddUnschedulableIfNotPresent: %v", err)
+					}
+				}
+
+				s, _, err := initScheduler(ctx, schedulerCache, queue, apiDispatcher, client, informerFactory)
+				if err != nil {
+					t.Fatalf("Failed to initialize test scheduler: %v", err)
+				}
+
+				if tt.assumedPod != nil {
+					err := schedulerCache.AssumePod(logger, tt.assumedPod)
+					if err != nil {
+						t.Fatalf("Failed to assume pod: %v", err)
+					}
+				}
+
+				if len(s.SchedulingQueue.PodsInActiveQ()) > 0 {
+					t.Errorf("No pods were expected to be in the activeQ before the update, but there were %v", s.SchedulingQueue.PodsInActiveQ())
+				}
+
+				s.updatePod(tt.oldPod, tt.newPod)
+
+				podsInActiveOrBackoff := s.SchedulingQueue.PodsInActiveQ()
+				podsInActiveOrBackoff = append(podsInActiveOrBackoff, s.SchedulingQueue.PodsInBackoffQ()...)
+				if len(podsInActiveOrBackoff) != len(tt.wantInActiveOrBackoff) {
+					t.Errorf("Different number of pods were expected to be in the activeQ or backoffQ, but found actual %v vs. expected %v", podsInActiveOrBackoff, tt.wantInActiveOrBackoff)
+				}
+				for _, pod := range podsInActiveOrBackoff {
+					if !tt.wantInActiveOrBackoff.Has(pod.Name) {
+						t.Errorf("Found unexpected pod in activeQ or backoffQ: %s", pod.Name)
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestDeletePod(t *testing.T) {
 	pod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("supported-scheduler").Obj()
 	otherPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj()

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1079,7 +1079,7 @@ func TestUpdatePod_WakeUpPodsOnExternalScheduling(t *testing.T) {
 					// disable backoff queue
 					internalqueue.WithPodInitialBackoffDuration(0),
 					internalqueue.WithPodMaxBackoffDuration(0))
-				schedulerCache := internalcache.New(ctx, 30*time.Second, nil)
+				schedulerCache := internalcache.New(ctx, nil)
 
 				// Put test pods into unschedulable queue
 				for _, pod := range unschedulablePods {

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -986,6 +986,8 @@ func TestUpdatePod_WakeUpPodsOnExternalScheduling(t *testing.T) {
 	assumedPodOnNodeA.Spec.NodeName = "node-a"
 	boundPodOnNodeB := pod.DeepCopy()
 	boundPodOnNodeB.Spec.NodeName = "node-b"
+	boundPodOnNodeA := pod.DeepCopy()
+	boundPodOnNodeA.Spec.NodeName = "node-a"
 
 	medPriorityNominatedPodOnNodeA := pod.DeepCopy()
 	medPriorityNominatedPodOnNodeA.Status.NominatedNodeName = "node-a"
@@ -1023,10 +1025,23 @@ func TestUpdatePod_WakeUpPodsOnExternalScheduling(t *testing.T) {
 			wantInActiveOrBackoff: sets.New(lowPriorityPod.Name, medPriorityPod.Name, highPriorityPod.Name),
 		},
 		{
-			name:                  "nominated pod externally bound to a different node should wake up other pods with lower or equaL priority",
+			name:                  "nominated pod externally bound to a different node should wake up other pods with lower or equal priority",
 			oldPod:                medPriorityNominatedPodOnNodeA,
 			newPod:                boundPodOnNodeB,
 			wantInActiveOrBackoff: sets.New(lowPriorityPod.Name, medPriorityPod.Name),
+		},
+		{
+			name:                  "assumed pod externally bound to the same node should not wake up other pods",
+			oldPod:                pod,
+			newPod:                boundPodOnNodeA,
+			assumedPod:            assumedPodOnNodeA,
+			wantInActiveOrBackoff: sets.New[string](),
+		},
+		{
+			name:                  "nominated pod externally bound to a the same node should not wake up other pods",
+			oldPod:                medPriorityNominatedPodOnNodeA,
+			newPod:                boundPodOnNodeA,
+			wantInActiveOrBackoff: sets.New[string](),
 		},
 	}
 

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -258,7 +258,7 @@ func TestUpdateAssignedPodInCache(t *testing.T) {
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 				logger:          logger,
 			}
-			sched.addAssignedPodToCache(tt.oldPod)
+			sched.addAssignedPodToCache(tt.oldPod, nil)
 			sched.updateAssignedPodInCache(tt.oldPod, tt.newPod)
 
 			if tt.oldPod.UID != tt.newPod.UID {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this? 

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: Fix External binding on a pod that is in scheduling, does not wake up unschedulable pods for NNN and assumed NN

#### Which issue(s) this PR is related to: Fixes https://github.com/kubernetes/kubernetes/issues/134859
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change? No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

