### PR TITLE
Fix data race in PopulateRefs by copying Items and AdditionalProperties

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go
@@ -86,7 +86,9 @@ func populateRefs(schemaOf func(ref string) (*spec.Schema, bool), visited sets.S
 		}
 		if populated != result.AdditionalProperties.Schema {
 			changed = true
-			result.AdditionalProperties.Schema = populated
+			newProps := *result.AdditionalProperties
+			newProps.Schema = populated
+			result.AdditionalProperties = &newProps
 		}
 	}
 	// schema is a list, populate its items
@@ -97,7 +99,9 @@ func populateRefs(schemaOf func(ref string) (*spec.Schema, bool), visited sets.S
 		}
 		if populated != result.Items.Schema {
 			changed = true
-			result.Items.Schema = populated
+			newItems := *result.Items
+			newItems.Schema = populated
+			result.Items = &newItems
 		}
 	}
 	if changed {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fixes a data race in `PopulateRefs` function in `staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go`.

The `populateRefs` function was modifying `result.Items.Schema` and `result.AdditionalProperties.Schema` directly. Since `result` is a shallow copy of the input schema (`result := *schema`), these pointer fields still reference the original shared structures, causing a data race when multiple goroutines call `PopulateRefs` concurrently.

## Which issue(s) this PR fixes:

Fixes #135627

## How the issue was reproduced:

The race was detected by the race detector during E2E tests with race detection enabled, as reported in the issue.

## How it was fixed:

Create copies of `Items` and `AdditionalProperties` before modifying their `Schema` field:

```go
// Before (race):
result.AdditionalProperties.Schema = populated

// After (no race):
newProps := *result.AdditionalProperties
newProps.Schema = populated
result.AdditionalProperties = &newProps
```

The same pattern is applied to `result.Items`.

## Special notes for your reviewer:

The fix is minimal and follows the existing copy-on-write pattern already used in this file (e.g., for `props` map).

/sig api-machinery
/area apiserver
/priority important-soon