### PR TITLE
Migrate FlowSchema, HPA, CSR, and VolumeAttachment to declarative validation

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -939,7 +939,7 @@ func validateValidationActions(va []admissionregistration.ValidationAction, fldP
 		allErrors = append(allErrors, field.Invalid(fldPath, va, "must not contain both Deny and Warn (repeating the same validation failure information in the API response and headers serves no purpose)"))
 	}
 	if len(actions) == 0 {
-		allErrors = append(allErrors, field.Required(fldPath, "at least one validation action is required"))
+		allErrors = append(allErrors, field.Required(fldPath, "at least one validation action is required")).MarkCoveredByDeclarative()
 	}
 	return allErrors
 }
@@ -1182,7 +1182,7 @@ func validateValidatingAdmissionPolicyBindingSpec(spec *admissionregistration.Va
 	var allErrors field.ErrorList
 
 	if len(spec.PolicyName) == 0 {
-		allErrors = append(allErrors, field.Required(fldPath.Child("policyName"), ""))
+		allErrors = append(allErrors, field.Required(fldPath.Child("policyName"), "")).MarkCoveredByDeclarative()
 	} else {
 		for _, msg := range genericvalidation.NameIsDNSSubdomain(spec.PolicyName, false) {
 			allErrors = append(allErrors, field.Invalid(fldPath.Child("policyName"), spec.PolicyName, msg))

--- a/pkg/apis/autoscaling/v1/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.validations.go
@@ -47,14 +47,6 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
-	// type HorizontalPodAutoscalerList
-	scheme.AddValidationFunc((*autoscalingv1.HorizontalPodAutoscalerList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/":
-			return Validate_HorizontalPodAutoscalerList(ctx, op, nil /* fldPath */, obj.(*autoscalingv1.HorizontalPodAutoscalerList), safe.Cast[*autoscalingv1.HorizontalPodAutoscalerList](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
 	// type Scale
 	scheme.AddValidationFunc((*autoscalingv1.Scale)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -132,29 +124,6 @@ func Validate_HorizontalPodAutoscaler(ctx context.Context, op operation.Operatio
 		}), oldObj != nil)...)
 
 	// field autoscalingv1.HorizontalPodAutoscaler.Status has no validation
-	return errs
-}
-
-// Validate_HorizontalPodAutoscalerList validates an instance of HorizontalPodAutoscalerList according
-// to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscalerList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscalerList) (errs field.ErrorList) {
-	// field autoscalingv1.HorizontalPodAutoscalerList.TypeMeta has no validation
-	// field autoscalingv1.HorizontalPodAutoscalerList.ListMeta has no validation
-
-	// field autoscalingv1.HorizontalPodAutoscalerList.Items
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []autoscalingv1.HorizontalPodAutoscaler, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_HorizontalPodAutoscaler)...)
-			return
-		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerList) []autoscalingv1.HorizontalPodAutoscaler {
-			return oldObj.Items
-		}), oldObj != nil)...)
-
 	return errs
 }
 

--- a/pkg/apis/autoscaling/v1/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.validations.go
@@ -26,6 +26,7 @@ import (
 	fmt "fmt"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
@@ -38,6 +39,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type HorizontalPodAutoscaler
+	scheme.AddValidationFunc((*autoscalingv1.HorizontalPodAutoscaler)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_HorizontalPodAutoscaler(ctx, op, nil /* fldPath */, obj.(*autoscalingv1.HorizontalPodAutoscaler), safe.Cast[*autoscalingv1.HorizontalPodAutoscaler](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type HorizontalPodAutoscalerList
+	scheme.AddValidationFunc((*autoscalingv1.HorizontalPodAutoscalerList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_HorizontalPodAutoscalerList(ctx, op, nil /* fldPath */, obj.(*autoscalingv1.HorizontalPodAutoscalerList), safe.Cast[*autoscalingv1.HorizontalPodAutoscalerList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type Scale
 	scheme.AddValidationFunc((*autoscalingv1.Scale)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -47,6 +64,121 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_CrossVersionObjectReference validates an instance of CrossVersionObjectReference according
+// to declarative validation rules in the API schema.
+func Validate_CrossVersionObjectReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.CrossVersionObjectReference) (errs field.ErrorList) {
+	// field autoscalingv1.CrossVersionObjectReference.Kind
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("kind"), &obj.Kind, safe.Field(oldObj, func(oldObj *autoscalingv1.CrossVersionObjectReference) *string { return &oldObj.Kind }), oldObj != nil)...)
+
+	// field autoscalingv1.CrossVersionObjectReference.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *autoscalingv1.CrossVersionObjectReference) *string { return &oldObj.Name }), oldObj != nil)...)
+
+	// field autoscalingv1.CrossVersionObjectReference.APIVersion has no validation
+	return errs
+}
+
+// Validate_HorizontalPodAutoscaler validates an instance of HorizontalPodAutoscaler according
+// to declarative validation rules in the API schema.
+func Validate_HorizontalPodAutoscaler(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscaler) (errs field.ErrorList) {
+	// field autoscalingv1.HorizontalPodAutoscaler.TypeMeta has no validation
+	// field autoscalingv1.HorizontalPodAutoscaler.ObjectMeta has no validation
+
+	// field autoscalingv1.HorizontalPodAutoscaler.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_HorizontalPodAutoscalerSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscaler) *autoscalingv1.HorizontalPodAutoscalerSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
+
+	// field autoscalingv1.HorizontalPodAutoscaler.Status has no validation
+	return errs
+}
+
+// Validate_HorizontalPodAutoscalerList validates an instance of HorizontalPodAutoscalerList according
+// to declarative validation rules in the API schema.
+func Validate_HorizontalPodAutoscalerList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscalerList) (errs field.ErrorList) {
+	// field autoscalingv1.HorizontalPodAutoscalerList.TypeMeta has no validation
+	// field autoscalingv1.HorizontalPodAutoscalerList.ListMeta has no validation
+
+	// field autoscalingv1.HorizontalPodAutoscalerList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []autoscalingv1.HorizontalPodAutoscaler, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_HorizontalPodAutoscaler)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerList) []autoscalingv1.HorizontalPodAutoscaler {
+			return oldObj.Items
+		}), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_HorizontalPodAutoscalerSpec validates an instance of HorizontalPodAutoscalerSpec according
+// to declarative validation rules in the API schema.
+func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) (errs field.ErrorList) {
+	// field autoscalingv1.HorizontalPodAutoscalerSpec.ScaleTargetRef
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv1.CrossVersionObjectReference, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CrossVersionObjectReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("scaleTargetRef"), &obj.ScaleTargetRef, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *autoscalingv1.CrossVersionObjectReference {
+			return &oldObj.ScaleTargetRef
+		}), oldObj != nil)...)
+
+	// field autoscalingv1.HorizontalPodAutoscalerSpec.MinReplicas has no validation
+	// field autoscalingv1.HorizontalPodAutoscalerSpec.MaxReplicas has no validation
+	// field autoscalingv1.HorizontalPodAutoscalerSpec.TargetCPUUtilizationPercentage has no validation
+	return errs
 }
 
 // Validate_Scale validates an instance of Scale according

