### PR TITLE
Bring the fuzz testing  changes back which was removed due to  an accident 

### DIFF
--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -76,6 +76,9 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 					allRules := append([]field.NormalizationRule{}, resourcevalidation.ResourceNormalizationRules...)
 					allRules = append(allRules, nodevalidation.NodeNormalizationRules...)
 					opts = append(opts, WithNormalizationRules(allRules...))
+					if gv.Group == "autoscaling" {
+						opts = append(opts, WithIgnoreObjectConversionErrors())
+					}
 
 					VerifyVersionedValidationEquivalence(t, obj, nil, opts...)
 


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR restores the logic to apply `WithIgnoreObjectConversionErrors()` exclusively to the `autoscaling` group within `TestVersionedValidationByFuzzing` in `pkg/api/testing/validation_test.go`.

This logic was accidentally removed or omitted during the changes in **#134909**. As discussed in related PRs like **#136034**, the `autoscaling` group requires this option due to known `Scale` type incompatibilities that cause conversion errors during versioned validation fuzzing. Scoping this to only the `autoscaling` group ensures that we do not inadvertently hide legitimate conversion regressions in other API groups.

#### Which issue(s) this PR is related to:
Relates to #134909 and #136034.

#### Special notes for your reviewer:
This change ensures that `TestVersionedValidationByFuzzing` continues to pass for `autoscaling` while maintaining strict conversion checks for all other groups, as originally intended during the rollout of declarative validation testing.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
N/A
```