### PR TITLE
 Enable Declarative Validation (DV) support for ServiceAccount

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -7664,7 +7664,11 @@ func ValidateLimitRange(limitRange *core.LimitRange) field.ErrorList {
 
 // ValidateServiceAccount tests if required fields in the ServiceAccount are set.
 func ValidateServiceAccount(serviceAccount *core.ServiceAccount) field.ErrorList {
-	allErrs := ValidateObjectMeta(&serviceAccount.ObjectMeta, true, ValidateServiceAccountName, field.NewPath("metadata"))
+	validateLongName := func(fldPath *field.Path, name string) field.ErrorList {
+		return validate.LongName(context.Background(), operation.Operation{}, fldPath, &name, nil).MarkCoveredByDeclarative()
+	}
+
+	allErrs := ValidateObjectMetaWithOpts(&serviceAccount.ObjectMeta, true, validateLongName, field.NewPath("metadata"))
 	return allErrs
 }
 

--- a/pkg/registry/core/serviceaccount/declarative_validation_test.go
+++ b/pkg/registry/core/serviceaccount/declarative_validation_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestDeclarativeValidateForDeclarative(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: "v1",
+	})
+	testCases := map[string]struct {
+		input        api.ServiceAccount
+		expectedErrs field.ErrorList
+	}{
+		// baseline
+		"empty resource": {
+			input: mkValidServiceAccount(),
+		},
+		// metadata.name
+		"name: empty": {
+			input: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Name = ""
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("metadata.name"), ""),
+			},
+		},
+		"name: label format": {
+			input: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Name = "this-is-a-label"
+			}),
+		},
+		"name: subdomain format": {
+			input: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Name = "this.is.a.subdomain"
+			}),
+		},
+		"name: invalid label format": {
+			input: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Name = "-this-is-not-a-label"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, ""),
+			},
+		},
+		"name: invalid subdomain format": {
+			input: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Name = ".this.is.not.a.subdomain"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, ""),
+			},
+		},
+		"name: label format with trailing dash": {
+			input: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Name = "this-is-a-label-"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, ""),
+			},
+		},
+		"name: too long": {
+			input: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Name = strings.Repeat("x", 254)
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, ""),
+			},
+		},
+		// metadata.namespace
+		"namespace: empty": {
+			input: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Namespace = ""
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("metadata.namespace"), ""),
+			},
+		},
+		"namespace: valid": {
+			input: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Namespace = "valid-namespace"
+			}),
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+		})
+	}
+}
+
+func TestValidateUpdateForDeclarative(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: "v1",
+	})
+	testCases := map[string]struct {
+		old          api.ServiceAccount
+		update       api.ServiceAccount
+		expectedErrs field.ErrorList
+	}{
+		// baseline
+		"no change": {
+			old:    mkValidServiceAccount(),
+			update: mkValidServiceAccount(),
+		},
+		// metadata.name
+		"name: changed": {
+			old: mkValidServiceAccount(),
+			update: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Name += "x"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, ""),
+			},
+		},
+		// metadata.namespace
+		"namespace: changed": {
+			old: mkValidServiceAccount(),
+			update: mkValidServiceAccount(func(sa *api.ServiceAccount) {
+				sa.Namespace = "other-namespace"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.namespace"), nil, ""),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.old.ObjectMeta.ResourceVersion = "1"
+			tc.update.ObjectMeta.ResourceVersion = "1"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}
+
+// mkValidServiceAccount produces a ServiceAccount which passes
+// validation with no tweaks.
+func mkValidServiceAccount(tweaks ...func(sa *api.ServiceAccount)) api.ServiceAccount {
+	sa := api.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&sa)
+	}
+	return sa
+}

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -6036,6 +6036,8 @@ message ServiceAccount {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
+  // +k8s:subfield(name)=+k8s:optional
+  // +k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -6309,6 +6309,8 @@ type ServiceAccount struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
+	// +k8s:subfield(name)=+k8s:optional
+	// +k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Enables the declarative validation framework for `core/v1` API group's **ServiceAccount** resource.

- Adds declarative validation support for **ServiceAccount**
- Updates the strategy file to invoke `rest.ValidateDeclarativelyWithMigrationChecks()` for both create and update operations
- Adds declarative validation tests to verify equivalence between hand-written and declarative validation

#### Which issue(s) this PR is related to:

part of #134280

#### Special notes for your reviewer:

The `pkg/apis/core/v1/doc.go` file already contains the `+k8s:validation-gen=TypeMeta` and `+k8s:validation-gen-input=k8s.io/api/core/v1` tags, so no changes were needed there.

This PR only enables the declarative validation framework. The migration of existing validation rules will be handled in separate, subsequent PRs.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP 5073](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md)
- Migration Guide: https://github.com/jpbetz/validation-gen/blob/main/staging/src/k8s.io/code-generator/cmd/validation-gen/README.md#2-migrating-handwritten-validation-to-declarative-validation