### PR TITLE
Promote component-base metrics to beta

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/controllers/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/controllers/metrics.go
@@ -29,7 +29,7 @@ var (
 		&k8smetrics.GaugeOpts{
 			Name:           "running_managed_controllers",
 			Help:           "Indicates where instances of a controller are currently running",
-			StabilityLevel: k8smetrics.ALPHA,
+			StabilityLevel: k8smetrics.BETA,
 		},
 		[]string{"name", "manager"},
 	)

--- a/staging/src/k8s.io/component-base/metrics/prometheus/controllers/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/controllers/metrics_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestRunningManagedControllers(t *testing.T) {
+	controllerInstanceCount.Reset()
+
+	Register()
+
+	managerName := "test-manager"
+	metrics := NewControllerManagerMetrics(managerName)
+
+	controllerName := "test-controller"
+	metrics.ControllerStarted(controllerName)
+
+	wantStarted := `
+		# HELP running_managed_controllers [BETA] Indicates where instances of a controller are currently running
+		# TYPE running_managed_controllers gauge
+		running_managed_controllers{manager="test-manager",name="test-controller"} 1
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantStarted), "running_managed_controllers"); err != nil {
+		t.Fatal(err)
+	}
+
+	metrics.ControllerStopped(controllerName)
+
+	wantStopped := `
+		# HELP running_managed_controllers [BETA] Indicates where instances of a controller are currently running
+		# TYPE running_managed_controllers gauge
+		running_managed_controllers{manager="test-manager",name="test-controller"} 0
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantStopped), "running_managed_controllers"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/staging/src/k8s.io/component-base/metrics/prometheus/version/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/version/metrics.go
@@ -27,7 +27,7 @@ var (
 		&metrics.GaugeOpts{
 			Name:           "kubernetes_build_info",
 			Help:           "A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"major", "minor", "git_version", "git_commit", "git_tree_state", "build_date", "go_version", "compiler", "platform"},
 	)

--- a/staging/src/k8s.io/component-base/metrics/version.go
+++ b/staging/src/k8s.io/component-base/metrics/version.go
@@ -23,7 +23,7 @@ var (
 		&GaugeOpts{
 			Name:           "kubernetes_build_info",
 			Help:           "A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.",
-			StabilityLevel: ALPHA,
+			StabilityLevel: BETA,
 		},
 		[]string{"major", "minor", "git_version", "git_commit", "git_tree_state", "build_date", "go_version", "compiler", "platform"},
 	)

--- a/staging/src/k8s.io/component-base/metrics/version_test.go
+++ b/staging/src/k8s.io/component-base/metrics/version_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/component-base/version"
+)
+
+func TestRegisterBuildInfo(t *testing.T) {
+	registry := metrics.NewKubeRegistry()
+
+	metrics.RegisterBuildInfo(registry)
+
+	info := version.Get()
+
+	want := fmt.Sprintf(`
+		# HELP kubernetes_build_info [BETA] A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
+		# TYPE kubernetes_build_info gauge
+		kubernetes_build_info{build_date=%q,compiler=%q,git_commit=%q,git_tree_state=%q,git_version=%q,go_version=%q,major=%q,minor=%q,platform=%q} 1
+	`,
+		info.BuildDate,
+		info.Compiler,
+		info.GitCommit,
+		info.GitTreeState,
+		info.GitVersion,
+		info.GoVersion,
+		info.Major,
+		info.Minor,
+		info.Platform,
+	)
+
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(want), "kubernetes_build_info"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -5483,7 +5483,7 @@
     commit, git tree state, build date, Go version, and compiler from which Kubernetes
     was built, and platform on which it is running.
   type: Gauge
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - build_date
   - compiler

--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -3013,11 +3013,11 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	</ul>
-	</div><div class="metric" data-stability="alpha">
+	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">kubernetes_build_info</div>
 	<div class="metric_help">A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.</div>
 	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">build_date</span><span class="metric_label">compiler</span><span class="metric_label">git_commit</span><span class="metric_label">git_tree_state</span><span class="metric_label">git_version</span><span class="metric_label">go_version</span><span class="metric_label">major</span><span class="metric_label">minor</span><span class="metric_label">platform</span></li></ul>
 	</div><div class="metric" data-stability="alpha">

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -227,6 +227,22 @@
   help: Number of requested image volumes.
   type: Counter
   stabilityLevel: BETA
+- name: kubernetes_build_info
+  help: A metric with a constant '1' value labeled by major, minor, git version, git
+    commit, git tree state, build date, Go version, and compiler from which Kubernetes
+    was built, and platform on which it is running.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - build_date
+  - compiler
+  - git_commit
+  - git_tree_state
+  - git_version
+  - go_version
+  - major
+  - minor
+  - platform
 - name: feature_enabled
   namespace: kubernetes
   help: This metric records the data about the stage and enablement of a k8s feature.
@@ -256,6 +272,13 @@
   labels:
   - deprecated_version
   - stability_level
+- name: running_managed_controllers
+  help: Indicates where instances of a controller are currently running
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - manager
+  - name
 - name: pod_scheduling_sli_duration_seconds
   subsystem: scheduler
   help: E2e latency for a pod being scheduled, from the time the pod enters the scheduling


### PR DESCRIPTION
/kind feature

#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes a small set of widely used **component-base metrics** from **Alpha to Beta** stability.  
These metrics have been in production use for multiple releases and are relied upon by Kubernetes operators, dashboards, tooling, etc.  
Graduating them to **Beta** provides stronger API and label stability guarantees while still allowing additive evolution.

This PR is intentionally scoped to **component-base** only.  Follow-up PRs will handle scheduler, kubelet, controller-manager, and apiserver metrics.

Metrics promoted in this PR:
- `kubernetes_build_info`
- `rest_client_requests_total`
- `rest_client_request_duration_seconds`
- `running_managed_controllers`

#### Which issue(s) this PR is related to:
Fixes #136107

#### Special notes for your reviewer:
This PR follows the Kubernetes metrics stability policy for Alpha -> Beta graduation:
- Tests have been added or updated to validate metric registration, emission, and expected labels/values.
- Help text is verified and updated where needed.
- No labels were removed (Beta compatibility guarantee).

This is PR #1 of a planned series that will promote the remaining metrics from the linked issue by component for easier review.

#### Does this PR introduce a user-facing change?
Yes. These metrics are now **Beta**, meaning:
- Existing labels are now guaranteed not to be removed.
- Users can rely on them with stronger compatibility guarantees.

```release-note
Promoted several component-base metrics (`kubernetes_build_info`, `rest_client_requests_total`, `rest_client_request_duration_seconds`, `running_managed_controllers`) from Alpha to Beta stability, providing stronger API and label stability guarantees for consumers.
```