### PR TITLE
Fix data race in garbage collector on node.owners field

### DIFF
--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -783,7 +783,7 @@ func (gb *GraphBuilder) processGraphChanges(logger klog.Logger) bool {
 			// waiting for the deletion of their dependents.
 			gb.addUnblockedOwnersToDeleteQueue(logger, removed, changed)
 			// update the node itself
-			existingNode.owners = accessor.GetOwnerReferences()
+			existingNode.setOwners(accessor.GetOwnerReferences())
 			// Add the node to its new owners' dependent lists.
 			gb.addDependentToOwners(logger, existingNode, added)
 			// remove the node from the dependent list of node that are no longer in

--- a/pkg/controller/garbagecollector/patch.go
+++ b/pkg/controller/garbagecollector/patch.go
@@ -134,7 +134,7 @@ func (n *node) unblockOwnerReferencesStrategicMergePatch() ([]byte, error) {
 	var dummy metaonly.MetadataOnlyObject
 	var blockingRefs []metav1.OwnerReference
 	falseVar := false
-	for _, owner := range n.owners {
+	for _, owner := range n.getOwners() {
 		if owner.BlockOwnerDeletion != nil && *owner.BlockOwnerDeletion {
 			ref := owner
 			ref.BlockOwnerDeletion = &falseVar
@@ -157,7 +157,7 @@ func (gc *GarbageCollector) unblockOwnerReferencesJSONMergePatch(n *node) ([]byt
 	expectedObjectMeta.ResourceVersion = accessor.GetResourceVersion()
 	var expectedOwners []metav1.OwnerReference
 	falseVar := false
-	for _, owner := range n.owners {
+	for _, owner := range n.getOwners() {
 		owner.BlockOwnerDeletion = &falseVar
 		expectedOwners = append(expectedOwners, owner)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Add ownersLock to protect concurrent access to node.owners between GraphBuilder.processGraphChanges() (writer) and GC worker goroutines reading in blockingDependents() and unblockOwnerReferences() methods.

Also fix concurrent reads in the HTTP debug handler (/graph endpoint) for owners, dependents, beingDeleted, deletingDependents, and virtual fields by using their respective thread-safe accessor methods.

#### Which issue(s) this PR is related to:

Fixes: #135621

#### Special notes for your reviewer:

The fix follows the existing locking pattern in the node struct (dependentsLock, beingDeletedLock, etc.). GraphBuilder's own reads of `node.owners` remain as direct field access since it is single-threaded and the only writer.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
