### PR TITLE
Execute GangScheduling plugin only for requeuing unschedulable pods on Add/Pod

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1098,7 +1098,8 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 
 	var events []fwk.ClusterEvent
 	if p.isSchedulingQueueHintEnabled {
-		events = framework.PodSchedulingPropertiesChange(newPod, oldPod)
+		// Because the pod itself is being updated here, events are associated with the resource TargetPod.
+		events = framework.PodSchedulingPropertiesChange(newPod, oldPod, true)
 	}
 
 	updated := false
@@ -1233,7 +1234,7 @@ func (p *PriorityQueue) AssignedPodAdded(logger klog.Logger, pod *v1.Pod) {
 // may make pending pods with matching affinity terms schedulable.
 func (p *PriorityQueue) AssignedPodUpdated(logger klog.Logger, oldPod, newPod *v1.Pod, event fwk.ClusterEvent) {
 	p.lock.Lock()
-	if (framework.MatchClusterEvents(fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodScaleDown}, event)) {
+	if (framework.MatchClusterEvents(fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodScaleDown}, event)) {
 		// In this case, we don't want to pre-filter Pods by getUnschedulablePodsWithCrossTopologyTerm
 		// because Pod related events may make Pods that were rejected by NodeResourceFit schedulable.
 		p.moveAllToActiveOrBackoffQueue(logger, event, oldPod, newPod, nil)

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -1264,7 +1264,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 	skipPlugin := "skipPlugin"
 	queueingHintMap := QueueingHintMapPerProfile{
 		"": {
-			framework.EventUnscheduledPodUpdate: {
+			framework.EventTargetPodUpdate: {
 				{
 					PluginName:     queuePlugin,
 					QueueingHintFn: queueHintReturnQueue,
@@ -1459,7 +1459,7 @@ func TestPriorityQueue_UpdateWhenInflight(t *testing.T) {
 
 	m := makeEmptyQueueingHintMapPerProfile()
 	// fakePlugin could change its scheduling result by any updates in Pods.
-	m[""][framework.EventUnscheduledPodUpdate] = []*QueueingHintFunction{
+	m[""][framework.EventTargetPodUpdate] = []*QueueingHintFunction{
 		{
 			PluginName:     "fakePlugin",
 			QueueingHintFn: queueHintReturnQueue,
@@ -2586,7 +2586,7 @@ func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
 			name:               "Pod rejected by pod affinity is requeued with matching Pod's update",
 			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj(),
 			unschedPlugin:      names.InterPodAffinity,
-			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			event:              fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodLabel},
 			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("ns1").Label("service", "securityscan").Node("node1").Obj(),
 			wantToRequeue:      true,
 		},
@@ -2594,7 +2594,7 @@ func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
 			name:               "Pod rejected by pod affinity isn't requeued with unrelated Pod's update",
 			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj(),
 			unschedPlugin:      names.InterPodAffinity,
-			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			event:              fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodLabel},
 			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("unrelated").Label("unrelated", "unrelated").Node("node1").Obj(),
 			wantToRequeue:      false,
 		},
@@ -2602,7 +2602,7 @@ func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
 			name:               "Pod rejected by pod topology spread is requeued with Pod's update in the same namespace",
 			unschedPod:         st.MakePod().Name("tsp").Namespace("ns1").UID("tsp").SpreadConstraint(1, "node", v1.DoNotSchedule, nil, nil, nil, nil, nil).Obj(),
 			unschedPlugin:      names.PodTopologySpread,
-			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			event:              fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodLabel},
 			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("ns1").Label("service", "securityscan").Node("node1").Obj(),
 			wantToRequeue:      true,
 		},
@@ -2610,7 +2610,7 @@ func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
 			name:               "Pod rejected by pod topology spread isn't requeued with unrelated Pod's update",
 			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj(),
 			unschedPlugin:      names.PodTopologySpread,
-			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			event:              fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodLabel},
 			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("unrelated").Label("unrelated", "unrelated").Node("node1").Obj(),
 			wantToRequeue:      false,
 		},
@@ -2618,7 +2618,7 @@ func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
 			name:               "Pod rejected by resource fit is requeued with assigned Pod's scale down",
 			unschedPod:         st.MakePod().Name("rp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
 			unschedPlugin:      names.NodeResourcesFit,
-			event:              fwk.ClusterEvent{Resource: fwk.EventResource("AssignedPod"), ActionType: fwk.UpdatePodScaleDown},
+			event:              fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodScaleDown},
 			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("ns2").Node("node1").Obj(),
 			wantToRequeue:      true,
 		},
@@ -2626,7 +2626,7 @@ func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
 			name:               "Pod rejected by other plugins isn't requeued with any Pod's update",
 			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").Obj(),
 			unschedPlugin:      "fakePlugin",
-			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			event:              fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodLabel},
 			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("unrelated").Label("unrelated", "unrelated").Node("node1").Obj(),
 			wantToRequeue:      false,
 		},
@@ -2641,7 +2641,7 @@ func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
 			c := testingclock.NewFakeClock(time.Now())
 			m := makeEmptyQueueingHintMapPerProfile()
 			m[""] = map[fwk.ClusterEvent][]*QueueingHintFunction{
-				{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel}: {
+				{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodLabel}: {
 					{
 						PluginName:     "fakePlugin",
 						QueueingHintFn: queueHintReturnQueue,
@@ -2655,7 +2655,7 @@ func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
 						QueueingHintFn: queueHintReturnQueue,
 					},
 				},
-				{Resource: fwk.Pod, ActionType: fwk.UpdatePodScaleDown}: {
+				{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodScaleDown}: {
 					{
 						PluginName:     names.NodeResourcesFit,
 						QueueingHintFn: queueHintReturnQueue,
@@ -3970,7 +3970,7 @@ scheduler_pending_pods{queue="unschedulable"} 0
 			resetPodInfos()
 
 			m := makeEmptyQueueingHintMapPerProfile()
-			m[""][framework.EventUnscheduledPodUpdate] = []*QueueingHintFunction{
+			m[""][framework.EventTargetPodUpdate] = []*QueueingHintFunction{
 				{
 					PluginName:     preenqueuePluginName,
 					QueueingHintFn: queueHintReturnQueue,
@@ -4134,37 +4134,37 @@ func TestIncomingPodsMetrics(t *testing.T) {
 				add,
 			},
 			want: `
-            scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+            scheduler_queue_incoming_pods_total{event="UnscheduledPodAdd",queue="active"} 3
 `,
 		},
 		{
-			name: "add pods to unschedulablePods",
+			name: "add unscheduled pods then make them unschedulable",
 			operations: []operation{
 				popAndRequeueAsUnschedulable,
 			},
-			want: `scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+			want: `scheduler_queue_incoming_pods_total{event="UnscheduledPodAdd",queue="active"} 3
              scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="unschedulable"} 3
 `,
 		},
 		{
-			name: "add pods to unschedulablePods and then move all to backoffQ",
+			name: "add unscheduled pods, make them unschedulable, and move them to backoffQ",
 			operations: []operation{
 				popAndRequeueAsUnschedulable,
 				moveAllToActiveOrBackoffQ,
 			},
-			want: `scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+			want: `scheduler_queue_incoming_pods_total{event="UnscheduledPodAdd",queue="active"} 3
 			scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="unschedulable"} 3
             scheduler_queue_incoming_pods_total{event="UnschedulableTimeout",queue="backoff"} 3
 `,
 		},
 		{
-			name: "add pods to unschedulablePods and then move all to activeQ",
+			name: "add unscheduled pods, make them unschedulable, and move them to activeQ",
 			operations: []operation{
 				popAndRequeueAsUnschedulable,
 				moveClockForward,
 				moveAllToActiveOrBackoffQ,
 			},
-			want: `scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+			want: `scheduler_queue_incoming_pods_total{event="UnscheduledPodAdd",queue="active"} 3
 			scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="unschedulable"} 3
             scheduler_queue_incoming_pods_total{event="UnschedulableTimeout",queue="active"} 3
 `,
@@ -4176,7 +4176,7 @@ func TestIncomingPodsMetrics(t *testing.T) {
 				moveClockForward,
 				flushBackoffQ,
 			},
-			want: `scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+			want: `scheduler_queue_incoming_pods_total{event="UnscheduledPodAdd",queue="active"} 3
 			scheduler_queue_incoming_pods_total{event="BackoffComplete",queue="active"} 3
             scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="backoff"} 3
 `,

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -286,7 +286,8 @@ func (sched *Scheduler) updatePodInSchedulingQueue(oldPod, newPod *v1.Pod) {
 	}
 
 	defer metrics.EventHandlingLatency.ObserveSince(start, framework.EventUnscheduledPodUpdate.Label())()
-	for _, evt := range framework.PodSchedulingPropertiesChange(newPod, oldPod) {
+	// Target pod is not being updated here (target pod gets updated through sched.SchedulingQueue.Update call), hence isTargetPod is set to false.
+	for _, evt := range framework.PodSchedulingPropertiesChange(newPod, oldPod, false) {
 		if evt.Label() != framework.EventUnscheduledPodUpdate.Label() {
 			defer metrics.EventHandlingLatency.ObserveSince(start, evt.Label())()
 		}
@@ -409,7 +410,8 @@ func (sched *Scheduler) updateAssignedPodInCache(oldPod, newPod *v1.Pod) {
 		utilruntime.HandleErrorWithLogger(logger, err, "Scheduler cache UpdatePod failed", "pod", klog.KObj(oldPod))
 	}
 
-	events := framework.PodSchedulingPropertiesChange(newPod, oldPod)
+	// This pod is assigned, so it cannot be a target pod.
+	events := framework.PodSchedulingPropertiesChange(newPod, oldPod, false)
 
 	// Save the time it takes to update the pod in the cache.
 	updatingDuration := metrics.SinceInSeconds(start)

--- a/pkg/scheduler/framework/events.go
+++ b/pkg/scheduler/framework/events.go
@@ -46,17 +46,19 @@ const (
 
 var (
 	// EventAssignedPodAdd is the event when an assigned pod is added.
-	EventAssignedPodAdd = fwk.ClusterEvent{Resource: assignedPod, ActionType: fwk.Add}
+	EventAssignedPodAdd = fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Add}
 	// EventAssignedPodUpdate is the event when an assigned pod is updated.
-	EventAssignedPodUpdate = fwk.ClusterEvent{Resource: assignedPod, ActionType: fwk.Update}
+	EventAssignedPodUpdate = fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Update}
 	// EventAssignedPodDelete is the event when an assigned pod is deleted.
-	EventAssignedPodDelete = fwk.ClusterEvent{Resource: assignedPod, ActionType: fwk.Delete}
+	EventAssignedPodDelete = fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}
 	// EventUnscheduledPodAdd is the event when an unscheduled pod is added.
-	EventUnscheduledPodAdd = fwk.ClusterEvent{Resource: unschedulablePod, ActionType: fwk.Add}
+	EventUnscheduledPodAdd = fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.Add}
 	// EventUnscheduledPodUpdate is the event when an unscheduled pod is updated.
-	EventUnscheduledPodUpdate = fwk.ClusterEvent{Resource: unschedulablePod, ActionType: fwk.Update}
+	EventUnscheduledPodUpdate = fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.Update}
 	// EventUnscheduledPodDelete is the event when an unscheduled pod is deleted.
-	EventUnscheduledPodDelete = fwk.ClusterEvent{Resource: unschedulablePod, ActionType: fwk.Delete}
+	EventUnscheduledPodDelete = fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.Delete}
+	// EventTargetPodUpdate is the event when a target pod is being updated.
+	EventTargetPodUpdate = fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.Update}
 	// EventUnschedulableTimeout is the event when a pod stays in unschedulable for longer than timeout.
 	EventUnschedulableTimeout = fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.All, CustomLabel: UnschedulableTimeout}
 	// EventForceActivate is the event when a pod is moved from unschedulablePods/backoffQ to activeQ.
@@ -65,10 +67,15 @@ var (
 
 // PodSchedulingPropertiesChange interprets the update of a pod and returns corresponding UpdatePodXYZ event(s).
 // Once we have other pod update events, we should update here as well.
-func PodSchedulingPropertiesChange(newPod *v1.Pod, oldPod *v1.Pod) (events []fwk.ClusterEvent) {
-	r := assignedPod
-	if newPod.Spec.NodeName == "" {
-		r = unschedulablePod
+// isTargetPod indicates whether the pod is the direct subject of this update event.
+func PodSchedulingPropertiesChange(newPod *v1.Pod, oldPod *v1.Pod, isTargetPod bool) (events []fwk.ClusterEvent) {
+	var r fwk.EventResource
+	if newPod.Spec.NodeName != "" {
+		r = fwk.AssignedPod
+	} else if isTargetPod {
+		r = fwk.TargetPod
+	} else {
+		r = fwk.UnscheduledPod
 	}
 
 	podChangeExtractors := []podChangeExtractor{

--- a/pkg/scheduler/framework/events_test.go
+++ b/pkg/scheduler/framework/events_test.go
@@ -433,6 +433,7 @@ func Test_podSchedulingPropertiesChange(t *testing.T) {
 		name        string
 		newPod      *v1.Pod
 		oldPod      *v1.Pod
+		isTargetPod bool
 		draDisabled bool
 		want        []fwk.ClusterEvent
 	}{
@@ -440,96 +441,112 @@ func Test_podSchedulingPropertiesChange(t *testing.T) {
 			name:   "assigned pod is updated",
 			newPod: st.MakePod().Label("foo", "bar").Node("node").Obj(),
 			oldPod: st.MakePod().Label("foo", "bar2").Node("node").Obj(),
-			want:   []fwk.ClusterEvent{{Resource: assignedPod, ActionType: fwk.UpdatePodLabel}},
+			want:   []fwk.ClusterEvent{{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodLabel}},
 		},
 		{
-			name:   "only label is updated",
+			name:   "unscheduled pod label is updated",
 			newPod: st.MakePod().Label("foo", "bar").Obj(),
 			oldPod: st.MakePod().Label("foo", "bar2").Obj(),
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodLabel}},
+			want:   []fwk.ClusterEvent{{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdatePodLabel}},
 		},
 		{
 			name:   "pod's resource request is scaled down",
-			oldPod: podWithBigRequest,
 			newPod: podWithSmallRequest,
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodScaleDown}},
+			oldPod: podWithBigRequest,
+			want:   []fwk.ClusterEvent{{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdatePodScaleDown}},
 		},
 		{
 			name:   "pod's resource request is scaled up",
-			oldPod: podWithSmallRequest,
 			newPod: podWithBigRequest,
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.Update}},
+			oldPod: podWithSmallRequest,
+			want:   []fwk.ClusterEvent{{Resource: fwk.UnscheduledPod, ActionType: fwk.Update}},
 		},
 		{
 			name:   "both pod's resource request and label are updated",
-			oldPod: podWithBigRequest,
 			newPod: podWithSmallRequestAndLabel,
+			oldPod: podWithBigRequest,
 			want: []fwk.ClusterEvent{
-				{Resource: unschedulablePod, ActionType: fwk.UpdatePodLabel},
-				{Resource: unschedulablePod, ActionType: fwk.UpdatePodScaleDown},
+				{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdatePodLabel},
+				{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdatePodScaleDown},
 			},
 		},
 		{
 			name:   "untracked properties of pod is updated",
 			newPod: st.MakePod().Annotation("foo", "bar").Obj(),
 			oldPod: st.MakePod().Annotation("foo", "bar2").Obj(),
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.Update}},
+			want:   []fwk.ClusterEvent{{Resource: fwk.UnscheduledPod, ActionType: fwk.Update}},
 		},
 		{
-			name:   "scheduling gate is eliminated",
-			newPod: st.MakePod().SchedulingGates([]string{}).Obj(),
-			oldPod: st.MakePod().SchedulingGates([]string{"foo"}).Obj(),
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodSchedulingGatesEliminated}},
+			name:        "scheduling gate is eliminated",
+			newPod:      st.MakePod().SchedulingGates([]string{}).Obj(),
+			oldPod:      st.MakePod().SchedulingGates([]string{"foo"}).Obj(),
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodSchedulingGatesEliminated}},
 		},
 		{
-			name:   "scheduling gate is removed, but not completely eliminated",
-			newPod: st.MakePod().SchedulingGates([]string{"foo"}).Obj(),
-			oldPod: st.MakePod().SchedulingGates([]string{"foo", "bar"}).Obj(),
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.Update}},
+			name:        "scheduling gate is removed, but not completely eliminated",
+			newPod:      st.MakePod().SchedulingGates([]string{"foo"}).Obj(),
+			oldPod:      st.MakePod().SchedulingGates([]string{"foo", "bar"}).Obj(),
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.TargetPod, ActionType: fwk.Update}},
 		},
 		{
-			name:   "pod's tolerations are updated",
-			newPod: st.MakePod().Toleration("key").Toleration("key2").Obj(),
-			oldPod: st.MakePod().Toleration("key").Obj(),
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodToleration}},
+			name:        "pod's tolerations are updated",
+			newPod:      st.MakePod().Toleration("key").Toleration("key2").Obj(),
+			oldPod:      st.MakePod().Toleration("key").Obj(),
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodToleration}},
 		},
 		{
 			name:        "pod claim statuses change, feature disabled",
 			draDisabled: true,
 			newPod:      st.MakePod().ResourceClaimStatuses(claimStatusA).Obj(),
 			oldPod:      st.MakePod().Obj(),
-			want:        []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.Update}},
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.TargetPod, ActionType: fwk.Update}},
 		},
 		{
-			name:   "pod claim statuses change, feature enabled",
-			newPod: st.MakePod().ResourceClaimStatuses(claimStatusA).Obj(),
-			oldPod: st.MakePod().Obj(),
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
+			name:        "pod claim statuses change, feature enabled",
+			newPod:      st.MakePod().ResourceClaimStatuses(claimStatusA).Obj(),
+			oldPod:      st.MakePod().Obj(),
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
 		},
 		{
-			name:   "pod claim statuses swapped",
-			newPod: st.MakePod().ResourceClaimStatuses(claimStatusA, claimStatusB).Obj(),
-			oldPod: st.MakePod().ResourceClaimStatuses(claimStatusB, claimStatusA).Obj(),
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
+			name:        "pod claim statuses swapped",
+			newPod:      st.MakePod().ResourceClaimStatuses(claimStatusA, claimStatusB).Obj(),
+			oldPod:      st.MakePod().ResourceClaimStatuses(claimStatusB, claimStatusA).Obj(),
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
 		},
 		{
 			name:        "pod extended resource claim status change, feature disabled",
 			draDisabled: true,
 			newPod:      st.MakePod().ExtendedResourceClaimStatus(extendedClaimStatusA).Obj(),
 			oldPod:      st.MakePod().Obj(),
-			want:        []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.Update}},
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.TargetPod, ActionType: fwk.Update}},
 		},
 		{
-			name:   "pod extended resource claim status change, feature enabled",
-			newPod: st.MakePod().ExtendedResourceClaimStatus(extendedClaimStatusA).Obj(),
-			oldPod: st.MakePod().Obj(),
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
+			name:        "pod extended resource claim status change, feature enabled",
+			newPod:      st.MakePod().ExtendedResourceClaimStatus(extendedClaimStatusA).Obj(),
+			oldPod:      st.MakePod().Obj(),
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
 		},
 		{
-			name:   "pod extended resource claim status swapped",
-			newPod: st.MakePod().ExtendedResourceClaimStatus(extendedClaimStatusB).Obj(),
-			oldPod: st.MakePod().ExtendedResourceClaimStatus(extendedClaimStatusA).Obj(),
-			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
+			name:        "pod extended resource claim status swapped",
+			newPod:      st.MakePod().ExtendedResourceClaimStatus(extendedClaimStatusB).Obj(),
+			oldPod:      st.MakePod().ExtendedResourceClaimStatus(extendedClaimStatusA).Obj(),
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
+		},
+		{
+			name:        "scheduling gate is eliminated for an assigned pod, it takes precedence over target pod resource type",
+			newPod:      st.MakePod().SchedulingGates([]string{}).Node("node").Obj(),
+			oldPod:      st.MakePod().SchedulingGates([]string{"foo"}).Node("node").Obj(),
+			isTargetPod: true,
+			want:        []fwk.ClusterEvent{{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodSchedulingGatesEliminated}},
 		},
 	}
 	for _, tt := range tests {
@@ -538,7 +555,7 @@ func Test_podSchedulingPropertiesChange(t *testing.T) {
 				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.34"))
 			}
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DynamicResourceAllocation, !tt.draDisabled)
-			got := PodSchedulingPropertiesChange(tt.newPod, tt.oldPod)
+			got := PodSchedulingPropertiesChange(tt.newPod, tt.oldPod, tt.isTargetPod)
 			if diff := cmp.Diff(tt.want, got, cmpopts.EquateComparable(fwk.ClusterEvent{})); diff != "" {
 				t.Errorf("unexpected event is returned from podSchedulingPropertiesChange (-want, +got):\n%s", diff)
 			}

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -191,7 +191,7 @@ func (pl *DefaultPreemption) EventsToRegister(_ context.Context) ([]fwk.ClusterE
 	if pl.fts.EnableAsyncPreemption {
 		return []fwk.ClusterEventWithHint{
 			// We need to register the event to tell the scheduling queue that the pod could be un-gated after some Pods' deletion.
-			{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}, QueueingHintFn: pl.isPodSchedulableAfterPodDeletion},
+			{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}, QueueingHintFn: pl.isPodSchedulableAfterAssignedPodDeletion},
 		}, nil
 	}
 
