### PR TITLE
[release-1.32] hack/lib/util.sh: support uutils' `date` command

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -720,22 +720,22 @@ function kube::util::ensure-gnu-sed {
   kube::util::sourced_variable "${SED}"
 }
 
-# kube::util::ensure-gnu-date
+# kube::util::ensure-gnu-compatible-date
 # Determines which date binary is gnu-date on linux/darwin
 #
 # Sets:
 #  DATE: The name of the gnu-date binary
 #
-function kube::util::ensure-gnu-date {
+function kube::util::ensure-gnu-compatible-date {
   # NOTE: the echo below is a workaround to ensure date is executed before the grep.
   # see: https://github.com/kubernetes/kubernetes/issues/87251
-  date_help="$(LANG=C date --help 2>&1 || true)"
-  if echo "${date_help}" | grep -q "GNU\|BusyBox"; then
+  date_version="$(LANG=C date --version 2>&1 || true)"
+  if echo "${date_version}" | grep -q "GNU\|BusyBox\|uutils"; then
     DATE="date"
   elif command -v gdate &>/dev/null; then
     DATE="gdate"
   else
-    kube::log::error "Failed to find GNU date as date or gdate. If you are on Mac: brew install coreutils." >&2
+    kube::log::error "Failed to find GNU-compatible date as date or gdate. If you are on Mac: brew install coreutils." >&2
     return 1
   fi
   kube::util::sourced_variable "${DATE}"

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -161,7 +161,7 @@ kube::version::ldflags() {
     )
   }
 
-  kube::util::ensure-gnu-date
+  kube::util::ensure-gnu-compatible-date
 
   add_ldflag "buildDate" "$(${DATE} ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} -u +'%Y-%m-%dT%H:%M:%SZ')"
   if [[ -n ${KUBE_GIT_COMMIT-} ]]; then


### PR DESCRIPTION
Cherry-pick:
- #135211
- - -
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Support uutils' `date` command.

Prior to this PR, `make` was printing the following warning on Ubuntu 25.10, which switched away from GNU coreutils to uutils:

```
!!! [1107 12:46:24] Failed to find GNU date as date or gdate. If you are on Mac: brew install coreutils.
<GOPATH>/src/k8s.io/kubernetes/hack/lib/version.sh: line 166: DATE: unbound variable
```


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #135210

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
