### PR TITLE
Default EndpointSlice.Endpoints to empty list instead of nil

### DIFF
--- a/pkg/apis/discovery/v1/defaults.go
+++ b/pkg/apis/discovery/v1/defaults.go
@@ -31,6 +31,13 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
+func SetDefaults_EndpointSlice(obj *discoveryv1.EndpointSlice) {
+	// Ensure Endpoints is an empty slice instead of nil to satisfy OpenAPI required field contract (must not be null).
+	if obj.Endpoints == nil {
+		obj.Endpoints = []discoveryv1.Endpoint{}
+	}
+}
+
 func SetDefaults_EndpointPort(obj *discoveryv1.EndpointPort) {
 	if obj.Name == nil {
 		obj.Name = &defaultPortName

--- a/pkg/apis/discovery/v1/zz_generated.defaults.go
+++ b/pkg/apis/discovery/v1/zz_generated.defaults.go
@@ -36,6 +36,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_EndpointSlice(in *discoveryv1.EndpointSlice) {
+	SetDefaults_EndpointSlice(in)
 	for i := range in.Ports {
 		a := &in.Ports[i]
 		SetDefaults_EndpointPort(a)


### PR DESCRIPTION
EndpointSlice.Endpoints is defined in the OpenAPI schema as a required array (non-nullable) because it lacks the omitempty tag. However, when an EndpointSlice has zero endpoints (e.g., scaled to 0), the API server serializes this field as null because of the underlying slice being nil.

This behavior violates the OpenAPI contract, breaking strict clients (such as the Java and OpenAPI Generator clients) which expect [] but receive null.

This commit adds a defaulting function SetDefaults_EndpointSlice to explicitly initialize Endpoints as an empty slice [] if it is nil. This ensures the API response is always compliant with the schema ("endpoints": []) while preserving semantic equivalence for Go consumers

/kind bug
/kind api-change

Fixes https://github.com/kubernetes/kubernetes/issues/135968

```release-note
Fixed an issue where EndpointSlices without endpoints were serialized with the list of endpoints represented as null instead of as `[]`. The previous incorrect behavior could cause errors or crashes in some clients.
```


@DEVMANISHOFFL added you as coauthor

/assign @danwinship @thockin @liggitt 
/cc @lmktfy 

Based on https://github.com/kubernetes/kubernetes/pull/135970#issuecomment-3703669351 , I think we should fix the root cause not just the particular problem