@@ -199,7 +199,7 @@ func (pl *DefaultPreemption) EventsToRegister(_ context.Context) ([]fwk.ClusterE
 	return nil, nil
 }
 
-// isPodSchedulableAfterPodDeletion returns the queueing hint for the pod after the pod deletion event,
+// isPodSchedulableAfterAssignedPodDeletion returns the queueing hint for the pod after the assigned pod deletion event,
 // which always return Skip.
 // The default preemption plugin is a bit tricky;
 // the pods rejected by it are the ones that have run/are running the preemption asynchronously.
@@ -207,7 +207,7 @@ func (pl *DefaultPreemption) EventsToRegister(_ context.Context) ([]fwk.ClusterE
 // which failure will be resolved by the preemption.
 // The reason why we return Skip here is that the preemption plugin should not make the decision of when to requeueing Pods,
 // and rather, those plugins should be responsible for that.
-func (pl *DefaultPreemption) isPodSchedulableAfterPodDeletion(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+func (pl *DefaultPreemption) isPodSchedulableAfterAssignedPodDeletion(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	return fwk.QueueSkip, nil
 }
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -264,7 +264,7 @@ func (pl *DynamicResources) EventsToRegister(_ context.Context) ([]fwk.ClusterEv
 		// Allocation is tracked in ResourceClaims, so any changes may make the pods schedulable.
 		{Event: fwk.ClusterEvent{Resource: fwk.ResourceClaim, ActionType: fwk.Add | fwk.Update}, QueueingHintFn: pl.isSchedulableAfterClaimChange},
 		// Adding the ResourceClaim name to the pod status makes pods waiting for their ResourceClaim schedulable.
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodGeneratedResourceClaim}, QueueingHintFn: pl.isSchedulableAfterPodChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodGeneratedResourceClaim}, QueueingHintFn: pl.isSchedulableAfterTargetPodUpdate},
 		// A pod might be waiting for a class to get created or modified.
 		{Event: fwk.ClusterEvent{Resource: fwk.DeviceClass, ActionType: fwk.Add | fwk.Update}},
 		// Adding or updating a ResourceSlice might make a pod schedulable because new resources became available.
@@ -353,19 +353,14 @@ func (pl *DynamicResources) isSchedulableAfterClaimChange(logger klog.Logger, po
 	return fwk.Queue, nil
 }
 
-// isSchedulableAfterPodChange is invoked for update pod events reported by
+// isSchedulableAfterTargetPodUpdate is invoked for update pod events reported by
 // an informer. It checks whether that change adds the ResourceClaim(s) that the
 // pod has been waiting for.
