### PR TITLE
Build kubelet as a static binary (CGO_ENABLED=0)

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -327,6 +327,7 @@ readonly KUBE_STATIC_BINARIES=(
   kubeadm
   kubectl
   kubectl-convert
+  kubelet
   kubemark
   mounter
 )

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -331,6 +331,7 @@ readonly KUBE_STATIC_BINARIES=(
   kubeadm
   kubectl
   kubectl-convert
+  kubelet
   kubemark
   mounter
 )

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -27,7 +27,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -149,15 +148,14 @@ func (kl *Kubelet) getKubeletMappings(logger klog.Logger, idsPerPod uint32) (uin
 	// So we check for the kubelet user first, if it exist and getsubids is present, we expect
 	// to get _some_ configuration. If the user exist and getsubids doesn't give us any
 	// configuration, then we consider the remote down and fail to start the kubelet.
-	_, err := user.Lookup(kubeletUser)
+	found, err := getentUserExists(kubeletUser)
 	if err != nil {
-		var unknownUserErr user.UnknownUserError
-		if goerrors.As(err, &unknownUserErr) {
-			// if the user is not found, we assume that the user is not configured
-			logger.V(5).Info("user namespaces: user not found, using default mappings", "user", kubeletUser)
-			return defaultFirstID, defaultLen, nil
-		}
 		return 0, 0, err
+	}
+	if !found {
+		// if the user is not found, we assume that the user is not configured
+		logger.V(5).Info("user namespaces: user not found, using default mappings", "user", kubeletUser)
+		return defaultFirstID, defaultLen, nil
 	}
 
 	execName := "getsubids"
@@ -182,6 +180,24 @@ func (kl *Kubelet) getKubeletMappings(logger klog.Logger, idsPerPod uint32) (uin
 	}
 	logger.V(5).Info("user namespaces: user found, using mappings from getsubids", "user", kubeletUser)
 	return parseGetSubIdsOutput(string(outUids))
+}
+
+// getentUserExists checks name via getent(1), so it sees NSS accounts (sssd,
+// LDAP, FreeIPA) that a static (CGO_ENABLED=0) os/user would miss.
+func getentUserExists(name string) (bool, error) {
+	getent, err := exec.LookPath("getent")
+	if err != nil {
+		return false, nil // no getent: same as "not configured"
+	}
+	err = exec.Command(getent, "passwd", name).Run()
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if goerrors.As(err, &exitErr) && exitErr.ExitCode() == 2 {
+		return false, nil // getent(1): 2 = key not found
+	}
+	return false, fmt.Errorf("looking up user %q via getent: %w", name, err)
 }
 
 // Get a list of pods that have data directories.

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -8567,6 +8567,64 @@ func TestParseGetSubIdsOutput(t *testing.T) {
 	}
 }
 
+func TestGetentUserExists(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("getent is a Linux tool")
+	}
+	tests := []struct {
+		name       string
+		getentExit string // shell script body for a fake "getent"; empty means no getent on PATH
+		wantFound  bool
+		wantErr    bool
+	}{
+		{
+			name:       "user found",
+			getentExit: "exit 0",
+			wantFound:  true,
+		},
+		{
+			name:       "user not found",
+			getentExit: "exit 2", // getent(1): 2 = key not found
+			wantFound:  false,
+		},
+		{
+			name:       "getent fails for another reason",
+			getentExit: "exit 1",
+			wantErr:    true,
+		},
+		{
+			name:      "getent not installed",
+			wantFound: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			if tc.getentExit != "" {
+				script := "#!/bin/sh\n" + tc.getentExit + "\n"
+				if err := os.WriteFile(filepath.Join(binDir, "getent"), []byte(script), 0o755); err != nil {
+					t.Fatalf("writing fake getent: %v", err)
+				}
+			}
+			t.Setenv("PATH", binDir)
+
+			found, err := getentUserExists("kubelet")
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("%s: expected error, got nil", tc.name)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+			}
+			if found != tc.wantFound {
+				t.Errorf("%s: got found=%v, want %v", tc.name, found, tc.wantFound)
+			}
+		})
+	}
+}
+
 func TestResolveRecursiveReadOnly(t *testing.T) {
 	testCases := []struct {
 		m                  v1.VolumeMount


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add kubelet to KUBE_STATIC_BINARIES so it is built without CGO by default,
like all other core Kubernetes binaries. This eliminates the glibc version
dependency, improving portability across Linux distributions.

To restore the previous behavior (CGO enabled):

  Regular builds:
    KUBE_CGO_OVERRIDES=kubelet make WHAT=cmd/kubelet

  E2e node tests:
    KUBE_CGO_OVERRIDES=kubelet make test-e2e-node

Also fixes the kubelet user namespace ID lookup: a CGO_ENABLED=0 kubelet's
os/user only reads /etc/passwd, so it silently missed accounts served by
NSS (sssd, LDAP, FreeIPA). getKubeletMappings now checks via getent(1)
instead, which resolves through NSS either way.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/135860

#### Special notes for your reviewer:

The getent-based lookup fix addresses a review finding from thc1006.

#### Does this PR introduce a user-facing change?

```release-note
kubelet is built by default without using CGO across all platforms. If you need CGO support, please use KUBE_CGO_OVERRIDES env variable when building kubernetes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
Kubelet now builds as a static binary (CGO_ENABLED=0). This changes how kubelet finds the kubelet system account used for user namespace ID ranges (feature UserNamespacesSupport, on by default since 1.36). If a node resolves the kubelet account through a directory service — LDAP, sssd, or FreeIPA — instead of a local /etc/passwd entry, kubelet now needs the getent command to see it. Most Linux distributions include getent already. If getent is missing, kubelet cannot find the account, and it silently falls back to the default ID range instead of the configured one. Confirm getent is on the node's PATH before you rely on a directory-service-managed kubelet account
```

#### AI usage disclosure:

YES — the getent-based user namespace lookup fix was drafted with an AI coding assistant, reviewed by the author.