### PR TITLE
kubelet/qos: guard zero memory capacity in OOM score

### DIFF
--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -56,6 +56,11 @@ func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapa
 		return besteffortOOMScoreAdj
 	}
 
+	if memoryCapacity <= 0 {
+		// Avoid divide-by-zero when memory capacity is unavailable.
+		return besteffortOOMScoreAdj - 1
+	}
+
 	// Burstable containers are a middle tier, between Guaranteed and Best-Effort. Ideally,
 	// we want to protect Burstable containers that consume less memory than requested.
 	// The formula below is a heuristic. A container requesting for 10% of a system's

--- a/pkg/kubelet/qos/policy_test.go
+++ b/pkg/kubelet/qos/policy_test.go
@@ -665,6 +665,13 @@ func TestGetContainerOOMScoreAdjust(t *testing.T) {
 				"cpu-limit": {lowOOMScoreAdj: 999, highOOMScoreAdj: 999},
 			},
 		},
+		"cpu-limit-zero-memory-capacity": {
+			pod:            &cpuLimit,
+			memoryCapacity: 0,
+			lowHighOOMScoreAdj: map[string]lowHighOOMScoreAdjTest{
+				"cpu-limit": {lowOOMScoreAdj: 999, highOOMScoreAdj: 999},
+			},
+		},
 		"memory-limit-cpu-request": {
 			pod:            &memoryLimitCPURequest,
 			memoryCapacity: 8000000000,


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
- Guard against `memoryCapacity <= 0` in `GetContainerOOMScoreAdjust` to avoid divide-by-zero.
- Add a unit test to cover the zero-capacity case.

#### Which issue(s) this PR is related to:
Fixes #113243

#### Special notes for your reviewer:
Tests: `go test ./pkg/kubelet/qos -run TestGetContainerOOMScoreAdjust`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A
