### PR TITLE
Add an integration test for partial binding failure

### DIFF
--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -319,7 +319,8 @@ func initSchedulerWithPlugins(t *testing.T, testContext *testutils.TestContext, 
 func TestPartialBindingFailureRetriedWithNNN(t *testing.T) {
 	// `bindFailures` describes how many times the scheduler will fail to bind pod1 before restarting the scheduler and scheduling pod2.
 	// The scheduler is restarted during binding, so even with 0 bind failures, the prebind will complete, but bind will not.
-	for _, bindFailures := range []int{0, 1, 2} {
+	// TODO(brejman): add the test for 2 bind failures once the issue that makes it fail is fixed (#135771)
+	for _, bindFailures := range []int{0, 1} {
 		t.Run(fmt.Sprintf("Test pod binds on the originally determined node after successful prebind and %v failed bind attempts and scheduler restart", bindFailures), func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NominatedNodeNameForExpectation, true)
 			testContext := testutils.InitTestAPIServer(t, "nnn-test", nil)

--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -312,11 +312,13 @@ func initSchedulerWithPlugins(t *testing.T, testContext *testutils.TestContext, 
 // The test does the following:
 // 1. Set up 2 nodes able to hold one pod each
 // 2. Try to schedule pod1 with dynamically provisioned pvc1 N times, but force failure at pod binding each time
-// 3. Schedule pod2 with dynamically provisioned pvc2, preferring the same node as pod1
-// 4. Schedule pod1
-// 5. Verify that pod1 and pod2 have been scheduled successfully
+// 3. Restart the scheduler during pod1 binding
+// 4. Schedule pod2 with dynamically provisioned pvc2, preferring the same node as pod1
+// 5. Schedule pod1
+// 6. Verify that pod1 and pod2 have been scheduled successfully
 func TestPartialBindingFailureRetriedWithNNN(t *testing.T) {
-	// `bindFailures` describes how many times the scheduler will fail to bind pod1 before scheduling pod2.
+	// `bindFailures` describes how many times the scheduler will fail to bind pod1 before restarting the scheduler and scheduling pod2.
+	// The scheduler is restarted during binding, so even with 0 bind failures, the prebind will complete, but bind will not.
 	for _, bindFailures := range []int{0, 1, 2} {
 		t.Run(fmt.Sprintf("Test pod binds on the originally determined node after successful prebind and %v failed bind attempts and scheduler restart", bindFailures), func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NominatedNodeNameForExpectation, true)

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -226,7 +226,7 @@ func StartFakePVController(ctx context.Context, clientSet clientset.Interface, i
 		}
 	}
 
-	pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			syncPV(obj.(*v1.PersistentVolume))
 		},
@@ -235,7 +235,7 @@ func StartFakePVController(ctx context.Context, clientSet clientset.Interface, i
 		},
 	})
 
-	pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			syncPVC(obj.(*v1.PersistentVolumeClaim))
 		},

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -143,7 +143,8 @@ func CreateResourceClaimController(ctx context.Context, tb ktesting.TB, clientSe
 	}
 }
 
-// StartFakePVController is a simplified pv controller logic that sets PVC VolumeName and annotation for each PV binding.
+// StartFakePVController is a simplified pv controller logic that sets PVC VolumeName and annotation for each PV binding
+// and creates PVs for PVCs that use dynamic provisioning.
 // TODO(mborsz): Use a real PV controller here.
 func StartFakePVController(ctx context.Context, clientSet clientset.Interface, informerFactory informers.SharedInformerFactory) {
 	pvInformer := informerFactory.Core().V1().PersistentVolumes()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

This PR tests a scenario where scheduler restart happens at an unfortunate time, i.e.:

1. PreBind succeeds (e.g. PVC is bound to a node)
2. Bind fails (pod itself is not bound, but is locked into the PVC-bound node)

The test runs by first failing N bind attempts for a pod, then closing the scheduler at N+1 bind attempt, where N = {0,1,2}. Then it schedules another pod and checks if the scheduler correctly takes the previous scheduling decisions into account.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#135771

#### Special notes for your reviewer:

The test case for "2 failed bind attempts before restart" fails right now. The cause is described in https://github.com/kubernetes/kubernetes/issues/135771#issuecomment-3674757831

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
