### PR TITLE
code-generator/defaulter-gen: generate defaults only if required tags are present

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/defaulter-gen/generators/defaulter.go
+++ b/staging/src/k8s.io/code-generator/cmd/defaulter-gen/generators/defaulter.go
@@ -73,12 +73,19 @@ func extractDefaultTag(comments []string) ([]string, error) {
 	return tags[defaultTagName], nil
 }
 
-func extractTag(comments []string) ([]string, error) {
+func extractTag(comments []string) ([]string, bool) {
 	tags, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{tagName}, comments)
 	if err != nil {
-		return nil, err
+		klog.Fatalf("Error extracting %s tag: %v", tagName, err)
+		return nil, false
 	}
-	return tags[tagName], nil
+
+	values, found := tags[tagName]
+	if !found || len(values) == 0 {
+		return nil, false
+	}
+
+	return values, true
 }
 
 func extractInputTag(comments []string) ([]string, error) {
@@ -330,9 +337,10 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 			getManualDefaultingFunctions(context, context.Universe[pp], existingDefaulters)
 		}
 
-		typesWith, err := extractTag(pkg.Comments)
-		if err != nil {
-			klog.Fatalf("Error extracting %s tag: %v", tagName, err)
+		typesWith, found := extractTag(pkg.Comments)
+		if !found {
+			klog.V(2).InfoS("  did not find required tag", "tag", tagName)
+			continue
 		}
 		shouldCreateObjectDefaulterFn := func(t *types.Type) bool {
 			if defaults, ok := existingDefaulters[t]; ok && defaults.object != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Today `defaulter-gen` always generates a defaults file, no matter whether the `+k8s:defaulter-gen` marker is present or not. This behaviour is different from what we see in other tools like `deepcopy-gen`, `validation-gen`, etc. as discussed in issue #135417 

This PR makes `defaulter-gen` consistent with the rest of the code-generator tools like `deepcopy-gen`, `validation-gen` and others.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #135417

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
