### PR TITLE
Add client-go pod-logs example

### DIFF
--- a/staging/src/k8s.io/client-go/examples/README.md
+++ b/staging/src/k8s.io/client-go/examples/README.md
@@ -32,6 +32,7 @@ import _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 - [**Managing resources with API**](./create-update-delete-deployment): Create,
   get, update, delete a Deployment resource.
+- [**Pod Logs**](./pod-logs): Retrieve and print logs from pods.
 
 ### Advanced Concepts
 

--- a/staging/src/k8s.io/client-go/examples/pod-logs/README.md
+++ b/staging/src/k8s.io/client-go/examples/pod-logs/README.md
@@ -1,0 +1,24 @@
+# Pod Logs
+
+This example demonstrates how to retrieve and print logs from all pods in all namespaces.
+
+## Running the example
+
+Make sure you have a Kubernetes cluster and `kubectl` is configured.
+
+Compile this example on your workstation:
+
+```bash
+cd pod-logs
+go build -o app .
+```
+
+Now, run this application on your workstation with your local kubeconfig file:
+
+```bash
+./app
+# or specify a kubeconfig file with flag
+./app -kubeconfig=$HOME/.kube/config
+```
+
+The example will list each pod's name, namespace, IP, and node, then print the last 5 lines of logs for each container within those pods.

--- a/staging/src/k8s.io/client-go/examples/pod-logs/main.go
+++ b/staging/src/k8s.io/client-go/examples/pod-logs/main.go
@@ -1,0 +1,111 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Note: the example only works with the code within the same release/branch.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"k8s.io/utils/ptr"
+	//
+	// Uncomment to load all auth plugins
+	// _ "k8s.io/client-go/plugin/pkg/client/auth"
+	//
+	// Or uncomment to load specific auth plugins
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/azure"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
+
+func main() {
+	var kubeconfig *string
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		panic(err.Error())
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	pods, err := clientset.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	for _, pod := range pods.Items {
+		podName := pod.ObjectMeta.Name
+		namespace := pod.ObjectMeta.Namespace
+		podIP := pod.Status.PodIP
+		nodeName := pod.Spec.NodeName
+
+		fmt.Printf("Name: %s, Namespace: %s, IP: %s, Node: %s\n", podName, namespace, podIP, nodeName)
+
+		for _, container := range pod.Spec.Containers {
+			containerName := container.Name
+			if err := getPodLogs(clientset, namespace, podName, containerName); err != nil {
+				fmt.Println(err)
+			}
+		}
+	}
+}
+
+func getPodLogs(clientset *kubernetes.Clientset, namespace, podName, containerName string) (err error) {
+	fmt.Printf("Logs for container %s:\n", containerName)
+
+	podLogOpts := apiv1.PodLogOptions{
+		Container: containerName,
+		TailLines: ptr.To(int64(5)),
+	}
+
+	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &podLogOpts)
+	var podLogs io.ReadCloser
+	podLogs, err = req.Stream(context.TODO())
+	if err != nil {
+		return fmt.Errorf("error getting logs for pod %s, container %s: %w", podName, containerName, err)
+	}
+	defer func() {
+		cerr := podLogs.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	_, err = io.Copy(os.Stdout, podLogs)
+	if err != nil {
+		return fmt.Errorf("error copying logs for pod %s, container %s: %w", podName, containerName, err)
+	}
+	fmt.Println()
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR adds a new example to staging/src/k8s.io/client-go/examples/pod-logs/ demonstrating how to retrieve and stream logs from pods.

#### Which issue(s) this PR is related to:

Fixes #136035

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE