### PR TITLE
[GCE] Pin Ubuntu image to 22.04 to fix ci-cos-containerd-e2e-ubuntu-gce

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -96,7 +96,18 @@ export MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-${IMAGE_PROJECT}}
 export NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}
 export NODE_IMAGE_FAMILY=${KUBE_GCE_NODE_IMAGE_FAMILY:-${IMAGE_FAMILY}}
 export NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-${IMAGE_PROJECT}}
+
+# Fix for https://github.com/kubernetes/kubernetes/issues/136113
+# The Ubuntu 24.04 image is currently broken. Force stable Ubuntu 22.04.
+if [[ "${NODE_OS_DISTRIBUTION}" == "ubuntu" ]]; then
+    IMAGE_PROJECT="ubuntu-os-gke-cloud"
+    IMAGE_FAMILY="ubuntu-gke-2204-1-34-amd64"
+    export NODE_IMAGE_PROJECT="${IMAGE_PROJECT}"
+    export NODE_IMAGE_FAMILY="${IMAGE_FAMILY}"
+fi
+
 export NODE_SERVICE_ACCOUNT=${KUBE_GCE_NODE_SERVICE_ACCOUNT:-default}
+
 
 # KUBELET_TEST_ARGS are extra arguments passed to kubelet.
 export KUBELET_TEST_ARGS=${KUBE_KUBELET_EXTRA_ARGS:-}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes #136113. 

The `ci-cos-containerd-e2e-ubuntu-gce` job has been failing consistently because the default Ubuntu image was updated to 24.04 (`ubuntu-gke-2404-1-34-amd64`), which appears to have broken provisioning/networking in the GCE environment.

This PR modifies `cluster/gce/config-default.sh` to explicitly pin the image family to the stable Ubuntu 22.04 version (`ubuntu-gke-2204-1-34-amd64`) whenever `NODE_OS_DISTRIBUTION` is set to `ubuntu`. This restores stability to the CI job.
#### Which issue(s) this PR is related to:
Fixes #136113
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
This is a temporary mitigation to unblock the release signal. Once the Ubuntu 24.04 image is fixed upstream or the cluster scripts are updated to support it, this override can be removed.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
