### PR TITLE
Fix goroutine leak in nestedpendingoperations

### DIFF
--- a/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go
+++ b/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go
@@ -353,7 +353,19 @@ func (grm *nestedPendingOperations) Wait() {
 	grm.lock.Lock()
 	defer grm.lock.Unlock()
 
-	for len(grm.operations) > 0 {
+	for {
+		hasPendingOps := false
+		// Check if any operation is still pending
+		for _, op := range grm.operations {
+			if op.operationPending {
+				hasPendingOps = true
+				break
+			}
+		}
+		// If no operations are pending, we are done
+		if !hasPendingOps {
+			break
+		}
 		grm.cond.Wait()
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes a goroutine leak in nestedpendingoperations.
Previously, Wait() blocked indefinitely if an operation failed with an error but was not removed from the map.
Now, Wait() checks the `operationPending` status instead of just the map length.

#### Which issue(s) this PR is related to:
Fixes #136075

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
