### PR TITLE
Document x-kubernetes-list-map-keys into OpenAPI extensions

### DIFF
--- a/api/openapi-spec/README.md
+++ b/api/openapi-spec/README.md
@@ -54,6 +54,34 @@ For example:
 }
 ```
 
+### `x-kubernetes-list-map-keys`
+
+Operations and Definitions may have `x-kubernetes-list-maps-keys` if they
+are associated with a [kubernetes resource](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources). `x-kubernetes-list-type` = `map` specifies field names inside each list element to serve as unique keys for the list-as-map.
+
+**For example:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "servers": {
+      "type": "array",
+      "x-kubernetes-list-type": "map",
+      "x-kubernetes-list-map-keys": ["name"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "address": { "type": "string" }
+        },
+        "required": ["name"]
+      }
+    }
+  }
+}
+```
+
 ### `x-kubernetes-patch-strategy` and `x-kubernetes-patch-merge-key`
 
 Some of the definitions may have these extensions. For more information about PatchStrategy and PatchMergeKey see


### PR DESCRIPTION
This PR adds missing OpenAPI vendor extension documentation for the following: x-kubernetes-list-map-keys

The provided documentation includes simple additions to api/openapi-spec/README.md with similar format to present documentation. Fixes issue #131724

#### What type of PR is this?

/kind documentation
Fixes #131724


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

