### PR TITLE
kubelet: verify OS-reported free hugepages during pod admission

### DIFF
--- a/pkg/kubelet/cm/memorymanager/sysfs_hugepages_linux.go
+++ b/pkg/kubelet/cm/memorymanager/sysfs_hugepages_linux.go
@@ -1,0 +1,126 @@
+//go:build linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memorymanager
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	corehelper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+)
+
+const (
+	// sysfsNodePath is the base path for NUMA node information in sysfs
+	sysfsNodePath = "/sys/devices/system/node"
+	// freeHugepagesFile is the name of the file containing free hugepage count
+	freeHugepagesFile = "free_hugepages"
+)
+
+// HugepagesReader provides an interface for reading hugepage information from the OS.
+// This interface allows for easier testing by enabling mock implementations.
+type HugepagesReader interface {
+	// GetFreeHugepages returns the number of free hugepages for a given NUMA node
+	// and hugepage size. The pageSize is in bytes.
+	GetFreeHugepages(numaNodeID int, pageSizeBytes uint64) (uint64, error)
+}
+
+// sysfsHugepagesReader reads hugepage information from sysfs
+type sysfsHugepagesReader struct {
+	sysfsPath string
+}
+
+// NewSysfsHugepagesReader creates a new HugepagesReader that reads from sysfs
+func NewSysfsHugepagesReader() HugepagesReader {
+	return &sysfsHugepagesReader{
+		sysfsPath: sysfsNodePath,
+	}
+}
+
+// newSysfsHugepagesReaderWithPath creates a HugepagesReader with a custom sysfs path (for testing)
+func newSysfsHugepagesReaderWithPath(path string) HugepagesReader {
+	return &sysfsHugepagesReader{
+		sysfsPath: path,
+	}
+}
+
+// GetFreeHugepages reads the number of free hugepages for a specific NUMA node and page size
+// from /sys/devices/system/node/node<N>/hugepages/hugepages-<size>kB/free_hugepages
+func (r *sysfsHugepagesReader) GetFreeHugepages(numaNodeID int, pageSizeBytes uint64) (uint64, error) {
+	// Convert page size from bytes to kB for the sysfs path
+	pageSizeKB := pageSizeBytes / 1024
+
+	// Build the path: /sys/devices/system/node/node<N>/hugepages/hugepages-<size>kB/free_hugepages
+	freeHugepagesPath := filepath.Join(
+		r.sysfsPath,
+		fmt.Sprintf("node%d", numaNodeID),
+		"hugepages",
+		fmt.Sprintf("hugepages-%dkB", pageSizeKB),
+		freeHugepagesFile,
+	)
+
+	data, err := os.ReadFile(freeHugepagesPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read free hugepages from %s: %w", freeHugepagesPath, err)
+	}
+
+	freePages, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse free hugepages value from %s: %w", freeHugepagesPath, err)
+	}
+
+	return freePages, nil
+}
+
+// GetFreeHugepagesBytes returns the total free hugepage memory in bytes for a specific
+// NUMA node and page size
+func (r *sysfsHugepagesReader) GetFreeHugepagesBytes(numaNodeID int, pageSizeBytes uint64) (uint64, error) {
+	freePages, err := r.GetFreeHugepages(numaNodeID, pageSizeBytes)
+	if err != nil {
+		return 0, err
+	}
+	return freePages * pageSizeBytes, nil
+}
+
+// resourceNameToPageSize extracts the page size in bytes from a hugepage resource name
+// e.g., "hugepages-2Mi" -> 2097152
+func resourceNameToPageSize(resourceName v1.ResourceName) (uint64, error) {
+	// Check if this is a hugepages resource
+	if !corehelper.IsHugePageResourceName(resourceName) {
+		return 0, fmt.Errorf("%s is not a hugepage resource", resourceName)
+	}
+
+	// Extract the quantity from the resource name
+	pageSize, err := corehelper.HugePageSizeFromResourceName(resourceName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to extract page size from resource name %s: %w", resourceName, err)
+	}
+
+	return uint64(pageSize.Value()), nil
+}
+
+// pageSizeToResourceName converts a page size in bytes to a hugepage resource name
+func pageSizeToResourceName(pageSizeBytes uint64) v1.ResourceName {
+	quantity := resource.NewQuantity(int64(pageSizeBytes), resource.BinarySI)
+	return corehelper.HugePageResourceName(*quantity)
+}

