### PR TITLE
kubectl exec: Fail if COMMAND is passed after resource

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -205,12 +205,18 @@ type ExecOptions struct {
 
 // Complete verifies command line arguments and loads data from the command environment
 func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []string, argsLenAtDash int) error {
+	// first arg before "--" is the resource
 	if len(argsIn) > 0 && argsLenAtDash != 0 {
 		p.ResourceName = argsIn[0]
 	}
 	if argsLenAtDash > -1 {
+		// We don't allow any commands after the resource name, i.e. "exec -it resource COMMAND -- COMMAND"
+		if argsLenAtDash > 1 {
+			return cmdutil.UsageErrorf(cmd, "exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead")
+		}
 		p.Command = argsIn[argsLenAtDash:]
 	} else if len(argsIn) > 1 || (len(argsIn) > 0 && len(p.FilenameOptions.Filenames) != 0) {
+		// We don't allow command execution without "--", i.e. "exec -it resource COMMAND"
 		return cmdutil.UsageErrorf(cmd, "exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead")
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
@@ -127,6 +127,14 @@ func TestPodAndContainer(t *testing.T) {
 			name:          "cmd, container in flag",
 			obj:           execPod(),
 		},
+		{
+			p:             &ExecOptions{},
+			args:          []string{"foo", "bar", "cmd"},
+			argsLenAtDash: 2,
+			expectError:   true,
+			name:          "multiple args before dash should error",
+			obj:           execPod(),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently kubectl exec does not fail this execution: `kubectl exec -it nginx COMMAND1 COMMAND2 -- COMMAND3`. Although it safely executes COMMAND3 by ignoring the others, it is not ideal to accept other arguments. This PR updates the kubectl exec to fail if there is any unexpected arguments passed.

This PR is revival of https://github.com/kubernetes/kubernetes/pull/131353 and https://github.com/kubernetes/kubernetes/pull/131374

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1745

#### Does this PR introduce a user-facing change?
```release-note
kubectl exec will fail if there is any extra arguments after the resource name and before "--".
```