### PR TITLE
lint: enable optionalfields linter for multiple API groups

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -163,7 +163,7 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage)"
       
       # optionalfields - Ignore existing issues for node API group
       - text: "optionalfields: field RuntimeClass.Handler should be a pointer."

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -163,7 +163,7 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage)"
       
       # optionalfields - Ignore existing issues for node API group
       - text: "optionalfields: field RuntimeClass.Handler should be a pointer."
@@ -174,6 +174,11 @@ linters:
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
       - text: "optionalfields: field StorageVersion.(Spec|Status) should (?:be a pointer|have the omitempty tag)\\."
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      # optionalfields - Ignore existing issues for coordination API group
+      - text: "optionalfields: field Lease.Spec should be a pointer."
+        path: "staging/src/k8s.io/api/coordination/(v1|v1beta1)/types.go"
+      - text: "optionalfields: field LeaseCandidateSpec.EmulationVersion should be a pointer."
+        path: "staging/src/k8s.io/api/coordination/(v1beta1|v1alpha2)/types.go"
       
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -163,7 +163,7 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
       
       # optionalfields - Ignore existing issues for node API group
       - text: "optionalfields: field RuntimeClass.Handler should be a pointer."

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -163,7 +163,11 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
+      
+      # optionalfields - Ignore existing issues for node API group
+      - text: "optionalfields: field RuntimeClass.Handler should be a pointer."
+        path: "staging/src/k8s.io/api/node/(v1|v1beta1)/types.go"
       
       # optionalfields - Ignore existing issues for apiserverinternal API group
       - text: "optionalfields: field StorageVersionCondition.(ObservedGeneration|LastTransitionTime) should be a pointer."

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -178,7 +178,7 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
       
       # optionalfields - Ignore existing issues for node API group
       - text: "optionalfields: field RuntimeClass.Handler should be a pointer."

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -178,7 +178,7 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage)"
       
       # optionalfields - Ignore existing issues for node API group
       - text: "optionalfields: field RuntimeClass.Handler should be a pointer."
@@ -189,6 +189,11 @@ linters:
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
       - text: "optionalfields: field StorageVersion.(Spec|Status) should (?:be a pointer|have the omitempty tag)\\."
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      # optionalfields - Ignore existing issues for coordination API group
+      - text: "optionalfields: field Lease.Spec should be a pointer."
+        path: "staging/src/k8s.io/api/coordination/(v1|v1beta1)/types.go"
+      - text: "optionalfields: field LeaseCandidateSpec.EmulationVersion should be a pointer."
+        path: "staging/src/k8s.io/api/coordination/(v1beta1|v1alpha2)/types.go"
       
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -178,7 +178,11 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
+      
+      # optionalfields - Ignore existing issues for node API group
+      - text: "optionalfields: field RuntimeClass.Handler should be a pointer."
+        path: "staging/src/k8s.io/api/node/(v1|v1beta1)/types.go"
       
       # optionalfields - Ignore existing issues for apiserverinternal API group
       - text: "optionalfields: field StorageVersionCondition.(ObservedGeneration|LastTransitionTime) should be a pointer."

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -178,7 +178,7 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage)"
       
       # optionalfields - Ignore existing issues for node API group
       - text: "optionalfields: field RuntimeClass.Handler should be a pointer."

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -39,7 +39,7 @@
 # optionalfields - Ignore optionalfields issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage)"
 
 # optionalfields - Ignore existing issues for node API group
 - text: "optionalfields: field RuntimeClass.Handler should be a pointer."

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -39,7 +39,7 @@
 # optionalfields - Ignore optionalfields issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
 
 # optionalfields - Ignore existing issues for node API group
 - text: "optionalfields: field RuntimeClass.Handler should be a pointer."

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -39,7 +39,7 @@
 # optionalfields - Ignore optionalfields issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage)"
+  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage)"
 
 # optionalfields - Ignore existing issues for node API group
 - text: "optionalfields: field RuntimeClass.Handler should be a pointer."
@@ -50,6 +50,11 @@
   path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
 - text: "optionalfields: field StorageVersion.(Spec|Status) should (?:be a pointer|have the omitempty tag)\\."
   path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+# optionalfields - Ignore existing issues for coordination API group
+- text: "optionalfields: field Lease.Spec should be a pointer."
+  path: "staging/src/k8s.io/api/coordination/(v1|v1beta1)/types.go"
+- text: "optionalfields: field LeaseCandidateSpec.EmulationVersion should be a pointer."
+  path: "staging/src/k8s.io/api/coordination/(v1beta1|v1alpha2)/types.go"
 
 # Pre-existing issues from the conflictmarkers linter
 # The Error field in some older API types is marked as both optional and required.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -39,7 +39,11 @@
 # optionalfields - Ignore optionalfields issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|policy|rbac|resource|scheduling|storage|storagemigration)"
+
+# optionalfields - Ignore existing issues for node API group
+- text: "optionalfields: field RuntimeClass.Handler should be a pointer."
+  path: "staging/src/k8s.io/api/node/(v1|v1beta1)/types.go"
 
 # optionalfields - Ignore existing issues for apiserverinternal API group
 - text: "optionalfields: field StorageVersionCondition.(ObservedGeneration|LastTransitionTime) should be a pointer."


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR continues the progressive enablement of the `optionalfields` rule for node,discovery,storagemigration, and coordination api groups. 
- No violations for node, discovery , storagemigration 
- some violations `Lease.Spec` and `LeaseCandidateSpec.EmulationVersion` are added as exceptions to suppress the linter errors.
- Bumps the KAL to the latest version to resolve a bug where the linter was specifically flagging named map and slice types.

#### Which issue(s) this PR is related to:
relates to #134671

#### Special notes for your reviewer:

```release-note
NONE
```