### PR TITLE
networking: add PodNetworkHealth API scaffolding

### DIFF
--- a/pkg/apis/networking/v1alpha1/register.go
+++ b/pkg/apis/networking/v1alpha1/register.go
@@ -1,0 +1,18 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var SchemeGroupVersion = metav1.GroupVersion{
+	Group:   "networking.k8s.io",
+	Version: "v1alpha1",
+}
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&PodNetworkHealth{},
+	)
+	return nil
+}

--- a/pkg/apis/networking/v1alpha1/types.go
+++ b/pkg/apis/networking/v1alpha1/types.go
@@ -1,0 +1,22 @@
+package v1alpha1
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type PodNetworkHealthSpec struct {
+	SourcePod string `json:"sourcePod"`
+	TargetPod string `json:"targetPod"`
+}
+
+type PodNetworkHealthStatus struct {
+	Reachable bool `json:"reachable,omitempty"`
+	LatencyMs int64 `json:"latencyMs,omitempty"`
+	LastCheck metav1.Time `json:"lastCheck,omitempty"`
+}
+
+type PodNetworkHealth struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   PodNetworkHealthSpec   `json:"spec,omitempty"`
+	Status PodNetworkHealthStatus `json:"status,omitempty"`
+}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -2609,3 +2609,5 @@ func init() {
 	runtime.Must(clientfeatures.AddVersionedFeaturesToExistingFeatureGates(ca))
 	clientfeatures.ReplaceFeatureGates(ca)
 }
+
+PodNetworkHealth featuregate.Feature = "PodNetworkHealth"

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -1,0 +1,3 @@
+PodNetworkHealth: {
+	{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
+},


### PR DESCRIPTION
/kind feature
/kind api-change

#### What type of PR is this?
This PR introduces a new alpha API type gated behind a feature flag.

#### What this PR does / why we need it:
This PR adds initial API scaffolding for a proposed `PodNetworkHealth`
resource under `networking.k8s.io/v1alpha1`.

Kubernetes currently lacks a native, standardized API for representing
basic pod-to-pod network health signals such as reachability and latency.
This PR lays the foundation for future work by defining API types and a
feature gate only.

There is **no functional behavior** introduced in this PR.

#### Which issue(s) this PR is related to:
N/A

KEP: TBD (to be submitted separately)

#### Special notes for your reviewer:
- API-only PR
- Feature gated and disabled by default
- No controller, kubelet, or networking logic
- No impact when the feature gate is disabled

#### Does this PR introduce a user-facing change?
```release-note
NONE
```