### PR TITLE
Fixed Container Statuses

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -336,6 +336,7 @@ func (m *manager) UpdatePodStatus(ctx context.Context, pod *v1.Pod, podStatus *v
 		podStatus.ContainerStatuses[i].Started = &started
 
 		if !started {
+			podStatus.ContainerStatuses[i].Ready = false
 			continue
 		}
 
@@ -391,6 +392,7 @@ func (m *manager) UpdatePodStatus(ctx context.Context, pod *v1.Pod, podStatus *v
 		}
 
 		if !started {
+			podStatus.InitContainerStatuses[i].Ready = false
 			continue
 		}
 

--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -7056,9 +7056,9 @@ var _ = SIGDescribe("Container Status After Restart", func() {
 				// Verify the invariant: if started is false, ready must also be false
 				if cs.Started != nil && !*cs.Started {
 					sawNotStartedState = true
-					gomega.Expect(cs.Ready).To(gomega.BeFalse(),
+					gomega.Expect(cs.Ready).To(gomega.BeFalseBecause(
 						"Bug #136047: ready should be false when started is false. "+
-							"Got ready=%v, started=%v", cs.Ready, *cs.Started)
+							"Got ready=%v, started=%v", cs.Ready, *cs.Started))
 				}
 
 				// If we've seen the not-started state and now the container is ready again, we're done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

This PR fixes an issue where `containerStatuses.ready` incorrectly stays `true` while `started` is `false` after a container restart.

**The Problem:**

When a container exits and restarts (with `restartPolicy: Always` or `OnFailure`), the startup probe needs to run again before the readiness probe can start. However, the `ready` field was retaining its stale `true` value from before the restart, while `started` was correctly reset to `false`.

This violates the Kubernetes probe design invariant: **readinessProbe should not pass until startupProbe succeeds**, meaning `ready` should never be `true` if `started` is still `false`.

**Root Cause:**

In [UpdatePodStatus()](cci:1://file:///home/popos/Documents/gsoc/kubernetes/pkg/kubelet/prober/prober_manager.go:90:1-92:57) within [pkg/kubelet/prober/prober_manager.go](cci:7://file:///home/popos/Documents/gsoc/kubernetes/pkg/kubelet/prober/prober_manager.go:0:0-0:0), when `started` was `false`, the code did a `continue` without updating the [Ready](cci:1://file:///home/popos/Documents/gsoc/kubernetes/pkg/kubelet/prober/prober_manager.go:297:0-329:1) field, leaving it with its previous stale value.

**The Fix:**

When `started` is `false`, explicitly set `ready` to `false` before continuing:

```diff
 if !started {
+    podStatus.ContainerStatuses[i].Ready = false
     continue
 }
```
 
 
 This change is applied to both regular containers and restartable init containers.

Which issue(s) this PR is related to:
Fixes #136047

Special notes for your reviewer:
The fix is minimal and targeted (2 lines added)
All existing prober tests pass:
TestUpdatePodStatus
TestUpdatePodStatusWithInitContainers
TestChangeContainerStatusOnKubeletRestart (12 sub-tests)
This maintains the invariant that ready can only be true when started is true
Does this PR introduce a user-facing change?
Fixed a bug where containerStatuses.ready incorrectly remained true while started was false after a container restart. The ready field is now correctly set to false when the container's started field is false.

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A