--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -82,7 +82,7 @@ func validateHorizontalPodAutoscalerSpec(autoscaler autoscaling.HorizontalPodAut
 func ValidateCrossVersionObjectReference(ref autoscaling.CrossVersionObjectReference, fldPath *field.Path, opts CrossVersionObjectReferenceValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(ref.Kind) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("kind"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("kind"), "").MarkCoveredByDeclarative())
 	} else {
 		for _, msg := range pathvalidation.IsValidPathSegmentName(ref.Kind) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), ref.Kind, msg))
@@ -90,7 +90,7 @@ func ValidateCrossVersionObjectReference(ref autoscaling.CrossVersionObjectRefer
 	}
 
 	if len(ref.Name) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "").MarkCoveredByDeclarative())
 	} else {
 		for _, msg := range pathvalidation.IsValidPathSegmentName(ref.Name) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ref.Name, msg))

--- a/pkg/apis/certificates/v1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1/zz_generated.validations.go
@@ -55,7 +55,20 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequest) (errs field.ErrorList) {
 	// field certificatesv1.CertificateSigningRequest.TypeMeta has no validation
 	// field certificatesv1.CertificateSigningRequest.ObjectMeta has no validation
-	// field certificatesv1.CertificateSigningRequest.Spec has no validation
+
+	// field certificatesv1.CertificateSigningRequest.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CertificateSigningRequestSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequest) *certificatesv1.CertificateSigningRequestSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
 
 	// field certificatesv1.CertificateSigningRequest.Status
 	errs = append(errs,
@@ -71,6 +84,100 @@ func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operat
 			return &oldObj.Status
 		}), oldObj != nil)...)
 
+	return errs
+}
+
+// Validate_CertificateSigningRequestList validates an instance of CertificateSigningRequestList according
+// to declarative validation rules in the API schema.
+func Validate_CertificateSigningRequestList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestList) (errs field.ErrorList) {
+	// field certificatesv1.CertificateSigningRequestList.TypeMeta has no validation
+	// field certificatesv1.CertificateSigningRequestList.ListMeta has no validation
+
+	// field certificatesv1.CertificateSigningRequestList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1.CertificateSigningRequest, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CertificateSigningRequest)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestList) []certificatesv1.CertificateSigningRequest {
+			return oldObj.Items
+		}), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_CertificateSigningRequestSpec validates an instance of CertificateSigningRequestSpec according
+// to declarative validation rules in the API schema.
+func Validate_CertificateSigningRequestSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestSpec) (errs field.ErrorList) {
+	// field certificatesv1.CertificateSigningRequestSpec.Request
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []byte, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("request"), obj.Request, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestSpec) []byte { return oldObj.Request }), oldObj != nil)...)
+
+	// field certificatesv1.CertificateSigningRequestSpec.SignerName
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("signerName"), &obj.SignerName, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestSpec) *string { return &oldObj.SignerName }), oldObj != nil)...)
+
+	// field certificatesv1.CertificateSigningRequestSpec.ExpirationSeconds has no validation
+
+	// field certificatesv1.CertificateSigningRequestSpec.Usages
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1.KeyUsage, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("usages"), obj.Usages, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestSpec) []certificatesv1.KeyUsage {
+			return oldObj.Usages
+		}), oldObj != nil)...)
+
+	// field certificatesv1.CertificateSigningRequestSpec.Username has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.UID has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.Groups has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.Extra has no validation
 	return errs
 }
 

--- a/pkg/apis/certificates/v1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1/zz_generated.validations.go
@@ -87,29 +87,6 @@ func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operat
 	return errs
 }
 
-// Validate_CertificateSigningRequestList validates an instance of CertificateSigningRequestList according
-// to declarative validation rules in the API schema.
-func Validate_CertificateSigningRequestList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestList) (errs field.ErrorList) {
-	// field certificatesv1.CertificateSigningRequestList.TypeMeta has no validation
-	// field certificatesv1.CertificateSigningRequestList.ListMeta has no validation
-
-	// field certificatesv1.CertificateSigningRequestList.Items
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []certificatesv1.CertificateSigningRequest, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CertificateSigningRequest)...)
-			return
-		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestList) []certificatesv1.CertificateSigningRequest {
-			return oldObj.Items
-		}), oldObj != nil)...)
-
-	return errs
-}
-
 // Validate_CertificateSigningRequestSpec validates an instance of CertificateSigningRequestSpec according
 // to declarative validation rules in the API schema.
 func Validate_CertificateSigningRequestSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestSpec) (errs field.ErrorList) {

--- a/pkg/apis/certificates/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.validations.go
@@ -55,7 +55,20 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequest) (errs field.ErrorList) {
 	// field certificatesv1beta1.CertificateSigningRequest.TypeMeta has no validation
 	// field certificatesv1beta1.CertificateSigningRequest.ObjectMeta has no validation
-	// field certificatesv1beta1.CertificateSigningRequest.Spec has no validation
+
+	// field certificatesv1beta1.CertificateSigningRequest.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CertificateSigningRequestSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequest) *certificatesv1beta1.CertificateSigningRequestSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
 
 	// field certificatesv1beta1.CertificateSigningRequest.Status
 	errs = append(errs,
@@ -71,6 +84,64 @@ func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operat
 			return &oldObj.Status
 		}), oldObj != nil)...)
 
