### PR TITLE
Automated cherry pick of #135903: Disable SchedulerAsyncAPICalls feature gate due to performance issues

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1748,7 +1748,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	SchedulerAsyncAPICalls: {
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	SchedulerAsyncPreemption: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1549,10 +1549,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.34"
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "1.35"
 - name: SchedulerAsyncPreemption
   versionedSpecs:
   - default: false


### PR DESCRIPTION
Cherry pick of #135903 on release-1.35.

#135903: Disable SchedulerAsyncAPICalls feature gate due to performance issues

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a 1.35.0 regression by disabling the `SchedulerAsyncAPICalls` feature gate. The regression was in scheduler performance, triggered by API client throttling.
```