### PR TITLE
test: Add XFS filesystem support to volume expansion e2e tests

### DIFF
--- a/test/e2e/storage/framework/testpattern.go
+++ b/test/e2e/storage/framework/testpattern.go
@@ -60,7 +60,7 @@ var (
 	DynamicCreatedSnapshot TestSnapshotType = "DynamicSnapshot"
 	// PreprovisionedCreatedSnapshot represents a snapshot type for pre-provisioned snapshot
 	PreprovisionedCreatedSnapshot TestSnapshotType = "PreprovisionedSnapshot"
-
+	// VolumeGroupSnapshot represents a group snapshot type for dynamic created volumegroupsnapshot
 	VolumeGroupSnapshot TestSnapshotType = "VolumeGroupSnapshot"
 )
 
@@ -229,6 +229,7 @@ var (
 		TestTags:               []interface{}{framework.WithSlow()},
 		SnapshotType:           DynamicCreatedSnapshot,
 		SnapshotDeletionPolicy: DeleteSnapshot,
+		AllowExpansion:         true,
 	}
 
 	// Definitions for ntfs
@@ -357,7 +358,7 @@ var (
 		SnapshotDeletionPolicy: RetainSnapshot,
 		VolType:                DynamicPV,
 	}
-	// EphemeralSnapshotDelete is TestPattern for snapshotting of a generic ephemeral volume
+	// EphemeralSnapshotRetain is TestPattern for snapshotting of a generic ephemeral volume
 	// where snapshots are preserved.
 	EphemeralSnapshotRetain = TestPattern{
 		Name:                   "Ephemeral Snapshot (retain policy)",

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -76,6 +76,7 @@ func InitCustomVolumeExpandTestSuite(patterns []storageframework.TestPattern) st
 func InitVolumeExpandTestSuite() storageframework.TestSuite {
 	patterns := []storageframework.TestPattern{
 		storageframework.DefaultFsDynamicPV,
+		storageframework.XfsDynamicPV,
 		storageframework.BlockVolModeDynamicPV,
 		storageframework.DefaultFsDynamicPVAllowExpansion,
 		storageframework.BlockVolModeDynamicPVAllowExpansion,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Different filesystems have different resize mechanisms:
   - ext3/ext4: Uses resize2fs
   - XFS: Uses xfs_growfs
   -  NTFS: Uses ntfsresize (Windows)
- This ensures XFS volumes are tested for expansion capabilities alongside the existing default filesystem, NTFS, and block volume mode patterns.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:
- I tested with external aws ebs csi passed.
```console
$ ginkgo --dry-run --timeout=1h -v -focus='External.Storage.*volume-expand' -skip='\[Serial\]|\[Disruptive\]|\[Feature:SELinux\]' ./_output/bin/e2e.test -- -provider=skeleton -kubeconfig=$HOME/.kube/config -storage.testdriver=$HOME/Downloads/ebs-test-driver.yaml|grep 'volume-expand'
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (xfs)] [Slow] volume-expand Verify if offline PVC expansion works [Slow]
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (xfs)] [Slow] volume-expand should resize volume when PVC is edited while pod is using it [Slow]
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (xfs)] [Slow] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished [Slow]
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (default fs)] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ntfs)] [Feature:Windows] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished [Feature:Windows]
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (block volmode)] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ntfs)] [Feature:Windows] volume-expand should resize volume when PVC is edited while pod is using it [Feature:Windows]
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ntfs)] [Feature:Windows] volume-expand Verify if offline PVC expansion works [Feature:Windows]
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (block volmode)] volume-expand Verify if offline PVC expansion works
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (default fs)] volume-expand should resize volume when PVC is edited while pod is using it
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (default fs)] volume-expand Verify if offline PVC expansion works
External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (block volmode)] volume-expand should resize volume when PVC is edited while pod is using it

$  ginkgo --timeout=1h -v -focus='External.Storage.*volume-expand' -skip='\[Serial\]|\[Disruptive\]|\[Feature:SELinux\]' ./_output/bin/e2e.test -- -provider=aws -non-blocking-taints=node-role.kubernetes.io/master,node-role.kubernetes.io/control-plane -kubeconfig=$HOME/.kube/config -storage.testdriver=$HOME/Downloads/ebs-test-driver.yaml 

...
Ran 9 of 7664 Specs in 589.371 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 7655 Skipped
PASS

Ginkgo ran 1 suite in 9m50.067823417s
Test Suite Passed
...
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
