### PR TITLE
[InPlacePodVerticalScaling] create an admission plugin to perform the OS and node capacity checks

### DIFF
--- a/pkg/controlplane/apiserver/samples/generic/server/admission_test.go
+++ b/pkg/controlplane/apiserver/samples/generic/server/admission_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/network/defaultingressclass"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodedeclaredfeatures"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
+	"k8s.io/kubernetes/plugin/pkg/admission/podresize"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"
 	podpriority "k8s.io/kubernetes/plugin/pkg/admission/priority"
 	"k8s.io/kubernetes/plugin/pkg/admission/runtimeclass"
@@ -46,6 +47,7 @@ var intentionallyOffPlugins = sets.New[string](
 	podsecurity.PluginName,                  // PodSecurity
 	podtopologylabels.PluginName,            // PodTopologyLabels
 	nodedeclaredfeatures.PluginName,         // NodeDeclaredFeatures
+	podresize.PluginName,                    // PodResize
 )
 
 func TestDefaultOffAdmissionPlugins(t *testing.T) {

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
 	"k8s.io/kubernetes/plugin/pkg/admission/podnodeselector"
+	"k8s.io/kubernetes/plugin/pkg/admission/podresize"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"
 	podpriority "k8s.io/kubernetes/plugin/pkg/admission/priority"
@@ -99,6 +100,7 @@ var AllOrderedPlugins = []string{
 	denyserviceexternalips.PluginName,       // DenyServiceExternalIPs
 	podtopologylabels.PluginName,            // PodTopologyLabels
 	nodedeclaredfeatures.PluginName,         // NodeDeclaredFeatureValidator
+	podresize.PluginName,                    // PodResizeValidator
 
 	// new admission plugins should generally be inserted above here
 	// webhook, resourcequota, and deny plugins must go at the end
@@ -152,6 +154,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	certsubjectrestriction.Register(plugins)
 	podtopologylabels.Register(plugins)
 	nodedeclaredfeatures.Register(plugins)
+	podresize.Register(plugins)
 }
 
 // DefaultOffAdmissionPlugins get admission plugins off by default for kube-apiserver.
@@ -180,6 +183,7 @@ func DefaultOffAdmissionPlugins() sets.Set[string] {
 		mutatingadmissionpolicy.PluginName,      // Mutatingadmissionpolicy, only active when feature gate MutatingAdmissionpolicy is enabled
 		validatingadmissionpolicy.PluginName,    // ValidatingAdmissionPolicy, only active when feature gate ValidatingAdmissionPolicy is enabled
 		nodedeclaredfeatures.PluginName,         // NodeDeclaredFeatureValidator, only active when feature gate NodeDeclaredFeatures is enabled
+		podresize.PluginName,                    // PodResizeValidator, only active when feature gate InPlacePodVerticalScaling is enabled
 	)
 
 	return sets.New(AllOrderedPlugins...).Difference(defaultOnPlugins)

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -292,9 +292,6 @@ func TestRetryPendingResizes(t *testing.T) {
 	if goruntime.GOOS == "windows" {
 		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
 	}
-	metrics.Register()
-	metrics.PodInfeasibleResizes.Reset()
-
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 	containerRestartPolicyAlways := v1.ContainerRestartPolicyAlways
 
@@ -473,7 +470,7 @@ func TestRetryPendingResizes(t *testing.T) {
 			expectPodSyncTriggered: "true",
 		},
 		{
-			name:                  "Request memory increase beyond node capacity - expect Infeasible",
+			name:                  "Request memory increase beyond node capacity - expect Deferred",
 			originalRequests:      v1.ResourceList{v1.ResourceCPU: cpu1000m, v1.ResourceMemory: mem1000M},
 			newRequests:           v1.ResourceList{v1.ResourceCPU: cpu1000m, v1.ResourceMemory: mem4500M},
 			expectedAllocatedReqs: v1.ResourceList{v1.ResourceCPU: cpu1000m, v1.ResourceMemory: mem1000M},
@@ -482,14 +479,14 @@ func TestRetryPendingResizes(t *testing.T) {
 				{
 					Type:    v1.PodResizePending,
 					Status:  "True",
-					Reason:  "Infeasible",
-					Message: "Node didn't have enough capacity: memory, requested: 4718592000, capacity: 4294967296",
+					Reason:  "Deferred",
+					Message: "Node didn't have enough resource: memory, requested: 4718592000, used: 2147483648, capacity: 4294967296",
 				},
 			},
 			expectPodSyncTriggered: "true",
 		},
 		{
-			name:                  "Request CPU increase beyond node capacity - expect Infeasible",
+			name:                  "Request CPU increase beyond node capacity - expect Deferred",
 			originalRequests:      v1.ResourceList{v1.ResourceCPU: cpu1000m, v1.ResourceMemory: mem1000M},
 			newRequests:           v1.ResourceList{v1.ResourceCPU: cpu5000m, v1.ResourceMemory: mem1000M},
 			expectedAllocatedReqs: v1.ResourceList{v1.ResourceCPU: cpu1000m, v1.ResourceMemory: mem1000M},
@@ -498,8 +495,8 @@ func TestRetryPendingResizes(t *testing.T) {
 				{
 					Type:    v1.PodResizePending,
 					Status:  "True",
-					Reason:  "Infeasible",
-					Message: "Node didn't have enough capacity: cpu, requested: 5000, capacity: 4000",
+					Reason:  "Deferred",
+					Message: "Node didn't have enough resource: cpu, requested: 5000, used: 2000, capacity: 4000",
 				},
 			},
 			expectPodSyncTriggered: "true",
@@ -688,7 +685,7 @@ func TestRetryPendingResizes(t *testing.T) {
 			expectPodSyncTriggered: "true",
 		},
 		{
-			name:                         "pod-level: Request memory increase beyond node capacity - expect Infeasible",
+			name:                         "pod-level: Request memory increase beyond node capacity - expect Deferred",
 			inPlacePodLevelResizeEnabled: true,
 			originalPodRequests:          v1.ResourceList{v1.ResourceCPU: cpu1500m, v1.ResourceMemory: mem1500M},
 			newPodRequests:               v1.ResourceList{v1.ResourceCPU: cpu1500m, v1.ResourceMemory: mem4500M},
@@ -700,8 +697,8 @@ func TestRetryPendingResizes(t *testing.T) {
 				{
 					Type:    v1.PodResizePending,
 					Status:  "True",
-					Reason:  "Infeasible",
-					Message: "Node didn't have enough capacity: memory, requested: 4718592000, capacity: 4294967296",
+					Reason:  "Deferred",
+					Message: "Node didn't have enough resource: memory, requested: 4718592000, used: 2147483648, capacity: 4294967296",
 				},
 			},
 			expectPodSyncTriggered: "true",
@@ -844,15 +841,6 @@ func TestRetryPendingResizes(t *testing.T) {
 			})
 		}
 	}
-
-	expectedMetrics := `
-		# HELP kubelet_pod_infeasible_resizes_total [ALPHA] Number of infeasible resizes for pods.
-	    # TYPE kubelet_pod_infeasible_resizes_total counter
-	    kubelet_pod_infeasible_resizes_total{reason_detail="insufficient_node_allocatable"} 5
-	`
-	assert.NoError(t, testutil.GatherAndCompare(
-		legacyregistry.DefaultGatherer, strings.NewReader(expectedMetrics), "kubelet_pod_infeasible_resizes_total",
-	))
 }
 
 func TestRetryPendingResizesGuanteedQOSPods(t *testing.T) {
@@ -1369,8 +1357,8 @@ func TestRetryPendingResizesMultipleConditions(t *testing.T) {
 				{
 					Type:               v1.PodResizePending,
 					Status:             "True",
-					Reason:             v1.PodReasonInfeasible,
-					Message:            "Node didn't have enough capacity: memory, requested: 4718592000, capacity: 4294967296",
+					Reason:             v1.PodReasonDeferred,
+					Message:            "Node didn't have enough resource: cpu, requested: 5000, used: 0, capacity: 4000",
 					ObservedGeneration: 2,
 				},
 				{
@@ -1379,7 +1367,7 @@ func TestRetryPendingResizesMultipleConditions(t *testing.T) {
 					ObservedGeneration: 1,
 				},
 			},
-			expectedEvent: `Warning ResizeInfeasible Pod resize Infeasible: {"containers":[{"name":"c1","resources":{"requests":{"cpu":"5","memory":"4500Mi"}}}],"generation":2,"error":"Node didn't have enough capacity: memory, requested: 4718592000, capacity: 4294967296"}`,
+			expectedEvent: `Warning ResizeDeferred Pod resize OutOfcpu: {"containers":[{"name":"c1","resources":{"requests":{"cpu":"5","memory":"4500Mi"}}}],"generation":2,"error":"Node didn't have enough resource: cpu, requested: 5000, used: 0, capacity: 4000"}`,
 		},
 		{
 			name:       "same as previous case to ensure no new event is generated",
@@ -1390,8 +1378,8 @@ func TestRetryPendingResizesMultipleConditions(t *testing.T) {
 				{
 					Type:               v1.PodResizePending,
 					Status:             "True",
-					Reason:             v1.PodReasonInfeasible,
-					Message:            "Node didn't have enough capacity: memory, requested: 4718592000, capacity: 4294967296",
+					Reason:             v1.PodReasonDeferred,
+					Message:            "Node didn't have enough resource: cpu, requested: 5000, used: 0, capacity: 4000",
 					ObservedGeneration: 2,
 				},
 				{

--- a/pkg/kubelet/allocation/handlers.go
+++ b/pkg/kubelet/allocation/handlers.go
@@ -24,7 +24,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	"k8s.io/kubernetes/pkg/api/v1/resource"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -97,25 +96,6 @@ func (h *podResizesAdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) life
 			metrics.PodInfeasibleResizes.WithLabelValues("guaranteed_pod_memory_manager_static_policy").Inc()
 			return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
 		}
-	}
-
-	allocatable := h.containerManager.GetNodeAllocatableAbsolute()
-	cpuAvailable := allocatable.Cpu().MilliValue()
-	memAvailable := allocatable.Memory().Value()
-	cpuRequests := resource.GetResourceRequest(pod, v1.ResourceCPU)
-	memRequests := resource.GetResourceRequest(pod, v1.ResourceMemory)
-
-	if cpuRequests > cpuAvailable || memRequests > memAvailable {
-		var msg string
-		if memRequests > memAvailable {
-			msg = fmt.Sprintf("memory, requested: %d, capacity: %d", memRequests, memAvailable)
-		} else {
-			msg = fmt.Sprintf("cpu, requested: %d, capacity: %d", cpuRequests, cpuAvailable)
-		}
-		msg = "Node didn't have enough capacity: " + msg
-		h.logger.V(3).Info(msg, "pod", klog.KObj(pod))
-		metrics.PodInfeasibleResizes.WithLabelValues("insufficient_node_allocatable").Inc()
-		return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
 	}
 
 	return lifecycle.PodAdmitResult{Admit: true}

--- a/plugin/pkg/admission/podresize/OWNERS
+++ b/plugin/pkg/admission/podresize/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-node-approvers
+reviewers:
+  - sig-node-reviewers
+labels:
+  - sig/node

--- a/plugin/pkg/admission/podresize/admission.go
+++ b/plugin/pkg/admission/podresize/admission.go
@@ -1,0 +1,215 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podresize
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/client-go/informers"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/component-base/featuregate"
+	"k8s.io/component-helpers/resource"
+	"k8s.io/kubernetes/pkg/apis/core"
+	v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+const (
+	// PluginName is the name of this admission controller plugin.
+	PluginName = "PodResizeValidator"
+
+	ReasonNodeCapacity        metav1.CauseType = "NodeCapacity"
+	ReasonUnsupportedPlatform metav1.CauseType = "UnsupportedPlatform"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewPlugin()
+	})
+}
+
+// Plugin is an admission controller that validates pod resize requests against the node's capabilities.
+type Plugin struct {
+	*admission.Handler
+	nodeLister                       corev1listers.NodeLister
+	inPlacePodVerticalScalingEnabled bool
+}
+
+var _ admission.ValidationInterface = &Plugin{}
+var _ = genericadmissioninitializer.WantsExternalKubeInformerFactory(&Plugin{})
+
+// New creates a new ResizeValidator admission plugin
+func NewPlugin() (*Plugin, error) {
+	return &Plugin{
+		Handler: admission.NewHandler(admission.Update),
+	}, nil
+}
+
+// SetExternalKubeInformerFactory sets the informer factory for the plugin.
+func (p *Plugin) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
+	nodeInformer := f.Core().V1().Nodes()
+	p.nodeLister = nodeInformer.Lister()
+	p.SetReadyFunc(nodeInformer.Informer().HasSynced)
+}
+
+// InspectFeatureGates sets the feature gates for the plugin.
+func (p *Plugin) InspectFeatureGates(featureGates featuregate.FeatureGate) {
+	p.inPlacePodVerticalScalingEnabled = featureGates.Enabled(features.InPlacePodVerticalScaling)
+}
+
+// ValidateInitialization ensures that the plugin is properly initialized.
+func (p *Plugin) ValidateInitialization() error {
+	if p.nodeLister == nil {
+		return fmt.Errorf("missing node lister for %s", PluginName)
+	}
+
+	return nil
+}
+
+// Validate is the core of the admission controller logic.
+func (p *Plugin) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	// Ignore if the feature gate is not enabled.
+	if !p.inPlacePodVerticalScalingEnabled {
+		return nil
+	}
+
+	if a.GetOperation() != admission.Update {
+		return nil
+	}
+
+	// We only care about Pod updates.
+	if a.GetResource().GroupResource() != core.Resource("pods") {
+		return nil
+	}
+
+	// Only validate updates to the custom "resize" subresource.
+	if a.GetSubresource() != "resize" {
+		return nil
+	}
+	pod, ok := a.GetObject().(*core.Pod)
+	if !ok {
+		return errors.NewBadRequest(fmt.Sprintf("expected a pod but got a %T", a.GetObject()))
+	}
+
+	// We only care about pods that are already bound to a node.
+	if len(pod.Spec.NodeName) == 0 {
+		return nil
+	}
+
+	oldPod, ok := a.GetOldObject().(*core.Pod)
+	if !ok {
+		return errors.NewBadRequest(fmt.Sprintf("expected an old pod but got a %T", a.GetOldObject()))
+	}
+
+	// Since generation is only incremented when the spec changes, we can skip validation if it doesnt.
+	if oldPod.Generation == pod.Generation {
+		return nil
+	}
+
+	if !p.WaitForReady() {
+		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+	}
+
+	return p.validatePodResize(pod, a)
+}
+
+func (p *Plugin) validatePodResize(pod *core.Pod, a admission.Attributes) error {
+	node, err := p.nodeLister.Get(pod.Spec.NodeName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return admission.NewForbidden(a, fmt.Errorf("node %q not found", pod.Spec.NodeName))
+		}
+		return admission.NewForbidden(a, fmt.Errorf("failed to get node %q: %w", pod.Spec.NodeName, err))
+	}
+
+	// If the node is not a linux node, reject the update.
+	if err := validateLinuxNode(node); err != nil {
+		return resizeValidationError(a, err, ReasonUnsupportedPlatform)
+	}
+
+	// If the new requests are larger than the node allocatable, reject the update.
+	if err := validateNodeAllocatable(pod, node); err != nil {
+		return resizeValidationError(a, err, ReasonNodeCapacity)
+	}
+
+	return nil
+}
+
+// Returns nil if the pod's resource requests fit within the node's allocatable, err otherwise.
+func validateNodeAllocatable(pod *core.Pod, node *corev1.Node) error {
+	// Convert internal to external pods for the helper library.
+	podV1 := &corev1.Pod{}
+	if err := v1.Convert_core_Pod_To_v1_Pod(pod, podV1, nil); err != nil {
+		return errors.NewBadRequest(fmt.Sprintf("failed to convert pod: %v", err))
+	}
+	return validateRequestsWithinAllocatable(podV1, node.Status.Allocatable)
+}
+
+// Returns nil if the node is a linux node, err otherwise.
+func validateLinuxNode(node *corev1.Node) error {
+	// This label should always be populated.
+	val, ok := node.Labels[corev1.LabelOSStable]
+	if !ok || val == "linux" {
+		return nil
+	}
+	return fmt.Errorf("pod resize is only supported on linux nodes, node %q is %q", node.Name, val)
+}
+
+func resizeValidationError(a admission.Attributes, err error, reason metav1.CauseType) error {
+	forbiddenErr := admission.NewForbidden(a, err)
+	var statusErr *errors.StatusError
+	if stderrors.As(forbiddenErr, &statusErr) {
+		statusErr.ErrStatus.Details.Causes = append(statusErr.ErrStatus.Details.Causes, metav1.StatusCause{
+			Type: reason,
+		})
+		return statusErr
+	}
+	return forbiddenErr
+}
+
+// validateRequestsWithinAllocatable returns an error if the pod requests exceed the allocatable
+// capacity.
+func validateRequestsWithinAllocatable(pod *corev1.Pod, allocatable corev1.ResourceList) error {
+	cpuAllocatable := allocatable.Cpu()
+	memAllocatable := allocatable.Memory()
+
+	requests := resource.PodRequests(pod, resource.PodResourcesOptions{})
+	cpuRequests := requests[corev1.ResourceCPU]
+	memRequests := requests[corev1.ResourceMemory]
+
+	var msg []string
+	if cpuRequests.Cmp(*cpuAllocatable) > 0 {
+		msg = append(msg, fmt.Sprintf("cpu, requested: %d, allocatable: %d", cpuRequests.MilliValue(), cpuAllocatable.MilliValue()))
+	}
+	if memRequests.Cmp(*memAllocatable) > 0 {
+		msg = append(msg, fmt.Sprintf("memory, requested: %d, allocatable: %d", memRequests.Value(), memAllocatable.Value()))
+	}
+	if len(msg) > 0 {
+		return fmt.Errorf("node didn't have enough allocatable resources: %s", strings.Join(msg, "; "))
+	}
+	return nil
+}

