### PR TITLE
docs: use hyphenated form for open-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ----
 
-Kubernetes, also known as K8s, is an open source system for managing [containerized applications]
+Kubernetes, also known as K8s, is an open-source system for managing [containerized applications]
 across multiple hosts. It provides basic mechanisms for the deployment, maintenance,
 and scaling of applications.
 


### PR DESCRIPTION
Corrected the hyphen in 'open source' to 'open-source'.

What type of PR is this?

/kind documentation

What this PR does / why we need it:

Corrects the wording in the README to use the standard hyphenated form "open-source" for consistency and clarity.

Which issue(s) this PR fixes:

NONE
Fixes #

NONE
Special notes for your reviewer:

NONE
Does this PR introduce a user-facing change?:

NONE
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NA