### PR TITLE
Update CoreDNS to v1.13.2

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -31,7 +31,7 @@ dependencies:
 
   # CoreDNS
   - name: "coredns-kube-up"
-    version: 1.13.1
+    version: 1.13.2
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
       match: registry.k8s.io/coredns
@@ -41,7 +41,7 @@ dependencies:
       match: registry.k8s.io/coredns
 
   - name: "coredns-kubeadm"
-    version: 1.13.1
+    version: 1.13.2
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -133,7 +133,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.13.1
+        image: registry.k8s.io/coredns/coredns:v1.13.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -133,7 +133,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.13.1
+        image: registry.k8s.io/coredns/coredns:v1.13.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -133,7 +133,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.13.1
+        image: registry.k8s.io/coredns/coredns:v1.13.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -364,7 +364,7 @@ const (
 	CoreDNSImageName = "coredns"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
-	CoreDNSVersion = "v1.13.1"
+	CoreDNSVersion = "v1.13.2"
 
 	// ClusterConfigurationKind is the string kind value for the ClusterConfiguration struct
 	ClusterConfigurationKind = "ClusterConfiguration"


### PR DESCRIPTION
This updates the CoreDNS image references to v1.13.2.

Note: The corefile-migration library (v1.0.29) does not yet include support for CoreDNS 1.13.2. A future update to corefile-migration will be needed for full kubeadm Corefile migration validation support.


/kind bug
/kind cleanup

Waiting for https://github.com/coredns/corefile-migration/pull/95 to be merged
