### PR TITLE
[Feature Cleanup] Checkpoint Container to Node Conformance

### DIFF
--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -34,9 +34,6 @@ var (
 	// - token-cleaner-controller
 	BootstrapTokens = framework.WithFeature(framework.ValidFeatures.Add("BootstrapTokens"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	BoundServiceAccountTokenVolume = framework.WithFeature(framework.ValidFeatures.Add("BoundServiceAccountTokenVolume"))
-
 	// Owner: sig-api-machinery
 	// Marks tests that exercise the CBOR data format for serving or storage.
 	CBOR = framework.WithFeature(framework.ValidFeatures.Add("CBOR"))
@@ -49,10 +46,6 @@ var (
 	// This label is used for tests which need:
 	// - run only CPU Manager tests on specific jobs, i.e., ci-kubernetes-node-kubelet-serial-cpu-manager and pull-kubernetes-node-kubelet-serial-cpu-manager
 	CPUManager = framework.WithFeature(framework.ValidFeatures.Add("CPUManager"))
-
-	// Owner: sig-node
-	// Marks test that exercise checkpointing of containers
-	CheckpointContainer = framework.WithFeature(framework.ValidFeatures.Add("CheckpointContainer"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	CloudProvider = framework.WithFeature(framework.ValidFeatures.Add("CloudProvider"))

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -34,6 +34,10 @@ var (
 	// - token-cleaner-controller
 	BootstrapTokens = framework.WithFeature(framework.ValidFeatures.Add("BootstrapTokens"))
 
+	// Owner: sig-auth
+	// TODO: document the feature (owning SIG, when to use this feature for a test)
+	BoundServiceAccountTokenVolume = framework.WithFeature(framework.ValidFeatures.Add("BoundServiceAccountTokenVolume"))
+
 	// Owner: sig-api-machinery
 	// Marks tests that exercise the CBOR data format for serving or storage.
 	CBOR = framework.WithFeature(framework.ValidFeatures.Add("CBOR"))

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -34,7 +34,6 @@ var (
 	// - token-cleaner-controller
 	BootstrapTokens = framework.WithFeature(framework.ValidFeatures.Add("BootstrapTokens"))
 
-	// Owner: sig-auth
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	BoundServiceAccountTokenVolume = framework.WithFeature(framework.ValidFeatures.Add("BoundServiceAccountTokenVolume"))
 

--- a/test/e2e_node/checkpoint_container.go
+++ b/test/e2e_node/checkpoint_container.go
@@ -129,7 +129,7 @@ func getCheckpointContainerErrorMetric(ctx context.Context, f *framework.Framewo
 	return 0, nil
 }
 
-var _ = SIGDescribe("Checkpoint Container", framework.WithConformance(), func() {
+var _ = SIGDescribe("Checkpoint Container", framework.WithNodeConformance(), func() {
 	f := framework.NewDefaultFramework("checkpoint-container-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 	ginkgo.It("will checkpoint a container out of a pod", func(ctx context.Context) {

--- a/test/e2e_node/checkpoint_container.go
+++ b/test/e2e_node/checkpoint_container.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -130,7 +129,7 @@ func getCheckpointContainerErrorMetric(ctx context.Context, f *framework.Framewo
 	return 0, nil
 }
 
-var _ = SIGDescribe("Checkpoint Container", feature.CheckpointContainer, func() {
+var _ = SIGDescribe("Checkpoint Container", framework.WithConformance(), func() {
 	f := framework.NewDefaultFramework("checkpoint-container-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 	ginkgo.It("will checkpoint a container out of a pod", func(ctx context.Context) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The [Forensic Container Checkpoint](https://kubernetes.io/blog/2022/12/05/forensic-container-checkpointing-alpha/) has graduated to Beta in [PR#4288](https://github.com/kubernetes/enhancements/pull/4288) per KEP 2008. The feature label has been removed from the feature definition file as well as the e2e test, and was transitioned to `framework.WithNodeConformance()`. 
#### Which issue(s) this PR is related to:
Partial fix for https://github.com/kubernetes/kubernetes/issues/134172

#### Special notes for your reviewer:
- FeatureGates is a separate cleanup
- Corresponding changes will be made in k/test-infra
- 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
