### PR TITLE
chore: handle stream v5 in kubelet

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/remotecommand/constants.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/remotecommand/constants.go
@@ -64,4 +64,4 @@ const (
 	StreamClose  = 255
 )
 
-var SupportedStreamingProtocols = []string{StreamProtocolV4Name, StreamProtocolV3Name, StreamProtocolV2Name, StreamProtocolV1Name}
+var SupportedStreamingProtocols = []string{StreamProtocolV5Name, StreamProtocolV4Name, StreamProtocolV3Name, StreamProtocolV2Name, StreamProtocolV1Name}

--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/httpstream.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/httpstream.go
@@ -149,6 +149,10 @@ func createHTTPStreamStreams(req *http.Request, w http.ResponseWriter, opts *Opt
 
 	var handler protocolHandler
 	switch protocol {
+	case remotecommandconsts.StreamProtocolV5Name:
+		// V5 is the same as V4 for SPDY streaming; the CLOSE signal
+		// is a WebSocket-specific feature handled in wsstream.
+		handler = &v4ProtocolHandler{}
 	case remotecommandconsts.StreamProtocolV4Name:
 		handler = &v4ProtocolHandler{}
 	case remotecommandconsts.StreamProtocolV3Name:

--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/websocket.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/websocket.go
@@ -37,6 +37,7 @@ const (
 	preV4Base64WebsocketProtocol = wsstream.Base64ChannelWebSocketProtocol
 	v4BinaryWebsocketProtocol    = "v4." + wsstream.ChannelWebSocketProtocol
 	v4Base64WebsocketProtocol    = "v4." + wsstream.Base64ChannelWebSocketProtocol
+	v5BinaryWebsocketProtocol    = "v5." + wsstream.ChannelWebSocketProtocol
 )
 
 // createChannels returns the standard channel types for a shell connection (STDIN 0, STDOUT 1, STDERR 2)
@@ -93,6 +94,10 @@ func createWebSocketStreams(req *http.Request, w http.ResponseWriter, opts *Opti
 			Binary:   false,
 			Channels: channels,
 		},
+		v5BinaryWebsocketProtocol: {
+			Binary:   true,
+			Channels: channels,
+		},
 	})
 	conn.SetIdleTimeout(idleTimeout)
 	negotiatedProtocol, streams, err := conn.Open(responsewriter.GetOriginal(w), req)
@@ -122,7 +127,7 @@ func createWebSocketStreams(req *http.Request, w http.ResponseWriter, opts *Opti
 	}
 
 	switch negotiatedProtocol {
-	case v4BinaryWebsocketProtocol, v4Base64WebsocketProtocol:
+	case v4BinaryWebsocketProtocol, v4Base64WebsocketProtocol, v5BinaryWebsocketProtocol:
 		ctx.writeStatus = v4WriteStatusFunc(streams[errorChannel])
 	default:
 		ctx.writeStatus = v1WriteStatusFunc(streams[errorChannel])


### PR DESCRIPTION
Suggested PR Template Content

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Adds server-side support for StreamProtocolV5 in the kubelet's CRI streaming code. V5 adds support for a CLOSE signal, allowing clients to signal graceful stream closure.

For SPDY streaming, V5 behaves identically to V4 since the CLOSE signal is WebSocket-specific and handled in wsstream.

#### Does this PR introduce a user-facing change?
NONE

```release-note
Added server-side support for remotecommand streaming protocol v5, which enables
graceful stream closure via the CLOSE signal for WebSocket connections.
```