### PR TITLE
Clean up Pod config sources: remove dead code

### DIFF
--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -27,14 +27,13 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 // WaitForAPIServerSyncPeriod is the period between checks for the node list/watch initial sync
 const WaitForAPIServerSyncPeriod = 1 * time.Second
 
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
-func NewSourceApiserver(logger klog.Logger, c clientset.Interface, nodeName types.NodeName, nodeHasSynced func() bool, updates chan<- interface{}) {
+func NewSourceApiserver(logger klog.Logger, c clientset.Interface, nodeName types.NodeName, nodeHasSynced func() bool, updates chan<- sourceUpdate) {
 	lw := cache.NewListWatchFromClient(c.CoreV1().RESTClient(), "pods", metav1.NamespaceAll, fields.OneTermEqualSelector("spec.nodeName", string(nodeName)))
 
 	// The Reflector responsible for watching pods at the apiserver should be run only after
@@ -55,13 +54,13 @@ func NewSourceApiserver(logger klog.Logger, c clientset.Interface, nodeName type
 }
 
 // newSourceApiserverFromLW holds creates a config source that watches and pulls from the apiserver.
-func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- interface{}) {
+func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- sourceUpdate) {
 	send := func(objs []interface{}) {
 		var pods []*v1.Pod
 		for _, o := range objs {
 			pods = append(pods, o.(*v1.Pod))
 		}
-		updates <- kubetypes.PodUpdate{Pods: pods, Op: kubetypes.SET, Source: kubetypes.ApiserverSource}
+		updates <- sourceUpdate{Pods: pods}
 	}
 	r := cache.NewReflector(lw, &v1.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc), 0)
 	go r.Run(wait.NeverStop)

--- a/pkg/kubelet/config/apiserver_test.go
+++ b/pkg/kubelet/config/apiserver_test.go
@@ -19,13 +19,12 @@ package config
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 type fakePodLW struct {
@@ -70,71 +69,66 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 		watchResp: fakeWatch,
 	}
 
-	ch := make(chan interface{})
+	ch := make(chan sourceUpdate)
 
 	newSourceApiserverFromLW(lw, ch)
 
-	got, ok := <-ch
+	update, ok := <-ch
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update := got.(kubetypes.PodUpdate)
-	expected := CreatePodUpdate(kubetypes.SET, kubetypes.ApiserverSource, pod1v1)
+	expected := createSourceUpdate(pod1v1)
 	if !apiequality.Semantic.DeepEqual(expected, update) {
-		t.Errorf("Expected %#v; Got %#v", expected, update)
+		t.Errorf("Expected %#v; update %#v", expected, update)
 	}
 
 	// Add another pod
 	fakeWatch.Add(pod2)
-	got, ok = <-ch
+	update, ok = <-ch
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubetypes.PodUpdate)
 	// Could be sorted either of these two ways:
-	expectedA := CreatePodUpdate(kubetypes.SET, kubetypes.ApiserverSource, pod1v1, pod2)
-	expectedB := CreatePodUpdate(kubetypes.SET, kubetypes.ApiserverSource, pod2, pod1v1)
+	expectedA := createSourceUpdate(pod1v1, pod2)
+	expectedB := createSourceUpdate(pod2, pod1v1)
 
 	if !apiequality.Semantic.DeepEqual(expectedA, update) && !apiequality.Semantic.DeepEqual(expectedB, update) {
-		t.Errorf("Expected %#v or %#v, Got %#v", expectedA, expectedB, update)
+		t.Errorf("Expected %#v or %#v, update %#v", expectedA, expectedB, update)
 	}
 
 	// Modify pod1
 	fakeWatch.Modify(pod1v2)
-	got, ok = <-ch
+	update, ok = <-ch
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubetypes.PodUpdate)
-	expectedA = CreatePodUpdate(kubetypes.SET, kubetypes.ApiserverSource, pod1v2, pod2)
-	expectedB = CreatePodUpdate(kubetypes.SET, kubetypes.ApiserverSource, pod2, pod1v2)
+	expectedA = createSourceUpdate(pod1v2, pod2)
+	expectedB = createSourceUpdate(pod2, pod1v2)
 
 	if !apiequality.Semantic.DeepEqual(expectedA, update) && !apiequality.Semantic.DeepEqual(expectedB, update) {
-		t.Errorf("Expected %#v or %#v, Got %#v", expectedA, expectedB, update)
+		t.Errorf("Expected %#v or %#v, update %#v", expectedA, expectedB, update)
 	}
 
 	// Delete pod1
 	fakeWatch.Delete(pod1v2)
