### PR TITLE
make test: run compilation under nice

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -171,6 +171,17 @@ else
 fi
 set -- "${testcases[@]+${testcases[@]}}"
 
+# Running tool commands (compilation, linking) under nice when available
+# reduces the risk that those commands steal CPU time from test binaries
+# running in parallel. Test binaries are sometimes sensitive to real-world
+# time and flake when blocked from running for too long.
+#
+# When used on a desktop system it keeps the desktop environment more
+# responsive.
+if command -v nice >/dev/null 2>&1; then
+  goflags+=(-toolexec nice)
+fi
+
 if [[ -n "${KUBE_RACE}" ]] ; then
   goflags+=("${KUBE_RACE}")
 fi


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Running tool commands (compilation, linking) under nice when available reduces the risk that those commands steal CPU time from test binaries running in parallel. Test binaries are sometimes senstive to real-world time and flake when blocked from running for too long.

When used on a desktop system it keeps the desktop environment more responsive.

This is enabled unconditionally when possible (= nice command available) because it shouldn't be necessary to disable or configure it and less option in the script is simpler.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This seems to help in https://github.com/kubernetes/kubernetes/pull/135395 which suffers from random unit test flakes because it changes timing.

Ultimately if a unit test flakes because of timing, it should be fixed, probably with synctest. This PR is meant to reduce the number of tests where that becomes necessary.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
