### PR TITLE
Add atomic resync operation for real fifo

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -912,10 +912,13 @@ func TestReplaceEvents(t *testing.T) {
 			source.Shutdown()
 		})
 		store := NewStore(DeletionHandlingMetaNamespaceKeyFunc)
-		fifo := NewRealFIFOWithOptions(RealFIFOOptions{
-			KnownObjects: store,
+		fifoOptions := RealFIFOOptions{
 			AtomicEvents: atomic,
-		})
+		}
+		if !atomic {
+			fifoOptions.KnownObjects = store
+		}
+		fifo := NewRealFIFOWithOptions(fifoOptions)
 		recorder := newEventRecorder(store)
 
 		cfg := &Config{
@@ -1044,11 +1047,15 @@ func TestResetWatch(t *testing.T) {
 			t.Cleanup(func() {
 				source.Shutdown()
 			})
+
 			store := NewStore(DeletionHandlingMetaNamespaceKeyFunc)
-			fifo := NewRealFIFOWithOptions(RealFIFOOptions{
-				KnownObjects: store,
+			fifoOptions := RealFIFOOptions{
 				AtomicEvents: atomic,
-			})
+			}
+			if !atomic {
+				fifoOptions.KnownObjects = store
+			}
+			fifo := NewRealFIFOWithOptions(fifoOptions)
 			recorder := newEventRecorder(store)
 
 			cfg := &Config{

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -187,6 +187,9 @@ const (
 	ReplacedAll DeltaType = "ReplacedAll"
 	// Sync is for synthetic events during a periodic resync.
 	Sync DeltaType = "Sync"
+	// SyncAll indicates all known objects should be reprocessed.
+	// This event contains an object of type SyncAllInfo.
+	SyncAll DeltaType = "SyncAll"
 )
 
 // Delta is a member of Deltas (a list of Delta objects) which


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds the atomic resync operation, as well as decoupling the process loop from the fifo lock. This enables processing which may take a long time to not rely on the FIFO lock being held. We do this by having the access to the store be separate from adding events to the FIFO. See https://docs.google.com/document/d/1HsJYi-2dOAgMPQ44sZPW8QsWHF5W5WwHD6S2isoOHf8/edit?resourcekey=0-ieH4pFGdzvADxAXbiUQcqQ&tab=t.0#heading=h.de5ack60vctw for more details.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5647
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
client-go: Informer resync processing improved handling of Resync handling. This reduces contention on store locks between incoming events and handler updates, which may result in observable timing differences of handler invocations. This behavior is guarded by an AtomicFIFO feature gate. This gate is enabled by default in 1.36, but can be disabled if needed to temporarily regain the previous behavior.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