-	got, ok = <-ch
+	update, ok = <-ch
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubetypes.PodUpdate)
-	expected = CreatePodUpdate(kubetypes.SET, kubetypes.ApiserverSource, pod2)
+	expected = createSourceUpdate(pod2)
 	if !apiequality.Semantic.DeepEqual(expected, update) {
-		t.Errorf("Expected %#v, Got %#v", expected, update)
+		t.Errorf("Expected %#v, update %#v", expected, update)
 	}
 
 	// Delete pod2
 	fakeWatch.Delete(pod2)
-	got, ok = <-ch
+	update, ok = <-ch
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubetypes.PodUpdate)
-	expected = CreatePodUpdate(kubetypes.SET, kubetypes.ApiserverSource)
+	expected = createSourceUpdate() // Empty update.
 	if !apiequality.Semantic.DeepEqual(expected, update) {
-		t.Errorf("Expected %#v, Got %#v", expected, update)
+		t.Errorf("Expected %#v, update %#v", expected, update)
 	}
 }
 
@@ -153,29 +147,27 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 		watchResp: fakeWatch,
 	}
 
-	ch := make(chan interface{})
+	ch := make(chan sourceUpdate)
 
 	newSourceApiserverFromLW(lw, ch)
 
-	got, ok := <-ch
+	update, ok := <-ch
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update := got.(kubetypes.PodUpdate)
 	// Make sure that we get both pods.  Catches bug #2294.
 	if !(len(update.Pods) == 2) {
-		t.Errorf("Expected %d, Got %d", 2, len(update.Pods))
+		t.Errorf("Expected %d, update %d", 2, len(update.Pods))
 	}
 
 	// Delete pod1
 	fakeWatch.Delete(&pod1)
-	got, ok = <-ch
+	update, ok = <-ch
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubetypes.PodUpdate)
 	if !(len(update.Pods) == 1) {
-		t.Errorf("Expected %d, Got %d", 1, len(update.Pods))
+		t.Errorf("Expected %d, update %d", 1, len(update.Pods))
 	}
 }
 
@@ -187,17 +179,16 @@ func TestNewSourceApiserverInitialEmptySendsEmptyPodUpdate(t *testing.T) {
 		watchResp: fakeWatch,
 	}
 
-	ch := make(chan interface{})
+	ch := make(chan sourceUpdate)
 
 	newSourceApiserverFromLW(lw, ch)
 
-	got, ok := <-ch
+	update, ok := <-ch
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update := got.(kubetypes.PodUpdate)
-	expected := CreatePodUpdate(kubetypes.SET, kubetypes.ApiserverSource)
+	expected := createSourceUpdate() // Expect empty update.
 	if !apiequality.Semantic.DeepEqual(expected, update) {
-		t.Errorf("Expected %#v; Got %#v", expected, update)
+		t.Errorf("Expected %#v; update %#v", expected, update)
 	}
 }

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -144,49 +144,40 @@ func expectNoPodUpdate(t *testing.T, ch <-chan kubetypes.PodUpdate) {
 func TestNewPodAdded(t *testing.T) {
 	tCtx := ktesting.Init(t)
 
-	channel, ch, config := createPodConfigTester(tCtx)
+	channel, ch, _ := createPodConfigTester(tCtx)
 
 	// see an update
 	podUpdate := createSourceUpdate(CreateValidPod("foo", "new"))
 	channel <- podUpdate
 	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.ADD, TestSource, CreateValidPod("foo", "new")))
