### PR TITLE
Fix goroutine leak in pluginmanager test

### DIFF
--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
@@ -34,6 +34,10 @@ import (
 const (
 	numPluginsToRegister   = 2
 	numPluginsToUnregister = 2
+	// maxConcurrentOperations is the buffer size for the ch channel.
+	// Must be >= max number of goroutines any test spawns to prevent
+	// goroutine leaks when timeout fires before all sends complete.
+	maxConcurrentOperations = max(numPluginsToRegister, numPluginsToUnregister)
 )
 
 var _ OperationGenerator = &fakeOperationGenerator{}
@@ -178,7 +182,7 @@ loop:
 
 func setup(t *testing.T) (context.Context, chan interface{}, chan interface{}, OperationExecutor) {
 	tCtx := ktesting.Init(t)
-	ch, quit := make(chan interface{}), make(chan interface{})
+	ch, quit := make(chan interface{}, maxConcurrentOperations), make(chan interface{})
 	return tCtx, ch, quit, NewOperationExecutor(newFakeOperationGenerator(ch, quit))
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Use a buffered channel for the operation start signal to prevent goroutines from blocking indefinitely. When the test receiver times out before all goroutines send their signal, an unbuffered channel causes those goroutines to block forever on the send operation.

#### Which issue(s) this PR is related to:
fixes: https://github.com/kubernetes/kubernetes/issues/134939

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
none

