### PR TITLE
POC: make test: ensure that packages don't steal CPU time

### DIFF
--- a/pkg/controller/devicetainteviction/main_test.go
+++ b/pkg/controller/devicetainteviction/main_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devicetainteviction
+
+import (
+	_ "k8s.io/apimachinery/pkg/util/benice" // Lower process priority.
+)

--- a/pkg/controller/volume/attachdetach/reconciler/main_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/main_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	_ "k8s.io/apimachinery/pkg/util/benice" // Lower process priority.
+)

--- a/pkg/kubelet/pluginmanager/reconciler/main_test.go
+++ b/pkg/kubelet/pluginmanager/reconciler/main_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	_ "k8s.io/apimachinery/pkg/util/benice" // Lower process priority.
+)

--- a/pkg/kubelet/volumemanager/reconciler/main_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/main_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	_ "k8s.io/apimachinery/pkg/util/benice" // Lower process priority.
+)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/main_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/main_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	_ "k8s.io/apimachinery/pkg/util/benice" // Lower process priority.
+)

--- a/staging/src/k8s.io/apimachinery/pkg/util/benice/benice_unix.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/benice/benice_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benice
+
+import (
+	"syscall"
+)
+
+func init() {
+	syscall.Setpriority(syscall.PRIO_PROCESS, 0, 10)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/benice/benice_unix_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/benice/benice_unix_test.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benice
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestPriority(t *testing.T) {
+	pri, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
+	if err != nil {
+		t.Fatalf("unexpected error from Getpriority: %v", err)
+	}
+	if pri != 10 {
+		t.Fatalf("unexpected priority %d, want 10", pri)
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/benice/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/benice/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package benice lowers the priority of the process during
+// init. This is useful in unit tests which would consume
+// too much CPU and cause other tests running in parallel
+// to flake.
+package benice

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/main_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/main_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregated
+
+import (
+	_ "k8s.io/apimachinery/pkg/util/benice" // Lower process priority.
+)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/main_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/main_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	_ "k8s.io/apimachinery/pkg/util/benice" // Lower process priority.
+)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We run GOMAXPROCS different test binaries in parallel. Each test binary may run up to GOMAXPROCS different sub-tests and/or goroutines. The effect is that CPU intensive test binaries can occupy the entire machine and cause other test binaries to flake because they don't run as quickly as expected.

The right approach is to rewrite all flaking tests with synctest to make them independent from real world timing. Examples:
- https://github.com/kubernetes/kubernetes/pull/135940: pending
- https://github.com/kubernetes/kubernetes/pull/135976: dfa6aa22b21af167634c05a63b1ec541a6004414
- https://github.com/kubernetes/kubernetes/pull/135948: 7a4d6501253a5df3f1b03bd0218ab16b6ad8c032
- https://github.com/kubernetes/kubernetes/pull/135933: 41c598c4dfaa2713c33e506184a7bd941079d2b4

After conversion, the binaries become CPU-bound instead of time-bound.  They themselves then may steal CPU time from other tests. Letting CPU-intensive tests run themselves with less priority was meant to avoid that.

To find tests which should lower their priority, test.sh sets up monitoring and makes a `make test` run fail if any problematic test binary is found. The test binaries modified here were found that way.

In the end, testing in https://github.com/kubernetes/kubernetes/pull/135395 had more flakes ([replicaset.test](https://storage.googleapis.com/k8s-triage/index.html?text=TestExpectationsOnRecreate), scheduler.test) with this change than without it. The monitoring via ps + bash might be too intrusive. It could be rewritten in pure Go, but time and effort is probably better spent on fixing flakes as they come up.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This PR is meant to share the POC. It most likely can be closed without merging.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
