### PR TITLE
feat(tools): support incremental enforcement of backticks in `check-missing-backticks` in `field_name_docs_check.go`

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
@@ -24,8 +24,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // APIServiceList is a list of APIService objects.
 type APIServiceList struct {
 	metav1.TypeMeta `json:",inline"`
-	// Standard list metadata
-	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// Standard list `metadata`
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#`metadata`
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
@@ -37,7 +37,7 @@ type APIServiceList struct {
 type ServiceReference struct {
 	// `namespace` is the `namespace` of the service
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
-	// Name is the name of the service
+	// `name` is the `name` of the service
 	Name string `json:"name,omitempty" protobuf:"bytes,2,opt,name=name"`
 	// If specified, the `port` on the service that hosting webhook.
 	// Default to 443 for backward compatibility.
@@ -116,7 +116,7 @@ const (
 
 // APIServiceCondition describes the state of an APIService at a particular point
 type APIServiceCondition struct {
-	// Type is the type of the condition.
+	// `type` is the `type` of the condition.
 	Type APIServiceConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=APIServiceConditionType"`
 	// `status` is the `status` of the condition.
 	// Can be True, False, Unknown.
@@ -152,9 +152,9 @@ type APIServiceStatus struct {
 // Name must be "version.group".
 type APIService struct {
 	metav1.TypeMeta `json:",inline"`
-	// Standard object's metadata.
-	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	// +optional
+	// Standard object's `metadata`.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#``
+	// +optionalmetadata
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// `spec` contains information for locating and communicating with a server

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
@@ -29,19 +29,19 @@ type APIServiceList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Items is the list of APIService
+	// `items` is the list of APIService
 	Items []APIService `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
 // ServiceReference holds a reference to Service.legacy.k8s.io
 type ServiceReference struct {
-	// Namespace is the namespace of the service
+	// `namespace` is the `namespace` of the service
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
 	// Name is the name of the service
 	Name string `json:"name,omitempty" protobuf:"bytes,2,opt,name=name"`
-	// If specified, the port on the service that hosting webhook.
+	// If specified, the `port` on the service that hosting webhook.
 	// Default to 443 for backward compatibility.
-	// `port` should be a valid port number (1-65535, inclusive).
+	// `port` should be a valid `port` number (1-65535, inclusive).
 	// +optional
 	Port *int32 `json:"port,omitempty" protobuf:"varint,3,opt,name=port"`
 }
@@ -49,43 +49,43 @@ type ServiceReference struct {
 // APIServiceSpec contains information for locating and communicating with a server.
 // Only https is supported, though you are able to disable certificate verification.
 type APIServiceSpec struct {
-	// Service is a reference to the service for this API server.  It must communicate
+	// `service` is a reference to the `service` for this API server.  It must communicate
 	// on port 443.
-	// If the Service is nil, that means the handling for the API groupversion is handled locally on this server.
+	// If the `service` is nil, that means the handling for the API groupversion is handled locally on this server.
 	// The call will simply delegate to the normal handler chain to be fulfilled.
 	// +optional
 	Service *ServiceReference `json:"service,omitempty" protobuf:"bytes,1,opt,name=service"`
-	// Group is the API group name this server hosts
+	// `group` is the API `group` name this server hosts
 	Group string `json:"group,omitempty" protobuf:"bytes,2,opt,name=group"`
-	// Version is the API version this server hosts.  For example, "v1"
+	// `version` is the API `version` this server hosts.  For example, "v1"
 	Version string `json:"version,omitempty" protobuf:"bytes,3,opt,name=version"`
 
-	// InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server.
-	// This is strongly discouraged.  You should use the CABundle instead.
+	// `insecureSkipTLSVerify` disables TLS certificate verification when communicating with this server.
+	// This is strongly discouraged.  You should use the `caBundle` instead.
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty" protobuf:"varint,4,opt,name=insecureSkipTLSVerify"`
-	// CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate.
+	// `caBundle` is a PEM encoded CA bundle which will be used to validate an API server's serving certificate.
 	// If unspecified, system trust roots on the apiserver are used.
 	// +listType=atomic
 	// +optional
 	CABundle []byte `json:"caBundle,omitempty" protobuf:"bytes,5,opt,name=caBundle"`
 
-	// GroupPriorityMinimum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones.
-	// Note that other versions of this group might specify even higher GroupPriorityMinimum values such that the whole group gets a higher priority.
-	// The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10).
+	// `groupPriorityMinimum` is the priority this `group` should have at least. Higher priority means that the `group` is preferred by clients over lower priority ones.
+	// Note that other versions of this `group` might specify even higher `groupPriorityMinimum` values such that the whole `group` gets a higher priority.
+	// The primary sort is based on `groupPriorityMinimum`, ordered highest number to lowest (20 before 10).
 	// The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo)
 	// We'd recommend something like: *.k8s.io (except extensions) at 18000 and
 	// PaaSes (OpenShift, Deis) are recommended to be in the 2000s
 	GroupPriorityMinimum int32 `json:"groupPriorityMinimum" protobuf:"varint,7,opt,name=groupPriorityMinimum"`
 
-	// VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero.
-	// The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10).
-	// Since it's inside of a group, the number can be small, probably in the 10s.
-	// In case of equal version priorities, the version string will be used to compute the order inside a group.
-	// If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered
-	// lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version),
-	// then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
-	// by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major
-	// version, then minor version. An example sorted list of versions:
+	// `versionPriority` controls the ordering of this API `version` inside of its `group`.  Must be greater than zero.
+	// The primary sort is based on `versionPriority`, ordered highest to lowest (20 before 10).
+	// Since it's inside of a `group`, the number can be small, probably in the 10s.
+	// In case of equal `version` priorities, the `version` string will be used to compute the order inside a `group`.
+	// If the `version` string is "kube-like", it will sort above non "kube-like" `version` strings, which are ordered
+	// lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major `version`),
+	// then optionally the string "alpha" or "beta" and another number (the minor `version`). These are sorted first
+	// by GA > beta > alpha (where GA is a `version` with no suffix such as beta or alpha), and then by comparing major
+	// `version`, then minor `version`. An example sorted list of versions:
 	// v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
 	VersionPriority int32 `json:"versionPriority" protobuf:"varint,8,opt,name=versionPriority"`
 
@@ -118,16 +118,16 @@ const (
 type APIServiceCondition struct {
 	// Type is the type of the condition.
 	Type APIServiceConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=APIServiceConditionType"`
-	// Status is the status of the condition.
+	// `status` is the `status` of the condition.
 	// Can be True, False, Unknown.
 	Status ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=ConditionStatus"`
-	// Last time the condition transitioned from one status to another.
+	// Last time the condition transitioned from one `status` to another.
 	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
-	// Unique, one-word, CamelCase reason for the condition's last transition.
+	// Unique, one-word, CamelCase `reason` for the condition's last transition.
 	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
-	// Human-readable message indicating details about last transition.
+	// Human-readable `message` indicating details about last transition.
 	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
@@ -157,8 +157,8 @@ type APIService struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Spec contains information for locating and communicating with a server
+	// `spec` contains information for locating and communicating with a server
 	Spec APIServiceSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-	// Status contains derived information about an API server
+	// `status` contains derived information about an API server
 	Status APIServiceStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind cleanup

#### What this PR does / why we need it:

This PR introduces a `check-missing-backticks` flag to the `field_name_docs_check.go` tool and the verification script.

Currently, the linter only checks for case mismatches in existing backticked fields, but ignores fields without backticks as noted in the TODO following:

https://github.com/kubernetes/kubernetes/blob/04d87a4b6e72336ee9afb1e5b477223c96a8fcbb/cmd/fieldnamedocscheck/field_name_docs_check.go#L83-L84

Enabling strict checks globally would immediately trigger thousands of errors. Therefore, I propose an incremental approach: starting with this initial set to gather feedback. This establishes a pattern we can extend to other types.go files in the future, ensuring consistent enforcement of backticks

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

To prevent breaking CI with thousands of existing errors, I adopted an allowlist approach (`ENFORCED_FILES`) in the verification script: 

- **Strict Mode:** Files in the allowlist are checked with the new `--check-missing-backticks` flag.
- **Legacy Mode:** All other files are checked with the existing logic, ensuring no regression.

I have verified this locally using `./hack/verify-fieldname-docs.sh` and confirmed that it passes without affecting other files.

The plan is to gradually migrate files to the `ENFORCED_FILES` list in follow-up PRs. Once all files are migrated, we can remove the allowlist logic and make strict mode the default standard. 

However, if the community believes that enforcing backticks on all docs adds unnecessary friction compared to its value, I am also open to submitting a PR that simply removes the TODO comment to close the technical debt. I would appreciate your thoughts on this direction.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
