### PR TITLE
Remove nil checks for unschedulable pods metrics recorder

### DIFF
--- a/pkg/scheduler/backend/queue/unschedulable_pods.go
+++ b/pkg/scheduler/backend/queue/unschedulable_pods.go
@@ -28,8 +28,10 @@ type unschedulablePods struct {
 	// podInfoMap is a map key by a pod's full-name and the value is a pointer to the QueuedPodInfo.
 	podInfoMap map[string]*framework.QueuedPodInfo
 	keyFunc    func(*v1.Pod) string
-	// unschedulableRecorder/gatedRecorder updates the counter when elements of an unschedulablePods
-	// get added or removed, and it does nothing if it's nil.
+	// unschedulableRecorder and gatedRecorder track the number of pods in the unschedulable queue.
+	// unschedulableRecorder tracks standard unschedulable pods, while gatedRecorder tracks pods
+	// that are specifically blocked by scheduling gates. These recorders handle
+	// increments, decrements, and transitions (Gated <-> Ungated).
 	unschedulableRecorder, gatedRecorder metrics.MetricRecorder
 }
 
@@ -52,20 +54,12 @@ func (u *unschedulablePods) updateMetricsOnStateChange(gatedBefore, isGated bool
 
 	if gatedBefore {
 		// Transition: Gated -> Ungated
-		if u.gatedRecorder != nil {
-			u.gatedRecorder.Dec()
-		}
-		if u.unschedulableRecorder != nil {
-			u.unschedulableRecorder.Inc()
-		}
+		u.gatedRecorder.Dec()
+		u.unschedulableRecorder.Inc()
 	} else {
 		// Transition: Ungated -> Gated
-		if u.unschedulableRecorder != nil {
-			u.unschedulableRecorder.Dec()
-		}
-		if u.gatedRecorder != nil {
-			u.gatedRecorder.Inc()
-		}
+		u.gatedRecorder.Inc()
+		u.unschedulableRecorder.Dec()
 	}
 }
 
@@ -76,9 +70,9 @@ func (u *unschedulablePods) addOrUpdate(pInfo *framework.QueuedPodInfo, gatedBef
 	if _, exists := u.podInfoMap[podID]; exists {
 		u.updateMetricsOnStateChange(gatedBefore, pInfo.Gated())
 	} else {
-		if pInfo.Gated() && u.gatedRecorder != nil {
+		if pInfo.Gated() {
 			u.gatedRecorder.Inc()
-		} else if !pInfo.Gated() && u.unschedulableRecorder != nil {
+		} else {
 			u.unschedulableRecorder.Inc()
 		}
 		metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", event).Inc()
@@ -91,9 +85,9 @@ func (u *unschedulablePods) addOrUpdate(pInfo *framework.QueuedPodInfo, gatedBef
 func (u *unschedulablePods) delete(pod *v1.Pod, gated bool) {
 	podID := u.keyFunc(pod)
 	if _, exists := u.podInfoMap[podID]; exists {
-		if gated && u.gatedRecorder != nil {
+		if gated {
 			u.gatedRecorder.Dec()
-		} else if !gated && u.unschedulableRecorder != nil {
+		} else {
 			u.unschedulableRecorder.Dec()
 		}
 	}
@@ -113,10 +107,6 @@ func (u *unschedulablePods) get(pod *v1.Pod) *framework.QueuedPodInfo {
 // clear removes all the entries from the unschedulable podInfoMap.
 func (u *unschedulablePods) clear() {
 	u.podInfoMap = make(map[string]*framework.QueuedPodInfo)
-	if u.unschedulableRecorder != nil {
-		u.unschedulableRecorder.Clear()
-	}
-	if u.gatedRecorder != nil {
-		u.gatedRecorder.Clear()
-	}
+	u.unschedulableRecorder.Clear()
+	u.gatedRecorder.Clear()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR removes defensive nil checks for gatedRecorder and unschedulableRecorder in the scheduling queue.

These recorders are mandatory components of the scheduler and are always initialized in production code paths. The nil checks previously existed solely to support unit tests that did not initialize these fields. By ensuring tests provide proper mocks, we can remove these redundant checks from the production logic, resulting in cleaner and more assertive code.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/pull/135368#discussion_r2584639622
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
This change assumes that the scheduler initialization logic guarantees these recorders are non-nil, which matches the current architecture. Tests that previously relied on these fields being nil have been updated to use mocks and also was added asserts for the metrics recorder.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
