### PR TITLE
Fix kubelet HTTP request duration metric recording incorrect values

### DIFF
--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/testutil"
 	zpagesfeatures "k8s.io/component-base/zpages/features"
 	"k8s.io/kubelet/pkg/cri/streaming"
 	"k8s.io/kubelet/pkg/cri/streaming/portforward"
@@ -69,6 +70,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
+	servermetrics "k8s.io/kubernetes/pkg/kubelet/server/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/kubernetes/pkg/volume"
 )
@@ -2013,4 +2015,48 @@ func TestNewServerRegistersMetricsSLIsEndpointTwice(t *testing.T) {
 	// Check if both servers registered the /metrics/slis endpoint
 	assert.Contains(t, server1.restfulCont.RegisteredHandlePaths(), "/metrics/slis", "First server should register /metrics/slis")
 	assert.Contains(t, server2.restfulCont.RegisteredHandlePaths(), "/metrics/slis", "Second server should register /metrics/slis")
+}
+
+// This test verifies that the HTTP request duration metric captures the actual
+// request handling time.
+func TestServeHTTPRequestDurationMetric(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
+	defer fw.testHTTPServer.Close()
+
+	// Register and reset the metric before the test
+	servermetrics.Register()
+	servermetrics.HTTPRequestsDuration.Reset()
+
+	// Add a delay to the pods handler to simulate request processing time.
+	// We use 50ms which is long enough to be clearly distinguishable from
+	// the ~2 microsecond bug, but short enough to not slow down tests.
+	handlerDelay := 50 * time.Millisecond
+	fw.fakeKubelet.podsFunc = func() []*v1.Pod {
+		time.Sleep(handlerDelay)
+		return []*v1.Pod{}
+	}
+
+	// Make a request to the pods endpoint
+	resp, err := http.Get(fw.testHTTPServer.URL + "/pods/")
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read the body to ensure the request is fully processed
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// Get the recorded duration from the metric
+	observerMetric := servermetrics.HTTPRequestsDuration.WithLabelValues("GET", "pods", "readwrite", "false")
+	metricValue, err := testutil.GetHistogramMetricValue(observerMetric)
+	require.NoError(t, err)
+
+	// Use the handler delay as the minimum expected duration. This avoids any
+	// timing-sensitive percentage-based checks.
+	minExpectedDuration := handlerDelay.Seconds()
+	assert.GreaterOrEqual(t, metricValue, minExpectedDuration,
+		"HTTP request duration metric recorded %v seconds, expected at least %v seconds. ",
+		metricValue, minExpectedDuration,
+	)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the `kubelet_http_requests_duration_seconds` metric which was recording
near-zero values (~2 microseconds) instead of actual request handling time.

The root cause was that arguments to deferred function calls in Go are evaluated
immediately at the defer statement. The original code:

```go
defer servermetrics.HTTPRequestsDuration.WithLabelValues(...).Observe(servermetrics.SinceInSeconds(startTime))
```

This evaluated `SinceInSeconds(startTime)` immediately, not when the request completed.

The fix wraps it in an anonymous function:

```go
defer func() {
    servermetrics.HTTPRequestsDuration.WithLabelValues(...).Observe(servermetrics.SinceInSeconds(startTime))
}()
```

#### Which issue(s) this PR is related to:

Fixes #135662

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the kubelet_http_requests_duration_seconds metric was recording
near-zero latency values instead of actual request handling time.
```

#### Additional documentation e.g., KEPs (Alarm CLI Enhancements Proposals), usage docs, etc.:

N/A