-func (pl *DynamicResources) isSchedulableAfterPodChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+func (pl *DynamicResources) isSchedulableAfterTargetPodUpdate(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	_, modifiedPod, err := schedutil.As[*v1.Pod](nil, newObj)
 	if err != nil {
 		// Shouldn't happen.
-		return fwk.Queue, fmt.Errorf("unexpected object in isSchedulableAfterClaimChange: %w", err)
-	}
-
-	if pod.UID != modifiedPod.UID {
-		logger.V(7).Info("pod is not schedulable after change in other pod", "pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-		return fwk.QueueSkip, nil
+		return fwk.Queue, fmt.Errorf("unexpected object in isSchedulableAfterTargetPodUpdate: %w", err)
 	}
 
 	if err := pl.foreachPodResourceClaim(modifiedPod, nil); err != nil {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4304,10 +4304,10 @@ func testIsSchedulableAfterClaimChange(tCtx ktesting.TContext) {
 	}
 }
 
-func TestIsSchedulableAfterPodChange(t *testing.T) {
-	testIsSchedulableAfterPodChange(ktesting.Init(t))
+func TestIsSchedulableAfterTargetPodUpdate(t *testing.T) {
+	testIsSchedulableAfterTargetPodUpdate(ktesting.Init(t))
 }
-func testIsSchedulableAfterPodChange(tCtx ktesting.TContext) {
+func testIsSchedulableAfterTargetPodUpdate(tCtx ktesting.TContext) {
 	testcases := map[string]struct {
 		objs     []apiruntime.Object
 		pod      *v1.Pod
@@ -4326,17 +4326,6 @@ func testIsSchedulableAfterPodChange(tCtx ktesting.TContext) {
 			pod:      podWithClaimTemplate,
 			obj:      podWithClaimTemplateInStatus,
 			wantHint: fwk.Queue,
-		},
-		"wrong-pod": {
-			objs: []apiruntime.Object{pendingClaim},
-			pod: func() *v1.Pod {
-				pod := podWithClaimTemplate.DeepCopy()
-				pod.Name += "2"
-				pod.UID += "2" // This is the relevant difference.
-				return pod
-			}(),
-			obj:      podWithClaimTemplateInStatus,
-			wantHint: fwk.QueueSkip,
 		},
 		"missing-claim": {
 			objs:     nil,
@@ -4369,7 +4358,7 @@ func testIsSchedulableAfterPodChange(tCtx ktesting.TContext) {
 				EnableDRAResourceClaimDeviceStatus: true,
 			}
 			testCtx := setup(tCtx, nil, nil, tc.claims, nil, nil, tc.objs, features, false, nil)
-			gotHint, err := testCtx.p.isSchedulableAfterPodChange(tCtx.Logger(), tc.pod, nil, tc.obj)
+			gotHint, err := testCtx.p.isSchedulableAfterTargetPodUpdate(tCtx.Logger(), tc.pod, nil, tc.obj)
 			if tc.wantErr {
 				if err == nil {
 					tCtx.Fatal("want an error, got none")

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -73,15 +73,18 @@ func (pl *GangScheduling) Name() string {
 // EventsToRegister returns the possible events that may make a Pod failed by this plugin schedulable.
 func (pl *GangScheduling) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return []fwk.ClusterEventWithHint{
-		// A new pod being added might be the one that completes a gang, meeting its MinCount requirement.
+		// A new pod (either unscheduled or pre-bound) being added might be the one that completes a gang, meeting its MinCount requirement.
 		// PodSchedulingGroup field is immutable, so there is no need to subscribe on Pod/Update event.
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPodAdded},
+		{Event: fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPodAdded},
+		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPodAdded},
 		// A PodGroup being added can be making a waiting gang schedulable.
 		// PodGroups are immutable, so there's no need to handle PodGroup/Update event.
 		{Event: fwk.ClusterEvent{Resource: fwk.PodGroup, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPodGroupAdded},
 	}, nil
 }
 
+// isSchedulableAfterPodAdded checks whether a newly added pod (either unscheduled or pre-bound)
+// could make a previously unschedulable pod schedulable by completing the gang's MinCount.
 func (pl *GangScheduling) isSchedulableAfterPodAdded(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	_, addedPod, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -59,6 +59,12 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			expectedHint: fwk.Queue,
 		},
 		{
+			name:         "add a newPod with NodeName set which matches the pod's scheduling group",
+			pod:          st.MakePod().Name("p").PodGroupName("pg").Obj(),
+			newPod:       st.MakePod().PodGroupName("pg").Node("node1").Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
 			name:         "add a newPod which doesn't match the pod's namespace",
 			pod:          st.MakePod().Name("p").PodGroupName("pg").Obj(),
 			newPod:       st.MakePod().Namespace("foo").PodGroupName("pg").Obj(),
@@ -89,10 +95,10 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			}
 			actualHint, err := p.(*GangScheduling).isSchedulableAfterPodAdded(logger, tc.pod, nil, tc.newPod)
 			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
-				t.Errorf("Expected QueuingHint doesn't match (-want,+got):\n%s", diff)
+				t.Errorf("unexpected QueueingHint (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -98,7 +98,8 @@ func (pl *InterPodAffinity) EventsToRegister(_ context.Context) ([]fwk.ClusterEv
 		// an unschedulable Pod schedulable.
 		// - Add. An unschedulable Pod may fail due to violating pod-affinity constraints,
 		// adding an assigned Pod may make it schedulable.
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add | fwk.UpdatePodLabel | fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterPodChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Add | fwk.UpdatePodLabel | fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterAssignedPodChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodLabel}, QueueingHintFn: pl.isSchedulableAfterTargetPodUpdateLabel},
 		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: nodeActionType}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
 	}, nil
 }
@@ -168,18 +169,10 @@ func GetNamespaceLabelsSnapshot(logger klog.Logger, ns string, nsLister listersv
 	return
 }
 
-func (pl *InterPodAffinity) isSchedulableAfterPodChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+func (pl *InterPodAffinity) isSchedulableAfterAssignedPodChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	originalPod, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
 		return fwk.Queue, err
-	}
-	if modifiedPod != nil && originalPod != nil && pod.UID == modifiedPod.UID {
-		// The only update event we listen on is UpdatePodLabel, so we can assume the labels have changed.
-		// The pod can become schedulable after update to its labels because e.g. some other pod might have
-		// anti-affinity on the old labels but not on the new ones.
-		logger.V(5).Info("the target pod labels have changed and it may be schedulable now",
-			"pod", klog.KObj(pod))
-		return fwk.Queue, nil
 	}
 	// We don't need to check cases where NodeName or NominatedNodeName changes on a pod because in those cases Add/Delete event is fired
 	if (modifiedPod != nil && modifiedPod.Spec.NodeName == "" && modifiedPod.Status.NominatedNodeName == "") ||
@@ -251,6 +244,14 @@ func (pl *InterPodAffinity) isSchedulableAfterPodChange(logger klog.Logger, pod 
 	logger.V(5).Info("a scheduled pod was deleted but it doesn't match the target pod's anti-affinity, nor vice versa",
 		"pod", klog.KObj(pod), "originalPod", klog.KObj(originalPod))
 	return fwk.QueueSkip, nil
+}
+
+func (pl *InterPodAffinity) isSchedulableAfterTargetPodUpdateLabel(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	// The pod can become schedulable after an update to its labels because e.g. some other
+	// pod might have anti-affinity on the old labels but not on the new ones.
+	logger.V(5).Info("the target pod labels have changed and it may be schedulable now",
+		"pod", klog.KObj(pod))
+	return fwk.Queue, nil
 }
 
 func (pl *InterPodAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
@@ -34,7 +34,7 @@ import (
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
-func Test_isSchedulableAfterPodChange(t *testing.T) {
+func Test_isSchedulableAfterAssignedPodChange(t *testing.T) {
 	tests := []struct {
 		name           string
 		pod            *v1.Pod
@@ -104,13 +104,6 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			expectedHint: fwk.Queue,
 		},
 		{
-			name:         "updated pod is the target pod",
-			pod:          st.MakePod().UID("p").Name("p").Label("foo", "baz").Obj(),
-			newPod:       st.MakePod().UID("p").Name("p").Label("foo", "baz").Obj(),
-			oldPod:       st.MakePod().UID("p").Name("p").Label("foo", "bar").Obj(),
-			expectedHint: fwk.Queue,
-		},
-		{
 			name:         "modify pod label to change it from satisfying pod anti-affinity to not satisfying anti-affinity",
 			pod:          st.MakePod().UID("p").Name("p").PodAntiAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().UID("other").Node("fake-node").Label("service", "aaaa").Obj(),
@@ -176,14 +169,33 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			snapshot := cache.NewSnapshot(nil, nil)
 			pl := plugintesting.SetupPluginWithInformers(ctx, t, schedruntime.FactoryAdapter(feature.Features{}, New), &config.InterPodAffinityArgs{}, snapshot, namespaces)
 			p := pl.(*InterPodAffinity)
-			actualHint, err := p.isSchedulableAfterPodChange(logger, tc.pod, tc.oldPod, tc.newPod)
+			actualHint, err := p.isSchedulableAfterAssignedPodChange(logger, tc.pod, tc.oldPod, tc.newPod)
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
-				t.Errorf("expected QueuingHint doesn't match (-want,+got): \n %s", diff)
+				t.Errorf("unexpected QueueingHint (-want, +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func Test_isSchedulableAfterTargetPodUpdateLabel(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	pod := st.MakePod().UID("p").Name("p").Label("foo", "baz").Obj()
+
+	snapshot := cache.NewSnapshot(nil, nil)
+	pl := plugintesting.SetupPluginWithInformers(ctx, t, schedruntime.FactoryAdapter(feature.Features{}, New), &config.InterPodAffinityArgs{}, snapshot, namespaces)
+	p := pl.(*InterPodAffinity)
+	actualHint, err := p.isSchedulableAfterTargetPodUpdateLabel(logger, pod, pod.DeepCopy(), pod.DeepCopy())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(fwk.Queue, actualHint); diff != "" {
+		t.Errorf("unexpected QueueingHint (-want, +got):\n%s", diff)
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures.go
+++ b/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures.go
@@ -149,8 +149,8 @@ func (pl *NodeDeclaredFeatures) EventsToRegister(_ context.Context) ([]fwk.Clust
 			QueueingHintFn: pl.isSchedulableAfterNodeChange,
 		},
 		{
-			Event:          fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Update},
-			QueueingHintFn: pl.isSchedulableAfterPodUpdate,
+			Event:          fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.Update},
+			QueueingHintFn: pl.isSchedulableAfterTargetPodUpdate,
 		},
 	}, nil
 }
@@ -167,16 +167,12 @@ func getPreFilterState(cycleState fwk.CycleState) (*preFilterState, error) {
 	return s, nil
 }
 
-func (pl *NodeDeclaredFeatures) isSchedulableAfterPodUpdate(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+func (pl *NodeDeclaredFeatures) isSchedulableAfterTargetPodUpdate(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	oldPod, newPod, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
 		return fwk.Queue, err
 	}
-	// If the pod that was updated is not the target pod, then we don't need to re-evaluate it.
-	if pod.UID != newPod.UID {
-		logger.V(5).Info("the update event is not for targetPod, skipping queueing", "pod", klog.KObj(newPod))
-		return fwk.QueueSkip, nil
-	}
+
 	oldPodInfo := &ndf.PodInfo{Spec: &oldPod.Spec}
 	newPodInfo := &ndf.PodInfo{Spec: &newPod.Spec}
 	oldReqs, err := pl.ndfFramework.InferForPodScheduling(oldPodInfo, pl.version)

--- a/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
+++ b/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
@@ -330,13 +330,12 @@ func TestEnqueueExtensionsNodeUpdate(t *testing.T) {
 	}
 }
 
-func TestEnqueueExtensionsPodUpdate(t *testing.T) {
+func TestIsSchedulableAfterTargetPodUpdate(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 
 	targetPodName := "test-pod"
 	targetPodUID := "123"
 
-	// Test isSchedulableAfterPodUpdate
 	testCases := []struct {
 		name              string
 		oldPod            *v1.Pod
@@ -408,18 +407,6 @@ func TestEnqueueExtensionsPodUpdate(t *testing.T) {
 			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:              "Updated pod not the same as target pod",
-			oldPod:            st.MakePod().Name("another-test-pod").UID("456").Label("foo", "bar").Obj(),
-			newPod:            st.MakePod().Name("another-test-pod").UID("456").Obj(),
-			componenetVersion: version.MustParseSemantic("1.35.0"),
-			setupMock: func(m *ndftesting.MockFeature) {
-				m.SetInferForScheduling(func(podInfo *ndf.PodInfo) bool { return false })
-				m.SetName("TestFeature")
-				m.SetMaxVersion(nil)
-			},
-			expectedHint: fwk.QueueSkip,
-		},
-		{
 			name:              "Infer returns error",
 			oldPod:            st.MakePod().Name(targetPodName).UID(targetPodUID).Obj(),
 			newPod:            st.MakePod().Name(targetPodName).UID(targetPodUID).Label("foo", "bar").Obj(),
@@ -445,7 +432,7 @@ func TestEnqueueExtensionsPodUpdate(t *testing.T) {
 				version:      tc.componenetVersion,
 				enabled:      true,
 			}
-			hint, err := plugin.isSchedulableAfterPodUpdate(logger, st.MakePod().Name(targetPodName).UID(targetPodUID).Obj(), tc.oldPod, tc.newPod)
+			hint, err := plugin.isSchedulableAfterTargetPodUpdate(logger, st.MakePod().Name(targetPodName).UID(targetPodUID).Obj(), tc.oldPod, tc.newPod)
 			if tc.expectedErr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tc.expectedErr)

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -116,16 +116,16 @@ func (pl *NodePorts) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWith
 
 	return []fwk.ClusterEventWithHint{
 		// Due to immutable fields `spec.containers[*].ports`, pod update events are ignored.
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
+		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterAssignedPodDeleted},
 		// We don't need the QueueingHintFn here because the scheduling of Pods will be always retried with backoff when this Event happens.
 		// (the same as Queue)
 		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: nodeActionType}},
 	}, nil
 }
 
-// isSchedulableAfterPodDeleted is invoked whenever a pod deleted. It checks whether
+// isSchedulableAfterAssignedPodDeleted is invoked whenever an assigned pod is deleted. It checks whether
 // that change made a previously unschedulable pod schedulable.
-func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+func (pl *NodePorts) isSchedulableAfterAssignedPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	deletedPod, _, err := util.As[*v1.Pod](oldObj, nil)
 	if err != nil {
 		return fwk.Queue, err

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2/ktesting"
@@ -220,7 +219,7 @@ func TestPreFilterDisabled(t *testing.T) {
 	}
 }
 
-func Test_isSchedulableAfterPodDeleted(t *testing.T) {
+func Test_isSchedulableAfterAssignedPodDeleted(t *testing.T) {
 	podWithHostPort := st.MakePod().HostPort(8080)
 
 	testcases := map[string]struct {
@@ -262,15 +261,21 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			logger, ctx := ktesting.NewTestContext(t)
 			p, err := New(ctx, nil, nil, feature.Features{})
 			if err != nil {
-				t.Fatalf("Creating plugin: %v", err)
+				t.Fatalf("creating plugin: %v", err)
 			}
-			actualHint, err := p.(*NodePorts).isSchedulableAfterPodDeleted(logger, tc.pod, tc.oldObj, nil)
+			actualHint, err := p.(*NodePorts).isSchedulableAfterAssignedPodDeleted(logger, tc.pod, tc.oldObj, nil)
 			if tc.expectedErr {
-				require.Error(t, err)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedHint, actualHint)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("unexpected hint (-want, +got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -368,13 +368,6 @@ func getPreFilterState(cycleState fwk.CycleState) (*preFilterState, error) {
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
 func (f *Fit) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
-	podActionType := fwk.Delete
-	if f.enableInPlacePodVerticalScaling {
-		// If InPlacePodVerticalScaling (KEP 1287) is enabled, then UpdatePodScaleDown event should be registered
-		// for this plugin since a Pod update may free up resources that make other Pods schedulable.
-		podActionType |= fwk.UpdatePodScaleDown
-	}
-
 	// A note about UpdateNodeTaint/UpdateNodeLabel event:
 	// Ideally, it's supposed to register only Add | UpdateNodeAllocatable because the only resource update could change the node resource fit plugin's result.
 	// But, we may miss Node/Add event due to preCheck, and we decided to register UpdateNodeTaint | UpdateNodeLabel for all plugins registering Node/Add.
@@ -386,7 +379,7 @@ func (f *Fit) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, e
 	}
 
 	events := []fwk.ClusterEventWithHint{
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: podActionType}, QueueingHintFn: f.isSchedulableAfterPodEvent},
+		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}, QueueingHintFn: f.isSchedulableAfterAssignedPodDelete},
 		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: nodeActionType}, QueueingHintFn: f.isSchedulableAfterNodeChange},
 	}
 	if f.enableDRAExtendedResource {
@@ -394,35 +387,49 @@ func (f *Fit) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, e
 			// A pod might be waiting for an exteneded resurce from a class to get created or modified.
 			fwk.ClusterEventWithHint{Event: fwk.ClusterEvent{Resource: fwk.DeviceClass, ActionType: fwk.Add | fwk.Update}, QueueingHintFn: f.isSchedulableAfterDeviceClassEvent})
 	}
+	if f.enableInPlacePodVerticalScaling {
+		// If InPlacePodVerticalScaling (KEP 1287) is enabled, then UpdatePodScaleDown event should be registered
+		// for this plugin since a Pod update may free up resources that make other Pods schedulable.
+		events = append(events,
+			fwk.ClusterEventWithHint{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodScaleDown}, QueueingHintFn: f.isSchedulableAfterAssignedPodScaleDown},
+			fwk.ClusterEventWithHint{Event: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodScaleDown}, QueueingHintFn: f.isSchedulableAfterTargetPodScaleDown})
+	}
 	return events, nil
 }
 
