### PR TITLE
Fix kyaml output of watch events

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/kyaml.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/kyaml.go
@@ -54,6 +54,8 @@ func (p *KYAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj.Object.Object)).Type().PkgPath()) {
 			return errors.New(InternalObjectPrinterErr)
 		}
+		return p.encoder.FromObject(obj, w)
+
 	case *runtime.Unknown:
 		return p.encoder.FromYAML(bytes.NewReader(obj.Raw), w)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -2587,6 +2587,98 @@ type: DELETED
 `,
 		},
 		{
+			format: "kyaml",
+			expected: `---
+{
+  type: "ADDED",
+  object: {
+    apiVersion: "v1",
+    kind: "Pod",
+    metadata: {
+      name: "bar",
+      namespace: "test",
+      resourceVersion: "9",
+    },
+    spec: {
+      containers: null,
+      dnsPolicy: "ClusterFirst",
+      enableServiceLinks: true,
+      restartPolicy: "Always",
+      securityContext: {},
+      terminationGracePeriodSeconds: 30,
+    },
+    status: {},
+  },
+}
+---
+{
+  type: "ADDED",
+  object: {
+    apiVersion: "v1",
+    kind: "Pod",
+    metadata: {
+      name: "foo",
+      namespace: "test",
+      resourceVersion: "10",
+    },
+    spec: {
+      containers: null,
+      dnsPolicy: "ClusterFirst",
+      enableServiceLinks: true,
+      restartPolicy: "Always",
+      securityContext: {},
+      terminationGracePeriodSeconds: 30,
+    },
+    status: {},
+  },
+}
+---
+{
+  type: "MODIFIED",
+  object: {
+    apiVersion: "v1",
+    kind: "Pod",
+    metadata: {
+      name: "foo",
+      namespace: "test",
+      resourceVersion: "11",
+    },
+    spec: {
+      containers: null,
+      dnsPolicy: "ClusterFirst",
+      enableServiceLinks: true,
+      restartPolicy: "Always",
+      securityContext: {},
+      terminationGracePeriodSeconds: 30,
+    },
+    status: {},
+  },
+}
+---
+{
+  type: "DELETED",
+  object: {
+    apiVersion: "v1",
+    kind: "Pod",
+    metadata: {
+      name: "foo",
+      namespace: "test",
+      resourceVersion: "12",
+    },
+    spec: {
+      containers: null,
+      dnsPolicy: "ClusterFirst",
+      enableServiceLinks: true,
+      restartPolicy: "Always",
+      securityContext: {},
+      terminationGracePeriodSeconds: 30,
+    },
+    status: {},
+  },
+}
+`,
+		},
+		{
 			format: `jsonpath={.type},{.object.metadata.name},{.object.metadata.resourceVersion}{"\n"}`,
 			expected: `ADDED,bar,9
 ADDED,foo,10


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes `kubectl get ... --watch --output-watch-events -o kyaml` which currently errors complaining about missing apiVersion/kind

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubectl: fixes kyaml output of `kubectl get ... --output-watch-events -o kyaml`
```

/sig cli
/assign @thockin