### PR TITLE
Fix(client-go): ensure fake client eviction deletes the pod

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/fake/fake_eviction_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/fake/fake_eviction_expansion.go
@@ -33,5 +33,13 @@ func (c *fakeEvictions) Evict(ctx context.Context, eviction *policy.Eviction) er
 	action.Object = eviction
 
 	_, err := c.Fake.Invokes(action, eviction)
+	if err == nil {
+		deleteAction := core.DeleteActionImpl{}
+		deleteAction.Verb = "delete"
+		deleteAction.Namespace = c.Namespace()
+		deleteAction.Resource = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+		deleteAction.Name = eviction.Name
+		_, err = c.Fake.Invokes(deleteAction, eviction)
+	}
 	return err
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig api-machinery

#### What this PR does / why we need it:
Fixes a bug in the fake client where `Eviction` operations would record the action but fail to actually delete the Pod from the fake tracker. This behavior is inconsistent with real clusters where eviction results in pod deletion.

#### Which issue(s) this PR is related to:
Fixes #112168

#### Special notes for your reviewer:
Verified locally with a reproduction test case that fails before the fix and passes after.

#### Does this PR introduce a user-facing change?
```release-note
Fixed client-go fake client to correctly delete pods when Eviction is requested.
```