### PR TITLE
Adds multiply, division and integer division to kubernetes resource quantity library

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -640,6 +640,8 @@ func (q *Quantity) Mul(y int64) bool {
 	return q.ToDec().d.Dec.Mul(q.d.Dec, inf.NewDec(y, inf.Scale(0))).UnscaledBig().IsInt64()
 }
 
+// QuoRound divides the current value by y and rounds the division result by roundVal digits.
+// the function panics on y=0 or roundVal < 0
 func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
 	if y == 0 {
 		panic(zeroDivErrMsg)
@@ -682,9 +684,12 @@ func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
 		q.d.Dec = infDec
 		return false
 	}
-	return q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundDown).UnscaledBig().IsInt64()
+	ret := q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundDown).UnscaledBig().IsInt64()
+	return ret
 }
 
+// QuoIntegerDivision integer divides the current value by y and rounds towards zero (round down).
+// the function panics on y=0
 func (q *Quantity) QuoIntegerDivision(y int64) bool {
 	if y == 0 {
 		panic(zeroDivErrMsg)

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -655,8 +655,12 @@ func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
 		infDec.QuoRound(infDec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundDown)
 		if int64(infDec.Scale()) == 0 {
 			// the scale is zero. then infdec is directly representable as an int
-			q.i = int64Amount{value: infDec.UnscaledBig().Int64()}
-			return true
+			if infDec.UnscaledBig().IsInt64() {
+				q.i = int64Amount{value: infDec.UnscaledBig().Int64()}
+				return true
+			}
+			q.i = int64Amount{value: math.MaxInt64}
+			return false
 		} else {
 			// the scale isn't zero, so the infDec might be a decimal. we need to check if after we bring it back to scale
 			// will there be remaining numbers after division by 10
@@ -666,8 +670,12 @@ func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
 				s := int64(infDec.Scale())
 				e := new(big.Int).Exp(big.NewInt(10), big.NewInt(s), nil)
 				infDec.UnscaledBig().Quo(infDec.UnscaledBig(), e)
-				q.i = int64Amount{value: infDec.UnscaledBig().Int64()}
-				return true
+				if infDec.UnscaledBig().IsInt64() {
+					q.i = int64Amount{value: infDec.UnscaledBig().Int64()}
+					return true
+				}
+				q.i = int64Amount{value: math.MaxInt64}
+				return false
 			}
 		}
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -150,6 +150,10 @@ const (
 	splitREString = "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
 )
 
+const (
+	zeroDivErrMsg = "division by zero error"
+)
+
 var (
 	// Errors that could happen while parsing a string.
 	ErrFormatWrong = errors.New("quantities must match the regular expression '" + splitREString + "'")
@@ -638,19 +642,35 @@ func (q *Quantity) Mul(y int64) bool {
 
 func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
 	if y == 0 {
-		panic("division by zero error")
+		panic(zeroDivErrMsg)
+	}
+	if roundVal < 0 {
+		panic("negative rounding values are not allowed")
 	}
 
 	q.s = ""
 	if q.d.Dec == nil {
-		val, _ := q.i.AsInt64()
-		infDec := inf.NewDec(val, inf.Scale(0))
+		realVal, _ := q.i.AsInt64()
+		infDec := inf.NewDec(realVal, inf.Scale(0))
 		infDec.QuoRound(infDec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundDown)
-		// check if its a whole number
-		if infDec.UnscaledBig().IsInt64() {
+		if int64(infDec.Scale()) == 0 {
+			// the scale is zero. then infdec is directly representable as an int
 			q.i = int64Amount{value: infDec.UnscaledBig().Int64()}
 			return true
+		} else {
+			// the scale isn't zero, so the infDec might be a decimal. we need to check if after we bring it back to scale
+			// will there be remaining numbers after division by 10
+			if rem := new(big.Int).Set(infDec.UnscaledBig()).Mod(infDec.UnscaledBig(), big.NewInt(10)); rem.Int64() == 0 {
+				// bring it back to scale by dividing by dividing by 10^scale, we don't need to account for
+				// the remainder since we are doing integer division
+				s := int64(infDec.Scale())
+				e := new(big.Int).Exp(big.NewInt(10), big.NewInt(s), nil)
+				infDec.UnscaledBig().Quo(infDec.UnscaledBig(), e)
+				q.i = int64Amount{value: infDec.UnscaledBig().Int64()}
+				return true
+			}
 		}
+
 		q.d.Dec = infDec
 		return false
 	}
@@ -659,7 +679,7 @@ func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
 
 func (q *Quantity) QuoIntegerDivision(y int64) bool {
 	if y == 0 {
-		panic("division by zero error")
+		panic(zeroDivErrMsg)
 	}
 
 	q.s = ""
@@ -667,6 +687,7 @@ func (q *Quantity) QuoIntegerDivision(y int64) bool {
 		val, _ := q.i.AsInt64()
 		q.i = int64Amount{value: val / y}
 	} else {
+		// this is zero scaled so its ok here for us to use the unscaled big as the final value
 		result := new(inf.Dec).QuoRound(q.d.Dec, inf.NewDec(y, 0), 0, inf.RoundDown)
 		q.i = int64Amount{value: result.UnscaledBig().Int64()}
 		q.d.Dec = nil

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -653,6 +653,19 @@ func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
 	return q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundHalfUp).UnscaledBig().IsInt64()
 }
 
+func (q *Quantity) QuoIntegerDivision(y int64) bool {
+	q.s = ""
+	if q.d.Dec == nil {
+		val, _ := q.i.AsInt64()
+		q.i = int64Amount{value: val / y}
+	} else {
+		result := new(inf.Dec).QuoRound(q.d.Dec, inf.NewDec(y, 0), 0, inf.RoundHalfUp)
+		q.i = int64Amount{value: result.UnscaledBig().Int64()}
+		q.d.Dec = nil
+	}
+	return true
+}
+
 // Cmp returns 0 if the quantity is equal to y, -1 if the quantity is less than y, or 1 if the
 // quantity is greater than y.
 func (q *Quantity) Cmp(y Quantity) int {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -636,6 +636,23 @@ func (q *Quantity) Mul(y int64) bool {
 	return q.ToDec().d.Dec.Mul(q.d.Dec, inf.NewDec(y, inf.Scale(0))).UnscaledBig().IsInt64()
 }
 
+func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
+	q.s = ""
+	if q.d.Dec == nil {
+		val, _ := q.i.AsInt64()
+		res := float64(val) / float64(y)
+		// check if its a whole number
+		if res == math.Trunc(res) {
+			q.i = int64Amount{value: int64(res)}
+			return true
+		}
+		unscaled := int64(math.Round(res * math.Pow(10, float64(roundVal))))
+		q.d.Dec = inf.NewDec(unscaled, inf.Scale(roundVal))
+		return false
+	}
+	return q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundHalfUp).UnscaledBig().IsInt64()
+}
+
 // Cmp returns 0 if the quantity is equal to y, -1 if the quantity is less than y, or 1 if the
 // quantity is greater than y.
 func (q *Quantity) Cmp(y Quantity) int {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -651,41 +651,7 @@ func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
 	}
 
 	q.s = ""
-	if q.d.Dec == nil {
-		realVal, _ := q.i.AsInt64()
-		infDec := inf.NewDec(realVal, inf.Scale(0))
-		infDec.QuoRound(infDec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundDown)
-		if int64(infDec.Scale()) == 0 {
-			// the scale is zero. then infdec is directly representable as an int
-			if infDec.UnscaledBig().IsInt64() {
-				q.i = int64Amount{value: infDec.UnscaledBig().Int64()}
-				return true
-			}
-			q.i = int64Amount{value: math.MaxInt64}
-			return false
-		} else {
-			// the scale isn't zero, so the infDec might be a decimal. we need to check if after we bring it back to scale
-			// will there be remaining numbers after division by 10
-			if rem := new(big.Int).Set(infDec.UnscaledBig()).Mod(infDec.UnscaledBig(), big.NewInt(10)); rem.Int64() == 0 {
-				// bring it back to scale by dividing by dividing by 10^scale, we don't need to account for
-				// the remainder since we are doing integer division
-				s := int64(infDec.Scale())
-				e := new(big.Int).Exp(big.NewInt(10), big.NewInt(s), nil)
-				infDec.UnscaledBig().Quo(infDec.UnscaledBig(), e)
-				if infDec.UnscaledBig().IsInt64() {
-					q.i = int64Amount{value: infDec.UnscaledBig().Int64()}
-					return true
-				}
-				q.i = int64Amount{value: math.MaxInt64}
-				return false
-			}
-		}
-
-		q.d.Dec = infDec
-		return false
-	}
-	ret := q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundDown).UnscaledBig().IsInt64()
-	return ret
+	return q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundDown).UnscaledBig().IsInt64()
 }
 
 // QuoIntegerDivision integer divides the current value by y and rounds towards zero (round down).
