### PR TITLE
Fix JSON-Schema URL format in JSONSchemaProps comment

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types_jsonschema.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types_jsonschema.go
@@ -36,7 +36,8 @@ const (
 	FieldValueForbidden FieldValueErrorReason = "FieldValueForbidden"
 )
 
-// JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+// JSONSchemaProps is a JSON-Schema following Specification Draft 4.
+// See: https://json-schema.org/
 type JSONSchemaProps struct {
 	ID                   string
 	Schema               JSONSchemaURL


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fix the URL in the `JSONSchemaProps` comment to render correctly. The current inline format `(http://json-schema.org/)` does not render as a proper link in godoc. Changed the format to use `See: <url>` to remove the trailing `)` which prevented the URL from being rendered as a proper hyperlink. Also updated http to https.

#### Which issue(s) this PR is related to:

Fixes #136158

#### Does this PR introduce a user-facing change?

```release-note
Fixed JSONSchemaProps comment to properly render JSON Schema URL as a valid link
```
