### PR TITLE
Automated cherry pick of #136127: kubeadm: fix a bug where kubeadm upgrade is failed if the content of the `kubeadm-flags.env` file is `KUBELET_KUBEADM_ARGS=""`

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -154,7 +154,7 @@ func ReadKubeletDynamicEnvFile(kubeletEnvFilePath string) ([]string, error) {
 	// Split the flags string by whitespace to get individual arguments.
 	trimmedFlags := strings.Fields(flags)
 	if len(trimmedFlags) == 0 {
-		return nil, errors.Errorf("no flags found in file %q", kubeletEnvFilePath)
+		return nil, nil
 	}
 
 	var updatedFlags []string

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -193,10 +193,10 @@ func TestReadKubeadmFlags(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name:          "no container-runtime-endpoint found",
+			name:          "has KUBELET_KUBEADM_ARGS line but no args",
 			fileContent:   `KUBELET_KUBEADM_ARGS=""`,
 			expectedValue: nil,
-			expectError:   true,
+			expectError:   false,
 		},
 		{
 			name:          "no KUBELET_KUBEADM_ARGS line",
@@ -248,8 +248,8 @@ func TestReadKubeadmFlags(t *testing.T) {
 			}
 
 			value, err := ReadKubeletDynamicEnvFile(tmpFile.Name())
-			if !tt.expectError && err != nil {
-				t.Errorf("Unexpected error: %v", err)
+			if tt.expectError != (err != nil) {
+				t.Errorf("Expect error: %v, got: %v, error: %v", tt.expectError, err != nil, err)
 			}
 
 			assert.Equal(t, tt.expectedValue, value)


### PR DESCRIPTION
Cherry pick of #136127 on release-1.35.

#136127: kubeadm: fix a bug where kubeadm upgrade is failed if the content of the `kubeadm-flags.env` file is `KUBELET_KUBEADM_ARGS=""`

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fix a bug where kubeadm upgrade is failed if the content of the `kubeadm-flags.env` file is `KUBELET_KUBEADM_ARGS=""`
```