### PR TITLE
Add test coverage for pod-level limit defaulting (stacked on #136147)

### DIFF
--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -477,34 +477,13 @@ func defaultPodRequests(obj *v1.Pod) {
 	}
 }
 
-// defaultPodLimits applies default values for pod-level resource limits.
-// Pod-level limits are defaulted only when they are unset and the pod has
-// explicitly opted into pod-level resource management by specifying pod-level
-// resource requests. In addition, all containers in the pod must explicitly
-// define resource limits. The following rules apply:
-//
-// 1. When pod-level limits are unset, pod-level resource requests are defined,
-//    and all containers in the pod explicitly specify resource limits, the
-//    pod-level limits are derived by aggregating the container-level limits.
-//
-// 2. When pod-level limits are unset but either pod-level resource requests are
-//    not defined or at least one container does not specify resource limits,
-//    no defaulting is performed and the pod remains unbounded at the pod level.
-//
-// This behavior aligns with the defaulting requirements defined in KEP-2837 and
-// ensures that pod-level limits are only inferred when container-level limits
-// are fully specified and the user has explicitly opted into pod-level resource
-// management.
-// See: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2837-pod-level-resource-spec/README.md#proposed-validation--defaulting-rules
-
+// defaultPodLimits defaults pod-level CPU/memory limits from container limits when
+// pod-level requests are set and all containers specify a limit for the resource.
 func defaultPodLimits(obj *v1.Pod) {
-	// If pod-level limits are already explicitly set, no defaulting is needed.
 	if resourcehelper.IsPodLevelLimitsSet(obj) {
 		return
 	}
 
-	// Pod-level limits are only defaulted when pod-level requests are defined,
-	// indicating the user has opted into pod-level resource management.
 	if !resourcehelper.IsPodLevelRequestsSet(obj) {
 		return
 	}
@@ -522,37 +501,26 @@ func defaultPodLimits(obj *v1.Pod) {
 
 	aggrCtrLimits := resourcehelper.AggregateContainerLimits(obj, resourcehelper.PodResourcesOptions{})
 
-	// When all containers specify limits for a resource (supported by
-	// PodLevelResources feature) and pod-level limits are not set, the pod-level limits
-	// default to the aggregated limits of all the containers for that resource.
-	// We check per-resource: only default if ALL containers have limits for that specific resource.
 	for key, aggrCtrLim := range aggrCtrLimits {
-		// Skip if pod-level limit already explicitly set for this resource
 		if _, exists := podLimits[key]; exists {
 			continue
 		}
 
-		// Only default supported pod-level resources
 		if !resourcehelper.IsSupportedPodLevelResource(key) {
 			continue
 		}
 
-		// Only default overcommittable resources (CPU, memory)
 		if !corev1helper.IsOvercommitAllowed(key) {
 			continue
 		}
 
-		// Check if ALL containers have limits for THIS specific resource
 		if !resourcehelper.AllContainersHaveLimitForResource(obj, key) {
 			continue
 		}
 
-		// Default this resource's pod-level limit
 		podLimits[key] = aggrCtrLim.DeepCopy()
 	}
 
-	// Only set pod-level resource limits in the PodSpec if the limits map
-	// contains entries after collecting container-level limits.
 	if len(podLimits) > 0 {
 		obj.Spec.Resources.Limits = podLimits
 	}

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -3422,8 +3422,8 @@ func TestDefaultPodLimits(t *testing.T) {
 							v1.ResourceMemory: resource.MustParse("256Mi"),
 						},
 						Limits: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("500m"),  // sum of containers
-							v1.ResourceMemory: resource.MustParse("256Mi"), // sum of containers
+							v1.ResourceCPU:    resource.MustParse("500m"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
 						},
 					},
 					Containers: []v1.Container{
@@ -3458,7 +3458,7 @@ func TestDefaultPodLimits(t *testing.T) {
 							v1.ResourceCPU: resource.MustParse("500m"),
 						},
 						Limits: v1.ResourceList{
-							v1.ResourceCPU: resource.MustParse("1000m"), // already set
+							v1.ResourceCPU: resource.MustParse("1000m"),
 						},
 					},
 					Containers: []v1.Container{
@@ -3480,7 +3480,7 @@ func TestDefaultPodLimits(t *testing.T) {
 							v1.ResourceCPU: resource.MustParse("500m"),
 						},
 						Limits: v1.ResourceList{
-							v1.ResourceCPU: resource.MustParse("1000m"), // unchanged
+							v1.ResourceCPU: resource.MustParse("1000m"),
 						},
 					},
 					Containers: []v1.Container{
@@ -3553,7 +3553,6 @@ func TestDefaultPodLimits(t *testing.T) {
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
 									v1.ResourceCPU: resource.MustParse("300m"),
-									// memory missing
 								},
 							},
 						},
@@ -3567,8 +3566,7 @@ func TestDefaultPodLimits(t *testing.T) {
 							v1.ResourceCPU: resource.MustParse("500m"),
 						},
 						Limits: v1.ResourceList{
-							v1.ResourceCPU: resource.MustParse("500m"), // defaulted
-							// memory not defaulted because not all containers have it
+							v1.ResourceCPU: resource.MustParse("500m"),
 						},
 					},
 					Containers: []v1.Container{
@@ -3640,7 +3638,7 @@ func TestDefaultPodLimits(t *testing.T) {
 							v1.ResourceCPU: resource.MustParse("500m"),
 						},
 						Limits: v1.ResourceList{
-							v1.ResourceCPU: resource.MustParse("500m"), // max(300+200, 100+200)
+							v1.ResourceCPU: resource.MustParse("500m"),
 						},
 					},
 					Containers: []v1.Container{
@@ -3695,9 +3693,7 @@ func TestDefaultPodLimits(t *testing.T) {
 						},
 						{
 							Name:      "container2",
-							Resources: v1.ResourceRequirements{
-								// no limits
-							},
+							Resources: v1.ResourceRequirements{},
 						},
 					},
 				},
