### PR TITLE
fix: prevent panic in device manager when allocating devices in parallel

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -2191,3 +2191,75 @@ func TestEndpointSyncOnDisconnect(t *testing.T) {
 	require.Empty(t, manager.healthyDevices)
 	require.Empty(t, manager.unhealthyDevices)
 }
+
+// TestDeviceAllocateParallel tests that parallel device allocation does not cause a panic
+// when one pod's devicesToReuse entry is deleted by another pod during allocation.
+// This is a regression test for https://github.com/kubernetes/kubernetes/issues/136021
+func TestDeviceAllocateParallel(t *testing.T) {
+	res1 := TestResource{
+		resourceName:     "domain3.com/resource3",
+		resourceQuantity: *resource.NewQuantity(int64(2), resource.DecimalSI),
+		devs:             checkpoint.DevicesPerNUMA{0: []string{"dev5", "dev6"}},
+		topology:         false,
+	}
+	res2 := TestResource{
+		resourceName:     "domain1.com/resource1",
+		resourceQuantity: *resource.NewQuantity(int64(2), resource.DecimalSI),
+		devs:             checkpoint.DevicesPerNUMA{0: []string{"dev1", "dev2"}},
+		topology:         false,
+	}
+
+	as := require.New(t)
+	podsStub := activePodsStub{
+		activePods: []*v1.Pod{},
+	}
+	tmpDir, err := os.MkdirTemp("", "checkpoint")
+	as.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, []TestResource{res1, res2})
+	as.NoError(err)
+	testManager.endpoints[res1.resourceName] = endpointInfo{
+		e: &MockEndpoint{
+			allocateFunc: func(devs []string) (*pluginapi.AllocateResponse, error) {
+				resp := new(pluginapi.ContainerAllocateResponse)
+				resp.Envs = make(map[string]string)
+				for _, dev := range devs {
+					switch dev {
+					case "dev5":
+						resp.Envs["key2"] = "val2"
+
+					case "dev6":
+						resp.Envs["key2"] = "val3"
+					}
+				}
+				resps := new(pluginapi.AllocateResponse)
+				resps.ContainerResponses = append(resps.ContainerResponses, resp)
+				fmt.Println("start sleep 2s")
+				time.Sleep(2 * time.Second)
+				return resps, nil
+			},
+		},
+		opts: nil,
+	}
+
+	pod1 := makePod(v1.ResourceList{
+		v1.ResourceName(res1.resourceName): res1.resourceQuantity})
+	pod2 := makePod(v1.ResourceList{
+		v1.ResourceName(res2.resourceName): res2.resourceQuantity})
+	activePods := []*v1.Pod{}
+	activePods = append(activePods, pod1, pod2)
+	podsStub.updateActivePods(activePods)
+
+	wg := sync.WaitGroup{}
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		err = testManager.Allocate(pod1, &pod1.Spec.Containers[0])
+		as.NoError(err)
+	}()
+
+	err = testManager.Allocate(pod2, &pod2.Spec.Containers[0])
+	as.NoError(err)
+	wg.Wait()
+}


### PR DESCRIPTION
## What this PR does
Fixes race condition in device manager's `Allocate()` function that causes a panic when multiple pods allocate devices in parallel.

## Problem
When allocating devices in parallel:
- Pod1 creates `m.devicesToReuse[pod1.uid]` and makes an RPC call
- Pod2 deletes `m.devicesToReuse[pod1.uid]` while Pod1's RPC is still running
- Pod1 tries to access `m.devicesToReuse[pod1.uid]` after RPC returns, causing a nil pointer panic

## Solution
Save a local reference to `devicesToReuse` for the current pod before the RPC call and use it throughout the function, preventing the race condition.

## Testing
- Added `TestDeviceAllocateParallel` test case that reproduces the issue
- Test verifies no panic occurs when allocating devices concurrently
-note
Fix race condition in device manager that caused panic when multiple pods allocate devices in parallel
Fixes #136021

/sig node
/kind bug