-// isSchedulableAfterPodEvent is invoked whenever a pod deleted or scaled down. It checks whether
-// that change made a previously unschedulable pod schedulable.
-func (f *Fit) isSchedulableAfterPodEvent(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+// isSchedulableAfterAssignedPodDelete is invoked whenever a scheduled pod
+// is deleted and checks whether that change could make a previously unschedulable pod schedulable.
+func (f *Fit) isSchedulableAfterAssignedPodDelete(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	deletedPod, _, err := schedutil.As[*v1.Pod](oldObj, newObj)
+	if err != nil {
+		return fwk.Queue, err
+	}
+
+	if deletedPod.Spec.NodeName == "" && deletedPod.Status.NominatedNodeName == "" {
+		logger.V(5).Info("the deleted pod was unscheduled and it wouldn't make the unscheduled pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
+		return fwk.QueueSkip, nil
+	}
+
+	// any deletion event to a scheduled pod could make the unscheduled pod schedulable.
+	logger.V(5).Info("another scheduled pod was deleted, and it may make the unscheduled pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
+	return fwk.Queue, nil
+}
+
+// isSchedulableAfterTargetPodScaleDown is invoked when the target pod is scaled down, making itself schedulable.
+func (f *Fit) isSchedulableAfterTargetPodScaleDown(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	logger.V(5).Info("the target pod got scaled down and it may be schedulable now", "pod", klog.KObj(pod))
+	return fwk.Queue, nil
+}
+
+// isSchedulableAfterAssignedPodScaleDown is invoked when a scheduled pod got scaled down, and checks
+// whether that change could make a previously unschedulable pod schedulable.
+func (f *Fit) isSchedulableAfterAssignedPodScaleDown(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	originalPod, modifiedPod, err := schedutil.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
 		return fwk.Queue, err
 	}
 
-	if modifiedPod == nil {
-		if originalPod.Spec.NodeName == "" && originalPod.Status.NominatedNodeName == "" {
-			logger.V(5).Info("the deleted pod was unscheduled and it wouldn't make the unscheduled pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(originalPod))
-			return fwk.QueueSkip, nil
-		}
-
-		// any deletion event to a scheduled pod could make the unscheduled pod schedulable.
-		logger.V(5).Info("another scheduled pod was deleted, and it may make the unscheduled pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(originalPod))
-		return fwk.Queue, nil
-	}
-
-	if !f.enableInPlacePodVerticalScaling {
-		// If InPlacePodVerticalScaling (KEP 1287) is disabled, the pod scale down event cannot free up any resources.
-		logger.V(5).Info("another pod was modified, but InPlacePodVerticalScaling is disabled, so it doesn't make the unscheduled pod schedulable", "pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-		return fwk.QueueSkip, nil
-	}
-
-	if !f.isSchedulableAfterPodScaleDown(pod, originalPod, modifiedPod) {
+	if !f.haveEnoughRelevantResourcesDecreased(pod, originalPod, modifiedPod) {
 		if loggerV := logger.V(10); loggerV.Enabled() {
 			// Log more information.
 			loggerV.Info("pod got scaled down, but the modification isn't related to the resource requests of the target pod", "pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod), "diff", diff.Diff(originalPod, modifiedPod))
@@ -432,19 +439,12 @@ func (f *Fit) isSchedulableAfterPodEvent(logger klog.Logger, pod *v1.Pod, oldObj
 		return fwk.QueueSkip, nil
 	}
 
-	logger.V(5).Info("another scheduled pod or the target pod itself got scaled down, and it may make the unscheduled pod schedulable", "pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
+	logger.V(5).Info("another scheduled pod got scaled down, and it may make the unscheduled pod schedulable", "pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
 	return fwk.Queue, nil
 }
 
-// isSchedulableAfterPodScaleDown checks whether the scale down event may make the target pod schedulable. Specifically:
-// - Returns true when the update event is for the target pod itself.
-// - Returns true when the update event shows a scheduled pod's resource request that the target pod also requests got reduced.
-func (f *Fit) isSchedulableAfterPodScaleDown(targetPod, originalPod, modifiedPod *v1.Pod) bool {
-	if modifiedPod.UID == targetPod.UID {
-		// If the scaling down event is for targetPod, it would make targetPod schedulable.
-		return true
-	}
-
+// haveAnyEnoughRelevantResourcesDecreased checks whether a scheduled pod's resource request that the target pod also requests got reduced.
+func (f *Fit) haveEnoughRelevantResourcesDecreased(targetPod *v1.Pod, originalPod, modifiedPod *v1.Pod) bool {
 	if modifiedPod.Spec.NodeName == "" {
 		// If the update event is for a unscheduled Pod,
 		// it wouldn't make targetPod schedulable.

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
@@ -1440,32 +1439,34 @@ func TestEventsToRegister(t *testing.T) {
 			name:                            "Register events with InPlacePodVerticalScaling feature enabled",
 			enableInPlacePodVerticalScaling: true,
 			expectedClusterEvents: []fwk.ClusterEventWithHint{
-				{Event: fwk.ClusterEvent{Resource: "Pod", ActionType: fwk.UpdatePodScaleDown | fwk.Delete}},
-				{Event: fwk.ClusterEvent{Resource: "Node", ActionType: fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel}},
+				{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}},
+				{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel}},
+				{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodScaleDown}},
+				{Event: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodScaleDown}},
 			},
 		},
 		{
 			name:                      "Register events with SchedulingQueueHint feature enabled",
 			enableSchedulingQueueHint: true,
 			expectedClusterEvents: []fwk.ClusterEventWithHint{
-				{Event: fwk.ClusterEvent{Resource: "Pod", ActionType: fwk.Delete}},
-				{Event: fwk.ClusterEvent{Resource: "Node", ActionType: fwk.Add | fwk.UpdateNodeAllocatable}},
+				{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}},
+				{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeAllocatable}},
 			},
 		},
 		{
 			name:                            "Register events with InPlacePodVerticalScaling feature disabled",
 			enableInPlacePodVerticalScaling: false,
 			expectedClusterEvents: []fwk.ClusterEventWithHint{
-				{Event: fwk.ClusterEvent{Resource: "Pod", ActionType: fwk.Delete}},
-				{Event: fwk.ClusterEvent{Resource: "Node", ActionType: fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel}},
+				{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}},
+				{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel}},
 			},
 		},
 		{
 			name:                      "Register events with DRAExtendedResource feature enabled",
 			enableDRAExtendedResource: true,
 			expectedClusterEvents: []fwk.ClusterEventWithHint{
-				{Event: fwk.ClusterEvent{Resource: "Pod", ActionType: fwk.Delete}},
-				{Event: fwk.ClusterEvent{Resource: "Node", ActionType: fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel}},
+				{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}},
+				{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel}},
 				{Event: fwk.ClusterEvent{Resource: fwk.DeviceClass, ActionType: fwk.Add | fwk.Update}},
 			},
 		},
@@ -1473,8 +1474,8 @@ func TestEventsToRegister(t *testing.T) {
 			name:                      "Register events with DRAExtendedResource feature disabled",
 			enableDRAExtendedResource: false,
 			expectedClusterEvents: []fwk.ClusterEventWithHint{
-				{Event: fwk.ClusterEvent{Resource: "Pod", ActionType: fwk.Delete}},
-				{Event: fwk.ClusterEvent{Resource: "Node", ActionType: fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel}},
+				{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}},
+				{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel}},
 			},
 		},
 	}
@@ -1497,102 +1498,72 @@ func TestEventsToRegister(t *testing.T) {
 	}
 }
 
-func Test_isSchedulableAfterPodChange(t *testing.T) {
+func Test_isSchedulableAfterAssignedPodDelete(t *testing.T) {
 	testcases := map[string]struct {
-		pod                             *v1.Pod
-		oldObj, newObj                  interface{}
-		enableInPlacePodVerticalScaling bool
-		expectedHint                    fwk.QueueingHint
-		expectedErr                     bool
+		pod          *v1.Pod
+		oldObj       interface{}
+		expectedHint fwk.QueueingHint
+		expectedErr  bool
 	}{
 		"backoff-wrong-old-object": {
-			pod:                             &v1.Pod{},
-			oldObj:                          "not-a-pod",
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.Queue,
-			expectedErr:                     true,
-		},
-		"backoff-wrong-new-object": {
-			pod:                             &v1.Pod{},
-			newObj:                          "not-a-pod",
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.Queue,
-			expectedErr:                     true,
+			pod:          &v1.Pod{},
+			oldObj:       "not-a-pod",
+			expectedHint: fwk.Queue,
+			expectedErr:  true,
 		},
 		"queue-on-other-pod-deleted": {
-			pod:                             st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			oldObj:                          st.MakePod().Name("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Node("fake").Obj(),
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.Queue,
+			pod:          st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			oldObj:       st.MakePod().Name("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Node("fake").Obj(),
+			expectedHint: fwk.Queue,
 		},
 		"skip-queue-on-unscheduled-pod-deleted": {
-			pod:                             &v1.Pod{},
-			oldObj:                          &v1.Pod{},
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.QueueSkip,
+			pod:          &v1.Pod{},
+			oldObj:       &v1.Pod{},
+			expectedHint: fwk.QueueSkip,
 		},
 		"queue-on-nominated-pod-deleted": {
-			pod:                             st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).UID("uid0").Obj(),
-			oldObj:                          st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).NominatedNodeName("fake").UID("uid1").Obj(),
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.Queue,
+			pod:          st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).UID("uid0").Obj(),
+			oldObj:       st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).NominatedNodeName("fake").UID("uid1").Obj(),
+			expectedHint: fwk.Queue,
 		},
-		"skip-queue-on-disable-inplace-pod-vertical-scaling": {
-			pod:    st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			oldObj: st.MakePod().Name("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Node("fake").Obj(),
-			// (Actually, this scale down cannot happen when InPlacePodVerticalScaling is disabled.)
-			newObj:                          st.MakePod().Name("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Node("fake").Obj(),
-			enableInPlacePodVerticalScaling: false,
-			expectedHint:                    fwk.QueueSkip,
-		},
-		"skip-queue-on-other-unscheduled-pod": {
-			pod:                             st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).UID("uid0").Obj(),
-			oldObj:                          st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).UID("uid1").Obj(),
-			newObj:                          st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).UID("uid1").Obj(),
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.QueueSkip,
-		},
-		"skip-queue-on-other-pod-unrelated-resource-scaled-down": {
-			pod:                             st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			oldObj:                          st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "2"}).Node("fake").Obj(),
-			newObj:                          st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "1"}).Node("fake").Obj(),
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.QueueSkip,
-		},
-		"skip-queue-on-other-pod-unrelated-pod-level-resource-scaled-down": {
-			pod:                             st.MakePod().Name("pod1").UID("pod1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			oldObj:                          st.MakePod().Name("pod2").UID("pod2").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceMemory: "2"}).Node("fake").Obj(),
-			newObj:                          st.MakePod().Name("pod2").UID("pod2").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceMemory: "1"}).Node("fake").Obj(),
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.QueueSkip,
-		},
-		"queue-on-other-pod-some-resource-scale-down": {
-			pod:                             st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			oldObj:                          st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Node("fake").Obj(),
-			newObj:                          st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Node("fake").Obj(),
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.Queue,
-		},
-		"queue-on-other-pod-some-pod-level-resource-scale-down": {
-			pod:                             st.MakePod().Name("pod1").UID("pod1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			oldObj:                          st.MakePod().Name("pod2").UID("pod2").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Node("fake").Obj(),
-			newObj:                          st.MakePod().Name("pod2").UID("pod2").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Node("fake").Obj(),
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.Queue,
-		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			p, err := NewFit(ctx, &config.NodeResourcesFitArgs{ScoringStrategy: defaultScoringStrategy}, nil, plfeature.Features{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			actualHint, err := p.(*Fit).isSchedulableAfterAssignedPodDelete(logger, tc.pod, tc.oldObj, nil)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("unexpected hint (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_isSchedulableAfterTargetPodScaleDown(t *testing.T) {
+	testcases := map[string]struct {
+		pod          *v1.Pod
+		expectedHint fwk.QueueingHint
+	}{
 		"queue-on-target-pod-some-resource-scale-down": {
-			pod:                             st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			oldObj:                          st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj(),
-			newObj:                          st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.Queue,
+			pod:          st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			expectedHint: fwk.Queue,
 		},
 		"queue-on-target-pod-some-pod-level-resource-scale-down": {
-			pod:                             st.MakePod().Name("pod1").UID("pod1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			oldObj:                          st.MakePod().Name("pod1").UID("pod1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj(),
-			newObj:                          st.MakePod().Name("pod1").UID("pod1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			enableInPlacePodVerticalScaling: true,
-			expectedHint:                    fwk.Queue,
+			pod:          st.MakePod().Name("pod1").UID("pod1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			expectedHint: fwk.Queue,
 		},
 	}
 
@@ -1600,18 +1571,95 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			logger, ctx := ktesting.NewTestContext(t)
 			p, err := NewFit(ctx, &config.NodeResourcesFitArgs{ScoringStrategy: defaultScoringStrategy}, nil, plfeature.Features{
-				EnableInPlacePodVerticalScaling: tc.enableInPlacePodVerticalScaling,
+				EnableInPlacePodVerticalScaling: true,
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
-			actualHint, err := p.(*Fit).isSchedulableAfterPodEvent(logger, tc.pod, tc.oldObj, tc.newObj)
+			actualHint, err := p.(*Fit).isSchedulableAfterTargetPodScaleDown(logger, tc.pod, nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("unexpected hint (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_isSchedulableAfterAssignedPodScaleDown(t *testing.T) {
+	testcases := map[string]struct {
+		pod            *v1.Pod
+		oldObj, newObj interface{}
+		expectedHint   fwk.QueueingHint
+		expectedErr    bool
+	}{
+		"backoff-wrong-old-object": {
+			pod:          &v1.Pod{},
+			oldObj:       "not-a-pod",
+			expectedHint: fwk.Queue,
+			expectedErr:  true,
+		},
+		"backoff-wrong-new-object": {
+			pod:          &v1.Pod{},
+			newObj:       "not-a-pod",
+			expectedHint: fwk.Queue,
+			expectedErr:  true,
+		},
+		"skip-queue-on-other-unscheduled-pod": {
+			pod:          st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).UID("uid0").Obj(),
+			oldObj:       st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).UID("uid1").Obj(),
+			newObj:       st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).UID("uid1").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		"skip-queue-on-other-pod-unrelated-resource-scaled-down": {
+			pod:          st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			oldObj:       st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "2"}).Node("fake").Obj(),
+			newObj:       st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceMemory: "1"}).Node("fake").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		"skip-queue-on-other-pod-unrelated-pod-level-resource-scaled-down": {
+			pod:          st.MakePod().Name("pod1").UID("pod1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			oldObj:       st.MakePod().Name("pod2").UID("pod2").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceMemory: "2"}).Node("fake").Obj(),
+			newObj:       st.MakePod().Name("pod2").UID("pod2").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceMemory: "1"}).Node("fake").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		"queue-on-other-pod-some-resource-scale-down": {
+			pod:          st.MakePod().Name("pod1").UID("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			oldObj:       st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Node("fake").Obj(),
+			newObj:       st.MakePod().Name("pod2").UID("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Node("fake").Obj(),
+			expectedHint: fwk.Queue,
+		},
+		"queue-on-other-pod-some-pod-level-resource-scale-down": {
+			pod:          st.MakePod().Name("pod1").UID("pod1").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			oldObj:       st.MakePod().Name("pod2").UID("pod2").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Node("fake").Obj(),
+			newObj:       st.MakePod().Name("pod2").UID("pod2").PodLevelResourceRequests(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Node("fake").Obj(),
+			expectedHint: fwk.Queue,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			p, err := NewFit(ctx, &config.NodeResourcesFitArgs{ScoringStrategy: defaultScoringStrategy}, nil, plfeature.Features{
+				EnableInPlacePodVerticalScaling: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			actualHint, err := p.(*Fit).isSchedulableAfterAssignedPodScaleDown(logger, tc.pod, tc.oldObj, tc.newObj)
 			if tc.expectedErr {
-				require.Error(t, err)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedHint, actualHint)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("unexpected hint (-want, +got):\n%s", diff)
+			}
 		})
 	}
 }
@@ -1735,11 +1783,17 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			}
 			actualHint, err := p.(*Fit).isSchedulableAfterNodeChange(logger, tc.pod, tc.oldObj, tc.newObj)
 			if tc.expectedErr {
-				require.Error(t, err)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedHint, actualHint)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("unexpected hint (-want, +got):\n%s", diff)
+			}
 		})
 	}
 }
@@ -1884,11 +1938,17 @@ func Test_isSchedulableAfterDeviceClassChange(t *testing.T) {
 			}
 			actualHint, err := p.(*Fit).isSchedulableAfterDeviceClassEvent(logger, tc.pod, tc.oldObj, tc.newObj)
 			if tc.expectedErr {
-				require.Error(t, err)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedHint, actualHint)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("unexpected hint (-want, +got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -71,36 +71,31 @@ func (pl *NodeUnschedulable) EventsToRegister(_ context.Context) ([]fwk.ClusterE
 		// the scheduling queue uses Pod/Update Queueing Hint
 		// to determine whether a Pod's update makes the Pod schedulable or not.
 		// https://github.com/kubernetes/kubernetes/pull/122234
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodToleration}, QueueingHintFn: pl.isSchedulableAfterPodTolerationChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodToleration}, QueueingHintFn: pl.isSchedulableAfterTargetPodTolerationChange},
 	}, nil
 }
 
