### PR TITLE
test: fix kind local registry config for kms ci jobs

### DIFF
--- a/test/e2e/testing-manifests/auth/encrypt/kind.yaml
+++ b/test/e2e/testing-manifests/auth/encrypt/kind.yaml
@@ -3,11 +3,14 @@ apiVersion: kind.x-k8s.io/v1alpha4
 # this containerd config patch sets the registry to the local registry where we push mock kms provider
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-    endpoint = ["http://kind-registry:5000"]
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
 nodes:
 - role: control-plane
   extraMounts:
+  - containerPath: /etc/containerd/certs.d
+    hostPath: test/e2e/testing-manifests/auth/encrypt/certs.d
+    readOnly: true
   - containerPath: /etc/kubernetes/encryption-config.yaml
     hostPath: test/e2e/testing-manifests/auth/encrypt/encryption-config.yaml
     readOnly: true

--- a/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
+++ b/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
@@ -90,6 +90,14 @@ connect_registry(){
     fi
 }
 
+# create_hosts_toml creates the hosts.toml file used to configure the local registry for the kind cluster.
+create_hosts_toml() {
+    mkdir -p "test/e2e/testing-manifests/auth/encrypt/certs.d/localhost:5000"
+    cat <<EOF > "test/e2e/testing-manifests/auth/encrypt/certs.d/localhost:5000/hosts.toml"
+[host."http://kind-registry:5000"]
+EOF
+}
+
 # create_cluster_and_run_test creates a kind cluster using kubetest2 and runs e2e tests.
 create_cluster_and_run_test() {
     CLUSTER_CREATE_ATTEMPTED=true
@@ -112,6 +120,8 @@ create_cluster_and_run_test() {
 }
 
 cleanup() {
+    rm -rf test/e2e/testing-manifests/auth/encrypt/certs.d
+
     # CLUSTER_CREATE_ATTEMPTED is true once we run kubetest2 kind --up
     if [ "${CLUSTER_CREATE_ATTEMPTED:-}" = true ]; then
         if [ "${SKIP_COLLECT_LOGS:-}" != "true" ]; then
@@ -162,6 +172,7 @@ main(){
     done;
 
     create_registry
+    create_hosts_toml
     build_and_push_mock_plugin
     connect_registry &
     create_cluster_and_run_test


### PR DESCRIPTION
/kind failing-test

Fix kind local registry config for kms ci jobs.
- Used https://kind.sigs.k8s.io/docs/user/local-registry/ for reference.

```release-note
NONE
```

fixes #136181 

/triage accepted
/sig auth