+	return errs
+}
+
+// Validate_CertificateSigningRequestList validates an instance of CertificateSigningRequestList according
+// to declarative validation rules in the API schema.
+func Validate_CertificateSigningRequestList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestList) (errs field.ErrorList) {
+	// field certificatesv1beta1.CertificateSigningRequestList.TypeMeta has no validation
+	// field certificatesv1beta1.CertificateSigningRequestList.ListMeta has no validation
+
+	// field certificatesv1beta1.CertificateSigningRequestList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1beta1.CertificateSigningRequest, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CertificateSigningRequest)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequestList) []certificatesv1beta1.CertificateSigningRequest {
+			return oldObj.Items
+		}), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_CertificateSigningRequestSpec validates an instance of CertificateSigningRequestSpec according
+// to declarative validation rules in the API schema.
+func Validate_CertificateSigningRequestSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestSpec) (errs field.ErrorList) {
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Request has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.SignerName has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.ExpirationSeconds has no validation
+
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Usages
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1beta1.KeyUsage, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("usages"), obj.Usages, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequestSpec) []certificatesv1beta1.KeyUsage {
+			return oldObj.Usages
+		}), oldObj != nil)...)
+
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Username has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.UID has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Groups has no validation
+	// field certificatesv1beta1.CertificateSigningRequestSpec.Extra has no validation
 	return errs
 }
 

--- a/pkg/apis/certificates/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.validations.go
@@ -87,29 +87,6 @@ func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operat
 	return errs
 }
 
