### PR TITLE
make test: fix support for PARALLEL

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -101,7 +101,7 @@ isnum() {
   [[ "$1" =~ ^[0-9]+$ ]]
 }
 
-PARALLEL="${PARALLEL:-1}"
+PARALLEL="${PARALLEL:--1}"
 while getopts "hp:i:" opt ; do
   case ${opt} in
     h)
@@ -173,6 +173,10 @@ set -- "${testcases[@]+${testcases[@]}}"
 
 if [[ -n "${KUBE_RACE}" ]] ; then
   goflags+=("${KUBE_RACE}")
+fi
+
+if [[ "${PARALLEL}" -gt 0 ]]; then
+  goflags+=(-p "${PARALLEL}")
 fi
 
 junitFilenamePrefix() {


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

There was an env variable PARALLEL and a -p command line flag, but the value then wasn't passed on to "go test".

The new default is to not set any explicit parallelism, which matches the prior (accidental?) behavior of ignoring PARALLEL.

It is unclear whether this configuration option is needed. I was experimenting with it in https://github.com/kubernetes/kubernetes/pull/135395 to reduce the average load in pull-kubernetes-unit, but in the end it wasn't useful. The alternative is to remove it. I don't have a strong opinion either way.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @dims @BenTheElder 