--- a/plugin/pkg/admission/podresize/admission_test.go
+++ b/plugin/pkg/admission/podresize/admission_test.go
@@ -1,0 +1,437 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podresize
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestResizeAdmission(t *testing.T) {
+	linuxNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "linux-node",
+			Labels: map[string]string{
+				corev1.LabelOSStable: "linux",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+	}
+
+	windowsNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "windows-node",
+			Labels: map[string]string{
+				corev1.LabelOSStable: "windows",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+	}
+
+	testPod := &core.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-pod",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: core.PodSpec{
+			NodeName: "linux-node",
+			Containers: []core.Container{
+				{
+					Name: "main",
+					Resources: core.ResourceRequirements{
+						Requests: core.ResourceList{
+							core.ResourceCPU:    resource.MustParse("1"),
+							core.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		subresource string
+		nodeName    string
+		oldPod      *core.Pod
+		newPod      func() *core.Pod
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:        "Successful cpu resize on Linux node",
+			subresource: "resize",
+			nodeName:    "linux-node",
+			oldPod:      testPod,
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Generation = 2
+				p.Spec.Containers[0].Resources.Requests[core.ResourceCPU] = resource.MustParse("2")
+				return p
+			},
+			expectErr: false,
+		},
+		{
+			name:        "Successful memory resize on Linux node",
+			subresource: "resize",
+			nodeName:    "linux-node",
+			oldPod:      testPod,
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Generation = 2
+				p.Spec.Containers[0].Resources.Requests[core.ResourceMemory] = resource.MustParse("2Gi")
+				return p
+			},
+			expectErr: false,
+		},
+		{
+			name:        "Skip validation if not resize subresource",
+			subresource: "",
+			nodeName:    "linux-node",
+			oldPod:      testPod,
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Generation = 2
+				p.Spec.Containers[0].Resources.Requests[core.ResourceCPU] = resource.MustParse("10") // Would fail if checked
+				return p
+			},
+			expectErr: false,
+		},
+		{
+			name:        "Skip validation if generation is unchanged",
+			subresource: "",
+			nodeName:    "linux-node",
+			oldPod:      testPod,
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Generation = 1
+				p.Spec.Containers[0].Resources.Requests[core.ResourceCPU] = resource.MustParse("10") // Would fail if checked
+				return p
+			},
+			expectErr: false,
+		},
+		{
+			name:        "Skip validation if pod not bound to a node",
+			subresource: "resize",
+			nodeName:    "",
+			oldPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Spec.NodeName = ""
+				return p
+			}(),
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Spec.NodeName = ""
+				p.Generation = 2
+				p.Spec.Containers[0].Resources.Requests[core.ResourceCPU] = resource.MustParse("10")
+				return p
+			},
+			expectErr: false,
+		},
+		{
+			name:        "Reject resize exceeding CPU allocatable",
+			subresource: "resize",
+			nodeName:    "linux-node",
+			oldPod:      testPod,
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Generation = 2
+				p.Spec.Containers[0].Resources.Requests[core.ResourceCPU] = resource.MustParse("10")
+				return p
+			},
+			expectErr:   true,
+			errContains: "node didn't have enough allocatable resources: cpu",
+		},
+		{
+			name:        "Reject resize exceeding memory allocatable",
+			subresource: "resize",
+			nodeName:    "linux-node",
+			oldPod:      testPod,
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Generation = 2
+				p.Spec.Containers[0].Resources.Requests[core.ResourceMemory] = resource.MustParse("10Gi")
+				return p
+			},
+			expectErr:   true,
+			errContains: "node didn't have enough allocatable resources: memory",
+		},
+		{
+			name:        "Reject resize exceeding both CPU and memory allocatable",
+			subresource: "resize",
+			nodeName:    "linux-node",
+			oldPod:      testPod,
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Generation = 2
+				p.Spec.Containers[0].Resources.Requests[core.ResourceCPU] = resource.MustParse("10")
+				p.Spec.Containers[0].Resources.Requests[core.ResourceMemory] = resource.MustParse("10Gi")
+				return p
+			},
+			expectErr:   true,
+			errContains: "node didn't have enough allocatable resources",
+		},
+		{
+			name:        "Reject resize on non-Linux node",
+			subresource: "resize",
+			nodeName:    "windows-node",
+			oldPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Spec.NodeName = "windows-node"
+				return p
+			}(),
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Spec.NodeName = "windows-node"
+				p.Generation = 2
+				p.Spec.Containers[0].Resources.Requests[core.ResourceCPU] = resource.MustParse("2")
+				return p
+			},
+			expectErr:   true,
+			errContains: "pod resize is only supported on linux nodes",
+		},
+		{
+			name:        "Reject if node not found",
+			subresource: "resize",
+			nodeName:    "missing-node",
+			oldPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Spec.NodeName = "missing-node"
+				return p
+			}(),
+			newPod: func() *core.Pod {
+				p := testPod.DeepCopy()
+				p.Spec.NodeName = "missing-node"
+				p.Generation = 2
+				return p
+			},
+			expectErr:   true,
+			errContains: "node \"missing-node\" not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(linuxNode, windowsNode)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+			plugin, err := NewPlugin()
+			require.NoError(t, err)
+			plugin.SetExternalKubeInformerFactory(informerFactory)
+			plugin.inPlacePodVerticalScalingEnabled = true
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
+
+			newPodObj := tc.newPod()
+			attrs := admission.NewAttributesRecord(
+				newPodObj,
+				tc.oldPod,
+				core.Kind("Pod").WithVersion("v1"),
+				newPodObj.Namespace,
+				newPodObj.Name,
+				core.Resource("pods").WithVersion("v1"),
+				tc.subresource,
+				admission.Update,
+				&metav1.UpdateOptions{},
+				false,
+				nil,
+			)
+
+			err = plugin.Validate(context.Background(), attrs, nil)
+
+			if tc.expectErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateRequestsWithinAllocatable(t *testing.T) {
+	testCases := []struct {
+		name        string
+		pod         *corev1.Pod
+		allocatable corev1.ResourceList
+		expectedErr bool
+		expectedMsg string
+	}{
+		{
+			name: "cpu and mem requests within allocatable",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+			expectedErr: false,
+		},
+		{
+			name: "cpu exceeds allocatable",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("500m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("200m"),
+			},
+			expectedErr: true,
+			expectedMsg: "cpu, requested: 500, allocatable: 200",
+		},
+		{
+			name: "mem exceeds allocatable",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("500Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			allocatable: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			expectedErr: true,
+			// 500Mi = 524288000 bytes, 256Mi = 268435456 bytes
+			expectedMsg: "memory, requested: 524288000, allocatable: 268435456",
+		},
+		{
+			name: "cpu and mem alone are within allocatable, but overhead causes failure",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Overhead: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("150m"),
+									corev1.ResourceMemory: resource.MustParse("150Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+			expectedErr: true,
+			// CPU: 150m + 100m = 250m. Mem: 150Mi + 100Mi = 250Mi (262144000 bytes)
+			expectedMsg: "cpu, requested: 250, allocatable: 200",
+		},
+		{
+			name: "pod level resources override container requests and fit",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("100m"),
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1000m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("200m"),
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRequestsWithinAllocatable(tc.pod, tc.allocatable)
+
+			if (err != nil) != tc.expectedErr {
+				t.Fatalf("ValidateRequestsWithinAllocatable() error = %v, expectedErr %v", err, tc.expectedErr)
+			}
+
+			if tc.expectedErr && err != nil {
+				if !strings.Contains(err.Error(), tc.expectedMsg) {
+					t.Errorf("ValidateRequestsWithinAllocatable() error message = %q, expected to contain %q", err.Error(), tc.expectedMsg)
+				}
+			}
+		})
+	}
+}

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -25,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -674,13 +676,17 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 		ginkgo.By(fmt.Sprintf("TEST3: Resize pod '%s' to exceed the node capacity", testPod1.Name))
-		testPod1, p1Err = f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
+		_, p1Err = f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
 			testPod1.Name, types.StrategicMergePatchType, []byte(patchTestpod1ExceedNodeAllocatable), metav1.PatchOptions{}, "resize")
