### PR TITLE
Fix data race in devicemanager PluginDisconnected logging

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -250,7 +250,7 @@ func (m *ManagerImpl) PluginDisconnected(logger klog.Logger, resourceName string
 
 	if ep, exists := m.endpoints[resourceName]; exists {
 		m.markResourceUnhealthy(logger, resourceName)
-		logger.V(2).Info("Endpoint became unhealthy", "resourceName", resourceName, "endpoint", ep)
+		logger.V(2).Info("Endpoint became unhealthy", "resourceName", resourceName)
 
 		ep.e.setStopTime(time.Now())
 	}


### PR DESCRIPTION
Don't log the endpoint struct in PluginDisconnected() - it contains a gRPC client and logging it via reflection races with Close().

The logger walks the struct with reflection, reading gRPC internals, while Close() is modifying mutex state in the background. Removing the endpoint from the log avoids the race. The resourceName is already logged which is enough to identify which endpoint disconnected.

This race becomes visible with gRPC v1.76.0+ due to timing changes in buffer handling and goroutine lifecycle during Close(). The ci-kubernetes-unit-dependencies job was hitting this ~10% of the time when testing with updated dependencies.

CI failures:
- https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-unit-dependencies/2009065501396832256/build-log.txt
- https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-unit-dependencies/2008641956699181056/build-log.txt
- https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-unit-dependencies/2007491912692404224/build-log.txt
- https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-unit-dependencies/2007431281842851840/build-log.txt

Recreatable using:
```
# Pin gRPC to v1.78.0
./hack/pin-dependency.sh google.golang.org/grpc v1.78.0
./hack/update-vendor.sh

# Run in Linux container
docker run --rm -v $(pwd):/kubernetes -w /kubernetes golang:latest \
  bash -c "go test -race -count=200 -run TestNewManagerImplStartProbeMode \
  k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
