### PR TITLE
fix DeepEqualWithNilDifferentFromEmpty comparison

### DIFF
--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
@@ -178,7 +178,7 @@ func (e Equalities) deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool,
 			}
 
 			// Two lists that are both empty and both non nil are equal
-			if v1.Len() == 0 || v2.Len() == 0 {
+			if v1.Len() == 0 && v2.Len() == 0 {
 				return true
 			}
 		}
@@ -229,7 +229,7 @@ func (e Equalities) deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool,
 			}
 
 			// Two maps that are both empty and both non nil are equal
-			if v1.Len() == 0 || v2.Len() == 0 {
+			if v1.Len() == 0 && v2.Len() == 0 {
 				return true
 			}
 		}


### PR DESCRIPTION
Ref. N/A
fix DeepEqualWithNilDifferentFromEmpty comparison and add tests

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug in DeepEqualWithNilDifferentFromEmpty where empty slices/maps were incorrectly considered equal to non-empty ones due to using OR (||) instead of AND (&&) logic. This could cause managed fields timestamps to not update when the only change was adding or removing all elements from a list or map.
```

/sig api-machinery
/kind bug
/assign @deads2k @fedebongio