-		framework.ExpectNoError(p1Err, "failed to patch pod for resize")
-		gomega.Expect(testPod1.Generation).To(gomega.BeEquivalentTo(4))
-		framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, testPod1.Namespace, testPod1.Name, "display pod resize status as infeasible", f.Timeouts.PodStart, func(pod *v1.Pod) (bool, error) {
-			return helpers.IsPodResizeInfeasible(pod), nil
-		}))
+
+		gomega.Expect(p1Err).To(gomega.HaveOccurred(), "expected patching pod to fail due to exceeding node allocatable")
+
+		var statusErr *apierrors.StatusError
+		gomega.Expect(errors.As(p1Err, &statusErr)).To(gomega.BeTrueBecause("Expected error to be a StatusError, but got: %v", p1Err))
+
+		gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonForbidden))
+		gomega.Expect(statusErr.Error()).To(gomega.ContainSubstring("node didn't have enough allocatable resources"))
+		gomega.Expect(statusErr.ErrStatus.Details.Causes[0].Type).To(gomega.Equal(metav1.CauseType("NodeCapacity")))
 
 		ginkgo.By("deleting pod 1")
 		delErr1 := e2epod.DeletePodWithWait(ctx, f.ClientSet, testPod1)

--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -18,6 +18,7 @@ package pods
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -1587,6 +1589,14 @@ func TestNodeDeclaredFeatureAdmission(t *testing.T) {
 				Status: v1.NodeStatus{
 					NodeInfo:         v1.NodeSystemInfo{KubeletVersion: tc.nodeVersion},
 					DeclaredFeatures: tc.nodeDeclaredFeatures,
+					Allocatable: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("12"),
+						v1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+					Capacity: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("12"),
+						v1.ResourceMemory: resource.MustParse("8Gi"),
+					},
 				},
 			}
 			_, err := client.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
