### PR TITLE
Fix(kubectl): describe node accounts for pod-level resources

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
@@ -17,15 +17,15 @@ limitations under the License.
 package resource
 
 import (
-	"fmt"
-	"math"
-	"strconv"
-	"strings"
+"fmt"
+"math"
+"strconv"
+"strings"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/sets"
-	helpers "k8s.io/component-helpers/resource"
+corev1 "k8s.io/api/core/v1"
+"k8s.io/apimachinery/pkg/api/resource"
+"k8s.io/apimachinery/pkg/util/sets"
+helpers "k8s.io/component-helpers/resource"
 )
 
 // PodRequestsAndLimits returns a dictionary of all defined resources summed up for all
@@ -33,242 +33,256 @@ import (
 // total container resource requests and to the total container limits which have a
 // non-zero quantity.
 func PodRequestsAndLimits(pod *corev1.Pod) (reqs, limits corev1.ResourceList) {
-	return podRequests(pod), podLimits(pod)
+return podRequests(pod), podLimits(pod)
 }
 
 // podRequests is a simplified form of PodRequests from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
 // feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
 func podRequests(pod *corev1.Pod) corev1.ResourceList {
-	// attempt to reuse the maps if passed, or allocate otherwise
-	reqs := corev1.ResourceList{}
+// attempt to reuse the maps if passed, or allocate otherwise
+reqs := corev1.ResourceList{}
 
-	containerStatuses := map[string]*corev1.ContainerStatus{}
-	for i := range pod.Status.ContainerStatuses {
-		containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
-	}
-	for i := range pod.Status.InitContainerStatuses {
-		containerStatuses[pod.Status.InitContainerStatuses[i].Name] = &pod.Status.InitContainerStatuses[i]
-	}
+containerStatuses := map[string]*corev1.ContainerStatus{}
+for i := range pod.Status.ContainerStatuses {
+containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
+}
+for i := range pod.Status.InitContainerStatuses {
+containerStatuses[pod.Status.InitContainerStatuses[i].Name] = &pod.Status.InitContainerStatuses[i]
+}
 
-	for _, container := range pod.Spec.Containers {
-		containerReqs := container.Resources.Requests
-		cs, found := containerStatuses[container.Name]
-		if found && cs.Resources != nil {
-			containerReqs = determineContainerReqs(pod, &container, cs)
-		}
-		addResourceList(reqs, containerReqs)
-	}
+for _, container := range pod.Spec.Containers {
+containerReqs := container.Resources.Requests
+cs, found := containerStatuses[container.Name]
+if found && cs.Resources != nil {
+containerReqs = determineContainerReqs(pod, &container, cs)
+}
+addResourceList(reqs, containerReqs)
+}
 
-	restartableInitContainerReqs := corev1.ResourceList{}
-	initContainerReqs := corev1.ResourceList{}
+restartableInitContainerReqs := corev1.ResourceList{}
+initContainerReqs := corev1.ResourceList{}
 
-	for _, container := range pod.Spec.InitContainers {
-		containerReqs := container.Resources.Requests
+for _, container := range pod.Spec.InitContainers {
+containerReqs := container.Resources.Requests
 
-		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
-			cs, found := containerStatuses[container.Name]
-			if found && cs.Resources != nil {
-				containerReqs = determineContainerReqs(pod, &container, cs)
-			}
-			// and add them to the resulting cumulative container requests
-			addResourceList(reqs, containerReqs)
+if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+cs, found := containerStatuses[container.Name]
+if found && cs.Resources != nil {
+containerReqs = determineContainerReqs(pod, &container, cs)
+}
+// and add them to the resulting cumulative container requests
+addResourceList(reqs, containerReqs)
 
-			// track our cumulative restartable init container resources
-			addResourceList(restartableInitContainerReqs, containerReqs)
-			containerReqs = restartableInitContainerReqs
-		} else {
-			tmp := corev1.ResourceList{}
-			addResourceList(tmp, containerReqs)
-			addResourceList(tmp, restartableInitContainerReqs)
-			containerReqs = tmp
-		}
-		maxResourceList(initContainerReqs, containerReqs)
-	}
+// track our cumulative restartable init container resources
+addResourceList(restartableInitContainerReqs, containerReqs)
+containerReqs = restartableInitContainerReqs
+} else {
+tmp := corev1.ResourceList{}
+addResourceList(tmp, containerReqs)
+addResourceList(tmp, restartableInitContainerReqs)
+containerReqs = tmp
+}
+maxResourceList(initContainerReqs, containerReqs)
+}
 
