### PR TITLE
hack/verify-featuregates.sh: print failure information to stderr

### DIFF
--- a/hack/verify-featuregates.sh
+++ b/hack/verify-featuregates.sh
@@ -32,7 +32,7 @@ kube::golang::setup_env
 cd "${KUBE_ROOT}"
 
 if ! go run test/compatibility_lifecycle/main.go feature-gates verify; then
-  echo "Please run 'hack/update-featuregates.sh' to update the feature list."
+  echo >&2 "Please run 'hack/update-featuregates.sh' to update the feature list."
   exit 1
 fi
 
@@ -44,7 +44,7 @@ trap 'rm -f "${TMPFILE}"' EXIT
 go run cmd/genfeaturegates/genfeaturegates.go -output="${TMPFILE}"
 
 if ! diff -q "${FEATURE_LIST_MD}" "${TMPFILE}" > /dev/null 2>&1; then
-  echo "${FEATURE_LIST_MD} is out of date."
-  echo "Please run 'hack/update-featuregates.sh' to update the feature list."
+  echo >&2 "${FEATURE_LIST_MD} is out of date."
+  echo >&2 "Please run 'hack/update-featuregates.sh' to update the feature list."
   exit 1
 fi


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Verify scripts are run such that stderr is captured and included in the JUnit files. Stdout is not. Therefore the instructions in case of a failure where only visible by searching the entire job log file, but not in the Prow summary.

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/132553

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