-// Validate_CertificateSigningRequestList validates an instance of CertificateSigningRequestList according
-// to declarative validation rules in the API schema.
-func Validate_CertificateSigningRequestList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestList) (errs field.ErrorList) {
-	// field certificatesv1beta1.CertificateSigningRequestList.TypeMeta has no validation
-	// field certificatesv1beta1.CertificateSigningRequestList.ListMeta has no validation
-
-	// field certificatesv1beta1.CertificateSigningRequestList.Items
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []certificatesv1beta1.CertificateSigningRequest, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CertificateSigningRequest)...)
-			return
-		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequestList) []certificatesv1beta1.CertificateSigningRequest {
-			return oldObj.Items
-		}), oldObj != nil)...)
-
-	return errs
-}
-
 // Validate_CertificateSigningRequestSpec validates an instance of CertificateSigningRequestSpec according
 // to declarative validation rules in the API schema.
 func Validate_CertificateSigningRequestSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestSpec) (errs field.ErrorList) {

--- a/pkg/apis/certificates/validation/validation.go
+++ b/pkg/apis/certificates/validation/validation.go
@@ -188,7 +188,7 @@ func validateCertificateSigningRequest(csr *certificates.CertificateSigningReque
 		allErrs = append(allErrs, field.Invalid(specPath.Child("request"), csr.Spec.Request, fmt.Sprintf("%v", err)))
 	}
 	if len(csr.Spec.Usages) == 0 {
-		allErrs = append(allErrs, field.Required(specPath.Child("usages"), ""))
+		allErrs = append(allErrs, field.Required(specPath.Child("usages"), "").MarkCoveredByDeclarative())
 	}
 	if !opts.allowUnknownUsages {
 		for i, usage := range csr.Spec.Usages {

--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -99,7 +99,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Required(specPath.Child("usages"), ""),
+				field.Required(specPath.Child("usages"), "").MarkCoveredByDeclarative(),
 			},
 		},
 		"CSR with no signerName set should fail": {
@@ -347,7 +347,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Required(specPath.Child("usages"), ""),
+				field.Required(specPath.Child("usages"), "").MarkCoveredByDeclarative(),
 			},
 		},
 		"unknown and duplicate usages": {

--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -123,7 +123,7 @@ func ValidateFlowSchemaSpec(fsName string, spec *flowcontrol.FlowSchemaSpec, fld
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("priorityLevelConfiguration").Child("name"), spec.PriorityLevelConfiguration.Name, msg))
 		}
 	} else {
-		allErrs = append(allErrs, field.Required(fldPath.Child("priorityLevelConfiguration").Child("name"), "must reference a priority level"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("priorityLevelConfiguration").Child("name"), "must reference a priority level").MarkCoveredByDeclarative())
 	}
 	for i, rule := range spec.Rules {
 		allErrs = append(allErrs, ValidateFlowSchemaPolicyRulesWithSubjects(&rule, fldPath.Child("rules").Index(i))...)

--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -46,6 +46,30 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
+	// type StorageClassList
+	scheme.AddValidationFunc((*storagev1.StorageClassList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_StorageClassList(ctx, op, nil /* fldPath */, obj.(*storagev1.StorageClassList), safe.Cast[*storagev1.StorageClassList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type VolumeAttachment
+	scheme.AddValidationFunc((*storagev1.VolumeAttachment)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_VolumeAttachment(ctx, op, nil /* fldPath */, obj.(*storagev1.VolumeAttachment), safe.Cast[*storagev1.VolumeAttachment](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type VolumeAttachmentList
+	scheme.AddValidationFunc((*storagev1.VolumeAttachmentList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_VolumeAttachmentList(ctx, op, nil /* fldPath */, obj.(*storagev1.VolumeAttachmentList), safe.Cast[*storagev1.VolumeAttachmentList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
 }
 
@@ -80,5 +104,96 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 	// field storagev1.StorageClass.AllowVolumeExpansion has no validation
 	// field storagev1.StorageClass.VolumeBindingMode has no validation
 	// field storagev1.StorageClass.AllowedTopologies has no validation
+	return errs
+}
+
+// Validate_StorageClassList validates an instance of StorageClassList according
+// to declarative validation rules in the API schema.
+func Validate_StorageClassList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.StorageClassList) (errs field.ErrorList) {
+	// field storagev1.StorageClassList.TypeMeta has no validation
+	// field storagev1.StorageClassList.ListMeta has no validation
+
+	// field storagev1.StorageClassList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []storagev1.StorageClass, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_StorageClass)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1.StorageClassList) []storagev1.StorageClass { return oldObj.Items }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_VolumeAttachment validates an instance of VolumeAttachment according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.VolumeAttachment) (errs field.ErrorList) {
+	// field storagev1.VolumeAttachment.TypeMeta has no validation
+	// field storagev1.VolumeAttachment.ObjectMeta has no validation
+
+	// field storagev1.VolumeAttachment.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *storagev1.VolumeAttachmentSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_VolumeAttachmentSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *storagev1.VolumeAttachment) *storagev1.VolumeAttachmentSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	// field storagev1.VolumeAttachment.Status has no validation
+	return errs
+}
+
+// Validate_VolumeAttachmentList validates an instance of VolumeAttachmentList according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachmentList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.VolumeAttachmentList) (errs field.ErrorList) {
+	// field storagev1.VolumeAttachmentList.TypeMeta has no validation
+	// field storagev1.VolumeAttachmentList.ListMeta has no validation
+
+	// field storagev1.VolumeAttachmentList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []storagev1.VolumeAttachment, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_VolumeAttachment)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1.VolumeAttachmentList) []storagev1.VolumeAttachment { return oldObj.Items }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_VolumeAttachmentSpec validates an instance of VolumeAttachmentSpec according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachmentSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.VolumeAttachmentSpec) (errs field.ErrorList) {
+	// field storagev1.VolumeAttachmentSpec.Attacher
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("attacher"), &obj.Attacher, safe.Field(oldObj, func(oldObj *storagev1.VolumeAttachmentSpec) *string { return &oldObj.Attacher }), oldObj != nil)...)
+
+	// field storagev1.VolumeAttachmentSpec.Source has no validation
+	// field storagev1.VolumeAttachmentSpec.NodeName has no validation
 	return errs
 }

--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -26,6 +26,7 @@ import (
 	fmt "fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
+	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
@@ -46,27 +47,11 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
-	// type StorageClassList
-	scheme.AddValidationFunc((*storagev1.StorageClassList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/":
-			return Validate_StorageClassList(ctx, op, nil /* fldPath */, obj.(*storagev1.StorageClassList), safe.Cast[*storagev1.StorageClassList](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
 	// type VolumeAttachment
 	scheme.AddValidationFunc((*storagev1.VolumeAttachment)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
 		case "/":
 			return Validate_VolumeAttachment(ctx, op, nil /* fldPath */, obj.(*storagev1.VolumeAttachment), safe.Cast[*storagev1.VolumeAttachment](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
-	// type VolumeAttachmentList
-	scheme.AddValidationFunc((*storagev1.VolumeAttachmentList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/":
-			return Validate_VolumeAttachmentList(ctx, op, nil /* fldPath */, obj.(*storagev1.VolumeAttachmentList), safe.Cast[*storagev1.VolumeAttachmentList](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
@@ -107,27 +92,6 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 	return errs
 }
 
-// Validate_StorageClassList validates an instance of StorageClassList according
-// to declarative validation rules in the API schema.
-func Validate_StorageClassList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.StorageClassList) (errs field.ErrorList) {
-	// field storagev1.StorageClassList.TypeMeta has no validation
-	// field storagev1.StorageClassList.ListMeta has no validation
-
-	// field storagev1.StorageClassList.Items
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []storagev1.StorageClass, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_StorageClass)...)
-			return
-		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1.StorageClassList) []storagev1.StorageClass { return oldObj.Items }), oldObj != nil)...)
-
-	return errs
-}
-
 // Validate_VolumeAttachment validates an instance of VolumeAttachment according
 // to declarative validation rules in the API schema.
 func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.VolumeAttachment) (errs field.ErrorList) {
@@ -147,27 +111,6 @@ func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldP
 		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *storagev1.VolumeAttachment) *storagev1.VolumeAttachmentSpec { return &oldObj.Spec }), oldObj != nil)...)
 
 	// field storagev1.VolumeAttachment.Status has no validation
-	return errs
-}
-
-// Validate_VolumeAttachmentList validates an instance of VolumeAttachmentList according
-// to declarative validation rules in the API schema.
-func Validate_VolumeAttachmentList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.VolumeAttachmentList) (errs field.ErrorList) {
-	// field storagev1.VolumeAttachmentList.TypeMeta has no validation
-	// field storagev1.VolumeAttachmentList.ListMeta has no validation
-
-	// field storagev1.VolumeAttachmentList.Items
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []storagev1.VolumeAttachment, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_VolumeAttachment)...)
-			return
-		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1.VolumeAttachmentList) []storagev1.VolumeAttachment { return oldObj.Items }), oldObj != nil)...)
-
 	return errs
 }
 

--- a/pkg/apis/storage/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1alpha1/zz_generated.validations.go
@@ -47,14 +47,6 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
-	// type VolumeAttachmentList
-	scheme.AddValidationFunc((*storagev1alpha1.VolumeAttachmentList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/":
-			return Validate_VolumeAttachmentList(ctx, op, nil /* fldPath */, obj.(*storagev1alpha1.VolumeAttachmentList), safe.Cast[*storagev1alpha1.VolumeAttachmentList](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
 	return nil
 }
 
@@ -79,29 +71,6 @@ func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldP
 		}), oldObj != nil)...)
 
 	// field storagev1alpha1.VolumeAttachment.Status has no validation
