### PR TITLE
Promote validation-gen tags to Stable

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
@@ -194,7 +194,7 @@ func (etv *enumTagValidator) GetValidations(context Context, _ codetags.Tag) (Va
 func (etv *enumTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            etv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         etv.ValidScopes().UnsortedList(),
 		Description:    "Indicates that a string type is an enum. All constant values of this type are considered values in the enum unless excluded using +k8s:enumExclude.",
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
@@ -120,7 +120,7 @@ func getFormatValidationFunction(format string) (FunctionGen, error) {
 func (ftv formatTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            ftv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         ftv.ValidScopes().UnsortedList(),
 		Description:    "Indicates that a string field has a particular format.",
 		Payloads: []TagPayloadDoc{{ // Keep this list alphabetized.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/item.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/item.go
@@ -249,7 +249,7 @@ func parseTypedValue(value string, argType codetags.ArgType) (any, codetags.Valu
 func (itv itemTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            itv.TagName(),
-		StabilityLevel: Alpha,
+		StabilityLevel: Stable,
 		Scopes:         itv.ValidScopes().UnsortedList(),
 		Description: "Declares a validation for an item of a slice declared as a +k8s:listType=map. " +
 			"The item to match is declared by providing field-value pair arguments. All key fields must be specified.",

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -79,7 +79,7 @@ func (maxLengthTagValidator) GetValidations(context Context, tag codetags.Tag) (
 func (mltv maxLengthTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mltv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         mltv.ValidScopes().UnsortedList(),
 		Description:    "Indicates that a string field has a limit on its length.",
 		Payloads: []TagPayloadDoc{{
@@ -137,7 +137,7 @@ func (maxItemsTagValidator) GetValidations(context Context, tag codetags.Tag) (V
 func (mitv maxItemsTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mitv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         mitv.ValidScopes().UnsortedList(),
 		Description:    "Indicates that a list has a limit on its size.",
 		Payloads: []TagPayloadDoc{{
@@ -187,7 +187,7 @@ func (minimumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 func (mtv minimumTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mtv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         mtv.ValidScopes().UnsortedList(),
 		Description:    "Indicates that a numeric field has a minimum value.",
 		Payloads: []TagPayloadDoc{{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
@@ -182,7 +182,7 @@ func (lttv listTypeTagValidator) GetValidations(context Context, tag codetags.Ta
 func (lttv listTypeTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            lttv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         lttv.ValidScopes().UnsortedList(),
 		Description:    "Declares a list field's semantic type and ownership behavior. atomic: single ownership, set: shared ownership with uniqueness, map: shared ownership with key-based uniqueness.",
 		Payloads: []TagPayloadDoc{{
@@ -250,7 +250,7 @@ func (lmktv listMapKeyTagValidator) GetValidations(context Context, tag codetags
 func (lmktv listMapKeyTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            lmktv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         lmktv.ValidScopes().UnsortedList(),
 		Description:    "Declares a named sub-field of a list's value-type to be part of the list-map key.",
 		Payloads: []TagPayloadDoc{{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -309,10 +309,10 @@ func (rtv requirednessTagValidator) Docs() TagDoc {
 
 	switch rtv.mode {
 	case requirednessRequired:
-		doc.StabilityLevel = Beta
+		doc.StabilityLevel = Stable
 		doc.Description = "Indicates that a field must be specified by clients."
 	case requirednessOptional:
-		doc.StabilityLevel = Beta
+		doc.StabilityLevel = Stable
 		doc.Description = "Indicates that a field is optional to clients."
 	case requirednessForbidden:
 		doc.StabilityLevel = Alpha

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -132,9 +132,9 @@ func (stv subfieldTagValidator) GetValidations(context Context, tag codetags.Tag
 }
 
 func (stv subfieldTagValidator) Docs() TagDoc {
-	doc := TagDoc{
+	return TagDoc{
 		Tag:            stv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         stv.ValidScopes().UnsortedList(),
 		Description:    "Declares a validation for a subfield of a struct.",
 		Args: []TagArgDoc{{
@@ -150,5 +150,4 @@ func (stv subfieldTagValidator) Docs() TagDoc {
 		PayloadsType:     codetags.ValueTypeTag,
 		PayloadsRequired: true,
 	}
-	return doc
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -156,7 +156,7 @@ func (umtv unionMemberTagValidator) GetValidations(context Context, tag codetags
 func (umtv unionMemberTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            umtv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         umtv.ValidScopes().UnsortedList(),
 		Description:    "Indicates that this field is a member of a union.",
 		Args: []TagArgDoc{{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/zeroorone.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/zeroorone.go
@@ -101,7 +101,7 @@ func (zmtv zeroOrOneOfMemberTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            zmtv.TagName(),
 		Scopes:         zmtv.ValidScopes().UnsortedList(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Description:    "Indicates that this field is a member of a zero-or-one-of union.",
 		Docs:           "A zero-or-one-of union allows at most one member to be set. Unlike regular unions, having no members set is valid.",
 		Warning:        "This tag should only be used on sets of list items, and never on struct fields directly.",


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR promotes the stability of several declarative validation tags in the `validation-gen` tool to **Stable**. These tags are used to define validation rules directly in Kubernetes API types as part of [**KEP-5073: Declarative Validation of Kubernetes Native Types**](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen). Consensus to promote these tags was built in a DV working group meeting.

Promoting these tags to Stable indicates they have met the graduation criteria, including sufficient soak time and reliability across releases. This allows API authors to use these tags with full stability guarantees for native Kubernetes types.

The following tags are promoted to Stable, with their introduction details in `staging/src/k8s.io/api` noted below:
- `k8s:enum` (2025-10-15): [9020a17](https://github.com/kubernetes/kubernetes/commit/9020a177318)
- `k8s:format` (2025-09-16): [8606fa0](https://github.com/kubernetes/kubernetes/commit/8606fa03dc7)
- `k8s:listMapKey` (2025-07-16): [6a2d5a1](https://github.com/kubernetes/kubernetes/commit/6a2d5a1e644)
- `k8s:listType` (2025-07-16): [6a2d5a1](https://github.com/kubernetes/kubernetes/commit/6a2d5a1e644)
- `k8s:maxItems` (2025-09-18): [11df504](https://github.com/kubernetes/kubernetes/commit/11df50453fc)
- `k8s:maxLength` (2025-10-22): [6fa8cb4](https://github.com/kubernetes/kubernetes/commit/6fa8cb4a993)
- `k8s:minimum` (2024-11-30): [e08bbf2](https://github.com/kubernetes/kubernetes/commit/e08bbf254c4)
- `k8s:optional` (2024-12-19): [0f47865](https://github.com/kubernetes/kubernetes/commit/0f4786536f7)
- `k8s:required` (2025-09-16): [8606fa0](https://github.com/kubernetes/kubernetes/commit/8606fa03dc7)
- `k8s:subfield` (2025-04-14): [229c6b1](https://github.com/kubernetes/kubernetes/commit/229c6b13ca7)
- `k8s:unionMember` (2025-10-23): [8a6b3ca](https://github.com/kubernetes/kubernetes/commit/8a6b3caaa0d)
- `k8s:zeroOrOneOfMember` (2025-07-16): [6a2d5a1](https://github.com/kubernetes/kubernetes/commit/6a2d5a1e644)
- `k8s:item` (2025-07-16): [6a2d5a1](https://github.com/kubernetes/kubernetes/commit/6a2d5a1e644)

#### Which issue(s) this PR is related to:
* **KEP**: [KEP-5073: Declarative Validation of Kubernetes Native Types](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen)
* **Issue**: kubernetes/enhancements#5073

#### Special notes for your reviewer:
 `k8s:item` was not discussed in the meeting for promotion, but it meets all criteria for being Stable. It has been used and "baked" for two releases (1.34 and 1.35). Note that it is graduating directly from Alpha to Stable in this PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```