### PR TITLE
cpumanager/static policy ensures atomic operation of writing to checkpoint for AddContainer and RemoveContainer.

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -99,6 +99,16 @@ func (s *mockState) GetCPUAssignments() state.ContainerCPUAssignments {
 	return s.assignments.Clone()
 }
 
+func (s *mockState) Allocate(podUID string, containerName string, cpuset cpuset.CPUSet) {
+	s.SetDefaultCPUSet(s.GetDefaultCPUSet().Difference(cpuset))
+	s.SetCPUSet(podUID, containerName, cpuset)
+}
+
+func (s *mockState) Reclaim(podUID string, containerName string, cpuset cpuset.CPUSet) {
+	s.Delete(podUID, containerName)
+	s.SetDefaultCPUSet(cpuset)
+}
+
 type mockPolicy struct {
 	err error
 }

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -49,6 +49,9 @@ type writer interface {
 	SetCPUAssignments(ContainerCPUAssignments)
 	Delete(podUID string, containerName string)
 	ClearState()
+
+	Allocate(podUID string, containerName string, cpuset cpuset.CPUSet)
+	Reclaim(podUID string, containerName string, cpuset cpuset.CPUSet)
 }
 
 // State interface provides methods for tracking and setting cpu/pod assignment

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -266,7 +266,7 @@ func (sc *stateCheckpoint) Allocate(podUID string, containerName string, cset cp
 
 	err := sc.storeState()
 	if err != nil {
-		klog.InfoS("Store state to checkpoint error", "err", err)
+		sc.logger.Error(err, "Failed to store state to checkpoint", "podUID", podUID, "containerName", containerName)
 	}
 }
 
@@ -281,6 +281,6 @@ func (sc *stateCheckpoint) Reclaim(podUID string, containerName string, cset cpu
 
 	err := sc.storeState()
 	if err != nil {
-		klog.InfoS("Store state to checkpoint error", "err", err)
+		sc.logger.Error(err, "Failed to store state to checkpoint", "podUID", podUID, "containerName", containerName)
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -445,7 +445,11 @@ func TestCheckpointStateAllocateAndReclaim(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testingDir)
+	defer func() {
+		if rmErr := os.RemoveAll(testingDir); rmErr != nil {
+			t.Fatalf("could not remove checkpoint: %v", rmErr)
+		}
+	}()
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
 	if err != nil {
@@ -455,7 +459,9 @@ func TestCheckpointStateAllocateAndReclaim(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// ensure there is no previous checkpoint
-			cpm.RemoveCheckpoint(testingCheckpoint)
+			if rmErr := cpm.RemoveCheckpoint(testingCheckpoint); rmErr != nil {
+				t.Fatalf("could not remove previous checkpoint: %v", rmErr)
+			}
 
 			logger, _ := ktesting.NewTestContext(t)
 			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -444,22 +444,16 @@ func TestCheckpointStateAllocateAndReclaim(t *testing.T) {
 	testingDir := t.TempDir()
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
-	if err != nil {
-		t.Fatalf("could not create testing checkpoint manager: %v", err)
-	}
+	require.NoError(t, err, "could not create testing checkpoint manager")
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// ensure there is no previous checkpoint
-			if rmErr := cpm.RemoveCheckpoint(testingCheckpoint); rmErr != nil {
-				t.Fatalf("could not remove previous checkpoint: %v", rmErr)
-			}
+			require.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove previous checkpoint")
 
 			logger, _ := ktesting.NewTestContext(t)
 			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
-			if err != nil {
-				t.Fatalf("could not create testing checkpointState instance: %v", err)
-			}
+			require.NoError(t, err, "could not create testing checkpointState instance")
 
 			defaultCPUset := tc.defaultCPUset
 			assignments := tc.assignments

--- a/pkg/kubelet/cm/cpumanager/state/state_mem.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_mem.go
@@ -121,3 +121,13 @@ func (s *stateMemory) ClearState() {
 	s.assignments = make(ContainerCPUAssignments)
 	s.logger.V(2).Info("Cleared state")
 }
+
+func (s *stateMemory) Allocate(podUID string, containerName string, cset cpuset.CPUSet) {
+	s.SetDefaultCPUSet(s.GetDefaultCPUSet().Difference(cset))
+	s.SetCPUSet(podUID, containerName, cset)
+}
+
+func (s *stateMemory) Reclaim(podUID string, containerName string, cset cpuset.CPUSet) {
+	s.Delete(podUID, containerName)
+	s.SetDefaultCPUSet(cset)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
This PR fixes a race condition in the CPUManager that can occur when the kubelet is restarted while the CPUManager is in the middle of writing its checkpoint file (function AddContainer and RemoveContainer). In such cases, the checkpoint file may be left in a partially written or inconsistent state. Upon restart, the kubelet fails to reconcile the CPU allocation state and exits with an error like:
```
current set of available CPUs 0-7 doesn't match with CPUs in state 0-3,5-7
```
This change ensures that checkpoint writes are atomic, preventing corruption or incompleteness of the checkpoint data during unexpected kubelet restarts.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes https://github.com/kubernetes/kubernetes/issues/84783
#### Special notes for your reviewer:
This issue requires that kubelet's cpumanager runs under the static policy and occurs probabilistically when the machine is powered off and then powered on again.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed CPUManager checkpoint corruption on abrupt kubelet shutdown, which previously caused kubelet startup failure due to CPU set mismatch.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