-	maxResourceList(reqs, initContainerReqs)
+maxResourceList(reqs, initContainerReqs)
 
-	// Add overhead for running a pod to the sum of requests if requested:
-	if pod.Spec.Overhead != nil {
-		addResourceList(reqs, pod.Spec.Overhead)
-	}
+// Process Pod-Level Resources (overrides container sums if set)
+if pod.Spec.Resources != nil {
+for name, quantity := range pod.Spec.Resources.Requests {
+reqs[name] = quantity.DeepCopy()
+}
+}
 
-	return reqs
+// Add overhead for running a pod to the sum of requests if requested:
+if pod.Spec.Overhead != nil {
+addResourceList(reqs, pod.Spec.Overhead)
+}
+
+return reqs
 }
 
 // podLimits is a simplified form of PodLimits from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
 // feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
 func podLimits(pod *corev1.Pod) corev1.ResourceList {
-	limits := corev1.ResourceList{}
+limits := corev1.ResourceList{}
 
-	for _, container := range pod.Spec.Containers {
-		addResourceList(limits, container.Resources.Limits)
-	}
+for _, container := range pod.Spec.Containers {
+addResourceList(limits, container.Resources.Limits)
+}
 
-	restartableInitContainerLimits := corev1.ResourceList{}
-	initContainerLimits := corev1.ResourceList{}
+restartableInitContainerLimits := corev1.ResourceList{}
+initContainerLimits := corev1.ResourceList{}
 
-	for _, container := range pod.Spec.InitContainers {
-		containerLimits := container.Resources.Limits
-		// Is the init container marked as a restartable init container?
-		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
-			addResourceList(limits, containerLimits)
+for _, container := range pod.Spec.InitContainers {
+containerLimits := container.Resources.Limits
+// Is the init container marked as a restartable init container?
+if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+addResourceList(limits, containerLimits)
 
-			// track our cumulative restartable init container resources
-			addResourceList(restartableInitContainerLimits, containerLimits)
-			containerLimits = restartableInitContainerLimits
-		} else {
-			tmp := corev1.ResourceList{}
-			addResourceList(tmp, containerLimits)
-			addResourceList(tmp, restartableInitContainerLimits)
-			containerLimits = tmp
-		}
+// track our cumulative restartable init container resources
+addResourceList(restartableInitContainerLimits, containerLimits)
+containerLimits = restartableInitContainerLimits
+} else {
+tmp := corev1.ResourceList{}
+addResourceList(tmp, containerLimits)
+addResourceList(tmp, restartableInitContainerLimits)
+containerLimits = tmp
+}
 
-		maxResourceList(initContainerLimits, containerLimits)
-	}
+maxResourceList(initContainerLimits, containerLimits)
+}
 
-	maxResourceList(limits, initContainerLimits)
+maxResourceList(limits, initContainerLimits)
 
-	// Add overhead to non-zero limits if requested:
-	if pod.Spec.Overhead != nil {
-		for name, quantity := range pod.Spec.Overhead {
-			if value, ok := limits[name]; ok && !value.IsZero() {
-				value.Add(quantity)
-				limits[name] = value
-			}
-		}
-	}
+// Process Pod-Level Resources (overrides container sums if set)
+if pod.Spec.Resources != nil {
+for name, quantity := range pod.Spec.Resources.Limits {
+limits[name] = quantity.DeepCopy()
+}
+}
 
