### PR TITLE
featuregate: implement ResetQueriedForTest to suppress false warnings

### DIFF
--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -854,6 +854,22 @@ func (f *featureGate) unsafeRecordQueried(key Feature) {
 	f.queriedFeatures.Store(newQueriedFeatures)
 }
 
+func (f *featureGate) ResetFeatureQueriedForTest(feature Feature) {
+	actual := f.queriedFeatures.Load()
+	if actual == nil {
+		return
+	}
+
+	currentSet, ok := actual.(sets.Set[Feature])
+	if !ok || !currentSet.Has(feature) {
+		return
+	}
+
+	newSet := sets.New(currentSet.UnsortedList()...)
+	newSet.Delete(feature)
+	f.queriedFeatures.Store(newSet)
+}
+
 func featureEnabled(key Feature, enabled map[Feature]bool, known map[Feature]VersionedSpecs, emulationVersion, minCompatibilityVersion *version.Version) bool {
 	// check explicitly set enabled list
 	if v, ok := enabled[key]; ok {

--- a/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go
@@ -38,6 +38,10 @@ func init() {
 
 type FeatureOverrides = map[featuregate.Feature]bool
 
+type queriedResetter interface {
+	ResetFeatureQueriedForTest(featuregate.Feature)
+}
+
 // SetFeatureGateDuringTest sets the specified gate to the specified value for duration of the test.
 // Fails when it detects second call to the same flag or is unable to set or restore feature flag.
 // When disabling a feature, this automatically disables all dependents.
@@ -147,6 +151,11 @@ func SetFeatureGatesDuringTest(tb TB, gate featuregate.FeatureGate, features Fea
 				tb.Errorf("error resetting %s: %v", f, err)
 			}
 		}
+		if mux, ok := gate.(queriedResetter); ok {
+			for f := range gate.(featuregate.MutableFeatureGate).GetAll() {
+				mux.ResetFeatureQueriedForTest(f)
+			}
+		}
 	})
 }
 
@@ -203,12 +212,24 @@ func SetFeatureGateVersionsDuringTest(tb TB, gate featuregate.FeatureGate, emuVe
 	if err := mutableGate.SetEmulationVersionAndMinCompatibilityVersion(emuVer, minCompatVer); err != nil {
 		tb.Fatalf("failed to set versions (emu=%s, min=%s) during test: %v", emuVer.String(), minCompatVer.String(), err)
 	}
+	// This clears queries made during the version change validation, ensuring the actual test logic starts with a clean gate.
+	if mux, ok := gate.(queriedResetter); ok {
+		for f := range gate.(featuregate.MutableFeatureGate).GetAll() {
+			mux.ResetFeatureQueriedForTest(f)
+		}
+	}
 
 	tb.Cleanup(func() {
 		tb.Helper()
 		detectParallelOverrideCleanup()
 		if err := mutableGate.SetEmulationVersionAndMinCompatibilityVersion(originalEmuVer, originalMinCompatVer); err != nil {
 			tb.Fatalf("failed to restore versions (emu=%s, min=%s) during test: %v", originalEmuVer.String(), originalMinCompatVer.String(), err)
+		}
+
+		if mux, ok := gate.(queriedResetter); ok {
+			for f := range gate.(featuregate.MutableFeatureGate).GetAll() {
+				mux.ResetFeatureQueriedForTest(f)
+			}
 		}
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR addresses the log noise and state leakage identified in #134009.

The `SetFeatureGatesDuringTest` helper previously only restored feature values (on/off) but left the "queried" flag set. In multi-iteration tests like `scheduler_perf`, this caused subsequent runs to trigger false "already queried" warnings because the gate remembered being read in previous iterations.

I introduced `ResetQueriedForTest()` to the `MutableFeatureGate` interface and implemented an atomic reset of the "queried" state. The testing helper now calls this during cleanup to ensure a truly isolated environment for every test run.

#### Which issue(s) this PR is related to:

Fixes #134009

#### Special notes for your reviewer:
- **Warnings Eliminated**: This fix successfully silences the wall of misleading "already queried" logs in integration tests.
- **Complete Teardown**: The `SetFeatureGatesDuringTest` cleanup is now thorough, resetting both the feature states and the gate's internal tracking memory.

```release-note
NONE
```