### PR TITLE
pkg/scheduler: remove duplicated "pod" key in scheduler logging

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1131,6 +1131,7 @@ func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.AP
 		_, err := apiCacher.PatchPodStatus(pod, condition, nominatingInfo)
 		return err
 	}
+
 	logger := klog.FromContext(ctx)
 	logValues := []any{"pod", klog.KObj(pod)}
 	if condition != nil {


### PR DESCRIPTION
pkg/scheduler: remove duplicated "pod" key in scheduler logging

Now that the pod is added to the context with klog.LoggerWithValues
at the beginning of the scheduling cycle, passing the redundant
"pod", klog.KObj(pod) key-value pair in every log line is no longer
necessary.

This change removes all remaining duplicated "pod" keys in
pkg/scheduler/scheduler.go to fully migrate to contextual logging.

This is part of the ongoing effort to adopt contextual logging in the
scheduler (KEP-3071).

/kind cleanup
/sig scheduling
/area code-organization

Signed-off-by: Liu Yutao liuyutao36@gmail.com

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Completes the migration to contextual logging in the core scheduler path
by removing the last ~17 duplicated `"pod", klog.KObj(pod)` occurrences.
No functional change.

#### Which issue(s) this PR is related to:
Related to #111672 (contextual logging migration)
Part of KEP-3071

#### Special notes for your reviewer:
- Pure log cleanup. No behavior change.
All unit tests and verify scripts pass locally.

#### Does this PR introduce a user-facing change?
```release-note
NONE