-
-	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.SET, kubetypes.AllSource, CreateValidPod("foo", "new")))
 }
 
 func TestNewPodAddedInvalidNamespace(t *testing.T) {
 	tCtx := ktesting.Init(t)
 
-	channel, ch, config := createPodConfigTester(tCtx)
+	channel, ch, _ := createPodConfigTester(tCtx)
 
 	// see an update
 	podUpdate := createSourceUpdate(CreateValidPod("foo", ""))
 	channel <- podUpdate
 	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.ADD, TestSource, CreateValidPod("foo", "")))
-
-	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.SET, kubetypes.AllSource, CreateValidPod("foo", "")))
 }
 
 func TestNewPodAddedDefaultNamespace(t *testing.T) {
 	tCtx := ktesting.Init(t)
 
-	channel, ch, config := createPodConfigTester(tCtx)
+	channel, ch, _ := createPodConfigTester(tCtx)
 
 	// see an update
 	podUpdate := createSourceUpdate(CreateValidPod("foo", "default"))
 	channel <- podUpdate
 	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.ADD, TestSource, CreateValidPod("foo", "default")))
-
-	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.SET, kubetypes.AllSource, CreateValidPod("foo", "default")))
 }
 
 func TestNewPodAddedDifferentNamespaces(t *testing.T) {
 	tCtx := ktesting.Init(t)
 
-	channel, ch, config := createPodConfigTester(tCtx)
+	channel, ch, _ := createPodConfigTester(tCtx)
 
 	// see an update
 	pod1 := CreateValidPod("foo", "default")
@@ -199,9 +190,6 @@ func TestNewPodAddedDifferentNamespaces(t *testing.T) {
 	podUpdate = createSourceUpdate(pod1, pod2)
 	channel <- podUpdate
 	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.ADD, TestSource, CreateValidPod("foo", "new")))
-
-	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.SET, kubetypes.AllSource, CreateValidPod("foo", "default"), CreateValidPod("foo", "new")))
 }
 
 func TestInvalidPodFiltered(t *testing.T) {

--- a/pkg/kubelet/config/file_linux.go
+++ b/pkg/kubelet/config/file_linux.go
@@ -26,12 +26,11 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/flowcontrol"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -72,7 +71,7 @@ func (s *sourceFile) doWatch(logger klog.Logger) error {
 			return err
 		}
 		// Emit an update with an empty PodList to allow FileSource to be marked as seen
-		s.updates <- kubetypes.PodUpdate{Pods: []*v1.Pod{}, Op: kubetypes.SET, Source: kubetypes.FileSource}
+		s.updates <- sourceUpdate{Pods: []*v1.Pod{}}
 		return &retryableError{"path does not exist, ignoring"}
 	}
 

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
@@ -41,7 +40,7 @@ func TestExtractFromBadDataFile(t *testing.T) {
 		t.Fatalf("unable to write test file %#v", err)
 	}
 
