### PR TITLE
cpumanager/static policy ensures atomic operation of writing to check…

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -49,6 +49,9 @@ type writer interface {
 	SetCPUAssignments(ContainerCPUAssignments)
 	Delete(podUID string, containerName string)
 	ClearState()
+
+	Allocate(podUID string, containerName string, cpuset cpuset.CPUSet)
+	Reclaim(podUID string, containerName string, cpuset cpuset.CPUSet)
 }
 
 // State interface provides methods for tracking and setting cpu/pod assignment


### PR DESCRIPTION
…point for AddContainer and RemoveContainer.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:

This PR fixes a race condition in the CPUManager that can occur when the kubelet is restarted while the CPUManager is in the middle of writing its checkpoint file (function `AddContainer` and `RemoveContainer`). In such cases, the checkpoint file may be left in a partially written or inconsistent state. Upon restart, the kubelet fails to reconcile the CPU allocation state and exits with an error like:
```
current set of available CPUs 0-7 doesn't match with CPUs in state 0-3,5-7
```
This change ensures that checkpoint writes are atomic, preventing corruption or incompleteness of the checkpoint data during unexpected kubelet restarts.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #84783

#### Special notes for your reviewer:

This issue requires that kubelet's cpumanager runs under the static policy and occurs probabilistically when the machine is powered off and then powered on again.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
