### PR TITLE
kubeadm: unset default kubelet staticPodPath if non-existent

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubelet_unix.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_unix.go
@@ -32,6 +32,9 @@ func (kc *kubeletConfig) Mutate() error {
 	if err := mutateResolverConfig(&kc.config, isServiceActive); err != nil {
 		return err
 	}
+	if err := mutateStaticPodPath(&kc.config); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
@@ -56,6 +56,11 @@ func (kc *kubeletConfig) Mutate() error {
 
 	// Mutate the paths in the config.
 	mutatePaths(&kc.config, drive)
+
+	if err := mutateStaticPodPath(&kc.config); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If a user does not set kubelet's `staticPodPath`, kubeadm applies the default `/etc/kubernetes/manifests`. If this directory doesn't actually exist, kubelet logs an error message once a second, forever.

This removes the `staticPodPath` default value if the directory does not exist.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

We could try to create the directory instead of unsetting the value, if there's concern about the behavior change. This didn't seem a proper use of `Mutate` from my quick look.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The default kubelet staticPodPath will no longer be set if the directory does not exist.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
