### PR TITLE
devicetainteviction: continue processing ReservedFor consumers

### DIFF
--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -1450,15 +1450,16 @@ func (tc *Controller) handlePods(claim *resourceapi.ResourceClaim) {
 			pod, err := tc.podLister.Pods(claim.Namespace).Get(consumer.Name)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
-					return
+					// Skip stale reservation entries.
+					continue
 				}
 				// Should not happen.
 				utilruntime.HandleErrorWithLogger(tc.logger, err, "retrieve pod from cache")
-				return
+				continue
 			}
 			if pod.UID != consumer.UID {
 				// Not the pod we were looking for.
-				return
+				continue
 			}
 			tc.handlePod(pod)
 		}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it
The device taint eviction controller iterates over `ResourceClaim.Status.ReservedFor` to find pod consumers. For shareable claims this list may contain multiple entries. `handlePods` previously returned early when the first entry referenced a missing pod (NotFound) or had a stale UID, which prevented processing of later consumers and could skip eviction/cancellation decisions for other pods sharing the same claim.

This PR changes `handlePods` to skip stale entries and continue iterating so that all consumers in `ReservedFor` are evaluated.

#### Which issue(s) this PR fixes
N/A

#### Special notes for your reviewer
- The behavioral change is limited to `handlePods` iteration semantics: stale or mismatched `ReservedFor` entries no longer short-circuit processing of the rest.
- Added regression coverage for both a missing first reservation and a UID mismatch ahead of another valid consumer.

#### Test plan
- `go test ./pkg/controller/devicetainteviction`
- `go test ./pkg/controller/devicetainteviction -run TestController/evict-shared-claim`

#### Does this PR introduce a user-facing change?
```release-note
Fixed device taint eviction to continue evaluating other consumers of a shared ResourceClaim when an earlier ReservedFor entry is stale (missing pod or UID mismatch).
```