--- a/pkg/kubelet/cm/memorymanager/sysfs_hugepages_linux_test.go
+++ b/pkg/kubelet/cm/memorymanager/sysfs_hugepages_linux_test.go
@@ -1,0 +1,186 @@
+//go:build linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memorymanager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestSysfsHugepagesReader(t *testing.T) {
+	// Create a temporary sysfs-like directory structure
+	tmpDir := t.TempDir()
+
+	// Create node0 hugepages directory structure
+	node0HugepagesDir := filepath.Join(tmpDir, "node0", "hugepages", "hugepages-2048kB")
+	if err := os.MkdirAll(node0HugepagesDir, 0755); err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+
+	// Write free_hugepages file with 100 pages
+	freeHugepagesPath := filepath.Join(node0HugepagesDir, "free_hugepages")
+	if err := os.WriteFile(freeHugepagesPath, []byte("100\n"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Create reader with custom path
+	reader := newSysfsHugepagesReaderWithPath(tmpDir)
+
+	// Test reading free hugepages
+	// 2048kB = 2097152 bytes
+	freePages, err := reader.GetFreeHugepages(0, 2097152)
+	if err != nil {
+		t.Errorf("GetFreeHugepages failed: %v", err)
+	}
+	if freePages != 100 {
+		t.Errorf("Expected 100 free pages, got %d", freePages)
+	}
+}
+
+func TestSysfsHugepagesReaderNonExistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	reader := newSysfsHugepagesReaderWithPath(tmpDir)
+
+	// Test reading from non-existent NUMA node
+	_, err := reader.GetFreeHugepages(99, 2097152)
+	if err == nil {
+		t.Error("Expected error when reading from non-existent NUMA node")
+	}
+}
+
+func TestSysfsHugepagesReaderMultiplePageSizes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testCases := []struct {
+		name           string
+		numaNode       int
+		pageSizeKB     uint64
+		pageSizeBytes  uint64
+		freePages      string
+		expectedPages  uint64
+	}{
+		{
+			name:           "2Mi hugepages",
+			numaNode:       0,
+			pageSizeKB:     2048,
+			pageSizeBytes:  2 * 1024 * 1024, // 2Mi
+			freePages:      "50",
+			expectedPages:  50,
+		},
+		{
+			name:           "1Gi hugepages",
+			numaNode:       1,
+			pageSizeKB:     1048576,
+			pageSizeBytes:  1024 * 1024 * 1024, // 1Gi
+			freePages:      "10",
+			expectedPages:  10,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create directory structure
+			hugepagesDir := filepath.Join(tmpDir,
+				"node"+string(rune('0'+tc.numaNode)),
+				"hugepages",
+				"hugepages-"+itoa(tc.pageSizeKB)+"kB")
+			if err := os.MkdirAll(hugepagesDir, 0755); err != nil {
+				t.Fatalf("Failed to create test directory: %v", err)
+			}
+
+			// Write free_hugepages
+			freeHugepagesPath := filepath.Join(hugepagesDir, "free_hugepages")
+			if err := os.WriteFile(freeHugepagesPath, []byte(tc.freePages+"\n"), 0644); err != nil {
+				t.Fatalf("Failed to write test file: %v", err)
+			}
+
+			reader := newSysfsHugepagesReaderWithPath(tmpDir)
+			freePages, err := reader.GetFreeHugepages(tc.numaNode, tc.pageSizeBytes)
+			if err != nil {
+				t.Errorf("GetFreeHugepages failed: %v", err)
+			}
+			if freePages != tc.expectedPages {
+				t.Errorf("Expected %d free pages, got %d", tc.expectedPages, freePages)
+			}
+		})
+	}
+}
+
+func TestResourceNameToPageSize(t *testing.T) {
+	testCases := []struct {
+		resourceName   v1.ResourceName
+		expectedSize   uint64
+		expectError    bool
+	}{
+		{
+			resourceName:   v1.ResourceName("hugepages-2Mi"),
+			expectedSize:   2 * 1024 * 1024,
+			expectError:    false,
+		},
+		{
+			resourceName:   v1.ResourceName("hugepages-1Gi"),
+			expectedSize:   1024 * 1024 * 1024,
+			expectError:    false,
+		},
+		{
+			resourceName:   v1.ResourceMemory,
+			expectedSize:   0,
+			expectError:    true,
+		},
+		{
+			resourceName:   v1.ResourceName("cpu"),
+			expectedSize:   0,
+			expectError:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.resourceName), func(t *testing.T) {
+			size, err := resourceNameToPageSize(tc.resourceName)
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if size != tc.expectedSize {
+					t.Errorf("Expected size %d, got %d", tc.expectedSize, size)
+				}
+			}
+		})
+	}
+}
+
+// Helper function to convert uint64 to string without importing strconv
+func itoa(n uint64) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/pkg/kubelet/cm/memorymanager/sysfs_hugepages_other.go
+++ b/pkg/kubelet/cm/memorymanager/sysfs_hugepages_other.go
@@ -1,0 +1,61 @@
+//go:build !linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memorymanager
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	corehelper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+)
+
+// HugepagesReader provides an interface for reading hugepage information from the OS.
+type HugepagesReader interface {
+	GetFreeHugepages(numaNodeID int, pageSizeBytes uint64) (uint64, error)
+}
+
+// stubHugepagesReader is a no-op implementation for non-Linux platforms
+type stubHugepagesReader struct{}
+
+// NewSysfsHugepagesReader returns a stub implementation on non-Linux platforms
+func NewSysfsHugepagesReader() HugepagesReader {
+	return &stubHugepagesReader{}
+}
+
+// GetFreeHugepages returns an error on non-Linux platforms as hugepages are Linux-specific
+func (r *stubHugepagesReader) GetFreeHugepages(numaNodeID int, pageSizeBytes uint64) (uint64, error) {
+	return 0, fmt.Errorf("hugepages are not supported on this platform")
+}
+
+// resourceNameToPageSize extracts the page size in bytes from a hugepage resource name.
+// This function works on all platforms as it uses the core helper functions.
+func resourceNameToPageSize(resourceName v1.ResourceName) (uint64, error) {
+	// Check if this is a hugepages resource
+	if !corehelper.IsHugePageResourceName(resourceName) {
+		return 0, fmt.Errorf("%s is not a hugepage resource", resourceName)
+	}
+
+	// Extract the quantity from the resource name
+	pageSize, err := corehelper.HugePageSizeFromResourceName(resourceName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to extract page size from resource name %s: %w", resourceName, err)
+	}
+
+	return uint64(pageSize.Value()), nil
+}


