### PR TITLE
fix(kubelet): ensure subpath volume cleanup on restart when pod was force-deleted while kubelet was stopped

### DIFF
--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -171,7 +171,7 @@ func cleanupSubpathVolumePath(subpathVolumePath string, mounter mount.Interface,
 		return nil
 	}
 
-	// Attempt to unmount subpathVolumePath if it cannot be deleted because it is still mounted.
+	// If subpathVolumePath cannot be deleted because it is still mounted, attempt to unmount it first.
 	// This is required for hostPath volumes when pods are force-deleted while the kubelet is down,
 	// as the volume manager cannot reconstruct orphaned pods' hostPath volumes, so it cannot automatically tear down such volumes.
 	if err = mount.CleanupMountPoint(subpathVolumePath, mounter, true); err == nil {

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -171,6 +171,9 @@ func cleanupSubpathVolumePath(subpathVolumePath string, mounter mount.Interface,
 		return nil
 	}
 
+	// Attempt to unmount subpathVolumePath if it cannot be deleted because it is still mounted.
+	// This is required for hostPath volumes when pods are force-deleted while the kubelet is down,
+	// as the volume manager cannot reconstruct orphaned pods' hostPath volumes, so it cannot automatically tear down such volumes.
 	if err = mount.CleanupMountPoint(subpathVolumePath, mounter, true); err == nil {
 		klog.InfoS("Cleaned up orphaned volume subpath from pod after cleanup mount point", "podUID", uid, "path", subpathVolumePath)
 		return nil

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/removeall"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
+	"k8s.io/mount-utils"
 )
 
 // ListVolumesForPod returns a map of the mounted volumes for the given pod.
@@ -144,10 +145,8 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(uid types.UID) []error {
 	if len(subpathVolumePaths) > 0 {
 		for _, subpathVolumePath := range subpathVolumePaths {
 			// Remove both files and empty directories here, as the subpath may have been a bind-mount of a file or a directory.
-			if err := os.Remove(subpathVolumePath); err != nil {
-				orphanVolumeErrors = append(orphanVolumeErrors, fmt.Errorf("orphaned pod %q found, but failed to remove subpath at path %v: %w", uid, subpathVolumePath, err))
-			} else {
-				klog.InfoS("Cleaned up orphaned volume subpath from pod", "podUID", uid, "path", subpathVolumePath)
+			if err := cleanupSubpathVolumePath(subpathVolumePath, kl.mounter, uid); err != nil {
+				orphanVolumeErrors = append(orphanVolumeErrors, err)
 			}
 		}
 	}
@@ -162,6 +161,22 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(uid types.UID) []error {
 	}
 
 	return orphanVolumeErrors
+}
+
+func cleanupSubpathVolumePath(subpathVolumePath string, mounter mount.Interface, uid types.UID) error {
+	var err error
+
+	if err = os.Remove(subpathVolumePath); err == nil {
+		klog.InfoS("Cleaned up orphaned volume subpath from pod", "podUID", uid, "path", subpathVolumePath)
+		return nil
+	}
+
+	if err = mount.CleanupMountPoint(subpathVolumePath, mounter, true); err == nil {
+		klog.InfoS("Cleaned up orphaned volume subpath from pod after cleanup mount point", "podUID", uid, "path", subpathVolumePath)
+		return nil
+	}
+
+	return fmt.Errorf("orphaned pod %q found, but failed to remove subpath at path %v: %w", uid, subpathVolumePath, err)
 }
 
 // cleanupOrphanedPodDirs removes the volumes of pods that should not be


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
When the kubelet on a node is stopped, and a pod on that node—which uses a hostPath volume mounted via subPath—is forcibly deleted using kubectl delete --force, the kubelet fails to clean up the corresponding subpath directory at /var/lib/kubelet/pods/<pod-uid>/volume-subpaths/ upon restart.

After the kubelet restarts, it detects the orphaned pod and repeatedly logs messages similar to:
```
orphaned pod \"xxxx\" found, but failed to rmdir() subpath at path /var/lib/kubelet/pods/xxxx/volume-subpaths/xxxx: remove /var/lib/kubelet/pods/xxxx/volume-subpaths/xxxx: device or resource busy
```
This occurs because the volume manager, upon kubelet restart after a forced pod deletion, lacks awareness of the pod’s original hostPath setup and cannot auto-unmount the subpath volume, blocking cleanup during reconciliation.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#135698
#### Special notes for your reviewer:
To reproduce the issue:

1. Create a pod that uses a hostPath volume mounted via subPath.
2. Stop the kubelet on the node where the pod is running.
3. Force-delete the pod using kubectl delete --force.
4. Restart the kubelet.

After restart, the directory /var/lib/kubelet/pods/<pod-uid>/volume-subpaths/ will remain on disk and cannot be cleaned up. The kubelet logs will repeatedly show errors such as:
```
orphaned pod \"xxxx\" found, but failed to rmdir() subpath at path /var/lib/kubelet/pods/xxxx/volume-subpaths/xxxx: remove /var/lib/kubelet/pods/xxxx/volume-subpaths/xxxx: device or resource busy
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed kubelet's failure to clean up subPath mounts for hostPath volumes after a forced pod deletion during kubelet downtime.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