@@ -1625,6 +1635,128 @@ func TestNodeDeclaredFeatureAdmission(t *testing.T) {
 					t.Errorf("Expected error containing %q, but got no error", tc.expectError)
 				} else if !strings.Contains(err.Error(), tc.expectError) {
 					t.Errorf("Expected error containing %q, but got: %v", tc.expectError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestPodResizeValidation(t *testing.T) {
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	defer server.TearDownFn()
+	client := clientset.NewForConfigOrDie(server.ClientConfig)
+	ns := framework.CreateNamespaceOrDie(client, "pod-resize-validation", t)
+	defer framework.DeleteNamespaceOrDie(client, ns, t)
+
+	ctx := context.Background()
+
+	createNode := func(name string, os string, cpu string, mem string) {
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					v1.LabelOSStable: os,
+				},
+			},
+			Status: v1.NodeStatus{
+				Allocatable: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse(cpu),
+					v1.ResourceMemory: resource.MustParse(mem),
+				},
+			},
+		}
+		if _, err := client.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create node %s: %v", name, err)
+		}
+	}
+
+	createNode("linux-node-small", "linux", "2", "2Gi")
+	createNode("windows-node", "windows", "8", "16Gi")
+
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-pod-",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "c1",
+					Image: "pause",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("500m"),
+							v1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		targetNode      string
+		resizeCPU       string
+		expectError     string
+		expectCauseType string
+	}{
+		{
+			name:       "valid resize on linux node",
+			targetNode: "linux-node-small",
+			resizeCPU:  "1",
+		},
+		{
+			name:            "fail resize exceeding node allocatable",
+			targetNode:      "linux-node-small",
+			resizeCPU:       "4", // Node only has 2
+			expectError:     "node didn't have enough allocatable resources: cpu",
+			expectCauseType: "NodeCapacity",
+		},
+		{
+			name:            "fail resize on non-linux node",
+			targetNode:      "windows-node",
+			resizeCPU:       "1",
+			expectError:     "pod resize is only supported on linux nodes",
+			expectCauseType: "UnsupportedPlatform",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := testPod.DeepCopy()
+			p.Spec.NodeName = tc.targetNode
+			pod, err := client.CoreV1().Pods(ns.Name).Create(ctx, p, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Error creating pod: %v", err)
+			}
+			defer func() {
+				err := client.CoreV1().Pods(ns.Name).Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{})
+				if err != nil {
+					t.Logf("Failed to delete pod %s: %v", testPod.Name, err)
+				}
+			}()
+
+			pod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU] = resource.MustParse(tc.resizeCPU)
+			_, err = client.CoreV1().Pods(ns.Name).UpdateResize(ctx, pod.Name, pod, metav1.UpdateOptions{})
+
+			if tc.expectError == "" {
+				if err != nil {
+					t.Errorf("Expected success, got error: %v", err)
+				}
+			} else if err == nil {
+				t.Error("Expected error but got success")
+			} else if !strings.Contains(err.Error(), tc.expectError) {
+				t.Errorf("Expected error containing %q, got: %v", tc.expectError, err)
+			} else {
+				var statusErr *apierrors.StatusError
+				if !errors.As(err, &statusErr) {
+					t.Errorf("Expected a StatusError, got: %v", err)
+				}
+				if len(statusErr.ErrStatus.Details.Causes) == 0 {
+					t.Errorf("Expected error causes, but got none")
+				}
+				if tc.expectCauseType != string(statusErr.ErrStatus.Details.Causes[0].Type) {
+					t.Errorf("Expected cause type %q, got: %v", tc.expectCauseType, statusErr.ErrStatus.Details.Causes[0].Type)
 				}
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

Create an admission plugin to perform the OS and node capacity checks for pod resizes. This is an optimization to fail faster when we know the resize won't succeed. More details are in https://github.com/kubernetes/kubernetes/issues/135341. 

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/135341

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
For pod resizes requested on nodes where the resize request exceeds the node's allocatable capacity or the node is running an OS that does not support resize, the request will now fail in admission rather than be marked as Infeasible in the pod status later. 
```

/hold
for alignment with https://github.com/kubernetes/autoscaler/pull/8818

/sig node
/assign @tallclair 
