### PR TITLE
Replace non-contextual API utilruntime.HandleError under /pkg/kubelet within the new context-aware version when possible

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -767,7 +767,7 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(ctx context.Context, pod 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 		if _, err := m.runner.Run(ctx, containerID, pod, containerSpec, containerSpec.Lifecycle.PreStop); err != nil {
 			logger.Error(err, "PreStop hook failed", "pod", klog.KObj(pod), "podUID", pod.UID,
 				"containerName", containerSpec.Name, "containerID", containerID.String())
@@ -923,7 +923,7 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Con
 	}
 	for _, container := range runningPod.Containers {
 		go func(container *kubecontainer.Container) {
-			defer utilruntime.HandleCrash()
+			defer utilruntime.HandleCrashWithContext(ctx)
 			defer wg.Done()
 
 			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, container.Name)

--- a/pkg/kubelet/oom/oom_watcher_linux.go
+++ b/pkg/kubelet/oom/oom_watcher_linux.go
@@ -78,7 +78,7 @@ func (ow *realWatcher) Start(ctx context.Context, ref *v1.ObjectReference) error
 
 	go func() {
 		logger := klog.FromContext(ctx)
-		defer runtime.HandleCrash()
+		defer runtime.HandleCrashWithContext(ctx)
 
 		for event := range outStream {
 			if event.VictimContainerName == recordEventContainerName {

--- a/pkg/kubelet/pluginmanager/plugin_manager.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager.go
@@ -107,7 +107,7 @@ type pluginManager struct {
 var _ PluginManager = &pluginManager{}
 
 func (pm *pluginManager) Run(ctx context.Context, sourcesReady config.SourcesReady, stopCh <-chan struct{}) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -214,7 +214,7 @@ func (w *worker) stop() {
 // Returns whether the worker should continue.
 func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	defer func() { recover() }() // Actually eat panics (HandleCrash takes care of logging)
-	defer runtime.HandleCrash(func(_ interface{}) { keepGoing = true })
+	defer runtime.HandleCrashWithContext(ctx, func(ctx context.Context, _ interface{}) { keepGoing = true })
 
 	logger := klog.FromContext(ctx)
 	startTime := time.Now()

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -298,7 +298,7 @@ func (e *VolumeAttachLimitExceededError) Error() string {
 
 func (vm *volumeManager) Run(ctx context.Context, sourcesReady config.SourcesReady) {
 	logger := klog.FromContext(ctx)
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	if vm.kubeClient != nil {
 		// start informer for CSIDriver


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR is piece of https://github.com/kubernetes/kubernetes/pull/135524 that was to big an covered many different SIG, this PR focus on call to `utilruntime.HandleError` under `/pkg/kubelet`.

When possible, updates existing calls to the non-contextual API `utilruntime.HandleError` within the new context-aware version `utilruntime.HandleErrorWithContext` or `utilruntime.HandleErrorWithLogger`.

This is required as part of the Kubernetes structured logging initiative to ensure that log output from this component is structured, carries contextual fields, and correctly respects context cancellation signals.

#### Which issue(s) this PR is related to:
Related to https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:
Context Prioritization: 

The inherited `context.Context` from the parent function was consistently reused and passed to the updated `HandleErrorWithContext` calls.

Where a context was absent but a logger was available, the call was updated to HandleErrorWithLogger.

Available context or logger instances stored as attributes of the implementing struct were used for the contextual calls (WithContext or WithLogger).

The context was extracted from any passed-in HTTP request or WebSocket object and used to complete the call to `HandleErrorWithContext`.

/wg structured-logging

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

- [Tracking Issue]: [https://github.com/kubernetes/kubernetes/issues/126379](https://github.com/kubernetes/kubernetes/issues/126379)