@@ -696,16 +662,12 @@ func (q *Quantity) QuoIntegerDivision(y int64) bool {
 	}
 
 	q.s = ""
-	if q.d.Dec == nil {
-		val, _ := q.i.AsInt64()
-		q.i = int64Amount{value: val / y}
-	} else {
-		// this is zero scaled so its ok here for us to use the unscaled big as the final value
-		result := new(inf.Dec).QuoRound(q.d.Dec, inf.NewDec(y, 0), 0, inf.RoundDown)
-		q.i = int64Amount{value: result.UnscaledBig().Int64()}
-		q.d.Dec = nil
+	if q.d.Dec == nil && q.i.scale == 0 {
+		q.i.value /= y
+		return true
 	}
-	return true
+
+	return q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, 0), 0, inf.RoundDown).UnscaledBig().IsInt64()
 }
 
 // Cmp returns 0 if the quantity is equal to y, -1 if the quantity is less than y, or 1 if the

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -150,15 +150,13 @@ const (
 	splitREString = "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
 )
 
-const (
-	zeroDivErrMsg = "division by zero error"
-)
-
 var (
 	// Errors that could happen while parsing a string.
-	ErrFormatWrong = errors.New("quantities must match the regular expression '" + splitREString + "'")
-	ErrNumeric     = errors.New("unable to parse numeric part of quantity")
-	ErrSuffix      = errors.New("unable to parse quantity's suffix")
+	ErrFormatWrong      = errors.New("quantities must match the regular expression '" + splitREString + "'")
+	ErrNumeric          = errors.New("unable to parse numeric part of quantity")
+	ErrSuffix           = errors.New("unable to parse quantity's suffix")
+	ErrZeroDivision     = errors.New("division by zero")
+	ErrNegativeRoundVal = errors.New("negative rounding values are not allowed")
 )
 
 // parseQuantityString is a fast scanner for quantity values.