@@ -3708,7 +3704,6 @@ func TestDefaultPodLimits(t *testing.T) {
 						Requests: v1.ResourceList{
 							v1.ResourceCPU: resource.MustParse("500m"),
 						},
-						// no limits defaulted
 					},
 					Containers: []v1.Container{
 						{
@@ -3778,8 +3773,8 @@ func TestDefaultPodLimits(t *testing.T) {
 							v1.ResourceMemory: resource.MustParse("512Mi"),
 						},
 						Limits: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("500m"),  // max(sum(containers), max(init))
-							v1.ResourceMemory: resource.MustParse("512Mi"), // max(sum(containers), max(init))
+							v1.ResourceCPU:    resource.MustParse("500m"),
+							v1.ResourceMemory: resource.MustParse("512Mi"),
 						},
 					},
 					Containers: []v1.Container{
@@ -3826,8 +3821,8 @@ func TestDefaultPodLimits(t *testing.T) {
 							v1.ResourceMemory: resource.MustParse("512Mi"),
 						},
 						Limits: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("1000m"),  // already set
-							v1.ResourceMemory: resource.MustParse("1024Mi"), // already set
+							v1.ResourceCPU:    resource.MustParse("1000m"),
+							v1.ResourceMemory: resource.MustParse("1024Mi"),
 						},
 					},
 					Containers: []v1.Container{
@@ -3860,8 +3855,8 @@ func TestDefaultPodLimits(t *testing.T) {
 							v1.ResourceMemory: resource.MustParse("512Mi"),
 						},
 						Limits: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("1000m"),  // unchanged
-							v1.ResourceMemory: resource.MustParse("1024Mi"), // unchanged
+							v1.ResourceCPU:    resource.MustParse("1000m"),
+							v1.ResourceMemory: resource.MustParse("1024Mi"),
 						},
 					},
 					Containers: []v1.Container{
@@ -3921,7 +3916,6 @@ func TestDefaultPodLimits(t *testing.T) {
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
 									v1.ResourceCPU: resource.MustParse("100m"),
-									// memory limit missing
 								},
 							},
 						},
@@ -3936,8 +3930,7 @@ func TestDefaultPodLimits(t *testing.T) {
 							v1.ResourceMemory: resource.MustParse("512Mi"),
 						},
 						Limits: v1.ResourceList{
-							v1.ResourceCPU: resource.MustParse("600m"), // CPU defaulted (all containers have CPU limits)
-							// memory NOT defaulted (per-resource: containerC is missing memory limit)
+							v1.ResourceCPU: resource.MustParse("600m"),
 						},
 					},
 					Containers: []v1.Container{
@@ -3976,11 +3969,9 @@ func TestDefaultPodLimits(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
-			// Apply defaulting
 			obj := roundTrip(t, runtime.Object(tc.pod))
 			pod := obj.(*v1.Pod)
 
-			// Compare results
 			if !equality.Semantic.DeepEqual(pod.Spec.Resources, tc.expected.Spec.Resources) {
 				t.Errorf("Pod resources mismatch:\n%s", cmp.Diff(tc.expected.Spec.Resources, pod.Spec.Resources))
 			}

--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -505,3 +505,21 @@ func reuseOrClearResourceList(reuse v1.ResourceList) v1.ResourceList {
 	}
 	return reuse
 }
+
+// AllContainersHaveLimitForResource checks if all containers in the pod explicitly
+// define a resource limit for a specific resource.
+func AllContainersHaveLimitForResource(pod *v1.Pod, resource v1.ResourceName) bool {
+	for _, container := range pod.Spec.Containers {
+		if _, exists := container.Resources.Limits[resource]; !exists {
+			return false
+		}
+	}
+
+	for _, container := range pod.Spec.InitContainers {
+		if _, exists := container.Resources.Limits[resource]; !exists {
+			return false
+		}
+	}
+
+	return true
+}

--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -506,8 +506,7 @@ func reuseOrClearResourceList(reuse v1.ResourceList) v1.ResourceList {
 	return reuse
 }
 
-// AllContainersHaveLimitForResource checks if all containers in the pod explicitly
-// define a resource limit for a specific resource.
+// AllContainersHaveLimitForResource reports whether every container has a limit for the given resource.
 func AllContainersHaveLimitForResource(pod *v1.Pod, resource v1.ResourceName) bool {
 	for _, container := range pod.Spec.Containers {
 		if _, exists := container.Resources.Limits[resource]; !exists {

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -2319,9 +2319,9 @@ func getPod(cname string, resources podResources) *v1.Pod {
 					Resources: r,
 				},
 			},
-		Overhead: overhead,
-	},
-}
+			Overhead: overhead,
+		},
+	}
 }
 
 func TestAllContainersHaveLimitForResource(t *testing.T) {


### PR DESCRIPTION
Stacked on #136147 (please merge #136147 first).

This PR adds regression coverage for the A/B/C partial-limits example described in #136147 making the intended pod-level resource defaulting behavior explicit and test-enforced.

Adds unit tests covering:

- mixed initContainers + containers defaulting
- no override when pod-level limits are already set
- partial limits behavior (per-resource defaulting: CPU may default even if memory can’t)

Refs: #136147, #136120

