### PR TITLE
client-go testing: fix List+Watch support

### DIFF
--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher_test.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher_test.go
@@ -313,6 +313,10 @@ func fakeKubeClientSetWithCTBList(t *testing.T, signerName string, ctbs ...runti
 			}
 		}
 
+		// Ensure that Watch doesn't return any objects either by bumping up the resource version
+		// beyond what the fake client uses.
+		retList.ResourceVersion = "1000"
+
 		return true, retList, nil
 	})
 

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
@@ -369,7 +369,7 @@ func TestListWithNoFixturesAndTypedScheme(t *testing.T) {
 
 	expectedList := &unstructured.UnstructuredList{}
 	expectedList.SetGroupVersionKind(listGVK)
-	expectedList.SetResourceVersion("") // by product of the fake setting resource version
+	expectedList.SetResourceVersion("0") // No objects created so far.
 	expectedList.SetContinue("")
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
@@ -186,7 +186,7 @@ func Test_ListKind(t *testing.T) {
 			"kind":       "TheKindList",
 			"metadata": map[string]interface{}{
 				"continue":        "",
-				"resourceVersion": "3", // Three objects created so far.
+				"resourceVersion": "4", // Three objects created so far, starting value is 1.
 			},
 		},
 		Items: []unstructured.Unstructured{
@@ -340,7 +340,7 @@ func TestListWithUnstructuredObjectsAndTypedScheme(t *testing.T) {
 
 	expectedList := &unstructured.UnstructuredList{}
 	expectedList.SetGroupVersionKind(listGVK)
-	expectedList.SetResourceVersion("1") // One object created so far.
+	expectedList.SetResourceVersion("2") // One object created so far, initial value is 1.
 	expectedList.SetContinue("")
 	expectedList.Items = append(expectedList.Items, u)
 
@@ -369,7 +369,7 @@ func TestListWithNoFixturesAndTypedScheme(t *testing.T) {
 
 	expectedList := &unstructured.UnstructuredList{}
 	expectedList.SetGroupVersionKind(listGVK)
-	expectedList.SetResourceVersion("0") // No objects created so far.
+	expectedList.SetResourceVersion("1") // No objects created so far.
 	expectedList.SetContinue("")
 
 	if diff := cmp.Diff(expectedList, list); diff != "" {
@@ -402,7 +402,7 @@ func TestListWithNoScheme(t *testing.T) {
 
 	expectedList := &unstructured.UnstructuredList{}
 	expectedList.SetGroupVersionKind(listGVK)
-	expectedList.SetResourceVersion("1") // One object created so far.
+	expectedList.SetResourceVersion("2") // One object created so far, initial value is 1.
 	expectedList.SetContinue("")
 	expectedList.Items = append(expectedList.Items, u)
 
@@ -443,7 +443,7 @@ func TestListWithTypedFixtures(t *testing.T) {
 
 	expectedList := &unstructured.UnstructuredList{}
 	expectedList.SetGroupVersionKind(listGVK)
-	expectedList.SetResourceVersion("1") // One object created so far.
+	expectedList.SetResourceVersion("2") // One object created so far, initial value is 1.
 	expectedList.SetContinue("")
 	expectedList.Items = []unstructured.Unstructured{u}
 

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -297,8 +297,11 @@ type tracker struct {
 	// see apimachinery/pkg/watch.DefaultChanSize) will cause a panic.
 	watchers map[schema.GroupVersionResource]map[string][]*watch.RaceFreeFakeWatcher
 	// resourceVersions is the highest resource version of any tracked object with
-	// a certain gvr. The resource version for that set of objects gets bumped before
-	// storing a new or modified object, so all entries are larger than 0.
+	// a certain gvr. Conceptually it starts at 1 when no objects are stored (0 is
+	// special in queries) but the map contains no entries in that case.
+	// The resource version for that set of objects gets bumped before
+	// storing a new or modified object.
+	//
 	// Object content does not get changed to preserve the traditional behavior
 	// (hence also the versionedObject type instead of storing a runtime.Object
 	// with modified ResourceVersion).
@@ -322,7 +325,8 @@ type tracker struct {
 // but this is not how fake client-go has traditionally worked and starting to do
 // that now might break tests.
 type versionedObject struct {
-	// resourceVersion is always > 0 for a stored object.
+	// resourceVersion is always > 1 for a stored object because 1
+	// is the initial value for an empty set of objects.
 	resourceVersion int64
 	runtime.Object
 }
@@ -370,7 +374,11 @@ func (t *tracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionK
 	defer t.lock.RUnlock()
 
 	if listMeta, err := meta.ListAccessor(list); err == nil {
-		listMeta.SetResourceVersion(fmt.Sprintf("%d", t.resourceVersions[gvr]))
+		resourceVersion, ok := t.resourceVersions[gvr]
+		if !ok {
+			resourceVersion = 1
+		}
+		listMeta.SetResourceVersion(fmt.Sprintf("%d", resourceVersion))
 	}
 
 	objs, ok := t.objects[gvr]
@@ -644,16 +652,23 @@ func (t *tracker) add(gvr schema.GroupVersionResource, obj runtime.Object, ns st
 		t.objects[gvr] = make(map[types.NamespacedName]versionedObject)
 	}
 
+	// Determine resource version for the new or updated object.
+	resourceVersion, ok := t.resourceVersions[gvr]
+	if !ok {
+		resourceVersion = 1
+	}
+	resourceVersion++
+
 	namespacedName := types.NamespacedName{Namespace: newMeta.GetNamespace(), Name: newMeta.GetName()}
 	if _, ok = t.objects[gvr][namespacedName]; ok {
 		if replaceExisting {
-			resourceVersion := t.resourceVersions[gvr] + 1
 			t.resourceVersions[gvr] = resourceVersion
+			t.objects[gvr][namespacedName] = versionedObject{resourceVersion, obj}
+
 			for _, w := range t.getWatches(gvr, ns) {
 				// To avoid the object from being accidentally modified by watcher
 				w.Modify(obj.DeepCopyObject())
 			}
-			t.objects[gvr][namespacedName] = versionedObject{resourceVersion, obj}
 			return nil
 		}
 		return apierrors.NewAlreadyExists(gr, newMeta.GetName())
@@ -664,7 +679,6 @@ func (t *tracker) add(gvr schema.GroupVersionResource, obj runtime.Object, ns st
 		return apierrors.NewNotFound(gr, newMeta.GetName())
 	}
 
-	resourceVersion := t.resourceVersions[gvr] + 1
 	t.resourceVersions[gvr] = resourceVersion
 	t.objects[gvr][namespacedName] = versionedObject{resourceVersion, obj}
 

--- a/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
+++ b/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
@@ -67,14 +67,14 @@ func testListAndWatch(t *testing.T) {
 				logger.Info("Listed", "configMaps", objs, "err", err)
 				if err != nil {
 					t.Errorf("Unexpected List error: %v", err)
-				} else if objs.ResourceVersion != "1" {
-					t.Errorf("Expected ListMeta ResourceVersion 1, got %q", objs.ResourceVersion)
+				} else if objs.ResourceVersion != "2" {
+					t.Errorf("Expected ListMeta ResourceVersion 2, got %q", objs.ResourceVersion)
 				}
 				return objs, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				if options.ResourceVersion != "1" {
-					t.Errorf("Expected ListOptions ResourceVersion 1, got %q", options.ResourceVersion)
+				if options.ResourceVersion != "2" {
+					t.Errorf("Expected ListOptions ResourceVersion 2, got %q", options.ResourceVersion)
 				}
 				logger.Info("Delaying Watch...")
 				<-createDone

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers_test.go
@@ -51,7 +51,7 @@ func TestGetPodList(t *testing.T) {
 			sortBy:  func(pods []*corev1.Pod) sort.Interface { return podutils.ByLogging(pods) },
 			expected: &corev1.PodList{
 				ListMeta: metav1.ListMeta{
-					ResourceVersion: "2", // Two objects created.
+					ResourceVersion: "3", // Two objects created, initial value is 1.
 				},
 				Items: []corev1.Pod{
 					{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

56448506075c3db1d added support for List+Watch to a fake client-go instance. However, that support was not quite working yet as seen when analyzing a test flake:

- List returned early when there were no objects, without adding the ResourceVersion. The ResourceVersion should have been "0" instead.
- When encountering "" as ResourceVersion, Watch didn't deliver any objects. That was meant to preserve compatibility with clients which don't expect objects from a Watch, but the right semantic of "" is "Start at most recent", which includes delivering existing objects.

#### Which issue(s) this PR is related to:

Fixes https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135395/pull-kubernetes-unit/2008849588844236800

https://github.com/kubernetes/kubernetes/blob/aee92bc072a79b8527cf84de17ac82d5c4f217ab/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go#L3143-L3144

relies on reliably delivering the created object.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
client-go: fake client-go (i.e. anything using k8s.io/client-go/testing) now supports separate List+Watch calls  with checking of ResourceVersion in the Watch call. This closes a race condition where creating an object directly after an informer cache has synced (= List call completed) and before the Watch call completed would cause that object to not be sent to the informer. A visible side-effect of adding that support is that List meta data contains a ResourceVersion (starting at "1" for the empty set, incremented by one  for each add/update) and that Watch may return objects where it previously didn't.

Note that this List+Watch is not to be confused with the ListWatch feature, which uses a single call. That feature is still not supported by fake client-go.
```

/assign @sttts 