### PR TITLE
ktesting: avoid increasing default verbosity

### DIFF
--- a/pkg/kubelet/cm/dra/claiminfo_test.go
+++ b/pkg/kubelet/cm/dra/claiminfo_test.go
@@ -34,6 +34,11 @@ import (
 	"k8s.io/kubernetes/test/utils/ktesting/initoption"
 )
 
+// Some of these tests capture log output. Don't reduce the verbosity or they will fail!
+func init() {
+	ktesting.SetDefaultVerbosity(5)
+}
+
 // ClaimInfo test cases
 
 const (

--- a/pkg/kubelet/watchdog/watchdog_linux_test.go
+++ b/pkg/kubelet/watchdog/watchdog_linux_test.go
@@ -29,6 +29,11 @@ import (
 	"k8s.io/kubernetes/test/utils/ktesting/initoption"
 )
 
+// Some of these tests capture log output. Don't reduce the verbosity or they will fail!
+func init() {
+	ktesting.SetDefaultVerbosity(5)
+}
+
 // Mock syncLoopHealthChecker
 type mockSyncLoopHealthChecker struct {
 	healthCheckErr error

--- a/test/utils/ktesting/ktesting.go
+++ b/test/utils/ktesting/ktesting.go
@@ -27,12 +27,6 @@ import (
 	_ "k8s.io/component-base/logs/testinit"
 )
 
-func init() {
-	// This is a good default for unit tests. Benchmarks should add their own
-	// init function or TestMain to lower the default, for example to 2.
-	SetDefaultVerbosity(5)
-}
-
 // SetDefaultVerbosity can be called during init to modify the default
 // log verbosity of the program.
 //


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind regression

#### What this PR does / why we need it:

Bumping to 5 is useful in unit tests. Those tend to produce less output and ideally use per-test output, so we end up keeping only the output of failed tests where increased verbosity also in CI runs is useful.

But ktesting now also gets imported into e2e test binaries through the framework. There the increased verbosity is apparently causing OOM killing in some jobs which previously worked fine.

Long term we need a better solution than simply disabling the verbosity change. We could modify each unit test to call SetDefaultVerbosity, but that's tedious. Perhaps an env variable? It cannot be a command line flag because not all unit tests accept `-v`.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/136126#issuecomment-3728279418

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @pacoxu 