### PR TITLE
client-go: include reason in event spam key

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/events_cache.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache.go
@@ -40,7 +40,7 @@ const (
 	defaultAggregateMaxEvents         = 10
 	defaultAggregateIntervalInSeconds = 600
 
-	// by default, allow a source to send 25 events about an object
+	// by default, allow a source to send 25 events about an object+reason
 	// but control the refill rate to 1 new event every 5 minutes
 	// this helps control the long-tail of events for things that are always
 	// unhealthy
@@ -66,7 +66,7 @@ func getEventKey(event *v1.Event) string {
 		"")
 }
 
-// getSpamKey builds unique event key based on source, involvedObject
+// getSpamKey builds unique event key based on source, involvedObject, reason
 func getSpamKey(event *v1.Event) string {
 	return strings.Join([]string{
 		event.Source.Component,
@@ -77,6 +77,7 @@ func getSpamKey(event *v1.Event) string {
 		string(event.InvolvedObject.UID),
 		event.InvolvedObject.APIVersion,
 		event.Type,
+		event.Reason,
 	},
 		"")
 }
@@ -430,7 +431,7 @@ type EventCorrelateResult struct {
 //     the same reason.
 //   - Events are incrementally counted if the exact same event is encountered multiple
 //     times.
-//   - A source may burst 25 events about an object, but has a refill rate budget
+//   - A source may burst 25 events about an object+reason, but has a refill rate budget
 //     per object of 1 event every 5 minutes to control long-tail of spam.
 func NewEventCorrelator(clock clock.PassiveClock) *EventCorrelator {
 	cacheSize := maxLruCacheEntries

--- a/staging/src/k8s.io/client-go/tools/record/events_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache_test.go
@@ -283,7 +283,7 @@ func TestEventCorrelator(t *testing.T) {
 }
 
 func TestEventSpamFilter(t *testing.T) {
-	spamKeyFuncBasedOnObjectsAndReason := func(e *v1.Event) string {
+	spamKeyFuncBasedOnObjectsReasonAndMessage := func(e *v1.Event) string {
 		return strings.Join([]string{
 			e.Source.Component,
 			e.Source.Host,
@@ -293,6 +293,7 @@ func TestEventSpamFilter(t *testing.T) {
 			string(e.InvolvedObject.UID),
 			e.InvolvedObject.APIVersion,
 			e.Reason,
+			e.Message,
 		},
 			"")
 	}
@@ -307,20 +308,20 @@ func TestEventSpamFilter(t *testing.T) {
 		expectedSkip  bool
 		spamKeyFunc   EventSpamKeyFunc
 	}{
-		"event should be reported as spam if object reference is the same for default spam filter": {
-			newEvent:     differentReasonEvent,
-			expectedSkip: true,
-		},
-		"event should not be reported as spam if object reference is the same, but reason is different for custom spam filter": {
+		"event should not be reported as spam if object reference is the same but reason is different for default spam filter": {
 			newEvent:      differentReasonEvent,
 			expectedEvent: differentReasonEvent,
 			expectedSkip:  false,
-			spamKeyFunc:   spamKeyFuncBasedOnObjectsAndReason,
 		},
-		"event should  be reported as spam if object reference and reason is the same, but message is different for custom spam filter": {
+		"event should be reported as spam if object reference and reason are the same for default spam filter": {
 			newEvent:     spamEvent,
 			expectedSkip: true,
-			spamKeyFunc:  spamKeyFuncBasedOnObjectsAndReason,
+		},
+		"event should not be reported as spam if object reference and reason are the same but message is different for custom spam filter": {
+			newEvent:      spamEvent,
+			expectedEvent: spamEvent,
+			expectedSkip:  false,
+			spamKeyFunc:   spamKeyFuncBasedOnObjectsReasonAndMessage,
 		},
 	}
 


### PR DESCRIPTION
/kind bug
/sig instrumentation

#### What this PR does / why we need it:
Issue link: https://github.com/kubernetes/kubernetes/issues/136061
Summary: include event reason in the default spam-filter key so distinct reasons for the same object are not throttled together.
Motivation: the event recorder limits bursts per object, which can drop later events when a controller emits many reasons for the same CR. Keying by reason preserves spam protection while avoiding early drops across reasons.
Validation:
- `go test ./staging/src/k8s.io/client-go/tools/record`

#### Which issue(s) this PR is related to:
Fixes #136061

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
Event spam filtering now keys by object+reason, allowing distinct reasons for the same object to be recorded instead of being dropped together.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
