### PR TITLE
[DRAFT:NOT-FOR-REVIEW]Automated cherry pick of #135748: Update vendored hnslib to v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.5.0
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
 	github.com/Microsoft/go-winio v0.6.2
-	github.com/Microsoft/hnslib v0.1.1
+	github.com/Microsoft/hnslib v0.1.2
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/blang/semver/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Microsoft/hnslib v0.1.1 h1:JsZy681SnvSOUAfCZVAxkX4LgQGp+CZZwPbLV0/pdF8=
-github.com/Microsoft/hnslib v0.1.1/go.mod h1:DRQR4IjLae6WHYVhW7uqe44hmFUiNhmaWA+jwMbz5tM=
+github.com/Microsoft/hnslib v0.1.2 h1:CshjwTQsNx1o7BIA1XO8HtgDsiCqn+b6kGjL/tIxXQQ=
+github.com/Microsoft/hnslib v0.1.2/go.mod h1:5vTyBey4N/VI2ZTNh2gdWhkPMefSbCFYjpvVwye+qtI=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=

--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -216,7 +216,6 @@
         "sigs.k8s.io/structured-merge-diff/v6"
       ],
       "github.com/pkg/errors": [
-        "github.com/Microsoft/hnslib",
         "github.com/google/cadvisor",
         "sigs.k8s.io/kustomize/api",
         "sigs.k8s.io/kustomize/kustomize/v5"
@@ -287,7 +286,6 @@
       "github.com/mailru/easyjson",
       "github.com/modern-go/concurrent",
       "github.com/modern-go/reflect2",
-      "github.com/pkg/errors",
       "golang.org/x/exp",
       "gopkg.in/yaml.v3"
     ]

--- a/vendor/github.com/Microsoft/hnslib/hcn/hcnglobals.go
+++ b/vendor/github.com/Microsoft/hnslib/hcn/hcnglobals.go
@@ -90,6 +90,7 @@ var (
 	// HNS 15.5+ allows for Modify Loadbalancer support in Zn
 	ModifyLoadbalancerVersion = VersionRanges{
 		VersionRange{MinVersion: Version{Major: 15, Minor: 5}, MaxVersion: Version{Major: 15, Minor: math.MaxInt32}},
+		VersionRange{MinVersion: Version{Major: 16, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}},
 	}
 	// HNS 15.4 allows for Accelnet support
 	AccelnetVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}

--- a/vendor/github.com/Microsoft/hnslib/hcn/hcnnetwork.go
+++ b/vendor/github.com/Microsoft/hnslib/hcn/hcnnetwork.go
@@ -11,6 +11,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// SubnetFlags represents the flags that can be set on a subnet
+type SubnetFlags uint32
+
+// SubnetFlags constants (based on HNS API documentation)
+const (
+	SubnetFlagsNone                       SubnetFlags = 0
+	SubnetFlagsDoNotReserveGatewayAddress SubnetFlags = 1 // This flag is needed to support scenario  GatewayAddress == ManagementIP
+)
+
 // Route is associated with a subnet.
 type Route struct {
 	NextHop           string `json:",omitempty"`
@@ -23,6 +32,7 @@ type Subnet struct {
 	IpAddressPrefix string            `json:",omitempty"`
 	Policies        []json.RawMessage `json:",omitempty"`
 	Routes          []Route           `json:",omitempty"`
+	Flags           SubnetFlags       `json:",omitempty"`
 }
 
 // Ipam (Internet Protocol Address Management) is associated with a network

--- a/vendor/github.com/Microsoft/hnslib/hcn/hcnsupport.go
+++ b/vendor/github.com/Microsoft/hnslib/hcn/hcnsupport.go
@@ -3,9 +3,9 @@
 package hcn
 
 import (
+	"fmt"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -87,7 +87,7 @@ func getSupportedFeatures() (SupportedFeatures, error) {
 	globals, err := GetGlobals()
 	if err != nil {
 		// It's expected if this fails once, it should always fail. It should fail on pre 1803 builds for example.
-		return SupportedFeatures{}, errors.Wrap(err, "failed to query HCN version number: this is expected on pre 1803 builds.")
+		return SupportedFeatures{}, fmt.Errorf("failed to query HCN version number (this is expected on pre 1803 builds): %w", err)
 	}
 	features.Acl = AclFeatures{
 		AclAddressLists:       isFeatureSupported(globals.Version, HNSVersion1803),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -22,7 +22,7 @@ github.com/Microsoft/go-winio/internal/fs
 github.com/Microsoft/go-winio/internal/socket
 github.com/Microsoft/go-winio/internal/stringbuffer
 github.com/Microsoft/go-winio/pkg/guid
-# github.com/Microsoft/hnslib v0.1.1
+# github.com/Microsoft/hnslib v0.1.2
 ## explicit; go 1.22.0
 github.com/Microsoft/hnslib
 github.com/Microsoft/hnslib/hcn


### PR DESCRIPTION
Cherry pick of #135748 on release-1.34.

#135748: Update vendored hnslib to v0.1.2

/kind bug
/kind cleanup

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
- Dropped archived dependency: Removed the deprecated and archived dependency: github.com/pkg/errors in favor of standard Go error handling.
- Updated to latest HNS version: hnslib is updated to work with the latest HNS APIs, including support for ModifyLoadBalancerPolicy, which allows updating existing load balancer policies instead of delete-and-recreate flows.
```