-// isSchedulableAfterPodTolerationChange is invoked whenever a pod's toleration changed.
-func (pl *NodeUnschedulable) isSchedulableAfterPodTolerationChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+// isSchedulableAfterTargetPodTolerationChange is invoked whenever a pod's toleration changed.
+func (pl *NodeUnschedulable) isSchedulableAfterTargetPodTolerationChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	_, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
 		return fwk.Queue, err
 	}
 
-	if pod.UID == modifiedPod.UID {
-		// Note: we don't need to check oldPod tolerations the taint because:
-		// - Taint can be added, but can't be modified nor removed.
-		// - If the Pod already has the toleration, it shouldn't have rejected by this plugin in the first place.
-		//   Meaning, here this Pod has been rejected by this plugin, and hence it shouldn't have the toleration yet.
-		if v1helper.TolerationsTolerateTaint(logger, modifiedPod.Spec.Tolerations, &v1.Taint{
-			Key:    v1.TaintNodeUnschedulable,
-			Effect: v1.TaintEffectNoSchedule,
-		}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators)) {
-			// This update makes the pod tolerate the unschedulable taint.
-			logger.V(5).Info("a new toleration is added for the unschedulable Pod, and it may make it schedulable", "pod", klog.KObj(modifiedPod))
-			return fwk.Queue, nil
-		}
-		logger.V(5).Info("a new toleration is added for the unschedulable Pod, but it's an unrelated toleration", "pod", klog.KObj(modifiedPod))
-		return fwk.QueueSkip, nil
+	// Note: we don't need to check oldPod tolerations the taint because:
+	// - Taint can be added, but can't be modified nor removed.
+	// - If the Pod already has the toleration, it shouldn't have rejected by this plugin in the first place.
+	//   Meaning, here this Pod has been rejected by this plugin, and hence it shouldn't have the toleration yet.
+	if v1helper.TolerationsTolerateTaint(logger, modifiedPod.Spec.Tolerations, &v1.Taint{
+		Key:    v1.TaintNodeUnschedulable,
+		Effect: v1.TaintEffectNoSchedule,
+	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators)) {
+		// This update makes the pod tolerate the unschedulable taint.
+		logger.V(5).Info("a new toleration is added for the unschedulable Pod, and it may make it schedulable", "pod", klog.KObj(modifiedPod))
+		return fwk.Queue, nil
 	}
 
-	logger.V(5).Info("a new toleration is added for a Pod, but it's an unrelated Pod and wouldn't change the TaintToleration plugin's decision", "pod", klog.KObj(modifiedPod))
-
+	logger.V(5).Info("a new toleration is added for the unschedulable Pod, but it's an unrelated toleration", "pod", klog.KObj(modifiedPod))
 	return fwk.QueueSkip, nil
 }
 

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -235,13 +235,6 @@ func TestIsSchedulableAfterPodTolerationChange(t *testing.T) {
 			expectedErr:  true,
 		},
 		{
-			name:         "skip-different-pod-update",
-			pod:          st.MakePod().UID("uid").Obj(),
-			newObj:       st.MakePod().UID("different-uid").Toleration(v1.TaintNodeUnschedulable).Obj(),
-			oldObj:       st.MakePod().UID("different-uid").Obj(),
-			expectedHint: fwk.QueueSkip,
-		},
-		{
 			name:         "queue-when-the-unsched-pod-gets-toleration",
 			pod:          st.MakePod().UID("uid").Obj(),
 			newObj:       st.MakePod().UID("uid").Toleration(v1.TaintNodeUnschedulable).Obj(),
@@ -261,7 +254,7 @@ func TestIsSchedulableAfterPodTolerationChange(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			pl := &NodeUnschedulable{}
-			got, err := pl.isSchedulableAfterPodTolerationChange(logger, testCase.pod, testCase.oldObj, testCase.newObj)
+			got, err := pl.isSchedulableAfterTargetPodTolerationChange(logger, testCase.pod, testCase.oldObj, testCase.newObj)
 			if err != nil && !testCase.expectedErr {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -92,16 +92,16 @@ func (pl *CSILimits) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWith
 		// because any new CSINode could make pods that were rejected by CSI volumes schedulable.
 		{Event: fwk.ClusterEvent{Resource: fwk.CSINode, ActionType: fwk.Add}},
 		{Event: fwk.ClusterEvent{Resource: fwk.CSINode, ActionType: fwk.Update}, QueueingHintFn: pl.isSchedulableAfterCSINodeUpdated},
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
+		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterAssignedPodDeleted},
 		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPVCAdded},
 		{Event: fwk.ClusterEvent{Resource: fwk.VolumeAttachment, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterVolumeAttachmentDeleted},
 	}, nil
 }
 
