### PR TITLE
local-up-cluster.sh: support more recent containerd like 2.2

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -1404,8 +1404,8 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
   # configure and start containerd
   echo "configuring containerd"
   containerd config default > /etc/containerd/config.toml
-  sed -ie 's|root = "/var/lib/containerd"|root = "/docker-graph/containerd/daemon"|' /etc/containerd/config.toml
-  sed -ie 's|state = "/run/containerd"|state = "/var/run/docker/containerd/daemon"|' /etc/containerd/config.toml
+  sed -ie 's|root = ./var/lib/containerd.|root = "/docker-graph/containerd/daemon"|' /etc/containerd/config.toml
+  sed -ie 's|state = ./run/containerd.|state = "/var/run/docker/containerd/daemon"|' /etc/containerd/config.toml
   sed -ie 's|enable_cdi = false|enable_cdi = true|' /etc/containerd/config.toml
 
   echo "starting containerd"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The kubekins image got updated from containerd 1.7 to 2.2, which broke local-up-cluster.sh in the CI because more recent containerd uses single quotation marks around strings instead of double quotation marks as before. The search/replace with sed no longer matched, causing containerd to fail mounting overlayfs on the default /var/lib/containerd. We have to use the emptyDir host mount under /docker-graph.

The fix is to relax the search term slightly so that it accepts both kinds of quotation marks.

#### Which issue(s) this PR is related to:

N/A

https://testgrid.k8s.io/conformance-all#local-up-cluster,%20master%20(dev)
https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-dra-integration
https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-dra-integration-1-34
https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-dra-integration-1-35

#### Special notes for your reviewer:

See also Slack:
- https://kubernetes.slack.com/archives/C0BP8PW9G/p1765218000997269
- https://kubernetes.slack.com/archives/C09QZ4DQB/p1765280178344129

This needs to be backported to 1.34 and 1.35 if it doesn't make it into 1.35.0.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
