### PR TITLE
[InPlacePodVerticalScaling] remove ineffectual static pod feasibility check

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -570,23 +570,6 @@ func TestRetryPendingResizes(t *testing.T) {
 			expectedResize:        nil,
 		},
 		{
-			name:                  "static pod, expect Infeasible",
-			originalRequests:      v1.ResourceList{v1.ResourceCPU: cpu1000m, v1.ResourceMemory: mem1000M},
-			newRequests:           v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
-			expectedAllocatedReqs: v1.ResourceList{v1.ResourceCPU: cpu1000m, v1.ResourceMemory: mem1000M},
-			annotations:           map[string]string{kubetypes.ConfigSourceAnnotationKey: kubetypes.FileSource},
-
-			expectedResize: []*v1.PodCondition{
-				{
-					Type:    v1.PodResizePending,
-					Status:  "True",
-					Reason:  "Infeasible",
-					Message: "In-place resize of static-pods is not supported",
-				},
-			},
-			expectPodSyncTriggered: "true",
-		},
-		{
 			name:                  "Increase CPU from min shares",
 			originalRequests:      v1.ResourceList{v1.ResourceCPU: cpu2m},
 			newRequests:           v1.ResourceList{v1.ResourceCPU: cpu1000m},
@@ -864,7 +847,6 @@ func TestRetryPendingResizes(t *testing.T) {
 		# HELP kubelet_pod_infeasible_resizes_total [ALPHA] Number of infeasible resizes for pods.
 	    # TYPE kubelet_pod_infeasible_resizes_total counter
 	    kubelet_pod_infeasible_resizes_total{reason_detail="insufficient_node_allocatable"} 5
-	    kubelet_pod_infeasible_resizes_total{reason_detail="static_pod"} 2
 	`
 	assert.NoError(t, testutil.GatherAndCompare(
 		legacyregistry.DefaultGatherer, strings.NewReader(expectedMetrics), "kubelet_pod_infeasible_resizes_total",

--- a/pkg/kubelet/allocation/features_linux.go
+++ b/pkg/kubelet/allocation/features_linux.go
@@ -23,15 +23,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 func IsInPlacePodVerticalScalingAllowed(pod *v1.Pod) (allowed bool, msg, reason string) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		return false, "InPlacePodVerticalScaling is disabled", "feature_gate_off"
-	}
-	if kubetypes.IsStaticPod(pod) {
-		return false, "In-place resize of static-pods is not supported", "static_pod"
 	}
 	return true, "", ""
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove the "static pod" feasibility check for pod resizes. It doesn't hurt to have the check here, but it doesn't do anything:
- The admission controller already blocks resize requests for mirror pods
- The kubelet treats modification of an underlying static pod manifest on the node as a "delete" followed by a "create", so resizing static pods in this way is permitted. I tried this on my own cluster to confirm.

#### Which issue(s) this PR is related to:

Related: https://github.com/kubernetes/kubernetes/issues/135341

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/assign @tallclair 
