### PR TITLE
Job: Clarify Job terminal success and failure semantics

### DIFF
--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -511,7 +511,12 @@ type JobStatus struct {
 	// Represents time when the job was completed. It is not guaranteed to
 	// be set in happens-before order across separate operations.
 	// It is represented in RFC3339 form and is in UTC.
-	// The completion time is set when the job finishes successfully, and only then.
+	//
+	// The presence of completionTime indicates that the Job has reached a 
+	// successful terminal state ("Complete").
+	// Fields such as .status.succeeded are not terminal signals and may be
+	// updated before the Job reaches a final state.
+	//
 	// The value cannot be updated or removed. The value indicates the same or
 	// later point in time as the startTime field.
 	// +optional

--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -481,10 +481,18 @@ type JobStatus struct {
 	// become false. When a Job is completed, one of the conditions will have
 	// type "Complete" and status true.
 	//
-	// A job is considered finished when it is in a terminal condition, either
-	// "Complete" or "Failed". A Job cannot have both the "Complete" and "Failed" conditions.
+	// The Job controller evaluates terminal conditions in a defined order.
+	// Failure conditions (for example, exceeding backoffLimit,
+	// activeDeadlineSeconds, or PodFailurePolicy actions) are evaluated
+	// before success conditions (such as completions or successPolicy).
+	//
+	// If both failure and success criteria are met during the same
+	// evaluation, the Job is marked as Failed.
+	// This behavior is intentional and part of the Job API contract.
+	//
+	// A Job cannot have both the "Complete" and "Failed" conditions.
 	// Additionally, it cannot be in the "Complete" and "FailureTarget" conditions.
-	// The "Complete", "Failed" and "FailureTarget" conditions cannot be disabled.
+	// The "Complete", "Failed", and "FailureTarget" conditions cannot be disabled.
 	//
 	// +optional
 	Conditions []JobCondition

--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -544,6 +544,10 @@ type JobStatus struct {
 	// The number of pods which reached phase Succeeded.
 	// The value increases monotonically for a given spec. However, it may
 	// decrease in reaction to scale down of elastic indexed jobs.
+	//
+	// This field does not indicate that the Job has completed successfully.
+	// A Job is only considered successfully completed when the "Complete"
+	// condition is set and completionTime is populated.
 	// +optional
 	Succeeded int32
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR clarifies Job terminal semantics in the Job API documentation.

Specifically, it documents:
- The defined evaluation order of Job terminal conditions, where failure criteria are evaluated before success criteria.
- That `.status.completionTime` indicates successful terminal completion.
- That `.status.succeeded` is not a terminal signal and may be updated before the Job reaches a final state.

These clarifications reflect existing Job controller behavior and help avoid confusion when Jobs meet both success and failure criteria during evaluation.

No behavior is changed by this PR.

#### Which issue(s) this PR is related to:

Related to:
- #128564 

#### Special notes for your reviewer:

This PR is documentation-only and does not modify controller logic or API behavior.
All changes are limited to comments in the Job API types to clarify existing semantics.

#### Does this PR introduce a user-facing change?

NONE