### PR TITLE
fix(kubelet): convert V().Error() to V().Info() for verbosity-aware logging

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -573,7 +573,7 @@ func (m *manager) RemovePod(uid types.UID) {
 	logger := klog.TODO()
 	if err := m.allocated.RemovePod(uid); err != nil {
 		// If the deletion fails, it will be retried by RemoveOrphanedPods, so we can safely ignore the error.
-		logger.V(3).Error(err, "Failed to delete pod allocation", "podUID", uid)
+		logger.V(3).Info("Failed to delete pod allocation", "podUID", uid, "err", err)
 	}
 }
 

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go
@@ -104,7 +104,7 @@ func (c *client) Disconnect(logger klog.Logger) error {
 	c.mutex.Lock()
 	if c.grpc != nil {
 		if err := c.grpc.Close(); err != nil {
-			logger.V(2).Error(err, "Failed to close grpc connection", "resource", c.Resource())
+			logger.V(2).Info("Failed to close grpc connection", "resource", c.Resource(), "err", err)
 		}
 		c.grpc = nil
 	}

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
@@ -395,7 +395,7 @@ func (pm *DRAPluginManager) add(driverName string, endpoint string, chosenServic
 				logger.V(4).Info("Attempting to start WatchResources health stream")
 				stream, err := p.NodeWatchResources(ctx)
 				if err != nil {
-					logger.V(3).Error(err, "Failed to establish WatchResources stream, will retry")
+					logger.V(3).Info("Failed to establish WatchResources stream, will retry", "err", err)
 					return
 				}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -427,7 +427,7 @@ func checkSwapControllerAvailability(ctx context.Context) bool {
 		// memory.swap.max does not exist in the cgroup root, so we check /sys/fs/cgroup/<SELF>/memory.swap.max
 		cm, err := libcontainercgroups.ParseCgroupFile("/proc/self/cgroup")
 		if err != nil {
-			logger.V(5).Error(fmt.Errorf("failed to parse /proc/self/cgroup: %w", err), warn)
+			logger.V(5).Info(warn, "err", fmt.Errorf("failed to parse /proc/self/cgroup: %w", err))
 			return false
 		}
 		// For cgroup v2 unified hierarchy, there are no per-controller
@@ -438,7 +438,7 @@ func checkSwapControllerAvailability(ctx context.Context) bool {
 	}
 	if _, err := os.Stat(p); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			logger.V(5).Error(err, warn)
+			logger.V(5).Info(warn, "err", err)
 		}
 		return false
 	}

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -82,7 +82,7 @@ func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.Cont
 		output, err := hr.commandRunner.RunInContainer(ctx, containerID, handler.Exec.Command, 0)
 		if err != nil {
 			msg = fmt.Sprintf("Exec lifecycle hook (%v) for Container %q in Pod %q failed - error: %v, message: %q", handler.Exec.Command, container.Name, format.Pod(pod), err, string(output))
-			logger.V(1).Error(err, "Exec lifecycle hook for Container in Pod failed", "execCommand", handler.Exec.Command, "containerName", container.Name, "pod", klog.KObj(pod), "message", string(output))
+			logger.V(1).Info("Exec lifecycle hook for Container in Pod failed", "execCommand", handler.Exec.Command, "containerName", container.Name, "pod", klog.KObj(pod), "message", string(output), "err", err)
 		}
 		return msg, err
 	case handler.HTTPGet != nil:
@@ -90,7 +90,7 @@ func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.Cont
 		var msg string
 		if err != nil {
 			msg = fmt.Sprintf("HTTP lifecycle hook (%s) for Container %q in Pod %q failed - error: %v", handler.HTTPGet.Path, container.Name, format.Pod(pod), err)
-			logger.V(1).Error(err, "HTTP lifecycle hook for Container in Pod failed", "path", handler.HTTPGet.Path, "containerName", container.Name, "pod", klog.KObj(pod))
+			logger.V(1).Info("HTTP lifecycle hook for Container in Pod failed", "path", handler.HTTPGet.Path, "containerName", container.Name, "pod", klog.KObj(pod), "err", err)
 		}
 		return msg, err
 	case handler.Sleep != nil:
@@ -98,7 +98,7 @@ func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.Cont
 		var msg string
 		if err != nil {
 			msg = fmt.Sprintf("Sleep lifecycle hook (%d) for Container %q in Pod %q failed - error: %v", handler.Sleep.Seconds, container.Name, format.Pod(pod), err)
-			logger.V(1).Error(err, "Sleep lifecycle hook for Container in Pod failed", "sleepSeconds", handler.Sleep.Seconds, "containerName", container.Name, "pod", klog.KObj(pod))
+			logger.V(1).Info("Sleep lifecycle hook for Container in Pod failed", "sleepSeconds", handler.Sleep.Seconds, "containerName", container.Name, "pod", klog.KObj(pod), "err", err)
 		}
 		return msg, err
 	default:
@@ -149,7 +149,7 @@ func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, contai
 	discardHTTPRespBody(resp)
 
 	if isHTTPResponseError(err) {
-		logger.V(1).Error(err, "HTTPS request to lifecycle hook got HTTP response, retrying with HTTP.", "pod", klog.KObj(pod), "host", req.URL.Host)
+		logger.V(1).Info("HTTPS request to lifecycle hook got HTTP response, retrying with HTTP.", "pod", klog.KObj(pod), "host", req.URL.Host, "err", err)
 
 		req := req.Clone(ctx)
 		req.URL.Scheme = "http"

--- a/pkg/kubelet/metrics/collectors/cri_metrics.go
+++ b/pkg/kubelet/metrics/collectors/cri_metrics.go
@@ -107,7 +107,7 @@ func (c *criMetricsCollector) criMetricToProm(logger klog.Logger, m *runtimeapi.
 	desc, ok := c.descriptors[m.Name]
 	if !ok {
 		err := fmt.Errorf("error converting CRI Metric to prometheus format")
-		logger.V(5).Error(err, "Descriptor not present in pre-populated list of descriptors", "name", m.Name)
+		logger.V(5).Info("Descriptor not present in pre-populated list of descriptors", "name", m.Name, "err", err)
 		return nil, err
 	}
 

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -297,7 +297,7 @@ func (g *GenericPLEG) Relist() {
 		status, updated, err := g.updateCache(ctx, pod, pid)
 		if err != nil {
 			// Rely on updateCache calling GetPodStatus to log the actual error.
-			g.logger.V(4).Error(err, "PLEG: Ignoring events for pod", "pod", klog.KRef(pod.Namespace, pod.Name))
+			g.logger.V(4).Info("PLEG: Ignoring events for pod", "pod", klog.KRef(pod.Namespace, pod.Name), "err", err)
 
 			// make sure we try to reinspect the pod during the next relisting
 			needsReinspection[pid] = pod

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -103,7 +103,7 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 	if err != nil {
 		// Handle probe error
-		logger.V(1).Error(err, "Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
+		logger.V(1).Info("Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "err", err)
 		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
 		return results.Failure, err
 	}

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -194,7 +194,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 		if c.StartupProbe != nil {
 			key.probeType = startup
 			if _, ok := m.workers[key]; ok {
-				logger.V(8).Error(nil, "Startup probe already exists for container",
+				logger.V(8).Info("Startup probe already exists for container",
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
@@ -206,7 +206,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 		if c.ReadinessProbe != nil {
 			key.probeType = readiness
 			if _, ok := m.workers[key]; ok {
-				logger.V(8).Error(nil, "Readiness probe already exists for container",
+				logger.V(8).Info("Readiness probe already exists for container",
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
@@ -218,7 +218,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 		if c.LivenessProbe != nil {
 			key.probeType = liveness
 			if _, ok := m.workers[key]; ok {
-				logger.V(8).Error(nil, "Liveness probe already exists for container",
+				logger.V(8).Info("Liveness probe already exists for container",
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -165,9 +165,7 @@ func (p *criStatsProvider) listPodStats(ctx context.Context, updateCPUNanoCoreUs
 			return nil, err
 		}
 		// CRI implementation doesn't support ListPodSandboxStats, warn and fallback.
-		logger.V(5).Error(err,
-			"CRI implementation must be updated to support ListPodSandboxStats if PodAndContainerStatsFromCRI feature gate is enabled. Falling back to populating with cAdvisor; this call will fail in the future.",
-		)
+		logger.V(5).Info("CRI implementation must be updated to support ListPodSandboxStats if PodAndContainerStatsFromCRI feature gate is enabled. Falling back to populating with cAdvisor; this call will fail in the future.", "err", err)
 	}
 	return p.listPodStatsPartiallyFromCRI(ctx, updateCPUNanoCoreUsage, containerMap, podSandboxMap, &rootFsInfo)
 }

--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -499,7 +499,7 @@ func makePodStorageStats(logger klog.Logger, s *statsapi.PodStats, rootFsInfo *c
 
 	logStats, err := hostStatsProvider.getPodLogStats(podNs, podName, podUID, rootFsInfo)
 	if err != nil {
-		logger.V(6).Error(err, "Unable to fetch pod log stats", "pod", klog.KRef(podNs, podName))
+		logger.V(6).Info("Unable to fetch pod log stats", "pod", klog.KRef(podNs, podName), "err", err)
 		// If people do in-place upgrade, there might be pods still using
 		// the old log path. For those pods, no pod log stats is returned.
 		// We should continue generating other stats in that case.
@@ -507,7 +507,7 @@ func makePodStorageStats(logger klog.Logger, s *statsapi.PodStats, rootFsInfo *c
 	}
 	etcHostsStats, err := hostStatsProvider.getPodEtcHostsStats(podUID, rootFsInfo)
 	if err != nil {
-		logger.V(6).Error(err, "Unable to fetch pod etc hosts stats", "pod", klog.KRef(podNs, podName))
+		logger.V(6).Info("Unable to fetch pod etc hosts stats", "pod", klog.KRef(podNs, podName), "err", err)
 	}
 	s.EphemeralStorage = calcEphemeralStorage(s.Containers, ephemeralStats, rootFsInfo, logStats, etcHostsStats, isCRIStatsProvider)
 }

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -670,7 +670,7 @@ func handleSELinuxMetricError(logger klog.Logger, err error, seLinuxSupported bo
 
 	// This is not an error yet, but it will be when support for other access modes is added.
 	warningMetric.Add(1.0)
-	logger.V(4).Error(err, "Please report this error in https://github.com/kubernetes/enhancements/issues/1710, together with full Pod yaml file")
+	logger.V(4).Info("Please report this error in https://github.com/kubernetes/enhancements/issues/1710, together with full Pod yaml file", "err", err)
 	return nil
 }
 
@@ -685,7 +685,7 @@ func getVolumePluginNameWithDriver(logger klog.Logger, plugin volume.VolumePlugi
 	driverName, err := csi.GetCSIDriverName(spec)
 	if err != nil {
 		// In theory this is unreachable - such volume would not pass validation.
-		logger.V(4).Error(err, "failed to get CSI driver name from volume spec")
+		logger.V(4).Info("failed to get CSI driver name from volume spec", "err", err)
 		driverName = "unknown"
 	}
 	// `/` is used to separate plugin + CSI driver in util.GetUniqueVolumeName() too

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -185,7 +185,7 @@ func (rc *reconciler) updateReconstructedFromNodeStatus(ctx context.Context) {
 	node, fetchErr := rc.kubeClient.CoreV1().Nodes().Get(ctx, string(rc.nodeName), metav1.GetOptions{})
 	if fetchErr != nil {
 		// This may repeat few times per second until kubelet is able to read its own status for the first time.
-		logger.V(4).Error(fetchErr, "Failed to get Node status to reconstruct device paths")
+		logger.V(4).Info("Failed to get Node status to reconstruct device paths", "err", fetchErr)
 		return
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes incorrect usage of `logger.V(N).Error()` across the kubelet package. The go-logr package design causes `Error()` calls to bypass verbosity level checks entirely, meaning these logs are always printed regardless of the configured verbosity level.

This causes production log flooding and defeats the purpose of using verbosity levels.

#### Which issue(s) this PR fixes:

Fixes #136027

#### Special notes for your reviewer:

The linter check from https://github.com/kubernetes-sigs/logtools/pull/32 identified 21 instances across the kubelet package. This PR addresses all of them.

**Files modified (15 files, 21 instances):**
- `pkg/kubelet/allocation/allocation_manager.go`
- `pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go`
- `pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go`
- `pkg/kubelet/images/pullmanager/metrics.go`
- `pkg/kubelet/kubelet.go`
- `pkg/kubelet/kuberuntime/kuberuntime_container_linux.go`
- `pkg/kubelet/lifecycle/handlers.go`
- `pkg/kubelet/metrics/collectors/cri_metrics.go`
- `pkg/kubelet/pleg/generic.go`
- `pkg/kubelet/prober/prober.go`
- `pkg/kubelet/prober/prober_manager.go`
- `pkg/kubelet/stats/cri_stats_provider.go`
- `pkg/kubelet/stats/helper.go`
- `pkg/kubelet/volumemanager/cache/desired_state_of_world.go`
- `pkg/kubelet/volumemanager/reconciler/reconstruct.go`

**Conversion patterns applied:**
- `V(N).Error(nil, "msg", ...)` → `V(N).Info("msg", ...)`
- `V(N).Error(err, "msg", ...)` → `V(N).Info("msg", ..., "err", err)`

#### Does this PR introduce a user-facing change?

```release-note
Fixed kubelet logging to properly respect verbosity levels. Previously, some debug/info messages using V().Error() would always be printed regardless of the configured log verbosity.
```

#### Additional documentation e.g., KEPs (Alarm Proposal Docs), usage docs, etc.:

N/A

/sig node
/area kubelet