### PR TITLE
Fix flaky typecheck by enforcing serial execution

### DIFF
--- a/hack/verify-typecheck.sh
+++ b/hack/verify-typecheck.sh
@@ -39,8 +39,8 @@ if [[ $# == 0 ]]; then
 fi
 
 ret=0
-TYPECHECK_SERIAL="${TYPECHECK_SERIAL:-false}"
-go run ./test/typecheck "$@" "--serial=$TYPECHECK_SERIAL" || ret=$?
+TYPECHECK_SERIAL="${TYPECHECK_SERIAL:-true}"
+go run ./test/typecheck "--serial=$TYPECHECK_SERIAL" "$@" || ret=$?
 
 if [[ $ret -ne 0 ]]; then
   echo "!!! Typecheck has failed. This may cause cross platform build failures." >&2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake /kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes a flake in the pull-kubernetes-typecheck job where the test would hang indefinitely due to memory exhaustion (OOM) on CI nodes.

This PR makes two changes to hack/verify-typecheck.sh:

Fixes flag parsing order: Moves the flags (like --serial) before the package arguments ("$@"). Previously, flag.Parse() in the Go tool was ignoring flags because they appeared after non-flag arguments.

Defaults to serial execution: Sets TYPECHECK_SERIAL to true by default. This ensures type-checks run sequentially (one platform at a time) rather than in parallel, significantly reducing memory usage to prevent CI hangs.
#### Which issue(s) this PR is related to:
Fixes #136121
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The verify-typecheck tool previously defaulted to running 2 checks in parallel. However, due to the flag parsing bug in the shell script, the --serial flag was being ignored even if set. By fixing the order and defaulting to serial, we ensure stable execution on resource-constrained CI runners.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