### PR DESCRIPTION
## Summary

Fixes: https://github.com/kubernetes/kubernetes/issues/134395

- Add verification of OS-reported free hugepages during pod admission in the Static Memory Manager
- Query sysfs (`/sys/devices/system/node/node<N>/hugepages/hugepages-<size>kB/free_hugepages`) to check actual hugepage availability
- Reject Guaranteed pods requesting hugepages when the OS reports insufficient free pages

## Problem

The Static Memory Manager doesn't verify OS-reported available hugepages during pod admission. This causes Guaranteed pods requesting hugepages to be admitted even when hugepages aren't actually available on the system.

**Root Cause:** The memory manager only tracks hugepage allocations for Guaranteed QoS pods. However, Burstable and BestEffort pods can also consume hugepages (via hugetlbfs mounts or `mmap` with `MAP_HUGETLB`) without being tracked. When these untracked pods consume hugepages, subsequent Guaranteed pods may be admitted based on stale allocation data, only to fail at runtime.

## Options Considered

| Option | Approach | Pros | Cons |
|--------|----------|------|------|
| **A (Chosen)** | Query sysfs for real hugepage availability during admission | Direct fix, minimal code changes, no upstream dependencies | Adds sysfs I/O during admission |
| B | Track all pod hugepage usage in memory manager | Complete visibility into hugepage usage | Significant refactoring, wouldn't catch external consumers |
| C | Add FreePages to cadvisor's HugePagesInfo | Clean integration with existing machine info | Requires upstream changes, longer timeline |

## Implementation

- Add `HugepagesReader` interface for reading free hugepages from sysfs
- Implement `sysfsHugepagesReader` for Linux, stub for other platforms
- Add `verifyOSHugepagesAvailability()` called during `Allocate()`
- Track successful reads separately from zero values to properly fail when hugepages are exhausted vs skip when sysfs is unavailable

## Test plan

- [x] Unit tests for `sysfsHugepagesReader` (reading from mock sysfs)
- [x] Unit tests for `verifyOSHugepagesAvailability()` covering:
  - Sufficient hugepages available
  - Insufficient hugepages (should fail)
  - Zero free hugepages / exhausted (should fail)
  - Aggregation across multiple NUMA nodes
  - Sysfs read failures (should skip verification gracefully)
  - Non-hugepage resources (should skip)
  - Nil hugepages reader (should skip)
- [x] All existing memory manager tests pass