### PR TITLE
test: skip APF header assertions after request timeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -712,7 +712,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		firstRequestPathPanic, secondRequestPathShouldWork := "/request/panic-as-designed", "/request/should-succeed-as-expected"
 		firstHandlerDoneCh, secondHandlerDoneCh := make(chan struct{}), make(chan struct{})
 		requestHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			headerMatcher.inspect(t, w, fsName, plName)
+			headerMatcher.inspect(t, w, r.Context(), fsName, plName)
 			switch {
 			case r.URL.Path == firstRequestPathPanic:
 				close(firstHandlerDoneCh)
@@ -785,7 +785,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		rquestTimesOutPath := "/request/time-out-as-designed"
 		reqHandlerCompletedCh, callerRoundTripDoneCh := make(chan struct{}), make(chan struct{})
 		requestHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			headerMatcher.inspect(t, w, fsName, plName)
+			headerMatcher.inspect(t, w, r.Context(), fsName, plName)
 
 			if r.URL.Path == rquestTimesOutPath {
 				defer close(reqHandlerCompletedCh)
@@ -858,7 +858,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		reqHandlerErrCh, callerRoundTripDoneCh := make(chan error, 1), make(chan struct{})
 		rquestTimesOutPath := "/request/time-out-as-designed"
 		requestHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			headerMatcher.inspect(t, w, fsName, plName)
+			headerMatcher.inspect(t, w, r.Context(), fsName, plName)
 
 			if r.URL.Path == rquestTimesOutPath {
 				<-callerRoundTripDoneCh
@@ -937,7 +937,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		rquestTimesOutPath := "/request/time-out-as-designed"
 		reqHandlerErrCh, callerRoundTripDoneCh := make(chan error, 1), make(chan struct{})
 		requestHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			headerMatcher.inspect(t, w, fsName, plName)
+			headerMatcher.inspect(t, w, r.Context(), fsName, plName)
 
 			if r.URL.Path == rquestTimesOutPath {
 
@@ -1016,7 +1016,7 @@ func TestPriorityAndFairnessWithPanicRecoveryAndTimeoutFilter(t *testing.T) {
 		firstReqHandlerErrCh, firstReqInProgressCh := make(chan error, 1), make(chan struct{})
 		firstReqRoundTripDoneCh, secondReqRoundTripDoneCh := make(chan struct{}), make(chan struct{})
 		requestHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			headerMatcher.inspect(t, w, fsName, plName)
+			headerMatcher.inspect(t, w, r.Context(), fsName, plName)
 			switch {
 			case r.URL.Path == firstRequestTimesOutPath:
 				close(firstReqInProgressCh)
@@ -1188,28 +1188,35 @@ func newHTTP2ServerWithClient(handler http.Handler, clientTimeout time.Duration)
 type headerMatcher struct{}
 
 // verifies that the expected flow schema and priority level UIDs are attached to the header.
-func (m *headerMatcher) inspect(t *testing.T, w http.ResponseWriter, expectedFS, expectedPL string) {
+func (m *headerMatcher) inspect(t *testing.T, w http.ResponseWriter, ctx context.Context, expectedFS, expectedPL string) {
 	t.Helper()
-	err := func() error {
-		if w == nil {
-			return fmt.Errorf("expected a non nil HTTP response")
-		}
 
-		key := flowcontrol.ResponseHeaderMatchedFlowSchemaUID
-		if value := w.Header().Get(key); expectedFS != value {
-			return fmt.Errorf("expected HTTP header %s to have value %q, but got: %q", key, expectedFS, value)
-		}
-
-		key = flowcontrol.ResponseHeaderMatchedPriorityLevelConfigurationUID
-		if value := w.Header().Get(key); expectedPL != value {
-			return fmt.Errorf("expected HTTP header %s to have value %q, but got %q", key, expectedPL, value)
-		}
-		return nil
-	}()
-	if err == nil {
+	if w == nil {
+		t.Errorf("expected a non nil HTTP response")
 		return
 	}
-	t.Errorf("Expected APF headers to match, but got: %v", err)
+
+	checkHeader := func(key, expected string) {
+		actual := w.Header().Get(key)
+		if actual == expected {
+			return
+		}
+
+		// Header writes are best-effort once the request context is canceled.
+		if actual == "" {
+			select {
+			case <-ctx.Done():
+				t.Logf("Skipping APF header assertion for %s: request context already done", key)
+				return
+			default:
+			}
+		}
+
+		t.Errorf("expected HTTP header %s to have value %q, but got: %q", key, expected, actual)
+	}
+
+	checkHeader(flowcontrol.ResponseHeaderMatchedFlowSchemaUID, expectedFS)
+	checkHeader(flowcontrol.ResponseHeaderMatchedPriorityLevelConfigurationUID, expectedPL)
 }
 
 // when a request panics, http2 resets the stream with an INTERNAL_ERROR message


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes a flaky unit test by relaxing APF header assertions when a request
has already timed out or been canceled.

In timeout scenarios, the outer TimeoutHandler may finalize the response before
the APF handler writes tracking headers. The existing test assumed these headers
were always present, which is not guaranteed and caused intermittent failures.

The change updates the test helper to skip APF header assertions when the request
context is already done.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Related to #135941

#### Special notes for your reviewer:
- Test-only change, no production behavior impact.
- Verified locally on x86 environment where the flake was reproducible.
- Aligns test expectations with documented timeout semantics.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
