### PR TITLE
DRA ExtendedResourceCache: avoid risk of flakes

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
@@ -102,6 +102,7 @@ func (c *ExtendedResourceCache) OnAdd(obj interface{}, isInInitialList bool) {
 		utilruntime.HandleErrorWithLogger(c.logger, nil, "Expected DeviceClass", "actual", fmt.Sprintf("%T", obj))
 		return
 	}
+	c.logger.V(5).Info("DeviceClass added", "deviceClass", klog.KObj(deviceClass))
 	c.updateResourceName2class(deviceClass, nil)
 	c.updateClass2ResourceName(deviceClass)
 
@@ -122,6 +123,7 @@ func (c *ExtendedResourceCache) OnUpdate(oldObj, newObj interface{}) {
 		utilruntime.HandleErrorWithLogger(c.logger, nil, "Expected DeviceClass", "actual", fmt.Sprintf("%T", oldObj))
 		return
 	}
+	c.logger.V(5).Info("DeviceClass updated", "deviceClass", klog.KObj(deviceClass))
 	c.updateResourceName2class(deviceClass, oldDeviceClass)
 	c.updateClass2ResourceName(deviceClass)
 
@@ -140,6 +142,7 @@ func (c *ExtendedResourceCache) OnDelete(obj interface{}) {
 		utilruntime.HandleErrorWithLogger(c.logger, nil, "Expected DeviceClass", "actual", fmt.Sprintf("%T", obj))
 		return
 	}
+	c.logger.V(5).Info("DeviceClass deleted", "deviceClass", klog.KObj(deviceClass))
 	c.removeResourceName2class(deviceClass)
 	c.removeClass2ResourceName(deviceClass)
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

The unit test flaked at least once so far in the CI. Can be reproduced locally by running many instances of the test in parallel.

There were two potential root causes:
- The watch must be set up completely before creating objects (a fake client-go limitation).
- The one second timeout might be too small on a loaded system.

By running the tests in a synctest bubble with synctest.Wait calls at the right places both problems are avoided. As a welcome side effect the test also completes faster.

Before:

    $ go test k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache
    ok  	k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache	9.300s

    $ stress -p 512 ./extendedresourcecache.test
    5s: 0 runs so far, 0 failures, 512 active
    10s: 8 runs so far, 0 failures, 512 active

    /tmp/go-stress-20251225T195231-2875181701
    --- FAIL: TestExtendedResourceCache (9.14s)
        extendedresourcecache_test.go:234: Expected to find device class 'gpu-class' for 'example.com/gpu', got nil
        extendedresourcecache_test.go:241: Expected to find device class 'fpga-class' for 'deviceclass.resource.kubernetes.io/fpga-class', got nil
        extendedresourcecache_test.go:247: Expected default mapping for gpu-class
        extendedresourcecache.go:197: I1225 19:52:36.332170] Updated extended resource cache for explicit mapping extendedResource="example.com/gpu" deviceClass="gpu-class-3"
        extendedresourcecache.go:204: I1225 19:52:36.332216] Updated extended resource cache for default mapping extendedResource="deviceclass.resource.kubernetes.io/gpu-class-3" deviceClass="gpu-class-3"
        extendedresourcecache.go:220: I1225 19:52:36.332245] Updated device class mapping deviceClass="gpu-class-3" extendedResource="example.com/gpu"
        extendedresourcecache_test.go:260: Expected to find device class 'gpu-class' for 'example.com/gpu', got &DeviceClass{ObjectMeta:{gpu-class-3      0 2025-12-24 19:52:35.32560833 +0100 CET m=-86396.691266715 <nil> <nil> map[] map[] [] [] [{unknown Update resource.k8s.io/v1 2025-12-25 18:52:36.332067439 +0000 UTC FieldsV1 {"f:spec":{"f:extendedResourceName":{}}} }]},Spec:DeviceClassSpec{Selectors:[]DeviceSelector{},Config:[]DeviceClassConfiguration{},ExtendedResourceName:*example.com/gpu,},}
        extendedresourcecache.go:197: I1225 19:52:37.336135] Updated extended resource cache for explicit mapping extendedResource="example.com/gpu" deviceClass="gpu-class-4"
        extendedresourcecache.go:204: I1225 19:52:37.336169] Updated extended resource cache for default mapping extendedResource="deviceclass.resource.kubernetes.io/gpu-class-4" deviceClass="gpu-class-4"
        extendedresourcecache.go:220: I1225 19:52:37.336192] Updated device class mapping deviceClass="gpu-class-4" extendedResource="example.com/gpu"
        extendedresourcecache.go:197: I1225 19:52:38.340121] Updated extended resource cache for explicit mapping extendedResource="example

After:

    ok  	k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache	0.064s
    ...
    2m0s: 7063 runs so far, 0 failures, 512 active


#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @yliaog 
/cc @bart0sh 