-	return errs
-}
-
-// Validate_VolumeAttachmentList validates an instance of VolumeAttachmentList according
-// to declarative validation rules in the API schema.
-func Validate_VolumeAttachmentList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1alpha1.VolumeAttachmentList) (errs field.ErrorList) {
-	// field storagev1alpha1.VolumeAttachmentList.TypeMeta has no validation
-	// field storagev1alpha1.VolumeAttachmentList.ListMeta has no validation
-
-	// field storagev1alpha1.VolumeAttachmentList.Items
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []storagev1alpha1.VolumeAttachment, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_VolumeAttachment)...)
-			return
-		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1alpha1.VolumeAttachmentList) []storagev1alpha1.VolumeAttachment {
-			return oldObj.Items
-		}), oldObj != nil)...)
-
 	return errs
 }
 

--- a/pkg/apis/storage/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1alpha1/zz_generated.validations.go
@@ -22,7 +22,16 @@ limitations under the License.
 package v1alpha1
 
 import (
+	context "context"
+	fmt "fmt"
+
+	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	equality "k8s.io/apimachinery/pkg/api/equality"
+	operation "k8s.io/apimachinery/pkg/api/operation"
+	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	field "k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
@@ -30,5 +39,95 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type VolumeAttachment
+	scheme.AddValidationFunc((*storagev1alpha1.VolumeAttachment)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_VolumeAttachment(ctx, op, nil /* fldPath */, obj.(*storagev1alpha1.VolumeAttachment), safe.Cast[*storagev1alpha1.VolumeAttachment](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type VolumeAttachmentList
+	scheme.AddValidationFunc((*storagev1alpha1.VolumeAttachmentList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_VolumeAttachmentList(ctx, op, nil /* fldPath */, obj.(*storagev1alpha1.VolumeAttachmentList), safe.Cast[*storagev1alpha1.VolumeAttachmentList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
+}
+
+// Validate_VolumeAttachment validates an instance of VolumeAttachment according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1alpha1.VolumeAttachment) (errs field.ErrorList) {
+	// field storagev1alpha1.VolumeAttachment.TypeMeta has no validation
+	// field storagev1alpha1.VolumeAttachment.ObjectMeta has no validation
+
+	// field storagev1alpha1.VolumeAttachment.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *storagev1alpha1.VolumeAttachmentSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_VolumeAttachmentSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *storagev1alpha1.VolumeAttachment) *storagev1alpha1.VolumeAttachmentSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
+
+	// field storagev1alpha1.VolumeAttachment.Status has no validation
+	return errs
+}
+
+// Validate_VolumeAttachmentList validates an instance of VolumeAttachmentList according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachmentList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1alpha1.VolumeAttachmentList) (errs field.ErrorList) {
+	// field storagev1alpha1.VolumeAttachmentList.TypeMeta has no validation
+	// field storagev1alpha1.VolumeAttachmentList.ListMeta has no validation
+
+	// field storagev1alpha1.VolumeAttachmentList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []storagev1alpha1.VolumeAttachment, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_VolumeAttachment)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1alpha1.VolumeAttachmentList) []storagev1alpha1.VolumeAttachment {
+			return oldObj.Items
+		}), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_VolumeAttachmentSpec validates an instance of VolumeAttachmentSpec according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachmentSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1alpha1.VolumeAttachmentSpec) (errs field.ErrorList) {
+	// field storagev1alpha1.VolumeAttachmentSpec.Attacher
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("attacher"), &obj.Attacher, safe.Field(oldObj, func(oldObj *storagev1alpha1.VolumeAttachmentSpec) *string { return &oldObj.Attacher }), oldObj != nil)...)
+
+	// field storagev1alpha1.VolumeAttachmentSpec.Source has no validation
+	// field storagev1alpha1.VolumeAttachmentSpec.NodeName has no validation
+	return errs
 }

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -46,6 +46,30 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
+	// type StorageClassList
+	scheme.AddValidationFunc((*storagev1beta1.StorageClassList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_StorageClassList(ctx, op, nil /* fldPath */, obj.(*storagev1beta1.StorageClassList), safe.Cast[*storagev1beta1.StorageClassList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type VolumeAttachment
+	scheme.AddValidationFunc((*storagev1beta1.VolumeAttachment)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_VolumeAttachment(ctx, op, nil /* fldPath */, obj.(*storagev1beta1.VolumeAttachment), safe.Cast[*storagev1beta1.VolumeAttachment](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type VolumeAttachmentList
+	scheme.AddValidationFunc((*storagev1beta1.VolumeAttachmentList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_VolumeAttachmentList(ctx, op, nil /* fldPath */, obj.(*storagev1beta1.VolumeAttachmentList), safe.Cast[*storagev1beta1.VolumeAttachmentList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
 }
 
@@ -80,5 +104,100 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 	// field storagev1beta1.StorageClass.AllowVolumeExpansion has no validation
 	// field storagev1beta1.StorageClass.VolumeBindingMode has no validation
 	// field storagev1beta1.StorageClass.AllowedTopologies has no validation
+	return errs
+}
+
+// Validate_StorageClassList validates an instance of StorageClassList according
+// to declarative validation rules in the API schema.
+func Validate_StorageClassList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.StorageClassList) (errs field.ErrorList) {
+	// field storagev1beta1.StorageClassList.TypeMeta has no validation
+	// field storagev1beta1.StorageClassList.ListMeta has no validation
+
+	// field storagev1beta1.StorageClassList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []storagev1beta1.StorageClass, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_StorageClass)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1beta1.StorageClassList) []storagev1beta1.StorageClass { return oldObj.Items }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_VolumeAttachment validates an instance of VolumeAttachment according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.VolumeAttachment) (errs field.ErrorList) {
+	// field storagev1beta1.VolumeAttachment.TypeMeta has no validation
+	// field storagev1beta1.VolumeAttachment.ObjectMeta has no validation
+
+	// field storagev1beta1.VolumeAttachment.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *storagev1beta1.VolumeAttachmentSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_VolumeAttachmentSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *storagev1beta1.VolumeAttachment) *storagev1beta1.VolumeAttachmentSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
+
+	// field storagev1beta1.VolumeAttachment.Status has no validation
+	return errs
+}
+
+// Validate_VolumeAttachmentList validates an instance of VolumeAttachmentList according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachmentList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.VolumeAttachmentList) (errs field.ErrorList) {
+	// field storagev1beta1.VolumeAttachmentList.TypeMeta has no validation
+	// field storagev1beta1.VolumeAttachmentList.ListMeta has no validation
+
+	// field storagev1beta1.VolumeAttachmentList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []storagev1beta1.VolumeAttachment, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_VolumeAttachment)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1beta1.VolumeAttachmentList) []storagev1beta1.VolumeAttachment {
+			return oldObj.Items
+		}), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_VolumeAttachmentSpec validates an instance of VolumeAttachmentSpec according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachmentSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.VolumeAttachmentSpec) (errs field.ErrorList) {
+	// field storagev1beta1.VolumeAttachmentSpec.Attacher
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("attacher"), &obj.Attacher, safe.Field(oldObj, func(oldObj *storagev1beta1.VolumeAttachmentSpec) *string { return &oldObj.Attacher }), oldObj != nil)...)
+
+	// field storagev1beta1.VolumeAttachmentSpec.Source has no validation
+	// field storagev1beta1.VolumeAttachmentSpec.NodeName has no validation
 	return errs
 }

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -26,6 +26,7 @@ import (
 	fmt "fmt"
 
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
@@ -46,27 +47,11 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
-	// type StorageClassList
-	scheme.AddValidationFunc((*storagev1beta1.StorageClassList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/":
-			return Validate_StorageClassList(ctx, op, nil /* fldPath */, obj.(*storagev1beta1.StorageClassList), safe.Cast[*storagev1beta1.StorageClassList](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
 	// type VolumeAttachment
 	scheme.AddValidationFunc((*storagev1beta1.VolumeAttachment)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
 		case "/":
 			return Validate_VolumeAttachment(ctx, op, nil /* fldPath */, obj.(*storagev1beta1.VolumeAttachment), safe.Cast[*storagev1beta1.VolumeAttachment](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
-	// type VolumeAttachmentList
-	scheme.AddValidationFunc((*storagev1beta1.VolumeAttachmentList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/":
-			return Validate_VolumeAttachmentList(ctx, op, nil /* fldPath */, obj.(*storagev1beta1.VolumeAttachmentList), safe.Cast[*storagev1beta1.VolumeAttachmentList](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
@@ -107,27 +92,6 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 	return errs
 }
 
-// Validate_StorageClassList validates an instance of StorageClassList according
-// to declarative validation rules in the API schema.
-func Validate_StorageClassList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.StorageClassList) (errs field.ErrorList) {
-	// field storagev1beta1.StorageClassList.TypeMeta has no validation
-	// field storagev1beta1.StorageClassList.ListMeta has no validation
-
-	// field storagev1beta1.StorageClassList.Items
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []storagev1beta1.StorageClass, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_StorageClass)...)
-			return
-		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1beta1.StorageClassList) []storagev1beta1.StorageClass { return oldObj.Items }), oldObj != nil)...)
-
-	return errs
-}
-
 // Validate_VolumeAttachment validates an instance of VolumeAttachment according
 // to declarative validation rules in the API schema.
 func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.VolumeAttachment) (errs field.ErrorList) {
@@ -149,29 +113,6 @@ func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldP
 		}), oldObj != nil)...)
 
 	// field storagev1beta1.VolumeAttachment.Status has no validation
-	return errs
-}
-
-// Validate_VolumeAttachmentList validates an instance of VolumeAttachmentList according
-// to declarative validation rules in the API schema.
-func Validate_VolumeAttachmentList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.VolumeAttachmentList) (errs field.ErrorList) {
-	// field storagev1beta1.VolumeAttachmentList.TypeMeta has no validation
-	// field storagev1beta1.VolumeAttachmentList.ListMeta has no validation
-
-	// field storagev1beta1.VolumeAttachmentList.Items
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []storagev1beta1.VolumeAttachment, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_VolumeAttachment)...)
-			return
-		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *storagev1beta1.VolumeAttachmentList) []storagev1beta1.VolumeAttachment {
-			return oldObj.Items
-		}), oldObj != nil)...)
-
 	return errs
 }
 

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -168,7 +168,7 @@ func validateVolumeAttachmentSpec(
 func validateAttacher(attacher string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(attacher) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath, attacher))
