### PR TITLE
Preempt pods based on their priority and qos

### DIFF
--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -176,12 +176,19 @@ func Preemptable(preemptor, preemptee *v1.Pod) bool {
 	if IsCriticalPod(preemptor) && !IsCriticalPod(preemptee) {
 		return true
 	}
-	if (preemptor != nil && preemptor.Spec.Priority != nil) &&
-		(preemptee != nil && preemptee.Spec.Priority != nil) {
-		return *(preemptor.Spec.Priority) > *(preemptee.Spec.Priority)
+
+	preemptorPriority := int32(0)
+	preempteePriority := int32(0)
+
+	if preemptor != nil && preemptor.Spec.Priority != nil {
+		preemptorPriority = *preemptor.Spec.Priority
 	}
 
-	return false
+	if preemptee != nil && preemptee.Spec.Priority != nil {
+		preempteePriority = *preemptee.Spec.Priority
+	}
+
+	return preemptorPriority > preempteePriority
 }
 
 // IsCriticalPodBasedOnPriority checks if the given pod is a critical pod based on priority resolved from pod Spec.

--- a/pkg/kubelet/types/pod_update_test.go
+++ b/pkg/kubelet/types/pod_update_test.go
@@ -323,6 +323,12 @@ func TestPreemptable(t *testing.T) {
 			preemptee: getTestPod(configSourceAnnotation(FileSource), &systemPriority, ""),
 			expected:  false,
 		},
+		{
+			name:      "a non critical pod with priority preempts a non critical pod without priority",
+			preemptor: getTestPod(nil, &systemPriority, ""),
+			preemptee: getTestPod(nil, nil, ""),
+			expected:  true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR changes the logic for preempting pods in Kubelet. Currently, only pods with lower QOS are considered for preemption, even when they are critical or have high priority. This PR considers the priority of pods as another factor when considering the set of pods that should be evicted. It first groups pods based on their priority and QOS, and then selects the best candidates in each group based on their distance to the requirements. This way, guaranteed pods with low priority can be evicted sooner than burstable pods with high priority.
#### Which issue(s) this PR is related to:
Fixes #135857
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Enabled priority-based pod preemption in Kubelet
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
