### PR TITLE
Fix REST API to return 4xx instead of 500 on invalid requests

### DIFF
--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/server/egressselector"
@@ -194,7 +195,7 @@ func (k *NodeConnectionInfoGetter) GetConnectionInfo(ctx context.Context, nodeNa
 	// Find a kubelet-reported address, using preferred address type
 	host, err := nodeutil.GetPreferredNodeAddress(node, k.preferredAddressTypes)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewBadRequest(err.Error())
 	}
 
 	// Use the kubelet-reported port, if present

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -333,7 +333,7 @@ func (r *Request) Name(resourceName string) *Request {
 		return r
 	}
 	if len(resourceName) == 0 {
-		r.err = fmt.Errorf("resource name may not be empty")
+		r.err = errors.NewBadRequest("resource name may not be empty")
 		return r
 	}
 	if len(r.resourceName) != 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In short, I discovered 2 reproducible bugs in the Kubernetes REST API, identified the root cause, and implemented fixes. Additionally, I wrote 2 unit tests to verify the resolution.

##### Steps to Reproduce Manually

1. Start a Kubernetes cluster (I used the `StartTestServer` function from the `testing` package, but I believe the results would be the same with other methods).
2. Send the following request (ensure the required credentials, such as tokens, are properly configured beforehand—omitted here for brevity):

```bash

# 1
# create a serviceaccount first
curl -X POST 'https://$IP:$PORT/api/v1/namespaces/default/serviceaccounts' \
  --header 'Content-Type: application/json' \
  --data-raw '{
	   "apiVersion": "v1",
	   "kind": "ServiceAccount",
	   "metadata": {
	       "name": "default"
	   }
	}'
# k8s returns 500 for this request
curl -X POST 'https://$IP:$PORT/api/v1/namespaces/default/pods' \
	--header 'Content-Type: application/json' \
	--data-raw '{"spec": {"runtimeClassName": ""}}'

# 2
# create a node first
curl -X POST 'https://$IP:$PORT/api/v1/nodes' \
	--header 'Content-Type: application/json' \
	--data-raw '{"metadata": {"name": "fixed"}}'
# k8s returns 500 for this request
curl -X POST 'https://$IP:$PORT/api/v1/nodes/fixed/proxy/'
```
Clearly, the server should return a 4xx error.

3. However, the actual responses are:

```json
// 1
{
    "kind": "Status",
    "apiVersion": "v1",
    "metadata": {},
    "status": "Failure",
    "message": "resource name may not be empty",
    "code": 500
}

// 2
{
    "kind": "Status",
    "apiVersion": "v1",
    "metadata": {},
    "status": "Failure",
    "message": "no preferred addresses found; known addresses: [{ }]",
    "code": 500
}
```

These are unexpected. The request should be properly handled, instead of returning an `Internal Server Error` (500).

4. Additionally, I observed a panic stack trace in the Kubernetes cluster logs. **This leads to unnecessary consumption of I/O resources.**

##### Unit Test & Fix

**To facilitate reproduction of the issue, I added 2 unit tests. Running these tests consistently reproduces the issue as described above.**

I applied the necessary fix in the source code, and after making the modification, the newly added unit test now behaves as expected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
return 400 for 2 REST APIs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```