### PR TITLE
Automated cherry pick of #135776: kubeadm: always retry Patch() Node API calls

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/idempotency.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency.go
@@ -192,10 +192,7 @@ func PatchNodeOnce(client clientset.Interface, nodeName string, patchFn func(*v1
 
 		if _, err := client.CoreV1().Nodes().Patch(ctx, n.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
 			*lastError = errors.Wrapf(err, "error patching Node %q", n.Name)
-			if apierrors.IsTimeout(err) || apierrors.IsConflict(err) || apierrors.IsServerTimeout(err) || apierrors.IsServiceUnavailable(err) {
-				return false, nil
-			}
-			return false, *lastError
+			return false, nil
 		}
 
 		return true, nil

--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -387,54 +387,6 @@ func TestPatchNodeOnce(t *testing.T) {
 			success: false,
 		},
 		{
-			name:       "patch node when timeout",
-			lookupName: "testnode",
-			node: v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "testnode",
-					Labels: map[string]string{v1.LabelHostname: ""},
-				},
-			},
-			success:   false,
-			fakeError: apierrors.NewTimeoutError("fake timeout", -1),
-		},
-		{
-			name:       "patch node when conflict",
-			lookupName: "testnode",
-			node: v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "testnode",
-					Labels: map[string]string{v1.LabelHostname: ""},
-				},
-			},
-			success:   false,
-			fakeError: apierrors.NewConflict(schema.GroupResource{}, "fake conflict", nil),
-		},
-		{
-			name:       "patch node when there is a server timeout",
-			lookupName: "testnode",
-			node: v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "testnode",
-					Labels: map[string]string{v1.LabelHostname: ""},
-				},
-			},
-			success:   false,
-			fakeError: apierrors.NewServerTimeout(schema.GroupResource{}, "fake server timeout", 1),
-		},
-		{
-			name:       "patch node when the service is unavailable",
-			lookupName: "testnode",
-			node: v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "testnode",
-					Labels: map[string]string{v1.LabelHostname: ""},
-				},
-			},
-			success:   false,
-			fakeError: apierrors.NewServiceUnavailable("fake service unavailable"),
-		},
-		{
 			name:       "patch node failed with unknown error",
 			lookupName: "testnode",
 			node: v1.Node{


### PR DESCRIPTION
Cherry pick of #135776 on release-1.35.

#135776: kubeadm: always retry Patch() Node API calls

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: when patching a Node object do not exit early on unknown (non-allowlisted) API errors. Instead, always retry within the duration of the polling for getting and patching a Node object.
```