### PR TITLE
resource: add AsInt64OrMax helper for Quantity

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -299,9 +299,7 @@ func ParseQuantity(str string) (Quantity, error) {
 	switch format {
 	case DecimalExponent, DecimalSI:
 		scale = exponent
-		precision = maxInt64Factors - int32(len(num)+len(denom)) //not making sense if large number then this will always be less than 0
-		//here precision tells how much capacity is left before int64 overflow
-
+		precision = maxInt64Factors - int32(len(num)+len(denom))
 	case BinarySI:
 		scale = 0
 		switch {
@@ -316,8 +314,6 @@ func ParseQuantity(str string) (Quantity, error) {
 	}
 
 	if precision >= 0 {
-		/* Basically if we have enough room in int64 without any problem (overflow) then proceed else store in dec
-		   format*/
 		// if we have a denominator, shift the entire value to the left by the number of places in the
 		// denominator
 		scale -= int32(len(denom))
@@ -348,13 +344,6 @@ func ParseQuantity(str string) (Quantity, error) {
 			}
 		}
 	}
-	/*
-		TODO: ADD A CHECK HERE FOR NUMBERS WHO ARE > or < range but are inside i
-		also check if the number is >nano, beacuse there might be numbers who are 0.1231313...10^19 value
-		which can go beyond range but we might miscalculate them
-		so if a number is not a decimal number, 0.12313 and is not out of the nano scale, then we can do calcs
-
-	*/
 
 	amount := new(inf.Dec)
 	if _, ok := amount.SetString(value); !ok {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode"
@@ -1819,4 +1820,75 @@ func TestQuantityRoundtripCBOR(t *testing.T) {
 			t.Errorf("Expected equal: %v, %v (cbor was '%s')", initial, final, diag)
 		}
 	}
+}
+
+func TestAsInt64OrMax(t *testing.T) {
+
+	// TestAsInt64OrMax verifies Kubernetes-specific int64 clamping semantics,
+
+	tests := []struct {
+		name    string
+		input   string
+		wantVal int64 //First output of AsInt64OrMax
+		wantOK  bool  //Second Output of AsInt64OrMax
+	}{
+
+		{
+			name:    "exact integer within boundary",
+			input:   "123456",
+			wantVal: 123456,
+			wantOK:  true,
+		},
+		{
+			name:    "value above kubernetes max boundary",
+			input:   strconv.FormatInt(math.MaxInt64, 10),
+			wantVal: 999_999_999_999_999_999,
+			wantOK:  true,
+		},
+		{
+			name:    "value below kubernetes min boundary",
+			input:   strconv.FormatInt(math.MinInt64, 10),
+			wantVal: -999_999_999_999_999_999,
+			wantOK:  true,
+		},
+		{
+			name:    "decimal within kubernetes boundary",
+			input:   "123.456",
+			wantVal: 0,
+			wantOK:  false,
+		},
+		{
+			name:    "exact kubernetes max boundary",
+			input:   "999999999999999999",
+			wantVal: 999_999_999_999_999_999,
+			wantOK:  true,
+		},
+		{
+			name:    "exact kubernetes min boundary",
+			input:   "-999999999999999999",
+			wantVal: -999_999_999_999_999_999,
+			wantOK:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt //Redefining to prevent wrong case scenario as subtests run asynchronously
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			q := MustParse(tt.input)
+			gotVal, gotOk := q.AsInt64OrMax()
+
+			if gotVal != tt.wantVal {
+				t.Fatalf("expected value is %d, got %d", tt.wantVal, gotVal)
+			}
+
+			if gotOk != tt.wantOK {
+				t.Fatalf("expected OK %v, got %v", tt.wantOK, gotOk)
+			}
+
+		})
+
+	}
+
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds an optional helper `Quantity.AsInt64OrMax()` for cases where a
`Quantity` needs to be converted to an `int64` with saturation behavior.

Today, quantities that are numerically large but cannot be safely represented
as `int64` due to internal arithmetic constraints are intentionally rejected by
`AsInt64()`. Some callers still need a bounded `int64` value in these cases.
This helper provides an explicit, opt-in way to do that.

As of now, `AsInt64()` only succeeds when an exact `int64` representation is
possible and never performs rounding or clamping (as it is not meant to).
This helper keeps that behavior unchanged, but provides a separate API for
callers that are okay with clamping values to Kubernetes’ supported numeric
boundaries when the value is out of range.

This change does not modify parsing, internal storage, or canonicalization
logic. All existing behavior remains the same.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Related to #135487

#### Special notes for your reviewer:

This change is intentionally small and opt-in. It adds a helper without
changing any existing parsing or conversion behavior.

The goal is to provide a safe way to get a bounded `int64` value while preserving
all existing invariants around internal arithmetic and canonicalization.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
