### PR TITLE
fix(garbagecollector): remove incorrect verbosity from Error logsfix(garbagecollector): remove incorrect verbosity from Error logs

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -360,7 +360,7 @@ func (gc *GarbageCollector) attemptToDeleteWorker(ctx context.Context, item inte
 			//    have a way to distinguish this from a valid type we will recognize
 			//    after the next discovery sync.
 			// For now, record the error and retry.
-			logger.V(5).Error(err, "error syncing item", "item", n.identity)
+			logger.Error(err, "error syncing item", "item", n.identity)
 		} else {
 			utilruntime.HandleError(fmt.Errorf("error syncing item %s: %v", n, err))
 		}

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -222,7 +222,7 @@ func (gb *GraphBuilder) controllerFor(logger klog.Logger, resource schema.GroupV
 
 	shared, err := gb.sharedInformers.ForResource(resource)
 	if err != nil {
-		logger.V(4).Error(err, "unable to use a shared informer", "resource", resource, "kind", kind)
+		logger.V(4).Info(err, "unable to use a shared informer", "resource", resource, "kind", kind)
 		return nil, nil, err
 	}
 	logger.V(4).Info("using a shared informer", "resource", resource, "kind", kind)


### PR DESCRIPTION
fix(garbagecollector): remove incorrect verbosity from Error logs

pkg/controller/garbagecollector/:

garbagecollector.go: V(5).Error → Error (critical sync failure, always log).
graph_builder.go: V(4).Error → V(4).Info (transient informer error, debug).
Refs https://github.com/kubernetes/kubernetes/issues/136027
/kind cleanup
/sig instrumentation

What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Fixes incorrect logger.V().Error() usage. Per logr spec, Error-level ignores V(),
causing unexpected log flooding regardless of verbosity setting. Converts to
appropriate Error() or Info() per Kubernetes logging conventions.

Which issue(s) this PR is related to?
https://github.com/kubernetes/kubernetes/issues/136027

Special notes for your reviewer:
Good first issue subtask (garbagecollector). No user impact/tests changed.

Does this PR introduce a user-facing change?
NONE