### PR TITLE
feat(audit-policy): allow leading wildcard in API group

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -63623,7 +63623,7 @@ func schema_pkg_apis_audit_v1_GroupResources(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Group is the name of the API group that contains the resources. The empty string represents the core API group. `*` matches all groups",
+							Description: "Group is the name of the API group that contains the resources. The empty string represents the core API group. `*` matches all groups. A leading `*.` matches all subgroups, e.g. `*.example.com` matches `foo.example.com` and `bar.foo.example.com`, but not `example.com` itself.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -275,7 +275,9 @@ type PolicyRule struct {
 type GroupResources struct {
 	// Group is the name of the API group that contains the resources.
 	// The empty string represents the core API group.
-	// `*` matches all groups
+	// `*` matches all groups.
+	// A leading `*.` matches all subgroups, e.g. `*.example.com` matches
+	// `foo.example.com` and `bar.foo.example.com`, but not `example.com` itself.
 	// +optional
 	Group string
 	// Resources is a list of resources this rule applies to.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
@@ -135,7 +135,9 @@ message EventList {
 message GroupResources {
   // Group is the name of the API group that contains the resources.
   // The empty string represents the core API group.
-  // `*` matches all groups
+  // `*` matches all groups.
+  // A leading `*.` matches all subgroups, e.g. `*.example.com` matches
+  // `foo.example.com` and `bar.foo.example.com`, but not `example.com` itself.
   // +optional
   optional string group = 1;
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/types.go
@@ -278,7 +278,9 @@ type PolicyRule struct {
 type GroupResources struct {
 	// Group is the name of the API group that contains the resources.
 	// The empty string represents the core API group.
-	// `*` matches all groups
+	// `*` matches all groups.
+	// A leading `*.` matches all subgroups, e.g. `*.example.com` matches
+	// `foo.example.com` and `bar.foo.example.com`, but not `example.com` itself.
 	// +optional
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resources is a list of resources this rule applies to.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/validation_test.go
@@ -43,6 +43,9 @@ func TestValidatePolicy(t *testing.T) {
 				"/metrics",
 				"*",
 			},
+		}, { // Wildcard in API group
+			Level:     audit.LevelRequestResponse,
+			Resources: []audit.GroupResources{{Group: "*.example.com"}},
 		}, { // Omit RequestReceived stage
 			Level: audit.LevelMetadata,
 			OmitStages: []audit.Stage{
@@ -120,6 +123,18 @@ func TestValidatePolicy(t *testing.T) {
 			OmitStages: []audit.Stage{
 				audit.Stage("foo"),
 			},
+		},
+		{ // leading wildcard without delimiter
+			Level:     audit.LevelMetadata,
+			Resources: []audit.GroupResources{{Group: "*example.com"}},
+		},
+		{ // wildcard in the middle of group name
+			Level:     audit.LevelMetadata,
+			Resources: []audit.GroupResources{{Group: "foo.*.example.com"}},
+		},
+		{ // trailing wildcard in group name
+			Level:     audit.LevelMetadata,
+			Resources: []audit.GroupResources{{Group: "example.*"}},
 		},
 	}
 	errorCases := []audit.Policy{}

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
@@ -191,7 +191,7 @@ func ruleMatchesResource(r *audit.PolicyRule, attrs authorizer.Attributes) bool 
 	name := attrs.GetName()
 
 	for _, gr := range r.Resources {
-		if gr.Group == apiGroup || gr.Group == "*" {
+		if apiGroupMatches(apiGroup, gr) {
 			if len(gr.Resources) == 0 {
 				return true
 			}
@@ -224,6 +224,13 @@ func hasString(slice []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func apiGroupMatches(apiGroup string, gr audit.GroupResources) bool {
+	if strings.HasPrefix(gr.Group, "*.") {
+		return strings.HasSuffix(apiGroup, gr.Group[1:])
+	}
+	return gr.Group == "*" || gr.Group == apiGroup
 }
 
 type fakePolicyRuleEvaluator struct {

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
@@ -74,6 +74,28 @@ var (
 			ResourceRequest: true,
 			Path:            "/api/v1/namespaces/default/pods/busybox",
 		},
+		"customResource": &authorizer.AttributesRecord{
+			User:            tim,
+			Verb:            "get",
+			Namespace:       "default",
+			APIGroup:        "example.com",
+			APIVersion:      "v1",
+			Resource:        "examples",
+			Name:            "my-example",
+			ResourceRequest: true,
+			Path:            "/apis/example.com/v1/namespaces/default/examples/my-example",
+		},
+		"customResourceSubgroup": &authorizer.AttributesRecord{
+			User:            tim,
+			Verb:            "get",
+			Namespace:       "default",
+			APIGroup:        "foo.example.com",
+			APIVersion:      "v1",
+			Resource:        "widgets",
+			Name:            "my-widget",
+			ResourceRequest: true,
+			Path:            "/apis/foo.example.com/v1/namespaces/default/widgets/my-widget",
+		},
 		"Unauthorized": &authorizer.AttributesRecord{
 			Verb:            "get",
 			Namespace:       "default",
@@ -181,6 +203,18 @@ var (
 				ResourceNames: []string{"edit"},
 			}},
 		},
+		"customAPIGroup": {
+			Level: audit.LevelMetadata,
+			Resources: []audit.GroupResources{{
+				Group: "example.com",
+			}},
+		},
+		"wildcardCustomAPIGroup": {
+			Level: audit.LevelRequestResponse,
+			Resources: []audit.GroupResources{{
+				Group: "*.example.com",
+			}},
+		},
 		"omit RequestReceived": {
 			Level: audit.LevelRequest,
 			OmitStages: []audit.Stage{
@@ -256,6 +290,9 @@ func testAuditLevel(t *testing.T, stages []audit.Stage) {
 	test(t, "subresource", audit.LevelRequest, stages, stages, "getPodWildcardMatching")
 	test(t, "subresource", audit.LevelRequest, stages, stages, "getPodResourceWildcardMatching")
 	test(t, "subresource", audit.LevelRequest, stages, stages, "getPodSubResourceWildcardMatching")
+
+	test(t, "customResource", audit.LevelMetadata, stages, stages, "customAPIGroup")
+	test(t, "customResourceSubgroup", audit.LevelRequestResponse, stages, stages, "wildcardCustomAPIGroup")
 
 	test(t, "Unauthorized", audit.LevelNone, stages, stages, "tims")
 	test(t, "Unauthorized", audit.LevelMetadata, stages, stages, "tims", "default")
@@ -443,6 +480,71 @@ func TestOmitManagedFields(t *testing.T) {
 			got := evaluator.EvaluatePolicyRule(attributes)
 			if test.want != got.OmitManagedFields {
 				t.Errorf("Expected OmitManagedFields to match, want: %t, got: %t", test.want, got.OmitManagedFields)
+			}
+		})
+	}
+}
+
+func Test_apiGroupMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiGroup string
+		gr       audit.GroupResources
+		want     bool
+	}{
+		{
+			name:     "exact match",
+			apiGroup: "example.com",
+			gr:       audit.GroupResources{Group: "example.com"},
+			want:     true,
+		},
+		{
+			name:     "no match",
+			apiGroup: "example.com",
+			gr:       audit.GroupResources{Group: "other.com"},
+			want:     false,
+		},
+		{
+			name:     "wildcard match",
+			apiGroup: "foo.example.com",
+			gr:       audit.GroupResources{Group: "*.example.com"},
+			want:     true,
+		},
+		{
+			name:     "wildcard no match",
+			apiGroup: "example.org",
+			gr:       audit.GroupResources{Group: "*.example.com"},
+			want:     false,
+		},
+		{
+			name:     "wildcard match subdomain",
+			apiGroup: "bar.foo.example.com",
+			gr:       audit.GroupResources{Group: "*.example.com"},
+			want:     true,
+		},
+		{
+			name:     "wildcard does not match root",
+			apiGroup: "example.com",
+			gr:       audit.GroupResources{Group: "*.example.com"},
+			want:     false,
+		},
+		{
+			name:     "star matches all groups",
+			apiGroup: "example.com",
+			gr:       audit.GroupResources{Group: "*"},
+			want:     true,
+		},
+		{
+			name:     "star matches core group",
+			apiGroup: "",
+			gr:       audit.GroupResources{Group: "*"},
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := apiGroupMatches(tt.apiGroup, tt.gr); got != tt.want {
+				t.Errorf("apiGroupMatches() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR allows a leading wildcard to be used for API groups in an audit policy. This is useful for applying a rule to all custom resources in a large organization (for example).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
An audit GroupResource.Group now allows leading wildcards in order to match subgroups. For example, `*.k8s.io` will match `example.k8s.io`. Note that it will *not* match `k8s.io`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
