### PR TITLE
added API Version and Kind in /configz serailized objects

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/cobra"
+
 	coordinationv1 "k8s.io/api/coordination/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,10 +77,12 @@ import (
 	"k8s.io/controller-manager/pkg/informerfactory"
 	"k8s.io/controller-manager/pkg/leadermigration"
 	"k8s.io/klog/v2"
+	configv1alpha1 "k8s.io/kube-controller-manager/config/v1alpha1"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
+	configv1alpha1conversion "k8s.io/kubernetes/pkg/controller/apis/config/v1alpha1"
 	garbagecollector "k8s.io/kubernetes/pkg/controller/garbagecollector"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 )
@@ -196,10 +199,16 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 	c.EventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.Client.CoreV1().Events("")})
 	defer c.EventBroadcaster.Shutdown()
 
-	if cfgz, err := configz.New(ConfigzName); err == nil {
-		cfgz.Set(c.ComponentConfig)
-	} else {
-		logger.Error(err, "Unable to register configz")
+	externalConfig := &configv1alpha1.KubeControllerManagerConfiguration{}
+	if err := configv1alpha1conversion.Convert_config_KubeControllerManagerConfiguration_To_v1alpha1_KubeControllerManagerConfiguration(&c.ComponentConfig, externalConfig, nil); err != nil {
+		return fmt.Errorf("unable to convert configz: %w", err)
+	}
+	externalConfig.SetGroupVersionKind(configv1alpha1.SchemeGroupVersion.WithKind("KubeControllerManagerConfiguration"))
+
+	if cfgz, err := configz.New(ConfigzName); err != nil {
+		return fmt.Errorf("unable to register configz: %w", err)
+	} else if err := cfgz.Set(externalConfig); err != nil {
+		return fmt.Errorf("unable to set configz: %w", err)
 	}
 
 	// Setup any healthz checks we will want to use.

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -30,6 +30,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/component-base/compatibility"
+	"k8s.io/component-base/configz"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	logsapi "k8s.io/component-base/logs/api/v1"
@@ -78,6 +79,7 @@ func StartTestServer(t *testing.T, ctx context.Context, customFlags []string) (r
 				logger.Error(err, "Failed to shutdown test server cleanly")
 			}
 		}
