### PR TITLE
Optimize DeepHashObject writes

### DIFF
--- a/pkg/util/hash/hash.go
+++ b/pkg/util/hash/hash.go
@@ -17,8 +17,8 @@ limitations under the License.
 package hash
 
 import (
-	"fmt"
 	"hash"
+	"io"
 
 	"k8s.io/apimachinery/pkg/util/dump"
 )
@@ -28,5 +28,6 @@ import (
 // ensuring the hash does not change when a pointer changes.
 func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
 	hasher.Reset()
-	fmt.Fprintf(hasher, "%v", dump.ForHash(objectToWrite))
+	// Write directly to the hash to avoid fmt overhead on hot paths.
+	_, _ = io.WriteString(hasher, dump.ForHash(objectToWrite))
 }

--- a/pkg/util/hash/hash_test.go
+++ b/pkg/util/hash/hash_test.go
@@ -39,6 +39,8 @@ type C struct {
 	y string
 }
 
+var benchmarkHash uint32
+
 func (c C) String() string {
 	return fmt.Sprintf("%d:%s", c.x, c.y)
 }
@@ -144,4 +146,26 @@ func TestDeepObjectPointer(t *testing.T) {
 			t.Errorf("hash1 (%d) and hash3(%d) must be the same because although they point to different objects, they have the same values for wheel size", hash1, hash3)
 		}
 	}
+}
+
+func BenchmarkDeepHashObject(b *testing.B) {
+	hasher := adler32.New()
+	obj := map[string]interface{}{
+		"ints":   []int{1, 2, 3, 4, 5},
+		"strings": []string{
+			"eight", "six", "seven", "five", "three", "oh", "nine",
+		},
+		"nested": map[string]B{
+			"a": {x: []int{8, 6, 7}, y: map[string]bool{"5": true, "3": true, "0": true, "9": true}},
+			"b": {x: []int{1, 2, 3}, y: map[string]bool{"x": true, "y": false}},
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DeepHashObject(hasher, obj)
+	}
+	b.StopTimer()
+	benchmarkHash = hasher.Sum32()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Optimize `DeepHashObject` to avoid `fmt.Fprintf` overhead by writing directly to the hash writer, reducing hot-path allocations and cycles; add a benchmark to track hashing performance.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:
- Go toolchain not available in this environment, so `gofmt` and tests were not run here; please run `gofmt` and `go test ./pkg/util/hash` locally/CI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