-	ch := make(chan interface{}, 1)
+	ch := make(chan sourceUpdate, 1)
 	lw := newSourceFile(fileName, "localhost", time.Millisecond, ch)
 	err = lw.listConfig(logger)
 	if err == nil {
@@ -58,18 +57,18 @@ func TestExtractFromEmptyDir(t *testing.T) {
 	defer removeAll(dirName, t)
 
 	logger, _ := ktesting.NewTestContext(t)
-	ch := make(chan interface{}, 1)
+	ch := make(chan sourceUpdate, 1)
 	lw := newSourceFile(dirName, "localhost", time.Millisecond, ch)
 	err = lw.listConfig(logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	update, ok := (<-ch).(kubetypes.PodUpdate)
+	update, ok := <-ch
 	if !ok {
 		t.Fatalf("unexpected type: %#v", update)
 	}
-	expected := CreatePodUpdate(kubetypes.SET, kubetypes.FileSource)
+	expected := createSourceUpdate() // Expect empty update.
 	if !apiequality.Semantic.DeepEqual(expected, update) {
 		t.Fatalf("expected %#v, got %#v", expected, update)
 	}

--- a/pkg/kubelet/config/mux.go
+++ b/pkg/kubelet/config/mux.go
@@ -28,7 +28,7 @@ type merger interface {
 	// Invoked when a change from a source is received.  May also function as an incremental
 	// merger if you wish to consume changes incrementally.  Must be reentrant when more than
 	// one source is defined.
-	Merge(ctx context.Context, source string, update interface{}) error
+	Merge(ctx context.Context, source string, update sourceUpdate) error
 }
 
 // mux is a class for merging configuration from multiple sources.  Changes are
@@ -40,13 +40,13 @@ type mux struct {
 	// Sources and their lock.
 	sourceLock sync.RWMutex
 	// Maps source names to channels
-	sources map[string]chan interface{}
+	sources map[string]chan sourceUpdate
 }
 
 // newMux creates a new mux that can merge changes from multiple sources.
 func newMux(merger merger) *mux {
 	mux := &mux{
-		sources: make(map[string]chan interface{}),
+		sources: make(map[string]chan sourceUpdate),
 		merger:  merger,
 	}
 	return mux
@@ -57,7 +57,7 @@ func newMux(merger merger) *mux {
 // source will return the same channel. This allows change and state based sources
 // to use the same channel. Different source names however will be treated as a
 // union.
-func (m *mux) ChannelWithContext(ctx context.Context, source string) chan interface{} {
+func (m *mux) ChannelWithContext(ctx context.Context, source string) chan sourceUpdate {
 	if len(source) == 0 {
 		panic("Channel given an empty name")
 	}
@@ -67,14 +67,14 @@ func (m *mux) ChannelWithContext(ctx context.Context, source string) chan interf
 	if exists {
 		return channel
 	}
-	newChannel := make(chan interface{})
+	newChannel := make(chan sourceUpdate)
 	m.sources[source] = newChannel
 
 	go wait.Until(func() { m.listen(ctx, source, newChannel) }, 0, ctx.Done())
 	return newChannel
 }
 
-func (m *mux) listen(ctx context.Context, source string, listenChannel <-chan interface{}) {
+func (m *mux) listen(ctx context.Context, source string, listenChannel <-chan sourceUpdate) {
 	logger := klog.FromContext(ctx)
 	for update := range listenChannel {
 		if err := m.merger.Merge(ctx, source, update); err != nil {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -373,7 +373,7 @@ func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, ku
 	}
 
 	// source of all configuration
-	cfg := config.NewPodConfig(config.PodConfigNotificationIncremental, kubeDeps.Recorder, kubeDeps.PodStartupLatencyTracker)
+	cfg := config.NewPodConfig(kubeDeps.Recorder, kubeDeps.PodStartupLatencyTracker)
 
 	// TODO:  it needs to be replaced by a proper context in the future
 	ctx := context.TODO()

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2611,9 +2611,6 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 			klog.V(2).InfoS("SyncLoop DELETE", "source", u.Source, "pods", klog.KObjSlice(u.Pods))
 			// DELETE is treated as a UPDATE because of graceful deletion.
 			handler.HandlePodUpdates(u.Pods)
-		case kubetypes.SET:
-			// TODO: Do we want to support this?
-			klog.ErrorS(nil, "Kubelet does not support snapshot update")
 		default:
 			klog.ErrorS(nil, "Invalid operation type received", "operation", u.Op)
 		}

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -38,10 +38,8 @@ type PodOperation int
 
 // These constants identify the PodOperations that can be made on a pod configuration.
 const (
-	// SET is the current pod configuration.
-	SET PodOperation = iota
 	// ADD signifies pods that are new to this source.
-	ADD
+	ADD PodOperation = iota
 	// DELETE signifies pods that are gracefully deleted from this source.
 	DELETE
 	// REMOVE signifies pods that have been removed from this source.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I was trying to figure out how the kubelet uses `kubetypes.SET` pod updates. It turns out, it basically doesn't. Everything that was dealing with SET updates was dead code, except for the direct pod sources, which _only_ use set. I added a new update type for the internal sources to make this single update type explicit, which meant we could delete a lot of code dealing with unused update types and unused modes, and ultimately remove the `kubetypes.SET` type completely.

Other cleanups included:
- The source update channels all used `interface{}` types, but were only ever used with a single type, so I changed it to the explicit type instead.

#### Special notes for your reviewer:

It might be easier to review the separate commits individually.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-longterm
/assign @natasha41575 
/cc @SergeyKanzhelev 