### PR TITLE
Fix unschedulable pods metric broke while preenqueue

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1133,6 +1133,10 @@ func (p *PriorityQueue) Delete(pod *v1.Pod) {
 	}
 	if pInfo = p.unschedulablePods.get(pod); pInfo != nil {
 		p.unschedulablePods.delete(pod, pInfo.Gated())
+		// Drop metric for deleted pod.
+		for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
+			metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
+		}
 	}
 }
 

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -610,8 +610,11 @@ func (p *PriorityQueue) runPreEnqueuePlugin(ctx context.Context, logger klog.Log
 		// No need to change GatingPlugin; it's overwritten by the next PreEnqueue plugin if they gate this pod, or it's overwritten with an empty string if all PreEnqueue plugins pass.
 		return s
 	}
+	// Only increment metric and insert if not already incremented for this plugin
+	if !pInfo.UnschedulablePlugins.Has(pl.Name()) && !pInfo.PendingPlugins.Has(pl.Name()) {
+		metrics.UnschedulableReason(pl.Name(), pod.Spec.SchedulerName).Inc()
+	}
 	pInfo.UnschedulablePlugins.Insert(pl.Name())
-	metrics.UnschedulableReason(pl.Name(), pod.Spec.SchedulerName).Inc()
 	pInfo.GatingPlugin = pl.Name()
 	pInfo.GatingPluginEvents = p.pluginToEventsMap[pInfo.GatingPlugin]
 	if s.Code() == fwk.Error {

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -1534,9 +1534,13 @@ func TestPriorityQueue_Activate(t *testing.T) {
 
 type preEnqueuePlugin struct {
 	allowlists []string
+	name       string
 }
 
 func (pl *preEnqueuePlugin) Name() string {
+	if pl.name != "" {
+		return pl.name
+	}
 	return "preEnqueuePlugin"
 }
 
@@ -3182,8 +3186,11 @@ var (
 	add = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		queue.Add(logger, pInfo.Pod)
 	}
-	pop = func(_ *testing.T, logger klog.Logger, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
-		queue.Pop(logger)
+	pop = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
+		_, err := queue.Pop(logger)
+		if err != nil {
+			t.Fatalf("Unexpected error during Pop: %v", err)
+		}
 	}
 	popAndRequeueAsUnschedulable = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent() below.
@@ -4652,116 +4659,144 @@ func TestPriorityQueue_GetPod(t *testing.T) {
 }
 
 func TestUnschedulablePodsMetric(t *testing.T) {
-	preenqueuePluginName := "preEnqueuePlugin"
-	queueable := "queueable"
-	timestamp := time.Now()
-	pInfos := makeQueuedPodInfos(30, "x", queueable, timestamp)
+	type step func(t *testing.T, logger klog.Logger, q *PriorityQueue)
 
-	makeGated := func(pInfos []*framework.QueuedPodInfo) []*framework.QueuedPodInfo {
-		for _, pInfo := range pInfos {
-			setQueuedPodInfoGated(pInfo, preenqueuePluginName, []fwk.ClusterEvent{framework.EventUnschedulableTimeout})
+	addPod := func(pInfo *framework.QueuedPodInfo) step {
+		return func(t *testing.T, logger klog.Logger, q *PriorityQueue) {
+			add(t, logger, q, pInfo)
 		}
-		return pInfos
+	}
+	deletePod := func(pInfo *framework.QueuedPodInfo) step {
+		return func(t *testing.T, logger klog.Logger, q *PriorityQueue) {
+			deletePod(t, logger, q, pInfo)
+		}
+	}
+	popPod := func() step {
+		return func(t *testing.T, logger klog.Logger, q *PriorityQueue) {
+			pop(t, logger, q, nil)
+		}
+	}
+	moveAllToActiveOrBackoffQ := func() step {
+		return func(t *testing.T, logger klog.Logger, q *PriorityQueue) {
+			moveAllToActiveOrBackoffQ(t, logger, q, nil)
+		}
+	}
+	updatePluginAllowList := func(pluginName string, list []string) step {
+		return func(t *testing.T, logger klog.Logger, q *PriorityQueue) {
+			q.preEnqueuePluginMap[""][pluginName].(*preEnqueuePlugin).allowlists = list
+		}
 	}
 
-	tests := []struct {
-		name           string
-		operations     []operation
-		operands       [][]*framework.QueuedPodInfo
-		expectedMetric int
-	}{
-		{
-			name: "Unschedulable pods metric must be 0 after a pod is gated, ungated, re-queued, and eventually popped from the scheduling queue",
-			operations: []operation{
-				updatePluginToGateAllPods,
-				add,
-				moveAllToActiveOrBackoffQ,
-				moveAllToActiveOrBackoffQ,
-				updatePluginToUngateAllPods,
-				moveAllToActiveOrBackoffQ,
-				pop,
-			},
-			operands: [][]*framework.QueuedPodInfo{
-				{nil},
-				pInfos[:1],
-				{nil},
-				{nil},
-				{nil},
-				{nil},
-				{nil},
-			},
-			expectedMetric: 0,
-		},
-		{
-			name: "Unschedulable pods metric must be 0 after pod is gated and then deleted",
-			operations: []operation{
-				updatePluginToGateAllPods,
-				add,
-				moveAllToActiveOrBackoffQ,
-				moveAllToActiveOrBackoffQ,
-				deletePod,
-			},
-			operands: [][]*framework.QueuedPodInfo{
-				{nil},
-				pInfos[:1],
-				{nil},
-				{nil},
-				pInfos[:1],
-			},
-			expectedMetric: 0,
-		},
-		{
-			name: "Unschedulable pods metric must be 1 after pod is gated multiple time by simillar plugin",
-			operations: []operation{
-				updatePluginToGateAllPods,
-				add,
-				moveAllToActiveOrBackoffQ,
-				moveAllToActiveOrBackoffQ,
-			},
-			operands: [][]*framework.QueuedPodInfo{
-				{nil},
-				pInfos[:1],
-				{nil},
-				{nil},
-			},
-			expectedMetric: 1,
-		},
-		{
-			name: "Unshedulable pods metric must be 0 after non gated pods is added and then deleted",
-			operations: []operation{
-				add,
-				deletePod,
-			},
-			operands: [][]*framework.QueuedPodInfo{
-				pInfos[:1],
-				pInfos[:1],
-			},
-			expectedMetric: 0,
-		},
-		{
-			name: "Unschedulable pods metric should not be duplicate if gated pods added and then gated with the same plugin again",
-			operations: []operation{
-				updatePluginToGateAllPods,
-				add,
-				moveAllToActiveOrBackoffQ,
-			},
-			operands: [][]*framework.QueuedPodInfo{
-				{nil},
-				makeGated(pInfos[:10]),
-				{nil},
-			},
-			expectedMetric: 10,
-		},
+	pluginName1 := "plugin1"
+	pluginName2 := "plugin2"
+	queueable := "queueable"
+	timestamp := time.Now()
+	pod := &framework.QueuedPodInfo{
+		PodInfo: mustNewPodInfo(
+			st.MakePod().Name("podA").Namespace("namespaceA").Label(queueable, "").UID("someUid").Obj()),
+		Timestamp:            timestamp,
+		UnschedulablePlugins: sets.New[string](),
 	}
 
 	resetMetrics := func() {
-		metrics.UnschedulableReason(preenqueuePluginName, "").Set(0)
+		metrics.UnschedulableReason(pluginName1, "").Set(0)
+		metrics.UnschedulableReason(pluginName2, "").Set(0)
 	}
-	resetPodInfos := func() {
-		for i := range pInfos {
-			pInfos[i].Attempts = 0
-			pInfos[i].UnschedulableCount = 0
-		}
+
+	makeGated := func(pInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo {
+		return setQueuedPodInfoGated(pInfo.DeepCopy(), pluginName1, []fwk.ClusterEvent{framework.EventUnschedulableTimeout})
+	}
+
+	tests := []struct {
+		name            string
+		steps           []step
+		expectedMetrics []int
+	}{
+		{
+			name: "Unschedulable pods metric must be 0 after a pod is gated, ungated, re-queued, and eventually popped from the scheduling queue",
+			steps: []step{
+				updatePluginAllowList(pluginName1, []string{}),
+				addPod(pod),
+				moveAllToActiveOrBackoffQ(),
+				updatePluginAllowList(pluginName1, []string{queueable}),
+				moveAllToActiveOrBackoffQ(),
+				popPod(),
+			},
+			expectedMetrics: []int{0, 0},
+		},
+		{
+			name: "Unschedulable pods metric must be 0 after pod is gated and then deleted",
+			steps: []step{
+				updatePluginAllowList(pluginName1, []string{}),
+				addPod(pod),
+				moveAllToActiveOrBackoffQ(),
+				deletePod(pod),
+			},
+			expectedMetrics: []int{0, 0},
+		},
+		{
+			name: "Unschedulable pods metric must be 1 after pod is gated multiple time by the same plugin",
+			steps: []step{
+				updatePluginAllowList(pluginName1, []string{}),
+				addPod(pod),
+				moveAllToActiveOrBackoffQ(),
+			},
+			expectedMetrics: []int{1, 0},
+		},
+		{
+			name: "Unschedulable pods metric must be 0 after non gated pods is added and then deleted",
+			steps: []step{
+				addPod(pod),
+				deletePod(pod),
+			},
+			expectedMetrics: []int{0, 0},
+		},
+		{
+			name: "Unschedulable pods metric should not be duplicate if gated pods added and then gated with the same plugin again",
+			steps: []step{
+				updatePluginAllowList(pluginName1, []string{}),
+				addPod(makeGated(pod)),
+				moveAllToActiveOrBackoffQ(),
+			},
+			expectedMetrics: []int{1, 0},
+		},
+		{
+			name: "Unschedulable pods metric should be 0 if pod was gated by two plugins sequentially and then ungated and popped",
+			steps: []step{
+				updatePluginAllowList(pluginName1, []string{}),
+				addPod(pod),
+				updatePluginAllowList(pluginName1, []string{queueable}),
+				updatePluginAllowList(pluginName2, []string{}),
+				moveAllToActiveOrBackoffQ(),
+				updatePluginAllowList(pluginName2, []string{queueable}),
+				moveAllToActiveOrBackoffQ(),
+				popPod(),
+			},
+			expectedMetrics: []int{0, 0},
+		},
+		{
+			name: "Unschedulable pods metric should be 0 if pod was gated by two plugins sequentially and then deleted",
+			steps: []step{
+				updatePluginAllowList(pluginName1, []string{}),
+				addPod(pod),
+				updatePluginAllowList(pluginName1, []string{queueable}),
+				updatePluginAllowList(pluginName2, []string{}),
+				moveAllToActiveOrBackoffQ(),
+				deletePod(pod),
+			},
+			expectedMetrics: []int{0, 0},
+		},
+		{
+			name: "Unschedulable pods metric should be 1 for both plugins if pod was gated by two plugins sequentially",
+			steps: []step{
+				updatePluginAllowList(pluginName1, []string{}),
+				addPod(pod),
+				updatePluginAllowList(pluginName1, []string{queueable}),
+				updatePluginAllowList(pluginName2, []string{}),
+				moveAllToActiveOrBackoffQ(),
+			},
+			expectedMetrics: []int{1, 1},
+		},
 	}
 
 	for _, tt := range tests {
@@ -4770,34 +4805,41 @@ func TestUnschedulablePodsMetric(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			resetMetrics()
-			resetPodInfos()
 
 			m := makeEmptyQueueingHintMapPerProfile()
 			m[""][framework.EventUnschedulableTimeout] = []*QueueingHintFunction{
 				{
-					PluginName:     preenqueuePluginName,
+					PluginName:     pluginName1,
+					QueueingHintFn: queueHintReturnQueue,
+				},
+				{
+					PluginName:     pluginName2,
 					QueueingHintFn: queueHintReturnQueue,
 				},
 			}
 
-			preenq := map[string]map[string]fwk.PreEnqueuePlugin{"": {(&preEnqueuePlugin{}).Name(): &preEnqueuePlugin{allowlists: []string{queueable}}}}
-			recorder := metrics.NewMetricsAsyncRecorder(3, 20*time.Microsecond, ctx.Done())
-			queue := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)), WithPreEnqueuePluginMap(preenq), WithMetricsRecorder(recorder), WithQueueingHintMapPerProfile(m))
+			plugin1 := preEnqueuePlugin{name: pluginName1, allowlists: []string{queueable}}
+			plugin2 := preEnqueuePlugin{name: pluginName2, allowlists: []string{queueable}}
 
-			for i, op := range tt.operations {
-				for _, pInfo := range tt.operands[i] {
-					op(t, logger, queue, pInfo)
+			preenq := map[string]map[string]fwk.PreEnqueuePlugin{"": {pluginName1: &plugin1, pluginName2: &plugin2}}
+			recorder := metrics.NewMetricsAsyncRecorder(3, 20*time.Microsecond, ctx.Done())
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)), WithPreEnqueuePluginMap(preenq), WithMetricsRecorder(recorder), WithQueueingHintMapPerProfile(m))
+
+			for _, step := range tt.steps {
+				step(t, logger, q)
+			}
+
+			for i, pluginName := range []string{pluginName1, pluginName2} {
+				val, err := testutil.GetGaugeMetricValue(metrics.UnschedulableReason(pluginName, ""))
+
+				if err != nil {
+					t.Errorf("Error while collection metric value:\n%s", err)
+				}
+				if int(val) != tt.expectedMetrics[i] {
+					t.Errorf("Unexpected metric for plugin %s result expected %d, actual %d", pluginName, tt.expectedMetrics[i], int(val))
 				}
 			}
 
-			val, err := testutil.GetGaugeMetricValue(metrics.UnschedulableReason(preenqueuePluginName, ""))
-
-			if err != nil {
-				t.Errorf("Error while collection metric value:\n%s", err)
-			}
-			if int(val) != tt.expectedMetric {
-				t.Errorf("Unexpected metric result expected %d, actual %d", tt.expectedMetric, int(val))
-			}
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes a bug in the scheduler_unschedulable_pods metric where the count could become desynchronized (leaked) when a Pod is rejected by a PreEnqueue plugin.

The Problem: Previously, the metric was unconditionally incremented when a Pod failed a PreEnqueue check. If a Pod was already in the scheduling queue (marked unschedulable by a specific plugin) and was then rejected again by the same plugin during PreEnqueue (e.g., during a retry cycle), the metric would be incremented a second time for the same Pod and Plugin.

However, when the Pod is eventually popped from the queue, the decrement logic only accounts for the Pod once. This resulted in the scheduler_unschedulable_pods value remaining permanently non-zero even after the Pod was scheduled or deleted.

The Fix: This PR ensures that the metric is not incremented if the Pod is already recorded as unschedulable for the specific plugin. It also adds drop metric while pod deletion.

#### Which issue(s) this PR is related to:
Fixes #132333

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where the `scheduler_unschedulable_pods` metric could be artificially inflated (leak) when a pod fails `PreEnqueue` plugins after being previously marked unschedulable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
