### PR TITLE
feat: add exclusion label for node lifecycle management

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller_test.go
@@ -508,6 +508,51 @@ func Test_NodesDeleted(t *testing.T) {
 				ExistsByProviderID: false,
 			},
 		},
+		{
+			name: "node is not ready and does not exist, but has exclusion label",
+			existingNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						LabelNodeLifecycleExclude: "true",
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionFalse,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						LabelNodeLifecycleExclude: "true",
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionFalse,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedDeleted: false,
+			fakeCloud: &fakecloud.Cloud{
+				ExistsByProviderID: false,
+			},
+		},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
Add support for excluding nodes from CloudNodeLifecycleController management via the node.kubernetes.io/exclude-from-lifecycle-management label. Nodes with this label will not be deleted even when their corresponding cloud instances do not exist.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
from https://github.com/kubernetes/cloud-provider/pull/78

Add support for excluding nodes from CloudNodeLifecycleController management via the node.kubernetes.io/exclude-from-lifecycle-management label. Nodes with this label will not be deleted even when their corresponding cloud instances do not exist.
because of we always need to add node to cluster but cross cloud, maybe some BM machine, so we need a way to exclusion for ccm node-controller management

#### Which issue(s) this PR is related to:
"N/A"

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
-->
```docs

```
