### PR TITLE
Fix(scheduler): resolve queue race and strengthen perf tool validation

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -504,5 +504,7 @@ func (aq *activeQueue) close() {
 
 // broadcast notifies the pop() operation that new pod(s) was added to the activeQueue.
 func (aq *activeQueue) broadcast() {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
 	aq.cond.Broadcast()
 }

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -19,10 +19,10 @@ package noderesources
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -215,7 +215,10 @@ func TestBrokenLinearFunction(t *testing.T) {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			function := helper.BuildBrokenLinearFunction(test.points)
 			for _, assertion := range test.assertions {
-				assert.InDelta(t, assertion.expected, function(assertion.p), 0.1, "points=%v, p=%d", test.points, assertion.p)
+				got := function(assertion.p)
+				if math.Abs(float64(got-assertion.expected)) > 0.1 {
+					t.Errorf("points=%v, p=%d: expected %d, got %d", test.points, assertion.p, assertion.expected, got)
+				}
 			}
 		})
 	}

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -659,7 +659,7 @@ type createNamespacesOp struct {
 
 func (cmo *createNamespacesOp) isValid(allowParameterization bool) error {
 	if cmo.Prefix == "" {
-		return fmt.Errorf("Prefix must be set")
+		return fmt.Errorf("prefix must be set")
 	}
 	if !isValidCount(allowParameterization, cmo.Count, cmo.CountParam) {
 		return fmt.Errorf("invalid Count=%d / CountParam=%q", cmo.Count, cmo.CountParam)
@@ -851,7 +851,7 @@ func (dpo *deletePodsOp) isValid(allowParameterization bool) error {
 		return fmt.Errorf("invalid opcode %q; expected %q", dpo.Opcode, deletePodsOpcode)
 	}
 	if dpo.Namespace == "" {
-		return fmt.Errorf("Namespace must be set")
+		return fmt.Errorf("namespace must be set")
 	}
 	if dpo.DeletePodsPerSecond < 0 {
 		return fmt.Errorf("invalid DeletePodsPerSecond=%d; should be non-negative", dpo.DeletePodsPerSecond)
@@ -971,7 +971,7 @@ type sleepOp struct {
 
 func (so *sleepOp) isValid(_ bool) error {
 	if so.Duration.Duration < 0 {
-		return fmt.Errorf("Duration must be non-negative")
+		return fmt.Errorf("duration must be non-negative")
 	}
 	return nil
 }

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -658,6 +658,9 @@ type createNamespacesOp struct {
 }
 
 func (cmo *createNamespacesOp) isValid(allowParameterization bool) error {
+	if cmo.Prefix == "" {
+		return fmt.Errorf("Prefix must be set")
+	}
 	if !isValidCount(allowParameterization, cmo.Count, cmo.CountParam) {
 		return fmt.Errorf("invalid Count=%d / CountParam=%q", cmo.Count, cmo.CountParam)
 	}
@@ -847,6 +850,9 @@ func (dpo *deletePodsOp) isValid(allowParameterization bool) error {
 	if dpo.Opcode != deletePodsOpcode {
 		return fmt.Errorf("invalid opcode %q; expected %q", dpo.Opcode, deletePodsOpcode)
 	}
+	if dpo.Namespace == "" {
+		return fmt.Errorf("Namespace must be set")
+	}
 	if dpo.DeletePodsPerSecond < 0 {
 		return fmt.Errorf("invalid DeletePodsPerSecond=%d; should be non-negative", dpo.DeletePodsPerSecond)
 	}
@@ -964,6 +970,9 @@ type sleepOp struct {
 }
 
 func (so *sleepOp) isValid(_ bool) error {
+	if so.Duration.Duration < 0 {
+		return fmt.Errorf("Duration must be non-negative")
+	}
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig scheduling

#### What this PR does / why we need it:
1. Fixes a potential race condition in `activeQueue.broadcast()` by acquiring the lock before broadcasting.
2. Adds validation for `Prefix`, `Namespace`, and `Duration` fields in the scheduler performance testing tool to prevent invalid configurations.

#### Which issue(s) this PR is related to:
NONE

#### Special notes for your reviewer:
The race fix ensures thread safety when signaling condition variables in the scheduling queue.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```