### PR TITLE
fix(kubeadm): prevent nil pointer panic in reset command

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -167,7 +167,7 @@ func newResetData(cmd *cobra.Command, opts *resetOptions, in io.Reader, out io.W
 		certificatesDir = opts.externalcfg.CertificatesDir
 	} else if len(resetCfg.CertificatesDir) > 0 { // configured in the ResetConfiguration
 		certificatesDir = resetCfg.CertificatesDir
-	} else if len(initCfg.ClusterConfiguration.CertificatesDir) > 0 { // fetch from cluster
+	} else if initCfg != nil && len(initCfg.ClusterConfiguration.CertificatesDir) > 0 { // fetch from cluster
 		certificatesDir = initCfg.ClusterConfiguration.CertificatesDir
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Fixes a potential nil pointer dereference in `kubeadm reset`.

Previously, if `FetchInitConfigurationFromCluster` failed (returning nil), the code would attempt to access `initCfg.ClusterConfiguration.CertificatesDir` without checking if `initCfg` was valid. This PR adds a nil check to prevent the panic.

#### Which issue(s) this PR is related to:
Relates to #135889

#### Special notes for your reviewer:
This PR addresses **only the first item** mentioned in issue #135889 (the `reset.go` panic). As requested by the maintainers, I am splitting the fixes into separate PRs.

#### Does this PR introduce a user-facing change?
```release-note
NONE