### PR TITLE
/configz is official endpoint, removing the misleading note

### DIFF
--- a/staging/src/k8s.io/component-base/configz/OWNERS
+++ b/staging/src/k8s.io/component-base/configz/OWNERS
@@ -1,9 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-# For lack of a better idea, assigned configz to api-approvers because
-# configz is an API that has been around for a long time, even if we don't
-# guarantee its stability.
-
 # Disable inheritance as this is an api owners file
 options:
   no_parent_owners: true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The comment is misleading. I think we can say that /configz is an official API by now.

#### Special notes for your reviewer:

We may need more documentation for it. But I don't think documentation must be blocker for removing this note.

```release-note
NONE
```