### PR TITLE
test/e2e: fix pod resize test flakes on CRI-O/runc environments

### DIFF
--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -51,12 +51,12 @@ const (
 	increasedCPU      = "25m"
 	increasedCPULimit = "35m"
 
-	originalMem       = "20Mi"
-	originalMemLimit  = "30Mi"
-	reducedMem        = "15Mi"
-	reducedMemLimit   = "25Mi"
-	increasedMem      = "25Mi"
-	increasedMemLimit = "35Mi"
+	originalMem       = "35Mi"
+	originalMemLimit  = "45Mi"
+	reducedMem        = "30Mi"
+	reducedMemLimit   = "40Mi"
+	increasedMem      = "40Mi"
+	increasedMemLimit = "50Mi"
 )
 
 func offsetCPU(index int, value string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind flake

#### What this PR does / why we need it:

Fixes intermittent failures in the `Pod InPlace Resize Container` e2e tests
on OpenShift and other CRI-O based clusters.

#### Root Cause

The pod resize tests create Guaranteed QoS pods with memory limits as low as
20Mi. On CRI-O, the `conmon` process (and the `runc` it spawns) runs inside
the pod's cgroup. Since runc requires ~20-22MB during container creation,
this causes OOM kills when:

1. Creating the initial container
2. Restarting containers during resize operations (RestartContainer policy)

The tests pass reliably on containerd because its shim runs outside the pod's
cgroup (`ShimCgroup=""`), so runc's memory is not charged to the pod.

#### Changes

Increase memory limits to provide ~8-10Mi headroom above runc's peak usage:

| Constant | Before | After |
|----------|--------|-------|
| originalMem | 20Mi | 35Mi |
| reducedMem | 15Mi | 30Mi |
| increasedMem | 25Mi | 40Mi |

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
