### PR TITLE
DRA scheduler: fix unit test flakes

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -655,7 +655,11 @@ func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *
 			// If the claim is not ready yet (ready false, no error) and binding has timed out
 			// or binding has failed (err non-nil), then the scheduler should consider deallocating this
 			// claim in PostFilter to unblock trying other devices.
-			if err != nil || !ready && pl.isClaimTimeout(claim) {
+			if err != nil {
+				logger.V(5).Info("Claim failed binding conditions check", "pod", klog.KObj(pod), "node", klog.KObj(node), "resourceclaim", klog.KObj(claim), "err", err)
+				unavailableClaims = append(unavailableClaims, index)
+			} else if !ready && pl.isClaimTimeout(claim) {
+				logger.V(5).Info("Claim timed out waiting for binding conditions", "pod", klog.KObj(pod), "node", klog.KObj(node), "resourceclaim", klog.KObj(claim))
 				unavailableClaims = append(unavailableClaims, index)
 			}
 		}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

Test_isSchedulableAfterClaimChange was sensitive to system load because of the arbitrary delay when waiting for the assume cache to catch up. Running inside a synctest bubble avoids this. While at it, the unit tests get converted to ktesting (nicer failure output, no extra indention needed for tCtx.SyncTest).

TestPlugin/prebind-fail-with-binding-timeout relied on setting up a claim with certain time stamps and then getting that test case tested within a certain real-world time window. It's surprising that this didn't flake more often because test execution order is random. Now the time stamp gets set right before the test case is about to be tested. Conversion to a synctest would be nicer, but synctests cannot have sub-tests, which are used here to track where log output and failures come from within the larger test case.

Inside the plugin itself some log output gets added to explain why a claim is unavailable on a node in case of a binding timeout or error during Filter.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Conceptually similar to https://github.com/kubernetes/kubernetes/pull/135948.

A blocker for https://github.com/kubernetes/kubernetes/pull/135395 because in that PR the flake occurs more frequently.

The binding conditions flake was also mentioned on Slack: https://kubernetes.slack.com/archives/C09TP78DV/p1765776929566949

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @macsko @KobayashiD27 