### PR TITLE
DRA device taints controller: add pohly to OWNERS

### DIFF
--- a/pkg/controller/devicetainteviction/OWNERS
+++ b/pkg/controller/devicetainteviction/OWNERS
@@ -2,7 +2,9 @@
 
 approvers:
   - sig-scheduling-maintainers
+  - pohly
 reviewers:
   - sig-scheduling
+  - pohly
 labels:
   - sig/scheduling


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

While the code is nominally owned by SIG Scheduling, in practice I am the one who knows it best, so I should be a reviewer and should be able to merge simple changes without additional approvals (will use cautiously!).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Discussed on Slack.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
