### PR TITLE
define endpointslice.endpoints as optional

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12804,8 +12804,7 @@
         }
       },
       "required": [
-        "addressType",
-        "endpoints"
+        "addressType"
       ],
       "type": "object",
       "x-kubernetes-group-version-kind": [

--- a/api/openapi-spec/v3/apis__discovery.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__discovery.k8s.io__v1_openapi.json
@@ -226,8 +226,7 @@
           }
         },
         "required": [
-          "addressType",
-          "endpoints"
+          "addressType"
         ],
         "type": "object",
         "x-kubernetes-group-version-kind": [

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -33256,7 +33256,7 @@ func schema_k8sio_api_discovery_v1_EndpointSlice(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"addressType", "endpoints"},
+				Required: []string{"addressType"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/discovery/v1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1/generated.proto
@@ -185,6 +185,7 @@ message EndpointSlice {
 
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
+  // +optional
   // +listType=atomic
   repeated Endpoint endpoints = 2;
 

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -52,6 +52,7 @@ type EndpointSlice struct {
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
+	// +optional
 	// +listType=atomic
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
 


### PR DESCRIPTION
/kind bug
/kind api-change
```release-note
The `endpoints` field in discovery.k8s.io/v1 EndpointSlice is now correctly defined as optional in the OpenAPI specification, matching the server's behavior.
```

/assign @liggitt 

Fixes https://github.com/kubernetes/kubernetes/issues/135968

See https://github.com/kubernetes/kubernetes/pull/136109#discussion_r2673147069