### PR TITLE
Add ignoreConversionErrors option to validation testing

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -89,7 +89,7 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object,
 		return
 	}
 	if old == nil {
-		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, accumulate, opts.SubResources...)
+		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, accumulate, opts.IgnoreObjectConversionErrors, opts.SubResources...)
 	} else {
 		// Convert old versioned object to internal format before validation.
 		// runtimetest.RunUpdateValidationForEachVersion requires unversioned (internal) objects as input.
@@ -100,7 +100,7 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object,
 		if internalOld == nil {
 			return
 		}
-		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, internalOld, accumulate, opts.SubResources...)
+		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, internalOld, accumulate, opts.IgnoreObjectConversionErrors, opts.SubResources...)
 	}
 
 	// Make a copy so we can modify it.
@@ -201,6 +201,9 @@ type validationOption struct {
 	SubResources []string
 	// NormalizationRules are the rules to apply to field paths before comparison.
 	NormalizationRules []field.NormalizationRule
+
+	// IgnoreObjectConversions skips the tests if the conversion between object fails.
+	IgnoreObjectConversionErrors bool
 }
 
 func WithSubResources(subResources ...string) ValidationTestConfig {
@@ -212,6 +215,12 @@ func WithSubResources(subResources ...string) ValidationTestConfig {
 func WithNormalizationRules(rules ...field.NormalizationRule) ValidationTestConfig {
 	return func(o *validationOption) {
 		o.NormalizationRules = rules
+	}
+}
+
+func WithIgnoreObjectConversionErrors() ValidationTestConfig {
+	return func(o *validationOption) {
+		o.IgnoreObjectConversionErrors = true
 	}
 }
 

--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -202,7 +202,8 @@ type validationOption struct {
 	// NormalizationRules are the rules to apply to field paths before comparison.
 	NormalizationRules []field.NormalizationRule
 
-	// IgnoreObjectConversions skips the tests if the conversion between object fails.
+	// IgnoreObjectConversions skips the tests if the conversion from the internal object
+	// to the versioned object fails.
 	IgnoreObjectConversionErrors bool
 }
 

--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -47,6 +47,10 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 		{Group: "node.k8s.io", Version: "v1beta1"},
 		{Group: "node.k8s.io", Version: "v1"},
 		{Group: "node.k8s.io", Version: "v1alpha1"},
+		{Group: "autoscaling", Version: "v1"},
+		{Group: "autoscaling", Version: "v1beta1"},
+		{Group: "autoscaling", Version: "v1beta2"},
+		{Group: "autoscaling", Version: "v2"},
 	}
 
 	fuzzIters := *roundtrip.FuzzIters / 10 // TODO: Find a better way to manage test running time
@@ -70,6 +74,7 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 					allRules := append([]field.NormalizationRule{}, resourcevalidation.ResourceNormalizationRules...)
 					allRules = append(allRules, nodevalidation.NodeNormalizationRules...)
 					opts = append(opts, WithNormalizationRules(allRules...))
+					opts = append(opts, WithIgnoreObjectConversionErrors())
 
 					VerifyVersionedValidationEquivalence(t, obj, nil, opts...)
 

--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -74,7 +74,9 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 					allRules := append([]field.NormalizationRule{}, resourcevalidation.ResourceNormalizationRules...)
 					allRules = append(allRules, nodevalidation.NodeNormalizationRules...)
 					opts = append(opts, WithNormalizationRules(allRules...))
-					opts = append(opts, WithIgnoreObjectConversionErrors())
+					if gv.Group == "autoscaling" {
+						opts = append(opts, WithIgnoreObjectConversionErrors())
+					}
 
 					VerifyVersionedValidationEquivalence(t, obj, nil, opts...)
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
@@ -98,7 +98,7 @@ func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options []string,
 						t.Fatal(err)
 					}
 					err = scheme.Convert(unversionedNew, versionedNew, nil)
