### PR TITLE
E2E framework: fix nil pointer crash in TContext

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -180,7 +180,9 @@ var _ ktesting.ContextTB = &Framework{}
 func (f *Framework) TContext(ctx context.Context) ktesting.TContext {
 	tCtx := ktesting.InitCtx(ctx, f)
 	tCtx = tCtx.WithClients(f.clientConfig, f.restMapper, f.ClientSet, f.DynamicClient, apiextensions.NewForConfigOrDie(f.clientConfig))
-	tCtx = tCtx.WithNamespace(f.Namespace.Name)
+	if f.Namespace != nil {
+		tCtx = tCtx.WithNamespace(f.Namespace.Name)
+	}
 	tCtx = ensureLogger(tCtx)
 	return tCtx
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Not all framework instances have a default namespace. TContext crashed for those.

#### Which issue(s) this PR is related to:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-kind-network/2009295267794259968

```
E0108 16:43:40.391543   65976 panic.go:262] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
	goroutine 12822 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x5ba9a40, 0xc004d78ff0}, {0x4c4d660, 0x7ce1f80})
		k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x5ba9998, 0x7ef5980}, {0x4c4d660, 0x7ce1f80}, {0x0, 0x0, 0x1a854c0?})
		k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0x116
	k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x5ba9998, 0x7ef5980}, {0x0, 0x0, 0x0})
		k8s.io/apimachinery/pkg/util/runtime/runtime.go:78 +0x5a
	panic({0x4c4d660?, 0x7ce1f80?})
		runtime/panic.go:783 +0x132
	k8s.io/kubernetes/test/e2e/framework.(*Framework).TContext(0xc00154d540, {0x5ba9998, 0x7ef5980})
		k8s.io/kubernetes/test/e2e/framework/framework.go:183 +0x22f
	k8s.io/kubernetes/test/e2e/framework/pod.ExecWithOptionsContext({0x5ba9998?, 0x7ef5980?}, 0x0?, {{0xc00517d450, 0x5, 0x5}, {0xc0040d7573, 0xd}, {0x5c38b88, 0x1}, ...})
		k8s.io/kubernetes/test/e2e/framework/pod/exec_util.go:62 +0x32
	k8s.io/kubernetes/test/e2e/framework/pod.ExecWithOptions(...)
		k8s.io/kubernetes/test/e2e/framework/pod/exec_util.go:58
	k8s.io/kubernetes/test/e2e/network/netpol.(*kubeManager).executeRemoteCommand(0xc002890ae0?, {0xc0040d7573?, 0xc002bf2ba0?}, {0x5c38b88?, 0x2?}, {0xc004554560?, 0x52dbf46?}, {0xc00517d450, 0x5, 0x5})
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/cc @aojea 