-func (pl *CSILimits) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+func (pl *CSILimits) isSchedulableAfterAssignedPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	deletedPod, _, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
-		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPodDeleted: %w", err)
+		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterAssignedPodDeleted: %w", err)
 	}
 
 	if len(deletedPod.Spec.Volumes) == 0 {

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -730,9 +730,9 @@ func TestCSILimitsQHint(t *testing.T) {
 				translator:           csitrans.New(),
 			}
 			logger, _ := ktesting.NewTestContext(t)
-			qhint, err := p.isSchedulableAfterPodDeleted(logger, test.newPod, test.deletedPod, nil)
+			qhint, err := p.isSchedulableAfterAssignedPodDeleted(logger, test.newPod, test.deletedPod, nil)
 			if err != nil {
-				t.Errorf("isSchedulableAfterPodDeleted failed: %v", err)
+				t.Errorf("isSchedulableAfterAssignedPodDeleted failed: %v", err)
 			}
 			if qhint != test.wantQHint {
 				t.Errorf("QHint does not match: %v, want: %v", qhint, test.wantQHint)

--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -154,7 +154,20 @@ func (pl *PodTopologySpread) setListers(factory informers.SharedInformerFactory)
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
 func (pl *PodTopologySpread) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
-	podActionType := fwk.Add | fwk.UpdatePodLabel | fwk.Delete
+	events := []fwk.ClusterEventWithHint{
+		// All ActionType includes the following events:
+		// - Add. An unschedulable Pod may fail due to violating topology spread constraints,
+		// adding an assigned Pod may make it schedulable.
+		// - UpdatePodLabel. Updating on an existing Pod's labels (e.g., removal) may make
+		// an unschedulable Pod schedulable.
+		// - Delete. An unschedulable Pod may fail due to violating an existing Pod's topology spread constraints,
+		// deleting an existing Pod may make it schedulable.
+		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Add | fwk.UpdatePodLabel | fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterAssignedPodChange},
+		// Node add|delete|update maybe lead an topology key changed,
+		// and make these pod in scheduling schedulable or unschedulable.
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.Delete | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+	}
+
 	if pl.enableSchedulingQueueHint {
 		// When the QueueingHint feature is enabled, the scheduling queue uses Pod/Update Queueing Hint
 		// to determine whether a Pod's update makes the Pod schedulable or not.
@@ -164,29 +177,17 @@ func (pl *PodTopologySpread) EventsToRegister(_ context.Context) ([]fwk.ClusterE
 		// The Pod rejected by this plugin can be schedulable when the Pod has a spread constraint with NodeTaintsPolicy:Honor
 		// and has got a new toleration.
 		// So, we add UpdatePodToleration here only when QHint is enabled.
-		podActionType = fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodToleration | fwk.Delete
+		events = append(events, fwk.ClusterEventWithHint{
+			Event:          fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodToleration | fwk.UpdatePodLabel},
+			QueueingHintFn: pl.isSchedulableAfterTargetPodChange,
+		})
 	}
 
-	return []fwk.ClusterEventWithHint{
-		// All ActionType includes the following events:
-		// - Add. An unschedulable Pod may fail due to violating topology spread constraints,
-		// adding an assigned Pod may make it schedulable.
-		// - UpdatePodLabel. Updating on an existing Pod's labels (e.g., removal) may make
-		// an unschedulable Pod schedulable.
-		// - Delete. An unschedulable Pod may fail due to violating an existing Pod's topology spread constraints,
-		// deleting an existing Pod may make it schedulable.
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: podActionType}, QueueingHintFn: pl.isSchedulableAfterPodChange},
-		// Node add|delete|update maybe lead an topology key changed,
-		// and make these pod in scheduling schedulable or unschedulable.
-		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.Delete | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
-	}, nil
+	return events, nil
 }
 
 // involvedInTopologySpreading returns true if the incomingPod is involved in the topology spreading of podWithSpreading.
 func involvedInTopologySpreading(incomingPod, podWithSpreading *v1.Pod) bool {
-	if incomingPod.UID == podWithSpreading.UID {
-		return true
-	}
 	if incomingPod.Spec.NodeName == "" && incomingPod.Status.NominatedNodeName == "" {
 		return false
 	}
@@ -203,7 +204,28 @@ func hasConstraintWithNodeTaintsPolicyHonor(constraints []topologySpreadConstrai
 	return false
 }
 
-func (pl *PodTopologySpread) isSchedulableAfterPodChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+func (pl *PodTopologySpread) isSchedulableAfterTargetPodChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	originalPod, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
+	if err != nil {
+		return fwk.Queue, err
+	}
+
+	constraints, err := pl.getConstraints(pod)
+	if err != nil {
+		return fwk.Queue, err
+	}
+
+	if !equality.Semantic.DeepEqual(modifiedPod.Spec.Tolerations, originalPod.Spec.Tolerations) && hasConstraintWithNodeTaintsPolicyHonor(constraints) {
+		// If any constraint has `NodeTaintsPolicy: Honor`, we can return Queue when the target Pod has got a new toleration.
+		logger.V(5).Info("the unschedulable pod has got a new toleration, which could make it schedulable",
+			"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
+		return fwk.Queue, nil
+	}
+
+	return pl.isSchedulableAfterPodLabelChange(logger, originalPod, modifiedPod, constraints)
+}
+
+func (pl *PodTopologySpread) isSchedulableAfterAssignedPodChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	originalPod, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
 		return fwk.Queue, err
@@ -222,31 +244,7 @@ func (pl *PodTopologySpread) isSchedulableAfterPodChange(logger klog.Logger, pod
 
 	// Pod is modified. Return Queue when the label(s) matching topologySpread's selector is added, changed, or deleted.
 	if modifiedPod != nil && originalPod != nil {
-		if pod.UID == modifiedPod.UID && !equality.Semantic.DeepEqual(modifiedPod.Spec.Tolerations, originalPod.Spec.Tolerations) && hasConstraintWithNodeTaintsPolicyHonor(constraints) {
-			// If any constraint has `NodeTaintsPolicy: Honor`, we can return Queue when the target Pod has got a new toleration.
-			logger.V(5).Info("the unschedulable pod has got a new toleration, which could make it schedulable",
-				"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-			return fwk.Queue, nil
-		}
-
-		if equality.Semantic.DeepEqual(modifiedPod.Labels, originalPod.Labels) {
-			logger.V(5).Info("the pod's update doesn't include the label update, which doesn't make the target pod schedulable",
-				"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-			return fwk.QueueSkip, nil
-		}
-		for _, c := range constraints {
-			if c.Selector.Matches(labels.Set(originalPod.Labels)) != c.Selector.Matches(labels.Set(modifiedPod.Labels)) {
-				// This modification makes this Pod match(or not match) with this constraint.
-				// Maybe now the scheduling result of topology spread gets changed by this change.
-				logger.V(5).Info("a scheduled pod's label was updated and it makes the updated pod match or unmatch the pod's topology spread constraints",
-					"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-				return fwk.Queue, nil
-			}
-		}
-		// This modification of labels doesn't change whether this Pod would match selector or not in any constraints.
-		logger.V(5).Info("a scheduled pod's label was updated, but it's a change unrelated to the pod's topology spread constraints",
-			"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-		return fwk.QueueSkip, nil
+		return pl.isSchedulableAfterPodLabelChange(logger, originalPod, modifiedPod, constraints)
 	}
 
 	// Pod is added. Return Queue when the added Pod has a label that matches with topologySpread's selector.
@@ -270,6 +268,27 @@ func (pl *PodTopologySpread) isSchedulableAfterPodChange(logger klog.Logger, pod
 	logger.V(5).Info("a scheduled pod was deleted, but it's unrelated to the pod's topology spread constraints",
 		"pod", klog.KObj(pod), "deletedPod", klog.KObj(originalPod))
 
+	return fwk.QueueSkip, nil
+}
+
+func (pl *PodTopologySpread) isSchedulableAfterPodLabelChange(logger klog.Logger, originalPod, modifiedPod *v1.Pod, constraints []topologySpreadConstraint) (fwk.QueueingHint, error) {
+	if equality.Semantic.DeepEqual(modifiedPod.Labels, originalPod.Labels) {
+		logger.V(5).Info("the pod's update doesn't include the label update, which doesn't make the target pod schedulable",
+			"pod", klog.KObj(originalPod), "modifiedPod", klog.KObj(modifiedPod))
+		return fwk.QueueSkip, nil
+	}
+	for _, c := range constraints {
+		if c.Selector.Matches(labels.Set(originalPod.Labels)) != c.Selector.Matches(labels.Set(modifiedPod.Labels)) {
+			// This modification makes this Pod match (or not match) with this constraint.
+			// Maybe now the scheduling result of topology spread gets changed by this change.
+			logger.V(5).Info("a scheduled or target pod's label was updated and it makes the updated pod match or unmatch the pod's topology spread constraints",
+				"pod", klog.KObj(originalPod), "modifiedPod", klog.KObj(modifiedPod))
+			return fwk.Queue, nil
+		}
+	}
+	// This modification of labels doesn't change whether this Pod would match selector or not in any constraints.
+	logger.V(5).Info("a scheduled or target pod's label was updated, but it's a change unrelated to the pod's topology spread constraints",
+		"pod", klog.KObj(originalPod), "modifiedPod", klog.KObj(modifiedPod))
 	return fwk.QueueSkip, nil
 }
 

--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin_test.go
@@ -19,7 +19,7 @@ package podtopologyspread
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2/ktesting"
@@ -161,23 +161,28 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			p := pl.(*PodTopologySpread)
 			actualHint, err := p.isSchedulableAfterNodeChange(logger, tc.pod, tc.oldNode, tc.newNode)
 			if tc.expectedErr {
-				require.Error(t, err)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedHint, actualHint)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("unexpected hint (-want, +got):\n%s", diff)
+			}
 		})
 	}
 }
 
-func Test_isSchedulableAfterPodChange(t *testing.T) {
+func Test_isSchedulableAfterAssignedPodChange(t *testing.T) {
 	testcases := []struct {
-		name                                         string
-		pod                                          *v1.Pod
-		oldPod, newPod                               *v1.Pod
-		expectedHint                                 fwk.QueueingHint
-		expectedErr                                  bool
-		enableNodeInclusionPolicyInPodTopologySpread bool
+		name           string
+		pod            *v1.Pod
+		oldPod, newPod *v1.Pod
+		expectedHint   fwk.QueueingHint
+		expectedErr    bool
 	}{
 		{
 			name: "add pod with labels match topologySpreadConstraints selector",
@@ -335,6 +340,40 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			newPod:       st.MakePod().UID("p2").Node("fake-node").Label("foo", "").Label("bar", "bar2").Obj(),
 			expectedHint: fwk.QueueSkip,
 		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			snapshot := cache.NewSnapshot(nil, nil)
+			pl := plugintesting.SetupPlugin(ctx, t, topologySpreadFunc, &config.PodTopologySpreadArgs{DefaultingType: config.ListDefaulting}, snapshot)
+			p := pl.(*PodTopologySpread)
+
+			actualHint, err := p.isSchedulableAfterAssignedPodChange(logger, tc.pod, tc.oldPod, tc.newPod)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("unexpected hint (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_isSchedulableAfterTargetPodChange(t *testing.T) {
+	testcases := []struct {
+		name                                         string
+		pod                                          *v1.Pod
+		oldPod, newPod                               *v1.Pod
+		expectedHint                                 fwk.QueueingHint
+		expectedErr                                  bool
+		enableNodeInclusionPolicyInPodTopologySpread bool
+	}{
 		{
 			name: "the unschedulable Pod has topologySpreadConstraint with NodeTaintsPolicy:Honor and has got a new toleration",
 			pod: st.MakePod().UID("p").Name("p").Label("foo", "").
@@ -385,13 +424,19 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			p := pl.(*PodTopologySpread)
 			p.enableNodeInclusionPolicyInPodTopologySpread = tc.enableNodeInclusionPolicyInPodTopologySpread
 
-			actualHint, err := p.isSchedulableAfterPodChange(logger, tc.pod, tc.oldPod, tc.newPod)
+			actualHint, err := p.isSchedulableAfterTargetPodChange(logger, tc.pod, tc.oldPod, tc.newPod)
 			if tc.expectedErr {
-				require.Error(t, err)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedHint, actualHint)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("unexpected hint (-want, +got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
@@ -27,7 +27,6 @@ import (
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
-	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 // Name of the plugin used in the plugin registry and configurations.
@@ -68,7 +67,7 @@ func (pl *SchedulingGates) EventsToRegister(_ context.Context) ([]fwk.ClusterEve
 	// https://github.com/kubernetes/kubernetes/pull/122234
 	return []fwk.ClusterEventWithHint{
 		// Pods can be more schedulable once it's gates are removed
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodSchedulingGatesEliminated}, QueueingHintFn: pl.isSchedulableAfterUpdatePodSchedulingGatesEliminated},
+		{Event: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodSchedulingGatesEliminated}, QueueingHintFn: pl.isSchedulableAfterUpdateTargetPodSchedulingGatesEliminated},
 	}, nil
 }
 
@@ -79,16 +78,6 @@ func New(_ context.Context, _ runtime.Object, _ fwk.Handle, fts feature.Features
 	}, nil
 }
 
-func (pl *SchedulingGates) isSchedulableAfterUpdatePodSchedulingGatesEliminated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
-	_, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
-	if err != nil {
-		return fwk.Queue, err
-	}
-
-	if modifiedPod.UID != pod.UID {
-		// If the update event is not for targetPod, it wouldn't make targetPod schedulable.
-		return fwk.QueueSkip, nil
-	}
-
+func (pl *SchedulingGates) isSchedulableAfterUpdateTargetPodSchedulingGatesEliminated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	return fwk.Queue, nil
 }

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -63,53 +62,22 @@ func TestPreEnqueue(t *testing.T) {
 	}
 }
 
-func Test_isSchedulableAfterPodChange(t *testing.T) {
-	testcases := map[string]struct {
-		pod            *v1.Pod
-		oldObj, newObj interface{}
-		expectedHint   fwk.QueueingHint
-		expectedErr    bool
-	}{
-		"backoff-wrong-old-object": {
-			pod:          &v1.Pod{},
-			oldObj:       "not-a-pod",
-			expectedHint: fwk.Queue,
-			expectedErr:  true,
-		},
-		"backoff-wrong-new-object": {
-			pod:          &v1.Pod{},
-			newObj:       "not-a-pod",
-			expectedHint: fwk.Queue,
-			expectedErr:  true,
-		},
-		"skip-queue-on-other-pod-updated": {
-			pod:          st.MakePod().Name("p").SchedulingGates([]string{"foo", "bar"}).UID("uid0").Obj(),
-			oldObj:       st.MakePod().Name("p1").SchedulingGates([]string{"foo", "bar"}).UID("uid1").Obj(),
-			newObj:       st.MakePod().Name("p1").SchedulingGates([]string{"foo"}).UID("uid1").Obj(),
-			expectedHint: fwk.QueueSkip,
-		},
-		"queue-on-the-unsched-pod-updated": {
-			pod:          st.MakePod().Name("p").SchedulingGates([]string{"foo"}).Obj(),
-			oldObj:       st.MakePod().Name("p").SchedulingGates([]string{"foo"}).Obj(),
-			newObj:       st.MakePod().Name("p").SchedulingGates([]string{}).Obj(),
-			expectedHint: fwk.Queue,
-		},
+func TestIsSchedulableAfterUpdateTargetPodSchedulingGatesEliminated(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	p, err := New(ctx, nil, nil, feature.Features{})
+	if err != nil {
+		t.Fatalf("Creating plugin: %v", err)
 	}
 
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
-			p, err := New(ctx, nil, nil, feature.Features{})
-			if err != nil {
-				t.Fatalf("Creating plugin: %v", err)
-			}
-			actualHint, err := p.(*SchedulingGates).isSchedulableAfterUpdatePodSchedulingGatesEliminated(logger, tc.pod, tc.oldObj, tc.newObj)
-			if tc.expectedErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedHint, actualHint)
-		})
+	pod := st.MakePod().Name("p").SchedulingGates([]string{"foo"}).Obj()
+	oldObj := st.MakePod().Name("p").SchedulingGates([]string{"foo"}).Obj()
+	newObj := st.MakePod().Name("p").Obj()
+
+	actualHint, err := p.(*SchedulingGates).isSchedulableAfterUpdateTargetPodSchedulingGatesEliminated(logger, pod, oldObj, newObj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(fwk.Queue, actualHint); diff != "" {
+		t.Errorf("unexpected hint (-want, +got):\n%s", diff)
 	}
 }

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -76,7 +76,7 @@ func (pl *TaintToleration) EventsToRegister(_ context.Context) ([]fwk.ClusterEve
 			// the scheduling queue uses Pod/Update Queueing Hint
 			// to determine whether a Pod's update makes the Pod schedulable or not.
 			// https://github.com/kubernetes/kubernetes/pull/122234
-			{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodToleration}, QueueingHintFn: pl.isSchedulableAfterPodTolerationChange},
+			{Event: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.UpdatePodToleration}, QueueingHintFn: pl.isSchedulableAfterTargetPodTolerationChange},
 		}, nil
 	}
 
@@ -225,20 +225,9 @@ func New(_ context.Context, _ runtime.Object, h fwk.Handle, fts feature.Features
 	}, nil
 }
 
-// isSchedulableAfterPodTolerationChange is invoked whenever a pod's toleration changed.
-func (pl *TaintToleration) isSchedulableAfterPodTolerationChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
-	_, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
-	if err != nil {
-		return fwk.Queue, err
-	}
-
-	if pod.UID == modifiedPod.UID {
-		// The updated Pod is the unschedulable Pod.
-		logger.V(5).Info("a new toleration is added for the unschedulable Pod, and it may make it schedulable", "pod", klog.KObj(modifiedPod))
-		return fwk.Queue, nil
-	}
-
-	logger.V(5).Info("a new toleration is added for a Pod, but it's an unrelated Pod and wouldn't change the TaintToleration plugin's decision", "pod", klog.KObj(modifiedPod))
-
-	return fwk.QueueSkip, nil
+// isSchedulableAfterTargetPodTolerationChange is invoked whenever a pod's toleration changed.
+func (pl *TaintToleration) isSchedulableAfterTargetPodTolerationChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	// The updated Pod is the unschedulable Pod.
+	logger.V(5).Info("a new toleration is added for the unschedulable Pod, and it may make it schedulable", "pod", klog.KObj(pod))
+	return fwk.Queue, nil
 }

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -597,57 +597,12 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 	}
 }
 
-func Test_isSchedulableAfterPodTolerationChange(t *testing.T) {
+func Test_isSchedulableAfterTargetPodTolerationChange(t *testing.T) {
 	testcases := map[string]struct {
 		pod            *v1.Pod
 		oldObj, newObj interface{}
 		expectedHint   fwk.QueueingHint
-		expectedErr    bool
 	}{
-		"backoff-wrong-new-object": {
-			pod:          &v1.Pod{},
-			newObj:       "not-a-pod",
-			expectedHint: fwk.Queue,
-			expectedErr:  true,
-		},
-		"backoff-wrong-old-object": {
-			pod:          &v1.Pod{},
-			oldObj:       "not-a-pod",
-			newObj:       &v1.Pod{},
-			expectedHint: fwk.Queue,
-			expectedErr:  true,
-		},
-		"skip-updates-other-pod": {
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod-1",
-					Namespace: "ns-1",
-					UID:       "uid0",
-				}},
-			oldObj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod-2",
-					Namespace: "ns-1",
-					UID:       "uid1",
-				}},
-			newObj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod-2",
-					Namespace: "ns-1",
-					UID:       "uid1",
-				},
-				Spec: v1.PodSpec{
-					Tolerations: []v1.Toleration{
-						{
-							Key:    "foo",
-							Effect: v1.TaintEffectNoSchedule,
-						},
-					},
-				},
-			},
-			expectedHint: fwk.QueueSkip,
-			expectedErr:  false,
-		},
 		"queue-on-toleration-added": {
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -674,7 +629,6 @@ func Test_isSchedulableAfterPodTolerationChange(t *testing.T) {
 				},
 			},
 			expectedHint: fwk.Queue,
-			expectedErr:  false,
 		},
 	}
 
@@ -685,16 +639,9 @@ func Test_isSchedulableAfterPodTolerationChange(t *testing.T) {
 			if err != nil {
 				t.Fatalf("creating plugin: %v", err)
 			}
-			actualHint, err := p.(*TaintToleration).isSchedulableAfterPodTolerationChange(logger, tc.pod, tc.oldObj, tc.newObj)
-			if tc.expectedErr {
-				if err == nil {
-					t.Errorf("unexpected success")
-				}
-				return
-			}
+			actualHint, err := p.(*TaintToleration).isSchedulableAfterTargetPodTolerationChange(logger, tc.pod, tc.oldObj, tc.newObj)
 			if err != nil {
-				t.Errorf("unexpected error")
-				return
+				t.Fatalf("Unexpected error: %v", err)
 			}
 			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
 				t.Errorf("Unexpected hint (-want, +got):\n%s", diff)

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -343,7 +343,7 @@ func (pl *VolumeRestrictions) EventsToRegister(_ context.Context) ([]fwk.Cluster
 		// Pods may fail to schedule because of volumes conflicting with other pods on same node.
 		// Once running pods are deleted and volumes have been released, the unschedulable pod will be schedulable.
 		// Due to immutable fields `spec.volumes`, pod update events are ignored.
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
+		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterAssignedPodDeleted},
 		// A new Node may make a pod schedulable.
 		// We intentionally don't set QueueingHint since all Node/Add events could make Pods schedulable.
 		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: nodeActionType}},
