### PR TITLE
mark the csi.volume.kubernetes.io/nodeid annotation of Nodes as deprecated

### DIFF
--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
@@ -76,9 +77,8 @@ func TestInstallCSIDriver(t *testing.T) {
 			},
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
-					Labels:      labelMap{"com.example.csi/zone": "zoneA"},
+					Name:   "node1",
+					Labels: labelMap{"com.example.csi/zone": "zoneA"},
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -120,9 +120,8 @@ func TestInstallCSIDriver(t *testing.T) {
 			},
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
-					Labels:      labelMap{"com.example.csi/zone": "zoneA"},
+					Name:   "node1",
+					Labels: labelMap{"com.example.csi/zone": "zoneA"},
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -160,9 +159,8 @@ func TestInstallCSIDriver(t *testing.T) {
 			},
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
-					Labels:      labelMap{"com.example.csi/zone": "zoneA"},
+					Name:   "node1",
+					Labels: labelMap{"com.example.csi/zone": "zoneA"},
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -205,10 +203,6 @@ func TestInstallCSIDriver(t *testing.T) {
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{
-						"com.example.csi.driver1":          "com.example.csi/csi-node1",
-						"net.example.storage.other-driver": "net.example.storage/test-node",
-					})},
 					Labels: labelMap{
 						"com.example.csi/zone":     "zoneA",
 						"net.example.storage/rack": "rack1",
@@ -285,8 +279,7 @@ func TestInstallCSIDriver(t *testing.T) {
 			},
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/other-node"})},
+					Name: "node1",
 					Labels: labelMap{
 						"com.example.csi/zone": "zoneA",
 						"com.example.csi/rack": "rack1",
@@ -325,9 +318,8 @@ func TestInstallCSIDriver(t *testing.T) {
 			inputNodeID: "com.example.csi/csi-node1",
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					UID:         types.UID("node1"),
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"": "com.example.csi/csi-node1"})},
+					Name: "node1",
+					UID:  types.UID("node1"),
 				},
 			},
 			expectedCSINode: func() *storage.CSINode {
@@ -366,9 +358,8 @@ func TestInstallCSIDriver(t *testing.T) {
 			inputNodeID: "com.example.csi/csi-node1",
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					UID:         types.UID("node1"),
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
+					Name: "node1",
+					UID:  types.UID("node1"),
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -392,8 +383,7 @@ func TestInstallCSIDriver(t *testing.T) {
 			inputTopology: nil,
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
+					Name: "node1",
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -433,8 +423,7 @@ func TestInstallCSIDriver(t *testing.T) {
 			inputTopology: nil,
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
+					Name: "node1",
 					Labels: labelMap{
 						"com.example.csi/zone": "zoneA",
 					},
@@ -478,10 +467,6 @@ func TestInstallCSIDriver(t *testing.T) {
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{
-						"com.example.csi.driver1":          "com.example.csi/csi-node1",
-						"net.example.storage.other-driver": "net.example.storage/test-node",
-					})},
 					Labels: labelMap{
 						"net.example.storage/rack": "rack1",
 					},
@@ -523,8 +508,7 @@ func TestInstallCSIDriver(t *testing.T) {
 			inputNodeID:      "com.example.csi/csi-node1",
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
+					Name: "node1",
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -552,8 +536,7 @@ func TestInstallCSIDriver(t *testing.T) {
 			inputNodeID:      "com.example.csi/csi-node1",
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
+					Name: "node1",
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -581,8 +564,7 @@ func TestInstallCSIDriver(t *testing.T) {
 			inputNodeID:      "com.example.csi/csi-node1",
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
+					Name: "node1",
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -610,8 +592,7 @@ func TestInstallCSIDriver(t *testing.T) {
 			inputNodeID:      "com.example.csi/csi-node1",
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
+					Name: "node1",
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -650,8 +631,7 @@ func TestInstallCSIDriver(t *testing.T) {
 			inputNodeID:      "com.example.csi/csi-node1",
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"com.example.csi.driver1": "com.example.csi/csi-node1"})},
+					Name: "node1",
 				},
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
@@ -756,9 +736,8 @@ func TestUninstallCSIDriver(t *testing.T) {
 			),
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"net.example.storage.other-driver": "net.example.storage/csi-node1"})},
-					Labels:      labelMap{"net.example.storage/zone": "zoneA"},
+					Name:   "node1",
+					Labels: labelMap{"net.example.storage/zone": "zoneA"},
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -802,8 +781,7 @@ func TestUninstallCSIDriver(t *testing.T) {
 				nil /* labels */, nil /*capacity*/),
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "node1",
-					Annotations: map[string]string{annotationKeyNodeID: marshall(nodeIDMap{"net.example.storage.other-driver": "net.example.storage/csi-node1"})},
+					Name: "node1",
 				},
 			},
 			expectedCSINode: &storage.CSINode{
@@ -1111,7 +1089,7 @@ func test(t *testing.T, addNodeInfo bool, testcases []testcase) {
 		}
 
 		if !helper.Semantic.DeepEqual(node, tc.expectedNode) {
-			t.Errorf("expected Node %v; got: %v", tc.expectedNode, node)
+			t.Errorf("expected Node %v; got: %v, diff: %v", tc.expectedNode, node, cmp.Diff(tc.expectedNode, node))
 		}
 
 		// CSINode validation
@@ -1141,7 +1119,7 @@ func generateNode(nodeIDs, labels map[string]string, capacity map[v1.ResourceNam
 	var annotations map[string]string
 	if len(nodeIDs) > 0 {
 		b, _ := json.Marshal(nodeIDs)
-		annotations = map[string]string{annotationKeyNodeID: string(b)}
+		annotations = map[string]string{deprecatedAnnotationKeyNodeID: string(b)}
 	}
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1156,11 +1134,6 @@ func generateNode(nodeIDs, labels map[string]string, capacity map[v1.ResourceNam
 		node.Status.Allocatable = v1.ResourceList(capacity)
 	}
 	return node
-}
-
-func marshall(nodeIDs nodeIDMap) string {
-	b, _ := json.Marshal(nodeIDs)
-	return string(b)
 }
 
 func generateCSINode(nodeIDs nodeIDMap, volumeLimits *storage.VolumeNodeResources, topologyKeys topologyKeyMap) *storage.CSINode {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind deprecation

#### What this PR does / why we need it:

The [Document](https://github.com/kubernetes/community/pull/2034) of Kubernetes CSI implementation indicates that the `csi.volume.kubernetes.io/nodeid` annotation should be deprecated and removed after 1 year. The external-attacher and node-driver-registrar have been deprecated and removed the dependency, see https://github.com/kubernetes-csi/external-attacher/pull/213 and https://github.com/kubernetes-csi/node-driver-registrar/pull/10

After searching the codebase via https://cs.k8s.io/?q=%22csi.volume.kubernetes.io%2Fnodeid%22&i=nope&literal=nope&files=&excludeFiles=&repos=, I find there are some dead code need to be cleaned up. It isn't a blocker for this PR. I created https://github.com/kubernetes-csi/external-attacher/pull/691 and https://github.com/kubernetes-csi/node-driver-registrar/pull/543 to do the cleanup.

All supported releases of external-attacher and node-driver-registrar have no dependency on the deprecated annotation, so this PR automatically remove the annotation if kubelet is (re)-restarted.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The annotation `csi.volume.kubernetes.io/nodeid` is not documented in https://kubernetes.io/docs/reference/labels-annotations-taints/, I'm unsure if I should update the website. cc @lmktfy


BTW, the `csi.alpha.kubernetes.io/node-id` annotation of VolumeAttachment is not documented after https://github.com/kubernetes-csi/external-attacher/pull/86 was merged. cc @jsafrane

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Marked the `csi.volume.kubernetes.io/nodeid` annotation of Nodes as deprecated; it now has no effect.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
