### PR TITLE
kubelet: Fix nil panic in podcertificatemanager

### DIFF
--- a/pkg/kubelet/podcertificate/podcertificatemanager.go
+++ b/pkg/kubelet/podcertificate/podcertificatemanager.go
@@ -481,7 +481,7 @@ func (m *IssuingManager) handleProjection(ctx context.Context, key projectionKey
 			// remember creating the PCR, then we must be in case 2.  Return to
 			// credStateInitial so we create a new PCR.
 			rec.curState = &credStateInitial{}
-			return fmt.Errorf("PodCertificateRequest %q appears to have been deleted", pcr.ObjectMeta.Namespace+"/"+pcr.ObjectMeta.Name)
+			return fmt.Errorf("PodCertificateRequest %q appears to have been deleted", key.Namespace+"/"+state.pcrName)
 		} else if err != nil {
 			return fmt.Errorf("while getting PodCertificateRequest %q: %w", key.Namespace+"/"+state.pcrName, err)
 		}


### PR DESCRIPTION
If the the PCR that kubelet created gets deleted before it is issued, a nil panic will be thrown while composing the error message.  This is fixed by taking the namespace and name from the current state, not from the (nil) object we just got from the informer.

This likely needs to be picked to 1.35.  The most likely scenario to hit this crash is if you create a pod that requests a certificate from a signer that is not implemented in the cluster (because you're still developing it, or you forgot to install it).  Then Kubelet will continue to watch it until it gets cleaned by the cleaner controller, at which point this nil panic will be hit.

/kind bug
/kind failing-test
/kind flake

```release-note
NONE
```