-	return limits
+// Add overhead to non-zero limits if requested:
+if pod.Spec.Overhead != nil {
+for name, quantity := range pod.Spec.Overhead {
+if value, ok := limits[name]; ok && !value.IsZero() {
+value.Add(quantity)
+limits[name] = value
+}
+}
+}
+
+return limits
 }
 
 // determineContainerReqs will return a copy of the container requests based on if resizing is feasible or not.
 func determineContainerReqs(pod *corev1.Pod, container *corev1.Container, cs *corev1.ContainerStatus) corev1.ResourceList {
-	if helpers.IsPodResizeInfeasible(pod) {
-		return max(cs.Resources.Requests, cs.AllocatedResources)
-	}
-	return max(container.Resources.Requests, cs.Resources.Requests, cs.AllocatedResources)
+if helpers.IsPodResizeInfeasible(pod) {
+return max(cs.Resources.Requests, cs.AllocatedResources)
+}
+return max(container.Resources.Requests, cs.Resources.Requests, cs.AllocatedResources)
 }
 
 // max returns the result of max(a, b...) for each named resource and is only used if we can't
 // accumulate into an existing resource list
 func max(a corev1.ResourceList, b ...corev1.ResourceList) corev1.ResourceList {
-	result := a.DeepCopy()
-	for _, other := range b {
-		maxResourceList(result, other)
-	}
-	return result
+result := a.DeepCopy()
+for _, other := range b {
+maxResourceList(result, other)
+}
+return result
 }
 
 // addResourceList adds the resources in newList to list
 func addResourceList(list, new corev1.ResourceList) {
-	for name, quantity := range new {
-		if value, ok := list[name]; !ok {
-			list[name] = quantity.DeepCopy()
-		} else {
-			value.Add(quantity)
-			list[name] = value
-		}
-	}
+for name, quantity := range new {
+if value, ok := list[name]; !ok {
+list[name] = quantity.DeepCopy()
+} else {
+value.Add(quantity)
+list[name] = value
+}
+}
 }
 
 // maxResourceList sets list to the greater of list/newList for every resource
 // either list
 func maxResourceList(list, new corev1.ResourceList) {
-	for name, quantity := range new {
-		if value, ok := list[name]; !ok {
-			list[name] = quantity.DeepCopy()
-			continue
-		} else {
-			if quantity.Cmp(value) > 0 {
-				list[name] = quantity.DeepCopy()
-			}
-		}
-	}
+for name, quantity := range new {
+if value, ok := list[name]; !ok {
+list[name] = quantity.DeepCopy()
+continue
+} else {
+if quantity.Cmp(value) > 0 {
+list[name] = quantity.DeepCopy()
+}
+}
+}
 }
 
 // ExtractContainerResourceValue extracts the value of a resource
 // in an already known container
 func ExtractContainerResourceValue(fs *corev1.ResourceFieldSelector, container *corev1.Container) (string, error) {
-	divisor := resource.Quantity{}
-	if divisor.Cmp(fs.Divisor) == 0 {
-		divisor = resource.MustParse("1")
-	} else {
-		divisor = fs.Divisor
-	}
+divisor := resource.Quantity{}
+if divisor.Cmp(fs.Divisor) == 0 {
+divisor = resource.MustParse("1")
+} else {
+divisor = fs.Divisor
+}
 
-	switch fs.Resource {
-	case "limits.cpu":
-		return convertResourceCPUToString(container.Resources.Limits.Cpu(), divisor)
-	case "limits.memory":
-		return convertResourceMemoryToString(container.Resources.Limits.Memory(), divisor)
-	case "limits.ephemeral-storage":
-		return convertResourceEphemeralStorageToString(container.Resources.Limits.StorageEphemeral(), divisor)
-	case "requests.cpu":
-		return convertResourceCPUToString(container.Resources.Requests.Cpu(), divisor)
-	case "requests.memory":
-		return convertResourceMemoryToString(container.Resources.Requests.Memory(), divisor)
-	case "requests.ephemeral-storage":
-		return convertResourceEphemeralStorageToString(container.Resources.Requests.StorageEphemeral(), divisor)
-	}
-	// handle extended standard resources with dynamic names
-	// example: requests.hugepages-<pageSize> or limits.hugepages-<pageSize>
-	if strings.HasPrefix(fs.Resource, "requests.") {
-		resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "requests."))
-		if IsHugePageResourceName(resourceName) {
-			return convertResourceHugePagesToString(container.Resources.Requests.Name(resourceName, resource.BinarySI), divisor)
-		}
-	}
-	if strings.HasPrefix(fs.Resource, "limits.") {
-		resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "limits."))
-		if IsHugePageResourceName(resourceName) {
-			return convertResourceHugePagesToString(container.Resources.Limits.Name(resourceName, resource.BinarySI), divisor)
-		}
-	}
-	return "", fmt.Errorf("Unsupported container resource : %v", fs.Resource)
+switch fs.Resource {
+case "limits.cpu":
+return convertResourceCPUToString(container.Resources.Limits.Cpu(), divisor)
+case "limits.memory":
+return convertResourceMemoryToString(container.Resources.Limits.Memory(), divisor)
+case "limits.ephemeral-storage":
+return convertResourceEphemeralStorageToString(container.Resources.Limits.StorageEphemeral(), divisor)
+case "requests.cpu":
+return convertResourceCPUToString(container.Resources.Requests.Cpu(), divisor)
+case "requests.memory":
+return convertResourceMemoryToString(container.Resources.Requests.Memory(), divisor)
+case "requests.ephemeral-storage":
+return convertResourceEphemeralStorageToString(container.Resources.Requests.StorageEphemeral(), divisor)
+}
+// handle extended standard resources with dynamic names
+// example: requests.hugepages-<pageSize> or limits.hugepages-<pageSize>
+if strings.HasPrefix(fs.Resource, "requests.") {
+resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "requests."))
+if IsHugePageResourceName(resourceName) {
+return convertResourceHugePagesToString(container.Resources.Requests.Name(resourceName, resource.BinarySI), divisor)
+}
+}
+if strings.HasPrefix(fs.Resource, "limits.") {
+resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "limits."))
+if IsHugePageResourceName(resourceName) {
+return convertResourceHugePagesToString(container.Resources.Limits.Name(resourceName, resource.BinarySI), divisor)
+}
+}
+return "", fmt.Errorf("Unsupported container resource : %v", fs.Resource)
 }
 
 // convertResourceCPUToString converts cpu value to the format of divisor and returns
 // ceiling of the value.
 func convertResourceCPUToString(cpu *resource.Quantity, divisor resource.Quantity) (string, error) {
-	c := int64(math.Ceil(float64(cpu.MilliValue()) / float64(divisor.MilliValue())))
-	return strconv.FormatInt(c, 10), nil
+c := int64(math.Ceil(float64(cpu.MilliValue()) / float64(divisor.MilliValue())))
+return strconv.FormatInt(c, 10), nil
 }
 
 // convertResourceMemoryToString converts memory value to the format of divisor and returns
 // ceiling of the value.
 func convertResourceMemoryToString(memory *resource.Quantity, divisor resource.Quantity) (string, error) {
-	m := int64(math.Ceil(float64(memory.Value()) / float64(divisor.Value())))
-	return strconv.FormatInt(m, 10), nil
+m := int64(math.Ceil(float64(memory.Value()) / float64(divisor.Value())))
+return strconv.FormatInt(m, 10), nil
 }
 
 // convertResourceHugePagesToString converts hugepages value to the format of divisor and returns
 // ceiling of the value.
 func convertResourceHugePagesToString(hugePages *resource.Quantity, divisor resource.Quantity) (string, error) {
-	m := int64(math.Ceil(float64(hugePages.Value()) / float64(divisor.Value())))
-	return strconv.FormatInt(m, 10), nil
+m := int64(math.Ceil(float64(hugePages.Value()) / float64(divisor.Value())))
+return strconv.FormatInt(m, 10), nil
 }
 
 // convertResourceEphemeralStorageToString converts ephemeral storage value to the format of divisor and returns
 // ceiling of the value.
 func convertResourceEphemeralStorageToString(ephemeralStorage *resource.Quantity, divisor resource.Quantity) (string, error) {
-	m := int64(math.Ceil(float64(ephemeralStorage.Value()) / float64(divisor.Value())))
-	return strconv.FormatInt(m, 10), nil
+m := int64(math.Ceil(float64(ephemeralStorage.Value()) / float64(divisor.Value())))
+return strconv.FormatInt(m, 10), nil
 }
 
 var standardContainerResources = sets.New[string](
-	string(corev1.ResourceCPU),
-	string(corev1.ResourceMemory),
-	string(corev1.ResourceEphemeralStorage),
+string(corev1.ResourceCPU),
+string(corev1.ResourceMemory),
+string(corev1.ResourceEphemeralStorage),
 )
 
 // IsStandardContainerResourceName returns true if the container can make a resource request
 // for the specified resource
 func IsStandardContainerResourceName(str string) bool {
-	return standardContainerResources.Has(str) || IsHugePageResourceName(corev1.ResourceName(str))
+return standardContainerResources.Has(str) || IsHugePageResourceName(corev1.ResourceName(str))
 }
 
 // IsHugePageResourceName returns true if the resource name has the huge page
 // resource prefix.
 func IsHugePageResourceName(name corev1.ResourceName) bool {
-	return strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix)
+return strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix)
 }

