### PR TITLE
Add new staging module - `constants`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -211,6 +211,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
@@ -230,6 +231,7 @@ replace (
 	k8s.io/code-generator => ./staging/src/k8s.io/code-generator
 	k8s.io/component-base => ./staging/src/k8s.io/component-base
 	k8s.io/component-helpers => ./staging/src/k8s.io/component-helpers
+	k8s.io/constants => ./staging/src/k8s.io/constants
 	k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
 	k8s.io/cri-api => ./staging/src/k8s.io/cri-api
 	k8s.io/cri-client => ./staging/src/k8s.io/cri-client

--- a/go.work
+++ b/go.work
@@ -17,6 +17,7 @@ use (
 	./staging/src/k8s.io/code-generator
 	./staging/src/k8s.io/component-base
 	./staging/src/k8s.io/component-helpers
+	./staging/src/k8s.io/constants
 	./staging/src/k8s.io/controller-manager
 	./staging/src/k8s.io/cri-api
 	./staging/src/k8s.io/cri-client

--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -37,6 +37,7 @@
 - baseImportPath: "./staging/src/k8s.io/apimachinery"
   allowedImports:
   - k8s.io/apimachinery
+  - k8s.io/constants
   - k8s.io/kube-openapi
   - k8s.io/streaming
   - k8s.io/utils/clock
@@ -50,6 +51,7 @@
   allowedImports:
   - k8s.io/api
   - k8s.io/apimachinery
+  - k8s.io/constants
   - k8s.io/klog
 
 - baseImportPath: "./staging/src/k8s.io/code-generator"
@@ -154,6 +156,7 @@
   - k8s.io/client-go
   - k8s.io/component-base
   - k8s.io/component-helpers
+  - k8s.io/constants
   - k8s.io/kubectl
   - k8s.io/kube-openapi
   - k8s.io/metrics

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1,7 +1,20 @@
 rules:
+# constants is published first as it has zero dependencies.
+# Other modules can depend on it for well-known Kubernetes constants.
+- destination: constants
+  branches:
+  - name: master
+    source:
+      branch: master
+      dirs:
+      - staging/src/k8s.io/constants
+  library: true
 - destination: streaming
   branches:
   - name: master
+    dependencies:
+    - repository: constants
+      branch: master
     source:
       branch: master
       dirs:
@@ -16,6 +29,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: streaming
       branch: master
     source:
@@ -55,6 +70,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -110,6 +127,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -201,6 +220,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -255,6 +276,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -334,6 +357,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -464,6 +489,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -567,6 +594,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -693,6 +722,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -849,6 +880,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -969,6 +1002,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -1107,6 +1142,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -1198,6 +1235,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: api
       branch: master
     - repository: apimachinery
@@ -1277,6 +1316,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: api
       branch: master
     - repository: apimachinery
@@ -1367,6 +1408,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -1491,6 +1534,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: api
       branch: master
     - repository: apimachinery
@@ -1613,6 +1658,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -1728,6 +1775,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: api
       branch: master
     - repository: apimachinery
@@ -1843,6 +1892,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: api
       branch: master
     - repository: apimachinery
@@ -1982,6 +2033,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -2133,6 +2186,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -2200,6 +2255,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: api
       branch: master
     - repository: apimachinery
@@ -2300,6 +2357,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: api
       branch: master
     - repository: apimachinery
@@ -2439,6 +2498,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: api
       branch: master
     - repository: apimachinery
@@ -2554,6 +2615,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -2700,6 +2763,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: apimachinery
       branch: master
     - repository: streaming
@@ -2831,6 +2896,8 @@ rules:
   branches:
   - name: master
     dependencies:
+    - repository: constants
+      branch: master
     - repository: api
       branch: master
     - repository: apimachinery

--- a/staging/src/k8s.io/api/core/v1/well_known_labels.go
+++ b/staging/src/k8s.io/api/core/v1/well_known_labels.go
@@ -16,22 +16,28 @@ limitations under the License.
 
 package v1
 
+import (
+	"k8s.io/constants/annotations"
+	"k8s.io/constants/labels"
+)
+
+// Well-known labels re-exported from k8s.io/constants/labels for backwards compatibility.
 const (
-	LabelHostname = "kubernetes.io/hostname"
+	LabelHostname = labels.Hostname
 
 	// Label value is the network location of kube-apiserver stored as <ip:port>
 	// Stored in APIServer Identity lease objects to view what address is used for peer proxy
-	AnnotationPeerAdvertiseAddress = "kubernetes.io/peer-advertise-address"
+	AnnotationPeerAdvertiseAddress = annotations.PeerAdvertiseAddress
 
-	LabelTopologyZone   = "topology.kubernetes.io/zone"
-	LabelTopologyRegion = "topology.kubernetes.io/region"
+	LabelTopologyZone   = labels.TopologyZone
+	LabelTopologyRegion = labels.TopologyRegion
 
 	// These label have been deprecated since 1.17, but will be supported for
 	// the foreseeable future, to accommodate things like long-lived PVs that
 	// use them.  New users should prefer the "topology.kubernetes.io/*"
 	// equivalents.
-	LabelFailureDomainBetaZone   = "failure-domain.beta.kubernetes.io/zone"   // deprecated
-	LabelFailureDomainBetaRegion = "failure-domain.beta.kubernetes.io/region" // deprecated
+	LabelFailureDomainBetaZone   = labels.DeprecatedFailureDomainBetaZone   // deprecated
+	LabelFailureDomainBetaRegion = labels.DeprecatedFailureDomainBetaRegion // deprecated
 
 	// Retained for compat when vendored.  Do not use these consts in new code.
 	LabelZoneFailureDomain       = LabelFailureDomainBetaZone   // deprecated
@@ -39,36 +45,37 @@ const (
 	LabelZoneFailureDomainStable = LabelTopologyZone            // deprecated
 	LabelZoneRegionStable        = LabelTopologyRegion          // deprecated
 
-	LabelInstanceType       = "beta.kubernetes.io/instance-type"
-	LabelInstanceTypeStable = "node.kubernetes.io/instance-type"
+	LabelInstanceType       = labels.DeprecatedInstanceType
+	LabelInstanceTypeStable = labels.InstanceTypeStable
 
-	LabelOSStable   = "kubernetes.io/os"
-	LabelArchStable = "kubernetes.io/arch"
+	LabelOSStable   = labels.OSStable
+	LabelArchStable = labels.ArchStable
 
 	// LabelWindowsBuild is used on Windows nodes to specify the Windows build number starting with v1.17.0.
 	// It's in the format MajorVersion.MinorVersion.BuildNumber (for ex: 10.0.17763)
-	LabelWindowsBuild = "node.kubernetes.io/windows-build"
+	LabelWindowsBuild = labels.WindowsBuild
 
 	// LabelNamespaceSuffixKubelet is an allowed label namespace suffix kubelets can self-set ([*.]kubelet.kubernetes.io/*)
-	LabelNamespaceSuffixKubelet = "kubelet.kubernetes.io"
+	LabelNamespaceSuffixKubelet = labels.NamespaceSuffixKubelet
 	// LabelNamespaceSuffixNode is an allowed label namespace suffix kubelets can self-set ([*.]node.kubernetes.io/*)
-	LabelNamespaceSuffixNode = "node.kubernetes.io"
+	LabelNamespaceSuffixNode = labels.NamespaceSuffixNode
 
 	// LabelNamespaceNodeRestriction is a forbidden label namespace that kubelets may not self-set when the NodeRestriction admission plugin is enabled
-	LabelNamespaceNodeRestriction = "node-restriction.kubernetes.io"
+	LabelNamespaceNodeRestriction = labels.NamespaceNodeRestriction
 
-	// IsHeadlessService is added by Controller to an Endpoint denoting if its parent
-	// Service is Headless. The existence of this label can be used further by other
-	// controllers and kube-proxy to check if the Endpoint objects should be replicated when
-	// using Headless Services
-	IsHeadlessService = "service.kubernetes.io/headless"
+	// IsHeadlessService is added by the Endpoints and EndpointSlice controllers
+	// to Endpoints and EndpointSlices denoting that their parent Service is
+	// Headless. The existence of this label can be used by other controllers
+	// and kube-proxy to decide whether the Endpoint objects should be replicated
+	// when using Headless Services.
+	IsHeadlessService = labels.IsHeadlessService
 
 	// LabelNodeExcludeBalancers specifies that the node should not be considered as a target
 	// for external load-balancers which use nodes as a second hop (e.g. many cloud LBs which only
 	// understand nodes). For services that use externalTrafficPolicy=Local, this may mean that
 	// any backends on excluded nodes are not reachable by those external load-balancers.
 	// Implementations of this exclusion may vary based on provider.
-	LabelNodeExcludeBalancers = "node.kubernetes.io/exclude-from-external-load-balancers"
+	LabelNodeExcludeBalancers = labels.NodeExcludeBalancers
 	// LabelMetadataName is the label name which, in-tree, is used to automatically label namespaces, so they can be selected easily by tools which require definitive labels
-	LabelMetadataName = "kubernetes.io/metadata.name"
+	LabelMetadataName = labels.MetadataName
 )

--- a/staging/src/k8s.io/api/core/v1/well_known_taints.go
+++ b/staging/src/k8s.io/api/core/v1/well_known_taints.go
@@ -16,37 +16,42 @@ limitations under the License.
 
 package v1
 
+import (
+	"k8s.io/constants/taints"
+)
+
+// Well-known taints re-exported from k8s.io/constants/taints for backwards compatibility.
 const (
 	// TaintNodeNotReady will be added when node is not ready
 	// and removed when node becomes ready.
-	TaintNodeNotReady = "node.kubernetes.io/not-ready"
+	TaintNodeNotReady = taints.NodeNotReady
 
 	// TaintNodeUnreachable will be added when node becomes unreachable
 	// (corresponding to NodeReady status ConditionUnknown)
 	// and removed when node becomes reachable (NodeReady status ConditionTrue).
-	TaintNodeUnreachable = "node.kubernetes.io/unreachable"
+	TaintNodeUnreachable = taints.NodeUnreachable
 
 	// TaintNodeUnschedulable will be added when node becomes unschedulable
 	// and removed when node becomes schedulable.
-	TaintNodeUnschedulable = "node.kubernetes.io/unschedulable"
+	TaintNodeUnschedulable = taints.NodeUnschedulable
 
 	// TaintNodeMemoryPressure will be added when node has memory pressure
 	// and removed when node has enough memory.
-	TaintNodeMemoryPressure = "node.kubernetes.io/memory-pressure"
+	TaintNodeMemoryPressure = taints.NodeMemoryPressure
 
 	// TaintNodeDiskPressure will be added when node has disk pressure
 	// and removed when node has enough disk.
-	TaintNodeDiskPressure = "node.kubernetes.io/disk-pressure"
+	TaintNodeDiskPressure = taints.NodeDiskPressure
 
 	// TaintNodeNetworkUnavailable will be added when node's network is unavailable
 	// and removed when network becomes ready.
-	TaintNodeNetworkUnavailable = "node.kubernetes.io/network-unavailable"
+	TaintNodeNetworkUnavailable = taints.NodeNetworkUnavailable
 
 	// TaintNodePIDPressure will be added when node has pid pressure
 	// and removed when node has enough pid.
-	TaintNodePIDPressure = "node.kubernetes.io/pid-pressure"
+	TaintNodePIDPressure = taints.NodePIDPressure
 
 	// TaintNodeOutOfService can be added when node is out of service in case of
 	// a non-graceful shutdown
-	TaintNodeOutOfService = "node.kubernetes.io/out-of-service"
+	TaintNodeOutOfService = taints.NodeOutOfService
 )

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -8,6 +8,7 @@ godebug default=go1.26
 
 require (
 	k8s.io/apimachinery v0.0.0
+	k8s.io/constants v0.0.0
 	k8s.io/klog/v2 v2.140.0
 )
 
@@ -37,5 +38,6 @@ require (
 
 replace (
 	k8s.io/apimachinery => ../apimachinery
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/constants/rfc"
 )
 
 const (
@@ -291,7 +291,7 @@ const ResourceSliceMaxDevices = 128
 // - list attributes (DRAListTypeAttributes feature gate)
 const ResourceSliceMaxDevicesWithAdvancedFeatures = 64
 
-const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
+const PoolNameMaxLength = rfc.DNS1123SubdomainMaxLength // Same as for a single node name.
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/constants/rfc"
 )
 
 const (
@@ -284,7 +284,7 @@ const ResourceSliceMaxDevices = 128
 // - list attributes (DRAListTypeAttributes feature gate)
 const ResourceSliceMaxDevicesWithAdvancedFeatures = 64
 
-const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
+const PoolNameMaxLength = rfc.DNS1123SubdomainMaxLength // Same as for a single node name.
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/constants/rfc"
 )
 
 const (
@@ -276,7 +276,7 @@ const ResourceSliceMaxDevices = 128
 // - list attributes (DRAListTypeAttributes feature gate)
 const ResourceSliceMaxDevicesWithAdvancedFeatures = 64
 
-const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
+const PoolNameMaxLength = rfc.DNS1123SubdomainMaxLength // Same as for a single node name.
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
 

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -120,6 +120,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/kms v0.0.0 // indirect
 	k8s.io/streaming v0.0.0 // indirect
@@ -133,6 +134,7 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/time v0.14.0
 	gopkg.in/evanphx/json-patch.v4 v4.13.0
 	gopkg.in/inf.v0 v0.9.1
+	k8s.io/constants v0.0.0
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a
 	k8s.io/streaming v0.0.0
@@ -50,4 +51,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace k8s.io/streaming => ../streaming
+replace (
+	k8s.io/constants => ../constants
+	k8s.io/streaming => ../streaming
+)

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/content/dns.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/content/dns.go
@@ -18,6 +18,8 @@ package content
 
 import (
 	"regexp"
+
+	"k8s.io/constants/rfc"
 )
 
 const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
@@ -25,7 +27,8 @@ const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
 const dns1123LabelErrMsg string = "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
 
 // DNS1123LabelMaxLength is a label's max length in DNS (RFC 1123)
-const DNS1123LabelMaxLength int = 63
+// Re-exported from k8s.io/constants/rfc for backwards compatibility.
+const DNS1123LabelMaxLength int = rfc.DNS1123LabelMaxLength
 
 var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
 
@@ -54,7 +57,8 @@ const dns1123SubdomainErrorMsg string = "a lowercase RFC 1123 subdomain must con
 const dns1123SubdomainCaselessErrorMsg string = "an RFC 1123 subdomain must consist of alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
 
 // DNS1123SubdomainMaxLength is a subdomain's max length in DNS (RFC 1123)
-const DNS1123SubdomainMaxLength int = 253
+// Re-exported from k8s.io/constants/rfc for backwards compatibility.
+const DNS1123SubdomainMaxLength int = rfc.DNS1123SubdomainMaxLength
 
 var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
 var dns1123SubdomainCaselessRegexp = regexp.MustCompile("^" + dns1123SubdomainFmtCaseless + "$")

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/content/kube.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/content/kube.go
@@ -19,6 +19,8 @@ package content
 import (
 	"regexp"
 	"strings"
+
+	"k8s.io/constants/limits"
 )
 
 const labelKeyCharFmt string = "[A-Za-z0-9]"
@@ -75,7 +77,8 @@ const labelValueFmt string = "(" + labelKeyFmt + ")?"
 const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
 
 // LabelValueMaxLength is a label's max length
-const LabelValueMaxLength int = 63
+// Re-exported from k8s.io/constants/limits for backwards compatibility.
+const LabelValueMaxLength int = limits.LabelValueMaxLength
 
 var labelValueRegexp = regexp.MustCompile("^" + labelValueFmt + "$")
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/constants/limits"
 
 	"k8s.io/utils/ptr"
 )
@@ -206,7 +207,8 @@ func ValidatePatchOptions(options *metav1.PatchOptions, patchType types.PatchTyp
 	return allErrs
 }
 
-var FieldManagerMaxLength = 128
+// FieldManagerMaxLength is re-exported from k8s.io/constants/limits for backwards compatibility.
+var FieldManagerMaxLength = limits.FieldManagerMaxLength
 
 // ValidateFieldManager valides that the fieldManager is the proper length and
 // only has printable characters.

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -24,8 +24,8 @@ import (
 	"unicode"
 
 	"k8s.io/apimachinery/pkg/api/validate/content"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/constants/rfc"
 )
 
 // IsQualifiedName tests whether the value passed is what Kubernetes calls a
@@ -158,7 +158,8 @@ const dns1123LabelFmtWithUnderscore string = "_?[a-z0-9]([-_a-z0-9]*[a-z0-9])?"
 const dns1123LabelErrMsg string = "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
 
 // DNS1123LabelMaxLength is a label's max length in DNS (RFC 1123)
-const DNS1123LabelMaxLength int = 63
+// Re-exported from k8s.io/constants/rfc for backwards compatibility.
+const DNS1123LabelMaxLength int = rfc.DNS1123LabelMaxLength
 
 var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
 
@@ -188,7 +189,8 @@ const dns1123SubdomainFmtWithUnderscore string = dns1123LabelFmtWithUnderscore +
 const dns1123SubdomainErrorMsgFG string = "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '_', '-' or '.', and must start and end with an alphanumeric character"
 
 // DNS1123SubdomainMaxLength is a subdomain's max length in DNS (RFC 1123)
-const DNS1123SubdomainMaxLength int = 253
+// Re-exported from k8s.io/constants/rfc for backwards compatibility.
+const DNS1123SubdomainMaxLength int = rfc.DNS1123SubdomainMaxLength
 
 var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
 var dns1123SubdomainRegexpWithUnderscore = regexp.MustCompile("^" + dns1123SubdomainFmtWithUnderscore + "$")
@@ -223,7 +225,8 @@ const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
 const dns1035LabelErrMsg string = "a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
 
 // DNS1035LabelMaxLength is a label's max length in DNS (RFC 1035)
-const DNS1035LabelMaxLength int = 63
+// Re-exported from k8s.io/constants/rfc for backwards compatibility.
+const DNS1035LabelMaxLength int = rfc.DNS1035LabelMaxLength
 
 var dns1035LabelRegexp = regexp.MustCompile("^" + dns1035LabelFmt + "$")
 

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -122,6 +122,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 )
 
 replace (
@@ -129,6 +130,7 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -63,6 +63,7 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
@@ -72,5 +73,6 @@ replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -58,10 +58,12 @@ require (
 	golang.org/x/text v0.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 )
 
 replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -102,6 +102,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kms v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.0.0 // indirect
@@ -119,6 +120,7 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/component-helpers => ../component-helpers
+	k8s.io/constants => ../constants
 	k8s.io/controller-manager => ../controller-manager
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming

--- a/staging/src/k8s.io/cluster-bootstrap/go.mod
+++ b/staging/src/k8s.io/cluster-bootstrap/go.mod
@@ -30,6 +30,7 @@ require (
 	golang.org/x/text v0.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
@@ -40,5 +41,6 @@ require (
 replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/code-generator/examples/go.mod
+++ b/staging/src/k8s.io/code-generator/examples/go.mod
@@ -44,6 +44,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
@@ -55,4 +56,5 @@ replace (
 	k8s.io/api => ../../api
 	k8s.io/apimachinery => ../../apimachinery
 	k8s.io/client-go => ../../client-go
+	k8s.io/constants => ../../constants
 )

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -44,11 +44,13 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
 
 replace (
 	k8s.io/apimachinery => ../apimachinery
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -79,6 +79,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.0.0 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
@@ -89,5 +90,6 @@ replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/component-helpers/go.mod
+++ b/staging/src/k8s.io/component-helpers/go.mod
@@ -44,6 +44,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
@@ -55,5 +56,6 @@ replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/constants/.github/PULL_REQUEST_TEMPLATE.md
+++ b/staging/src/k8s.io/constants/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+Sorry, we do not accept changes directly against this repository. Please see
+CONTRIBUTING.md for information on where and how to contribute instead.

--- a/staging/src/k8s.io/constants/LICENSE
+++ b/staging/src/k8s.io/constants/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/staging/src/k8s.io/constants/OWNERS
+++ b/staging/src/k8s.io/constants/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
+filters:
+  ".*":
+    approvers:
+      - api-approvers
+    reviewers:
+      - api-reviewers
+  "go\\.(mod|sum|work|work\\.sum)$":
+    approvers:
+      - dep-approvers
+    reviewers:
+      - dep-reviewers

--- a/staging/src/k8s.io/constants/README.md
+++ b/staging/src/k8s.io/constants/README.md
@@ -1,0 +1,146 @@
+# constants
+
+This module contains well-known constants used throughout Kubernetes.
+
+It has zero dependencies, making it suitable for external consumers who need
+Kubernetes constants without pulling in larger modules like `k8s.io/apimachinery`
+or `k8s.io/api`.
+
+## Packages
+
+- `rfc/` — length constants for Kubernetes name-like fields (historically named after DNS 1123/1035)
+- `limits/` — Kubernetes-specific size limits (label value/key, field manager)
+- `labels/` — well-known label keys
+- `annotations/` — well-known annotation keys
+- `taints/` — well-known node taints
+
+Identifiers in `labels/`, `annotations/`, and `taints/` intentionally omit the
+package-name prefix (`labels.Hostname`, not `labels.LabelHostname`).
+
+## Usage
+
+```go
+import (
+    "k8s.io/constants/rfc"
+    "k8s.io/constants/labels"
+)
+
+// Length constant
+if len(name) > rfc.DNS1123SubdomainMaxLength {
+    // ...
+}
+
+// Well-known label
+zone := node.Labels[labels.TopologyZone]
+```
+
+## Compatibility
+
+All constants that previously lived in `k8s.io/apimachinery` and `k8s.io/api/core/v1`
+are re-exported from their original locations and retain their legacy names, so
+existing code does not need to change.
+
+## Migrating from apimachinery/api to k8s.io/constants
+
+New code, and code that wants to minimise its dependency footprint, should import
+from `k8s.io/constants/*` directly. The legacy import paths continue to work; this
+module is simply the lighter-weight source.
+
+### Length and size constants
+
+Previously sourced from `k8s.io/apimachinery/pkg/util/validation` or
+`k8s.io/apimachinery/pkg/apis/meta/v1/validation`:
+
+```go
+// Before
+import "k8s.io/apimachinery/pkg/util/validation"
+_ = validation.DNS1123SubdomainMaxLength
+_ = validation.DNS1123LabelMaxLength
+_ = validation.DNS1035LabelMaxLength
+_ = validation.LabelValueMaxLength
+
+import metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+_ = metav1validation.FieldManagerMaxLength
+
+// After
+import (
+    "k8s.io/constants/rfc"
+    "k8s.io/constants/limits"
+)
+_ = rfc.DNS1123SubdomainMaxLength
+_ = rfc.DNS1123LabelMaxLength
+_ = rfc.DNS1035LabelMaxLength
+_ = limits.LabelValueMaxLength
+_ = limits.FieldManagerMaxLength
+```
+
+### Well-known labels
+
+Previously sourced from `k8s.io/api/core/v1`:
+
+```go
+// Before
+import corev1 "k8s.io/api/core/v1"
+zone := node.Labels[corev1.LabelTopologyZone]
+
+// After
+import "k8s.io/constants/labels"
+zone := node.Labels[labels.TopologyZone]
+```
+
+The `Label` prefix is dropped. Legacy identifiers (`LabelTopologyZone`,
+`LabelHostname`, …) remain available in `k8s.io/api/core/v1` as re-exports.
+
+### Well-known annotations
+
+Previously sourced from `k8s.io/api/core/v1` or `k8s.io/kubectl/pkg/cmd/apply`:
+
+```go
+// Before
+import corev1 "k8s.io/api/core/v1"
+v := obj.Annotations[corev1.AnnotationTopologyMode]
+
+// After
+import "k8s.io/constants/annotations"
+v := obj.Annotations[annotations.TopologyMode]
+```
+
+The `Annotation` prefix and `AnnotationKey` suffix are dropped. Deprecated
+annotations carry a `Deprecated` prefix and a godoc `Deprecated:` line pointing
+to the replacement field or constant.
+
+### Well-known taints
+
+Previously sourced from `k8s.io/api/core/v1`:
+
+```go
+// Before
+import corev1 "k8s.io/api/core/v1"
+if taint.Key == corev1.TaintNodeNotReady { /* ... */ }
+
+// After
+import "k8s.io/constants/taints"
+if taint.Key == taints.NodeNotReady { /* ... */ }
+```
+
+The `Taint` prefix is dropped. Legacy identifiers (`TaintNodeNotReady`, …)
+remain available in `k8s.io/api/core/v1` as re-exports.
+
+### Dependency footprint
+
+Importing `k8s.io/constants/*` brings in no transitive dependencies. Importing
+`k8s.io/api/core/v1` or `k8s.io/apimachinery/pkg/util/validation` pulls in the
+whole API type tree or the full validation package respectively.
+
+## Community, discussion, contribution, and support
+
+Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
+
+You can reach the maintainers of this project at:
+
+- [Slack](https://kubernetes.slack.com/messages/sig-architecture)
+- [Mailing List](https://groups.google.com/g/kubernetes-sig-architecture)
+
+### Code of conduct
+
+Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).

--- a/staging/src/k8s.io/constants/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/constants/SECURITY_CONTACTS
@@ -1,0 +1,18 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+cjcullen
+joelsmith
+liggitt
+philips
+tallclair
+dims

--- a/staging/src/k8s.io/constants/annotations/annotations.go
+++ b/staging/src/k8s.io/constants/annotations/annotations.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package annotations contains well-known Kubernetes annotation keys.
+// These are annotations that have special meaning to Kubernetes components.
+//
+// Identifiers in this package intentionally omit an "Annotation" prefix or
+// "AnnotationKey" suffix so that callers read naturally as
+// "annotations.MirrorPod" rather than "annotations.MirrorPodAnnotationKey".
+// Identifiers beginning with "Deprecated" are retained for backwards
+// compatibility; callers should use the replacement listed in each doc.
+package annotations
+
+// Pod and node annotations.
+const (
+	// MirrorPod is the annotation key set by kubelets when creating mirror pods.
+	MirrorPod = "kubernetes.io/config.mirror"
+
+	// PeerAdvertiseAddress is the network location of kube-apiserver stored
+	// as <ip:port>. Stored in APIServer Identity lease objects to view what
+	// address is used for peer proxy.
+	PeerAdvertiseAddress = "kubernetes.io/peer-advertise-address"
+
+	// ObjectTTL represents a suggestion for kubelet for how long it can cache
+	// an object (e.g. secret, config map) before fetching it again from
+	// apiserver. This annotation can be attached to node.
+	ObjectTTL = "node.alpha.kubernetes.io/ttl"
+)
+
+// kubectl annotations.
+const (
+	// LastAppliedConfig is the annotation used to store the previous
+	// configuration of a resource for use in a three way diff by UpdateApplyAnnotation.
+	LastAppliedConfig = "kubectl.kubernetes.io/last-applied-configuration"
+)
+
+// Service annotations.
+const (
+	// DeprecatedLoadBalancerSourceRanges is the key of the annotation on a
+	// service to set allowed ingress ranges on their LoadBalancers.
+	// It should be a comma-separated list of CIDRs.
+	//
+	// Deprecated: use service.spec.LoadBalancerSourceRanges instead.
+	DeprecatedLoadBalancerSourceRanges = "service.beta.kubernetes.io/load-balancer-source-ranges"
+
+	// TopologyMode can be used to enable or disable Topology Aware Routing
+	// for a Service. Well known values are "Auto" and "Disabled".
+	TopologyMode = "service.kubernetes.io/topology-mode"
+
+	// DeprecatedTopologyAwareHints can be used to enable or disable Topology
+	// Aware Hints for a Service.
+	//
+	// Deprecated: use TopologyMode instead.
+	DeprecatedTopologyAwareHints = "service.kubernetes.io/topology-aware-hints"
+)
+
+// Endpoint annotations.
+const (
+	// EndpointsLastChangeTriggerTime is the annotation key that represents the
+	// timestamp of the last change that triggered the endpoints object change.
+	EndpointsLastChangeTriggerTime = "endpoints.kubernetes.io/last-change-trigger-time"
+
+	// EndpointsOverCapacity is set on an Endpoints resource when it exceeds
+	// the maximum capacity of 1000 addresses.
+	EndpointsOverCapacity = "endpoints.kubernetes.io/over-capacity"
+)
+
+// Controller annotations.
+const (
+	// PodDeletionCost can be used to set the cost of deleting a pod compared
+	// to other pods belonging to the same ReplicaSet. Pods with lower deletion
+	// cost are preferred to be deleted before pods with higher deletion cost.
+	//
+	// This is an alpha annotation and requires enabling the
+	// PodDeletionCost feature gate.
+	PodDeletionCost = "controller.kubernetes.io/pod-deletion-cost"
+)
+
+// Storage annotations.
+const (
+	// MigratedPlugins is the annotation key, set for CSINode objects, that
+	// is a comma-separated list of in-tree plugins that will be serviced
+	// by the CSI backend on the Node.
+	MigratedPlugins = "storage.alpha.kubernetes.io/migrated-plugins"
+)
+
+// Deprecated security annotations - prefer using security context fields.
+const (
+	// DeprecatedSeccompPod represents the key of a seccomp profile applied
+	// to all containers of a pod.
+	//
+	// Deprecated: set a pod security context `seccompProfile` field.
+	DeprecatedSeccompPod = "seccomp.security.alpha.kubernetes.io/pod"
+
+	// DeprecatedSeccompContainerPrefix represents the key prefix of a seccomp
+	// profile applied to one container of a pod.
+	//
+	// Deprecated: set a container security context `seccompProfile` field.
+	DeprecatedSeccompContainerPrefix = "container.seccomp.security.alpha.kubernetes.io/"
+
+	// DeprecatedAppArmorBetaContainerPrefix is the prefix to an annotation key
+	// specifying a container's apparmor profile.
+	//
+	// Deprecated: use a pod or container security context `appArmorProfile` field instead.
+	DeprecatedAppArmorBetaContainerPrefix = "container.apparmor.security.beta.kubernetes.io/"
+)

--- a/staging/src/k8s.io/constants/code-of-conduct.md
+++ b/staging/src/k8s.io/constants/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/constants/doc.go
+++ b/staging/src/k8s.io/constants/doc.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package constants provides canonical definitions for Kubernetes constants.
+//
+// This module contains:
+//   - RFC-defined limits (DNS naming constraints from RFC 1123, RFC 1035)
+//   - Kubernetes-specific limits (label value length, field manager length)
+//   - Well-known label keys (topology, node labels)
+//   - Well-known annotation keys
+//   - Well-known taint keys
+//
+// This module has ZERO dependencies, making it suitable for any package that
+// needs Kubernetes constants without pulling in the full apimachinery or api modules.
+//
+// Other k8s.io modules re-export these constants for backwards compatibility,
+// but new code should import directly from this package for minimal dependencies.
+package constants

--- a/staging/src/k8s.io/constants/go.mod
+++ b/staging/src/k8s.io/constants/go.mod
@@ -1,0 +1,7 @@
+// This is a generated file. Do not edit directly.
+
+module k8s.io/constants
+
+go 1.26.0
+
+godebug default=go1.26

--- a/staging/src/k8s.io/constants/labels/labels.go
+++ b/staging/src/k8s.io/constants/labels/labels.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package labels contains well-known Kubernetes label keys.
+// These are labels that have special meaning to Kubernetes components.
+//
+// Identifiers in this package intentionally omit a "Label" prefix so that
+// callers read naturally as "labels.Hostname" rather than
+// "labels.LabelHostname".
+package labels
+
+// Node labels used for topology and scheduling.
+const (
+	// Hostname is the label key for the node hostname.
+	Hostname = "kubernetes.io/hostname"
+
+	// TopologyZone is the label key for the topology zone.
+	// This replaces the deprecated failure-domain.beta.kubernetes.io/zone.
+	TopologyZone = "topology.kubernetes.io/zone"
+
+	// TopologyRegion is the label key for the topology region.
+	// This replaces the deprecated failure-domain.beta.kubernetes.io/region.
+	TopologyRegion = "topology.kubernetes.io/region"
+
+	// OSStable is the label key for the node operating system.
+	OSStable = "kubernetes.io/os"
+
+	// ArchStable is the label key for the node architecture.
+	ArchStable = "kubernetes.io/arch"
+
+	// InstanceTypeStable is the label key for the node instance type.
+	InstanceTypeStable = "node.kubernetes.io/instance-type"
+
+	// WindowsBuild is used on Windows nodes to specify the Windows build number.
+	// It's in the format MajorVersion.MinorVersion.BuildNumber (for ex: 10.0.17763)
+	WindowsBuild = "node.kubernetes.io/windows-build"
+
+	// NodeExcludeBalancers specifies that the node should not be considered
+	// as a target for external load-balancers which use nodes as a second hop.
+	NodeExcludeBalancers = "node.kubernetes.io/exclude-from-external-load-balancers"
+)
+
+// Namespace labels.
+const (
+	// MetadataName is the label used to automatically label namespaces
+	// with their name, so they can be selected easily by tools.
+	MetadataName = "kubernetes.io/metadata.name"
+)
+
+// Service labels.
+const (
+	// IsHeadlessService is added by the Endpoints and EndpointSlice controllers
+	// to Endpoints and EndpointSlices denoting that their parent Service is
+	// Headless. The existence of this label can be used by other controllers
+	// and kube-proxy to decide whether the Endpoint objects should be replicated
+	// when using Headless Services.
+	IsHeadlessService = "service.kubernetes.io/headless"
+)
+
+// Label namespace suffixes for kubelet self-labeling.
+const (
+	// NamespaceSuffixKubelet is an allowed label namespace suffix
+	// kubelets can self-set ([*.]kubelet.kubernetes.io/*)
+	NamespaceSuffixKubelet = "kubelet.kubernetes.io"
+
+	// NamespaceSuffixNode is an allowed label namespace suffix
+	// kubelets can self-set ([*.]node.kubernetes.io/*)
+	NamespaceSuffixNode = "node.kubernetes.io"
+
+	// NamespaceNodeRestriction is a forbidden label namespace that
+	// kubelets may not self-set when the NodeRestriction admission plugin is enabled.
+	NamespaceNodeRestriction = "node-restriction.kubernetes.io"
+)
+
+// Deprecated labels - kept for backwards compatibility.
+// New code should prefer the non-deprecated equivalents listed in each entry.
+const (
+	// DeprecatedFailureDomainBetaZone is deprecated since 1.17.
+	// Use TopologyZone instead.
+	DeprecatedFailureDomainBetaZone = "failure-domain.beta.kubernetes.io/zone"
+
+	// DeprecatedFailureDomainBetaRegion is deprecated since 1.17.
+	// Use TopologyRegion instead.
+	DeprecatedFailureDomainBetaRegion = "failure-domain.beta.kubernetes.io/region"
+
+	// DeprecatedInstanceType is deprecated.
+	// Use InstanceTypeStable instead.
+	DeprecatedInstanceType = "beta.kubernetes.io/instance-type"
+)

--- a/staging/src/k8s.io/constants/limits/limits.go
+++ b/staging/src/k8s.io/constants/limits/limits.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package limits contains Kubernetes-specific size and length limits
+// used for validation throughout the system.
+package limits
+
+// Kubernetes-specific size limits for labels, annotations, and fields.
+const (
+	// LabelValueMaxLength is the maximum length of a Kubernetes label value.
+	// Label values must be 63 characters or less (can be empty), unless empty,
+	// must begin and end with an alphanumeric character ([a-z0-9A-Z]), and
+	// could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+	LabelValueMaxLength int = 63
+
+	// LabelKeyMaxLength is the maximum length of a Kubernetes label key.
+	// The key segment is required and must be 63 characters or less, beginning
+	// and ending with an alphanumeric character with dashes, underscores, dots,
+	// and alphanumerics between.
+	LabelKeyMaxLength int = 63
+
+	// FieldManagerMaxLength is the maximum length of a field manager name
+	// in server-side apply operations.
+	FieldManagerMaxLength int = 128
+)

--- a/staging/src/k8s.io/constants/rfc/dns.go
+++ b/staging/src/k8s.io/constants/rfc/dns.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rfc contains well-known length constants for the
+// Kubernetes-specific naming formats that are historically named after the
+// DNS RFCs (1123 and 1035). The Kubernetes formats do not strictly match the
+// RFC definitions — they are subsets tuned for Kubernetes object names — but
+// the identifiers below are kept as-is because they are widely used across
+// the codebase and the ecosystem. New code that needs a name limit should
+// prefer these constants over hard-coding the integer.
+//
+// See also KEP-5311 (relaxed validation for Service names) for the
+// in-progress effort to decouple Service name validation from the
+// RFC-1035 framing.
+package rfc
+
+// Length constants for Kubernetes name-like fields. The names retain their
+// "DNS1123"/"DNS1035" suffixes for source compatibility with the rest of
+// the ecosystem, but the formats they gate are Kubernetes-specific and are
+// not identical to the corresponding RFC grammars.
+const (
+	// DNS1123LabelMaxLength is the maximum length of a single "DNS-1123 label"
+	// as used by Kubernetes for fields such as container names, volume names,
+	// and port names.
+	//
+	// Kubernetes requires such values to consist of lower case alphanumeric
+	// characters or '-', start with an alphabetic character, and end with an
+	// alphanumeric character.
+	DNS1123LabelMaxLength int = 63
+
+	// DNS1123SubdomainMaxLength is the maximum length of a "DNS-1123 subdomain"
+	// as used by Kubernetes for most object names (namespace names, node
+	// names, service names, pod names, etc.).
+	//
+	// Kubernetes requires such values to consist of lower case alphanumeric
+	// characters, '-' or '.', and to start and end with an alphanumeric
+	// character.
+	DNS1123SubdomainMaxLength int = 253
+
+	// DNS1035LabelMaxLength is the maximum length of a "DNS-1035 label" as
+	// historically used by Kubernetes Service names.
+	//
+	// Note: KEP-5311 is relaxing Service name validation away from the
+	// RFC-1035 framing. New code SHOULD NOT introduce new uses of this
+	// constant; it is retained here for in-tree consumers only.
+	DNS1035LabelMaxLength int = 63
+)

--- a/staging/src/k8s.io/constants/taints/taints.go
+++ b/staging/src/k8s.io/constants/taints/taints.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package taints contains well-known Kubernetes taint keys.
+// These are taints that have special meaning to Kubernetes components.
+//
+// Identifiers in this package intentionally omit a "Taint" prefix so that
+// callers read naturally as "taints.NodeNotReady" rather than
+// "taints.TaintNodeNotReady".
+package taints
+
+// Node condition taints. These taints are automatically added and removed
+// by the node controller based on node conditions.
+const (
+	// NodeNotReady is added when node is not ready and removed when
+	// node becomes ready.
+	NodeNotReady = "node.kubernetes.io/not-ready"
+
+	// NodeUnreachable is added when node becomes unreachable (corresponding
+	// to NodeReady status ConditionUnknown) and removed when node becomes
+	// reachable (NodeReady status ConditionTrue).
+	NodeUnreachable = "node.kubernetes.io/unreachable"
+
+	// NodeUnschedulable is added when node becomes unschedulable and removed
+	// when node becomes schedulable.
+	NodeUnschedulable = "node.kubernetes.io/unschedulable"
+
+	// NodeMemoryPressure is added when node has memory pressure and removed
+	// when node has enough memory.
+	NodeMemoryPressure = "node.kubernetes.io/memory-pressure"
+
+	// NodeDiskPressure is added when node has disk pressure and removed when
+	// node has enough disk.
+	NodeDiskPressure = "node.kubernetes.io/disk-pressure"
+
+	// NodeNetworkUnavailable is added when node's network is unavailable and
+	// removed when network becomes ready.
+	NodeNetworkUnavailable = "node.kubernetes.io/network-unavailable"
+
+	// NodePIDPressure is added when node has pid pressure and removed when
+	// node has enough pid.
+	NodePIDPressure = "node.kubernetes.io/pid-pressure"
+
+	// NodeOutOfService can be added when node is out of service in case of a
+	// non-graceful shutdown.
+	NodeOutOfService = "node.kubernetes.io/out-of-service"
+)

--- a/staging/src/k8s.io/controller-manager/go.mod
+++ b/staging/src/k8s.io/controller-manager/go.mod
@@ -95,6 +95,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.0.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
@@ -110,6 +111,7 @@ replace (
 	k8s.io/apiserver => ../apiserver
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/cri-client/go.mod
+++ b/staging/src/k8s.io/cri-client/go.mod
@@ -43,5 +43,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/cri-api => ../cri-api
 )

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/text v0.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
@@ -39,5 +40,6 @@ require (
 replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/dynamic-resource-allocation/go.mod
+++ b/staging/src/k8s.io/dynamic-resource-allocation/go.mod
@@ -77,6 +77,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.0.0 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
@@ -90,6 +91,7 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/component-helpers => ../component-helpers
+	k8s.io/constants => ../constants
 	k8s.io/kms => ../kms
 	k8s.io/kubelet => ../kubelet
 	k8s.io/streaming => ../streaming

--- a/staging/src/k8s.io/endpointslice/go.mod
+++ b/staging/src/k8s.io/endpointslice/go.mod
@@ -58,6 +58,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
@@ -70,5 +71,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -107,6 +107,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/kms v0.0.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
@@ -121,6 +122,7 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/kube-controller-manager/go.mod
+++ b/staging/src/k8s.io/kube-controller-manager/go.mod
@@ -26,6 +26,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/component-base v0.0.0 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
@@ -42,6 +43,7 @@ replace (
 	k8s.io/cloud-provider => ../cloud-provider
 	k8s.io/component-base => ../component-base
 	k8s.io/component-helpers => ../component-helpers
+	k8s.io/constants => ../constants
 	k8s.io/controller-manager => ../controller-manager
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming

--- a/staging/src/k8s.io/kube-proxy/go.mod
+++ b/staging/src/k8s.io/kube-proxy/go.mod
@@ -40,6 +40,7 @@ require (
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
@@ -54,5 +55,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -69,6 +69,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.0.0 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
@@ -83,6 +84,7 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/component-helpers => ../component-helpers
+	k8s.io/constants => ../constants
 	k8s.io/dynamic-resource-allocation => ../dynamic-resource-allocation
 	k8s.io/kms => ../kms
 	k8s.io/kubelet => ../kubelet

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -36,6 +36,7 @@ require (
 	k8s.io/client-go v0.0.0
 	k8s.io/component-base v0.0.0
 	k8s.io/component-helpers v0.0.0
+	k8s.io/constants v0.0.0
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a
 	k8s.io/metrics v0.0.0
@@ -102,6 +103,7 @@ replace (
 	k8s.io/code-generator => ../code-generator
 	k8s.io/component-base => ../component-base
 	k8s.io/component-helpers => ../component-helpers
+	k8s.io/constants => ../constants
 	k8s.io/metrics => ../metrics
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -32,11 +32,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/constants/rfc"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
@@ -318,8 +318,8 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 		}
 
 		name := info.Name
-		if len(name) > validation.DNS1035LabelMaxLength {
-			name = name[:validation.DNS1035LabelMaxLength]
+		if len(name) > rfc.DNS1035LabelMaxLength {
+			name = name[:rfc.DNS1035LabelMaxLength]
 		}
 		o.DefaultName = name
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
@@ -27,11 +27,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/constants/limits"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -102,7 +102,7 @@ func NewCmdSelector(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobr
 		Use:                   "selector (-f FILENAME | TYPE NAME) EXPRESSIONS [--resource-version=version]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Set the selector on a resource"),
-		Long:                  fmt.Sprintf(selectorLong, validation.LabelValueMaxLength),
+		Long:                  fmt.Sprintf(selectorLong, limits.LabelValueMaxLength),
 		Example:               selectorExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
@@ -31,11 +31,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/constants/limits"
+	"k8s.io/constants/rfc"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/completion"
@@ -108,7 +109,7 @@ func NewCmdTaint(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.C
 		Use:                   "taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Update the taints on one or more nodes"),
-		Long:                  fmt.Sprintf(taintLong, validation.DNS1123SubdomainMaxLength, validation.LabelValueMaxLength),
+		Long:                  fmt.Sprintf(taintLong, rfc.DNS1123SubdomainMaxLength, limits.LabelValueMaxLength),
 		Example:               taintExample,
 		ValidArgsFunction:     completion.SpecifiedResourceTypeAndNameCompletionFunc(f, validArgs),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -46,6 +46,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
@@ -60,5 +61,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -49,6 +49,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
@@ -64,5 +65,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/pod-security-admission/go.mod
+++ b/staging/src/k8s.io/pod-security-admission/go.mod
@@ -99,6 +99,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/kms v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.0.0 // indirect
@@ -114,6 +115,7 @@ replace (
 	k8s.io/apiserver => ../apiserver
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -102,6 +102,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.0.0 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kms v0.0.0 // indirect
@@ -118,6 +119,7 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
 	k8s.io/component-base => ../component-base
+	k8s.io/constants => ../constants
 	k8s.io/kms => ../kms
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -55,6 +55,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.0.0 // indirect
 	k8s.io/apimachinery v0.0.0 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
@@ -71,5 +72,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/cli-runtime => ../cli-runtime
 	k8s.io/client-go => ../client-go
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -51,6 +51,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/constants v0.0.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
@@ -62,5 +63,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
+	k8s.io/constants => ../constants
 	k8s.io/streaming => ../streaming
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1084,6 +1084,8 @@ gopkg.in/yaml.v3
 ## explicit; go 1.26.0
 # k8s.io/component-helpers v0.0.0 => ./staging/src/k8s.io/component-helpers
 ## explicit; go 1.26.0
+# k8s.io/constants v0.0.0 => ./staging/src/k8s.io/constants
+## explicit; go 1.26.0
 # k8s.io/controller-manager v0.0.0 => ./staging/src/k8s.io/controller-manager
 ## explicit; go 1.26.0
 # k8s.io/cri-api v0.0.0 => ./staging/src/k8s.io/cri-api


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it

Introduces a new zero-dependency staging module `k8s.io/constants` that consolidates well-known Kubernetes constants in one foundational location, and wires apimachinery / api / kubectl to consume it as the single source of truth.

Layout:
- `rfc/`         — length constants for Kubernetes name-like fields (DNS-1123 label/subdomain, DNS-1035 label); docs describe the Kubernetes-specific grammars, not the RFCs.
- `limits/`      — `LabelValueMaxLength`, `LabelKeyMaxLength`, `FieldManagerMaxLength`.
- `labels/`      — well-known label keys (identifiers omit the `Label` prefix: `labels.Hostname`, `labels.TopologyZone`, …).
- `annotations/` — well-known annotation keys (identifiers omit the `Annotation`/`AnnotationKey` prefix/suffix).
- `taints/`      — well-known node taints (identifiers omit the `Taint` prefix).

#### Which issue(s) this PR is related to

Fixes #127889

#### Does this PR introduce a user-facing change?

```release-note
Added a new zero-dependency staging module k8s.io/constants containing well-known label, annotation, taint, RFC length, and Kubernetes-specific size constants. The existing constants in apimachinery and api/core/v1 are re-exported from the new module for backwards compatibility.
```

#### Additional documentation

- Issue: https://github.com/kubernetes/kubernetes/issues/127889