### PR TITLE
Enabled declarative validation for Certificates (`CertificateSigningRequest.Spec.Usages`)

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5011,7 +5011,8 @@
       },
       "required": [
         "request",
-        "signerName"
+        "signerName",
+        "usages"
       ],
       "type": "object"
     },

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
@@ -197,7 +197,8 @@
         },
         "required": [
           "request",
-          "signerName"
+          "signerName",
+          "usages"
         ],
         "type": "object"
       },

--- a/pkg/apis/certificates/v1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1/zz_generated.validations.go
@@ -63,7 +63,20 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequest) (errs field.ErrorList) {
 	// field certificatesv1.CertificateSigningRequest.TypeMeta has no validation
 	// field certificatesv1.CertificateSigningRequest.ObjectMeta has no validation
-	// field certificatesv1.CertificateSigningRequest.Spec has no validation
+
+	// field certificatesv1.CertificateSigningRequest.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CertificateSigningRequestSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequest) *certificatesv1.CertificateSigningRequestSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
 
 	// field certificatesv1.CertificateSigningRequest.Status
 	errs = append(errs,
@@ -102,6 +115,41 @@ func Validate_CertificateSigningRequestList(ctx context.Context, op operation.Op
 			return oldObj.Items
 		}), oldObj != nil)...)
 
+	return errs
+}
+
+// Validate_CertificateSigningRequestSpec validates an instance of CertificateSigningRequestSpec according
+// to declarative validation rules in the API schema.
+func Validate_CertificateSigningRequestSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestSpec) (errs field.ErrorList) {
+	// field certificatesv1.CertificateSigningRequestSpec.Request has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.SignerName has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.ExpirationSeconds has no validation
+
+	// field certificatesv1.CertificateSigningRequestSpec.Usages
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1.KeyUsage, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("usages"), obj.Usages, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestSpec) []certificatesv1.KeyUsage {
+			return oldObj.Usages
+		}), oldObj != nil)...)
+
+	// field certificatesv1.CertificateSigningRequestSpec.Username has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.UID has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.Groups has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.Extra has no validation
 	return errs
 }
 

--- a/pkg/apis/certificates/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.validations.go
@@ -63,7 +63,20 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequest) (errs field.ErrorList) {
 	// field certificatesv1beta1.CertificateSigningRequest.TypeMeta has no validation
 	// field certificatesv1beta1.CertificateSigningRequest.ObjectMeta has no validation
-	// field certificatesv1beta1.CertificateSigningRequest.Spec has no validation
+
+	// field certificatesv1beta1.CertificateSigningRequest.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CertificateSigningRequestSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequest) *certificatesv1beta1.CertificateSigningRequestSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
 
 	// field certificatesv1beta1.CertificateSigningRequest.Status
 	errs = append(errs,
@@ -102,6 +115,41 @@ func Validate_CertificateSigningRequestList(ctx context.Context, op operation.Op
 			return oldObj.Items
 		}), oldObj != nil)...)
 
+	return errs
+}
+
+// Validate_CertificateSigningRequestSpec validates an instance of CertificateSigningRequestSpec according
+// to declarative validation rules in the API schema.
+func Validate_CertificateSigningRequestSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestSpec) (errs field.ErrorList) {
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Request has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.SignerName has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.ExpirationSeconds has no validation
+
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Usages
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1beta1.KeyUsage, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("usages"), obj.Usages, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequestSpec) []certificatesv1beta1.KeyUsage {
+			return oldObj.Usages
+		}), oldObj != nil)...)
+
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Username has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.UID has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Groups has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Extra has no validation
 	return errs
 }
 

--- a/pkg/apis/certificates/validation/validation.go
+++ b/pkg/apis/certificates/validation/validation.go
@@ -188,7 +188,7 @@ func validateCertificateSigningRequest(csr *certificates.CertificateSigningReque
 		allErrs = append(allErrs, field.Invalid(specPath.Child("request"), csr.Spec.Request, fmt.Sprintf("%v", err)))
 	}
 	if len(csr.Spec.Usages) == 0 {
-		allErrs = append(allErrs, field.Required(specPath.Child("usages"), ""))
+		allErrs = append(allErrs, field.Required(specPath.Child("usages"), "").MarkCoveredByDeclarative())
 	}
 	if !opts.allowUnknownUsages {
 		for i, usage := range csr.Spec.Usages {

--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -99,7 +99,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Required(specPath.Child("usages"), ""),
+				field.Required(specPath.Child("usages"), "").MarkCoveredByDeclarative(),
 			},
 		},
 		"CSR with no signerName set should fail": {
@@ -347,7 +347,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Required(specPath.Child("usages"), ""),
+				field.Required(specPath.Child("usages"), "").MarkCoveredByDeclarative(),
 			},
 		},
 		"unknown and duplicate usages": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -19373,7 +19373,7 @@ func schema_k8sio_api_certificates_v1_CertificateSigningRequestSpec(ref common.R
 						},
 					},
 				},
-				Required: []string{"request", "signerName"},
+				Required: []string{"request", "signerName", "usages"},
 			},
 		},
 	}
