### PR TITLE
Support YAML directive

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -209,6 +209,48 @@ stuff: 1
 	}
 }
 
+func TestDecodeYAMLWithDirective(t *testing.T) {
+	s := NewYAMLToJSONDecoder(bytes.NewReader([]byte(`%YAML 1.1
+---
+`)))
+	var obj any
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj != nil {
+		t.Fatalf("expected nil document, got: %#v", obj)
+	}
+	if err := s.Decode(&obj); err != io.EOF { //nolint:errorlint
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDecodeYAMLWithDirectiveAndContent(t *testing.T) {
+	s := NewYAMLToJSONDecoder(bytes.NewReader([]byte(`%YAML 1.1
+---
+stuff: 1
+---
+stuff: 2
+`)))
+	obj := generic{}
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprintf("%#v", obj) != `yaml.generic{"stuff":1}` {
+		t.Fatalf("unexpected object: %#v", obj)
+	}
+	obj = generic{}
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprintf("%#v", obj) != `yaml.generic{"stuff":2}` {
+		t.Fatalf("unexpected object: %#v", obj)
+	}
+	if err := s.Decode(&obj); err != io.EOF { //nolint:errorlint
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDecodeYAMLSeparatorValidation(t *testing.T) {
 	s := NewYAMLToJSONDecoder(bytes.NewReader([]byte(`---
 stuff: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kubectl uses k8s.io/apimachinery/pkg/util/yaml.YAMLReader to split streams into documents. That reader treats any line starting with --- as a document boundary.

With a file like:

```
%YAML 1.1
---
```

the splitter returns the first "document" as just %YAML 1.1\n (without the required document start marker), and the YAML→JSON conversion then fails with yaml: line 1: did not find expected <document start>.

The PR solves the issue such that when the reader sees a --- line and the buffer so far contains only directives (e.g. %YAML), treat that --- as the required document-start marker for the same document and include it in the buffer, instead of terminating the previous chunk.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #135998 

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
