### PR TITLE
[1.38] kubeadm: preflight check ContainerRuntimeVersion return an error message

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -105,6 +105,8 @@ func (crc ContainerRuntimeCheck) Check() (warnings, errorList []error) {
 // ContainerRuntimeVersionCheck verifies the version compatibility between installed container runtime and kubelet.
 type ContainerRuntimeVersionCheck struct {
 	criSocket string
+	isUpgrade bool
+	exec      utilsexec.Interface
 
 	// stubbed out for testing
 	impl utilruntime.Impl
@@ -132,12 +134,28 @@ func (crvc ContainerRuntimeVersionCheck) Check() (warnings, errorList []error) {
 		return nil, []error{errors.Wrap(err, "could not check if the runtime config is available")}
 	}
 	if !ok {
-		// TODO: return an error once the kubelet version is 1.37 or higher.
-		// https://github.com/kubernetes/kubeadm/issues/3229
-		err := errors.New("You must update your container runtime to a version that supports the CRI method RuntimeConfig. " +
-			"Falling back to using cgroupDriver from kubelet config will be removed in 1.37. " +
+		// Get the kubelet version to determine if we need to error or just warn
+		kubeletVersion, err := GetKubeletVersion(crvc.exec)
+		if err != nil {
+			return nil, []error{errors.Wrap(err, "couldn't get kubelet version")}
+		}
+		// During upgrade we want to check the next kubelet MINOR version.
+		// The below approach does not support k8s MAJOR version bumps.
+		if crvc.isUpgrade {
+			kubeletVersion = kubeletVersion.WithMinor(kubeletVersion.Minor() + 1)
+		}
+
+		err = errors.New("You must update your container runtime to a version that supports the CRI method RuntimeConfig. " +
+			"Falling back to using cgroupDriver from kubelet config has been removed since 1.38. " +
 			"For more information, see https://git.k8s.io/enhancements/keps/sig-node/4033-group-driver-detection-over-cri")
-		warnings = append(warnings, err)
+
+		// TODO: Remove the version check and always return an error once 1.38 is the minimum supported version of kubelet.
+		// https://github.com/kubernetes/kubeadm/issues/3229
+		if kubeletVersion.Major() > 1 || kubeletVersion.Minor() >= 38 {
+			errorList = append(errorList, err)
+		} else {
+			warnings = append(warnings, err)
+		}
 	}
 
 	return warnings, errorList
@@ -1121,7 +1139,7 @@ func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfigura
 // kubeadm init and join commands
 func addCommonChecks(execer utilsexec.Interface, k8sVersion string, nodeReg *kubeadmapi.NodeRegistrationOptions, checks []Checker) []Checker {
 	checks = append(checks, ContainerRuntimeCheck{criSocket: nodeReg.CRISocket})
-	checks = append(checks, ContainerRuntimeVersionCheck{criSocket: nodeReg.CRISocket})
+	checks = append(checks, ContainerRuntimeVersionCheck{criSocket: nodeReg.CRISocket, exec: execer})
 
 	// non-windows checks
 	checks = addSwapCheck(checks)
@@ -1148,7 +1166,7 @@ func RunRootCheckOnly(ignorePreflightErrors sets.Set[string]) error {
 func RunUpgradeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfiguration, ignorePreflightErrors sets.Set[string]) error {
 	checks := []Checker{
 		SystemVerificationCheck{isUpgrade: true, exec: execer},
-		ContainerRuntimeVersionCheck{criSocket: cfg.NodeRegistration.CRISocket},
+		ContainerRuntimeVersionCheck{criSocket: cfg.NodeRegistration.CRISocket, isUpgrade: true, exec: execer},
 	}
 
 	return RunChecks(checks, os.Stderr, ignorePreflightErrors)

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -107,6 +107,8 @@ func (crc ContainerRuntimeCheck) Check() (warnings, errorList []error) {
 // ContainerRuntimeVersionCheck verifies the version compatibility between installed container runtime and kubelet.
 type ContainerRuntimeVersionCheck struct {
 	criSocket string
+	isUpgrade bool
+	exec      utilsexec.Interface
 
 	// stubbed out for testing
 	impl utilruntime.Impl
@@ -134,12 +136,28 @@ func (crvc ContainerRuntimeVersionCheck) Check() (warnings, errorList []error) {
 		return nil, []error{errors.Wrap(err, "could not check if the runtime config is available")}
 	}
 	if !ok {
-		// TODO: return an error once the kubelet version is 1.38 or higher.
-		// https://github.com/kubernetes/kubeadm/issues/3229
-		err := errors.New("You must update your container runtime to a version that supports the CRI method RuntimeConfig. " +
-			"Falling back to using cgroupDriver from kubelet config will be removed in 1.38. " +
+		// Get the kubelet version to determine if we need to error or just warn
+		kubeletVersion, err := GetKubeletVersion(crvc.exec)
+		if err != nil {
+			return nil, []error{errors.Wrap(err, "couldn't get kubelet version")}
+		}
+		// During upgrade we want to check the next kubelet MINOR version.
+		// The below approach does not support k8s MAJOR version bumps.
+		if crvc.isUpgrade {
+			kubeletVersion = kubeletVersion.WithMinor(kubeletVersion.Minor() + 1)
+		}
+
+		err = errors.New("You must update your container runtime to a version that supports the CRI method RuntimeConfig. " +
+			"Falling back to using cgroupDriver from kubelet config has been removed since 1.38. " +
 			"For more information, see https://git.k8s.io/enhancements/keps/sig-node/4033-group-driver-detection-over-cri")
-		warnings = append(warnings, err)
+
+		// TODO: Remove the version check and always return an error once 1.38 is the minimum supported version of kubelet.
+		// https://github.com/kubernetes/kubeadm/issues/3229
+		if kubeletVersion.Major() > 1 || kubeletVersion.Minor() >= 38 {
+			errorList = append(errorList, err)
+		} else {
+			warnings = append(warnings, err)
+		}
 	}
 
 	return warnings, errorList
@@ -1148,7 +1166,7 @@ func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfigura
 // kubeadm init and join commands
 func addCommonChecks(execer utilsexec.Interface, k8sVersion string, nodeReg *kubeadmapi.NodeRegistrationOptions, checks []Checker) []Checker {
 	checks = append(checks, ContainerRuntimeCheck{criSocket: nodeReg.CRISocket})
-	checks = append(checks, ContainerRuntimeVersionCheck{criSocket: nodeReg.CRISocket})
+	checks = append(checks, ContainerRuntimeVersionCheck{criSocket: nodeReg.CRISocket, exec: execer})
 
 	// non-windows checks
 	checks = addSwapCheck(checks)
@@ -1175,7 +1193,7 @@ func RunRootCheckOnly(ignorePreflightErrors sets.Set[string]) error {
 func RunUpgradeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfiguration, ignorePreflightErrors sets.Set[string]) error {
 	checks := []Checker{
 		SystemVerificationCheck{isUpgrade: true, exec: execer},
-		ContainerRuntimeVersionCheck{criSocket: cfg.NodeRegistration.CRISocket},
+		ContainerRuntimeVersionCheck{criSocket: cfg.NodeRegistration.CRISocket, isUpgrade: true, exec: execer},
 	}
 
 	return RunChecks(checks, os.Stderr, ignorePreflightErrors)

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -1066,25 +1066,53 @@ func TestContainerRuntimeVersionCheck(t *testing.T) {
 	tests := []struct {
 		name           string
 		prepare        func(*utilruntime.FakeImpl)
+		isUpgrade      bool
+		kubeletVersion string
 		expectErrors   int
 		expectWarnings int
 	}{
 		{
-			name: "ok",
+			name: "runtime config is implemented",
 		},
 		{
-			name: "runtime config not implemented",
-			prepare: func(mock *utilruntime.FakeImpl) {
-				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
-			},
-			expectWarnings: 1,
-		},
-		{
-			name: "call RuntimeConfig fails",
+			name: "call RuntimeConfig failed",
 			prepare: func(mock *utilruntime.FakeImpl) {
 				mock.RuntimeConfigReturns(nil, status.New(codes.DeadlineExceeded, "deadline exceeded").Err())
 			},
 			expectErrors: 1,
+		},
+		{
+			name: "runtime config is not implemented but kubelet version is compatible",
+			prepare: func(mock *utilruntime.FakeImpl) {
+				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
+			},
+			kubeletVersion: "v1.37.0",
+			expectWarnings: 1,
+		},
+		{
+			name: "runtime config is not implemented and kubelet version is not compatible during upgrade",
+			prepare: func(mock *utilruntime.FakeImpl) {
+				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
+			},
+			kubeletVersion: "v1.37.0",
+			isUpgrade:      true,
+			expectErrors:   1,
+		},
+		{
+			name: "runtime config is not implemented and kubelet version is not compatible",
+			prepare: func(mock *utilruntime.FakeImpl) {
+				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
+			},
+			kubeletVersion: "v1.38.0",
+			expectErrors:   1,
+		},
+		{
+			name: "runtime config is not implemented and pre-release kubelet version is not compatible",
+			prepare: func(mock *utilruntime.FakeImpl) {
+				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
+			},
+			kubeletVersion: "v1.38.0-alpha.1",
+			expectErrors:   1,
 		},
 	}
 
@@ -1095,7 +1123,18 @@ func TestContainerRuntimeVersionCheck(t *testing.T) {
 				test.prepare(mock)
 			}
 
-			warnings, errors := ContainerRuntimeVersionCheck{impl: mock}.Check()
+			fcmd := fakeexec.FakeCmd{
+				OutputScript: []fakeexec.FakeAction{
+					func() ([]byte, []byte, error) { return []byte("Kubernetes " + test.kubeletVersion), nil, nil },
+				},
+			}
+			fexec := &fakeexec.FakeExec{
+				CommandScript: []fakeexec.FakeCommandAction{
+					func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+				},
+			}
+
+			warnings, errors := ContainerRuntimeVersionCheck{impl: mock, isUpgrade: test.isUpgrade, exec: fexec}.Check()
 			if len(warnings) != test.expectWarnings {
 				t.Errorf("expected %d warning(s) but got %d: %q", test.expectWarnings, len(warnings), warnings)
 			}

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -1125,25 +1125,53 @@ func TestContainerRuntimeVersionCheck(t *testing.T) {
 	tests := []struct {
 		name           string
 		prepare        func(*utilruntime.FakeImpl)
+		isUpgrade      bool
+		kubeletVersion string
 		expectErrors   int
 		expectWarnings int
 	}{
 		{
-			name: "ok",
+			name: "runtime config is implemented",
 		},
 		{
-			name: "runtime config not implemented",
-			prepare: func(mock *utilruntime.FakeImpl) {
-				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
-			},
-			expectWarnings: 1,
-		},
-		{
-			name: "call RuntimeConfig fails",
+			name: "call RuntimeConfig failed",
 			prepare: func(mock *utilruntime.FakeImpl) {
 				mock.RuntimeConfigReturns(nil, status.New(codes.DeadlineExceeded, "deadline exceeded").Err())
 			},
 			expectErrors: 1,
+		},
+		{
+			name: "runtime config is not implemented but kubelet version is compatible",
+			prepare: func(mock *utilruntime.FakeImpl) {
+				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
+			},
+			kubeletVersion: "v1.37.0",
+			expectWarnings: 1,
+		},
+		{
+			name: "runtime config is not implemented and kubelet version is not compatible during upgrade",
+			prepare: func(mock *utilruntime.FakeImpl) {
+				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
+			},
+			kubeletVersion: "v1.37.0",
+			isUpgrade:      true,
+			expectErrors:   1,
+		},
+		{
+			name: "runtime config is not implemented and kubelet version is not compatible",
+			prepare: func(mock *utilruntime.FakeImpl) {
+				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
+			},
+			kubeletVersion: "v1.38.0",
+			expectErrors:   1,
+		},
+		{
+			name: "runtime config is not implemented and pre-release kubelet version is not compatible",
+			prepare: func(mock *utilruntime.FakeImpl) {
+				mock.RuntimeConfigReturns(nil, status.New(codes.Unimplemented, "not implemented").Err())
+			},
+			kubeletVersion: "v1.38.0-alpha.1",
+			expectErrors:   1,
 		},
 	}
 
@@ -1154,7 +1182,18 @@ func TestContainerRuntimeVersionCheck(t *testing.T) {
 				test.prepare(mock)
 			}
 
-			warnings, errors := ContainerRuntimeVersionCheck{impl: mock}.Check()
+			fcmd := fakeexec.FakeCmd{
+				OutputScript: []fakeexec.FakeAction{
+					func() ([]byte, []byte, error) { return []byte("Kubernetes " + test.kubeletVersion), nil, nil },
+				},
+			}
+			fexec := &fakeexec.FakeExec{
+				CommandScript: []fakeexec.FakeCommandAction{
+					func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+				},
+			}
+
+			warnings, errors := ContainerRuntimeVersionCheck{impl: mock, isUpgrade: test.isUpgrade, exec: fexec}.Check()
 			if len(warnings) != test.expectWarnings {
 				t.Errorf("expected %d warning(s) but got %d: %q", test.expectWarnings, len(warnings), warnings)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

See https://kubernetes.io/blog/2025/09/12/kubernetes-v1-34-cri-cgroup-driver-lookup-now-ga/#announcement-kubernetes-is-deprecating-containerd-v1-y-support

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Part of https://github.com/kubernetes/kubeadm/issues/3229

#### Special notes for your reviewer:

/hold
until falling back to using cgroupDriver is removed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: the preflight check `ContainerRuntimeVersion` validates if the installed container runtime supports the `RuntimeConfig` gRPC method. For kubelet 1.38 and later, if the container runtime does not support the `RuntimeConfig` gRPC method, kubeadm will return a preflight error. For older kubelet versions, it will return a preflight warning.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
