### PR TITLE
Reduce Netpol e2e test resource usage some more

### DIFF
--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -43,10 +43,9 @@ const defaultPollTimeoutSeconds = 10
 // there will be a corresponding TestPod. TestPod includes some runtime info
 // (namespace name, service IP) which is not available in the model.
 type TestPod struct {
-	Namespace     string
-	Name          string
-	ContainerName string
-	ServiceIP     string
+	Namespace string
+	Name      string
+	ServiceIP string
 }
 
 func (pod TestPod) PodString() PodString {
@@ -107,10 +106,9 @@ func (k *kubeManager) initializeClusterFromModel(ctx context.Context, model *Mod
 			}
 
 			k.allPods = append(k.allPods, TestPod{
-				Namespace:     kubePod.Namespace,
-				Name:          kubePod.Name,
-				ContainerName: pod.Containers[0].Name(),
-				ServiceIP:     svc.Spec.ClusterIP,
+				Namespace: kubePod.Namespace,
+				Name:      kubePod.Name,
+				ServiceIP: svc.Spec.ClusterIP,
 			})
 			k.allPodStrings = append(k.allPodStrings, NewPodString(kubePod.Namespace, kubePod.Name))
 		}
@@ -176,7 +174,7 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 		framework.Failf("protocol %s not supported", args.protocol)
 	}
 
-	commandDebugString := fmt.Sprintf("kubectl exec %s -c %s -n %s -- %s", args.podFrom, args.containerFrom, args.nsFrom, strings.Join(cmd, " "))
+	commandDebugString := fmt.Sprintf("kubectl exec %s -n %s -- %s", args.podFrom, args.nsFrom, strings.Join(cmd, " "))
 
 	attempt := 0
 
@@ -190,7 +188,7 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 	// the job when the observed value don't match the expected value, so we don't rely on return value of PollImmediate, we
 	// simply discard it and use probeError, defined outside scope of conditionFunc, for returning the result of probeConnectivity.
 	conditionFunc := func() (bool, error) {
-		_, stderr, probeError = k.executeRemoteCommand(args.nsFrom, args.podFrom, args.containerFrom, cmd)
+		_, stderr, probeError = k.executeRemoteCommand(args.nsFrom, args.podFrom, cmd)
 		// retry should only occur if expected and observed value don't match.
 		if args.expectConnectivity {
 			if probeError != nil {
@@ -237,12 +235,11 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 }
 
 // executeRemoteCommand executes a remote shell command on the given pod.
-func (k *kubeManager) executeRemoteCommand(namespace string, pod string, containerName string, command []string) (string, string, error) {
+func (k *kubeManager) executeRemoteCommand(namespace string, pod string, command []string) (string, string, error) {
 	return e2epod.ExecWithOptions(k.framework, e2epod.ExecOptions{
 		Command:            command,
 		Namespace:          namespace,
 		PodName:            pod,
-		ContainerName:      containerName,
 		Stdin:              nil,
 		CaptureStdout:      true,
 		CaptureStderr:      true,

--- a/test/e2e/network/netpol/model.go
+++ b/test/e2e/network/netpol/model.go
@@ -35,11 +35,6 @@ type Model struct {
 	Protocols  []v1.Protocol
 }
 
-// NewWindowsModel returns a model specific to windows testing.
-func NewWindowsModel(namespaceBaseNames []string, podNames []string, ports []int32) *Model {
-	return NewModel(namespaceBaseNames, podNames, ports, []v1.Protocol{v1.ProtocolTCP, v1.ProtocolUDP})
-}
-
 // NewModel instantiates a model based on:
 // - namespaceBaseNames
 // - pods

--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -1329,7 +1329,7 @@ var _ = common.SIGDescribe("Netpol", feature.SCTPConnectivity, "[LinuxOnly]", fu
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 	var k8s *kubeManager
 	ginkgo.BeforeEach(func() {
-		// Windows does not support network policies.
+		// Windows does not support SCTP
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
 	})
 
@@ -1418,9 +1418,6 @@ func getNamespaceBaseNames(rootNs string) []string {
 // defaultModel creates a new "model" pod system under namespaces (x,y,z) which has pods a, b, and c.  Thus resulting in the
 // truth table matrix that is identical for all tests, comprising 81 total connections between 9 pods (x/a, x/b, x/c, ..., z/c).
 func defaultModel(namespaces []string, protocols []v1.Protocol, ports []int32) *Model {
-	if framework.NodeOSDistroIs("windows") {
-		return NewWindowsModel(namespaces, []string{"a", "b", "c"}, ports)
-	}
 	return NewModel(namespaces, []string{"a", "b", "c"}, ports, protocols)
 }
 

--- a/test/e2e/network/netpol/probe.go
+++ b/test/e2e/network/netpol/probe.go
@@ -29,7 +29,6 @@ import (
 type probeConnectivityArgs struct {
 	nsFrom              string
 	podFrom             string
-	containerFrom       string
 	addrTo              string
 	protocol            v1.Protocol
 	toPort              int
@@ -132,7 +131,6 @@ func probeWorker(prober Prober, jobs <-chan *ProbeJob, results chan<- *ProbeJobR
 		connected, command, err := prober.probeConnectivity(&probeConnectivityArgs{
 			nsFrom:              podFrom.Namespace,
 			podFrom:             podFrom.Name,
-			containerFrom:       podFrom.ContainerName,
 			addrTo:              job.PodTo.ServiceIP,
 			protocol:            job.Protocol,
 			toPort:              job.ToPort,


### PR DESCRIPTION
#### What this PR does / why we need it:
Reduces the resource usage of the "Netpol" e2e tests some more...

WIP

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/area tests
/priority important-soon
/triage accepted
/cc