### PR TITLE
[release 1.32] Update pod resize test to accept new cpu.weight conversion

### DIFF
--- a/test/e2e/framework/pod/cgroups_linux.go
+++ b/test/e2e/framework/pod/cgroups_linux.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"math"
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
+)
+
+func GetExpectedCPUShares(rr *v1.ResourceRequirements, podOnCgroupv2 bool) []string {
+	// This function is moved out from cgroups.go because opencontainers/cgroups can only be compiled in linux platforms.
+	cpuRequest := rr.Requests.Cpu()
+	cpuLimit := rr.Limits.Cpu()
+	var shares int64
+	if cpuRequest.IsZero() && !cpuLimit.IsZero() {
+		shares = int64(kubecm.MilliCPUToShares(cpuLimit.MilliValue()))
+	} else {
+		shares = int64(kubecm.MilliCPUToShares(cpuRequest.MilliValue()))
+	}
+	if podOnCgroupv2 {
+		// Because of https://github.com/kubernetes/kubernetes/issues/131216, the way of conversion has been changed.
+		// runc: https://github.com/opencontainers/runc/pull/4785
+		// crun: https://github.com/containers/crun/issues/1721
+		// This is dependent on the container runtime version. In order not to break the tests when we upgrade the
+		// container runtimes, we check if either the old or the new conversion matches the actual value for now.
+		// TODO: Remove the old conversion once container runtimes are updated.
+		oldConverted := 1 + ((shares-2)*9999)/262142
+		converted := ConvertCPUSharesToCgroupV2Value(uint64(shares))
+		return []string{strconv.FormatInt(oldConverted, 10), strconv.FormatInt(int64(converted), 10)}
+	} else {
+		return []string{strconv.FormatInt(shares, 10)}
+	}
+}
+
+// ConvertCPUSharesToCgroupV2Value matches opencontainers/cgroups, but avoids pulling it as a dependency.
+func ConvertCPUSharesToCgroupV2Value(cpuShares uint64) uint64 {
+	// The value of 0 means "unset".
+	if cpuShares == 0 {
+		return 0
+	}
+	if cpuShares <= 2 {
+		return 1
+	}
+	if cpuShares >= 262144 {
+		return 10000
+	}
+	l := math.Log2(float64(cpuShares))
+	// Quadratic function which fits min, max, and default.
+	exponent := (l*l+125*l)/612.0 - 7.0/34.0
+
+	return uint64(math.Ceil(math.Pow(10, exponent)))
+}

--- a/test/e2e/framework/pod/cgroups_unsupported.go
+++ b/test/e2e/framework/pod/cgroups_unsupported.go
@@ -1,0 +1,26 @@
+//go:build !linux
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import v1 "k8s.io/api/core/v1"
+
+func GetExpectedCPUShares(rr *v1.ResourceRequirements, podOnCgroupv2 bool) []string {
+	// cgroup is only supported in linux.
+	return []string{}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind failing-test

#### What this PR does / why we need it:
Tests are failing when clusters are using containerd 1.3.2+.
Backport of #132791.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Refs #135214

#### Special notes for your reviewer:

Cherry-pick of https://github.com/kubernetes/kubernetes/pull/135789

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
