### PR TITLE
kubectl: Fix panic in exec terminal size queue

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -411,6 +411,10 @@ type terminalSizeQueueAdapter struct {
 }
 
 func (a *terminalSizeQueueAdapter) Next() *remotecommand.TerminalSize {
+	if a.delegate == nil {
+		return nil
+	}
+
 	next := a.delegate.Next()
 	if next == nil {
 		return nil


### PR DESCRIPTION
Check if delegate is nil before calling Next() in terminalSizeQueueAdapter to prevent a nil pointer dereference.

Fixes https://github.com/kubernetes/kubectl/issues/1809

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Check if delegate is nil before calling Next() in terminalSizeQueueAdapter to prevent a nil pointer dereference.
This prevents a panic observed when running `kubectl exec` in certain environments where the terminal size queue is not fully initialized.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1809

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed a panic in `kubectl exec` when the terminal size queue delegate is uninitialized.
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```