### PR TITLE
Optimize NodeDeclaredFeatures with a bitmap FeatureSet implementation

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -43,7 +43,6 @@ import (
 
 	"k8s.io/client-go/informers"
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
-	ndffeatures "k8s.io/component-helpers/nodedeclaredfeatures/features"
 	"k8s.io/mount-utils"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -1073,10 +1072,7 @@ func NewMainKubelet(ctx context.Context,
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse version: %w", err)
 		}
-		framework, err := ndf.New(ndffeatures.AllFeatures)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create node feature helper: %w", err)
-		}
+		framework := ndf.DefaultFramework
 		klet.version = v
 		klet.nodeDeclaredFeaturesFramework = framework
 		klet.nodeDeclaredFeatures = klet.discoverNodeDeclaredFeatures()

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1076,7 +1076,7 @@ func NewMainKubelet(ctx context.Context,
 		klet.version = v
 		klet.nodeDeclaredFeaturesFramework = framework
 		klet.nodeDeclaredFeatures = klet.discoverNodeDeclaredFeatures()
-		klet.nodeDeclaredFeaturesSet = ndf.NewFeatureSet(klet.nodeDeclaredFeatures...)
+		klet.nodeDeclaredFeaturesSet = framework.MustMapSorted(klet.nodeDeclaredFeatures)
 	}
 
 	// Safe, allowed sysctls can always be used as unsafe sysctls in the spec.
