### PR TITLE
Switch ipvs and winkernel back to more regular forced syncs

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -401,8 +401,8 @@ func NewProxier(
 		proxier.ipsetList[is.name] = NewIPSet(ipset, is.name, is.setType, (ipFamily == v1.IPv6Protocol), is.comment)
 	}
 
-	logger.V(2).Info("ipvs sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", proxyutil.FullSyncPeriod)
-	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, proxyutil.FullSyncPeriod)
+	logger.V(2).Info("ipvs sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", syncPeriod)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, syncPeriod)
 
 	proxier.gracefuldeleteManager.Run()
 	return proxier, nil

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -750,8 +750,8 @@ func NewProxier(
 		return nil, err
 	}
 
-	klog.V(3).Info("Record sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", proxyutil.FullSyncPeriod)
-	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, proxyutil.FullSyncPeriod)
+	klog.V(3).Info("Record sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", syncPeriod)
+	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, syncPeriod)
 
 	return proxier, nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
In the BoundedFrequencyRunner rewrite (#131615) we changed the "resync even if nothing changed" period for ipvs and winkernel from 30s (configurable) to 1h (hardcoded). (It was already 1h for iptables and nftables.) This just flips it back.

In _most_ cases the extra resyncs are unnecessary and wasteful, but maybe some people have use cases where they need them, so let's not change the behavior right before deprecating IPVS.

(@princepereira The same change happened for winkernel and I'm reverting that back to the 1.33 behavior now too.)

#### Which issue(s) this PR is related to:
Fixes #134147

#### Does this PR introduce a user-facing change?
```release-note
Fixes a 1.34+ regression in ipvs and winkernel kube-proxy backends; these are now reverted back to their
pre-1.34 behavior of regularly rechecking all of their rules even when no
Services or EndpointSlices change.
```

/kind bug
/kind regression
/sig network
/sig windows
/area kube-proxy
/area ipvs
/priority important-soon