### PR TITLE
Fix pod level limit defaulting

### DIFF
--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -505,3 +505,21 @@ func reuseOrClearResourceList(reuse v1.ResourceList) v1.ResourceList {
 	}
 	return reuse
 }
+
+// AllContainersHaveLimitForResource checks if all containers in the pod explicitly
+// define a resource limit for a specific resource.
+func AllContainersHaveLimitForResource(pod *v1.Pod, resource v1.ResourceName) bool {
+	for _, container := range pod.Spec.Containers {
+		if _, exists := container.Resources.Limits[resource]; !exists {
+			return false
+		}
+	}
+
+	for _, container := range pod.Spec.InitContainers {
+		if _, exists := container.Resources.Limits[resource]; !exists {
+			return false
+		}
+	}
+
+	return true
+}

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -2319,9 +2319,9 @@ func getPod(cname string, resources podResources) *v1.Pod {
 					Resources: r,
 				},
 			},
-		Overhead: overhead,
-	},
-}
+			Overhead: overhead,
+		},
+	}
 }
 
 func TestAllContainersHaveLimitForResource(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR implements defaulting of pod-level resource limits from aggregated
container-level limits when the pod has explicitly opted into pod-level
resource management.

Pod-level limits are defaulted only when:
- pod-level resource requests are defined, and
- all containers (including init containers) explicitly define limits for
  supported overcommittable resources (CPU and memory).

This avoids defaulting pod-level limits in cases where any container is
partially unbounded, which could otherwise allow access to unknown resource
quantities up to node allocatable capacity.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes  Pod-level limits defaults not set when all containers have limits set and pod-level request is set https://github.com/kubernetes/kubernetes/issues/136120

#### Special notes for your reviewer:
**Edge case clarification:**

In this PR, "all containers have limits set" is interpreted to mean that **each
container defines limits for all supported overcommittable resources (CPU and
memory)**.

For example, consider a pod with three containers:
- Container A sets a CPU limit but does not set a memory limit
- Container B sets a memory limit but does not set a CPU limit
- Container C sets both CPU and memory limits

Although each resource dimension is covered by at least one container, no
single container defines limits for all resources. This pod is therefore
treated as **not having all container limits set**, and pod-level limit
defaulting is skipped.

This behavior is intentional to avoid implicitly granting pods access to
"unknown" or unbounded resources.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Yes. When pod-level requests are specified and all containers define limits
for supported resources, pod-level limits will now default to the aggregated
container limits if no pod-level limits are explicitly set.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/d57336d85b8673959916529873e71010a5d2a4fd/keps/sig-node/2837-pod-level-resource-spec/README.md?plain=1#L503-L507
```