+		configz.Delete(app.ConfigzName)
 	}
 	defer func() {
 		if result.TearDownFn == nil {

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -65,12 +65,14 @@ import (
 	zpagesfeatures "k8s.io/component-base/zpages/features"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
+	configv1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/proxy/apis"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	proxyconfigscheme "k8s.io/kubernetes/pkg/proxy/apis/config/scheme"
+	v1alpha1conversion "k8s.io/kubernetes/pkg/proxy/apis/config/v1alpha1"
 	"k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	proxymetrics "k8s.io/kubernetes/pkg/proxy/metrics"
@@ -186,11 +188,19 @@ func newProxyServer(ctx context.Context, config *kubeproxyconfig.KubeProxyConfig
 		flagz:  flagzReader,
 	}
 
+	externalConfig := &configv1alpha1.KubeProxyConfiguration{}
+	if err := v1alpha1conversion.Convert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(config, externalConfig, nil); err != nil {
+		return nil, fmt.Errorf("unable to convert configz: %w", err)
+	}
+	externalConfig.SetGroupVersionKind(configv1alpha1.SchemeGroupVersion.WithKind("KubeProxyConfiguration"))
+
 	cz, err := configz.New(kubeproxyconfig.GroupName)
 	if err != nil {
-		return nil, fmt.Errorf("unable to register configz: %s", err)
+		return nil, fmt.Errorf("unable to register configz: %w", err)
 	}
-	cz.Set(config)
+	if err := cz.Set(externalConfig); err != nil {
+		return nil, fmt.Errorf("unable to set configz: %w", err)
+	}
 
 	if len(config.ShowHiddenMetricsForVersion) > 0 {
 		metrics.SetShowHidden()

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -18,8 +18,10 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -27,9 +29,12 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/server/statusz"
 	"k8s.io/apiserver/pkg/util/compatibility"
+	"k8s.io/component-base/configz"
+	kubeproxyconfigv1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
 
 	v1 "k8s.io/api/core/v1"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
@@ -642,5 +647,65 @@ func TestStatuszRegistryReceivesListedPaths(t *testing.T) {
 	if !wantSet.Equal(gotSet) {
 		t.Errorf("statusz listed paths mismatch.\nwant: %v\ngot:  %v\nbody:\n%s",
 			wantSet.UnsortedList(), gotSet.UnsortedList(), body)
+	}
+}
+
+func TestConfigz(t *testing.T) {
+	configz.Delete(kubeproxyconfig.GroupName)
+	cz, err := configz.New(kubeproxyconfig.GroupName)
+	if err != nil {
+		t.Fatalf("unable to register configz: %v", err)
+	}
+	defer configz.Delete(kubeproxyconfig.GroupName)
+
+	externalConfig := &kubeproxyconfigv1alpha1.KubeProxyConfiguration{}
+	externalConfig.SetGroupVersionKind(kubeproxyconfigv1alpha1.SchemeGroupVersion.WithKind("KubeProxyConfiguration"))
+	if err := cz.Set(externalConfig); err != nil {
+		t.Fatalf("unable to set configz: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	configz.InstallHandler(mux)
+	s := httptest.NewServer(mux)
+	defer s.Close()
+
+	resp, err := http.Get(s.URL + "/configz")
+	if err != nil {
+		t.Fatalf("unable to GET /configz: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %v", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want status 200, got %d", resp.StatusCode)
+	}
+
+	var configzResp map[string]unstructured.Unstructured
+	if err := json.Unmarshal(body, &configzResp); err != nil {
+		t.Fatalf("failed to unmarshal configz: %v", err)
+	}
+	cfg, ok := configzResp[kubeproxyconfig.GroupName]
+	if !ok {
+		t.Fatalf("configz missing %q key", kubeproxyconfig.GroupName)
+	}
+	if cfg.GetAPIVersion() != "kubeproxy.config.k8s.io/v1alpha1" {
+		t.Errorf("unexpected APIVersion: %s", cfg.GetAPIVersion())
+	}
+	if cfg.GetKind() != "KubeProxyConfiguration" {
+		t.Errorf("unexpected Kind: %s", cfg.GetKind())
+	}
+
+	// confirm that they expose public config type
+	var proxyConfig kubeproxyconfigv1alpha1.KubeProxyConfiguration
+	err = json.Unmarshal(body, &struct {
+		ComponentConfig *kubeproxyconfigv1alpha1.KubeProxyConfiguration `json:"kubeproxy.config.k8s.io"`
+	}{ComponentConfig: &proxyConfig})
+	if err != nil {
+		t.Errorf("failed to deserialize into public config type: %v", err)
 	}
 }

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/cobra"
+
 	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -63,12 +64,14 @@ import (
 	"k8s.io/component-base/version/verflag"
 	zpagesfeatures "k8s.io/component-base/zpages/features"
 	"k8s.io/klog/v2"
+	configv1 "k8s.io/kube-scheduler/config/v1"
 	schedulerserverconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app/options"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
+	conversionv1 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/metrics/resources"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
@@ -176,11 +179,17 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 
 	logger.Info("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
 
+	externalConfig := &configv1.KubeSchedulerConfiguration{}
+	if err := conversionv1.Convert_config_KubeSchedulerConfiguration_To_v1_KubeSchedulerConfiguration(&cc.ComponentConfig, externalConfig, nil); err != nil {
+		return fmt.Errorf("unable to convert configz: %w", err)
+	}
+	externalConfig.SetGroupVersionKind(configv1.SchemeGroupVersion.WithKind("KubeSchedulerConfiguration"))
+
 	// Configz registration.
 	if cz, err := configz.New("componentconfig"); err != nil {
-		return fmt.Errorf("unable to register configz: %s", err)
-	} else {
-		cz.Set(cc.ComponentConfig)
+		return fmt.Errorf("unable to register configz: %w", err)
+	} else if err := cz.Set(externalConfig); err != nil {
+		return fmt.Errorf("unable to set configz: %w", err)
 	}
 
 	// Start events processing pipeline.

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -557,12 +557,12 @@ func setConfigz(cz *configz.Config, kc *kubeletconfiginternal.KubeletConfigurati
 	if err != nil {
 		return err
 	}
-	versioned := kubeletconfigv1beta1.KubeletConfiguration{}
-	if err := scheme.Convert(kc, &versioned, nil); err != nil {
+	versioned := &kubeletconfigv1beta1.KubeletConfiguration{}
+	if err := scheme.Convert(kc, versioned, nil); err != nil {
 		return err
 	}
-	cz.Set(versioned)
-	return nil
+	versioned.GetObjectKind().SetGroupVersionKind(kubeletconfigv1beta1.SchemeGroupVersion.WithKind("KubeletConfiguration"))
+	return cz.Set(versioned)
 }
 
 func initConfigz(ctx context.Context, kc *kubeletconfiginternal.KubeletConfiguration) error {

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -39,6 +40,9 @@ import (
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/component-base/configz"
+	"k8s.io/kubelet/config/v1beta1"
 	"k8s.io/utils/ptr"
 
 	v1 "k8s.io/api/core/v1"
@@ -572,6 +576,69 @@ func TestStatusz(t *testing.T) {
 	reg := regexp.MustCompile(`Paths([:=\s]+)/configz /debug /healthz /metrics\n$`)
 	if reg.FindStringSubmatch(string(resBody)) == nil {
 		t.Errorf("statusz paths missing: %s\n\nExpected: %q", string(resBody), "Paths<delimter> /configz /debug /healthz /metrics")
+	}
+}
+
+func TestConfigz(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	configz.Delete("kubeletconfig")
+	cz, err := configz.New("kubeletconfig")
+	if err != nil {
+		t.Fatalf("unable to register configz: %v", err)
+	}
+	defer configz.Delete("kubeletconfig")
+	kc := &v1beta1.KubeletConfiguration{}
+	kc.TypeMeta.APIVersion = "kubelet.config.k8s.io/v1beta1"
+	kc.TypeMeta.Kind = "KubeletConfiguration"
+	if err := cz.Set(kc); err != nil {
+		t.Fatalf("unable to set configz: %v", err)
+	}
+
+	fw := newServerTest(tCtx)
+	defer fw.testHTTPServer.Close()
+
+	req, err := http.NewRequest(http.MethodGet, fw.testHTTPServer.URL+"/configz", nil)
+	if err != nil {
+		t.Fatalf("Got error creating request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Got error GETing: %v", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Got error reading response body: %v", err)
+	}
+
+	var configz map[string]unstructured.Unstructured
+	if err := json.Unmarshal(body, &configz); err != nil {
+		t.Fatalf("failed to unmarshal configz: %v", err)
+	}
+	cfg, ok := configz["kubeletconfig"]
+	if !ok {
+		t.Fatalf("configz missing 'kubeletconfig' key")
+	}
+	if cfg.GetAPIVersion() != "kubelet.config.k8s.io/v1beta1" {
+		t.Errorf("unexpected APIVersion: %s", cfg.GetAPIVersion())
+	}
+	if cfg.GetKind() != "KubeletConfiguration" {
+		t.Errorf("unexpected Kind: %s", cfg.GetKind())
+	}
+
+	// confirm that they expose public config type
+	var kubeletConfig v1beta1.KubeletConfiguration
+	err = json.Unmarshal(body, &struct {
+		ComponentConfig *v1beta1.KubeletConfiguration `json:"kubeletconfig"`
+	}{ComponentConfig: &kubeletConfig})
+	if err != nil {
+		t.Errorf("failed to deserialize into public config type: %v", err)
 	}
 }
 

--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	cloudprovider "k8s.io/cloud-provider"
 	cloudcontrollerconfig "k8s.io/cloud-provider/app/config"
+	configv1alpha "k8s.io/cloud-provider/config/v1alpha1"
 	"k8s.io/cloud-provider/names"
 	"k8s.io/cloud-provider/options"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -164,11 +165,17 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 	c.EventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.Client.CoreV1().Events("")})
 	defer c.EventBroadcaster.Shutdown()
 
+	externalConfig := &configv1alpha.CloudControllerManagerConfiguration{}
+	if err := configv1alpha.Convert_config_CloudControllerManagerConfiguration_To_v1alpha1_CloudControllerManagerConfiguration(&c.ComponentConfig, externalConfig, nil); err != nil {
+		return fmt.Errorf("unable to convert configz: %w", err)
+	}
+	externalConfig.SetGroupVersionKind(configv1alpha.SchemeGroupVersion.WithKind("CloudControllerManagerConfiguration"))
+
 	// setup /configz endpoint
-	if cz, err := configz.New(ConfigzName); err == nil {
-		cz.Set(c.ComponentConfig)
-	} else {
-		klog.Errorf("unable to register configz: %v", err)
+	if cz, err := configz.New(ConfigzName); err != nil {
+		return fmt.Errorf("unable to register configz: %w", err)
+	} else if err := cz.Set(externalConfig); err != nil {
+		return fmt.Errorf("unable to set configz: %w", err)
 	}
 
 	// Setup any health checks we will want to use.

--- a/staging/src/k8s.io/cloud-provider/app/testing/testserver.go
+++ b/staging/src/k8s.io/cloud-provider/app/testing/testserver.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/cloud-provider/names"
 	"k8s.io/cloud-provider/options"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/configz"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 )
@@ -99,6 +100,7 @@ func StartTestServerWithOptions(t *testing.T,
 				klog.Errorf("Failed to shutdown test server clearly: %v", err)
 			}
 		}
+		configz.Delete(app.ConfigzName)
 	}
 	defer func() {
 		if result.TearDownFn == nil {

--- a/staging/src/k8s.io/component-base/configz/configz.go
+++ b/staging/src/k8s.io/component-base/configz/configz.go
@@ -20,23 +20,34 @@ limitations under the License.
 // object, and the program should call InstallHandler once. e.g.,
 //
 //	func main() {
+//		if err := setupConfigz(); err != nil {
+//			klog.Fatalf("Failed to setup configz: %v", err)
+//		}
+//		http.ListenAndServe(":8080", http.DefaultServeMux)
+//	}
+//
+//	func setupConfigz() error {
 //		boatConfig := getBoatConfig()
 //		planeConfig := getPlaneConfig()
 //
 //		bcz, err := configz.New("boat")
 //		if err != nil {
-//			panic(err)
+//			return fmt.Errorf("unable to register boat config: %w", err)
 //		}
-//		bcz.Set(boatConfig)
+//		if err := bcz.Set(boatConfig); err != nil {
+//			return fmt.Errorf("unable to set boat config: %w", err)
+//		}
 //
 //		pcz, err := configz.New("plane")
 //		if err != nil {
-//			panic(err)
+//			return fmt.Errorf("unable to register plane config: %w", err)
 //		}
-//		pcz.Set(planeConfig)
+//		if err := pcz.Set(planeConfig); err != nil {
+//			return fmt.Errorf("unable to set plane config: %w", err)
+//		}
 //
 //		configz.InstallHandler(http.DefaultServeMux)
-//		http.ListenAndServe(":8080", http.DefaultServeMux)
+//		return nil
 //	}
 package configz
 
@@ -45,6 +56,8 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const DefaultConfigzPath = "/configz"
@@ -57,7 +70,7 @@ var (
 // Config is a handle to a ComponentConfig object. Don't create these directly;
 // use New() instead.
 type Config struct {
-	val interface{}
+	val runtime.Object
 }
 
 // InstallHandler adds an HTTP handler on the given mux for the "/configz"
@@ -92,10 +105,24 @@ func Delete(name string) {
 }
 
 // Set sets the ComponentConfig for this Config.
-func (v *Config) Set(val interface{}) {
+func (v *Config) Set(val runtime.Object) error {
 	configsGuard.Lock()
 	defer configsGuard.Unlock()
+	if val == nil {
+		return fmt.Errorf("val may not be nil")
+	}
+	gvk := val.GetObjectKind().GroupVersionKind()
+	if len(gvk.Kind) == 0 {
+		return fmt.Errorf("val must specify a kind")
+	}
+	if gvk.GroupVersion().Empty() {
+		return fmt.Errorf("val must specify a group/version")
+	}
+	if gvk.Version == runtime.APIVersionInternal {
+		return fmt.Errorf("val must specify an external version")
+	}
 	v.val = val
+	return nil
 }
 
 // MarshalJSON marshals the ComponentConfig as JSON data.

--- a/staging/src/k8s.io/component-base/configz/configz_test.go
+++ b/staging/src/k8s.io/component-base/configz/configz_test.go
@@ -20,7 +20,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestConfigz(t *testing.T) {
@@ -29,7 +33,9 @@ func TestConfigz(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	v.Set("blah")
+	if err := v.Set(&unstructured.Unstructured{Object: map[string]any{"apiVersion": "example.com/v1", "kind": "Blah"}}); err != nil {
+		t.Fatal(err)
+	}
 
 	s := httptest.NewServer(http.HandlerFunc(handle))
 	defer s.Close()
@@ -43,11 +49,13 @@ func TestConfigz(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if string(body) != `{"testing":"blah"}` {
+	if string(body) != `{"testing":{"apiVersion":"example.com/v1","kind":"Blah"}}` {
 		t.Fatalf("unexpected output: %s", body)
 	}
 
-	v.Set("bing")
+	if err := v.Set(&unstructured.Unstructured{Object: map[string]any{"apiVersion": "example.com/v1", "kind": "Bing"}}); err != nil {
+		t.Fatal(err)
+	}
 	resp, err = http.Get(s.URL + "/configz")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -57,7 +65,7 @@ func TestConfigz(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if string(body) != `{"testing":"bing"}` {
+	if string(body) != `{"testing":{"apiVersion":"example.com/v1","kind":"Bing"}}` {
 		t.Fatalf("unexpected output: %s", body)
 	}
 
@@ -76,5 +84,113 @@ func TestConfigz(t *testing.T) {
 	}
 	if resp.Header.Get("Content-Type") != "application/json" {
 		t.Fatalf("unexpected Content-Type: %s", resp.Header.Get("Content-Type"))
+	}
+}
+
+func TestConfigzWithAPIVersionAndKind(t *testing.T) {
+	cfg := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "test.k8s.io/v1",
+			"kind":       "TestConfig",
+			"value":      "test-value",
+		},
+	}
+
+	v, err := New("testobj")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if err := v.Set(cfg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(handle))
+	defer s.Close()
+
+	resp, err := http.Get(s.URL + "/configz")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	expected := `{"testobj":{"apiVersion":"test.k8s.io/v1","kind":"TestConfig","value":"test-value"}}`
+	if string(body) != expected {
+		t.Fatalf("unexpected output: %s, expected: %s", body, expected)
+	}
+
+	Delete("testobj")
+}
+
+func TestConfigzErrors(t *testing.T) {
+	v, err := New("errors")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer Delete("errors")
+
+	tests := []struct {
+		name     string
+		obj      runtime.Object
+		expected string
+	}{
+		{
+			name:     "nil",
+			obj:      nil,
+			expected: "val may not be nil",
+		},
+		{
+			name:     "empty kind",
+			obj:      &unstructured.Unstructured{Object: map[string]any{"apiVersion": "example.com/v1"}},
+			expected: "val must specify a kind",
+		},
+		{
+			name:     "empty version",
+			obj:      &unstructured.Unstructured{Object: map[string]any{"kind": "Blah"}},
+			expected: "val must specify a group/version",
+		},
+		{
+			name:     "internal version",
+			obj:      &unstructured.Unstructured{Object: map[string]any{"apiVersion": "__internal", "kind": "Blah"}},
+			expected: "val must specify an external version",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := v.Set(test.obj)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if err.Error() != test.expected {
+				t.Fatalf("expected error %q, got %q", test.expected, err.Error())
+			}
+		})
+	}
+}
+
+func TestDuplicateNew(t *testing.T) {
+	name := "duplicate"
+	v1, err := New(name)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if v1 == nil {
+		t.Fatalf("expected non-nil config")
+	}
+	defer Delete(name)
+
+	v2, err := New(name)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if v2 != nil {
+		t.Fatalf("expected nil config, got %v", v2)
+	}
+	if !strings.Contains(err.Error(), "register config \"duplicate\" twice") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }

--- a/test/e2e_node/endpoints_test.go
+++ b/test/e2e_node/endpoints_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"k8s.io/kubernetes/pkg/cluster/ports"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+// configzWrapper is a wrapper for the KubeletConfiguration returned by the /configz endpoint.
+type configzWrapper struct {
+	ComponentConfig kubeletconfigv1beta1.KubeletConfiguration `json:"kubeletconfig"`
+}
+
+// getKubeletConfigz fetches and decodes the kubelet's configuration from the /configz endpoint.
+func getKubeletConfigz(ctx context.Context) (*configzWrapper, error) {
+	endpoint := fmt.Sprintf("https://127.0.0.1:%d/configz", ports.KubeletPort)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", framework.TestContext.BearerToken))
+	req.Header.Add("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			framework.Logf("Error closing response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("/configz response status not 200, was: %d", resp.StatusCode)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	configz := &configzWrapper{}
+	err = json.Unmarshal(respBody, configz)
+	if err != nil {
+		return nil, err
+	}
+	return configz, nil
+}
+
+// Serial because it has a test case for config reloading and kubelet restart.
+var _ = SIGDescribe("Kubelet Endpoints", framework.WithNodeConformance(), framework.WithSerial(), func() {
+	f := framework.NewDefaultFramework("kubelet-endpoints-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.It("should return APIVersion and Kind fields in /configz", func(ctx context.Context) {
+		var configz *configzWrapper
+		ginkgo.By("getting initial /configz")
+		gomega.Eventually(ctx, func(ctx context.Context) error {
+			var err error
+			configz, err = getKubeletConfigz(ctx)
+			return err
+		}, 1*time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+		gomega.Expect(configz.ComponentConfig.APIVersion).To(gomega.Equal("kubelet.config.k8s.io/v1beta1"))
+		gomega.Expect(configz.ComponentConfig.Kind).To(gomega.Equal("KubeletConfiguration"))
+	})
+
+	ginkgo.Context("when config is updated", func() {
+		var newFileCheckFrequency metav1.Duration
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			newFileCheckFrequency = metav1.Duration{Duration: 30 * time.Second}
+			initialConfig.FileCheckFrequency = newFileCheckFrequency // this is just a sample field. Any other field would do here for a test.
+		})
+
+		ginkgo.It("should be reflected in /configz", func(ctx context.Context) {
+			ginkgo.By("waiting for the updated /configz to be reflected")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				resp, err := getKubeletConfigz(ctx)
+				if err != nil {
+					return err
+				}
+				updatedConfig := &resp.ComponentConfig
+				if updatedConfig.FileCheckFrequency != newFileCheckFrequency {
+					return fmt.Errorf("config not yet reflected, expected %v, got %v", newFileCheckFrequency, updatedConfig.FileCheckFrequency)
+				}
+				return nil
+			}, 1*time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+			ginkgo.By("getting updated /configz")
+			resp, err := getKubeletConfigz(ctx)
+			framework.ExpectNoError(err)
+			updatedConfig := &resp.ComponentConfig
+
+			gomega.Expect(updatedConfig.APIVersion).To(gomega.Equal("kubelet.config.k8s.io/v1beta1"))
+			gomega.Expect(updatedConfig.Kind).To(gomega.Equal("KubeletConfiguration"))
+			gomega.Expect(updatedConfig.FileCheckFrequency).To(gomega.Equal(newFileCheckFrequency))
+		})
+	})
+})

--- a/test/integration/scheduler/serving/endpoints_test.go
+++ b/test/integration/scheduler/serving/endpoints_test.go
@@ -19,6 +19,7 @@ package serving
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,6 +30,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiserverfeat "k8s.io/apiserver/pkg/features"
 	flagzv1alpha1 "k8s.io/apiserver/pkg/server/flagz/api/v1alpha1"
 	flagzv1beta1 "k8s.io/apiserver/pkg/server/flagz/api/v1beta1"
@@ -41,6 +43,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/zpages/features"
 	"k8s.io/klog/v2/ktesting"
+	kubeschedulerconfigv1 "k8s.io/kube-scheduler/config/v1"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	kubeschedulertesting "k8s.io/kubernetes/cmd/kube-scheduler/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
@@ -234,7 +237,7 @@ func TestSchedulerZPages(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	result, err := kubeschedulertesting.StartTestServer(
 		t, ctx,
-		[]string{"--kubeconfig", apiserverConfig.Name(), "--leader-elect=false", "--authorization-always-allow-paths=/statusz,/flagz"},
+		[]string{"--kubeconfig", apiserverConfig.Name(), "--leader-elect=false", "--authorization-always-allow-paths=/statusz,/flagz,/configz"},
 	)
 	if err != nil {
 		t.Fatalf("Failed to start kube-scheduler server: %v", err)
@@ -458,6 +461,18 @@ func TestSchedulerZPages(t *testing.T) {
 		},
 	}
 
+	configzTestCases := []struct {
+		name         string
+		acceptHeader string
+		wantStatus   int
+	}{
+		{
+			name:         "application/json response",
+			acceptHeader: "application/json",
+			wantStatus:   http.StatusOK,
+		},
+	}
+
 	for _, tc := range statuszTestCases {
 		t.Run("statusz_"+tc.name, func(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, base+"/statusz", nil)
@@ -533,6 +548,60 @@ func TestSchedulerZPages(t *testing.T) {
 				if tc.wantBodyStructured != nil {
 					warnings := append([]string{}, r.Header.Values("Warning")...)
 					flagztesting.VerifyStructuredResponse(t, tc.acceptHeader, body, warnings, tc.wantBodyStructured, tc.wantDeprecationHeader)
+				}
+			}
+		})
+	}
+
+	for _, tc := range configzTestCases {
+		t.Run("configz_"+tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, base+"/configz", nil)
+			if err != nil {
+				t.Fatalf("failed to request: %v", err)
+			}
+
+			req.Header.Set("Accept", tc.acceptHeader)
+			r, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("failed to GET /configz: %v", err)
+			}
+
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("failed to read response body: %v", err)
+			}
+
+			if err = r.Body.Close(); err != nil {
+				t.Fatalf("failed to close response body: %v", err)
+			}
+
+			if r.StatusCode != tc.wantStatus {
+				t.Fatalf("want status %d, got %d", tc.wantStatus, r.StatusCode)
+			}
+
+			if tc.wantStatus == http.StatusOK {
+				var configz map[string]unstructured.Unstructured
+				if err := json.Unmarshal(body, &configz); err != nil {
+					t.Fatalf("failed to unmarshal configz: %v", err)
+				}
+				cfg, ok := configz["componentconfig"]
+				if !ok {
+					t.Fatalf("configz missing 'componentconfig' key")
+				}
+				if cfg.GetAPIVersion() != "kubescheduler.config.k8s.io/v1" {
+					t.Errorf("unexpected APIVersion: %s", cfg.GetAPIVersion())
+				}
+				if cfg.GetKind() != "KubeSchedulerConfiguration" {
+					t.Errorf("unexpected Kind: %s", cfg.GetKind())
+				}
+
+				// confirm that they expose public config type
+				var schedulerConfig kubeschedulerconfigv1.KubeSchedulerConfiguration
+				err = json.Unmarshal(body, &struct {
+					ComponentConfig *kubeschedulerconfigv1.KubeSchedulerConfiguration `json:"componentconfig"`
+				}{ComponentConfig: &schedulerConfig})
+				if err != nil {
+					t.Errorf("failed to deserialize into public config type: %v", err)
 				}
 			}
 		})

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -31,6 +32,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiserverfeat "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server"
 	flagzv1alpha1 "k8s.io/apiserver/pkg/server/flagz/api/v1alpha1"
@@ -44,6 +46,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	cloudprovider "k8s.io/cloud-provider"
 	cloudctrlmgrtesting "k8s.io/cloud-provider/app/testing"
+	cloudproviderconfigv1alpha1 "k8s.io/cloud-provider/config/v1alpha1"
 	"k8s.io/cloud-provider/fake"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -51,6 +54,7 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 	zpagesfeatures "k8s.io/component-base/zpages/features"
 	"k8s.io/klog/v2/ktesting"
+	kubecontrollermanagerconfigv1alpha1 "k8s.io/kube-controller-manager/config/v1alpha1"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	kubectrlmgrtesting "k8s.io/kubernetes/cmd/kube-controller-manager/app/testing"
 	kubeschedulertesting "k8s.io/kubernetes/cmd/kube-scheduler/app/testing"
@@ -571,7 +575,7 @@ users:
 		"--authentication-skip-lookup",
 		"--authentication-kubeconfig", apiserverConfig.Name(),
 		"--authorization-kubeconfig", apiserverConfig.Name(),
-		"--authorization-always-allow-paths", "/statusz,/flagz",
+		"--authorization-always-allow-paths", "/statusz,/flagz,/configz",
 		"--kubeconfig", apiserverConfig.Name(),
 		"--leader-elect=false",
 	}
@@ -591,6 +595,7 @@ users:
 	}
 	statuszURL := fmt.Sprintf("https://127.0.0.1:%s/statusz", port)
 	flagzURL := fmt.Sprintf("https://127.0.0.1:%s/flagz", port)
+	configzURL := fmt.Sprintf("https://127.0.0.1:%s/configz", port)
 
 	// read self-signed server cert disk
 	pool := x509.NewCertPool()
@@ -688,6 +693,55 @@ users:
 			}
 		})
 	}
+
+	t.Run("configz", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, configzURL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req.Header.Add("Authorization", fmt.Sprintf("Token %s", token))
+		r, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("failed to GET /configz: %v", err)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read response body: %v", err)
+		}
+		defer func() {
+			_ = r.Body.Close()
+		}()
+
+		if r.StatusCode != http.StatusOK {
+			t.Fatalf("want status %d, got %d", http.StatusOK, r.StatusCode)
+		}
+
+		var configz map[string]unstructured.Unstructured
+		if err := json.Unmarshal(body, &configz); err != nil {
+			t.Fatalf("failed to unmarshal configz: %v", err)
+		}
+		cfg, ok := configz["kubecontrollermanager.config.k8s.io"]
+		if !ok {
+			t.Fatalf("configz missing 'kubecontrollermanager.config.k8s.io' key")
+		}
+		if cfg.GetAPIVersion() != "kubecontrollermanager.config.k8s.io/v1alpha1" {
+			t.Errorf("unexpected APIVersion: %s", cfg.GetAPIVersion())
+		}
+		if cfg.GetKind() != "KubeControllerManagerConfiguration" {
+			t.Errorf("unexpected Kind: %s", cfg.GetKind())
+		}
+
+		// confirm that they expose public config type
+		var kcmConfig kubecontrollermanagerconfigv1alpha1.KubeControllerManagerConfiguration
+		err = json.Unmarshal(body, &struct {
+			ComponentConfig *kubecontrollermanagerconfigv1alpha1.KubeControllerManagerConfiguration `json:"kubecontrollermanager.config.k8s.io"`
+		}{ComponentConfig: &kcmConfig})
+		if err != nil {
+			t.Errorf("failed to deserialize into public config type: %v", err)
+		}
+	})
 }
 
 func TestKubeControllerManagerInformerMetrics(t *testing.T) {
@@ -836,4 +890,150 @@ users:
 	if !foundKCM {
 		t.Errorf("expected to find informer_queued_items metric with name=\"kube-controller-manager\" label")
 	}
+}
+
+func TestCloudControllerManagerServingZPages(t *testing.T) {
+	if !cloudprovider.IsCloudProvider("fake") {
+		cloudprovider.RegisterCloudProvider("fake", fakeCloudProviderFactory)
+	}
+	// authenticate to apiserver via bearer token
+	token := "flwqkenfjasasdfmwerasd" // Fake token for testing.
+	tokenFile, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = fmt.Fprintf(tokenFile, "\n%s,system:cloud-controller-manager,system:cloud-controller-manager,\"\"\n", token); err != nil {
+		t.Fatal(err)
+	}
+	if err = tokenFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// start apiserver
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--token-auth-file", tokenFile.Name(),
+		"--authorization-mode", "RBAC",
+	}, framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	// create kubeconfig for the apiserver
+	apiserverConfig, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = fmt.Fprintf(apiserverConfig, `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: %s
+    certificate-authority: %s
+  name: integration
+contexts:
+- context:
+    cluster: integration
+    user: cloud-controller-manager
+  name: default-context
+current-context: default-context
+users:
+- name: cloud-controller-manager
+  user:
+    token: %s
+`, server.ClientConfig.Host, server.ServerOpts.SecureServing.ServerCert.CertKey.CertFile, token); err != nil {
+		t.Fatal(err)
+	}
+	if err = apiserverConfig.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, ctx := ktesting.NewTestContext(t)
+	flags := []string{
+		"--authentication-skip-lookup",
+		"--authentication-kubeconfig", apiserverConfig.Name(),
+		"--authorization-kubeconfig", apiserverConfig.Name(),
+		"--authorization-always-allow-paths", "/statusz,/flagz,/configz",
+		"--kubeconfig", apiserverConfig.Name(),
+		"--leader-elect=false",
+		"--cloud-provider=fake",
+		"--webhook-secure-port=0",
+	}
+	secureOptions, secureInfo, tearDownFn, err := cloudControllerManagerTester{}.StartTestServer(t, ctx, flags)
+	if tearDownFn != nil {
+		defer tearDownFn()
+	}
+	if err != nil {
+		t.Fatalf("StartTestServer() error = %v", err)
+	}
+	if secureInfo == nil {
+		t.Fatalf("SecureServing not enabled")
+	}
+	_, port, err := net.SplitHostPort(secureInfo.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("could not get host and port from %s : %v", secureInfo.Listener.Addr().String(), err)
+	}
+	configzURL := fmt.Sprintf("https://127.0.0.1:%s/configz", port)
+
+	// read self-signed server cert disk
+	pool := x509.NewCertPool()
+	serverCertPath := path.Join(secureOptions.ServerCert.CertDirectory, secureOptions.ServerCert.PairName+".crt")
+	serverCert, err := os.ReadFile(serverCertPath)
+	if err != nil {
+		t.Fatalf("Failed to read component server cert %q: %v", serverCertPath, err)
+	}
+	pool.AppendCertsFromPEM(serverCert)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: pool,
+		},
+	}
+	client := &http.Client{Transport: tr}
+
+	t.Run("configz", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, configzURL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req.Header.Add("Authorization", fmt.Sprintf("Token %s", token))
+		r, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("failed to GET /configz: %v", err)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read response body: %v", err)
+		}
+		defer func() {
+			_ = r.Body.Close()
+		}()
+
+		if r.StatusCode != http.StatusOK {
+			t.Fatalf("want status %d, got %d", http.StatusOK, r.StatusCode)
+		}
+
+		var configz map[string]unstructured.Unstructured
+		if err := json.Unmarshal(body, &configz); err != nil {
+			t.Fatalf("failed to unmarshal configz: %v", err)
+		}
+		cfg, ok := configz["cloudcontrollermanager.config.k8s.io"]
+		if !ok {
+			t.Fatalf("configz missing 'cloudcontrollermanager.config.k8s.io' key")
+		}
+		if cfg.GetAPIVersion() != "cloudcontrollermanager.config.k8s.io/v1alpha1" {
+			t.Errorf("unexpected APIVersion: %s", cfg.GetAPIVersion())
+		}
+		if cfg.GetKind() != "CloudControllerManagerConfiguration" {
+			t.Errorf("unexpected Kind: %s", cfg.GetKind())
+		}
+
+		// confirm that they expose public config type
+		var ccmConfig cloudproviderconfigv1alpha1.CloudControllerManagerConfiguration
+		err = json.Unmarshal(body, &struct {
+			ComponentConfig *cloudproviderconfigv1alpha1.CloudControllerManagerConfiguration `json:"cloudcontrollermanager.config.k8s.io"`
+		}{ComponentConfig: &ccmConfig})
+		if err != nil {
+			t.Errorf("failed to deserialize into public config type: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

I believe these fields were lost after the drop-in configuration was added to the kubelet.

#### What this PR does / why we need it:

It is best to version objects when serialize them.

#### Does this PR introduce a user-facing change?
```release-note
The /configz endpoint of kubelet, scheduler, cloud controller manager, and kube-proxy serializes the APIVersion and Kind fields as well as using public types instead of internal.
```
