### PR TITLE
Add HTTP Echo server to agnhost

### DIFF
--- a/test/images/agnhost/README.md
+++ b/test/images/agnhost/README.md
@@ -243,6 +243,20 @@ Usage:
     kubectl exec test-agnhost -- /agnhost help
 ```
 
+### http-echo
+
+Echoes the HTTP request as a JSON payload, containing the path, host, method, protocol, headers, the server
+http port and the environment variables of POD_NAME and POD_NAMESPACE.
+
+The subcommand can accept the following flags:
+
+- `port` (default: `8080`): The port number to listen to.
+
+Usage:
+
+```console
+    kubectl exec test-agnhost -- /agnhost http-echo [--port <port>]
+```
 
 ### inclusterclient
 

--- a/test/images/agnhost/agnhost.go
+++ b/test/images/agnhost/agnhost.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/test/images/agnhost/fakeregistryserver"
 	grpchealthchecking "k8s.io/kubernetes/test/images/agnhost/grpc-health-checking"
 	"k8s.io/kubernetes/test/images/agnhost/guestbook"
+	httpecho "k8s.io/kubernetes/test/images/agnhost/http-echo"
 	"k8s.io/kubernetes/test/images/agnhost/inclusterclient"
 	"k8s.io/kubernetes/test/images/agnhost/liveness"
 	logsgen "k8s.io/kubernetes/test/images/agnhost/logs-generator"
@@ -73,6 +74,7 @@ func main() {
 	rootCmd.AddCommand(fakegitserver.CmdFakeGitServer)
 	rootCmd.AddCommand(fakeregistryserver.CmdFakeRegistryServer)
 	rootCmd.AddCommand(guestbook.CmdGuestbook)
+	rootCmd.AddCommand(httpecho.CmdHTTPEcho)
 	rootCmd.AddCommand(inclusterclient.CmdInClusterClient)
 	rootCmd.AddCommand(liveness.CmdLiveness)
 	rootCmd.AddCommand(logsgen.CmdLogsGenerator)

--- a/test/images/agnhost/http-echo/http-echo.go
+++ b/test/images/agnhost/http-echo/http-echo.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// A small utility to echo back an HTTP Request as JSON
+// This utility is an extraction of Gateway API Echo server: https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go
+
+package httpecho
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// CmdServeHostname is used by agnhost Cobra.
+var CmdHTTPEcho = &cobra.Command{
+	Use:   "http-echo",
+	Short: "Echoes back the HTTP request as a JSON",
+	Long:  `Echoes back the HTTP request as a JSON payload, including headers.`,
+	Args:  cobra.MaximumNArgs(0),
+	Run:   main,
+}
+
+var (
+	httpPort int
+	context  Context
+)
+
+func init() {
+	CmdHTTPEcho.Flags().IntVar(&httpPort, "port", 8080, "Port number.")
+}
+
+// Context contains information about the context where the echoserver is running
+type Context struct {
+	Namespace string `json:"namespace"`
+	Pod       string `json:"pod"`
+}
+
+// RequestPayload contains information about the request
+type RequestPayload struct {
+	Path     string              `json:"path"`
+	Host     string              `json:"host"`
+	Method   string              `json:"method"`
+	Proto    string              `json:"proto"`
+	Headers  map[string][]string `json:"headers"`
+	HTTPPort string              `json:"httpPort"`
+
+	Context `json:",inline"`
+}
+
+func main(cmd *cobra.Command, args []string) {
+	context = Context{
+		Namespace: os.Getenv("NAMESPACE"),
+		Pod:       os.Getenv("POD_NAME"),
+	}
+
+	http.HandleFunc("/", echoHandler)
+
+	go func() {
+		// Run in a closure so http.ListenAndServe doesn't block
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", httpPort), nil))
+	}()
+
+	log.Printf("Serving on port %d.\n", httpPort)
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGTERM)
+	sig := <-signals
+	log.Printf("Shutting down after receiving signal: %s.\n", sig)
+	log.Printf("Awaiting pod deletion.\n")
+	time.Sleep(60 * time.Second)
+}
+
+func echoHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Echoing back request made to %s to client (%s)\n", r.RequestURI, r.RemoteAddr)
+
+	requestPayload := RequestPayload{
+		r.RequestURI,
+		r.Host,
+		r.Method,
+		r.Proto,
+		r.Header,
+		strconv.Itoa(httpPort),
+
+		context,
+	}
+
+	js, err := json.MarshalIndent(requestPayload, "", " ")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	_, err = w.Write(js)
+	if err != nil {
+		log.Printf("error writing the response back: %s", err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds a new "http-echo" service to agnhost

This service can be used by tests or demos that wants to show how a HTTP request is received by a backend. The most notable example we are using it right now is on Gateway API, to demonstrate the correct work of an implementation.

This same echo service is an extraction of the implementation we are using on Gateway API for conformance tests: https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/echo-basic/echo-basic.go#L227


#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
Idea of having this service on agnhost is to stop:
* relying on Ingress NGINX echo-service for some demos
* do not rely on gateway api echo-service to demos and tests that are non Gateway API related
* provide users a way to test their own Gateway API and Ingress installations

Additionally the service added here can be used by some simple tests where asserting that the right header was sent to a backend is desired

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
