### PR TITLE
ad-controller: allow immediate detach when node deleted

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -590,7 +590,13 @@ func (adc *attachDetachController) nodeDelete(logger klog.Logger, obj interface{
 		logger.Info("Error removing node from desired-state-of-world", "node", klog.KObj(node), "err", err)
 	}
 
-	adc.processVolumesInUse(logger, nodeName, node.Status.VolumesInUse)
+	// When a node is deleted, we clear MountedByNode immediately to allow
+	// detach to proceed without waiting for force-detach.
+	// Node deletion typically means the underlying node is gone, there is no point to wait.
+	// If the node is deleted by accident, it is still acceptable because
+	// detach is still gated by pod deletion (typically by PodGC controller),
+	// and once pods are deleted, kubelet cannot clean up anyway (CNI/CSI pods are likely deleted together).
+	adc.processVolumesInUse(logger, nodeName, nil)
 }
 
 func (adc *attachDetachController) enqueuePVC(obj interface{}) {

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -396,7 +396,11 @@ func (asw *actualStateOfWorld) SetVolumesMountedByNode(
 	asw.Lock()
 	defer asw.Unlock()
 
-	asw.inUseVolumes[nodeName] = sets.New(volumeNames...)
+	if volumeNames == nil {
+		delete(asw.inUseVolumes, nodeName)
+	} else {
+		asw.inUseVolumes[nodeName] = sets.New(volumeNames...)
+	}
 	logger.V(5).Info("SetVolumesMountedByNode volume to the node",
 		"node", klog.KRef("", string(nodeName)),
 		"volumeNames", volumeNames)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When a node is deleted, its `volumesInUse` is preserved in the AD controller cache as `MountedByNode`, preventing detach until the 6-minute force-detach timeout expires. This change clears `MountedByNode` immediately on node deletion instead.

Node deletion typically means the underlying node is gone, so waiting 6 minutes provides no benefit. If the node is deleted by accident, this is still acceptable because:
- detach is still gated by pod deletion (PodGC deletes pods on deleted nodes after ~40s quarantine)
- once pods are deleted, kubelet cannot clean up anyway (CNI/CSI pods are force-deleted together with the node)

Additional motivation:
- Without this change, volumes on deleted nodes are stuck permanently when `--disable-force-detach-on-timeout` is enabled, as out-of-service taint cannot be applied to a deleted node and `MountedByNode` blocks reconciliation
- This fixes a slow memory leak: deleted nodes' `volumesInUse` entries remain in cache indefinitely if nodes are constantly recycled

**Relationship to kubelet graceful shutdown (#139660):** The kubelet fix addresses nodes that are shut down but the Node object is not deleted. This PR addresses nodes where the Node object is deleted, where kubelet is irrelevant.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Related: #65392 — that issue and the subsequent non-graceful shutdown KEP ([KEP-2268](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2268-non-graceful-shutdown)) address the case where the Node object still exists but the node is unreachable. This PR handles the complementary case where the Node object is deleted (e.g. node scaled down, crashed, or manually removed).


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow immediate volume detach when node is deleted
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