@@ -380,12 +380,12 @@ func (pl *VolumeRestrictions) isSchedulableAfterPersistentVolumeClaimAdded(logge
 	return fwk.QueueSkip, nil
 }
 
-// isSchedulableAfterPodDeleted is invoked whenever a pod deleted,
+// isSchedulableAfterAssignedPodDeleted is invoked whenever an assigned pod is deleted,
 // It checks whether the deleted pod will conflict with volumes of other pods on the same node
-func (pl *VolumeRestrictions) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+func (pl *VolumeRestrictions) isSchedulableAfterAssignedPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	deletedPod, _, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
-		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPodDeleted: %w", err)
+		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterAssignedPodDeleted: %w", err)
 	}
 
 	if deletedPod.Namespace != pod.Namespace {

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -486,7 +486,7 @@ func TestAccessModeConflicts(t *testing.T) {
 	}
 }
 
-func Test_isSchedulableAfterPodDeleted(t *testing.T) {
+func Test_isSchedulableAfterAssignedPodDeleted(t *testing.T) {
 	GCEDiskVolState := v1.Volume{
 		VolumeSource: v1.VolumeSource{
 			GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
@@ -672,7 +672,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			defer cancel()
 			p := newPluginWithListers(ctx, t, tc.existingPods, nil, []*v1.PersistentVolumeClaim{tc.existingPVC})
 
-			actualHint, err := p.(*VolumeRestrictions).isSchedulableAfterPodDeleted(logger, tc.pod, tc.oldObj, nil)
+			actualHint, err := p.(*VolumeRestrictions).isSchedulableAfterAssignedPodDeleted(logger, tc.pod, tc.oldObj, nil)
 			if tc.expectedErr {
 				if err == nil {
 					t.Error("Expect error, but got nil")

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -52,20 +52,13 @@ var (
 	nodeActionTypes = []fwk.ActionType{fwk.UpdateNodeAllocatable, fwk.UpdateNodeLabel, fwk.UpdateNodeTaint, fwk.UpdateNodeCondition, fwk.UpdateNodeAnnotation}
 )
 
-// Constants for GVKs.
-const (
-	// These assignedPod and unschedulablePod are internal resources that are used to represent the type of Pod.
-	// We don't expose them to the plugins deliberately because we don't publish Pod events with unschedulable Pods in the first place.
-	assignedPod      fwk.EventResource = "AssignedPod"
-	unschedulablePod fwk.EventResource = "UnschedulablePod"
-)
-
 var (
 	// allResources is a list of all resources.
 	allResources = []fwk.EventResource{
 		fwk.Pod,
-		assignedPod,
-		unschedulablePod,
+		fwk.AssignedPod,
+		fwk.UnscheduledPod,
+		fwk.TargetPod,
 		fwk.Node,
 		fwk.PersistentVolume,
 		fwk.PersistentVolumeClaim,
@@ -129,9 +122,8 @@ func matchEventResources(r, resource fwk.EventResource) bool {
 	return r == fwk.WildCard ||
 		// Exact match
 		r == resource ||
-		// Pod matches assignedPod and unschedulablePod.
-		// (assignedPod and unschedulablePod aren't exposed and hence only used for incoming events and never used in EventsToRegister)
-		r == fwk.Pod && (resource == assignedPod || resource == unschedulablePod)
+		// Pod matches any of these: AssignedPod, UnscheduledPod, TargetPod.
+		r == fwk.Pod && (resource == fwk.AssignedPod || resource == fwk.UnscheduledPod || resource == fwk.TargetPod)
 }
 
 func MatchAnyClusterEvent(ce fwk.ClusterEvent, incomingEvents []fwk.ClusterEvent) bool {
@@ -145,7 +137,9 @@ func MatchAnyClusterEvent(ce fwk.ClusterEvent, incomingEvents []fwk.ClusterEvent
 
 func UnrollWildCardResource() []fwk.ClusterEventWithHint {
 	events := []fwk.ClusterEventWithHint{
-		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.All}},
 		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.All}},
 		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolume, ActionType: fwk.All}},
 		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.All}},
@@ -160,6 +154,17 @@ func UnrollWildCardResource() []fwk.ClusterEventWithHint {
 		events = append(events, fwk.ClusterEventWithHint{Event: fwk.ClusterEvent{Resource: fwk.PodGroup, ActionType: fwk.All}})
 	}
 	return events
+}
+
+// UnrollPodEvent splits the cluster event with the resource Pod into three cluster events
+// with resources AssignedPod, UnscheduledPod, and TargetPod.
+// It assumes that event.Resource == fwk.Pod.
+func UnrollPodEvent(event fwk.ClusterEvent) []fwk.ClusterEvent {
+	return []fwk.ClusterEvent{
+		{Resource: fwk.AssignedPod, ActionType: event.ActionType},
+		{Resource: fwk.UnscheduledPod, ActionType: event.ActionType},
+		{Resource: fwk.TargetPod, ActionType: event.ActionType},
+	}
 }
 
 // NodeInfo is node level aggregated information.

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -2367,7 +2367,7 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 	}
 }
 
-func TestCloudEvent_Match(t *testing.T) {
+func TestClusterEventMatching(t *testing.T) {
 	testCases := []struct {
 		name        string
 		event       fwk.ClusterEvent
@@ -2381,15 +2381,15 @@ func TestCloudEvent_Match(t *testing.T) {
 			wantResult:  true,
 		},
 		{
-			name:        "event with resource = 'Pod' matching with coming events carries same actionType",
+			name:        "event with resource = 'Pod' matching with coming events carries matching actionType",
 			event:       fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel | fwk.UpdateNodeTaint},
 			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel},
 			wantResult:  true,
 		},
 		{
-			name:        "event with resource = 'Pod' matching with coming events carries unschedulablePod",
+			name:        "event with resource = 'Pod' also matches event with 'UnscheduledPod' resource and matching actionType",
 			event:       fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel | fwk.UpdateNodeTaint},
-			comingEvent: fwk.ClusterEvent{Resource: unschedulablePod, ActionType: fwk.UpdateNodeLabel},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdateNodeLabel},
 			wantResult:  true,
 		},
 		{
@@ -2422,6 +2422,72 @@ func TestCloudEvent_Match(t *testing.T) {
 			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel},
 			wantResult:  true,
 		},
