### PR TITLE
PoC tracing streamed responses

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
@@ -260,7 +260,10 @@ func handleWatch(ctx context.Context, rw rest.Watcher, scope *RequestScope, req 
 	var onWatchListComplete WatchListCompleteHook
 	if isListWatchRequest(opts) {
 		ctx, span = tracing.Start(ctx, "WatchList", traceFields(req)...)
-		onWatchListComplete = func() { span.End(500 * time.Millisecond) }
+		onWatchListComplete = func() { 
+
+			span.End(500 * time.Millisecond) 
+		}
 		req = req.WithContext(ctx)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -32,6 +32,7 @@ import (
 
 	"k8s.io/apiserver/pkg/features"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -97,20 +98,23 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 		attribute.String("url", req.URL.Path),
 		attribute.String("protocol", req.Proto),
 		attribute.String("mediaType", mediaType),
-		attribute.String("encoder", string(encoder.Identifier())))
+		attribute.String("encoder", string(encoder.Identifier())),
+	)
 	req = req.WithContext(ctx)
 	defer span.End(5 * time.Second)
 
-	w := &deferredResponseWriter{
-		mediaType:       mediaType,
-		statusCode:      statusCode,
-		contentEncoding: negotiateContentEncoding(req),
-		hw:              hw,
-		ctx:             ctx,
-	}
+	w := NewDeferredResponseWriter(ctx, mediaType, statusCode, negotiateContentEncoding(req), hw)
 
+	start := time.Now()
 	err := encoder.Encode(object, w)
 	if err == nil {
+		var duration time.Duration
+		for _, tracer := range w.tracers {
+			span.AddParallelEvent(tracer.name, tracer.duration-duration, attribute.Int64("size", tracer.bytes))
+			duration = tracer.duration
+		}
+		span.AddParallelEvent("serialize", time.Since(start)-duration, attribute.Int("count", meta.LenList(object)))
+		span.AddEvent("Write call succeeded")
 		err = w.Close()
 		if err != nil {
 			// we cannot write an error to the writer anymore as the Encode call was successful.
@@ -118,6 +122,13 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 		}
 		return
 	}
+	var duration time.Duration
+	for _, tracer := range w.tracers {
+		span.AddParallelEvent(tracer.name, tracer.duration-duration, attribute.Int64("size", tracer.bytes))
+		duration = tracer.duration
+	}
+	span.AddParallelEvent("serialize", time.Since(start)-duration)
+	span.AddEvent("Write call failed", attribute.String("err", err.Error()))
 
 	// make a best effort to write the object if a failure is detected
 	utilruntime.HandleError(fmt.Errorf("apiserver was unable to write a JSON response: %v", err))
@@ -190,6 +201,16 @@ func negotiateContentEncoding(req *http.Request) string {
 	return ""
 }
 
+func NewDeferredResponseWriter(ctx context.Context, mediaType string, statusCode int, contentEncoding string, hw http.ResponseWriter) *deferredResponseWriter {
+	return &deferredResponseWriter{
+		mediaType:       mediaType,
+		statusCode:      statusCode,
+		contentEncoding: contentEncoding,
+		hw:              hw,
+		ctx:             ctx,
+	}
+}
+
 type deferredResponseWriter struct {
 	mediaType       string
 	statusCode      int
@@ -199,13 +220,14 @@ type deferredResponseWriter struct {
 	buffer      []byte
 	hasWritten  bool
 	hw          http.ResponseWriter
-	w           io.Writer
+	w           *TraceWriter
 	// totalBytes is the number of bytes written to `w` and does not include buffered bytes
 	totalBytes int
 	// lastWriteErr holds the error result (if any) of the last write attempt to `w`
 	lastWriteErr error
 
-	ctx context.Context
+	ctx     context.Context
+	tracers []*TraceWriter
 }
 
 func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
@@ -256,8 +278,10 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 	}
 	w.hasWritten = true
 
-	hw := w.hw
-	header := hw.Header()
+	hw := NewTraceWriter("write response", w.hw)
+	w.w = hw
+	w.tracers = append(w.tracers, hw)
+	header := w.hw.Header()
 	switch {
 	case w.contentEncoding == "gzip" && len(p) > defaultGzipThresholdBytes:
 		header.Set("Content-Encoding", "gzip")
@@ -265,41 +289,17 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 
 		gw := gzipPool.Get().(*gzip.Writer)
 		gw.Reset(hw)
-
-		w.w = gw
-	default:
-		w.w = hw
+		tw := NewTraceWriter("compress gzip", gw)
+		w.tracers = append(w.tracers, tw)
+		w.w = tw
 	}
 
-	span := tracing.SpanFromContext(w.ctx)
-	span.AddEvent("About to start writing response",
-		attribute.String("writer", fmt.Sprintf("%T", w.w)),
-		attribute.Int("size", len(p)),
-	)
-
 	header.Set("Content-Type", w.mediaType)
-	hw.WriteHeader(w.statusCode)
+	w.hw.WriteHeader(w.statusCode)
 	return w.w.Write(p)
 }
 
 func (w *deferredResponseWriter) Close() (err error) {
-	defer func() {
-		if !w.hasWritten {
-			return
-		}
-
-		span := tracing.SpanFromContext(w.ctx)
-
-		if w.lastWriteErr != nil {
-			span.AddEvent("Write call failed",
-				attribute.Int("size", w.totalBytes),
-				attribute.String("err", w.lastWriteErr.Error()))
-		} else {
-			span.AddEvent("Write call succeeded",
-				attribute.Int("size", w.totalBytes))
-		}
-	}()
-
 	if !w.hasWritten {
 		if !w.hasBuffered {
 			return nil
@@ -309,10 +309,9 @@ func (w *deferredResponseWriter) Close() (err error) {
 		w.buffer = nil
 		return err
 	}
-
-	switch t := w.w.(type) {
+	err = w.w.Close()
+	switch t := w.w.next.(type) {
 	case *gzip.Writer:
-		err = t.Close()
 		t.Reset(nil)
 		gzipPool.Put(t)
 	}
@@ -406,4 +405,33 @@ func WriteRawJSON(statusCode int, object interface{}, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	w.Write(output)
+}
+
+func NewTraceWriter(name string, next io.Writer) *TraceWriter {
+	return &TraceWriter{
+		name: name,
+		next: next,
+	}
+}
+
+type TraceWriter struct {
+	name     string
+	duration time.Duration
+	bytes    int64
+	next     io.Writer
+}
+
+func (t *TraceWriter) Write(p []byte) (n int, err error) {
+	start := time.Now()
+	n, err = t.next.Write(p)
+	t.duration += time.Since(start)
+	t.bytes += int64(n)
+	return n, err
+}
+
+func (t *TraceWriter) Close() error {
+	if closer, ok := t.next.(io.WriteCloser); ok {
+		return closer.Close()
+	}
+	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -254,13 +254,14 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}()
 
-	flusher, ok := w.(http.Flusher)
+	_, ok := w.(http.Flusher)
 	if !ok {
 		err := fmt.Errorf("unable to start watch - can't get http.Flusher: %#v", w)
 		utilruntime.HandleErrorWithContext(req.Context(), err, "Unable to start watch")
 		s.Scope.err(errors.NewInternalError(err), w, req)
 		return
 	}
+	writer := NewTraceWriter("Network", w)
 
 	framer := s.Framer.NewFrameWriter(w)
 	if framer == nil {
@@ -279,7 +280,7 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", s.MediaType)
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	writer.Flush()
 
 	gvr := s.Scope.Resource
 
@@ -294,6 +295,8 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 	done := req.Context().Done()
 
 	span.AddEvent("About to start writing response")
+	var duration time.Duration
+	var count int64
 	for {
 		select {
 		case <-s.ServerShuttingDownCh:
@@ -316,15 +319,18 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 			isWatchListLatencyRecordingRequired := shouldRecordWatchListLatency(req.Context(), event)
 
+			start := time.Now()
 			if err := watchEncoder.Encode(event); err != nil {
 				utilruntime.HandleErrorWithContext(req.Context(), err, "Failed to encode watch event")
 				// client disconnect.
 				return
 			}
 			recorder.RecordEvent()
+			duration += time.Since(start)
+			count++
 
 			if len(ch) == 0 {
-				flusher.Flush()
+				writer.Flush()
 			}
 			if isWatchListLatencyRecordingRequired {
 				// Record completion of initial listing phase for WatchList
@@ -338,6 +344,9 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 					klog.V(3).InfoS("WatchList initial events sent", "path", req.URL.Path, "auditID", auditID, "initLatency", initLatency)
 					httplog.AddKeyValue(req.Context(), "watchlist_init_latency", initLatency)
 					span.AddEvent("Writing initial events done")
+					span.AddParallelEvent(writer.name, writer.writeDuration, attribute.Int64("size", writer.writeBytes), attribute.Int64("count", writer.writeCount))
+					span.AddParallelEvent("Flush", writer.flushDuration, attribute.Int64("count", writer.flushCount))
+					span.AddParallelEvent("Serialize", duration-writer.writeDuration, attribute.Int64("count", count-1))
 					span.End(5 * time.Second)
 					s.watchListCompleteHook()
 				}
@@ -442,4 +451,48 @@ func shouldRecordWatchListLatency(ctx context.Context, event watch.Event) bool {
 		return false
 	}
 	return hasAnnotation
+}
+
+func NewTraceWriter(name string, next io.Writer) *TraceWriter {
+	return &TraceWriter{
+		name: name,
+		next: next,
+	}
+}
+
+type TraceWriter struct {
+	name     string
+	writeDuration time.Duration
+	writeBytes    int64
+	writeCount    int64
+	flushDuration time.Duration
+	flushCount    int64
+	next          io.Writer
+}
+
+func (t *TraceWriter) Write(p []byte) (n int, err error) {
+	start := time.Now()
+	n, err = t.next.Write(p)
+	t.writeDuration += time.Since(start)
+	t.writeBytes += int64(n)
+	t.writeCount++
+	return n, err
+}
+
+func (t *TraceWriter) Flush() {
+	flusher, ok := t.next.(http.Flusher)
+	if !ok {
+		return
+	}
+	start := time.Now()
+	flusher.Flush()
+	t.flushDuration += time.Since(start)
+	t.flushCount++
+}
+
+func (t *TraceWriter) Close() error {
+	if closer, ok := t.next.(io.WriteCloser); ok {
+		return closer.Close()
+	}
+	return nil
 }

--- a/staging/src/k8s.io/component-base/tracing/tracing.go
+++ b/staging/src/k8s.io/component-base/tracing/tracing.go
@@ -60,6 +60,12 @@ func (s *Span) AddEvent(name string, attributes ...attribute.KeyValue) {
 	}
 }
 
+func (s *Span) AddParallelEvent(name string, duration time.Duration, attributes ...attribute.KeyValue) {
+	if s.utilSpan != nil {
+		s.utilSpan.ParallelStep(name, duration, attributesToFields(attributes)...)
+	}
+}
+
 // End ends the span, and logs if the span duration is greater than the logThreshold.
 func (s *Span) End(logThreshold time.Duration) {
 	s.otelSpan.End()


### PR DESCRIPTION
/kind feature

**Before**

Streamed response writing results in traces mixing compressing, encoding and network. As result it only shows combined latency and inaccurate values of sizes. As measured on client side, the size presented in "About to start writing response" writer:*gzip.Writer,size:201240 227ms” is incorrect as it’s not the amount of data compressed, but the size of the first chunk. 

```
Trace[1461829279]: ["SerializeObject" audit-id:e2ed459c-4f3c-47e4-abb3-099e8a4ad38d,method:GET,url:/api/v1/namespaces/0/pods,protocol:HTTP/2.0,mediaType:application/vnd.kubernetes.protobuf,encoder:{"encodeGV":"v1","encoder":"protobuf","name":"versioning"} 9230ms (12:49:16.965)
Trace[1461829279]:  ---"About to start writing response" writer:*gzip.Writer,size:201240 227ms (12:49:17.192)
Trace[1461829279]:  ---"Write call succeeded" size:1006056694 9003ms (12:49:26.196)]
Trace[1461829279]: ---"Writing http response done" count:10000 0ms (12:49:26.196)
Trace[1461829279]: [9.244573577s] [9.244573577s] END
```

**After:**

With improved tracing we see three separate latencies: Network, Compress and Serialize. Each shows individual latency measurement and accurate size of data processed. Here we can see that gzip archives around a 5x compression ratio, which checks out on client side.

```
Trace[2139214577]: ["SerializeObject" audit-id:858bb641-5ba4-44d5-8e6a-d60e6609d4ed,method:GET,url:/api/v1/namespaces/0/pods,protocol:HTTP/2.0,mediaType:application/vnd.kubernetes.protobuf,encoder:{"encodeGV":"v1","encoder":"protobuf","name":"versioning"} 9246ms (13:54:00.023)
Trace[2139214577]:  ---"Network" size:188001850 2796ms
Trace[2139214577]:  ---"Compress" size:1006056312 4966ms
Trace[2139214577]:  ---"Serialize" count:10000 1483ms
Trace[2139214577]:  ---"Write call succeeded" 0ms (13:54:09.270)]
Trace[2139214577]: [9.251880697s] [9.251880697s] END
```
**Bonus WatchList:**
```
I0102 15:08:04.102809       1 trace.go:250] Trace[1455537276]: "SerializeObject" audit-id:bfdf3082-2666-44b7-b8cc-0208147aa063,method:GET,url:/api/v1/namespaces/0/pods,protocol:HTTP/2.0,mediaType:application/vnd.kubernetes.protobuf;stream=watch,encoder:{"encodeGV":"v1","encoder":"raw-protobuf","name":"versioning"} (02-Jan-2026 15:08:00.061) (total time: 4041ms):
Trace[1455537276]: ---"Network" size:1003095731 3031ms
Trace[1455537276]: ---"Serialize" count:10000 986ms
Trace[1455537276]: [4.041542797s] [4.041542797s] END
```

```release-note

```
