### PR TITLE
ktesting: don't install signals automatically

### DIFF
--- a/test/utils/ktesting/main_test.go
+++ b/test/utils/ktesting/main_test.go
@@ -29,6 +29,9 @@ func TestMain(m *testing.M) {
 	// Bail out early when -help was given as parameter.
 	flag.Parse()
 
+	// The unit tests assume that they run as a unit test, with progress reporting enabled.
+	InitSignals()
+
 	// Must be called *before* creating new goroutines.
 	goleakOpts := []goleak.Option{
 		goleak.IgnoreCurrent(),

--- a/test/utils/ktesting/signals.go
+++ b/test/utils/ktesting/signals.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	interruptCtx context.Context
+	interruptCtx = context.Background()
 
 	defaultProgressReporter = new(progressReporter)
 	defaultSignalChannel    chan os.Signal
@@ -39,7 +39,10 @@ type ginkgoReporter interface {
 	AttachProgressReporter(reporter func() string) func()
 }
 
-func init() {
+// InitSignals is meant to be used in unit or integration tests.
+// It implements support for triggering a progress report in
+// a running test when sending it a USR1 signal.
+func InitSignals() {
 	// Setting up signals is intentionally done in an init function because
 	// then importing ktesting in a unit or integration test is sufficient
 	// to activate the signal behavior.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The ktesting package now also gets imported in E2E suites and then must not affect signals. This seems to conflict with Ginkgo (but only in some jobs?!).

https://testgrid.k8s.io/sig-network-gce#gci-gce-slow
https://testgrid.k8s.io/sig-network-gce#gci-gce

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/136149
https://github.com/kubernetes/kubernetes/issues/136148
https://github.com/kubernetes/kubernetes/issues/136126

#### Special notes for your reviewer:

How to enable this again automatically only in unit tests is an open question, will be handled later.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @dims @pacoxu 