### PR TITLE
Automated cherry pick of #135692: local-up-cluster.sh: support more recent containerd like 2.2

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -1388,8 +1388,8 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
   # configure and start containerd
   echo "configuring containerd"
   containerd config default > /etc/containerd/config.toml
-  sed -ie 's|root = "/var/lib/containerd"|root = "/docker-graph/containerd/daemon"|' /etc/containerd/config.toml
-  sed -ie 's|state = "/run/containerd"|state = "/var/run/docker/containerd/daemon"|' /etc/containerd/config.toml
+  sed -ie 's|root = ./var/lib/containerd.|root = "/docker-graph/containerd/daemon"|' /etc/containerd/config.toml
+  sed -ie 's|state = ./run/containerd.|state = "/var/run/docker/containerd/daemon"|' /etc/containerd/config.toml
   sed -ie 's|enable_cdi = false|enable_cdi = true|' /etc/containerd/config.toml
 
   echo "starting containerd"


### PR DESCRIPTION
Cherry pick of #135692 on release-1.34.

#135692: local-up-cluster.sh: support more recent containerd like 2.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```