-					if err != nil && ignoreConversionErrors {
+					if ignoreConversionErrors && err != nil {
 						t.Skipf("Failed to convert object from internal type to %s: %v", gvk.Version, err)
 					} else if err != nil {
 						t.Fatal(err)
@@ -111,7 +111,7 @@ func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options []string,
 						}
 
 						err = scheme.Convert(unversionedOld, versionedOld, nil)
-						if err != nil && ignoreConversionErrors {
+						if ignoreConversionErrors && err != nil {
 							t.Skipf("Failed to convert object from internal type to %s: %v", gvk.Version, err)
 						} else if err != nil {
 							t.Fatal(err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
@@ -37,16 +37,16 @@ type VersionValidationRunner func(t *testing.T, gv string, versionValidationErro
 //	      errs = append(errs, versionValidationErrors...) // generated declarative validation
 //		  // Validate that the errors are what was expected for this test case.
 //		})
-func RunValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options []string, unversioned runtime.Object, fn VersionValidationRunner, subresources ...string) {
-	runValidation(t, scheme, options, unversioned, fn, subresources...)
+func RunValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options []string, unversioned runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
+	runValidation(t, scheme, options, unversioned, fn, ignoreConversionErrors, subresources...)
 }
 
 // RunUpdateValidationForEachVersion is like RunValidationForEachVersion but for update validation.
-func RunUpdateValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options []string, unversioned, unversionedOld runtime.Object, fn VersionValidationRunner, subresources ...string) {
-	runUpdateValidation(t, scheme, options, unversioned, unversionedOld, fn, subresources...)
+func RunUpdateValidationForEachVersion(t *testing.T, scheme *runtime.Scheme, options []string, unversioned, unversionedOld runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
+	runUpdateValidation(t, scheme, options, unversioned, unversionedOld, fn, ignoreConversionErrors, subresources...)
 }
 
-func runValidation(t *testing.T, scheme *runtime.Scheme, options []string, unversioned runtime.Object, fn VersionValidationRunner, subresources ...string) {
+func runValidation(t *testing.T, scheme *runtime.Scheme, options []string, unversioned runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
 	unversionedGVKs, _, err := scheme.ObjectKinds(unversioned)
 	if err != nil {
 		t.Fatal(err)
@@ -66,7 +66,9 @@ func runValidation(t *testing.T, scheme *runtime.Scheme, options []string, unver
 						t.Fatal(err)
 					}
 					err = scheme.Convert(unversioned, versioned, nil)
-					if err != nil {
+					if ignoreConversionErrors && err != nil {
+						t.Skipf("Failed to convert object from internal type to %s: %v", gvk.Version, err)
+					} else if err != nil {
 						t.Fatal(err)
 					}
 					fn(t, gv.String(), scheme.Validate(context.Background(), options, versioned, subresources...))
@@ -76,7 +78,7 @@ func runValidation(t *testing.T, scheme *runtime.Scheme, options []string, unver
 	}
 }
 
-func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options []string, unversionedNew, unversionedOld runtime.Object, fn VersionValidationRunner, subresources ...string) {
+func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options []string, unversionedNew, unversionedOld runtime.Object, fn VersionValidationRunner, ignoreConversionErrors bool, subresources ...string) {
 	unversionedGVKs, _, err := scheme.ObjectKinds(unversionedNew)
 	if err != nil {
 		t.Fatal(err)
@@ -96,10 +98,11 @@ func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options []string,
 						t.Fatal(err)
 					}
 					err = scheme.Convert(unversionedNew, versionedNew, nil)
-					if err != nil {
+					if err != nil && ignoreConversionErrors {
+						t.Skipf("Failed to convert object from internal type to %s: %v", gvk.Version, err)
+					} else if err != nil {
 						t.Fatal(err)
 					}
-
 					var versionedOld runtime.Object
 					if unversionedOld != nil {
 						versionedOld, err = scheme.New(gvk)
@@ -108,7 +111,9 @@ func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options []string,
 						}
 
 						err = scheme.Convert(unversionedOld, versionedOld, nil)
-						if err != nil {
+						if err != nil && ignoreConversionErrors {
+							t.Skipf("Failed to convert object from internal type to %s: %v", gvk.Version, err)
+						} else if err != nil {
 							t.Fatal(err)
 						}
 					}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR introduces an `IgnoreObjectConversionErrors` option to the validation testing framework in `k8s.io/apimachinery` and `pkg/api/testing`.

This change is necessary for `TestVersionedValidationByFuzzing` to support API groups where certain types cannot be converted to every other version (e.g., due to missing fields or schema incompatibilities in older versions). By enabling this option, the test runner will skip individual versions that fail conversion instead of failing the entire test suite.

Specifically, this unblocks the inclusion of the `autoscaling` group in fuzz testing, which previously failed because the `Scale` type exists across `autoscaling/v1`, `apps/v1beta1`, `apps/v1beta2`, and `extensions/v1beta1` with incompatible conversion paths.

The ScaleStatus.Selector field has inconsistent representations across Kubernetes API groups. In the internal autoscaling representation, the Selector is a string. However, in legacy versioned APIs—specifically extensions/v1beta1, apps/v1beta1, and apps/v1beta2—this field is represented as a map[string]string.

During TestVersionedValidationByFuzzing, the fuzzer generates randomized Unicode strings for the internal Selector field. The conversion logic for these older versions attempts to parse this string into a valid map-based label selector. This process fails because the fuzzer-generated strings often do not conform to the specific format required to be a valid, parsable selector.

The conversion errors, such as "failed to parse selector", are expected behaviors for these legacy paths when presented with non-standard fuzzed data. Rather than modifying the conversion logic for these deprecated or legacy API versions, we are introducing the IgnoreObjectConversionErrors option to allow the validation tests to skip these specific versioned failures while continuing to test valid conversion paths.

#### Which issue(s) this PR is related to:
Relates to #135412 and the Declarative Validation (DV) migration umbrella issue #134280.

#### Special notes for your reviewer:
This infrastructure fix was surfaced during the HPA DV migration and is being handled as a separate PR as per the recommended process. 

The implementation updates `RunValidationForEachVersion` and `RunUpdateValidationForEachVersion` to accept a new `ignoreConversionErrors` boolean parameter.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
```