+		{
+			name:        "event with resource = 'Pod' also matches event with 'UnscheduledPod' resource and matching actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel | fwk.UpdateNodeTaint},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdateNodeLabel},
+			wantResult:  true,
+		},
+		{
+			name:        "event with resource = 'Pod' also matches event with AssignedPod resource and same actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.UpdateNodeLabel},
+			wantResult:  true,
+		},
+		{
+			name:        "event with resource = 'Pod' also matches event with 'TargetPod' resource and same actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeTaint},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.UpdateNodeTaint},
+			wantResult:  true,
+		},
+		{
+			name:        "event with resource 'AssignedPod' does not match event with 'UnscheduledPod' resource and same actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Add},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.Add},
+			wantResult:  false,
+		},
+		{
+			name:        "event with resource 'AssignedPod' does not match event with 'TargetPod' resource and same actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Update},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.Update},
+			wantResult:  false,
+		},
+		{
+			name:        "event with resource 'TargetPod' does not match event with 'AssignedPod' resource and same actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.Update},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Update},
+			wantResult:  false,
+		},
+		{
+			name:        "event with resource 'AssignedPod' does not match with broad 'Pod' resource and same actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Add},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add},
+			wantResult:  false,
+		},
+		{
+			name:        "event with resource 'AssignedPod' does not match with 'WildCard' resource and same actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Add},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.Add},
+			wantResult:  false,
+		},
+		{
+			name:        "event with resource 'UnscheduledPod' does not match with broad 'Pod' resource and same actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.Add},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add},
+			wantResult:  false,
+		},
+		{
+			name:        "event with resource 'UnscheduledPod' does not match with 'WildCard' resource and same actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.Add},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.Add},
+			wantResult:  false,
+		},
+		{
+			name:        "WildCard matches with a pod sub-type resource 'TargetPod' and any actionType",
+			event:       fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.All},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.TargetPod, ActionType: fwk.Update},
+			wantResult:  true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2429,6 +2495,44 @@ func TestCloudEvent_Match(t *testing.T) {
 			got := MatchClusterEvents(tc.event, tc.comingEvent)
 			if got != tc.wantResult {
 				t.Fatalf("unexpected result")
+			}
+		})
+	}
+}
+
+func TestUnrollPodEvent(t *testing.T) {
+	tests := []struct {
+		name      string
+		event     fwk.ClusterEvent
+		wantTypes []fwk.EventResource
+	}{
+		{
+			name:      "Pod/Add unrolls into pod sub-types with add action type",
+			event:     fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add},
+			wantTypes: []fwk.EventResource{fwk.AssignedPod, fwk.UnscheduledPod, fwk.TargetPod},
+		},
+		{
+			name:      "Pod/Delete unrolls into pod sub-types with delete action type",
+			event:     fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete},
+			wantTypes: []fwk.EventResource{fwk.AssignedPod, fwk.UnscheduledPod, fwk.TargetPod},
+		},
+		{
+			name:      "Pod/Update unrolls into pod sub-types with update action type",
+			event:     fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Update},
+			wantTypes: []fwk.EventResource{fwk.AssignedPod, fwk.UnscheduledPod, fwk.TargetPod},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UnrollPodEvent(tt.event)
+			for i, res := range tt.wantTypes {
+				if got[i].Resource != res {
+					t.Errorf("event[%d]: expected resource %q, got %q", i, res, got[i].Resource)
+				}
+				if got[i].ActionType != tt.event.ActionType {
+					t.Errorf("event[%d]: expected ActionType %v, got %v", i, tt.event.ActionType, got[i].ActionType)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -511,10 +511,18 @@ func buildQueueingHintMap(ctx context.Context, es []fwk.EnqueueExtensions) (inte
 				}
 			}
 
-			queueingHintMap[event.Event] = append(queueingHintMap[event.Event], &internalqueue.QueueingHintFunction{
+			queueingHintFn := &internalqueue.QueueingHintFunction{
 				PluginName:     e.Name(),
 				QueueingHintFn: fn,
-			})
+			}
+
+			if event.Event.Resource == fwk.Pod {
+				for _, podEvent := range framework.UnrollPodEvent(event.Event) {
+					queueingHintMap[podEvent] = append(queueingHintMap[podEvent], queueingHintFn)
+				}
+			} else {
+				queueingHintMap[event.Event] = append(queueingHintMap[event.Event], queueingHintFn)
+			}
 		}
 		if registerNodeAdded && !registerNodeTaintUpdated {
 			// Temporally fix for the issue https://github.com/kubernetes/kubernetes/issues/109437

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -648,6 +648,7 @@ const (
 	fakeBind                       = "bind-plugin"
 	emptyEventExtensions           = "emptyEventExtensions"
 	fakePermit                     = "fakePermit"
+	fakeAssignedPod                = "fakeAssignedPodPlugin"
 )
 
 func Test_buildQueueingHintMap(t *testing.T) {
@@ -662,7 +663,13 @@ func Test_buildQueueingHintMap(t *testing.T) {
 			name:    "filter without EnqueueExtensions plugin",
 			plugins: []fwk.Plugin{&filterWithoutEnqueueExtensionsPlugin{}},
 			want: map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{
-				{Resource: fwk.Pod, ActionType: fwk.All}: {
+				{Resource: fwk.AssignedPod, ActionType: fwk.All}: {
+					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
+				},
+				{Resource: fwk.UnscheduledPod, ActionType: fwk.All}: {
+					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
+				},
+				{Resource: fwk.TargetPod, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
 				{Resource: fwk.Node, ActionType: fwk.All}: {
@@ -701,7 +708,13 @@ func Test_buildQueueingHintMap(t *testing.T) {
 			name:    "node and pod plugin",
 			plugins: []fwk.Plugin{&fakeNodePlugin{}, &fakePodPlugin{}},
 			want: map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{
-				{Resource: fwk.Pod, ActionType: fwk.Add}: {
+				{Resource: fwk.AssignedPod, ActionType: fwk.Add}: {
+					{PluginName: fakePod, QueueingHintFn: fakePodPluginQueueingFn},
+				},
+				{Resource: fwk.UnscheduledPod, ActionType: fwk.Add}: {
+					{PluginName: fakePod, QueueingHintFn: fakePodPluginQueueingFn},
+				},
+				{Resource: fwk.TargetPod, ActionType: fwk.Add}: {
 					{PluginName: fakePod, QueueingHintFn: fakePodPluginQueueingFn},
 				},
 				{Resource: fwk.Node, ActionType: fwk.Add}: {
@@ -717,7 +730,13 @@ func Test_buildQueueingHintMap(t *testing.T) {
 			plugins:             []fwk.Plugin{&fakeNodePlugin{}, &fakePodPlugin{}},
 			featuregateDisabled: true,
 			want: map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{
-				{Resource: fwk.Pod, ActionType: fwk.Add}: {
+				{Resource: fwk.AssignedPod, ActionType: fwk.Add}: {
+					{PluginName: fakePod, QueueingHintFn: defaultQueueingHintFn}, // default queueing hint due to disabled feature gate.
+				},
+				{Resource: fwk.TargetPod, ActionType: fwk.Add}: {
+					{PluginName: fakePod, QueueingHintFn: defaultQueueingHintFn}, // default queueing hint due to disabled feature gate.
+				},
+				{Resource: fwk.UnscheduledPod, ActionType: fwk.Add}: {
 					{PluginName: fakePod, QueueingHintFn: defaultQueueingHintFn}, // default queueing hint due to disabled feature gate.
 				},
 				{Resource: fwk.Node, ActionType: fwk.Add}: {
@@ -737,7 +756,13 @@ func Test_buildQueueingHintMap(t *testing.T) {
 			name:    "register plugins including emptyEventPlugin",
 			plugins: []fwk.Plugin{&emptyEventPlugin{}, &fakeNodePlugin{}},
 			want: map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{
-				{Resource: fwk.Pod, ActionType: fwk.Add}: {
+				{Resource: fwk.AssignedPod, ActionType: fwk.Add}: {
+					{PluginName: fakePod, QueueingHintFn: fakePodPluginQueueingFn},
+				},
+				{Resource: fwk.UnscheduledPod, ActionType: fwk.Add}: {
+					{PluginName: fakePod, QueueingHintFn: fakePodPluginQueueingFn},
+				},
+				{Resource: fwk.TargetPod, ActionType: fwk.Add}: {
 					{PluginName: fakePod, QueueingHintFn: fakePodPluginQueueingFn},
 				},
 				{Resource: fwk.Node, ActionType: fwk.Add}: {
@@ -753,6 +778,15 @@ func Test_buildQueueingHintMap(t *testing.T) {
 			plugins: []fwk.Plugin{&errorEventsToRegisterPlugin{}},
 			want:    map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{},
 			wantErr: errors.New("mock error"),
+		},
+		{
+			name:    "plugin registering to a specific pod resource 'AssignedPod'",
+			plugins: []fwk.Plugin{&fakeAssignedPodPlugin{}},
+			want: map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{
+				{Resource: fwk.AssignedPod, ActionType: fwk.Update}: {
+					{PluginName: fakeAssignedPod, QueueingHintFn: fakeAssignedPodPluginQueueingFn},
+				},
+			},
 		},
 	}
 
@@ -830,6 +864,7 @@ func Test_buildQueueingHintMap(t *testing.T) {
 }
 
 // Test_UnionedGVKs tests UnionedGVKs worked with buildQueueingHintMap.
+// It verifies that a given set of plugins is correctly registered for a specific set of cluster events.
 func Test_UnionedGVKs(t *testing.T) {
 	tests := []struct {
 		name                            string
@@ -852,7 +887,9 @@ func Test_UnionedGVKs(t *testing.T) {
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod:                   fwk.All,
+				fwk.AssignedPod:           fwk.All,
+				fwk.UnscheduledPod:        fwk.All,
+				fwk.TargetPod:             fwk.All,
 				fwk.Node:                  fwk.All,
 				fwk.CSINode:               fwk.All,
 				fwk.CSIDriver:             fwk.All,
@@ -875,7 +912,9 @@ func Test_UnionedGVKs(t *testing.T) {
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod:                   fwk.All,
+				fwk.AssignedPod:           fwk.All,
+				fwk.UnscheduledPod:        fwk.All,
+				fwk.TargetPod:             fwk.All,
 				fwk.Node:                  fwk.All,
 				fwk.CSINode:               fwk.All,
 				fwk.CSIDriver:             fwk.All,
@@ -917,7 +956,9 @@ func Test_UnionedGVKs(t *testing.T) {
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod: fwk.Add,
+				fwk.AssignedPod:    fwk.Add,
+				fwk.UnscheduledPod: fwk.Add,
+				fwk.TargetPod:      fwk.Add,
 			},
 		},
 		{
@@ -932,8 +973,10 @@ func Test_UnionedGVKs(t *testing.T) {
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod:  fwk.Add,
-				fwk.Node: fwk.Add | fwk.UpdateNodeTaint, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
+				fwk.AssignedPod:    fwk.Add,
+				fwk.UnscheduledPod: fwk.Add,
+				fwk.TargetPod:      fwk.Add,
+				fwk.Node:           fwk.Add | fwk.UpdateNodeTaint, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
 			},
 		},
 		{
@@ -952,7 +995,8 @@ func Test_UnionedGVKs(t *testing.T) {
 			name:    "plugins with default profile (No feature gate enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.Delete,
+				fwk.AssignedPod:           fwk.Add | fwk.UpdatePodLabel | fwk.Delete,
+				fwk.TargetPod:             fwk.UpdatePodLabel,
 				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
@@ -967,7 +1011,8 @@ func Test_UnionedGVKs(t *testing.T) {
 			name:    "plugins with default profile (InPlacePodVerticalScaling: enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.Delete,
+				fwk.AssignedPod:           fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.Delete,
+				fwk.TargetPod:             fwk.UpdatePodLabel | fwk.UpdatePodScaleDown,
 				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
@@ -983,7 +1028,8 @@ func Test_UnionedGVKs(t *testing.T) {
 			name:    "plugins with default profile (queueingHint/InPlacePodVerticalScaling: enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete,
+				fwk.AssignedPod:           fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.Delete,
+				fwk.TargetPod:             fwk.UpdatePodLabel | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.UpdatePodScaleDown,
 				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
@@ -1000,7 +1046,8 @@ func Test_UnionedGVKs(t *testing.T) {
 			name:    "plugins with default profile (DynamicResourceAllocation: enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.Delete,
+				fwk.AssignedPod:           fwk.Add | fwk.UpdatePodLabel | fwk.Delete,
+				fwk.TargetPod:             fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim,
 				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
@@ -1019,7 +1066,8 @@ func Test_UnionedGVKs(t *testing.T) {
 			name:    "plugins with default profile (queueingHint/DynamicResourceAllocation: enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete,
+				fwk.AssignedPod:           fwk.Add | fwk.UpdatePodLabel | fwk.Delete,
+				fwk.TargetPod:             fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated,
 				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
@@ -1040,7 +1088,8 @@ func Test_UnionedGVKs(t *testing.T) {
 			plugins: defaults.PluginsV1.MultiPoint,
 			want: map[fwk.EventResource]fwk.ActionType{
 				// NodeDeclaredFeatures adds fwk.Update
-				fwk.Pod: fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete | fwk.Update,
+				fwk.AssignedPod: fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.Delete,
+				fwk.TargetPod:   fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Update,
 				// NodeDeclaredFeatures adds fwk.UpdateNodeDeclaredFeature
 				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete | fwk.UpdateNodeDeclaredFeature,
 				fwk.CSINode:               fwk.All - fwk.Delete,
@@ -1060,10 +1109,26 @@ func Test_UnionedGVKs(t *testing.T) {
 			enableInPlacePodVerticalScaling: true,
 		},
 		{
+			name: "plugin registering to a specific pod resource 'AssignedPod'",
+			plugins: schedulerapi.PluginSet{
+				Enabled: []schedulerapi.Plugin{
+					{Name: fakeAssignedPod},
+					{Name: queueSort},
+					{Name: fakeBind},
+				},
+				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
+			},
+			want: map[fwk.EventResource]fwk.ActionType{
+				fwk.AssignedPod: fwk.Update,
+			},
+		},
+		{
 			name:    "plugins with default profile and GangScheduling",
 			plugins: schedulerapi.PluginSet{Enabled: append(defaults.PluginsV1.MultiPoint.Enabled, schedulerapi.Plugin{Name: names.GangScheduling})},
 			want: map[fwk.EventResource]fwk.ActionType{
-				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete,
+				fwk.AssignedPod:           fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.Delete,
+				fwk.TargetPod:             fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodScaleDown | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated,
+				fwk.UnscheduledPod:        fwk.Add,
 				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
@@ -1135,7 +1200,7 @@ func Test_UnionedGVKs(t *testing.T) {
 			registry := plugins.NewInTreeRegistry()
 
 			cfgPls := &schedulerapi.Plugins{MultiPoint: tt.plugins}
-			plugins := []fwk.Plugin{&fakeNodePlugin{}, &fakePodPlugin{}, &filterWithoutEnqueueExtensionsPlugin{}, &emptyEventsToRegisterPlugin{}, &fakeQueueSortPlugin{}, &fakebindPlugin{}}
+			plugins := []fwk.Plugin{&fakeNodePlugin{}, &fakePodPlugin{}, &fakeAssignedPodPlugin{}, &filterWithoutEnqueueExtensionsPlugin{}, &emptyEventsToRegisterPlugin{}, &fakeQueueSortPlugin{}, &fakebindPlugin{}}
 			for _, pl := range plugins {
 				tmpPl := pl
 				if err := registry.Register(pl.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
@@ -1397,6 +1462,26 @@ func (*fakePodPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ f
 func (pl *fakePodPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return []fwk.ClusterEventWithHint{
 		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add}, QueueingHintFn: fakePodPluginQueueingFn},
+	}, nil
+}
+
+var hintFromFakeAssignedPod = fwk.QueueingHint(102)
+
+type fakeAssignedPodPlugin struct{}
+
+var fakeAssignedPodPluginQueueingFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (fwk.QueueingHint, error) {
+	return hintFromFakeAssignedPod, nil
+}
+
+func (*fakeAssignedPodPlugin) Name() string { return fakeAssignedPod }
+
+func (*fakeAssignedPodPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ fwk.NodeInfo) *fwk.Status {
+	return nil
+}
+
+func (pl *fakeAssignedPodPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Update}, QueueingHintFn: fakeAssignedPodPluginQueueingFn},
 	}, nil
 }
 

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -148,7 +148,16 @@ const (
 	// the previous rejection from noderesources plugin can be resolved.
 	// this plugin would implement QueueingHint for Pod/Update event
 	// that returns Queue when such label changes are made in unscheduled Pods.
+	//
+	// There is one general pod resource: Pod, that contains three specific pod resources: AssignedPod, UnscheduledPod, and TargetPod.
+	// Plugins can and are expected to register to specific pod events for better performance.
 	Pod EventResource = "Pod"
+	// AssignedPod resource is associated with the cluster event that gets triggered when a scheduled pod is updated.
+	AssignedPod EventResource = "AssignedPod"
+	// UnscheduledPod resource is associated with the cluster event that gets triggered when an unscheduled pod is updated, other than the target pod.
+	UnscheduledPod EventResource = "UnscheduledPod"
+	// TargetPod resource is associated with the cluster event that gets triggered when an unscheduled pod itself is updated.
+	TargetPod EventResource = "TargetPod"
 
 	// A note about NodeAdd event and UpdateNodeTaint event:
 	// When QHint is disabled, NodeAdd often isn't worked expectedly because of the internal feature called preCheck.

--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -121,15 +121,6 @@ type CoreResourceEnqueueTestCase struct {
 	EnableGangScheduling bool
 }
 
-var (
-	// These resources are unexported from the framework intentionally
-	// because they're only used internally for the metric labels/logging.
-	// We need to declare them here to use them in the test
-	// because this test is using the metric labels.
-	assignedPod      fwk.EventResource = "AssignedPod"
-	unschedulablePod fwk.EventResource = "UnschedulablePod"
-)
-
 // We define all the test cases here in the one place,
 // and those will be run either in ./former or ./queueinghint tests, depending on EnableSchedulingQueueHint.
 // We needed to do this because running all these test cases resulted in the timeout.
@@ -270,7 +261,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Container("image").Toleration("taint-key").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the pod: %w", err)
 			}
-			return map[fwk.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: fwk.UpdatePodToleration}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdatePodToleration}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -328,7 +319,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).UpdateResize(testCtx.Ctx, "pod1", st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to resize the pod: %w", err)
 			}
-			return map[fwk.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: fwk.UpdatePodScaleDown}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdatePodScaleDown}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -616,7 +607,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Label("key", "val").Container("image").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the pod: %w", err)
 			}
-			return map[fwk.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: fwk.UpdatePodLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdatePodLabel}: 1}, nil
 		},
 		WantRequeuedPods: sets.Set[string]{},
 		// This behaviour is only true when enabling QHint
@@ -677,7 +668,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Label("anti2", "anti2").Container("image").Node("fake-node").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update pod1: %w", err)
 			}
-			return map[fwk.ClusterEvent]uint64{{Resource: assignedPod, ActionType: fwk.UpdatePodLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodLabel}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -701,7 +692,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, "pod1", metav1.DeleteOptions{GracePeriodSeconds: new(int64)}); err != nil {
 				return nil, fmt.Errorf("failed to delete pod1: %w", err)
 			}
-			return map[fwk.ClusterEvent]uint64{{Resource: assignedPod, ActionType: fwk.Delete}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.AssignedPod, ActionType: fwk.Delete}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod3"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -725,7 +716,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, "pod1", metav1.DeleteOptions{GracePeriodSeconds: new(int64)}); err != nil {
 				return nil, fmt.Errorf("failed to delete pod1: %w", err)
 			}
-			return map[fwk.ClusterEvent]uint64{{Resource: assignedPod, ActionType: fwk.Delete}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.AssignedPod, ActionType: fwk.Delete}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod3"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -748,7 +739,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Label("aaa", "bbb").Container("image").Node("fake-node").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update pod1: %w", err)
 			}
-			return map[fwk.ClusterEvent]uint64{{Resource: assignedPod, ActionType: fwk.UpdatePodLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.AssignedPod, ActionType: fwk.UpdatePodLabel}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -2621,7 +2612,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, updatedPod, metav1.UpdateOptions{}); err != nil {
 				return nil, err
 			}
-			return map[fwk.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: fwk.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.UnscheduledPod, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -2647,7 +2638,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, updatedPod, metav1.UpdateOptions{}); err != nil {
 				return nil, err
 			}
-			return map[fwk.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: fwk.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.UnscheduledPod, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods: sets.Set[string]{},
 	},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Right now, if a plugin is subscribed to a cluster pod event, and such events happen, plugin will execute its corresponding queuing hint function, but it may be useless. resulting in performance loss.

Example Scenario:
When a pod that is part of a gang is added, an event "Pod/Add" happen (to possibly requeue unschedulable other gang pods to complete the gang), and while many plugins are registered to it, only one single plugin benefits from this exact case: **GangScheduling** plugin.

Solution:
We Refine cluster events, by splitting the pod resource into three different types: "AssignedPod", "UnscheduledPod" and "TargetPod". Now we can have more specific cluster events, and plugins subscribe to such events instead.
Also most of plugin queuing hint functions are updated to be specific according to pod resource type.

#### Which issue(s) this PR is related to:
Fixes #135528

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
Three different subtypes of the cluster event resource "Pod" are being added: "AssignedPod", "UnscheduledPod", "TargetPod". Plugins can and are expected to register to specific pod events for better performance.
```
