### PR TITLE
Fix context timeout test flake

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/internal/generic/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/internal/generic/controller_test.go
@@ -370,7 +370,7 @@ func TestIgnoredUpdate(t *testing.T) {
 
 // Shows that an object which fails reconciliation will retry
 func TestReconcileRetry(t *testing.T) {
-	testContext, testCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	testContext, testCancel := context.WithTimeout(context.Background(), wait.ForeverTestTimeout)
 	defer testCancel()
 
 	calls := atomic.Uint64{}


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Fixes rare flake seen in https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/136066/pull-kubernetes-unit/2008892728825352192

https://storage.googleapis.com/k8s-triage/index.html?pr=1&text=TestReconcileRetry

```release-note
NONE
```

/cc @serathius 
/sig api-machinery