### PR TITLE
Put pods preempted in WaitOnPermit to backoff queue

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1791,11 +1791,10 @@ func (f *frameworkImpl) GetWaitingPod(uid types.UID) fwk.WaitingPod {
 }
 
 // RejectWaitingPod rejects a WaitingPod given its UID.
-// The returned value indicates if the given pod is waiting or not.
+// The returned value indicates if the rejection was successful.
 func (f *frameworkImpl) RejectWaitingPod(uid types.UID) bool {
 	if waitingPod := f.waitingPods.get(uid); waitingPod != nil {
-		waitingPod.Reject("", "removed")
-		return true
+		return waitingPod.Reject("", "removed")
 	}
 	return false
 }

--- a/pkg/scheduler/framework/runtime/waiting_pods_map_test.go
+++ b/pkg/scheduler/framework/runtime/waiting_pods_map_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+)
+
+func TestWaitingPodReturnFalseOnAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		action     func(wp *waitingPod) bool
+		actionName string
+	}{
+		{
+			name: "Preempt returns false on allowed pod",
+			action: func(wp *waitingPod) bool {
+				return wp.Preempt("preemption-plugin", "preempted")
+			},
+			actionName: "Preempt",
+		},
+		{
+			name: "Reject returns false on allowed pod",
+			action: func(wp *waitingPod) bool {
+				return wp.Reject("reject-plugin", "rejected")
+			},
+			actionName: "Reject",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := st.MakePod().Name("test-pod").UID("test-uid").Obj()
+			wp := newWaitingPod(pod, map[string]time.Duration{"plugin1": 10 * time.Second})
+
+			// 1. Simulate Allow from Plugin
+			wp.Allow("plugin1")
+
+			// 2. Perform Action
+			if success := tt.action(wp); success {
+				t.Errorf("Expected %s to return false (failed), but it returned true (success)", tt.actionName)
+			}
+
+			// 3. Check what signal the pod received (should be Success from Allow)
+			select {
+			case status := <-wp.s:
+				if !status.IsSuccess() {
+					t.Errorf("Expected Pod to stay Allowed (Success), but got status: %v", status)
+				}
+			default:
+				t.Fatal("No status received")
+			}
+		})
+	}
+}
+
+func TestWaitingPodMultipleActions(t *testing.T) {
+	pod := st.MakePod().Name("test-pod").UID("test-uid").Obj()
+	wp := newWaitingPod(pod, map[string]time.Duration{"plugin1": 10 * time.Second})
+	startWaitOnPermit := make(chan struct{})
+	endWaitOnPermit := make(chan struct{})
+
+	// Simulate WaitOnPermit
+	go func() {
+		close(startWaitOnPermit)
+		<-wp.s
+		close(endWaitOnPermit)
+	}()
+
+	<-startWaitOnPermit
+	// 1. Simulate Allow from Plugin, it should be consumed by WaitOnPermit
+	wp.Allow("plugin1")
+	<-endWaitOnPermit
+
+	// 2. Simulate Rejection from Plugin
+	res := wp.Reject("plugin2", "rejected")
+	if res {
+		t.Fatalf("Expected reject to fail, but it succeeded")
+	}
+
+	// 3. Simulate Preempt from Plugin
+	res = wp.Preempt("preemption-plugin", "preempted")
+	if res {
+		t.Fatalf("Expected preempt to fail, but it succeeded")
+	}
+}

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -326,7 +326,10 @@ type WaitingPod interface {
 	// to unblock the pod.
 	Allow(pluginName string)
 	// Reject declares the waiting pod unschedulable.
-	Reject(pluginName, msg string)
+	Reject(pluginName, msg string) bool
+	// Preempt preempts the waiting pod. Compared to reject it does not mark the pod as unschedulable,
+	// allowing it to be rescheduled.
+	Preempt(pluginName, msg string) bool
 }
 
 // PreFilterResult wraps needed info for scheduler framework to act upon PreFilter phase.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR changes the behavior of the scheduler when it preempts the pods that are in "WaitOnPermit" phase. Currently the pods are Rejected by a preemption plugin which moves the victim pod to unschedulable queue, adding the information about preemption to PodCondition. It means that this pod will be stuck in unschedulable queue until some event in the cluster pushes it back to backoff/active queue. It seems undesirable as it does not give a strong signal to the component owning the pod to recreate it (compared to default preemption which deletes the pod completely). After this PR the victim pod will be moved to the backoff queue, allowing the scheduler to try to schedule it once again after some time. 

#### Which issue(s) this PR is related to:

This was found as a part of the https://github.com/kubernetes/kubernetes/issues/132332

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Changed the behavior of default scheduler preemption plugin when preempting pods that are in "WaitOnPermit" phase. They are now moved to the scheduler backoff queue instead of being marked as unschedulable. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

/sig scheduling
