### PR TITLE
E2E framework: make usage of Ginkgo wrappers optional

### DIFF
--- a/test/e2e/auth/projected_clustertrustbundle.go
+++ b/test/e2e/auth/projected_clustertrustbundle.go
@@ -162,7 +162,7 @@ var _ = SIGDescribe(framework.WithFeatureGate(features.ClusterTrustBundle), fram
 		}
 	})
 
-	ginkgo.Describe("should prevent a pod from starting if: ", func() {
+	ginkgo.Describe("should prevent a pod from starting if:", func() {
 
 		for _, tt := range []struct {
 			name string

--- a/test/e2e/common/node/image_credential_provider.go
+++ b/test/e2e/common/node/image_credential_provider.go
@@ -48,7 +48,7 @@ var _ = SIGDescribe("ImageCredentialProvider", feature.KubeletCredentialProvider
 		Testname: Test kubelet image pull with external credential provider plugins
 		Description: Create Pod with an image from a private registry. This test assumes that the kubelet credential provider plugin is enabled for the registry hosting imageutils.AgnhostPrivate.
 	*/
-	ginkgo.It("should be able to create pod with image credentials fetched from external credential provider ", func(ctx context.Context) {
+	ginkgo.It("should be able to create pod with image credentials fetched from external credential provider", func(ctx context.Context) {
 		privateimage := imageutils.GetConfig(imageutils.AgnhostPrivate)
 		name := "pod-auth-image-" + string(uuid.NewUUID())
 

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -84,13 +84,13 @@ var _ = common.SIGDescribe("Proxy", func() {
 			Test for Proxy, logs port endpoint
 			Select any node in the cluster to invoke /proxy/nodes/<nodeip>:10250/logs endpoint. This endpoint MUST be reachable.
 		*/
-		ginkgo.It("should proxy logs on node with explicit kubelet port using proxy subresource ", func(ctx context.Context) { nodeProxyTest(ctx, f, prefix+"/nodes/", ":10250/proxy/logs/") })
+		ginkgo.It("should proxy logs on node with explicit kubelet port using proxy subresource", func(ctx context.Context) { nodeProxyTest(ctx, f, prefix+"/nodes/", ":10250/proxy/logs/") })
 
 		/*
 			Test for Proxy, logs endpoint
 			Select any node in the cluster to invoke /proxy/nodes/<nodeip>//logs endpoint. This endpoint MUST be reachable.
 		*/
-		ginkgo.It("should proxy logs on node using proxy subresource ", func(ctx context.Context) { nodeProxyTest(ctx, f, prefix+"/nodes/", "/proxy/logs/") })
+		ginkgo.It("should proxy logs on node using proxy subresource", func(ctx context.Context) { nodeProxyTest(ctx, f, prefix+"/nodes/", "/proxy/logs/") })
 
 		/*
 			Release: v1.9

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -902,7 +902,7 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.It("should be updated after adding or deleting ports ", func(ctx context.Context) {
+	ginkgo.It("should be updated after adding or deleting ports", func(ctx context.Context) {
 		serviceName := "edit-port-test"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
@@ -3675,7 +3675,7 @@ var _ = common.SIGDescribe("Services", func() {
 		Testname: Service, same ports with different protocols on a Load Balancer Service
 		Description: Create a LoadBalancer service with two ports that have the same value but use different protocols. Add a Pod that listens on both ports. The Pod must be reachable via the ClusterIP and both ports
 	*/
-	ginkgo.It("should serve endpoints on same port and different protocol for internal traffic on Type LoadBalancer ", func(ctx context.Context) {
+	ginkgo.It("should serve endpoints on same port and different protocol for internal traffic on Type LoadBalancer", func(ctx context.Context) {
 		serviceName := "multiprotocol-lb-test"
 		ns := f.Namespace.Name
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -40,7 +40,7 @@ var _ = SIGDescribe("Events", func() {
 	f := framework.NewDefaultFramework("events")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
-	ginkgo.It("should be sent by kubelets and the scheduler about pods scheduling and running ", func(ctx context.Context) {
+	ginkgo.It("should be sent by kubelets and the scheduler about pods scheduling and running", func(ctx context.Context) {
 
 		podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
 

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -492,7 +492,7 @@ var _ = SIGDescribe("kubelet", func() {
 			returns the kubelet logs
 		*/
 
-		ginkgo.It("should return the kubelet logs ", func(ctx context.Context) {
+		ginkgo.It("should return the kubelet logs", func(ctx context.Context) {
 			ginkgo.By("Starting the command")
 			tk := e2ekubectl.NewTestKubeconfig(framework.TestContext.CertDir, framework.TestContext.Host, framework.TestContext.KubeConfig, framework.TestContext.KubeContext, framework.TestContext.KubectlPath, ns)
 

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -1136,7 +1136,7 @@ var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithFeature
 			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute))
 		})
 
-		ginkgo.It("should restart all containers on a previously restarted regular container exit ", func(ctx context.Context) {
+		ginkgo.It("should restart all containers on a previously restarted regular container exit", func(ctx context.Context) {
 			podName := "restart-rules-exit-code-" + string(uuid.NewUUID())
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/node/runtimeclass.go
+++ b/test/e2e/node/runtimeclass.go
@@ -128,7 +128,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		gomega.Expect(pod.Spec.Tolerations).To(gomega.ContainElement(tolerations[0]))
 	})
 
-	ginkgo.It("should run a Pod requesting a RuntimeClass with scheduling without taints ", func(ctx context.Context) {
+	ginkgo.It("should run a Pod requesting a RuntimeClass with scheduling without taints", func(ctx context.Context) {
 		if err := e2eruntimeclass.NodeSupportsPreconfiguredRuntimeClassHandler(ctx, f); err != nil {
 			e2eskipper.Skipf("Skipping test as node does not have E2E runtime class handler preconfigured in container runtime config: %v", err)
 		}

--- a/test/e2e/storage/non_graceful_node_shutdown.go
+++ b/test/e2e/storage/non_graceful_node_shutdown.go
@@ -78,7 +78,7 @@ var _ = utils.SIGDescribe(framework.WithDisruptive(), "[LinuxOnly] NonGracefulNo
 	})
 
 	ginkgo.Describe("[NonGracefulNodeShutdown] pod that uses a persistent volume via gce pd driver", func() {
-		ginkgo.It("should get immediately rescheduled to a different node after non graceful node shutdown ", func(ctx context.Context) {
+		ginkgo.It("should get immediately rescheduled to a different node after non graceful node shutdown", func(ctx context.Context) {
 			// Install gce pd csi driver
 			ginkgo.By("deploying csi gce-pd driver")
 			driver := drivers.InitGcePDCSIDriver()

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -180,7 +180,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			// Create an nfs PV, then a claim that matches the PV, and a pod that
 			// contains the claim. Verify that the PV and PVC bind correctly, and
 			// that the pod can write to the nfs volume.
-			ginkgo.It("should create a non-pre-bound PV and PVC: test write access ", func(ctx context.Context) {
+			ginkgo.It("should create a non-pre-bound PV and PVC: test write access", func(ctx context.Context) {
 				pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfig, ns, false)
 				framework.ExpectNoError(err)
 				completeTest(ctx, f, c, ns, pv, pvc)

--- a/test/e2e_node/hugepages_test.go
+++ b/test/e2e_node/hugepages_test.go
@@ -387,7 +387,7 @@ var _ = SIGDescribe("HugePages", framework.WithSerial(), feature.HugePages, func
 			waitForHugepages(f, ctx, hugepages)
 		})
 
-		ginkgo.Context("with the resources requests that contain only one hugepages resource ", func() {
+		ginkgo.Context("with the resources requests that contain only one hugepages resource", func() {
 			ginkgo.Context("with the backward compatible API", func() {
 				ginkgo.BeforeEach(func() {
 					expectedHugepageLimits = v1.ResourceList{
@@ -461,7 +461,7 @@ var _ = SIGDescribe("HugePages", framework.WithSerial(), feature.HugePages, func
 			})
 		})
 
-		ginkgo.Context("with the resources requests that contain multiple hugepages resources ", func() {
+		ginkgo.Context("with the resources requests that contain multiple hugepages resources", func() {
 			ginkgo.BeforeEach(func() {
 				hugepages = map[string]int{
 					hugepagesResourceName2Mi: 5,

--- a/test/e2e_node/mirror_pod_grace_period_test.go
+++ b/test/e2e_node/mirror_pod_grace_period_test.go
@@ -42,7 +42,7 @@ import (
 var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
 	f := framework.NewDefaultFramework("mirror-pod-with-grace-period")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
-	ginkgo.Context("when create a mirror pod ", func() {
+	ginkgo.Context("when create a mirror pod", func() {
 		var ns, podPath, staticPodName, mirrorPodName string
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			ns = f.Namespace.Name

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -51,7 +51,7 @@ import (
 var _ = SIGDescribe("MirrorPod", func() {
 	f := framework.NewDefaultFramework("mirror-pod")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
-	ginkgo.Context("when create a mirror pod ", func() {
+	ginkgo.Context("when create a mirror pod", func() {
 		var ns, podPath, staticPodName, mirrorPodName string
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			ns = f.Namespace.Name
@@ -148,7 +148,7 @@ var _ = SIGDescribe("MirrorPod", func() {
 			}, 2*time.Minute, time.Second*4).Should(gomega.BeNil())
 		})
 	})
-	ginkgo.Context("when create a mirror pod without changes ", func() {
+	ginkgo.Context("when create a mirror pod without changes", func() {
 		var ns, podPath, staticPodName, mirrorPodName string
 		ginkgo.BeforeEach(func() {
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Previously it was necessary to use the Ginkgo wrappers when using any of the custom arguments like `WithSlow()`. Now the new hook within Ginkgo for modifying arguments is used such that e.g. the original `ginkgo.It` also works:

    ginkgo.It("some test", framework.WithSlow())

This avoids developer confusion (when forgetting to switch from ginkgo.It to framework.It when adding some of our custom parameters) and code churn (when switching).

It also finds a few cases of unnecessary trailing spaces in current test names (fixed in first commit). Previously that was only called out when using our wrappers.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Part of https://github.com/kubernetes/kubernetes/pull/134708, pulled out because it is useful on its own.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 