### PR TITLE
[Feature Cleanup] BoundServiceAccountTokenVolume to Node Conformance

### DIFF
--- a/test/e2e/cloud/gcp/auth/service_account_admission_controller_migration.go
+++ b/test/e2e/cloud/gcp/auth/service_account_admission_controller_migration.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"k8s.io/kubernetes/test/e2e/cloud/gcp/common"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 	"k8s.io/kubernetes/test/e2e/upgrades/auth"
@@ -34,7 +33,7 @@ var upgradeTests = []upgrades.Test{
 	&auth.ServiceAccountAdmissionControllerMigrationTest{},
 }
 
-var _ = SIGDescribe("ServiceAccount admission controller migration", feature.BoundServiceAccountTokenVolume, func() {
+var _ = SIGDescribe("ServiceAccount admission controller migration", framework.WithNodeConformance(), func() {
 	f := framework.NewDefaultFramework("serviceaccount-admission-controller-migration")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	testFrameworks := upgrades.CreateUpgradeFrameworks(upgradeTests)

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -34,9 +34,6 @@ var (
 	// - token-cleaner-controller
 	BootstrapTokens = framework.WithFeature(framework.ValidFeatures.Add("BootstrapTokens"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	BoundServiceAccountTokenVolume = framework.WithFeature(framework.ValidFeatures.Add("BoundServiceAccountTokenVolume"))
-
 	// Owner: sig-api-machinery
 	// Marks tests that exercise the CBOR data format for serving or storage.
 	CBOR = framework.WithFeature(framework.ValidFeatures.Add("CBOR"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The BoundServiceAccountTokenVolume feature is now on by default per the kubernetes [docs](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume), thus the feature label can be removed from the e2e tests and from the feature file since it was only used there once. 

#### Which issue(s) this PR is related to:
Partial fix for https://github.com/kubernetes/kubernetes/issues/134172
Test-infra corresponding changes: (will update with url here)

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
- FeatureGates is a separate cleanup
- Corresponding changes will be made in k/test-infra
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
