### PR TITLE
kubeadm: fix a bug where kubeadm upgrade is failed if the content of the `kubeadm-flags.env` file is `KUBELET_KUBEADM_ARGS=""`

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -154,7 +154,7 @@ func ReadKubeletDynamicEnvFile(kubeletEnvFilePath string) ([]string, error) {
 	// Split the flags string by whitespace to get individual arguments.
 	trimmedFlags := strings.Fields(flags)
 	if len(trimmedFlags) == 0 {
-		return nil, errors.Errorf("no flags found in file %q", kubeletEnvFilePath)
+		return nil, nil
 	}
 
 	var updatedFlags []string

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -193,10 +193,10 @@ func TestReadKubeadmFlags(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name:          "no container-runtime-endpoint found",
+			name:          "has KUBELET_KUBEADM_ARGS line but no args",
 			fileContent:   `KUBELET_KUBEADM_ARGS=""`,
 			expectedValue: nil,
-			expectError:   true,
+			expectError:   false,
 		},
 		{
 			name:          "no KUBELET_KUBEADM_ARGS line",
@@ -248,8 +248,8 @@ func TestReadKubeadmFlags(t *testing.T) {
 			}
 
 			value, err := ReadKubeletDynamicEnvFile(tmpFile.Name())
-			if !tt.expectError && err != nil {
-				t.Errorf("Unexpected error: %v", err)
+			if tt.expectError != (err != nil) {
+				t.Errorf("Expect error: %v, got: %v, error: %v", tt.expectError, err != nil, err)
 			}
 
 			assert.Equal(t, tt.expectedValue, value)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kubeadm upgrade apply fails during the post-upgrade phase when /var/lib/kubelet/kubeadm-flags.env contains no flags (i.e., KUBELET_KUBEADM_ARGS="").

Error message:

```
error: error execution phase post-upgrade: error reading kubelet env file: no flags found in file "/var/lib/kubelet/kubeadm-flags.env"
```
It is caused by #133778

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes https://github.com/kubernetes/kubeadm/issues/3279

#### Special notes for your reviewer:

we need to backport this PR to release-1.35

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix a bug where kubeadm upgrade is failed if the content of the `kubeadm-flags.env` file is `KUBELET_KUBEADM_ARGS=""`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