--- a/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
@@ -17,15 +17,15 @@ limitations under the License.
 package resource
 
 import (
-"fmt"
-"math"
-"strconv"
-"strings"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
 
-corev1 "k8s.io/api/core/v1"
-"k8s.io/apimachinery/pkg/api/resource"
-"k8s.io/apimachinery/pkg/util/sets"
-helpers "k8s.io/component-helpers/resource"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
+	helpers "k8s.io/component-helpers/resource"
 )
 
 // PodRequestsAndLimits returns a dictionary of all defined resources summed up for all
@@ -33,256 +33,254 @@ helpers "k8s.io/component-helpers/resource"
 // total container resource requests and to the total container limits which have a
 // non-zero quantity.
 func PodRequestsAndLimits(pod *corev1.Pod) (reqs, limits corev1.ResourceList) {
-return podRequests(pod), podLimits(pod)
+	reqs, limits = podRequests(pod), podLimits(pod)
+
+	// If Pod-level resources are specified, they overwrite the calculated sums
+	if pod.Spec.Resources != nil {
+		for name, quantity := range pod.Spec.Resources.Requests {
+			reqs[name] = quantity.DeepCopy()
+		}
+		for name, quantity := range pod.Spec.Resources.Limits {
+			limits[name] = quantity.DeepCopy()
+		}
+	}
+
+	return reqs, limits
 }
 
 // podRequests is a simplified form of PodRequests from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
 // feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
 func podRequests(pod *corev1.Pod) corev1.ResourceList {
-// attempt to reuse the maps if passed, or allocate otherwise
-reqs := corev1.ResourceList{}
+	// attempt to reuse the maps if passed, or allocate otherwise
+	reqs := corev1.ResourceList{}
 
-containerStatuses := map[string]*corev1.ContainerStatus{}
-for i := range pod.Status.ContainerStatuses {
-containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
-}
-for i := range pod.Status.InitContainerStatuses {
-containerStatuses[pod.Status.InitContainerStatuses[i].Name] = &pod.Status.InitContainerStatuses[i]
-}
+	containerStatuses := map[string]*corev1.ContainerStatus{}
+	for i := range pod.Status.ContainerStatuses {
+		containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		containerStatuses[pod.Status.InitContainerStatuses[i].Name] = &pod.Status.InitContainerStatuses[i]
+	}
 
-for _, container := range pod.Spec.Containers {
-containerReqs := container.Resources.Requests
-cs, found := containerStatuses[container.Name]
-if found && cs.Resources != nil {
-containerReqs = determineContainerReqs(pod, &container, cs)
-}
-addResourceList(reqs, containerReqs)
-}
+	for _, container := range pod.Spec.Containers {
+		containerReqs := container.Resources.Requests
+		cs, found := containerStatuses[container.Name]
+		if found && cs.Resources != nil {
+			containerReqs = determineContainerReqs(pod, &container, cs)
+		}
+		addResourceList(reqs, containerReqs)
+	}
 
-restartableInitContainerReqs := corev1.ResourceList{}
-initContainerReqs := corev1.ResourceList{}
+	restartableInitContainerReqs := corev1.ResourceList{}
+	initContainerReqs := corev1.ResourceList{}
 
-for _, container := range pod.Spec.InitContainers {
-containerReqs := container.Resources.Requests
+	for _, container := range pod.Spec.InitContainers {
+		containerReqs := container.Resources.Requests
 
-if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
-cs, found := containerStatuses[container.Name]
-if found && cs.Resources != nil {
-containerReqs = determineContainerReqs(pod, &container, cs)
-}
-// and add them to the resulting cumulative container requests
-addResourceList(reqs, containerReqs)
+		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			cs, found := containerStatuses[container.Name]
+			if found && cs.Resources != nil {
+				containerReqs = determineContainerReqs(pod, &container, cs)
+			}
+			// and add them to the resulting cumulative container requests
+			addResourceList(reqs, containerReqs)
 
-// track our cumulative restartable init container resources
-addResourceList(restartableInitContainerReqs, containerReqs)
-containerReqs = restartableInitContainerReqs
-} else {
-tmp := corev1.ResourceList{}
-addResourceList(tmp, containerReqs)
-addResourceList(tmp, restartableInitContainerReqs)
-containerReqs = tmp
-}
-maxResourceList(initContainerReqs, containerReqs)
-}
+			// track our cumulative restartable init container resources
+			addResourceList(restartableInitContainerReqs, containerReqs)
+			containerReqs = restartableInitContainerReqs
+		} else {
+			tmp := corev1.ResourceList{}
+			addResourceList(tmp, containerReqs)
+			addResourceList(tmp, restartableInitContainerReqs)
+			containerReqs = tmp
+		}
+		maxResourceList(initContainerReqs, containerReqs)
+	}
 
