### PR TITLE
Fix potential goroutine leak in kubelet operation_executor_test

### DIFF
--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
@@ -185,6 +185,9 @@ func setup(t *testing.T) (context.Context, chan interface{}, chan interface{}, O
 // This function starts by writing to ch and blocks on the quit channel
 // until it is closed by the currently running test
 func startOperationAndBlock(ch chan<- interface{}, quit <-chan interface{}) {
-	ch <- nil
-	<-quit
+	select {
+	case ch <- nil:
+		<-quit
+	case <-quit:
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

This PR fixes a potential goroutine leak in `pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go`.

In the `TestOperationExecutor_UnregisterPlugin_ConcurrentUnregisterPlugin` test, the helper function `startOperationAndBlock` spawns a goroutine that sends to channel `ch`. If the test's `isOperationRunConcurrently` function times out, it stops receiving from `ch` and closes the `quit` channel. Since `ch` is unbuffered, the sender blocks forever on `ch <- nil`, causing a goroutine leak.

This change updates `startOperationAndBlock` to use a `select` statement. It attempts to send to `ch`, but also listens on the `quit` channel. If `quit` is closed (indicating the test has finished or timed out), the goroutine exits immediately, preventing the leak.

#### Which issue(s) this PR is related to:

Fixes #134939

#### Special notes for your reviewer:

This issue is similar to the one reported in `pkg/volume/util/operationexecutor/operation_executor_test.go` (PR #135241). This PR specifically addresses the `pkg/kubelet` package to avoid conflicts with existing open PRs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