@@ -19808,7 +19808,7 @@ func schema_k8sio_api_certificates_v1beta1_CertificateSigningRequestSpec(ref com
 						},
 					},
 				},
-				Required: []string{"request"},
+				Required: []string{"request", "usages"},
 			},
 		},
 	}

--- a/pkg/registry/certificates/certificates/declarative_validation_test.go
+++ b/pkg/registry/certificates/certificates/declarative_validation_test.go
@@ -87,6 +87,22 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf"),
 			},
 		},
+		"spec.usages: nil = invalid": {
+			input: makeValidCSR(func(csr *api.CertificateSigningRequest) {
+				csr.Spec.Usages = nil
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "usages"), ""),
+			},
+		},
+		"spec.usages: empty = invalid": {
+			input: makeValidCSR(func(csr *api.CertificateSigningRequest) {
+				csr.Spec.Usages = []api.KeyUsage{}
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "usages"), ""),
+			},
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {

--- a/pkg/registry/certificates/certificates/declarative_validation_test.go
+++ b/pkg/registry/certificates/certificates/declarative_validation_test.go
@@ -198,6 +198,26 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 			update:       makeValidCSR(withDeniedCondition(), withDeniedCondition(), withApprovedCondition(), withApprovedCondition()),
 			subresources: []string{"/status"},
 		},
+		"spec.usages: nil = invalid on update": {
+			old: makeValidCSR(),
+			update: makeValidCSR(func(csr *api.CertificateSigningRequest) {
+				csr.Spec.Usages = nil
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "usages"), ""),
+			},
+			subresources: []string{"/"},
+		},
+		"spec.usages: empty = invalid on update": {
+			old: makeValidCSR(),
+			update: makeValidCSR(func(csr *api.CertificateSigningRequest) {
+				csr.Spec.Usages = []api.KeyUsage{}
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "usages"), ""),
+			},
+			subresources: []string{"/"},
+		},
 	}
 
 	for k, tc := range testCases {

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -173,6 +173,7 @@ message CertificateSigningRequestSpec {
   //  "ipsec end system", "ipsec tunnel", "ipsec user",
   //  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
   // +listType=atomic
+  // +k8s:required
   repeated string usages = 5;
 
   // username contains the name of the user that created the CertificateSigningRequest.

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -173,6 +173,7 @@ message CertificateSigningRequestSpec {
   //  "ipsec end system", "ipsec tunnel", "ipsec user",
   //  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
   // +listType=atomic
+  // +required
   // +k8s:required
   repeated string usages = 5;
 

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -123,6 +123,7 @@ type CertificateSigningRequestSpec struct {
 	//  "ipsec end system", "ipsec tunnel", "ipsec user",
 	//  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
 	// +listType=atomic
+	// +k8s:required
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 
 	// username contains the name of the user that created the CertificateSigningRequest.

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -123,6 +123,7 @@ type CertificateSigningRequestSpec struct {
 	//  "ipsec end system", "ipsec tunnel", "ipsec user",
 	//  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
 	// +listType=atomic
+	// +required
 	// +k8s:required
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -154,6 +154,7 @@ message CertificateSigningRequestSpec {
   //  "microsoft sgc",
   //  "netscape sgc"
   // +listType=atomic
+  // +k8s:required
   repeated string usages = 5;
 
   // Information about the requesting user.

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -154,6 +154,7 @@ message CertificateSigningRequestSpec {
   //  "microsoft sgc",
   //  "netscape sgc"
   // +listType=atomic
+  // +required
   // +k8s:required
   repeated string usages = 5;
 

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -120,6 +120,7 @@ type CertificateSigningRequestSpec struct {
 	//  "microsoft sgc",
 	//  "netscape sgc"
 	// +listType=atomic
+	// +k8s:required
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 
 	// Information about the requesting user.

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -120,6 +120,7 @@ type CertificateSigningRequestSpec struct {
 	//  "microsoft sgc",
 	//  "netscape sgc"
 	// +listType=atomic
+	// +required
 	// +k8s:required
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Migrates `CertificateSigningRequest.spec.usages` required-field validation from handwritten Go checks to Declarative Validation by adding `+k8s:required` on the versioned API types (v1 and v1beta1). Regenerates validation output, marks the existing handwritten `spec.usages` required error as covered by declarative validation, and adds/updates equivalence tests to ensure declarative and handwritten validation results match during the migration.

#### Which issue(s) this PR is related to:

Part of #135752 

#### Special notes for your reviewer:

- Added `+k8s:required` for `spec.usages` in:
  - `staging/src/k8s.io/api/certificates/v1/types.go`
  - `staging/src/k8s.io/api/certificates/v1beta1/types.go`
- Ran `hack/update-codegen.sh validation` and committed generated `zz_generated.validations.go` updates.
- Marked the handwritten `field.Required(spec.usages)` error with `.MarkCoveredByDeclarative()`.
- Added declarative validation equivalence coverage for `spec.usages` (nil/empty cases).

#### Does this PR introduce a user-facing change?

```release-note
NONE