@@ -2927,8 +2927,8 @@ func (kl *Kubelet) HandlePodUpdates(ctx context.Context, pods []*v1.Pod) {
 			if err != nil {
 				logger.Error(err, "Failed to infer required features for pod update", "pod", klog.KObj(pod))
 			}
-			if reqs.Len() != 0 {
-				matchResult, err := ndf.MatchNodeFeatureSet(reqs, kl.nodeDeclaredFeaturesSet)
+			if !reqs.IsEmpty() {
+				matchResult, err := kl.nodeDeclaredFeaturesFramework.MatchNodeFeatureSet(reqs, kl.nodeDeclaredFeaturesSet)
 				if err != nil {
 					logger.Error(err, "Failed to match pod features with the node", "pod", klog.KObj(pod))
 

--- a/pkg/kubelet/kubelet_node_declared_features_test.go
+++ b/pkg/kubelet/kubelet_node_declared_features_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -88,8 +87,7 @@ func TestDeclaredFeatureDiscovery(t *testing.T) {
 			kubelet := testKubelet.kubelet
 			fakeCM := cm.NewFakeContainerManagerWithNodeConfig(cm.NodeConfig{})
 			kubelet.containerManager = fakeCM
-			framework, err := ndf.New(registeredFeatures)
-			require.NoError(t, err)
+			framework := ndf.New(registeredFeatures)
 			kubelet.nodeDeclaredFeaturesFramework = framework
 			kubelet.version = tc.kubeletVersion
 
@@ -130,8 +128,7 @@ func TestExtendWebSocketsToKubeletFeatureDiscovery(t *testing.T) {
 			defer testKubelet.Cleanup()
 			kubelet := testKubelet.kubelet
 
-			framework, err := ndf.New(ndffeatures.AllFeatures)
-			require.NoError(t, err)
+			framework := ndf.New(ndffeatures.AllFeatures)
 			kubelet.nodeDeclaredFeaturesFramework = framework
 
 			features := kubelet.discoverNodeDeclaredFeatures()

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -5041,8 +5041,7 @@ func TestSyncPodNodeDeclaredFeaturesUpdate(t *testing.T) {
 			recorder := record.NewFakeRecorder(10)
 			kubelet.recorder = recorder
 
-			framework, err := ndf.New(tc.registeredFeatures)
-			require.NoError(t, err)
+			framework := ndf.New(tc.registeredFeatures)
 			kubelet.nodeDeclaredFeaturesFramework = framework
 			kubelet.nodeDeclaredFeatures = tc.nodeFeatures
 			kubelet.nodeDeclaredFeaturesSet = ndf.NewFeatureSet(kubelet.nodeDeclaredFeatures...)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -5002,7 +5002,7 @@ func TestSyncPodNodeDeclaredFeaturesUpdate(t *testing.T) {
 			oldPod:             oldPod,
 			newPod:             newPod,
 			nodeFeatures:       []string{"FeatureB"},
-			registeredFeatures: []ndf.Feature{createMockFeature(t, "FeatureA", true, "")},
+			registeredFeatures: []ndf.Feature{createMockFeature(t, "FeatureA", true, ""), createMockFeature(t, "FeatureB", false, "")},
 			expectEvent:        true,
 			expectedEventMsg:   "Pod requires node features that are not available: FeatureA",
 		},
@@ -5012,7 +5012,7 @@ func TestSyncPodNodeDeclaredFeaturesUpdate(t *testing.T) {
 			componentVersion:   "1.35.0",
 			oldPod:             oldPod,
 			newPod:             newPod,
-			nodeFeatures:       []string{""},
+			nodeFeatures:       []string{},
 			registeredFeatures: []ndf.Feature{createMockFeature(t, "FeatureA", true, "1.34.0")},
 			expectEvent:        false,
 		},
@@ -5023,7 +5023,7 @@ func TestSyncPodNodeDeclaredFeaturesUpdate(t *testing.T) {
 			oldPod:             nil,
 			newPod:             newPod,
 			nodeFeatures:       []string{"FeatureB"},
-			registeredFeatures: []ndf.Feature{createMockFeature(t, "FeatureA", true, "")},
+			registeredFeatures: []ndf.Feature{createMockFeature(t, "FeatureA", true, ""), createMockFeature(t, "FeatureB", false, "")},
 			expectEvent:        false,
 		},
 	}
@@ -5044,7 +5044,7 @@ func TestSyncPodNodeDeclaredFeaturesUpdate(t *testing.T) {
 			framework := ndf.New(tc.registeredFeatures)
 			kubelet.nodeDeclaredFeaturesFramework = framework
 			kubelet.nodeDeclaredFeatures = tc.nodeFeatures
-			kubelet.nodeDeclaredFeaturesSet = ndf.NewFeatureSet(kubelet.nodeDeclaredFeatures...)
+			kubelet.nodeDeclaredFeaturesSet = framework.MustMapSorted(kubelet.nodeDeclaredFeatures)
 			kubelet.version = utilversion.MustParse("1.35.0")
 
 			if tc.oldPod != nil {

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -271,11 +271,11 @@ func (c *declaredFeaturesAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmit
 		}
 	}
 
-	if reqs.Len() == 0 {
+	if reqs.IsEmpty() {
 		return PodAdmitResult{Admit: true}
 	}
 
-	matchResult, err := ndf.MatchNodeFeatureSet(reqs, c.ndfSet)
+	matchResult, err := c.ndfFramework.MatchNodeFeatureSet(reqs, c.ndfSet)
 	if err != nil {
 		return PodAdmitResult{
 			Admit:   false,

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -909,8 +909,7 @@ func TestDeclaredFeaturesAdmitHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			framework, err := ndf.New(tc.registeredFeatures)
-			require.NoError(t, err)
+			framework := ndf.New(tc.registeredFeatures)
 			handler := NewDeclaredFeaturesAdmitHandler(framework, ndf.NewFeatureSet(tc.nodeDeclaredFeatures...), tc.version)
 			attrs := &PodAdmitAttributes{Pod: pod}
 

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -910,7 +910,8 @@ func TestDeclaredFeaturesAdmitHandler(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			framework := ndf.New(tc.registeredFeatures)
-			handler := NewDeclaredFeaturesAdmitHandler(framework, ndf.NewFeatureSet(tc.nodeDeclaredFeatures...), tc.version)
+			fs := framework.MustMapSorted(tc.nodeDeclaredFeatures)
+			handler := NewDeclaredFeaturesAdmitHandler(framework, fs, tc.version)
 			attrs := &PodAdmitAttributes{Pod: pod}
 
 			result := handler.Admit(attrs)

--- a/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures.go
+++ b/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures.go
@@ -24,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/version"
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
@@ -94,7 +93,7 @@ func (pl *NodeDeclaredFeatures) PreFilter(ctx context.Context, cycleState fwk.Cy
 	if err != nil {
 		return nil, fwk.AsStatus(err)
 	}
-	if reqs.Len() == 0 {
+	if reqs.IsEmpty() {
 		return nil, fwk.NewStatus(fwk.Skip)
 	}
 	cycleState.Write(preFilterStateKey, &preFilterState{reqs: reqs})
@@ -115,7 +114,7 @@ func (pl *NodeDeclaredFeatures) Filter(ctx context.Context, cycleState fwk.Cycle
 	if err != nil {
 		return fwk.AsStatus(err)
 	}
-	result, err := ndf.MatchNodeFeatureSet(s.reqs, nodeInfo.GetNodeDeclaredFeatures())
+	result, err := ndf.DefaultFramework.MatchNodeFeatureSet(s.reqs, nodeInfo.GetNodeDeclaredFeatures())
 	if err != nil {
 		return fwk.AsStatus(err)
 	}
@@ -131,9 +130,8 @@ func (pl *NodeDeclaredFeatures) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk
 	if err != nil {
 		return nil, fwk.AsStatus(err)
 	}
-	featuresList := sets.List(fs.Set)
 	return []fwk.SignFragment{
-		{Key: fwk.FeaturesSignerName, Value: featuresList},
+		{Key: fwk.FeaturesSignerName, Value: fs.String()},
 	}, nil
 }
 

--- a/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures.go
+++ b/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures.go
@@ -28,7 +28,6 @@ import (
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/version"
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
-	"k8s.io/component-helpers/nodedeclaredfeatures/features"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -76,10 +75,7 @@ func New(ctx context.Context, plArgs runtime.Object, fh fwk.Handle, fts feature.
 		// Disabled, won't do anything.
 		return &NodeDeclaredFeatures{}, nil
 	}
-	ndfFramework, err := ndf.New(features.AllFeatures)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create node feature framework: %w", err)
-	}
+	ndfFramework := ndf.DefaultFramework
 	ver, err := versionutil.Parse(version.Get().String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version: %w", err)

--- a/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures.go
+++ b/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,6 +38,9 @@ const (
 	Name = names.NodeDeclaredFeatures
 	// preFilterStateKey is the key in CycleState used to store the pod's feature requirements.
 	preFilterStateKey fwk.StateKey = "PreFilter" + Name
+	// errReasonUnsatisfiedRequirements is the status reason given when a node's declared features
+	// doesn't meet the pod's required features.
+	errReasonUnsatisfiedRequirements = "node(s) didn't match Pod's required features"
 )
 
 // preFilterState computed at PreFilter and used at Filter.
@@ -114,12 +116,13 @@ func (pl *NodeDeclaredFeatures) Filter(ctx context.Context, cycleState fwk.Cycle
 	if err != nil {
 		return fwk.AsStatus(err)
 	}
-	result, err := ndf.DefaultFramework.MatchNodeFeatureSet(s.reqs, nodeInfo.GetNodeDeclaredFeatures())
+	// Don't use ndf.MatchNodeFeatureSet(...) here since we don't want to pay the cost of computing the feature diff.
+	isMatch, err := s.reqs.IsSubset(nodeInfo.GetNodeDeclaredFeatures())
 	if err != nil {
 		return fwk.AsStatus(err)
 	}
-	if !result.IsMatch {
-		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node declared features check failed - unsatisfied requirements: %s", strings.Join(result.UnsatisfiedRequirements, ", ")))
+	if !isMatch {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, errReasonUnsatisfiedRequirements)
 	}
 	return nil
 }

--- a/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
+++ b/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
@@ -121,10 +121,7 @@ func TestPreFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ndfFramework, err := ndf.New(tc.nodeFeatures)
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
+			ndfFramework := ndf.New(tc.nodeFeatures)
 
 			plugin := &NodeDeclaredFeatures{
 				ndfFramework: ndfFramework,
@@ -235,12 +232,8 @@ func TestFilter(t *testing.T) {
 			nodeInfo := framework.NewNodeInfo()
 			nodeInfo.SetNode(tc.node)
 
-			ndfFramework, err := ndf.New([]ndf.Feature{})
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
 			plugin := &NodeDeclaredFeatures{
-				ndfFramework: ndfFramework,
+				ndfFramework: ndf.DefaultFramework,
 				version:      version.MustParseSemantic("1.35.0"),
 				enabled:      tc.pluginEnabled,
 			}
@@ -297,10 +290,7 @@ func TestEnqueueExtensionsNodeUpdate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ndfFramework, err := ndf.New([]ndf.Feature{})
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
+			ndfFramework := ndf.New([]ndf.Feature{})
 			plugin := &NodeDeclaredFeatures{
 				ndfFramework: ndfFramework,
 				version:      version.MustParseSemantic("1.35.0"),
@@ -427,10 +417,7 @@ func TestEnqueueExtensionsPodUpdate(t *testing.T) {
 			mockF := ndftesting.NewMockFeature(t)
 			tc.setupMock(mockF)
 
-			ndfFramework, err := ndf.New([]ndf.Feature{mockF})
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
+			ndfFramework := ndf.New([]ndf.Feature{mockF})
 			plugin := &NodeDeclaredFeatures{
 				ndfFramework: ndfFramework,
 				version:      tc.componenetVersion,

--- a/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
+++ b/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
@@ -51,6 +51,14 @@ func createMockFeature(t *testing.T, name string, infer bool, maxVersionStr stri
 }
 
 func TestPreFilter(t *testing.T) {
+	const (
+		feature1 = "TestFeature1"
+		feature2 = "TestFeature2"
+	)
+	mapper := ndf.NewFeatureMapper([]string{feature1, feature2})
+	newFS := func(features ...string) ndf.FeatureSet {
+		return mapper.MustMapSorted(features)
+	}
 	_, ctx := ktesting.NewTestContext(t)
 	testCases := []struct {
 		name              string
@@ -67,7 +75,7 @@ func TestPreFilter(t *testing.T) {
 			pod:               st.MakePod().Name("test-pod").Obj(),
 			componenetVersion: "1.35.0",
 			nodeFeatures: []ndf.Feature{
-				createMockFeature(t, "TestFeature", true, ""),
+				createMockFeature(t, feature1, true, ""),
 			},
 			expectedStatus: fwk.NewStatus(fwk.Skip),
 			expectedState:  nil,
@@ -78,10 +86,10 @@ func TestPreFilter(t *testing.T) {
 			pod:               st.MakePod().Name("test-pod").Obj(),
 			componenetVersion: "1.35.0",
 			nodeFeatures: []ndf.Feature{
-				createMockFeature(t, "TestFeature", true, ""),
+				createMockFeature(t, feature1, true, ""),
 			},
 			expectedStatus: fwk.NewStatus(fwk.Success),
-			expectedState:  &preFilterState{reqs: ndf.NewFeatureSet("TestFeature")},
+			expectedState:  &preFilterState{reqs: newFS(feature1)},
 		},
 		{
 			name:              "Pod with multiple feature requirements",
@@ -89,11 +97,11 @@ func TestPreFilter(t *testing.T) {
 			pod:               st.MakePod().Name("test-pod").Obj(),
 			componenetVersion: "1.35.0",
 			nodeFeatures: []ndf.Feature{
-				createMockFeature(t, "TestFeature1", true, "1.38.0"),
-				createMockFeature(t, "TestFeature2", true, "1.38.0"),
+				createMockFeature(t, feature1, true, "1.38.0"),
+				createMockFeature(t, feature2, true, "1.38.0"),
 			},
 			expectedStatus: fwk.NewStatus(fwk.Success),
-			expectedState:  &preFilterState{reqs: ndf.NewFeatureSet("TestFeature1", "TestFeature2")},
+			expectedState:  &preFilterState{reqs: newFS(feature1, feature2)},
 		},
 		{
 			name:              "Pod with no requirements",
@@ -101,7 +109,7 @@ func TestPreFilter(t *testing.T) {
 			pod:               st.MakePod().Name("test-pod").Obj(),
 			componenetVersion: "1.35.0",
 			nodeFeatures: []ndf.Feature{
-				createMockFeature(t, "TestFeature", false, ""),
+				createMockFeature(t, feature1, false, ""),
 			},
 			expectedStatus: fwk.NewStatus(fwk.Skip),
 			expectedState:  nil,
@@ -112,7 +120,7 @@ func TestPreFilter(t *testing.T) {
 			pod:               st.MakePod().Name("test-pod").Obj(),
 			componenetVersion: "1.34.0",
 			nodeFeatures: []ndf.Feature{
-				createMockFeature(t, "TestFeature", true, "1.33.0"),
+				createMockFeature(t, feature1, true, "1.33.0"),
 			},
 			expectedStatus: fwk.NewStatus(fwk.Skip),
 			expectedState:  nil,
@@ -159,6 +167,16 @@ func TestPreFilter(t *testing.T) {
 
 func TestFilter(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
+	const (
+		featureA = "FeatureA"
+		featureB = "FeatureB"
+		featureC = "FeatureC"
+	)
+	f, _ := ndftesting.NewMockFramework(t, featureA, featureB, featureC)
+	ndftesting.SetFrameworkDuringTest(t, f)
+	newFS := func(features ...string) ndf.FeatureSet {
+		return f.MustMapSorted(features)
+	}
 
 	testCases := []struct {
 		name           string
@@ -172,7 +190,7 @@ func TestFilter(t *testing.T) {
 			name:           "plugin disabled",
 			pluginEnabled:  false,
 			pod:            st.MakePod().Name("test-pod").Obj(),
-			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{"FeatureA", "FeatureB"}).Obj(),
+			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{featureA, featureB}).Obj(),
 			preFilterReqs:  nil,
 			expectedStatus: nil,
 		},
@@ -180,23 +198,23 @@ func TestFilter(t *testing.T) {
 			name:           "Node matches requirements",
 			pluginEnabled:  true,
 			pod:            st.MakePod().Name("test-pod").Obj(),
-			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{"FeatureA", "FeatureB"}).Obj(),
-			preFilterReqs:  []string{"FeatureA"},
+			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{featureA, featureB}).Obj(),
+			preFilterReqs:  []string{featureA},
 			expectedStatus: fwk.NewStatus(fwk.Success),
 		},
 		{
 			name:           "Node does not match requirements",
 			pluginEnabled:  true,
 			pod:            st.MakePod().Name("test-pod").Obj(),
-			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{"FeatureB"}).Obj(),
-			preFilterReqs:  []string{"FeatureA"},
+			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{featureB}).Obj(),
+			preFilterReqs:  []string{featureA},
 			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node declared features check failed - unsatisfied requirements: FeatureA"),
 		},
 		{
 			name:           "Node with multiple features, pod requires subset",
 			pod:            st.MakePod().Name("test-pod").Obj(),
-			node:           st.MakeNode().Name("node-multi").DeclaredFeatures([]string{"FeatureA", "FeatureB", "FeatureC"}).Obj(),
-			preFilterReqs:  []string{"FeatureA", "FeatureC"},
+			node:           st.MakeNode().Name("node-multi").DeclaredFeatures([]string{featureA, featureB, featureC}).Obj(),
+			preFilterReqs:  []string{featureA, featureC},
 			expectedStatus: fwk.NewStatus(fwk.Success),
 		},
 		{
@@ -204,15 +222,15 @@ func TestFilter(t *testing.T) {
 			pluginEnabled:  true,
 			pod:            st.MakePod().Name("test-pod").Obj(),
 			node:           st.MakeNode().Name("node-1").Obj(),
-			preFilterReqs:  []string{"FeatureA"},
+			preFilterReqs:  []string{featureA},
 			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node declared features check failed - unsatisfied requirements: FeatureA"),
 		},
 		{
 			name:           "Node with some but not all required features",
 			pluginEnabled:  true,
 			pod:            st.MakePod().Name("test-pod").Obj(),
-			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{"FeatureA"}).Obj(),
-			preFilterReqs:  []string{"FeatureA", "FeatureB"},
+			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{featureA}).Obj(),
+			preFilterReqs:  []string{featureA, featureB},
 			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node declared features check failed - unsatisfied requirements: FeatureB"),
 		},
 		{
@@ -239,7 +257,7 @@ func TestFilter(t *testing.T) {
 			}
 			cycleState := framework.NewCycleState()
 			if tc.preFilterReqs != nil {
-				cycleState.Write(preFilterStateKey, &preFilterState{reqs: ndf.NewFeatureSet(tc.preFilterReqs...)})
+				cycleState.Write(preFilterStateKey, &preFilterState{reqs: newFS(tc.preFilterReqs...)})
 			}
 
 			status := plugin.Filter(ctx, cycleState, tc.pod, nodeInfo)

--- a/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
+++ b/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
@@ -208,7 +208,7 @@ func TestFilter(t *testing.T) {
 			pod:            st.MakePod().Name("test-pod").Obj(),
 			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{featureB}).Obj(),
 			preFilterReqs:  []string{featureA},
-			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node declared features check failed - unsatisfied requirements: FeatureA"),
+			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, errReasonUnsatisfiedRequirements),
 		},
 		{
 			name:           "Node with multiple features, pod requires subset",
@@ -223,7 +223,7 @@ func TestFilter(t *testing.T) {
 			pod:            st.MakePod().Name("test-pod").Obj(),
 			node:           st.MakeNode().Name("node-1").Obj(),
 			preFilterReqs:  []string{featureA},
-			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node declared features check failed - unsatisfied requirements: FeatureA"),
+			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, errReasonUnsatisfiedRequirements),
 		},
 		{
 			name:           "Node with some but not all required features",
@@ -231,7 +231,7 @@ func TestFilter(t *testing.T) {
 			pod:            st.MakePod().Name("test-pod").Obj(),
 			node:           st.MakeNode().Name("node-1").DeclaredFeatures([]string{featureA}).Obj(),
 			preFilterReqs:  []string{featureA, featureB},
-			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node declared features check failed - unsatisfied requirements: FeatureB"),
+			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, errReasonUnsatisfiedRequirements),
 		},
 		{
 			name:           "Error getting pre-filter state",

--- a/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
+++ b/pkg/scheduler/framework/plugins/nodedeclaredfeatures/nodedeclaredfeatures_test.go
@@ -76,6 +76,7 @@ func TestPreFilter(t *testing.T) {
 			componenetVersion: "1.35.0",
 			nodeFeatures: []ndf.Feature{
 				createMockFeature(t, feature1, true, ""),
+				createMockFeature(t, feature2, false, ""),
 			},
 			expectedStatus: fwk.NewStatus(fwk.Skip),
 			expectedState:  nil,
@@ -87,6 +88,7 @@ func TestPreFilter(t *testing.T) {
 			componenetVersion: "1.35.0",
 			nodeFeatures: []ndf.Feature{
 				createMockFeature(t, feature1, true, ""),
+				createMockFeature(t, feature2, false, ""),
 			},
 			expectedStatus: fwk.NewStatus(fwk.Success),
 			expectedState:  &preFilterState{reqs: newFS(feature1)},
@@ -110,6 +112,7 @@ func TestPreFilter(t *testing.T) {
 			componenetVersion: "1.35.0",
 			nodeFeatures: []ndf.Feature{
 				createMockFeature(t, feature1, false, ""),
+				createMockFeature(t, feature2, false, ""),
 			},
 			expectedStatus: fwk.NewStatus(fwk.Skip),
 			expectedState:  nil,
@@ -121,6 +124,7 @@ func TestPreFilter(t *testing.T) {
 			componenetVersion: "1.34.0",
 			nodeFeatures: []ndf.Feature{
 				createMockFeature(t, feature1, true, "1.33.0"),
+				createMockFeature(t, feature2, false, ""),
 			},
 			expectedStatus: fwk.NewStatus(fwk.Skip),
 			expectedState:  nil,

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -478,7 +478,10 @@ func (n *NodeInfo) SetNode(node *v1.Node) {
 	n.node = node
 	n.Allocatable = NewResource(node.Status.Allocatable)
 	if utilfeature.DefaultFeatureGate.Enabled(features.NodeDeclaredFeatures) {
-		n.DeclaredFeatures = ndf.NewFeatureSet(node.Status.DeclaredFeatures...)
+		// Use TryMap rather than Map here in case the node has unknown features. Since we're only
+		// concerned with matching known features to the node, there is no risk to discarding
+		// unknown features.
+		n.DeclaredFeatures = ndf.DefaultFramework.TryMap(node.Status.DeclaredFeatures)
 	}
 	n.Generation = nextGeneration()
 }

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -30,6 +30,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
+	ndftesting "k8s.io/component-helpers/nodedeclaredfeatures/testing"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
@@ -362,6 +363,8 @@ func TestNewNodeInfo(t *testing.T) {
 
 func TestNodeInfoClone(t *testing.T) {
 	nodeName := "test-node"
+	declaredFeatureSet := ndf.NewFeatureMapper([]string{"A", "B", "C"}).MustMapSorted([]string{"A", "C"})
+
 	tests := []struct {
 		nodeInfo *NodeInfo
 		expected *NodeInfo
@@ -557,7 +560,7 @@ func TestNodeInfoClone(t *testing.T) {
 				UsedPorts:        fwk.HostPortInfo{},
 				ImageStates:      map[string]*fwk.ImageStateSummary{},
 				PVCRefCounts:     map[string]int{},
-				DeclaredFeatures: ndf.NewFeatureSet("FeatureA", "FeatureB"),
+				DeclaredFeatures: declaredFeatureSet.Clone(),
 			},
 			expected: &NodeInfo{
 				Requested:        &Resource{},
@@ -567,7 +570,7 @@ func TestNodeInfoClone(t *testing.T) {
 				UsedPorts:        fwk.HostPortInfo{},
 				ImageStates:      map[string]*fwk.ImageStateSummary{},
 				PVCRefCounts:     map[string]int{},
-				DeclaredFeatures: ndf.NewFeatureSet("FeatureA", "FeatureB"),
+				DeclaredFeatures: declaredFeatureSet,
 			},
 		},
 	}
@@ -1240,11 +1243,13 @@ func TestNodeInfoRemovePod(t *testing.T) {
 }
 
 func TestSetNodeDeclaredFeatures(t *testing.T) {
+	ndfFramework, _ := ndftesting.NewMockFramework(t, "FeatureA", "FeatureB")
+	ndftesting.SetFrameworkDuringTest(t, ndfFramework)
 	tests := []struct {
 		name               string
 		featureGateEnabled bool
 		nodeStatus         v1.NodeStatus
-		expectedFeatures   ndf.FeatureSet
+		expectedFeatures   []string
 	}{
 		{
 			name:               "Feature gate disabled",
@@ -1252,7 +1257,7 @@ func TestSetNodeDeclaredFeatures(t *testing.T) {
 			nodeStatus: v1.NodeStatus{
 				DeclaredFeatures: []string{"FeatureA", "FeatureB"},
 			},
-			expectedFeatures: ndf.NewFeatureSet(),
+			expectedFeatures: nil,
 		},
 		{
 			name:               "Feature gate enabled, node has features",
@@ -1260,7 +1265,7 @@ func TestSetNodeDeclaredFeatures(t *testing.T) {
 			nodeStatus: v1.NodeStatus{
 				DeclaredFeatures: []string{"FeatureA", "FeatureB"},
 			},
-			expectedFeatures: ndf.NewFeatureSet("FeatureA", "FeatureB"),
+			expectedFeatures: []string{"FeatureA", "FeatureB"},
 		},
 		{
 			name:               "Feature gate enabled, node has no features",
@@ -1268,7 +1273,15 @@ func TestSetNodeDeclaredFeatures(t *testing.T) {
 			nodeStatus: v1.NodeStatus{
 				DeclaredFeatures: []string{},
 			},
-			expectedFeatures: ndf.NewFeatureSet(),
+			expectedFeatures: nil,
+		},
+		{
+			name:               "Feature gate enabled, node has an unknown feature",
+			featureGateEnabled: true,
+			nodeStatus: v1.NodeStatus{
+				DeclaredFeatures: []string{"FeatureA", "OtherFeature"},
+			},
+			expectedFeatures: []string{"FeatureA"},
 		},
 		{
 			name:               "Feature gate enabled, node status has nil features",
@@ -1276,7 +1289,7 @@ func TestSetNodeDeclaredFeatures(t *testing.T) {
 			nodeStatus: v1.NodeStatus{
 				DeclaredFeatures: nil,
 			},
-			expectedFeatures: ndf.NewFeatureSet(),
+			expectedFeatures: nil,
 		},
 	}
 
@@ -1290,8 +1303,23 @@ func TestSetNodeDeclaredFeatures(t *testing.T) {
 			}
 			ni.SetNode(node)
 			gotFeatures := ni.GetNodeDeclaredFeatures()
-			if !gotFeatures.Equal(tt.expectedFeatures) {
-				t.Errorf("SetNode() or GetNodeDeclaredFeatures() unexpected result, got: %v, want: %v", gotFeatures, tt.expectedFeatures)
+			if !tt.featureGateEnabled {
+				if !gotFeatures.IsEmpty() {
+					got, err := ndfFramework.Unmap(gotFeatures)
+					if err != nil {
+						t.Fatalf("Failed to unmap features: %v", err)
+					}
+					t.Errorf("Expected GetNodeDeclaredFeatures() to return nil; got %v", got)
+				}
+				return
+			}
+			expected := ndfFramework.MustMapSorted(tt.expectedFeatures)
+			if !gotFeatures.Equal(expected) {
+				got, err := ndfFramework.Unmap(gotFeatures)
+				if err != nil {
+					t.Fatalf("Failed to unmap features: %v", err)
+				}
+				t.Errorf("SetNode() or GetNodeDeclaredFeatures() unexpected result, got: %v, want: %v", got, tt.expectedFeatures)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -747,8 +747,9 @@ func TestNodeInfoAddPod(t *testing.T) {
 				{Protocol: "TCP", Port: 8080}: {},
 			},
 		},
-		ImageStates:  map[string]*fwk.ImageStateSummary{},
-		PVCRefCounts: map[string]int{"node_info_cache_test/pvc-1": 2, "node_info_cache_test/pvc-2": 1},
+		ImageStates:      map[string]*fwk.ImageStateSummary{},
+		PVCRefCounts:     map[string]int{"node_info_cache_test/pvc-1": 2, "node_info_cache_test/pvc-2": 1},
+		DeclaredFeatures: ndf.DefaultFramework.NewFeatureSet(), // Empty FeatureSet.
 		Pods: []fwk.PodInfo{
 			&PodInfo{
 				Pod: &v1.Pod{
@@ -997,8 +998,9 @@ func TestNodeInfoRemovePod(t *testing.T) {
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				ImageStates:  map[string]*fwk.ImageStateSummary{},
-				PVCRefCounts: map[string]int{"node_info_cache_test/pvc-1": 1},
+				ImageStates:      map[string]*fwk.ImageStateSummary{},
+				PVCRefCounts:     map[string]int{"node_info_cache_test/pvc-1": 1},
+				DeclaredFeatures: ndf.DefaultFramework.NewFeatureSet(), // Empty FeatureSet.
 				Pods: []fwk.PodInfo{
 					&PodInfo{
 						Pod: &v1.Pod{
@@ -1163,8 +1165,9 @@ func TestNodeInfoRemovePod(t *testing.T) {
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				ImageStates:  map[string]*fwk.ImageStateSummary{},
-				PVCRefCounts: map[string]int{},
+				ImageStates:      map[string]*fwk.ImageStateSummary{},
+				PVCRefCounts:     map[string]int{},
+				DeclaredFeatures: ndf.DefaultFramework.NewFeatureSet(), // Empty FeatureSet.
 				Pods: []fwk.PodInfo{
 					&PodInfo{
 						Pod: &v1.Pod{
@@ -1305,20 +1308,14 @@ func TestSetNodeDeclaredFeatures(t *testing.T) {
 			gotFeatures := ni.GetNodeDeclaredFeatures()
 			if !tt.featureGateEnabled {
 				if !gotFeatures.IsEmpty() {
-					got, err := ndfFramework.Unmap(gotFeatures)
-					if err != nil {
-						t.Fatalf("Failed to unmap features: %v", err)
-					}
+					got := ndfFramework.Unmap(gotFeatures)
 					t.Errorf("Expected GetNodeDeclaredFeatures() to return nil; got %v", got)
 				}
 				return
 			}
 			expected := ndfFramework.MustMapSorted(tt.expectedFeatures)
 			if !gotFeatures.Equal(expected) {
-				got, err := ndfFramework.Unmap(gotFeatures)
-				if err != nil {
-					t.Fatalf("Failed to unmap features: %v", err)
-				}
+				got := ndfFramework.Unmap(gotFeatures)
 				t.Errorf("SetNode() or GetNodeDeclaredFeatures() unexpected result, got: %v, want: %v", got, tt.expectedFeatures)
 			}
 		})

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -1308,14 +1308,20 @@ func TestSetNodeDeclaredFeatures(t *testing.T) {
 			gotFeatures := ni.GetNodeDeclaredFeatures()
 			if !tt.featureGateEnabled {
 				if !gotFeatures.IsEmpty() {
-					got := ndfFramework.Unmap(gotFeatures)
+					got, err := ndfFramework.Unmap(gotFeatures)
+					if err != nil {
+						t.Fatalf("Failed to unmap features: %v", err)
+					}
 					t.Errorf("Expected GetNodeDeclaredFeatures() to return nil; got %v", got)
 				}
 				return
 			}
 			expected := ndfFramework.MustMapSorted(tt.expectedFeatures)
 			if !gotFeatures.Equal(expected) {
-				got := ndfFramework.Unmap(gotFeatures)
+				got, err := ndfFramework.Unmap(gotFeatures)
+				if err != nil {
+					t.Fatalf("Failed to unmap features: %v", err)
+				}
 				t.Errorf("SetNode() or GetNodeDeclaredFeatures() unexpected result, got: %v, want: %v", got, tt.expectedFeatures)
 			}
 		})

--- a/plugin/pkg/admission/nodedeclaredfeatures/admission.go
+++ b/plugin/pkg/admission/nodedeclaredfeatures/admission.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/version"
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
-	ndffeatures "k8s.io/component-helpers/nodedeclaredfeatures/features"
 	"k8s.io/kubernetes/pkg/apis/core"
 	v1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/kubernetes/pkg/features"
@@ -65,18 +64,13 @@ var _ genericadmissioninitializer.WantsFeatures = &Plugin{}
 
 // New creates a new Plugin admission plugin
 func NewPlugin() (*Plugin, error) {
-	framework, err := ndf.New(ndffeatures.AllFeatures)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create node declared features helper: %w", err)
-	}
-
 	ver, err := versionutil.Parse(version.Get().String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version: %w", err)
 	}
 	return &Plugin{
 		Handler:                      admission.NewHandler(admission.Update),
-		nodeDeclaredFeatureFramework: framework,
+		nodeDeclaredFeatureFramework: ndf.DefaultFramework,
 		version:                      ver,
 	}, nil
 }
@@ -100,11 +94,7 @@ func (p *Plugin) ValidateInitialization() error {
 	}
 
 	if p.nodeDeclaredFeatureFramework == nil {
-		framework, err := ndf.New(ndffeatures.AllFeatures)
-		if err != nil {
-			return fmt.Errorf("failed to create node feature helper for %s: %w", PluginName, err)
-		}
-		p.nodeDeclaredFeatureFramework = framework
+		p.nodeDeclaredFeatureFramework = ndf.DefaultFramework
 	}
 	return nil
 }

--- a/plugin/pkg/admission/nodedeclaredfeatures/admission.go
+++ b/plugin/pkg/admission/nodedeclaredfeatures/admission.go
@@ -163,7 +163,7 @@ func (p *Plugin) validatePodUpdate(pod, oldPod *core.Pod, a admission.Attributes
 		return admission.NewForbidden(a, fmt.Errorf("failed to infer pod capability requirements: %w", err))
 	}
 	// If there are no specific feature requirements for this update, we're done.
-	if reqs.Len() == 0 {
+	if reqs.IsEmpty() {
 		return nil
 	}
 	node, err := p.nodeLister.Get(pod.Spec.NodeName)
@@ -173,7 +173,7 @@ func (p *Plugin) validatePodUpdate(pod, oldPod *core.Pod, a admission.Attributes
 		}
 		return admission.NewForbidden(a, fmt.Errorf("failed to get node %q: %w", pod.Spec.NodeName, err))
 	}
-	result, err := ndf.MatchNode(reqs, node)
+	result, err := p.nodeDeclaredFeatureFramework.MatchNode(reqs, node)
 	if err != nil {
 		return admission.NewForbidden(a, fmt.Errorf("failed to match pod requirements against node %q: %w", node.Name, err))
 	}

--- a/plugin/pkg/admission/nodedeclaredfeatures/admission_test.go
+++ b/plugin/pkg/admission/nodedeclaredfeatures/admission_test.go
@@ -242,8 +242,7 @@ func TestAdmission(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.featureGateEnabled {
-				framework, err := ndf.New(tc.registeredFeatures)
-				require.NoError(t, err)
+				framework := ndf.New(tc.registeredFeatures)
 				target.nodeDeclaredFeatureFramework = framework
 				target.version = version.MustParseSemantic(tc.componentVersion)
 			}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/bitmap.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/bitmap.go
@@ -1,0 +1,121 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedeclaredfeatures
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"slices"
+)
+
+type bitmap []uint64
+
+// newBitmap creates a new bitmap that can store the number of bits specified by size.
+func newBitmap(size int) bitmap {
+	return make(bitmap, (size+63)/64)
+}
+
+// Set sets the bit at the specified index.
+func (b bitmap) Set(i int) {
+	if i < 0 || i/64+1 > len(b) {
+		panic(fmt.Sprintf("bitmap index out of range: %d", i))
+	}
+
+	b[i/64] |= 1 << (i % 64)
+}
+
+// Get returns the bit value at the specified index.
+func (b bitmap) Get(i int) bool {
+	if i < 0 || i/64+1 > len(b) {
+		panic(fmt.Sprintf("bitmap index out of range: %d", i))
+	}
+
+	return b[i/64]&(1<<(i%64)) != 0
+}
+
+// Difference returns a new bitmap containing bits set in b but not in other.
+func (b bitmap) Difference(other bitmap) (bitmap, error) {
+	if len(b) != len(other) {
+		return nil, fmt.Errorf("bitmap size mismatch: %d != %d", len(b), len(other))
+	}
+
+	diff := make(bitmap, len(b))
+	for i := range b {
+		diff[i] = b[i] &^ other[i]
+	}
+	return diff, nil
+}
+
+// Contains checks whether b is a subset of other.
+func (b bitmap) IsSubset(other bitmap) (bool, error) {
+	if len(b) != len(other) {
+		return false, fmt.Errorf("bitmap size mismatch; %d != %d", len(b), len(other))
+	}
+	for i := range b {
+		if b[i]&^other[i] != 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// Equal returns true if b and other have the same bits set.
+func (b bitmap) Equal(other bitmap) bool {
+	if len(b) != len(other) {
+		return false
+	}
+
+	for i := range b {
+		if b[i] != other[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// IsEmpty returns true if no bits are set in the bitmap.
+func (b bitmap) IsEmpty() bool {
+	for i := range b {
+		if b[i] != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Clone returns a deep copy of the bitmap.
+func (b bitmap) Clone() bitmap {
+	return slices.Clone(b)
+}
+
+// String returns a binary representation, with leftmost character representing
+// the first (0th) bit.
+func (b bitmap) String() string {
+	// Pre-allocate buffer (16 chars per uint64)
+	buf := make([]byte, len(b)*16)
+
+	var scratch [8]byte // Holds byte representation
+	for i, n := range b {
+		// Convert uint64 to bytes
+		binary.BigEndian.PutUint64(scratch[:], n)
+		// Encode bytes to 16 hex characters.
+		hex.Encode(buf[i*16:], scratch[:])
+	}
+
+	return string(buf)
+}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/bitmap.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/bitmap.go
@@ -17,57 +17,61 @@ limitations under the License.
 package nodedeclaredfeatures
 
 import (
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"slices"
 )
 
-type bitmap []uint64
+type bitmap struct {
+	words []uint64
+	size  int
+}
 
 // newBitmap creates a new bitmap that can store the number of bits specified by size.
 func newBitmap(size int) bitmap {
-	return make(bitmap, (size+63)/64)
+	if size < 0 {
+		panic(fmt.Sprintf("bitmap size must be positive: %d", size))
+	}
+	return bitmap{make([]uint64, (size+63)/64), size}
 }
 
 // Set sets the bit at the specified index.
 func (b bitmap) Set(i int) {
-	if i < 0 || i/64+1 > len(b) {
+	if i < 0 || i >= b.size {
 		panic(fmt.Sprintf("bitmap index out of range: %d", i))
 	}
 
-	b[i/64] |= 1 << (i % 64)
+	b.words[i/64] |= 1 << (i % 64)
 }
 
 // Get returns the bit value at the specified index.
 func (b bitmap) Get(i int) bool {
-	if i < 0 || i/64+1 > len(b) {
+	if i < 0 || i >= b.size {
 		panic(fmt.Sprintf("bitmap index out of range: %d", i))
 	}
 
-	return b[i/64]&(1<<(i%64)) != 0
+	return b.words[i/64]&(1<<(i%64)) != 0
 }
 
 // Difference returns a new bitmap containing bits set in b but not in other.
 func (b bitmap) Difference(other bitmap) (bitmap, error) {
-	if len(b) != len(other) {
-		return nil, fmt.Errorf("bitmap size mismatch: %d != %d", len(b), len(other))
+	if b.size != other.size {
+		return bitmap{}, fmt.Errorf("bitmap size mismatch: %d != %d", b.size, other.size)
 	}
 
-	diff := make(bitmap, len(b))
-	for i := range b {
-		diff[i] = b[i] &^ other[i]
+	diff := newBitmap(b.size)
+	for i := range b.words {
+		diff.words[i] = b.words[i] &^ other.words[i]
 	}
 	return diff, nil
 }
 
 // Contains checks whether b is a subset of other.
 func (b bitmap) IsSubset(other bitmap) (bool, error) {
-	if len(b) != len(other) {
-		return false, fmt.Errorf("bitmap size mismatch; %d != %d", len(b), len(other))
+	if b.size != other.size {
+		return false, fmt.Errorf("bitmap size mismatch; %d != %d", b.size, other.size)
 	}
-	for i := range b {
-		if b[i]&^other[i] != 0 {
+	for i := range b.words {
+		if b.words[i]&^other.words[i] != 0 {
 			return false, nil
 		}
 	}
@@ -76,12 +80,12 @@ func (b bitmap) IsSubset(other bitmap) (bool, error) {
 
 // Equal returns true if b and other have the same bits set.
 func (b bitmap) Equal(other bitmap) bool {
-	if len(b) != len(other) {
+	if b.size != other.size {
 		return false
 	}
 
-	for i := range b {
-		if b[i] != other[i] {
+	for i := range b.words {
+		if b.words[i] != other.words[i] {
 			return false
 		}
 	}
@@ -90,8 +94,8 @@ func (b bitmap) Equal(other bitmap) bool {
 
 // IsEmpty returns true if no bits are set in the bitmap.
 func (b bitmap) IsEmpty() bool {
-	for i := range b {
-		if b[i] != 0 {
+	for i := range b.words {
+		if b.words[i] != 0 {
 			return false
 		}
 	}
@@ -100,22 +104,22 @@ func (b bitmap) IsEmpty() bool {
 
 // Clone returns a deep copy of the bitmap.
 func (b bitmap) Clone() bitmap {
-	return slices.Clone(b)
+	return bitmap{
+		words: slices.Clone(b.words),
+		size:  b.size,
+	}
 }
 
 // String returns a binary representation, with leftmost character representing
 // the first (0th) bit.
 func (b bitmap) String() string {
-	// Pre-allocate buffer (16 chars per uint64)
-	buf := make([]byte, len(b)*16)
-
-	var scratch [8]byte // Holds byte representation
-	for i, n := range b {
-		// Convert uint64 to bytes
-		binary.BigEndian.PutUint64(scratch[:], n)
-		// Encode bytes to 16 hex characters.
-		hex.Encode(buf[i*16:], scratch[:])
+	buf := make([]byte, b.size)
+	for i := 0; i < b.size; i++ {
+		if (b.words[i/64]>>(uint(i)%64))&1 != 0 {
+			buf[i] = '1'
+		} else {
+			buf[i] = '0'
+		}
 	}
-
 	return string(buf)
 }

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/bitmap_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/bitmap_test.go
@@ -39,8 +39,8 @@ func TestNewBitmap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := newBitmap(tt.size)
-			if len(b) != tt.expected {
-				t.Errorf("len(b) = %d, want %d", len(b), tt.expected)
+			if len(b.words) != tt.expected {
+				t.Errorf("len(b) = %d, want %d", len(b.words), tt.expected)
 			}
 		})
 	}
@@ -170,9 +170,6 @@ func TestBitmap_DifferenceSubset(t *testing.T) {
 				if err == nil {
 					t.Error("expected error, got nil")
 				}
-				if diff != nil {
-					t.Errorf("expected nil diff, got %v", diff)
-				}
 			} else {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -275,37 +272,42 @@ func TestBitmap_Clone(t *testing.T) {
 }
 
 func TestBitmap_String(t *testing.T) {
-	// Size 64 -> 1 uint64
-	b := newBitmap(64)
-	// 0x0000000000000001 (bit 0 set)
-	b.Set(0)
-	// Output is hex encoded BigEndian of the uint64
-	// uint64(1) -> bytes: [0 0 0 0 0 0 0 1]
-	// hex: "0000000000000001"
-	if got, want := b.String(), "0000000000000001"; got != want {
-		t.Errorf("got %q, want %q", got, want)
+	tests := []struct {
+		name     string
+		size     int
+		sets     []int
+		expected string
+	}{
+		{
+			name:     "Size 5, bit 0 and 4 set",
+			size:     5,
+			sets:     []int{0, 4},
+			expected: "10001",
+		},
+		{
+			name:     "Size 10, no bits set",
+			size:     10,
+			sets:     []int{},
+			expected: "0000000000",
+		},
+		{
+			name:     "Size 65, bit 0 and 64 set",
+			size:     65,
+			sets:     []int{0, 64},
+			expected: "10000000000000000000000000000000000000000000000000000000000000001",
+		},
 	}
 
-	b2 := newBitmap(64)
-	b2.Set(63)
-	// 1 << 63 is the highest bit.
-	// 0x8000000000000000
-	// bytes: [128 0 0 0 0 0 0 0] -> hex "8000000000000000"
-	if got, want := b2.String(), "8000000000000000"; got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-
-	// Multi-word
-	b3 := newBitmap(128)
-	b3.Set(0)
-	b3.Set(64)
-	// Array of 2 uint64s.
-	// b3[0] has bit 0 set -> "0000000000000001"
-	// b3[1] has bit 0 (global 64) set -> "0000000000000001"
-	// Output order: iterates slice.
-	// "0000000000000001" + "0000000000000001"
-	if got, want := b3.String(), "00000000000000010000000000000001"; got != want {
-		t.Errorf("got %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newBitmap(tt.size)
+			for _, s := range tt.sets {
+				b.Set(s)
+			}
+			if got := b.String(); got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
+			}
+		})
 	}
 }
 

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/bitmap_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/bitmap_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedeclaredfeatures
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewBitmap(t *testing.T) {
+	tests := []struct {
+		name     string
+		size     int
+		expected int // number of uint64 elements
+	}{
+		{"Size 0", 0, 0},
+		{"Size 1", 1, 1},
+		{"Size 63", 63, 1},
+		{"Size 64", 64, 1}, // (64+63)/64 = 1
+		{"Size 65", 65, 2},
+		{"Size 128", 128, 2}, // (128+63)/64 = 2
+		{"Size 129", 129, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newBitmap(tt.size)
+			if len(b) != tt.expected {
+				t.Errorf("len(b) = %d, want %d", len(b), tt.expected)
+			}
+		})
+	}
+}
+
+func TestBitmap_GetSet(t *testing.T) {
+	b := newBitmap(128)
+	indices := []int{0, 63, 64, 127}
+
+	// Initially all false
+	for _, i := range indices {
+		if b.Get(i) {
+			t.Errorf("expected bit %d to be false initially", i)
+		}
+	}
+
+	// Set bits
+	for _, i := range indices {
+		b.Set(i)
+	}
+
+	for _, i := range indices {
+		if !b.Get(i) {
+			t.Errorf("expected bit %d to be true after Set", i)
+		}
+	}
+
+	// Verify other bits are still false
+	for _, i := range []int{1, 62, 65} {
+		if b.Get(i) {
+			t.Errorf("expected bit %d to be false", i)
+		}
+	}
+
+	// Error bounds.
+	for _, i := range []int{-1, 128} {
+		msg := fmt.Sprintf("bitmap index out of range: %d", i)
+		t.Run(fmt.Sprintf("Panic_Set_%d", i), func(t *testing.T) {
+			defer expectPanic(t, msg)
+			b.Set(i)
+		})
+		t.Run(fmt.Sprintf("Panic_Get_%d", i), func(t *testing.T) {
+			defer expectPanic(t, msg)
+			b.Get(i)
+		})
+	}
+}
+
+func TestBitmap_DifferenceSubset(t *testing.T) {
+	tests := []struct {
+		name         string
+		bSize        int
+		otherSize    int
+		bSets        []int
+		otherSets    []int
+		expectedErr  bool
+		expectedDiff []int // expect other.Contains IFF expectedDiff is empty.
+	}{
+		{
+			name:        "Mismatch size",
+			bSize:       64,
+			otherSize:   128,
+			expectedErr: true,
+		},
+		{
+			name:         "Disjoint sets",
+			bSize:        64,
+			otherSize:    64,
+			bSets:        []int{1, 2},
+			otherSets:    []int{3, 4},
+			expectedDiff: []int{1, 2},
+		},
+		{
+			name:         "Overlap",
+			bSize:        64,
+			otherSize:    64,
+			bSets:        []int{1, 2, 3},
+			otherSets:    []int{2, 3, 4},
+			expectedDiff: []int{1}, // 2 and 3 removed
+		},
+		{
+			name:         "Identical",
+			bSize:        64,
+			otherSize:    64,
+			bSets:        []int{1, 2},
+			otherSets:    []int{1, 2},
+			expectedDiff: []int{},
+		},
+		{
+			name:         "Subset",
+			bSize:        64,
+			otherSize:    64,
+			bSets:        []int{1, 2},
+			otherSets:    []int{1, 2, 3},
+			expectedDiff: []int{},
+		},
+		{
+			name:         "Superset",
+			bSize:        64,
+			otherSize:    64,
+			bSets:        []int{1, 2, 3},
+			otherSets:    []int{1, 2},
+			expectedDiff: []int{3},
+		},
+		{
+			name:         "Empty contains Empty",
+			bSize:        64,
+			otherSize:    64,
+			expectedDiff: []int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newBitmap(tt.bSize)
+			for _, i := range tt.bSets {
+				b.Set(i)
+			}
+			other := newBitmap(tt.otherSize)
+			for _, i := range tt.otherSets {
+				other.Set(i)
+			}
+
+			// Test Difference
+			diff, err := b.Difference(other)
+			if tt.expectedErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				if diff != nil {
+					t.Errorf("expected nil diff, got %v", diff)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				for _, i := range tt.expectedDiff {
+					if !diff.Get(i) {
+						t.Errorf("Difference: Index %d should be set", i)
+					}
+				}
+				// Verify count of set bits for Difference
+				count := 0
+				for i := 0; i < tt.bSize; i++ {
+					if diff.Get(i) {
+						count++
+					}
+				}
+				if count != len(tt.expectedDiff) {
+					t.Errorf("Difference: Unexpected number of bits set, got %d, want %d", count, len(tt.expectedDiff))
+				}
+			}
+
+			// Test IsSubset
+			result, err := b.IsSubset(other)
+			if tt.expectedErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				if result {
+					t.Error("expected result to be false on error")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expectedResult := len(tt.expectedDiff) == 0
+				if result != expectedResult {
+					t.Errorf("IsSubset result mismatch: got %v, want %v", result, expectedResult)
+				}
+			}
+		})
+	}
+}
+
+func TestBitmap_Equal(t *testing.T) {
+	b1 := newBitmap(64)
+	b1.Set(1)
+
+	b2 := newBitmap(64)
+	b2.Set(1)
+
+	b3 := newBitmap(64)
+	b3.Set(2)
+
+	b4 := newBitmap(128) // Different size
+	b4.Set(1)
+
+	if !b1.Equal(b2) {
+		t.Error("expected b1 to equal b2")
+	}
+	if b1.Equal(b3) {
+		t.Error("expected b1 not to equal b3")
+	}
+	if b1.Equal(b4) {
+		t.Error("expected b1 not to equal b4")
+	}
+}
+
+func TestBitmap_IsEmpty(t *testing.T) {
+	b := newBitmap(64)
+	if !b.IsEmpty() {
+		t.Error("expected b to be empty")
+	}
+
+	b.Set(10)
+	if b.IsEmpty() {
+		t.Error("expected b not to be empty")
+	}
+}
+
+func TestBitmap_Clone(t *testing.T) {
+	b := newBitmap(64)
+	b.Set(1)
+
+	clone := b.Clone()
+	if !b.Equal(clone) {
+		t.Error("expected clone to equal original")
+	}
+
+	// Modify clone, original should not change
+	clone.Set(2)
+	if clone.Equal(b) {
+		t.Error("expected modified clone not to equal original")
+	}
+	if b.Get(2) {
+		t.Error("expected original not to have bit 2 set")
+	}
+	if !clone.Get(2) {
+		t.Error("expected clone to have bit 2 set")
+	}
+}
+
+func TestBitmap_String(t *testing.T) {
+	// Size 64 -> 1 uint64
+	b := newBitmap(64)
+	// 0x0000000000000001 (bit 0 set)
+	b.Set(0)
+	// Output is hex encoded BigEndian of the uint64
+	// uint64(1) -> bytes: [0 0 0 0 0 0 0 1]
+	// hex: "0000000000000001"
+	if got, want := b.String(), "0000000000000001"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	b2 := newBitmap(64)
+	b2.Set(63)
+	// 1 << 63 is the highest bit.
+	// 0x8000000000000000
+	// bytes: [128 0 0 0 0 0 0 0] -> hex "8000000000000000"
+	if got, want := b2.String(), "8000000000000000"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// Multi-word
+	b3 := newBitmap(128)
+	b3.Set(0)
+	b3.Set(64)
+	// Array of 2 uint64s.
+	// b3[0] has bit 0 set -> "0000000000000001"
+	// b3[1] has bit 0 (global 64) set -> "0000000000000001"
+	// Output order: iterates slice.
+	// "0000000000000001" + "0000000000000001"
+	if got, want := b3.String(), "00000000000000010000000000000001"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func expectPanic(t *testing.T, expected interface{}) {
+	r := recover()
+	if r == nil {
+		t.Errorf("expected panic %v, but did not panic", expected)
+	} else if r != expected {
+		t.Errorf("expected panic %v, but got %v", expected, r)
+	}
+}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/extendwebsocketstokubelet/feature.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/extendwebsocketstokubelet/feature.go
@@ -18,11 +18,11 @@ package extendwebsocketstokubelet
 
 import (
 	"k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/component-helpers/nodedeclaredfeatures"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
 // Ensure the feature struct implements the unified Feature interface.
-var _ nodedeclaredfeatures.Feature = &extendWebSocketsToKubeletFeature{}
+var _ types.Feature = &extendWebSocketsToKubeletFeature{}
 
 const (
 	ExtendWebSocketsToKubeletFeatureGate = "ExtendWebSocketsToKubelet"
@@ -37,22 +37,22 @@ func (f *extendWebSocketsToKubeletFeature) Name() string {
 	return ExtendWebSocketsToKubeletFeatureGate
 }
 
-func (f *extendWebSocketsToKubeletFeature) Requirements() *nodedeclaredfeatures.FeatureRequirements {
-	return &nodedeclaredfeatures.FeatureRequirements{
+func (f *extendWebSocketsToKubeletFeature) Requirements() *types.FeatureRequirements {
+	return &types.FeatureRequirements{
 		EnabledFeatureGates: []string{ExtendWebSocketsToKubeletFeatureGate},
 	}
 }
 
-func (f *extendWebSocketsToKubeletFeature) Discover(cfg *nodedeclaredfeatures.NodeConfiguration) bool {
+func (f *extendWebSocketsToKubeletFeature) Discover(cfg *types.NodeConfiguration) bool {
 	return cfg.FeatureGates.Enabled(ExtendWebSocketsToKubeletFeatureGate)
 }
 
-func (f *extendWebSocketsToKubeletFeature) InferForScheduling(podInfo *nodedeclaredfeatures.PodInfo) bool {
+func (f *extendWebSocketsToKubeletFeature) InferForScheduling(podInfo *types.PodInfo) bool {
 	// This feature does not affect scheduling.
 	return false
 }
 
-func (f *extendWebSocketsToKubeletFeature) InferForUpdate(oldPodInfo, newPodInfo *nodedeclaredfeatures.PodInfo) bool {
+func (f *extendWebSocketsToKubeletFeature) InferForUpdate(oldPodInfo, newPodInfo *types.PodInfo) bool {
 	// This feature does not affect updates.
 	return false
 }

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/inplacepodresize/pod_level_resource_resize.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/inplacepodresize/pod_level_resource_resize.go
@@ -19,11 +19,11 @@ package inplacepodresize
 import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/component-helpers/nodedeclaredfeatures"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
 // Ensure the feature struct implements the unified Feature interface.
-var _ nodedeclaredfeatures.Feature = &podLevelResourcesResizeFeature{}
+var _ types.Feature = &podLevelResourcesResizeFeature{}
 
 // IPPRPodLevelResourcesFeatureGate is the feature gate for IPPRPodLevelResourcesVerticalScaling.
 const IPPRPodLevelResourcesFeatureGate = "InPlacePodLevelResourcesVerticalScaling"
@@ -37,21 +37,22 @@ func (f *podLevelResourcesResizeFeature) Name() string {
 	return IPPRPodLevelResourcesFeatureGate
 }
 
-func (f *podLevelResourcesResizeFeature) Discover(cfg *nodedeclaredfeatures.NodeConfiguration) bool {
+func (f *podLevelResourcesResizeFeature) Discover(cfg *types.NodeConfiguration) bool {
 	return cfg.FeatureGates.Enabled(IPPRPodLevelResourcesFeatureGate)
 }
 
-func (f *podLevelResourcesResizeFeature) Requirements() *nodedeclaredfeatures.FeatureRequirements {
-	return &nodedeclaredfeatures.FeatureRequirements{
+func (f *podLevelResourcesResizeFeature) Requirements() *types.FeatureRequirements {
+	return &types.FeatureRequirements{
 		EnabledFeatureGates: []string{IPPRPodLevelResourcesFeatureGate},
 	}
 }
-func (f *podLevelResourcesResizeFeature) InferForScheduling(podInfo *nodedeclaredfeatures.PodInfo) bool {
+
+func (f *podLevelResourcesResizeFeature) InferForScheduling(podInfo *types.PodInfo) bool {
 	// This feature is only relevant for pod updates.
 	return false
 }
 
-func (f *podLevelResourcesResizeFeature) InferForUpdate(oldPodInfo, newPodInfo *nodedeclaredfeatures.PodInfo) bool {
+func (f *podLevelResourcesResizeFeature) InferForUpdate(oldPodInfo, newPodInfo *types.PodInfo) bool {
 	if oldPodInfo.Spec.Resources == nil && newPodInfo.Spec.Resources == nil {
 		return false
 	}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/inplacepodresize/pod_level_resource_resize_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/inplacepodresize/pod_level_resource_resize_test.go
@@ -21,8 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/component-helpers/nodedeclaredfeatures"
-	test "k8s.io/component-helpers/nodedeclaredfeatures/testing"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
 func TestPodLevelResourcesResizeFeature_Requirements(t *testing.T) {
@@ -56,10 +55,7 @@ func TestPodLevelResourcesResizeFeatureDiscover(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockFG := test.NewMockFeatureGate(t)
-			mockFG.SetEnabled(IPPRPodLevelResourcesFeatureGate, tt.featureGate)
-
-			cfg := &nodedeclaredfeatures.NodeConfiguration{FeatureGates: mockFG}
+			cfg := &types.NodeConfiguration{FeatureGates: types.FeatureGateMap{IPPRPodLevelResourcesFeatureGate: tt.featureGate}}
 			enabled := PodLevelResourcesResizeFeature.Discover(cfg)
 			if want, got := tt.expected, enabled; want != got {
 				t.Fatalf("want=%v,got=%v", want, got)
@@ -69,7 +65,7 @@ func TestPodLevelResourcesResizeFeatureDiscover(t *testing.T) {
 }
 
 func TestPodLevelResourcesResizeFeatureInferForScheduling(t *testing.T) {
-	podInfo := &nodedeclaredfeatures.PodInfo{Spec: &v1.PodSpec{}, Status: &v1.PodStatus{}}
+	podInfo := &types.PodInfo{Spec: &v1.PodSpec{}, Status: &v1.PodStatus{}}
 	if PodLevelResourcesResizeFeature.InferForScheduling(podInfo) {
 		t.Fatalf("InferForScheduling should always be false")
 	}
@@ -78,13 +74,13 @@ func TestPodLevelResourcesResizeFeatureInferForScheduling(t *testing.T) {
 func TestPodLevelResourcesResizeFeatureInferForUpdate(t *testing.T) {
 	tests := []struct {
 		name       string
-		oldPodInfo *nodedeclaredfeatures.PodInfo
-		newPodInfo *nodedeclaredfeatures.PodInfo
+		oldPodInfo *types.PodInfo
+		newPodInfo *types.PodInfo
 		expected   bool
 	}{
 		{
 			name: "NoResourcesChanged",
-			oldPodInfo: &nodedeclaredfeatures.PodInfo{
+			oldPodInfo: &types.PodInfo{
 				Spec: &v1.PodSpec{
 					Resources: &v1.ResourceRequirements{
 						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
@@ -93,7 +89,7 @@ func TestPodLevelResourcesResizeFeatureInferForUpdate(t *testing.T) {
 				},
 				Status: &v1.PodStatus{},
 			},
-			newPodInfo: &nodedeclaredfeatures.PodInfo{
+			newPodInfo: &types.PodInfo{
 				Spec: &v1.PodSpec{
 					Resources: &v1.ResourceRequirements{
 						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
@@ -106,11 +102,11 @@ func TestPodLevelResourcesResizeFeatureInferForUpdate(t *testing.T) {
 		},
 		{
 			name: "ResourcesAdded",
-			oldPodInfo: &nodedeclaredfeatures.PodInfo{
+			oldPodInfo: &types.PodInfo{
 				Spec:   &v1.PodSpec{},
 				Status: &v1.PodStatus{},
 			},
-			newPodInfo: &nodedeclaredfeatures.PodInfo{
+			newPodInfo: &types.PodInfo{
 				Spec: &v1.PodSpec{
 					Resources: &v1.ResourceRequirements{
 						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
@@ -123,7 +119,7 @@ func TestPodLevelResourcesResizeFeatureInferForUpdate(t *testing.T) {
 		},
 		{
 			name: "ResourcesRemoved",
-			oldPodInfo: &nodedeclaredfeatures.PodInfo{
+			oldPodInfo: &types.PodInfo{
 				Spec: &v1.PodSpec{
 					Resources: &v1.ResourceRequirements{
 						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
@@ -132,7 +128,7 @@ func TestPodLevelResourcesResizeFeatureInferForUpdate(t *testing.T) {
 				},
 				Status: &v1.PodStatus{},
 			},
-			newPodInfo: &nodedeclaredfeatures.PodInfo{
+			newPodInfo: &types.PodInfo{
 				Spec:   &v1.PodSpec{},
 				Status: &v1.PodStatus{},
 			},
@@ -140,7 +136,7 @@ func TestPodLevelResourcesResizeFeatureInferForUpdate(t *testing.T) {
 		},
 		{
 			name: "ResourcesChanged",
-			oldPodInfo: &nodedeclaredfeatures.PodInfo{
+			oldPodInfo: &types.PodInfo{
 				Spec: &v1.PodSpec{
 					Resources: &v1.ResourceRequirements{
 						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
@@ -149,7 +145,7 @@ func TestPodLevelResourcesResizeFeatureInferForUpdate(t *testing.T) {
 				},
 				Status: &v1.PodStatus{},
 			},
-			newPodInfo: &nodedeclaredfeatures.PodInfo{
+			newPodInfo: &types.PodInfo{
 				Spec: &v1.PodSpec{
 					Resources: &v1.ResourceRequirements{
 						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
@@ -162,11 +158,11 @@ func TestPodLevelResourcesResizeFeatureInferForUpdate(t *testing.T) {
 		},
 		{
 			name: "NilResources",
-			oldPodInfo: &nodedeclaredfeatures.PodInfo{
+			oldPodInfo: &types.PodInfo{
 				Spec:   &v1.PodSpec{},
 				Status: &v1.PodStatus{},
 			},
-			newPodInfo: &nodedeclaredfeatures.PodInfo{
+			newPodInfo: &types.PodInfo{
 				Spec:   &v1.PodSpec{},
 				Status: &v1.PodStatus{},
 			},

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/registry.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/registry.go
@@ -17,16 +17,16 @@ limitations under the License.
 package features
 
 import (
-	"k8s.io/component-helpers/nodedeclaredfeatures"
 	"k8s.io/component-helpers/nodedeclaredfeatures/features/extendwebsocketstokubelet"
 	"k8s.io/component-helpers/nodedeclaredfeatures/features/inplacepodresize"
 	"k8s.io/component-helpers/nodedeclaredfeatures/features/restartallcontainers"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
 // AllFeatures is the central registry for all declared features.
 // New features are added to this list to be automatically included in both
 // discovery and inference logic.
-var AllFeatures = []nodedeclaredfeatures.Feature{
+var AllFeatures = []types.Feature{
 	restartallcontainers.Feature,
 	inplacepodresize.PodLevelResourcesResizeFeature,
 	extendwebsocketstokubelet.Feature,

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/registry_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/registry_test.go
@@ -14,21 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package features
+package features_test
 
 import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/component-helpers/nodedeclaredfeatures"
+	"k8s.io/component-helpers/nodedeclaredfeatures/features"
 	testhelpers "k8s.io/component-helpers/nodedeclaredfeatures/testing"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
 // TestFeatureRequirementsConsistency checks that each feature's Discover method
 // actually checks the gates it declares in Requirements
 // and returns the correct boolean value.
 func TestFeatureRequirementsConsistency(t *testing.T) {
-	for _, registeredFeature := range AllFeatures {
+	for _, registeredFeature := range features.AllFeatures {
 		t.Run(registeredFeature.Name(), func(t *testing.T) {
 			reqs := registeredFeature.Requirements()
 			if reqs == nil {
@@ -45,7 +46,7 @@ func TestFeatureRequirementsConsistency(t *testing.T) {
 				mockFG.SetEnabled(gate, true)
 			}
 
-			discoverCfg := &nodedeclaredfeatures.NodeConfiguration{
+			discoverCfg := &types.NodeConfiguration{
 				FeatureGates: mockFG,
 				Version:      version.MustParse("1.36.0"),
 			}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/restartallcontainers/restart_all_containers.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/restartallcontainers/restart_all_containers.go
@@ -19,11 +19,11 @@ package restartallcontainers
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/component-helpers/nodedeclaredfeatures"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
 // Ensure the feature struct implements the unified Feature interface.
-var _ nodedeclaredfeatures.Feature = &restartAllContainersFeature{}
+var _ types.Feature = &restartAllContainersFeature{}
 
 const (
 	RestartRulesFeatureGate              = "ContainerRestartRules"
@@ -39,16 +39,17 @@ func (f *restartAllContainersFeature) Name() string {
 	return RestartAllContainersOnContainerExits
 }
 
-func (f *restartAllContainersFeature) Discover(cfg *nodedeclaredfeatures.NodeConfiguration) bool {
+func (f *restartAllContainersFeature) Discover(cfg *types.NodeConfiguration) bool {
 	return cfg.FeatureGates.Enabled(RestartAllContainersOnContainerExits)
 }
 
-func (f *restartAllContainersFeature) Requirements() *nodedeclaredfeatures.FeatureRequirements {
-	return &nodedeclaredfeatures.FeatureRequirements{
+func (f *restartAllContainersFeature) Requirements() *types.FeatureRequirements {
+	return &types.FeatureRequirements{
 		EnabledFeatureGates: []string{RestartAllContainersOnContainerExits},
 	}
 }
-func (f *restartAllContainersFeature) InferForScheduling(podInfo *nodedeclaredfeatures.PodInfo) bool {
+
+func (f *restartAllContainersFeature) InferForScheduling(podInfo *types.PodInfo) bool {
 	for _, c := range podInfo.Spec.Containers {
 		for _, rule := range c.RestartPolicyRules {
 			if rule.Action == v1.ContainerRestartRuleActionRestartAllContainers {
@@ -66,7 +67,7 @@ func (f *restartAllContainersFeature) InferForScheduling(podInfo *nodedeclaredfe
 	return false
 }
 
-func (f *restartAllContainersFeature) InferForUpdate(oldPodInfo, newPodInfo *nodedeclaredfeatures.PodInfo) bool {
+func (f *restartAllContainersFeature) InferForUpdate(oldPodInfo, newPodInfo *types.PodInfo) bool {
 	// container.restartPolicy and container.restartPolicyRules are not mutable.
 	return false
 }

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/restartallcontainers/restart_all_containers_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/restartallcontainers/restart_all_containers_test.go
@@ -20,8 +20,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/component-helpers/nodedeclaredfeatures"
-	test "k8s.io/component-helpers/nodedeclaredfeatures/testing"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
 func TestRequirements(t *testing.T) {
@@ -56,10 +55,8 @@ func TestDiscover(t *testing.T) {
 	feature := &restartAllContainersFeature{}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockFG := test.NewMockFeatureGate(t)
-			mockFG.SetEnabled(RestartAllContainersOnContainerExits, tc.featureGateEnabled)
-			config := &nodedeclaredfeatures.NodeConfiguration{
-				FeatureGates: mockFG,
+			config := &types.NodeConfiguration{
+				FeatureGates: types.FeatureGateMap{RestartAllContainersOnContainerExits: tc.featureGateEnabled},
 			}
 			enabled := feature.Discover(config)
 			if want, got := tc.expected, enabled; want != got {
@@ -118,7 +115,7 @@ func TestInferForScheduling(t *testing.T) {
 	feature := &restartAllContainersFeature{}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			podInfo := &nodedeclaredfeatures.PodInfo{Spec: tc.pod}
+			podInfo := &types.PodInfo{Spec: tc.pod}
 			if want, got := tc.expected, feature.InferForScheduling(podInfo); want != got {
 				t.Fatalf("want=%v,got=%v", want, got)
 			}
@@ -128,7 +125,7 @@ func TestInferForScheduling(t *testing.T) {
 
 func TestInferForUpdate(t *testing.T) {
 	feature := &restartAllContainersFeature{}
-	podInfo := &nodedeclaredfeatures.PodInfo{Spec: &v1.PodSpec{}}
+	podInfo := &types.PodInfo{Spec: &v1.PodSpec{}}
 	if feature.InferForUpdate(nil, podInfo) {
 		t.Fatalf("expect InferForUpdate to be false")
 	}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/featureset.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/featureset.go
@@ -1,0 +1,106 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedeclaredfeatures
+
+import (
+	"fmt"
+	"slices"
+)
+
+// FeatureSet is a set of node features.
+type FeatureSet = bitmap
+
+// FeatureMapper maps feature names to bit positions in a FeatureSet.
+type FeatureMapper struct {
+	registeredFeatures []string
+}
+
+// NewFeatureMapper creates a FeatureMapper from a list of known features.
+func NewFeatureMapper(features []string) *FeatureMapper {
+	sortedFeatures := slices.Clone(features)
+	slices.Sort(sortedFeatures)
+	return &FeatureMapper{sortedFeatures}
+}
+
+// NewFeatureSet returns an empty FeatureSet sized to the registered features.
+func (m *FeatureMapper) NewFeatureSet() FeatureSet {
+	return FeatureSet(newBitmap(len(m.registeredFeatures)))
+}
+
+// MapSorted creates a FeatureSet from a sorted slice of feature names.
+func (m *FeatureMapper) MapSorted(sortedFeatures []string) (FeatureSet, error) {
+	return m.mapSorted(sortedFeatures, false)
+}
+
+// MustMapSorted is a convenience wrapper around MapSorted that panics on errors.
+func (m *FeatureMapper) MustMapSorted(sortedFeatures []string) FeatureSet {
+	s, err := m.MapSorted(sortedFeatures)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// TryMap creates a FeatureSet from a sorted slice, ignoring unknown features.
+func (m *FeatureMapper) TryMap(sortedFeatures []string) FeatureSet {
+	fs, _ := m.mapSorted(sortedFeatures, true)
+	return fs
+}
+
+func (m *FeatureMapper) mapSorted(sortedFeatures []string, ignoreUnknown bool) (FeatureSet, error) {
+	s := m.NewFeatureSet()
+
+	if len(sortedFeatures) == 0 {
+		return s, nil
+	}
+
+	i, j := 0, 0
+	for i < len(sortedFeatures) && j < len(m.registeredFeatures) {
+		if sortedFeatures[i] == m.registeredFeatures[j] {
+			s.Set(j)
+			i++
+			j++
+		} else if sortedFeatures[i] < m.registeredFeatures[j] {
+			if !ignoreUnknown {
+				return s, fmt.Errorf("unknown feature %s", sortedFeatures[i])
+			}
+			i++
+		} else {
+			j++
+		}
+	}
+
+	if !ignoreUnknown && i < len(sortedFeatures) {
+		return s, fmt.Errorf("unknown feature %s", sortedFeatures[i])
+	}
+	return s, nil
+}
+
+// Unmap returns the names of the features set in the FeatureSet (sorted).
+func (m *FeatureMapper) Unmap(s FeatureSet) []string {
+	if s.IsEmpty() {
+		return nil
+	}
+
+	var keys []string
+	for i, k := range m.registeredFeatures {
+		if s.Get(i) {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/featureset.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/featureset.go
@@ -18,6 +18,7 @@ package nodedeclaredfeatures
 
 import (
 	"fmt"
+	"math/bits"
 	"slices"
 )
 
@@ -91,16 +92,19 @@ func (m *FeatureMapper) mapSorted(sortedFeatures []string, ignoreUnknown bool) (
 }
 
 // Unmap returns the names of the features set in the FeatureSet (sorted).
-func (m *FeatureMapper) Unmap(s FeatureSet) []string {
-	if s.IsEmpty() {
-		return nil
+func (m *FeatureMapper) Unmap(s FeatureSet) ([]string, error) {
+	if s.size != len(m.registeredFeatures) {
+		return nil, fmt.Errorf("feature size mismatch! s.size=%d; len(m.registeredFeatures)=%d", s.size, len(m.registeredFeatures))
 	}
 
 	var keys []string
-	for i, k := range m.registeredFeatures {
-		if s.Get(i) {
-			keys = append(keys, k)
+	for i, w := range s.words {
+		for w != 0 {
+			t := bits.TrailingZeros64(w) // Find the index of the least significant bit.
+			index := i*64 + t
+			keys = append(keys, m.registeredFeatures[index])
+			w &^= 1 << uint(t) // Clear the least significant bit.
 		}
 	}
-	return keys
+	return keys, nil
 }

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/featureset_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/featureset_test.go
@@ -117,8 +117,11 @@ func TestFeatureMapper(t *testing.T) {
 				}
 			}
 
-			// Test Unmap
-			unmapped := mapper.Unmap(fs)
+			// Test Unmap and UnmapSparse
+			unmapped, err := mapper.Unmap(fs)
+			if err != nil {
+				t.Fatalf("unexpected Unmap error: %v", err)
+			}
 			if len(unmapped) != tt.expectedSet.Len() {
 				t.Errorf("len(unmapped) = %d, want %d", len(unmapped), tt.expectedSet.Len())
 			}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/featureset_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/featureset_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedeclaredfeatures
+
+import (
+	"slices"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestFeatureMapper(t *testing.T) {
+	features := []string{"a", "b", "c", "d"}
+	mapper := NewFeatureMapper(features)
+
+	tests := []struct {
+		name        string
+		input       []string
+		expectError bool
+		expectedSet sets.Set[int] // indices in features
+	}{
+		{
+			name:        "Empty input",
+			input:       nil,
+			expectedSet: nil,
+		},
+		{
+			name:        "Single valid feature",
+			input:       []string{"a"},
+			expectedSet: sets.New(0),
+		},
+		{
+			name:        "Multiple valid features",
+			input:       []string{"a", "c"},
+			expectedSet: sets.New(0, 2),
+		},
+		{
+			name:        "All features",
+			input:       []string{"a", "b", "c", "d"},
+			expectedSet: sets.New(0, 1, 2, 3),
+		},
+		{
+			name:        "Unknown feature (start)",
+			input:       []string{"0", "a"},
+			expectError: true,
+			expectedSet: sets.New(0),
+		},
+		{
+			name:        "Unknown feature (middle)",
+			input:       []string{"a", "ab", "b"},
+			expectError: true,
+			expectedSet: sets.New(0, 1),
+		},
+		{
+			name:        "Unknown feature (end)",
+			input:       []string{"d", "e"},
+			expectError: true,
+			expectedSet: sets.New(3),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test TryMap
+			fs := mapper.TryMap(tt.input)
+			for i, known := range features {
+				expected := tt.expectedSet.Has(i)
+				got := fs.Get(i)
+				if got != expected {
+					t.Errorf("Feature %s (index %d) state mismatch: got %v, want %v", known, i, got, expected)
+				}
+			}
+
+			// Test MapSorted
+			fs2, err := mapper.MapSorted(tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error from MapSorted, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error from MapSorted: %v", err)
+				}
+				if !fs.Equal(fs2) {
+					t.Errorf("fs != fs2: got %v, want %v", fs2, fs)
+				}
+			}
+
+			// Test MustMapSorted
+			if tt.expectError {
+				func() {
+					defer func() {
+						if r := recover(); r == nil {
+							t.Error("expected panic from MustMapSorted, but did not panic")
+						}
+					}()
+					mapper.MustMapSorted(tt.input)
+				}()
+			} else {
+				got := mapper.MustMapSorted(tt.input)
+				if !fs.Equal(got) {
+					t.Errorf("MustMapSorted result mismatch: got %v, want %v", got, fs)
+				}
+			}
+
+			// Test Unmap
+			unmapped := mapper.Unmap(fs)
+			if len(unmapped) != tt.expectedSet.Len() {
+				t.Errorf("len(unmapped) = %d, want %d", len(unmapped), tt.expectedSet.Len())
+			}
+			if tt.expectError {
+				// If there's an error, just verify that the unmapped results of TryMap are
+				// contained within the input.
+				inputSets := sets.New(tt.input...)
+				for _, u := range unmapped {
+					if !inputSets.Has(u) {
+						t.Errorf("unmapped result %q not found in input %v", u, tt.input)
+					}
+				}
+			} else {
+				if !slices.Equal(tt.input, unmapped) {
+					t.Errorf("Unmap result mismatch: got %v, want %v", unmapped, tt.input)
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
@@ -23,12 +23,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
 // Framework provides functions for discovering node features and inferring pod feature requirements.
 // It is stateful and holds the feature registry.
 type Framework struct {
-	registry []Feature
+	registry []types.Feature
 }
 
 // FeatureSet is a set of node features.
@@ -55,7 +56,7 @@ func (s *FeatureSet) Clone() FeatureSet {
 }
 
 // New creates a new instance of the Framework.
-func New(registry []Feature) (*Framework, error) {
+func New(registry []types.Feature) (*Framework, error) {
 	if registry == nil {
 		return nil, fmt.Errorf("registry must not be nil")
 	}
@@ -66,7 +67,7 @@ func New(registry []Feature) (*Framework, error) {
 
 // DiscoverNodeFeatures determines which features from the registry are enabled
 // for a specific node configuration. It returns a sorted, unique list of feature names.
-func (f *Framework) DiscoverNodeFeatures(cfg *NodeConfiguration) []string {
+func (f *Framework) DiscoverNodeFeatures(cfg *types.NodeConfiguration) []string {
 	var enabledFeatures []string
 	for _, f := range f.registry {
 		if f.Discover(cfg) {
@@ -81,7 +82,7 @@ func (f *Framework) DiscoverNodeFeatures(cfg *NodeConfiguration) []string {
 }
 
 // InferForPodScheduling determines which features from the registry are required by a pod scheduling for a given target version.
-func (f *Framework) InferForPodScheduling(podInfo *PodInfo, targetVersion *version.Version) (FeatureSet, error) {
+func (f *Framework) InferForPodScheduling(podInfo *types.PodInfo, targetVersion *version.Version) (FeatureSet, error) {
 	if targetVersion == nil {
 		return FeatureSet{}, fmt.Errorf("target version cannot be nil")
 	}
@@ -99,7 +100,7 @@ func (f *Framework) InferForPodScheduling(podInfo *PodInfo, targetVersion *versi
 }
 
 // InferForPodUpdate determines which features are required by a pod update operation for a given target version.
-func (f *Framework) InferForPodUpdate(oldPodInfo, newPodInfo *PodInfo, targetVersion *version.Version) (FeatureSet, error) {
+func (f *Framework) InferForPodUpdate(oldPodInfo, newPodInfo *types.PodInfo, targetVersion *version.Version) (FeatureSet, error) {
 	if targetVersion == nil {
 		return FeatureSet{}, fmt.Errorf("target version cannot be nil")
 	}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
@@ -120,10 +120,7 @@ func (f *Framework) MatchNode(requiredFeatures FeatureSet, node *v1.Node) (*Matc
 	if node == nil {
 		return nil, fmt.Errorf("node cannot be nil")
 	}
-	fs, err := f.MapSorted(node.Status.DeclaredFeatures)
-	if err != nil {
-		return nil, err
-	}
+	fs := f.TryMap(node.Status.DeclaredFeatures)
 	return f.MatchNodeFeatureSet(requiredFeatures, fs)
 }
 
@@ -135,13 +132,17 @@ func (f *Framework) MatchNodeFeatureSet(requiredFeatures FeatureSet, nodeFeature
 	if requiredFeatures.IsEmpty() {
 		return &MatchResult{IsMatch: true}, nil // No requirements to match.
 	}
-	diff, err := requiredFeatures.Difference(nodeFeatures)
+	// Perform an explicit IsSubset check first to optimize for the success path,
+	// since IsSubset is faster than Difference (no allocations).
+	isMatch, err := requiredFeatures.IsSubset(nodeFeatures)
 	if err != nil {
 		return nil, err
 	}
-	if diff.IsEmpty() {
+	if isMatch {
 		return &MatchResult{IsMatch: true}, nil
 	}
+
+	diff, _ := requiredFeatures.Difference(nodeFeatures) // Difference will error IFF IsSubset also does, so we can ignore the error here.
 	unsatisfiedRequirements := f.Unmap(diff)
 	return &MatchResult{IsMatch: false, UnsatisfiedRequirements: unsatisfiedRequirements}, nil
 }

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
@@ -18,9 +18,10 @@ package nodedeclaredfeatures
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-helpers/nodedeclaredfeatures/features"
 	"k8s.io/component-helpers/nodedeclaredfeatures/types"
@@ -29,38 +30,25 @@ import (
 // Framework provides functions for discovering node features and inferring pod feature requirements.
 // It is stateful and holds the feature registry.
 type Framework struct {
+	*FeatureMapper
 	registry []types.Feature
-}
-
-// FeatureSet is a set of node features.
-type FeatureSet struct {
-	sets.Set[string]
-}
-
-// NewFeatureSet creates a FeatureSet from a list of feature names.
-func NewFeatureSet(features ...string) FeatureSet {
-	return FeatureSet{Set: sets.New(features...)}
-}
-
-// Equal returns true if both the sets have the same features.
-func (s *FeatureSet) Equal(other FeatureSet) bool {
-	return s.Set.Equal(other.Set)
-}
-
-// Clone returns a copy of the FeatureSet.
-func (s *FeatureSet) Clone() FeatureSet {
-	if s.Set == nil {
-		return FeatureSet{Set: nil}
-	}
-	return FeatureSet{Set: s.Set.Clone()}
 }
 
 var DefaultFramework = New(features.AllFeatures)
 
 // New creates a new instance of the Framework.
 func New(registry []types.Feature) *Framework {
+	// Ensure the features are sorted.
+	slices.SortFunc(registry, func(a, b types.Feature) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
+	featureNames := make([]string, len(registry))
+	for i, f := range registry {
+		featureNames[i] = f.Name()
+	}
 	return &Framework{
-		registry: registry,
+		registry:      registry,
+		FeatureMapper: NewFeatureMapper(featureNames),
 	}
 }
 
@@ -84,14 +72,14 @@ func (f *Framework) InferForPodScheduling(podInfo *types.PodInfo, targetVersion 
 	if targetVersion == nil {
 		return FeatureSet{}, fmt.Errorf("target version cannot be nil")
 	}
-	reqs := NewFeatureSet()
-	for _, f := range f.registry {
+	reqs := f.NewFeatureSet()
+	for i, f := range f.registry {
 		if f.MaxVersion() != nil && targetVersion.GreaterThan(f.MaxVersion()) {
 			// If target version is greater than the feature's max version, no need to require the feature
 			continue
 		}
 		if f.InferForScheduling(podInfo) {
-			reqs.Insert(f.Name())
+			reqs.Set(i)
 		}
 	}
 	return reqs, nil
@@ -102,14 +90,14 @@ func (f *Framework) InferForPodUpdate(oldPodInfo, newPodInfo *types.PodInfo, tar
 	if targetVersion == nil {
 		return FeatureSet{}, fmt.Errorf("target version cannot be nil")
 	}
-	reqs := NewFeatureSet()
-	for _, f := range f.registry {
+	reqs := f.NewFeatureSet()
+	for i, f := range f.registry {
 		if f.MaxVersion() != nil && targetVersion.GreaterThan(f.MaxVersion()) {
 			// If target version is greater than the feature's max version, no need to require the feature
 			continue
 		}
 		if f.InferForUpdate(oldPodInfo, newPodInfo) {
-			reqs.Insert(f.Name())
+			reqs.Set(i)
 		}
 	}
 	return reqs, nil
@@ -128,32 +116,34 @@ type MatchResult struct {
 // It returns a MatchResult:
 // - IsMatch is true if all requiredFeatures are present in node.status.declaredFeatures.
 // - UnsatisfiedRequirements lists features in requiredFeatures but not in node.status.declaredFeatures.
-func MatchNode(requiredFeatures FeatureSet, node *v1.Node) (*MatchResult, error) {
+func (f *Framework) MatchNode(requiredFeatures FeatureSet, node *v1.Node) (*MatchResult, error) {
 	if node == nil {
 		return nil, fmt.Errorf("node cannot be nil")
 	}
-	return MatchNodeFeatureSet(requiredFeatures, NewFeatureSet(node.Status.DeclaredFeatures...))
+	fs, err := f.MapSorted(node.Status.DeclaredFeatures)
+	if err != nil {
+		return nil, err
+	}
+	return f.MatchNodeFeatureSet(requiredFeatures, fs)
 }
 
 // MatchNodeFeatureSet compares a set of required features against a set of features present on a node.
 // It returns a MatchResult:
 // - IsMatch is true if all requiredFeatures are present in nodeFeatures.
 // - UnsatisfiedRequirements lists features in requiredFeatures but not in nodeFeatures.
-func MatchNodeFeatureSet(requiredFeatures FeatureSet, nodeFeatures FeatureSet) (*MatchResult, error) {
-	if requiredFeatures.Len() == 0 {
+func (f *Framework) MatchNodeFeatureSet(requiredFeatures FeatureSet, nodeFeatures FeatureSet) (*MatchResult, error) {
+	if requiredFeatures.IsEmpty() {
 		return &MatchResult{IsMatch: true}, nil // No requirements to match.
 	}
-	var mismatched []string
-	for req := range requiredFeatures.Set {
-		if !nodeFeatures.Has(req) {
-			mismatched = append(mismatched, req)
-			continue
-		}
+	diff, err := requiredFeatures.Difference(nodeFeatures)
+	if err != nil {
+		return nil, err
 	}
-	if len(mismatched) > 0 {
-		return &MatchResult{IsMatch: false, UnsatisfiedRequirements: mismatched}, nil
+	if diff.IsEmpty() {
+		return &MatchResult{IsMatch: true}, nil
 	}
-	return &MatchResult{IsMatch: true}, nil
+	unsatisfiedRequirements := f.Unmap(diff)
+	return &MatchResult{IsMatch: false, UnsatisfiedRequirements: unsatisfiedRequirements}, nil
 }
 
 // GetFeatureRequirements returns the feature gates that a feature depends on.

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
@@ -143,7 +143,10 @@ func (f *Framework) MatchNodeFeatureSet(requiredFeatures FeatureSet, nodeFeature
 	}
 
 	diff, _ := requiredFeatures.Difference(nodeFeatures) // Difference will error IFF IsSubset also does, so we can ignore the error here.
-	unsatisfiedRequirements := f.Unmap(diff)
+	unsatisfiedRequirements, err := f.Unmap(diff)
+	if err != nil {
+		return nil, err
+	}
 	return &MatchResult{IsMatch: false, UnsatisfiedRequirements: unsatisfiedRequirements}, nil
 }
 

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework.go
@@ -18,11 +18,11 @@ package nodedeclaredfeatures
 
 import (
 	"fmt"
-	"slices"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-helpers/nodedeclaredfeatures/features"
 	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
@@ -55,14 +55,13 @@ func (s *FeatureSet) Clone() FeatureSet {
 	return FeatureSet{Set: s.Set.Clone()}
 }
 
+var DefaultFramework = New(features.AllFeatures)
+
 // New creates a new instance of the Framework.
-func New(registry []types.Feature) (*Framework, error) {
-	if registry == nil {
-		return nil, fmt.Errorf("registry must not be nil")
-	}
+func New(registry []types.Feature) *Framework {
 	return &Framework{
 		registry: registry,
-	}, nil
+	}
 }
 
 // DiscoverNodeFeatures determines which features from the registry are enabled
@@ -77,7 +76,6 @@ func (f *Framework) DiscoverNodeFeatures(cfg *types.NodeConfiguration) []string 
 			enabledFeatures = append(enabledFeatures, f.Name())
 		}
 	}
-	slices.Sort(enabledFeatures)
 	return enabledFeatures
 }
 

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework_test.go
@@ -40,13 +40,24 @@ type mockFeature struct {
 	requirements       func() *FeatureRequirements
 }
 
-func (f *mockFeature) Name() string                               { return f.name }
-func (f *mockFeature) Discover(cfg *types.NodeConfiguration) bool { return f.discover(cfg) }
+func (f *mockFeature) Name() string { return f.name }
+func (f *mockFeature) Discover(cfg *types.NodeConfiguration) bool {
+	if f.discover != nil {
+		return f.discover(cfg)
+	}
+	return true
+}
 func (f *mockFeature) InferForScheduling(podInfo *types.PodInfo) bool {
-	return f.inferForScheduling(podInfo)
+	if f.inferForScheduling != nil {
+		return f.inferForScheduling(podInfo)
+	}
+	return false
 }
 func (f *mockFeature) InferForUpdate(oldPodInfo, newPodInfo *types.PodInfo) bool {
-	return f.inferForUpdate(oldPodInfo, newPodInfo)
+	if f.inferForUpdate != nil {
+		return f.inferForUpdate(oldPodInfo, newPodInfo)
+	}
+	return false
 }
 func (f *mockFeature) MaxVersion() *version.Version       { return f.maxVersion }
 func (f *mockFeature) Requirements() *FeatureRequirements { return f.requirements() }
@@ -64,6 +75,17 @@ func (m *mockFeatureGate) Enabled(key string) bool {
 
 func newMockFeatureGate(features map[string]bool) *mockFeatureGate {
 	return &mockFeatureGate{features: features}
+}
+
+func newTestFramework(features ...string) *Framework {
+	slices.Sort(features)
+
+	allFeatures := make([]Feature, len(features))
+	for i, name := range features {
+		allFeatures[i] = &mockFeature{name: name}
+	}
+
+	return New(allFeatures)
 }
 
 func TestDiscoverNodeFeatures(t *testing.T) {
@@ -188,7 +210,7 @@ func TestInferForPodScheduling(t *testing.T) {
 		registry      []types.Feature
 		newPod        *v1.Pod
 		targetVersion *version.Version
-		expectedReqs  FeatureSet
+		expectedReqs  []string
 		expectErr     bool
 		errContains   string
 	}{
@@ -203,7 +225,7 @@ func TestInferForPodScheduling(t *testing.T) {
 			},
 			newPod:        podWithPodLevelResources,
 			targetVersion: version.MustParse("1.30.0"),
-			expectedReqs:  NewFeatureSet("PodLevelResources"),
+			expectedReqs:  []string{"PodLevelResources"},
 			expectErr:     false,
 		},
 		{
@@ -217,7 +239,7 @@ func TestInferForPodScheduling(t *testing.T) {
 			},
 			newPod:        podWithoutPodLevelResources,
 			targetVersion: version.MustParse("1.30.0"),
-			expectedReqs:  NewFeatureSet(),
+			expectedReqs:  nil,
 			expectErr:     false,
 		},
 		{
@@ -232,7 +254,7 @@ func TestInferForPodScheduling(t *testing.T) {
 			},
 			newPod:        podWithPodLevelResources,
 			targetVersion: version.MustParse("1.31.0"),
-			expectedReqs:  NewFeatureSet(),
+			expectedReqs:  nil,
 			expectErr:     false,
 		},
 		{
@@ -247,7 +269,21 @@ func TestInferForPodScheduling(t *testing.T) {
 			},
 			newPod:        podWithPodLevelResources,
 			targetVersion: version.MustParse("0.0.0-alpha.2.39+049eafd34dfbd2"),
-			expectedReqs:  NewFeatureSet("PodLevelResources"),
+			expectedReqs:  []string{"PodLevelResources"},
+			expectErr:     false,
+		},
+		{
+			name: "exceeds max version",
+			registry: []types.Feature{
+				&mockFeature{
+					name:               "PodLevelResources",
+					inferForScheduling: inferPodlevelResources,
+					maxVersion:         version.MustParse("1.30.0"),
+				},
+			},
+			newPod:        podWithPodLevelResources,
+			targetVersion: version.MustParse("1.40.0"),
+			expectedReqs:  nil,
 			expectErr:     false,
 		},
 		{
@@ -261,7 +297,7 @@ func TestInferForPodScheduling(t *testing.T) {
 			},
 			newPod:        podWithPodLevelResources,
 			targetVersion: nil,
-			expectedReqs:  NewFeatureSet(),
+			expectedReqs:  nil,
 			expectErr:     true,
 			errContains:   "target version cannot be nil",
 		},
@@ -280,9 +316,11 @@ func TestInferForPodScheduling(t *testing.T) {
 				}
 			} else {
 				if err != nil {
-					t.Errorf("unexpected error %v", err)
-				} else if !reflect.DeepEqual(tc.expectedReqs, reqs) {
-					t.Errorf("expected %#v, got %#v", tc.expectedReqs, reqs)
+					t.Fatalf("unexpected error %v", err)
+				}
+				unmappedReqs := framework.Unmap(reqs)
+				if !reflect.DeepEqual(tc.expectedReqs, unmappedReqs) {
+					t.Errorf("expected %#v, got %#v", tc.expectedReqs, unmappedReqs)
 				}
 			}
 		})
@@ -331,7 +369,7 @@ func TestInferForPodUpdate(t *testing.T) {
 		oldPod        *v1.Pod
 		newPod        *v1.Pod
 		targetVersion *version.Version
-		expectedReqs  FeatureSet
+		expectedReqs  []string
 		expectErr     bool
 		errContains   string
 	}{
@@ -347,7 +385,7 @@ func TestInferForPodUpdate(t *testing.T) {
 			oldPod:        podWith1CPU,
 			newPod:        podWith2CPU,
 			targetVersion: version.MustParse("1.30.0"),
-			expectedReqs:  NewFeatureSet("InPlacePodResize"),
+			expectedReqs:  []string{"InPlacePodResize"},
 			expectErr:     false,
 		},
 		{
@@ -362,7 +400,7 @@ func TestInferForPodUpdate(t *testing.T) {
 			oldPod:        podWith1CPU,
 			newPod:        podWith2CPU,
 			targetVersion: version.MustParse("1.35.0-alpha.2.39+049eafd34dfbd2"),
-			expectedReqs:  NewFeatureSet("InPlacePodResize"),
+			expectedReqs:  []string{"InPlacePodResize"},
 			expectErr:     false,
 		},
 		{
@@ -377,7 +415,7 @@ func TestInferForPodUpdate(t *testing.T) {
 			oldPod:        podWith1CPU,
 			newPod:        podWith1CPU,
 			targetVersion: version.MustParse("1.30.0"),
-			expectedReqs:  NewFeatureSet(),
+			expectedReqs:  nil,
 			expectErr:     false,
 		},
 		{
@@ -393,7 +431,7 @@ func TestInferForPodUpdate(t *testing.T) {
 			oldPod:        podWith1CPU,
 			newPod:        podWith2CPU,
 			targetVersion: version.MustParse("1.31.0"),
-			expectedReqs:  NewFeatureSet(),
+			expectedReqs:  nil,
 			expectErr:     false,
 		},
 		{
@@ -408,7 +446,7 @@ func TestInferForPodUpdate(t *testing.T) {
 			oldPod:        podWith1CPU,
 			newPod:        podWith2CPU,
 			targetVersion: nil,
-			expectedReqs:  NewFeatureSet(),
+			expectedReqs:  nil,
 			expectErr:     true,
 			errContains:   "target version cannot be nil",
 		},
@@ -427,9 +465,11 @@ func TestInferForPodUpdate(t *testing.T) {
 				}
 			} else {
 				if err != nil {
-					t.Errorf("unexpected error %v", err)
-				} else if !reflect.DeepEqual(tc.expectedReqs, reqs) {
-					t.Errorf("expected %#v, got %#v", tc.expectedReqs, reqs)
+					t.Fatalf("unexpected error %v", err)
+				}
+				unmappedReqs := framework.Unmap(reqs)
+				if !reflect.DeepEqual(tc.expectedReqs, unmappedReqs) {
+					t.Errorf("expected %#v, got %#v", tc.expectedReqs, unmappedReqs)
 				}
 			}
 		})
@@ -437,44 +477,45 @@ func TestInferForPodUpdate(t *testing.T) {
 }
 
 func TestMatchNode(t *testing.T) {
+	framework := newTestFramework("feature-a", "feature-b", "feature-c")
 	testCases := []struct {
 		name                   string
-		podFeatureRequirements FeatureSet
+		podFeatureRequirements []string
 		nodeFeatures           []string
 		expectedMatch          bool
 		expectedUnsatisfied    []string
 	}{
 		{
 			name:                   "all features match",
-			podFeatureRequirements: NewFeatureSet("feature-a", "feature-b"),
+			podFeatureRequirements: []string{"feature-a", "feature-b"},
 			nodeFeatures:           []string{"feature-a", "feature-b", "feature-c"},
 			expectedMatch:          true,
 			expectedUnsatisfied:    nil,
 		},
 		{
 			name:                   "some features missing",
-			podFeatureRequirements: NewFeatureSet("feature-a", "feature-b"),
+			podFeatureRequirements: []string{"feature-a", "feature-b"},
 			nodeFeatures:           []string{"feature-a", "feature-c"},
 			expectedMatch:          false,
 			expectedUnsatisfied:    []string{"feature-b"},
 		},
 		{
 			name:                   "all features missing",
-			podFeatureRequirements: NewFeatureSet("feature-a", "feature-b"),
+			podFeatureRequirements: []string{"feature-a", "feature-b"},
 			nodeFeatures:           []string{"feature-c"},
 			expectedMatch:          false,
 			expectedUnsatisfied:    []string{"feature-a", "feature-b"},
 		},
 		{
 			name:                   "no node features",
-			podFeatureRequirements: NewFeatureSet("feature-a", "feature-b"),
+			podFeatureRequirements: []string{"feature-a", "feature-b"},
 			nodeFeatures:           []string{},
 			expectedMatch:          false,
 			expectedUnsatisfied:    []string{"feature-a", "feature-b"},
 		},
 		{
 			name:                   "no requirements",
-			podFeatureRequirements: NewFeatureSet(),
+			podFeatureRequirements: []string{},
 			nodeFeatures:           []string{"feature-a", "feature-b", "feature-c"},
 			expectedMatch:          true,
 			expectedUnsatisfied:    nil,
@@ -492,9 +533,9 @@ func TestMatchNode(t *testing.T) {
 					switch variationName {
 					case "MatchNode":
 						node := &v1.Node{Status: v1.NodeStatus{DeclaredFeatures: tc.nodeFeatures}}
-						result, err = MatchNode(tc.podFeatureRequirements, node)
+						result, err = framework.MatchNode(framework.MustMapSorted(tc.podFeatureRequirements), node)
 					case "MatchNodeFeatureSet":
-						result, err = MatchNodeFeatureSet(tc.podFeatureRequirements, NewFeatureSet(tc.nodeFeatures...))
+						result, err = framework.MatchNodeFeatureSet(framework.MustMapSorted(tc.podFeatureRequirements), framework.MustMapSorted(tc.nodeFeatures))
 					default:
 						t.Fatalf("unknown match variation: %s", variationName)
 					}
@@ -518,7 +559,7 @@ func TestMatchNode(t *testing.T) {
 	}
 
 	// Test nil node
-	_, err := MatchNode(NewFeatureSet("feature-a"), nil)
+	_, err := framework.MatchNode(framework.MustMapSorted([]string{"feature-a"}), nil)
 	if err == nil {
 		t.Fatalf("MatchNode should return an error for a nil node")
 	}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework_test.go
@@ -318,7 +318,10 @@ func TestInferForPodScheduling(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpected error %v", err)
 				}
-				unmappedReqs := framework.Unmap(reqs)
+				unmappedReqs, err := framework.Unmap(reqs)
+				if err != nil {
+					t.Fatalf("unexpected error %v", err)
+				}
 				if !reflect.DeepEqual(tc.expectedReqs, unmappedReqs) {
 					t.Errorf("expected %#v, got %#v", tc.expectedReqs, unmappedReqs)
 				}
@@ -467,7 +470,10 @@ func TestInferForPodUpdate(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpected error %v", err)
 				}
-				unmappedReqs := framework.Unmap(reqs)
+				unmappedReqs, err := framework.Unmap(reqs)
+				if err != nil {
+					t.Fatalf("unexpected error %v", err)
+				}
 				if !reflect.DeepEqual(tc.expectedReqs, unmappedReqs) {
 					t.Errorf("expected %#v, got %#v", tc.expectedReqs, unmappedReqs)
 				}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework_test.go
@@ -66,18 +66,6 @@ func newMockFeatureGate(features map[string]bool) *mockFeatureGate {
 	return &mockFeatureGate{features: features}
 }
 
-func TestNewFramework(t *testing.T) {
-	_, err := New(nil)
-	if err == nil {
-		t.Fatalf("NewFramework should return an error with a nil registry")
-	}
-
-	_, err = New([]types.Feature{})
-	if err != nil {
-		t.Fatalf("NewFramework should not return an error with an empty registry")
-	}
-}
-
 func TestDiscoverNodeFeatures(t *testing.T) {
 	featureMaxVersion := version.MustParse("1.38.0")
 	registry := []types.Feature{
@@ -107,7 +95,7 @@ func TestDiscoverNodeFeatures(t *testing.T) {
 		},
 	}
 
-	framework, _ := New(registry)
+	framework := New(registry)
 
 	testCases := []struct {
 		name     string
@@ -281,7 +269,7 @@ func TestInferForPodScheduling(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			framework, _ := New(tc.registry)
+			framework := New(tc.registry)
 			reqs, err := framework.InferForPodScheduling(&types.PodInfo{Spec: &tc.newPod.Spec, Status: &tc.newPod.Status}, tc.targetVersion)
 
 			if tc.expectErr {
@@ -428,7 +416,7 @@ func TestInferForPodUpdate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			framework, _ := New(tc.registry)
+			framework := New(tc.registry)
 			reqs, err := framework.InferForPodUpdate(&types.PodInfo{Spec: &tc.oldPod.Spec, Status: &tc.oldPod.Status}, &types.PodInfo{Spec: &tc.newPod.Spec, Status: &tc.newPod.Status}, tc.targetVersion)
 
 			if tc.expectErr {

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework_test.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/framework_test.go
@@ -27,22 +27,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
 // mockFeature is a mock implementation of the Feature interface for testing.
 type mockFeature struct {
 	name               string
-	discover           func(cfg *NodeConfiguration) bool
-	inferForScheduling func(podInfo *PodInfo) bool
-	inferForUpdate     func(oldPodInfo, newPodInfo *PodInfo) bool
+	discover           func(cfg *types.NodeConfiguration) bool
+	inferForScheduling func(podInfo *types.PodInfo) bool
+	inferForUpdate     func(oldPodInfo, newPodInfo *types.PodInfo) bool
 	maxVersion         *version.Version
 	requirements       func() *FeatureRequirements
 }
 
-func (f *mockFeature) Name() string                             { return f.name }
-func (f *mockFeature) Discover(cfg *NodeConfiguration) bool     { return f.discover(cfg) }
-func (f *mockFeature) InferForScheduling(podInfo *PodInfo) bool { return f.inferForScheduling(podInfo) }
-func (f *mockFeature) InferForUpdate(oldPodInfo, newPodInfo *PodInfo) bool {
+func (f *mockFeature) Name() string                               { return f.name }
+func (f *mockFeature) Discover(cfg *types.NodeConfiguration) bool { return f.discover(cfg) }
+func (f *mockFeature) InferForScheduling(podInfo *types.PodInfo) bool {
+	return f.inferForScheduling(podInfo)
+}
+func (f *mockFeature) InferForUpdate(oldPodInfo, newPodInfo *types.PodInfo) bool {
 	return f.inferForUpdate(oldPodInfo, newPodInfo)
 }
 func (f *mockFeature) MaxVersion() *version.Version       { return f.maxVersion }
@@ -69,7 +72,7 @@ func TestNewFramework(t *testing.T) {
 		t.Fatalf("NewFramework should return an error with a nil registry")
 	}
 
-	_, err = New([]Feature{})
+	_, err = New([]types.Feature{})
 	if err != nil {
 		t.Fatalf("NewFramework should not return an error with an empty registry")
 	}
@@ -77,10 +80,10 @@ func TestNewFramework(t *testing.T) {
 
 func TestDiscoverNodeFeatures(t *testing.T) {
 	featureMaxVersion := version.MustParse("1.38.0")
-	registry := []Feature{
+	registry := []types.Feature{
 		&mockFeature{
 			name: "FeatureA",
-			discover: func(cfg *NodeConfiguration) bool {
+			discover: func(cfg *types.NodeConfiguration) bool {
 				return cfg.FeatureGates.Enabled("feature-a")
 			},
 			requirements: func() *FeatureRequirements {
@@ -92,7 +95,7 @@ func TestDiscoverNodeFeatures(t *testing.T) {
 		},
 		&mockFeature{
 			name: "FeatureB",
-			discover: func(cfg *NodeConfiguration) bool {
+			discover: func(cfg *types.NodeConfiguration) bool {
 				return cfg.FeatureGates.Enabled("feature-b")
 			},
 			requirements: func() *FeatureRequirements {
@@ -108,19 +111,19 @@ func TestDiscoverNodeFeatures(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		config   *NodeConfiguration
+		config   *types.NodeConfiguration
 		expected []string
 	}{
 		{
 			name: "Feature Enabled",
-			config: &NodeConfiguration{
+			config: &types.NodeConfiguration{
 				FeatureGates: newMockFeatureGate(map[string]bool{string("feature-a"): true}),
 			},
 			expected: []string{"FeatureA"},
 		},
 		{
 			name: "multiple features enabled",
-			config: &NodeConfiguration{
+			config: &types.NodeConfiguration{
 				FeatureGates: newMockFeatureGate(map[string]bool{
 					string("feature-a"): true,
 					string("feature-b"): true,
@@ -130,7 +133,7 @@ func TestDiscoverNodeFeatures(t *testing.T) {
 		},
 		{
 			name: "no features enabled",
-			config: &NodeConfiguration{
+			config: &types.NodeConfiguration{
 				FeatureGates: newMockFeatureGate(map[string]bool{
 					string("feature-a"): false,
 					string("feature-b"): false,
@@ -140,7 +143,7 @@ func TestDiscoverNodeFeatures(t *testing.T) {
 		},
 		{
 			name: "feature past max version",
-			config: &NodeConfiguration{
+			config: &types.NodeConfiguration{
 				FeatureGates: newMockFeatureGate(map[string]bool{string("feature-a"): true}),
 				Version:      featureMaxVersion.AddMinor(1),
 			},
@@ -148,7 +151,7 @@ func TestDiscoverNodeFeatures(t *testing.T) {
 		},
 		{
 			name: "feature past max version - pre-release version",
-			config: &NodeConfiguration{
+			config: &types.NodeConfiguration{
 				FeatureGates: newMockFeatureGate(map[string]bool{string("feature-a"): true}),
 				Version:      version.MustParse("1.39.0-alpha.2.39+049eafd34dfbd2"),
 			},
@@ -167,7 +170,7 @@ func TestDiscoverNodeFeatures(t *testing.T) {
 }
 
 func TestInferForPodScheduling(t *testing.T) {
-	inferPodlevelResources := func(p *PodInfo) bool {
+	inferPodlevelResources := func(p *types.PodInfo) bool {
 		return p.Spec.Resources != nil
 	}
 	podWithPodLevelResources := &v1.Pod{
@@ -194,7 +197,7 @@ func TestInferForPodScheduling(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		registry      []Feature
+		registry      []types.Feature
 		newPod        *v1.Pod
 		targetVersion *version.Version
 		expectedReqs  FeatureSet
@@ -203,7 +206,7 @@ func TestInferForPodScheduling(t *testing.T) {
 	}{
 		{
 			name: "pod with feature, inferred during scheduling",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:               "PodLevelResources",
 					inferForScheduling: inferPodlevelResources,
@@ -217,7 +220,7 @@ func TestInferForPodScheduling(t *testing.T) {
 		},
 		{
 			name: "pod without feature",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:               "PodLevelResources",
 					inferForScheduling: inferPodlevelResources,
@@ -231,7 +234,7 @@ func TestInferForPodScheduling(t *testing.T) {
 		},
 		{
 			name: "feature universally available, not inferred during create",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:               "PodLevelResources",
 					inferForScheduling: inferPodlevelResources,
@@ -246,7 +249,7 @@ func TestInferForPodScheduling(t *testing.T) {
 		},
 		{
 			name: "pre-release target version",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:               "PodLevelResources",
 					inferForScheduling: inferPodlevelResources,
@@ -261,7 +264,7 @@ func TestInferForPodScheduling(t *testing.T) {
 		},
 		{
 			name: "target version nil",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:               "PodLevelResources",
 					inferForScheduling: inferPodlevelResources,
@@ -279,7 +282,7 @@ func TestInferForPodScheduling(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			framework, _ := New(tc.registry)
-			reqs, err := framework.InferForPodScheduling(&PodInfo{Spec: &tc.newPod.Spec, Status: &tc.newPod.Status}, tc.targetVersion)
+			reqs, err := framework.InferForPodScheduling(&types.PodInfo{Spec: &tc.newPod.Spec, Status: &tc.newPod.Status}, tc.targetVersion)
 
 			if tc.expectErr {
 				if err == nil {
@@ -299,7 +302,7 @@ func TestInferForPodScheduling(t *testing.T) {
 }
 
 func TestInferForPodUpdate(t *testing.T) {
-	inferResize := func(oldPodInfo, newPodInfo *PodInfo) bool {
+	inferResize := func(oldPodInfo, newPodInfo *types.PodInfo) bool {
 		oldCPU := oldPodInfo.Spec.Containers[0].Resources.Requests.Cpu()
 		newCPU := newPodInfo.Spec.Containers[0].Resources.Requests.Cpu()
 		if oldCPU != nil && newCPU != nil && !oldCPU.Equal(*newCPU) {
@@ -336,7 +339,7 @@ func TestInferForPodUpdate(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		registry      []Feature
+		registry      []types.Feature
 		oldPod        *v1.Pod
 		newPod        *v1.Pod
 		targetVersion *version.Version
@@ -346,7 +349,7 @@ func TestInferForPodUpdate(t *testing.T) {
 	}{
 		{
 			name: "pod update requires feature",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:           "InPlacePodResize",
 					inferForUpdate: inferResize,
@@ -361,7 +364,7 @@ func TestInferForPodUpdate(t *testing.T) {
 		},
 		{
 			name: "pod update requires feature with pre-release version",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:           "InPlacePodResize",
 					inferForUpdate: inferResize,
@@ -376,7 +379,7 @@ func TestInferForPodUpdate(t *testing.T) {
 		},
 		{
 			name: "pod update does not require feature",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:           "InPlacePodResize",
 					inferForUpdate: inferResize,
@@ -391,7 +394,7 @@ func TestInferForPodUpdate(t *testing.T) {
 		},
 		{
 			name: "feature universally available, not inferred during update",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:           "InPlacePodResize",
 					inferForUpdate: inferResize,
@@ -407,7 +410,7 @@ func TestInferForPodUpdate(t *testing.T) {
 		},
 		{
 			name: "target version nil",
-			registry: []Feature{
+			registry: []types.Feature{
 				&mockFeature{
 					name:           "InPlacePodResize",
 					inferForUpdate: inferResize,
@@ -426,7 +429,7 @@ func TestInferForPodUpdate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			framework, _ := New(tc.registry)
-			reqs, err := framework.InferForPodUpdate(&PodInfo{Spec: &tc.oldPod.Spec, Status: &tc.oldPod.Status}, &PodInfo{Spec: &tc.newPod.Spec, Status: &tc.newPod.Status}, tc.targetVersion)
+			reqs, err := framework.InferForPodUpdate(&types.PodInfo{Spec: &tc.oldPod.Spec, Status: &tc.oldPod.Status}, &types.PodInfo{Spec: &tc.newPod.Spec, Status: &tc.newPod.Status}, tc.targetVersion)
 
 			if tc.expectErr {
 				if err == nil {

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/testing/framework.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/testing/framework.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"slices"
+	"testing"
+
+	"k8s.io/component-helpers/nodedeclaredfeatures"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
+)
+
+// SetFrameworkDuringTest overrides the global default nodedeclaredfeatures.Framework for the
+// duration of the test.
+func SetFrameworkDuringTest(tb testing.TB, framework nodedeclaredfeatures.Framework) {
+	tb.Helper()
+	originalDefaultFramework := nodedeclaredfeatures.DefaultFramework
+	nodedeclaredfeatures.DefaultFramework = &framework
+	tb.Cleanup(func() {
+		tb.Helper()
+		nodedeclaredfeatures.DefaultFramework = originalDefaultFramework
+	})
+}
+
+// NewMockFramework generates a map of mock features with the given names, and creates a Framework
+// with those features registered.
+func NewMockFramework(tb testing.TB, features ...string) (nodedeclaredfeatures.Framework, map[string]*MockFeature) {
+	slices.Sort(features)
+	var allFeatures []types.Feature
+	mockFeatures := map[string]*MockFeature{}
+
+	for _, name := range features {
+		m := NewMockFeature(tb)
+		m.SetName(name)
+
+		allFeatures = append(allFeatures, m)
+		mockFeatures[name] = m
+	}
+
+	return *nodedeclaredfeatures.New(allFeatures), mockFeatures
+}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/testing/mocks.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/testing/mocks.go
@@ -52,7 +52,7 @@ func NewMockFeatureGate(t *testing.T) *MockFeatureGate {
 var _ = types.Feature((*MockFeature)(nil))
 
 type MockFeature struct {
-	t                  *testing.T
+	t                  testing.TB
 	name               *string
 	discover           func(cfg *types.NodeConfiguration) bool
 	inferForScheduling func(podInfo *types.PodInfo) bool
@@ -122,7 +122,7 @@ func (m *MockFeature) SetRequirements(req *nodedeclaredfeatures.FeatureRequireme
 	m.requirements = &req
 }
 
-func NewMockFeature(t *testing.T) *MockFeature {
+func NewMockFeature(t testing.TB) *MockFeature {
 	return &MockFeature{
 		t: t,
 	}

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/testing/mocks.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/testing/mocks.go
@@ -21,9 +21,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-helpers/nodedeclaredfeatures"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
-var _ = nodedeclaredfeatures.FeatureGate((*MockFeatureGate)(nil))
+var _ = types.FeatureGate((*MockFeatureGate)(nil))
 
 type MockFeatureGate struct {
 	t        *testing.T
@@ -48,16 +49,16 @@ func NewMockFeatureGate(t *testing.T) *MockFeatureGate {
 	}
 }
 
-var _ = nodedeclaredfeatures.Feature((*MockFeature)(nil))
+var _ = types.Feature((*MockFeature)(nil))
 
 type MockFeature struct {
 	t                  *testing.T
 	name               *string
-	discover           func(cfg *nodedeclaredfeatures.NodeConfiguration) bool
-	inferForScheduling func(podInfo *nodedeclaredfeatures.PodInfo) bool
-	inferForUpdate     func(oldPodInfo, newPodInfo *nodedeclaredfeatures.PodInfo) bool
+	discover           func(cfg *types.NodeConfiguration) bool
+	inferForScheduling func(podInfo *types.PodInfo) bool
+	inferForUpdate     func(oldPodInfo, newPodInfo *types.PodInfo) bool
 	maxVersion         **version.Version
-	requirements       **nodedeclaredfeatures.FeatureRequirements
+	requirements       **types.FeatureRequirements
 }
 
 func (m *MockFeature) Name() string {
@@ -70,34 +71,34 @@ func (m *MockFeature) Name() string {
 func (m *MockFeature) SetName(name string) {
 	m.name = &name
 }
-func (m *MockFeature) Discover(cfg *nodedeclaredfeatures.NodeConfiguration) bool {
+func (m *MockFeature) Discover(cfg *types.NodeConfiguration) bool {
 	if m.discover == nil {
 		m.t.Errorf("unexpected call to Discover")
 		return false
 	}
 	return m.discover(cfg)
 }
-func (m *MockFeature) SetDiscover(discover func(cfg *nodedeclaredfeatures.NodeConfiguration) bool) {
+func (m *MockFeature) SetDiscover(discover func(cfg *types.NodeConfiguration) bool) {
 	m.discover = discover
 }
-func (m *MockFeature) InferForScheduling(podInfo *nodedeclaredfeatures.PodInfo) bool {
+func (m *MockFeature) InferForScheduling(podInfo *types.PodInfo) bool {
 	if m.inferForScheduling == nil {
 		m.t.Errorf("unexpected call to InferForScheduling")
 		return false
 	}
 	return m.inferForScheduling(podInfo)
 }
-func (m *MockFeature) SetInferForScheduling(inferForScheduling func(podInfo *nodedeclaredfeatures.PodInfo) bool) {
+func (m *MockFeature) SetInferForScheduling(inferForScheduling func(podInfo *types.PodInfo) bool) {
 	m.inferForScheduling = inferForScheduling
 }
-func (m *MockFeature) InferForUpdate(oldPodInfo, newPodInfo *nodedeclaredfeatures.PodInfo) bool {
+func (m *MockFeature) InferForUpdate(oldPodInfo, newPodInfo *types.PodInfo) bool {
 	if m.inferForUpdate == nil {
 		m.t.Errorf("unexpected call to InferForUpdate")
 		return false
 	}
 	return m.inferForUpdate(oldPodInfo, newPodInfo)
 }
-func (m *MockFeature) SetInferForUpdate(inferForUpdate func(oldPodInfo, newPodInfo *nodedeclaredfeatures.PodInfo) bool) {
+func (m *MockFeature) SetInferForUpdate(inferForUpdate func(oldPodInfo, newPodInfo *types.PodInfo) bool) {
 	m.inferForUpdate = inferForUpdate
 }
 func (m *MockFeature) MaxVersion() *version.Version {

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/types.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/types.go
@@ -17,65 +17,14 @@ limitations under the License.
 package nodedeclaredfeatures
 
 import (
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-helpers/nodedeclaredfeatures/types"
 )
 
-// PodInfo is an extensible data structure that wraps the pod object
-// and can be expanded in the future to include ancillary resources
-// like ResourceClaims or PVCs.
-type PodInfo struct {
-	// Spec is the Pod's specification.
-	Spec *v1.PodSpec
-	// Status is the Pod's current status. This field can be nil, for example,
-	// when this struct represents a pod not yet created.
-	// (e.g., during scheduling).
-	Status *v1.PodStatus
-	// Add other ancillary resources here in the future as needed.
-	// Example: ResourceClaims []*v1.ResourceClaim
-}
+// The following type aliases are provided as convenience to framework users.
 
-// Feature encapsulates all logic for a given declared feature.
-type Feature interface {
-	// Name returns the feature's well-known name.
-	Name() string
-
-	// Discover checks if a node provides the feature based on its configuration.
-	Discover(cfg *NodeConfiguration) bool
-
-	// Requirements returns the feature's feature gate and static config dependencies.
-	Requirements() *FeatureRequirements
-
-	// InferForScheduling checks if pod scheduling requires the feature.
-	InferForScheduling(podInfo *PodInfo) bool
-
-	// InferForUpdate checks if a pod update requires the feature.
-	InferForUpdate(oldPodInfo, newPodInfo *PodInfo) bool
-
-	// MaxVersion specifies the upper bound Kubernetes version (inclusive) for this feature's relevance
-	// as a scheduling factor. Should be set based on the feature's GA version
-	// and the cluster's version skew policy. Nil means no upper version bound.
-	// Comparisons use the full semantic versioning scheme.
-	MaxVersion() *version.Version
-}
-
-// FeatureRequirements lists the potential dependencies of a feature.
-type FeatureRequirements struct {
-	// EnabledFeatureGates lists feature gate strings that the feature depends on.
-	EnabledFeatureGates []string
-}
-
-// FeatureGate is an interface that abstracts feature gate checking.
-type FeatureGate interface {
-	// Enabled returns true if the named feature gate is enabled.
-	Enabled(key string) bool
-}
-
-// NodeConfiguration provides a generic view of a node's static configuration.
-type NodeConfiguration struct {
-	// FeatureGates holds an implementation of the FeatureGate interface.
-	FeatureGates FeatureGate
-	// Version holds the current node version. This is used for full semantic version comparisons
-	// with Feature.MaxVersion() to determine if a feature needs to be reported.
-	Version *version.Version
-}
+type PodInfo = types.PodInfo
+type Feature = types.Feature
+type FeatureRequirements = types.FeatureRequirements
+type FeatureGate = types.FeatureGate
+type StaticConfiguration = types.StaticConfiguration
+type NodeConfiguration = types.NodeConfiguration

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/types/types.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/types/types.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/version"
+)
+
+// PodInfo is an extensible data structure that wraps the pod object
+// and can be expanded in the future to include ancillary resources
+// like ResourceClaims or PVCs.
+type PodInfo struct {
+	// Spec is the Pod's specification.
+	Spec *v1.PodSpec
+	// Status is the Pod's current status. This field can be nil, for example,
+	// when this struct represents a pod not yet created.
+	// (e.g., during scheduling).
+	Status *v1.PodStatus
+	// Add other ancillary resources here in the future as needed.
+	// Example: ResourceClaims []*v1.ResourceClaim
+}
+
+// Feature encapsulates all logic for a given declared feature.
+type Feature interface {
+	// Name returns the feature's well-known name.
+	Name() string
+
+	// Discover checks if a node provides the feature based on its configuration.
+	Discover(cfg *NodeConfiguration) bool
+
+	// Requirements returns the feature's feature gate and static config dependencies.
+	Requirements() *FeatureRequirements
+
+	// InferForScheduling checks if pod scheduling requires the feature.
+	InferForScheduling(podInfo *PodInfo) bool
+
+	// InferForUpdate checks if a pod update requires the feature.
+	InferForUpdate(oldPodInfo, newPodInfo *PodInfo) bool
+
+	// MaxVersion specifies the upper bound Kubernetes version (inclusive) for this feature's relevance
+	// as a scheduling factor. Should be set based on the feature's GA version
+	// and the cluster's version skew policy. Nil means no upper version bound.
+	// Comparisons use the full semantic versioning scheme.
+	MaxVersion() *version.Version
+}
+
+// FeatureRequirements lists the potential dependencies of a feature.
+type FeatureRequirements struct {
+	// EnabledFeatureGates lists feature gate strings that the feature depends on.
+	EnabledFeatureGates []string
+}
+
+// FeatureGate is an interface that abstracts feature gate checking.
+type FeatureGate interface {
+	// Enabled returns true if the named feature gate is enabled.
+	Enabled(key string) bool
+}
+
+// StaticConfiguration provides a view of a node's static configuration required for feature discovery.
+type StaticConfiguration struct {
+	// Add configuration fields here as required by registered features.
+}
+
+// NodeConfiguration provides a generic view of a node's static configuration.
+type NodeConfiguration struct {
+	// FeatureGates holds an implementation of the FeatureGate interface.
+	FeatureGates FeatureGate
+	// StaticConfig holds node static configuration.
+	StaticConfig StaticConfiguration
+	// Version holds the current node version. This is used for full semantic version comparisons
+	// with Feature.MaxVersion() to determine if a feature needs to be reported.
+	Version *version.Version
+}
+
+// FeatureGateMap is provided as a convenience implementation of FeatureGate
+type FeatureGateMap map[string]bool
+
+func (m FeatureGateMap) Enabled(key string) bool {
+	return m[key]
+}
+
+var _ FeatureGate = FeatureGateMap{}

--- a/test/integration/scheduler/filters/filters_test.go
+++ b/test/integration/scheduler/filters/filters_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
-	ndffeatures "k8s.io/component-helpers/nodedeclaredfeatures/features"
 	ndftesting "k8s.io/component-helpers/nodedeclaredfeatures/testing"
 	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/kubernetes/pkg/features"
@@ -3197,6 +3196,9 @@ func TestNodeDeclaredFeaturesFilter(t *testing.T) {
 	mockFeature.SetInferForUpdate(func(_, _ *ndf.PodInfo) bool { return false })
 	mockFeature.SetDiscover(func(*ndf.NodeConfiguration) bool { return false })
 
+	ndfFramework := ndf.New([]ndf.Feature{mockFeature})
+	ndftesting.SetFrameworkDuringTest(t, *ndfFramework)
+
 	tests := []struct {
 		name           string
 		pod            *v1.Pod
@@ -3251,13 +3253,6 @@ func TestNodeDeclaredFeaturesFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeDeclaredFeatures, tt.featureEnabled)
-			if tt.featureEnabled {
-				originalAllFeatures := ndffeatures.AllFeatures
-				ndffeatures.AllFeatures = []ndf.Feature{mockFeature}
-				defer func() {
-					ndffeatures.AllFeatures = originalAllFeatures
-				}()
-			}
 			testCtx := testutils.InitTestSchedulerWithNS(t, "node-features-filter")
 			cs := testCtx.ClientSet
 			ns := testCtx.NS.Name

--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
-	ndffeatures "k8s.io/component-helpers/nodedeclaredfeatures/features"
 	ndftesting "k8s.io/component-helpers/nodedeclaredfeatures/testing"
 	"k8s.io/component-helpers/storage/volume"
 	configv1 "k8s.io/kube-scheduler/config/v1"
@@ -2718,11 +2717,8 @@ func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
 		})
 		mockFeature.SetMaxVersion(nil)
 
-		originalAllFeatures := ndffeatures.AllFeatures
-		ndffeatures.AllFeatures = []ndf.Feature{mockFeature}
-		defer func() {
-			ndffeatures.AllFeatures = originalAllFeatures
-		}()
+		ndfFramework := ndf.New([]ndf.Feature{mockFeature})
+		ndftesting.SetFrameworkDuringTest(t, *ndfFramework)
 	}
 	if tt.EnableGangScheduling {
 		featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Optimize the NodeDeclaredFeatures Framework by switching to a bitmap-backed FeatureSet implementation, which makes feature set comparison constant-time.

Mapping and unmapping FeatureSets requires that the full list of features is known ahead of time, which requires a registry / Framework. To avoid a lot of extra plumbing, I opted for a global default registry.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/enhancements/issues/5328

#### Special notes for your reviewer:

I wrote my own bitmap implementation. Using a `big.Int` is simpler, but in micro benchmarks the implementation in this PR is consistently about twice as fast. It might be overkill, but it's pretty simple.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node scheduling
/milestone v1.36
/priority important-soon
/assign @pravk03 