### PR TITLE
Normalize RuntimeClass handler paths for list validation

### DIFF
--- a/pkg/apis/node/validation/validation.go
+++ b/pkg/apis/node/validation/validation.go
@@ -17,21 +17,23 @@ limitations under the License.
 package validation
 
 import (
+	"regexp"
+
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/node"
-	"regexp"
 )
 
 // Define normalization rules to handle field name differences across API versions
 // v1alpha1 uses "spec.runtimeHandler" while v1/v1beta1 use "handler"
 var NodeNormalizationRules = []field.NormalizationRule{
 	{
-		Regexp:      regexp.MustCompile(`^spec\.runtimeHandler(.*)$`),
-		Replacement: "handler$1",
+		// Handle list items: items[0].spec.runtimeHandler -> items[0].handler
+		Regexp:      regexp.MustCompile(`^(items\[[0-9]+\]\.)?spec\.runtimeHandler(.*)$`),
+		Replacement: "${1}handler$2",
 	},
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes versioned validation equivalence failures for
RuntimeClass after enabling declarative validation, which was done as part of this PR -https://github.com/kubernetes/kubernetes/pull/135046/files

RuntimeClass evolved across versions:
- v1alpha1 uses spec.runtimeHandler
- v1beta1 and v1 use handler

Declarative validation reports errors using the versioned schema paths.
When validating list objects (RuntimeClassList), this results in
different error paths such as:

items[0].spec.runtimeHandler   (v1alpha1)
items[0].handler               (v1 / v1beta1)

Although these errors refer to the same logical field, the fuzz test
requires byte-for-byte equivalence and fails due to the path mismatch.

Prior normalization rules only handled object-level paths starting with
spec.runtimeHandler. With declarative validation, list-level paths
(items[n].spec.runtimeHandler) are now common and were not normalized.

This PR updates NodeNormalizationRules to:

- Preserve any items[n]. list prefix

 - Rewrite spec.runtimeHandler to the canonical handler field

 - Preserve any trailing sub-paths
This brings all API versions into alignment for validation comparison.
#### Which issue(s) this PR is related to:
<!--

Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The failure rate is higher -https://storage.googleapis.com/k8s-triage/index.html?text=TestVersionedValidationByFuzzing&xjob=s3
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
