### PR TITLE
[fix]: Extract Run() method from MetricAsyncRecorder constructor

### DIFF
--- a/pkg/scheduler/backend/queue/testing.go
+++ b/pkg/scheduler/backend/queue/testing.go
@@ -45,6 +45,7 @@ func NewTestQueueWithObjects(
 	// Because some major functions (e.g., Pop) requires the metric recorder to be set,
 	// we always set a metric recorder here.
 	recorder := metrics.NewMetricsAsyncRecorder(10, 20*time.Microsecond, ctx.Done())
+	go recorder.Run()
 	// We set it before the options that users provide, so that users can override it.
 	opts = append([]Option{WithMetricsRecorder(recorder)}, opts...)
 	return NewTestQueueWithInformerFactory(ctx, lessFn, informerFactory, opts...)

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -304,7 +304,7 @@ var _ framework.Framework = &frameworkImpl{}
 
 // NewFramework initializes plugins given the configuration and the registry.
 //
-// It creates background goroutines (for example, via defaultFrameworkOptions -> metrics.NewMetricsAsyncRecorder)
+// It creates background goroutines (for example, via metrics.NewMetricsAsyncRecorder)
 // which continue running until the context gets canceled. WaitForShutdown can be used to block
 // until they have terminated.
 func NewFramework(ctx context.Context, r Registry, profile *config.KubeSchedulerProfile, opts ...Option) (framework.Framework, error) {
@@ -312,6 +312,8 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 	for _, opt := range opts {
 		opt(&options)
 	}
+
+	go options.metricsRecorder.Run()
 
 	logger := klog.FromContext(ctx)
 	if options.logger != nil {

--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -124,7 +124,7 @@ type MetricAsyncRecorder struct {
 }
 
 func NewMetricsAsyncRecorder(bufferSize int, interval time.Duration, stopCh <-chan struct{}) *MetricAsyncRecorder {
-	recorder := &MetricAsyncRecorder{
+	return &MetricAsyncRecorder{
 		bufferCh:                      make(chan *histogramVecMetric, bufferSize),
 		bufferSize:                    bufferSize,
 		interval:                      interval,
@@ -134,8 +134,6 @@ func NewMetricsAsyncRecorder(bufferSize int, interval time.Duration, stopCh <-ch
 		aggregatedInflightEventMetricBufferCh:      make(chan *gaugeVecMetric, bufferSize),
 		IsStoppedCh:                                make(chan struct{}),
 	}
-	go recorder.run()
-	return recorder
 }
 
 // ObservePluginDurationAsync observes the plugin_execution_duration_seconds metric.
@@ -190,8 +188,8 @@ func (r *MetricAsyncRecorder) observeMetricAsync(m *metrics.HistogramVec, value 
 	}
 }
 
-// run flushes buffered metrics into Prometheus every second.
-func (r *MetricAsyncRecorder) run() {
+// Run flushes buffered metrics into Prometheus every second.
+func (r *MetricAsyncRecorder) Run() {
 	for {
 		select {
 		case <-r.stopCh:

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1056,6 +1056,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 						}
 
 						ar := metrics.NewMetricsAsyncRecorder(10, 1*time.Second, ctx.Done())
+						go ar.Run()
 						queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar), internalqueue.WithAPIDispatcher(apiDispatcher))
 						if asyncAPICallsEnabled {
 							schedFramework.SetAPICacher(apicache.New(queue, cache))
@@ -1606,6 +1607,7 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 
 					informerFactory := informers.NewSharedInformerFactory(client, 0)
 					ar := metrics.NewMetricsAsyncRecorder(10, 1*time.Second, ctx.Done())
+					go ar.Run()
 					queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar), internalqueue.WithAPIDispatcher(apiDispatcher))
 
 					schedFramework, err := NewFakeFramework(
@@ -2259,6 +2261,7 @@ func TestSchedulerBinding(t *testing.T) {
 				if asyncAPICallsEnabled {
 					informerFactory := informers.NewSharedInformerFactory(client, 0)
 					ar := metrics.NewMetricsAsyncRecorder(10, 1*time.Second, ctx.Done())
+					go ar.Run()
 					queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar), internalqueue.WithAPIDispatcher(apiDispatcher))
 					fwk.SetAPICacher(apicache.New(queue, cache))
 				}
@@ -2514,6 +2517,7 @@ func TestUpdatePodStatus(t *testing.T) {
 
 					informerFactory := informers.NewSharedInformerFactory(cs, 0)
 					ar := metrics.NewMetricsAsyncRecorder(10, 1*time.Second, ctx.Done())
+					go ar.Run()
 					queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar), internalqueue.WithAPIDispatcher(apiDispatcher))
 					apiCacher = apicache.New(queue, nil)
 				}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -321,6 +321,7 @@ func New(ctx context.Context,
 
 	snapshot := internalcache.NewEmptySnapshot()
 	metricsRecorder := metrics.NewMetricsAsyncRecorder(1000, time.Second, stopEverything)
+	go metricsRecorder.Run()
 	// waitingPods holds all the pods that are in the scheduler and waiting in the permit stage
 	waitingPods := frameworkruntime.NewWaitingPodsMap()
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -308,6 +308,7 @@ func TestFailureHandler(t *testing.T) {
 				}
 
 				recorder := metrics.NewMetricsAsyncRecorder(3, 20*time.Microsecond, ctx.Done())
+				go recorder.Run()
 				queue := internalqueue.NewPriorityQueue(nil, informerFactory, internalqueue.WithClock(testingclock.NewFakeClock(time.Now())), internalqueue.WithMetricsRecorder(recorder), internalqueue.WithAPIDispatcher(apiDispatcher))
 				schedulerCache := internalcache.New(ctx, 30*time.Second, apiDispatcher)
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Separate the goroutine start from recorder construction to allow custom recorders to be passed without leaking goroutines.

- NewMetricsAsyncRecorder no longer starts the background goroutine
- Added `Run()` method to start the metrics flushing goroutine
- NewFramework now calls `Run()` after options are applied
- Using `WithMetricsRecorder` no longer leaks a goroutine

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
