### PR TITLE
Add pohly and bart0sh as approvers for kubelet/cm/dra

### DIFF
--- a/pkg/kubelet/cm/dra/OWNERS
+++ b/pkg/kubelet/cm/dra/OWNERS
@@ -1,2 +1,5 @@
 labels:
   - wg/device-management
+approvers:
+  - pohly
+  - bart0sh


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Ads @pohly and @bart0sh(self-nomination) as approvers for the Kubelet DRA code.
Both are active maintainers of the code and have written most part of it.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/cc @ffromani @klueska @swatisehgal @SergeyKanzhelev @mrunalp