### PR TITLE
Fix(apimachinery): preserve apiVersion/kind when decoding without conversion

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
@@ -253,13 +253,7 @@ type WithoutVersionDecoder struct {
 
 // Decode does not do conversion. It removes the gvk during deserialization.
 func (d WithoutVersionDecoder) Decode(data []byte, defaults *schema.GroupVersionKind, into Object) (Object, *schema.GroupVersionKind, error) {
-	obj, gvk, err := d.Decoder.Decode(data, defaults, into)
-	if obj != nil {
-		kind := obj.GetObjectKind()
-		// clearing the gvk is just a convention of a codec
-		kind.SetGroupVersionKind(schema.GroupVersionKind{})
-	}
-	return obj, gvk, err
+	return d.Decoder.Decode(data, defaults, into)
 }
 
 type encoderWithAllocator struct {

--- a/staging/src/k8s.io/client-go/rest/client_test.go
+++ b/staging/src/k8s.io/client-go/rest/client_test.go
@@ -90,11 +90,14 @@ func TestDoRequestSuccess(t *testing.T) {
 
 func TestDoRequestFailed(t *testing.T) {
 	status := &metav1.Status{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Status",
+			APIVersion: "v1",
+		},
 		Code:    http.StatusNotFound,
 		Status:  metav1.StatusFailure,
 		Reason:  metav1.StatusReasonNotFound,
-		Message: " \"\" not found",
-		Details: &metav1.StatusDetails{},
+		Message: "the server could not find the requested resource",
 	}
 	expectedBody, _ := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), status)
 	fakeHandler := utiltesting.FakeHandler{

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -887,7 +887,11 @@ func TestTransformUnstructuredError(t *testing.T) {
 			Res:   &http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(bytes.NewReader([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","code":404}`)))},
 			ErrFn: apierrors.IsBadRequest,
 			Transformed: &apierrors.StatusError{
-				ErrStatus: metav1.Status{Status: metav1.StatusFailure, Code: http.StatusNotFound},
+				ErrStatus: metav1.Status{
+					TypeMeta:   metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+					Status:     metav1.StatusFailure,
+					Code:       http.StatusNotFound,
+				},
 			},
 		},
 		{
@@ -909,7 +913,11 @@ func TestTransformUnstructuredError(t *testing.T) {
 			Res:   &http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(bytes.NewReader([]byte(`{"kind":"Status","status":"Failure","code":404}`)))},
 			ErrFn: apierrors.IsBadRequest,
 			Transformed: &apierrors.StatusError{
-				ErrStatus: metav1.Status{Status: metav1.StatusFailure, Code: http.StatusNotFound},
+				ErrStatus: metav1.Status{
+					TypeMeta:   metav1.TypeMeta{Kind: "Status", APIVersion: ""},
+					Status:     metav1.StatusFailure,
+					Code:       http.StatusNotFound,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig api-machinery

#### What this PR does / why we need it:
Currently, `WithoutVersionDecoder` explicitly clears the `apiVersion` and `kind` fields of deserialized objects. This is undesirable when dealing with versioned structs (not internal API types), as it makes `GroupVersionKind()` less useful on the returned object.

This PR removes the clearing logic in `WithoutVersionDecoder`, allowing `apiVersion` and `kind` to be preserved if they were present in the serialized data.

This fix also updates several tests in `client-go/rest` that relied on the previous behavior of cleared GVKs.

#### Which issue(s) this PR is related to:
Fixes #80609

#### Special notes for your reviewer:
Verified with a reproduction test case and by running all tests in `k8s.io/apimachinery/pkg/runtime` and `k8s.io/client-go/rest`.

#### Does this PR introduce a user-facing change?
```release-note
            Fixed a bug where some decoders would incorrectly clear apiVersion and kind fields when reading Kubernetes objects from serialised data.
```