### PR TITLE
Fix flaky LoadBalancer e2e tests by increasing timeout

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -129,7 +129,7 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		}
 	})
 
-	f.It("should be able to change the type and ports of a TCP service", f.WithSlow(), func(ctx context.Context) {
+	f.It("should be able to change the type and ports of a TCP service", f.WithSlow(), ginkgo.Timeout(30*time.Minute), func(ctx context.Context) {
 		// FIXME: need a better platform-independent timeout
 		loadBalancerLagTimeout := e2eservice.LoadBalancerLagTimeoutAWS
 		loadBalancerCreateTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(ctx, cs)
@@ -267,7 +267,7 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		testNotReachableHTTP(ctx, tcpIngressIP, svcPort, loadBalancerLagTimeout)
 	})
 
-	f.It("should be able to change the type and ports of a UDP service", f.WithSlow(), func(ctx context.Context) {
+	f.It("should be able to change the type and ports of a UDP service", f.WithSlow(), ginkgo.Timeout(30*time.Minute), func(ctx context.Context) {
 		// FIXME: some cloud providers do not support UDP LoadBalancers
 
 		loadBalancerLagTimeout := e2eservice.LoadBalancerLagTimeoutDefault


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes flaky `LoadBalancers` E2E tests by increasing the spec timeout to 30 minutes for the monolithic TCP and UDP service tests.

These tests perform multiple LoadBalancer operations (create, update, delete) in sequence. Each "Wait for LoadBalancer" operation can take up to 15 minutes (default `loadBalancerCreateTimeout`), and there are multiple such waits (e.g., initial creation, then destroying at the end).

In slower cloud environments or CI runs, the default spec timeout (often 10-15m depending on config) is insufficient, leading to `context deadline exceeded` errors as observed in #131863.

**Which issue(s) this PR fixes**:
Fixes #131863

**Special notes for your reviewer**:
The timeout is increased to 30 minutes using `ginkgo.Timeout(30 * time.Minute)`. This provides enough buffer for at least two full LB provisioning/deprovisioning cycles plus other test steps.

**Does this PR introduce a user-facing change?**:
```release-note
NONE