-maxResourceList(reqs, initContainerReqs)
+	maxResourceList(reqs, initContainerReqs)
 
-// Process Pod-Level Resources (overrides container sums if set)
-if pod.Spec.Resources != nil {
-for name, quantity := range pod.Spec.Resources.Requests {
-reqs[name] = quantity.DeepCopy()
-}
-}
+	// Add overhead for running a pod to the sum of requests if requested:
+	if pod.Spec.Overhead != nil {
+		addResourceList(reqs, pod.Spec.Overhead)
+	}
 
-// Add overhead for running a pod to the sum of requests if requested:
-if pod.Spec.Overhead != nil {
-addResourceList(reqs, pod.Spec.Overhead)
-}
-
-return reqs
+	return reqs
 }
 
 // podLimits is a simplified form of PodLimits from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
 // feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
 func podLimits(pod *corev1.Pod) corev1.ResourceList {
-limits := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
 
-for _, container := range pod.Spec.Containers {
-addResourceList(limits, container.Resources.Limits)
-}
+	for _, container := range pod.Spec.Containers {
+		addResourceList(limits, container.Resources.Limits)
+	}
 
-restartableInitContainerLimits := corev1.ResourceList{}
-initContainerLimits := corev1.ResourceList{}
+	restartableInitContainerLimits := corev1.ResourceList{}
+	initContainerLimits := corev1.ResourceList{}
 
-for _, container := range pod.Spec.InitContainers {
-containerLimits := container.Resources.Limits
-// Is the init container marked as a restartable init container?
-if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
-addResourceList(limits, containerLimits)
+	for _, container := range pod.Spec.InitContainers {
+		containerLimits := container.Resources.Limits
+		// Is the init container marked as a restartable init container?
+		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			addResourceList(limits, containerLimits)
 
-// track our cumulative restartable init container resources
-addResourceList(restartableInitContainerLimits, containerLimits)
-containerLimits = restartableInitContainerLimits
-} else {
-tmp := corev1.ResourceList{}
-addResourceList(tmp, containerLimits)
-addResourceList(tmp, restartableInitContainerLimits)
-containerLimits = tmp
-}
+			// track our cumulative restartable init container resources
+			addResourceList(restartableInitContainerLimits, containerLimits)
+			containerLimits = restartableInitContainerLimits
+		} else {
+			tmp := corev1.ResourceList{}
+			addResourceList(tmp, containerLimits)
+			addResourceList(tmp, restartableInitContainerLimits)
+			containerLimits = tmp
+		}
 
-maxResourceList(initContainerLimits, containerLimits)
-}
+		maxResourceList(initContainerLimits, containerLimits)
+	}
 
