### PR TITLE
feat(kube-api-linter): add dependenttags linter for k8s:unionMember

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -396,6 +396,7 @@ linters:
               - "ssatags" # Ensure lists have a listType tag.
               # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
               - "duplicatemarkers" #Prevent identical markers from being present on types and fields
+              - "dependenttags" # Ensure markers dependent on other markers are present.
           lintersConfig:
             conditions:
               isFirstField: Ignore
@@ -413,6 +414,12 @@ linters:
                 - ["k8s:required", "required", "kubebuilder:validation:Required"]
                 - ["default"]
                 description: "fields with default values are always optional"
+            dependenttags:
+              rules:
+                - identifier: "k8s:unionMember"
+                  type: "All"
+                  dependsOn:
+                    - "k8s:optional"
             # jsonTags:
             #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
             # nomaps:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -405,6 +405,7 @@ linters:
               - "ssatags" # Ensure lists have a listType tag.
               # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
               - "duplicatemarkers" #Prevent identical markers from being present on types and fields
+              - "dependenttags" # Ensure markers dependent on other markers are present.
           lintersConfig:
             conditions:
               isFirstField: Ignore
@@ -422,6 +423,12 @@ linters:
                 - ["k8s:required", "required", "kubebuilder:validation:Required"]
                 - ["default"]
                 description: "fields with default values are always optional"
+            dependenttags:
+              rules:
+                - identifier: "k8s:unionMember"
+                  type: "All"
+                  dependsOn:
+                    - "k8s:optional"
             # jsonTags:
             #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
             # nomaps:

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -21,6 +21,7 @@ linters:
     - "ssatags" # Ensure lists have a listType tag.
     # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
     - "duplicatemarkers" #Prevent identical markers from being present on types and fields
+    - "dependenttags" # Ensure markers dependent on other markers are present.
 lintersConfig:
   conditions:
     isFirstField: Ignore
@@ -38,6 +39,12 @@ lintersConfig:
       - ["k8s:required", "required", "kubebuilder:validation:Required"]
       - ["default"]
       description: "fields with default values are always optional"
+  dependenttags:
+    rules:
+      - identifier: "k8s:unionMember"
+        type: "All"
+        dependsOn:
+          - "k8s:optional"
   # jsonTags:
   #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
   # nomaps:

--- a/hack/tools/golangci-lint/go.mod
+++ b/hack/tools/golangci-lint/go.mod
@@ -222,7 +222,7 @@ require (
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect
-	sigs.k8s.io/kube-api-linter v0.0.0-20251208100930-d3015c953951 // indirect
+	sigs.k8s.io/kube-api-linter v0.0.0-20260114104534-18147eee9c49 // indirect
 	sigs.k8s.io/logtools v0.9.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/hack/tools/golangci-lint/go.sum
+++ b/hack/tools/golangci-lint/go.sum
@@ -1006,8 +1006,8 @@ mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15/go.mod h1:4M5MMXl2kW6fivUT6y
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/kube-api-linter v0.0.0-20251208100930-d3015c953951 h1:pjOeiLsYwEPaSRYTiMtVfdn7gSoRilw7Peyjw6kyUu4=
-sigs.k8s.io/kube-api-linter v0.0.0-20251208100930-d3015c953951/go.mod h1:5mP60UakkCye+eOcZ5p98VnV2O49qreW1gq9TdsUf7Q=
+sigs.k8s.io/kube-api-linter v0.0.0-20260114104534-18147eee9c49 h1:Dlr79S/bnHg+g86cBxul/lbctdVfMTLN1c5XeN6/0JM=
+sigs.k8s.io/kube-api-linter v0.0.0-20260114104534-18147eee9c49/go.mod h1:5mP60UakkCye+eOcZ5p98VnV2O49qreW1gq9TdsUf7Q=
 sigs.k8s.io/logtools v0.9.0 h1:IMP/HTDkfM6rg6os/tcEjmQeIHyOyu/enduM/cOPGNQ=
 sigs.k8s.io/logtools v0.9.0/go.mod h1:74Z5BP7ehrMHi/Q31W1gSf8YgwT/4GPjVH5xPSPeZA0=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Refer: https://github.com/kubernetes/kubernetes/issues/134671

This PR updates the kube-api-linter configuration to enable the dependenttags linter. It adds a rule requiring that any field marked with `+k8s:unionMember` must also be explicitly marked with `+k8s:optional`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Experimented with change:
```diff
diff --git a/staging/src/k8s.io/api/resource/v1beta2/types.go b/staging/src/k8s.io/api/resource/v1beta2/types.go
index 8bb62f71a29..39beb2e1cee 100644
--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -633,7 +633,6 @@ type DeviceAttribute struct {
        // Must not be longer than 64 characters.
        //
        // +optional
-       // +k8s:optional
        // +k8s:unionMember
        VersionValue *string `json:"version,omitempty" protobuf:"bytes,5,opt,name=version"`
 }
```
The golangci-lint has following result:
```
ERROR: staging/src/k8s.io/api/resource/v1beta2/types.go:637:2: dependenttags: field DeviceAttribute.VersionValue with marker +k8s:unionMember is missing required marker(s): +k8s:optional (kubeapilinter)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
