### PR TITLE
Docs: event cache key generation functions require non-nil inputs

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/events_cache.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache.go
@@ -48,7 +48,7 @@ const (
 	defaultSpamQPS   = 1. / 300.
 )
 
-// getEventKey builds unique event key based on source, involvedObject, reason, message
+// getEventKey builds unique event key based on source, involvedObject, reason, message.
 func getEventKey(event *v1.Event) string {
 	return strings.Join([]string{
 		event.Source.Component,
@@ -66,7 +66,7 @@ func getEventKey(event *v1.Event) string {
 		"")
 }
 
-// getSpamKey builds unique event key based on source, involvedObject
+// getSpamKey builds unique event key based on source, involvedObject.
 func getSpamKey(event *v1.Event) string {
 	return strings.Join([]string{
 		event.Source.Component,
@@ -124,6 +124,7 @@ type spamRecord struct {
 }
 
 // Filter controls that a given source+object are not exceeding the allowed rate.
+// The event parameter must not be nil.
 func (f *EventSourceObjectSpamFilter) Filter(event *v1.Event) bool {
 	var record spamRecord
 
@@ -157,7 +158,8 @@ func (f *EventSourceObjectSpamFilter) Filter(event *v1.Event) bool {
 type EventAggregatorKeyFunc func(event *v1.Event) (aggregateKey string, localKey string)
 
 // EventAggregatorByReasonFunc aggregates events by exact match on event.Source, event.InvolvedObject, event.Type,
-// event.Reason, event.ReportingController and event.ReportingInstance
+// event.Reason, event.ReportingController and event.ReportingInstance.
+// The event parameter must not be nil.
 func EventAggregatorByReasonFunc(event *v1.Event) (string, string) {
 	return strings.Join([]string{
 		event.Source.Component,
@@ -235,6 +237,8 @@ type aggregateRecord struct {
 //   - The cache key for the event, for correlation purposes. This will be set to
 //     the full key for normal events, and to the result of
 //     EventAggregatorMessageFunc for aggregate events.
+//
+// The newEvent parameter must not be nil.
 func (e *EventAggregator) EventAggregate(newEvent *v1.Event) (*v1.Event, string) {
 	now := metav1.NewTime(e.clock.Now())
 	var record aggregateRecord
@@ -515,7 +519,8 @@ func (c *EventCorrelator) EventCorrelate(newEvent *v1.Event) (*EventCorrelateRes
 	return &EventCorrelateResult{Event: observedEvent, Patch: patch}, err
 }
 
-// UpdateState based on the latest observed state from server
+// UpdateState based on the latest observed state from server.
+// The event parameter must not be nil.
 func (c *EventCorrelator) UpdateState(event *v1.Event) {
 	c.logger.updateState(event)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
  /kind bug

#### What this PR does / why we need it:
  Adds nil checks for the `event` parameter in `getEventKey`, `getSpamKey`, and
  `EventAggregatorByReasonFunc` to prevent nil pointer dereference panics.

  If `event` is nil, accessing any of its fields (e.g., `event.Source.Component`,
  `event.InvolvedObject.Kind`) causes a panic. This fix returns empty strings
  early when `event` is nil.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Address https://github.com/kubernetes/kubernetes/issues/135924 
#### Special notes for your reviewer:
  The `event` parameter is a pointer (`*v1.Event`). If it's nil, dereferencing
  it to access fields like `event.Source` causes a nil pointer panic.

  ```go
  func getEventKey(event *v1.Event) string {
      return strings.Join([]string{
          event.Source.Component,  // panics if event == nil
          ...
      }, "")
  }

  Fix:

  func getEventKey(event *v1.Event) string {
      if event == nil {
          return ""
      }
      return strings.Join([]string{
          event.Source.Component,  // safe now
          ...
      }, "")
  }
```
  
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
 ```release-note
  Fixed a nil pointer dereference panic in client-go event recorder when processing events with nil fields.

  Additional documentation e.g., KEPs (Kubernetes Enhancements Proposals), usage docs, etc.:

  N/A

  /sig api-machinery
  /area client-libraries
  /priority important-soon
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