+		allErrs = append(allErrs, field.Required(fldPath, attacher)).MarkCoveredByDeclarative()
 	}
 	return allErrs
 }

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
@@ -20,9 +20,11 @@ import (
 	"context"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
@@ -83,6 +85,7 @@ func (v *validatingAdmissionPolicyBindingStrategy) PrepareForUpdate(ctx context.
 // Validate validates a new ValidatingAdmissionPolicyBinding.
 func (v *validatingAdmissionPolicyBindingStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	errs := validation.ValidateValidatingAdmissionPolicyBinding(obj.(*admissionregistration.ValidatingAdmissionPolicyBinding))
+	errs = rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, errs, operation.Create)
 	if len(errs) == 0 {
 		// if the object is well-formed, also authorize the paramRef
 		if err := v.authorizeCreate(ctx, obj); err != nil {
@@ -109,6 +112,7 @@ func (v *validatingAdmissionPolicyBindingStrategy) AllowCreateOnUpdate() bool {
 // ValidateUpdate is the default update validation for an end user.
 func (v *validatingAdmissionPolicyBindingStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	errs := validation.ValidateValidatingAdmissionPolicyBindingUpdate(obj.(*admissionregistration.ValidatingAdmissionPolicyBinding), old.(*admissionregistration.ValidatingAdmissionPolicyBinding))
+	errs = rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, errs, operation.Update)
 	if len(errs) == 0 {
 		// if the object is well-formed, also authorize the paramRef
 		if err := v.authorizeUpdate(ctx, obj, old); err != nil {

--- a/pkg/registry/storage/volumeattachment/strategy.go
+++ b/pkg/registry/storage/volumeattachment/strategy.go
@@ -19,9 +19,11 @@ package volumeattachment
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -70,7 +72,8 @@ func (volumeAttachmentStrategy) Validate(ctx context.Context, obj runtime.Object
 
 	// tighten up validation of newly created v1 attachments
 	errs = append(errs, validation.ValidateVolumeAttachmentV1(volumeAttachment)...)
-	return errs
+
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, volumeAttachment, nil, errs, operation.Create)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -99,7 +102,9 @@ func (volumeAttachmentStrategy) PrepareForUpdate(ctx context.Context, obj, old r
 func (volumeAttachmentStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newVolumeAttachmentObj := obj.(*storage.VolumeAttachment)
 	oldVolumeAttachmentObj := old.(*storage.VolumeAttachment)
-	return validation.ValidateVolumeAttachmentUpdate(newVolumeAttachmentObj, oldVolumeAttachmentObj)
+	errs := validation.ValidateVolumeAttachmentUpdate(newVolumeAttachmentObj, oldVolumeAttachmentObj)
+
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newVolumeAttachmentObj, oldVolumeAttachmentObj, errs, operation.Update)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
@@ -623,6 +623,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to.
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
+  // +k8s:required
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -680,6 +681,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   //
   // Required.
   // +listType=set
+  // +k8s:required
   repeated string validationActions = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -474,6 +474,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to.
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
+	// +k8s:required
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -531,6 +532,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	//
 	// Required.
 	// +listType=set
+	// +k8s:required
 	ValidationActions []ValidationAction `json:"validationActions,omitempty" protobuf:"bytes,4,rep,name=validationActions"`
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
@@ -646,6 +646,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to.
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
+  // +k8s:required
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -703,6 +704,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   //
   // Required.
   // +listType=set
+  // +k8s:required
   repeated string validationActions = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
@@ -414,6 +414,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to.
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
+	// +k8s:required
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -471,6 +472,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	//
 	// Required.
 	// +listType=set
+	// +k8s:required
 	ValidationActions []ValidationAction `json:"validationActions,omitempty" protobuf:"bytes,4,rep,name=validationActions"`
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
@@ -872,6 +872,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to.
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
+  // +k8s:required
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -929,6 +930,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   //
   // Required.
   // +listType=set
+  // +k8s:required
   repeated string validationActions = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -427,6 +427,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to.
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
+	// +k8s:required
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -484,6 +485,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	//
 	// Required.
 	// +listType=set
+	// +k8s:required
 	ValidationActions []ValidationAction `json:"validationActions,omitempty" protobuf:"bytes,4,rep,name=validationActions"`
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -88,9 +88,11 @@ message ContainerResourceMetricStatus {
 // +structType=atomic
 message CrossVersionObjectReference {
   // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  // +k8s:required
   optional string kind = 1;
 
   // name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+  // +k8s:required
   optional string name = 2;
 
   // apiVersion is the API version of the referent

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -26,9 +26,11 @@ import (
 // +structType=atomic
 type CrossVersionObjectReference struct {
 	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +k8s:required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 
 	// name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +k8s:required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
 	// apiVersion is the API version of the referent

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -67,9 +67,11 @@ message ContainerResourceMetricStatus {
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 message CrossVersionObjectReference {
   // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  // +k8s:required
   optional string kind = 1;
 
   // name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+  // +k8s:required
   optional string name = 2;
 
   // apiVersion is the API version of the referent
@@ -240,6 +242,7 @@ message HorizontalPodAutoscalerList {
 message HorizontalPodAutoscalerSpec {
   // scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics
   // should be collected, as well as to actually change the replica count.
+  // +k8s:required
   optional CrossVersionObjectReference scaleTargetRef = 1;
 
   // minReplicas is the lower limit for the number of replicas to which the autoscaler
@@ -252,6 +255,7 @@ message HorizontalPodAutoscalerSpec {
 
   // maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
   // It cannot be less that minReplicas.
+  // +k8s:required
   optional int32 maxReplicas = 3;
 
   // metrics contains the specifications for which to use to calculate the

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -52,6 +52,7 @@ type HorizontalPodAutoscaler struct {
 type HorizontalPodAutoscalerSpec struct {
 	// scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics
 	// should be collected, as well as to actually change the replica count.
+	// +k8s:required
 	ScaleTargetRef CrossVersionObjectReference `json:"scaleTargetRef" protobuf:"bytes,1,opt,name=scaleTargetRef"`
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler
 	// can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the
@@ -63,6 +64,7 @@ type HorizontalPodAutoscalerSpec struct {
 
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
 	// It cannot be less that minReplicas.
+	// +k8s:required
 	MaxReplicas int32 `json:"maxReplicas" protobuf:"varint,3,opt,name=maxReplicas"`
 
 	// metrics contains the specifications for which to use to calculate the
@@ -87,9 +89,11 @@ type HorizontalPodAutoscalerSpec struct {
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 type CrossVersionObjectReference struct {
 	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +k8s:required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 
 	// name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +k8s:required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
 	// apiVersion is the API version of the referent

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -111,6 +111,7 @@ message CertificateSigningRequestList {
 message CertificateSigningRequestSpec {
   // request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block.
   // When serialized as JSON or YAML, the data is additionally base64-encoded.
+  // +k8s:required
   optional bytes request = 1;
 
   // signerName indicates the requested signer, and is a qualified name.
@@ -134,6 +135,7 @@ message CertificateSigningRequestSpec {
   //  4. Required, permitted, or forbidden key usages / extended key usages.
   //  5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
   //  6. Whether or not requests for CA certificates are allowed.
+  // +k8s:required
   optional string signerName = 7;
 
   // expirationSeconds is the requested duration of validity of the issued
@@ -173,6 +175,7 @@ message CertificateSigningRequestSpec {
   //  "ipsec end system", "ipsec tunnel", "ipsec user",
   //  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
   // +listType=atomic
+  // +k8s:required
   repeated string usages = 5;
 
   // username contains the name of the user that created the CertificateSigningRequest.

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -61,6 +61,7 @@ type CertificateSigningRequest struct {
 type CertificateSigningRequestSpec struct {
 	// request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block.
 	// When serialized as JSON or YAML, the data is additionally base64-encoded.
+	// +k8s:required
 	Request []byte `json:"request" protobuf:"bytes,1,opt,name=request"`
 
 	// signerName indicates the requested signer, and is a qualified name.
@@ -84,6 +85,7 @@ type CertificateSigningRequestSpec struct {
 	//  4. Required, permitted, or forbidden key usages / extended key usages.
 	//  5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
 	//  6. Whether or not requests for CA certificates are allowed.
+	// +k8s:required
 	SignerName string `json:"signerName" protobuf:"bytes,7,opt,name=signerName"`
 
 	// expirationSeconds is the requested duration of validity of the issued
@@ -123,8 +125,8 @@ type CertificateSigningRequestSpec struct {
 	//  "ipsec end system", "ipsec tunnel", "ipsec user",
 	//  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
 	// +listType=atomic
+	// +k8s:required
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
-
 	// username contains the name of the user that created the CertificateSigningRequest.
 	// Populated by the API server on creation and immutable.
 	// +optional

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -154,6 +154,7 @@ message CertificateSigningRequestSpec {
   //  "microsoft sgc",
   //  "netscape sgc"
   // +listType=atomic
+  // +k8s:required
   repeated string usages = 5;
 
   // Information about the requesting user.

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -120,6 +120,7 @@ type CertificateSigningRequestSpec struct {
 	//  "microsoft sgc",
 	//  "netscape sgc"
 	// +listType=atomic
+	// +k8s:required
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 
 	// Information about the requesting user.

--- a/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
@@ -126,6 +126,7 @@ message FlowSchemaSpec {
   // `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
   // be resolved, the FlowSchema will be ignored and marked as invalid in its status.
   // Required.
+  // +k8s:required
   optional PriorityLevelConfigurationReference priorityLevelConfiguration = 1;
 
   // `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
@@ -351,6 +352,7 @@ message PriorityLevelConfigurationList {
 message PriorityLevelConfigurationReference {
   // `name` is the name of the priority level configuration being referenced
   // Required.
+  // +k8s:required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1/types.go
@@ -146,6 +146,7 @@ type FlowSchemaSpec struct {
 	// `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
 	// be resolved, the FlowSchema will be ignored and marked as invalid in its status.
 	// Required.
+	// +k8s:required
 	PriorityLevelConfiguration PriorityLevelConfigurationReference `json:"priorityLevelConfiguration" protobuf:"bytes,1,opt,name=priorityLevelConfiguration"`
 	// `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
 	// FlowSchema is among those with the numerically lowest (which we take to be logically highest)
@@ -194,6 +195,7 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +k8s:required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
@@ -344,6 +344,7 @@ message PriorityLevelConfigurationList {
 message PriorityLevelConfigurationReference {
   // `name` is the name of the priority level configuration being referenced
   // Required.
+  // +k8s:required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
@@ -196,6 +196,7 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +k8s:required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
@@ -344,6 +344,7 @@ message PriorityLevelConfigurationList {
 message PriorityLevelConfigurationReference {
   // `name` is the name of the priority level configuration being referenced
   // Required.
+  // +k8s:required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
@@ -196,6 +196,7 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +k8s:required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
@@ -126,6 +126,7 @@ message FlowSchemaSpec {
   // `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
   // be resolved, the FlowSchema will be ignored and marked as invalid in its status.
   // Required.
+  // +k8s:required
   optional PriorityLevelConfigurationReference priorityLevelConfiguration = 1;
 
   // `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
@@ -346,6 +347,7 @@ message PriorityLevelConfigurationList {
 message PriorityLevelConfigurationReference {
   // `name` is the name of the priority level configuration being referenced
   // Required.
+  // +k8s:required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
@@ -162,6 +162,7 @@ type FlowSchemaSpec struct {
 	// `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
 	// be resolved, the FlowSchema will be ignored and marked as invalid in its status.
 	// Required.
+	// +k8s:required
 	PriorityLevelConfiguration PriorityLevelConfigurationReference `json:"priorityLevelConfiguration" protobuf:"bytes,1,opt,name=priorityLevelConfiguration"`
 	// `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
 	// FlowSchema is among those with the numerically lowest (which we take to be logically highest)
@@ -210,6 +211,7 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +k8s:required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -552,6 +552,7 @@ message VolumeAttachmentSource {
 message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
+  // +k8s:required
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -161,6 +161,7 @@ type VolumeAttachmentList struct {
 type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
+	// +k8s:required
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
@@ -177,6 +177,7 @@ message VolumeAttachmentSource {
 message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
+  // +k8s:required
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types.go
@@ -74,6 +74,7 @@ type VolumeAttachmentList struct {
 type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
+	// +k8s:required
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -554,6 +554,7 @@ message VolumeAttachmentSource {
 message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
+  // +k8s:required
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -168,6 +168,7 @@ type VolumeAttachmentList struct {
 type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
+	// +k8s:required
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig api-machinery

#### What this PR does / why we need it:
This PR migrates the validation of the following fields to declarative validation using the `+k8s:required` tag, as part of KEP-5073:

- **FlowSchema**: `Spec.PriorityLevelConfiguration`
- **HorizontalPodAutoscaler**: `Spec.ScaleTargetRef`, `Spec.MaxReplicas`
- **CertificateSigningRequest**: `Spec.Request`, `Spec.SignerName`, `Spec.Usages`
- **VolumeAttachment**: `Spec.Attacher`

It also updates the corresponding validation logic to use `.MarkCoveredByDeclarative()`.

#### Which issue(s) this PR is related to:
Part of #135752

#### Special notes for your reviewer:
- Ran `hack/update-codegen.sh`.
- Verified with unit tests in `pkg/apis/flowcontrol`, `pkg/apis/autoscaling`, `pkg/apis/certificates`, and `pkg/apis/storage`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```