@@ -641,33 +639,33 @@ func (q *Quantity) Mul(y int64) bool {
 }
 
 // QuoRound divides the current value by y and rounds the division result by roundVal digits.
-// the function panics on y=0 or roundVal < 0
-func (q *Quantity) QuoRound(y int64, roundVal int64) bool {
+// the function errors on y=0 or roundVal < 0
+func (q *Quantity) QuoRound(y int64, roundVal int64) (bool, error) {
 	if y == 0 {
-		panic(zeroDivErrMsg)
+		return false, ErrZeroDivision
 	}
 	if roundVal < 0 {
-		panic("negative rounding values are not allowed")
+		return false, ErrNegativeRoundVal
 	}
 
 	q.s = ""
-	return q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundDown).UnscaledBig().IsInt64()
+	return q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, inf.Scale(0)), inf.Scale(roundVal), inf.RoundDown).UnscaledBig().IsInt64(), nil
 }
 
 // QuoIntegerDivision integer divides the current value by y and rounds towards zero (round down).
-// the function panics on y=0
-func (q *Quantity) QuoIntegerDivision(y int64) bool {
+// the function errors on y=0
+func (q *Quantity) QuoIntegerDivision(y int64) (bool, error) {
 	if y == 0 {
-		panic(zeroDivErrMsg)
+		return false, ErrZeroDivision
 	}
 
 	q.s = ""
 	if q.d.Dec == nil && q.i.scale == 0 {
 		q.i.value /= y
-		return true
+		return true, nil
 	}
 
-	return q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, 0), 0, inf.RoundDown).UnscaledBig().IsInt64()
+	return q.ToDec().d.Dec.QuoRound(q.d.Dec, inf.NewDec(y, 0), 0, inf.RoundDown).UnscaledBig().IsInt64(), nil
 }
 
 // Cmp returns 0 if the quantity is equal to y, -1 if the quantity is less than y, or 1 if the

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1148,6 +1148,7 @@ func TestQuoRound(t *testing.T) {
 	}{
 		{decQuantity(10, 0, DecimalSI), 2, 0, intQuantity(5, 0, DecimalSI)},                                                              // normal division
 		{decQuantity(-10, 0, BinarySI), 2, 0, decQuantity(-5, 0, BinarySI)},                                                              // normal division, negative number
+		{intQuantity(25, 0, DecimalSI), 10, 2, intQuantity(25, -1, DecimalSI)},                                                           // normal division, scale is properly preserved
 		{decQuantity(100, 0, BinarySI), 3, 3, Quantity{d: infDecAmount{inf.NewDec(33333, 3)}}},                                           // arbitrary precision on an infinite decimal
 		{decQuantity(0, 0, DecimalSI), 2, 0, intQuantity(0, 0, DecimalSI)},                                                               // zero
 		{decQuantity(0, 0, DecimalSI), 2, 100, intQuantity(0, 0, DecimalSI)},                                                             // roundVal doesn't affect zero division

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1169,7 +1169,10 @@ func TestQuoRound(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		test.a.QuoRound(test.b, test.roundVal)
+		_, err := test.a.QuoRound(test.b, test.roundVal)
+		if err != nil {
+			t.Errorf("QuoRound error: %s", err.Error())
+		}
 		if test.a.Cmp(test.expected) != 0 {
 			fmt.Println(test.a.d.Dec)
 			t.Errorf("[%d] Expected %q, got %q", i, test.expected.String(), test.a.String())
@@ -1196,7 +1199,10 @@ func TestQuoIntegerDivision(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		test.a.QuoIntegerDivision(test.b)
+		_, err := test.a.QuoIntegerDivision(test.b)
+		if err != nil {
+			t.Errorf("QuoIntegerDivision error: %s", err.Error())
+		}
 		if test.a.Cmp(test.expected) != 0 {
 			t.Errorf("[%d] Expected %q, got %q", i, test.expected.String(), test.a.String())
 		}

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/format_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/format_test.go
@@ -226,7 +226,7 @@ func TestFormat(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			testQuantity(t, tc.expr, tc.expectValue, tc.expectedRuntimeErr, tc.expectedCompileErr)
+			testQuantity(t, tc.expr, tc.expectValue, tc.expectedRuntimeErr, tc.expectedCompileErr, nil)
 		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
@@ -58,6 +58,8 @@ func TestLibraryCompatibility(t *testing.T) {
 		// Kubernetes <1.32>:
 		"jsonpatch.escapeKey",
 		// Kubernetes <1.33>:
+		"mul", "div", "divInt",
+		// Kubernetes <1.36>
 		"semver", "isSemver", "major", "minor", "patch",
 		// Kubernetes <1.??>:
 	)

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
@@ -58,10 +58,10 @@ func TestLibraryCompatibility(t *testing.T) {
 		// Kubernetes <1.32>:
 		"jsonpatch.escapeKey",
 		// Kubernetes <1.33>:
-		"mul", "div", "divInt",
-		// Kubernetes <1.36>
 		"semver", "isSemver", "major", "minor", "patch",
 		// Kubernetes <1.??>:
+		"mul", "div", "divInt",
+		// Kubernetes <1.36>
 	)
 
 	// TODO: test celgo function lists

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
@@ -139,6 +139,8 @@ func Quantity() cel.EnvOption {
 
 var quantityLib = &quantity{}
 
+const zeroDivErrMsg = "division by zero error"
+
 type quantity struct{}
 
 func (*quantity) LibraryName() string {
@@ -387,6 +389,10 @@ func quantityDivideIntDefaultRounding(arg ref.Val, div ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(div)
 	}
 
+	if denominator == 0 {
+		panic(zeroDivErrMsg)
+	}
+
 	copy := *q
 	copy.QuoRound(denominator, 4)
 	return &apiservercel.Quantity{
@@ -403,6 +409,10 @@ func quantityIntegerDivision(arg ref.Val, div ref.Val) ref.Val {
 	denominator, ok := div.Value().(int64)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(div)
+	}
+
+	if denominator == 0 {
+		panic(zeroDivErrMsg)
 	}
 
 	copy := *q
@@ -428,8 +438,12 @@ func quantityDivideIntRound(args ...ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(args[2])
 	}
 
-	if roundVal > 10 {
-		return types.WrapErr(fmt.Errorf("the maximum value for rounding float division is 10 but %d was passed", roundVal))
+	if denominator == 0 {
+		panic(zeroDivErrMsg)
+	}
+
+	if roundVal > 10 || roundVal < 0 {
+		return types.WrapErr(fmt.Errorf("the valid range for roundVal is 0 to 10 but %d was passed", roundVal))
 	}
 
 	copy := *q

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
@@ -196,6 +196,9 @@ var quantityLibraryDecls = map[string][]cel.FunctionOpt{
 		cel.MemberOverload("quantity_divide_int_default_rounding", []*cel.Type{apiservercel.QuantityType, cel.IntType}, apiservercel.QuantityType, cel.BinaryBinding(quantityDivideIntDefaultRounding)),
 		cel.MemberOverload("quantity_divide_int_round", []*cel.Type{apiservercel.QuantityType, cel.IntType, cel.IntType}, apiservercel.QuantityType, cel.FunctionBinding(quantityDivideIntRound)),
 	},
+	"divInt": {
+		cel.MemberOverload("quantity_divide_int", []*cel.Type{apiservercel.QuantityType, cel.IntType}, apiservercel.QuantityType, cel.BinaryBinding(quantityIntegerDivision)),
+	},
 }
 
 func (*quantity) CompileOptions() []cel.EnvOption {
@@ -386,6 +389,24 @@ func quantityDivideIntDefaultRounding(arg ref.Val, div ref.Val) ref.Val {
 
 	copy := *q
 	copy.QuoRound(denominator, 4)
+	return &apiservercel.Quantity{
+		Quantity: &copy,
+	}
+}
+
+func quantityIntegerDivision(arg ref.Val, div ref.Val) ref.Val {
+	q, ok := arg.Value().(*resource.Quantity)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	denominator, ok := div.Value().(int64)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(div)
+	}
+
+	copy := *q
+	copy.QuoIntegerDivision(denominator)
 	return &apiservercel.Quantity{
 		Quantity: &copy,
 	}

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
@@ -139,8 +139,6 @@ func Quantity() cel.EnvOption {
 
 var quantityLib = &quantity{}
 
-const zeroDivErrMsg = "division by zero error"
-
 type quantity struct{}
 
 func (*quantity) LibraryName() string {
@@ -390,7 +388,7 @@ func quantityDivideIntDefaultRounding(arg ref.Val, div ref.Val) ref.Val {
 	}
 
 	if denominator == 0 {
-		panic(zeroDivErrMsg)
+		return types.NewErr("division by zero")
 	}
 
 	copy := *q
@@ -412,7 +410,7 @@ func quantityIntegerDivision(arg ref.Val, div ref.Val) ref.Val {
 	}
 
 	if denominator == 0 {
-		panic(zeroDivErrMsg)
+		return types.NewErr("division by zero")
 	}
 
 	copy := *q
@@ -439,7 +437,7 @@ func quantityDivideIntRound(args ...ref.Val) ref.Val {
 	}
 
 	if denominator == 0 {
-		panic(zeroDivErrMsg)
+		return types.NewErr("division by zero")
 	}
 
 	if roundVal > 10 || roundVal < 0 {

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
@@ -387,12 +387,12 @@ func quantityDivideIntDefaultRounding(arg ref.Val, div ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(div)
 	}
 
-	if denominator == 0 {
-		return types.NewErr("division by zero")
-	}
-
 	copy := *q
-	copy.QuoRound(denominator, 4)
+
+	_, err := copy.QuoRound(denominator, 4)
+	if err != nil {
+		return types.NewErr("%s", err.Error())
+	}
 	return &apiservercel.Quantity{
 		Quantity: &copy,
 	}
@@ -409,12 +409,12 @@ func quantityIntegerDivision(arg ref.Val, div ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(div)
 	}
 
-	if denominator == 0 {
-		return types.NewErr("division by zero")
-	}
-
 	copy := *q
-	copy.QuoIntegerDivision(denominator)
+
+	_, err := copy.QuoIntegerDivision(denominator)
+	if err != nil {
+		return types.NewErr("%s", err.Error())
+	}
 	return &apiservercel.Quantity{
 		Quantity: &copy,
 	}
@@ -445,7 +445,10 @@ func quantityDivideIntRound(args ...ref.Val) ref.Val {
 	}
 
 	copy := *q
-	copy.QuoRound(denominator, roundVal)
+	_, err := copy.QuoRound(denominator, roundVal)
+	if err != nil {
+		return types.NewErr("%s", err.Error())
+	}
 	return &apiservercel.Quantity{
 		Quantity: &copy,
 	}

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity_test.go
@@ -289,6 +289,17 @@ func TestQuantity(t *testing.T) {
 			},
 		},
 		{
+			name:        "divide_float_custom_precision",
+			expr:        `quantity("10000").div(3, 2).asApproximateFloat()`,
+			expectValue: types.Double(3333.33),
+			cmpFunc: func(expected, actual any) bool {
+				e := expected.(types.Double)
+				a := actual.(types.Double)
+				tolerance := 0.01
+				return math.Abs(float64(e)-float64(a)) < tolerance
+			},
+		},
+		{
 			name:        "divide_scaled",
 			expr:        `quantity("10k").div(2) == quantity("5000")`,
 			expectValue: trueVal,

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity_test.go
@@ -266,6 +266,21 @@ func TestQuantity(t *testing.T) {
 			expectValue: trueVal,
 		},
 		{
+			name:        "multiply",
+			expr:        `quantity("50k").mul(2) == quantity("100000")`,
+			expectValue: trueVal,
+		},
+		{
+			name:        "divide",
+			expr:        `quantity("100").div(2) == quantity("50")`,
+			expectValue: trueVal,
+		},
+		{
+			name:        "divide_scaled",
+			expr:        `quantity("10k").div(3) == quantity("5000")`,
+			expectValue: trueVal,
+		},
+		{
 			name:        "arith_chain_1",
 			expr:        `quantity("50k").add(20).sub(quantity("100k")).asInteger()`,
 			expectValue: types.Int(-49980),

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity_test.go
@@ -278,6 +278,26 @@ func TestQuantity(t *testing.T) {
 			expectValue: trueVal,
 		},
 		{
+			name:        "divide_zero_scale",
+			expr:        `quantity("10").div(2, 0) == quantity("5")`,
+			expectValue: trueVal,
+		},
+		{
+			name:        "div_large_whole_number",
+			expr:        `quantity("1329227995784915872903807060280344576").div(256) == quantity("5192296858534827628530496329220096")`,
+			expectValue: trueVal,
+		},
+		{
+			name:        "large_integer_no_precision_loss",
+			expr:        `quantity("1152921504606846976").divInt(2) == quantity("576460752303423488")`,
+			expectValue: trueVal,
+		},
+		{
+			name:        "divide_scaled",
+			expr:        `quantity("10k").div(2) == quantity("5000")`,
+			expectValue: trueVal,
+		},
+		{
 			name:        "divide_float_result",
 			expr:        `quantity("10000").div(3).asApproximateFloat()`,
 			expectValue: types.Double(3333.3333),
@@ -298,11 +318,6 @@ func TestQuantity(t *testing.T) {
 				tolerance := 0.01
 				return math.Abs(float64(e)-float64(a)) < tolerance
 			},
-		},
-		{
-			name:        "divide_scaled",
-			expr:        `quantity("10k").div(2) == quantity("5000")`,
-			expectValue: trueVal,
 		},
 		{
 			name:        "integer_division",


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds multiply, division and integer division to kubernetes resource quantity library.  It also adds the `Quo` and `QuoIntegerDivision` to the `Quantity` type which previously didn't support division

#### Which issue(s) this PR is related to:
Fixes: https://github.com/kubernetes/kubernetes/issues/135994

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
add division and multiplication to the resource.quantity cel type
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