-maxResourceList(limits, initContainerLimits)
+	maxResourceList(limits, initContainerLimits)
 
-// Process Pod-Level Resources (overrides container sums if set)
-if pod.Spec.Resources != nil {
-for name, quantity := range pod.Spec.Resources.Limits {
-limits[name] = quantity.DeepCopy()
-}
-}
+	// Add overhead to non-zero limits if requested:
+	if pod.Spec.Overhead != nil {
+		for name, quantity := range pod.Spec.Overhead {
+			if value, ok := limits[name]; ok && !value.IsZero() {
+				value.Add(quantity)
+				limits[name] = value
+			}
+		}
+	}
 
-// Add overhead to non-zero limits if requested:
-if pod.Spec.Overhead != nil {
-for name, quantity := range pod.Spec.Overhead {
-if value, ok := limits[name]; ok && !value.IsZero() {
-value.Add(quantity)
-limits[name] = value
-}
-}
-}
-
-return limits
+	return limits
 }
 
 // determineContainerReqs will return a copy of the container requests based on if resizing is feasible or not.
 func determineContainerReqs(pod *corev1.Pod, container *corev1.Container, cs *corev1.ContainerStatus) corev1.ResourceList {
-if helpers.IsPodResizeInfeasible(pod) {
-return max(cs.Resources.Requests, cs.AllocatedResources)
-}
-return max(container.Resources.Requests, cs.Resources.Requests, cs.AllocatedResources)
+	if helpers.IsPodResizeInfeasible(pod) {
+		return max(cs.Resources.Requests, cs.AllocatedResources)
+	}
+	return max(container.Resources.Requests, cs.Resources.Requests, cs.AllocatedResources)
 }
 
 // max returns the result of max(a, b...) for each named resource and is only used if we can't
 // accumulate into an existing resource list
 func max(a corev1.ResourceList, b ...corev1.ResourceList) corev1.ResourceList {
-result := a.DeepCopy()
-for _, other := range b {
-maxResourceList(result, other)
-}
-return result
+	result := a.DeepCopy()
+	for _, other := range b {
+		maxResourceList(result, other)
+	}
+	return result
 }
 
 // addResourceList adds the resources in newList to list
 func addResourceList(list, new corev1.ResourceList) {
-for name, quantity := range new {
-if value, ok := list[name]; !ok {
-list[name] = quantity.DeepCopy()
-} else {
-value.Add(quantity)
-list[name] = value
-}
-}
+	for name, quantity := range new {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+		} else {
+			value.Add(quantity)
+			list[name] = value
+		}
+	}
 }
 
 // maxResourceList sets list to the greater of list/newList for every resource
 // either list
 func maxResourceList(list, new corev1.ResourceList) {
-for name, quantity := range new {
-if value, ok := list[name]; !ok {
-list[name] = quantity.DeepCopy()
-continue
-} else {
-if quantity.Cmp(value) > 0 {
-list[name] = quantity.DeepCopy()
-}
-}
-}
+	for name, quantity := range new {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+			continue
+		} else {
+			if quantity.Cmp(value) > 0 {
+				list[name] = quantity.DeepCopy()
+			}
+		}
+	}
 }
 
 // ExtractContainerResourceValue extracts the value of a resource
 // in an already known container
 func ExtractContainerResourceValue(fs *corev1.ResourceFieldSelector, container *corev1.Container) (string, error) {
-divisor := resource.Quantity{}
-if divisor.Cmp(fs.Divisor) == 0 {
-divisor = resource.MustParse("1")
-} else {
-divisor = fs.Divisor
-}
+	divisor := resource.Quantity{}
+	if divisor.Cmp(fs.Divisor) == 0 {
+		divisor = resource.MustParse("1")
+	} else {
+		divisor = fs.Divisor
+	}
 
-switch fs.Resource {
-case "limits.cpu":
-return convertResourceCPUToString(container.Resources.Limits.Cpu(), divisor)
-case "limits.memory":
-return convertResourceMemoryToString(container.Resources.Limits.Memory(), divisor)
-case "limits.ephemeral-storage":
-return convertResourceEphemeralStorageToString(container.Resources.Limits.StorageEphemeral(), divisor)
-case "requests.cpu":
-return convertResourceCPUToString(container.Resources.Requests.Cpu(), divisor)
-case "requests.memory":
-return convertResourceMemoryToString(container.Resources.Requests.Memory(), divisor)
-case "requests.ephemeral-storage":
-return convertResourceEphemeralStorageToString(container.Resources.Requests.StorageEphemeral(), divisor)
-}
-// handle extended standard resources with dynamic names
-// example: requests.hugepages-<pageSize> or limits.hugepages-<pageSize>
-if strings.HasPrefix(fs.Resource, "requests.") {
-resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "requests."))
-if IsHugePageResourceName(resourceName) {
-return convertResourceHugePagesToString(container.Resources.Requests.Name(resourceName, resource.BinarySI), divisor)
-}
-}
-if strings.HasPrefix(fs.Resource, "limits.") {
-resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "limits."))
-if IsHugePageResourceName(resourceName) {
-return convertResourceHugePagesToString(container.Resources.Limits.Name(resourceName, resource.BinarySI), divisor)
-}
-}
-return "", fmt.Errorf("Unsupported container resource : %v", fs.Resource)
+	switch fs.Resource {
+	case "limits.cpu":
+		return convertResourceCPUToString(container.Resources.Limits.Cpu(), divisor)
+	case "limits.memory":
+		return convertResourceMemoryToString(container.Resources.Limits.Memory(), divisor)
+	case "limits.ephemeral-storage":
+		return convertResourceEphemeralStorageToString(container.Resources.Limits.StorageEphemeral(), divisor)
+	case "requests.cpu":
+		return convertResourceCPUToString(container.Resources.Requests.Cpu(), divisor)
+	case "requests.memory":
+		return convertResourceMemoryToString(container.Resources.Requests.Memory(), divisor)
+	case "requests.ephemeral-storage":
+		return convertResourceEphemeralStorageToString(container.Resources.Requests.StorageEphemeral(), divisor)
+	}
+	// handle extended standard resources with dynamic names
+	// example: requests.hugepages-<pageSize> or limits.hugepages-<pageSize>
+	if strings.HasPrefix(fs.Resource, "requests.") {
+		resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "requests."))
+		if IsHugePageResourceName(resourceName) {
+			return convertResourceHugePagesToString(container.Resources.Requests.Name(resourceName, resource.BinarySI), divisor)
+		}
+	}
+	if strings.HasPrefix(fs.Resource, "limits.") {
+		resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "limits."))
+		if IsHugePageResourceName(resourceName) {
+			return convertResourceHugePagesToString(container.Resources.Limits.Name(resourceName, resource.BinarySI), divisor)
+		}
+	}
+	return "", fmt.Errorf("Unsupported container resource : %v", fs.Resource)
 }
 
 // convertResourceCPUToString converts cpu value to the format of divisor and returns
 // ceiling of the value.
 func convertResourceCPUToString(cpu *resource.Quantity, divisor resource.Quantity) (string, error) {
-c := int64(math.Ceil(float64(cpu.MilliValue()) / float64(divisor.MilliValue())))
-return strconv.FormatInt(c, 10), nil
+	c := int64(math.Ceil(float64(cpu.MilliValue()) / float64(divisor.MilliValue())))
+	return strconv.FormatInt(c, 10), nil
 }
 
 // convertResourceMemoryToString converts memory value to the format of divisor and returns
 // ceiling of the value.
 func convertResourceMemoryToString(memory *resource.Quantity, divisor resource.Quantity) (string, error) {
-m := int64(math.Ceil(float64(memory.Value()) / float64(divisor.Value())))
-return strconv.FormatInt(m, 10), nil
+	m := int64(math.Ceil(float64(memory.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
 }
 
 // convertResourceHugePagesToString converts hugepages value to the format of divisor and returns
 // ceiling of the value.
 func convertResourceHugePagesToString(hugePages *resource.Quantity, divisor resource.Quantity) (string, error) {
-m := int64(math.Ceil(float64(hugePages.Value()) / float64(divisor.Value())))
-return strconv.FormatInt(m, 10), nil
+	m := int64(math.Ceil(float64(hugePages.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
 }
 
 // convertResourceEphemeralStorageToString converts ephemeral storage value to the format of divisor and returns
 // ceiling of the value.
 func convertResourceEphemeralStorageToString(ephemeralStorage *resource.Quantity, divisor resource.Quantity) (string, error) {
-m := int64(math.Ceil(float64(ephemeralStorage.Value()) / float64(divisor.Value())))
-return strconv.FormatInt(m, 10), nil
+	m := int64(math.Ceil(float64(ephemeralStorage.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
 }
 
-var standardContainerResources = sets.New[string](
-string(corev1.ResourceCPU),
-string(corev1.ResourceMemory),
-string(corev1.ResourceEphemeralStorage),
+var standardContainerResources = sets.New(
+	string(corev1.ResourceCPU),
+	string(corev1.ResourceMemory),
+	string(corev1.ResourceEphemeralStorage),
 )
 
 // IsStandardContainerResourceName returns true if the container can make a resource request
 // for the specified resource
 func IsStandardContainerResourceName(str string) bool {
-return standardContainerResources.Has(str) || IsHugePageResourceName(corev1.ResourceName(str))
+	return standardContainerResources.Has(str) || IsHugePageResourceName(corev1.ResourceName(str))
 }
 
 // IsHugePageResourceName returns true if the resource name has the huge page
 // resource prefix.
 func IsHugePageResourceName(name corev1.ResourceName) bool {
-return strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix)
+	return strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix)
 }


### PR DESCRIPTION
Updates kubectl describe node logic to correctly calculate allocated resources by respecting pod-level resources (pod.Spec.Resources) when present, as introduced in KEP-2837.

Fixes kubernetes/kubectl#1807

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR updates `kubectl describe node` to correctly account for Pod-Level Resources (introduced in KEP-2837).

Previously, the resource allocation logic in `describe.go` only iterated over `pod.Spec.Containers` and `pod.Spec.InitContainers`. This meant that pods using `pod.Spec.Resources` (instead of container-level resources) were reported as consuming `0` resources in the "Allocated resources" table.

This fix updates the logic to check `pod.Spec.Resources` first. If present, it uses those values for the summary; otherwise, it falls back to the existing behavior of summing container resources.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1807

#### Special notes for your reviewer:

I have added a new regression test case `TestDescribeNodeWithPodLevelResources` in `staging/src/k8s.io/kubectl/pkg/describe/describe_test.go` to verify that pods with `Spec.Resources` are correctly aggregated in the node description output.

#### Does this PR introduce a user-facing change?

```release-note
kubectl describe node now correctly accounts for Pod-level resources (KEP-2837) when calculating allocated resources.

- [KEP]: [https://github.com/kubernetes/enhancements/issues/2837](https://github.com/kubernetes/enhancements/issues/2837)