### PR TITLE
Promote volume metrics to beta

### DIFF
--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -529,6 +529,50 @@
   labels:
   - plugin
   - profile
+- name: storage_operation_duration_seconds
+  help: Storage operation duration
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - migrated
+  - operation_name
+  - status
+  - volume_plugin
+  buckets:
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+  - 15
+  - 25
+  - 50
+  - 120
+  - 300
+  - 600
+- name: volume_operation_total_seconds
+  help: Storage operation end to end duration in seconds
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - operation_name
+  - plugin_name
+  buckets:
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+  - 15
+  - 25
+  - 50
+  - 120
+  - 300
+  - 600
 - name: adds_total
   subsystem: workqueue
   help: Total number of adds handled by workqueue

--- a/pkg/volume/util/metrics.go
+++ b/pkg/volume/util/metrics.go
@@ -48,7 +48,7 @@ var StorageOperationMetric = metrics.NewHistogramVec(
 		Name:           "storage_operation_duration_seconds",
 		Help:           "Storage operation duration",
 		Buckets:        []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 25, 50, 120, 300, 600},
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 	[]string{"volume_plugin", "operation_name", "status", "migrated"},
 )
@@ -58,7 +58,7 @@ var storageOperationEndToEndLatencyMetric = metrics.NewHistogramVec(
 		Name:           "volume_operation_total_seconds",
 		Help:           "Storage operation end to end duration in seconds",
 		Buckets:        []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 25, 50, 120, 300, 600},
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 	[]string{"plugin_name", "operation_name"},
 )

--- a/pkg/volume/util/metrics_test.go
+++ b/pkg/volume/util/metrics_test.go
@@ -18,10 +18,15 @@ package util
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/util/types"
+	"k8s.io/utils/ptr"
 )
 
 func TestGetFullQualifiedPluginNameForVolume(t *testing.T) {
@@ -87,5 +92,53 @@ func TestGetFullQualifiedPluginNameForVolume(t *testing.T) {
 				t.Errorf("Case name: %s, GetFullQualifiedPluginNameForVolume, pluginName:%s, spec: %v, return:%s, want:%s", test.name, test.pluginName, test.spec, fullPluginName, test.wantFullName)
 			}
 		})
+	}
+}
+
+func TestOperationCompleteHook_StorageOperationMetric_CollectAndCompare(t *testing.T) {
+	StorageOperationMetric.Reset()
+
+	errNil := error(nil)
+	OperationCompleteHook("kubernetes.io/fake-plugin", "mount_volume")(types.CompleteFuncParam{Err: &errNil})
+
+	errFail := fmt.Errorf("test error")
+	OperationCompleteHook("kubernetes.io/fake-plugin", "unmount_volume")(types.CompleteFuncParam{Err: &errFail, Migrated: ptr.To(true)})
+
+	want := `# HELP storage_operation_duration_seconds [BETA] Storage operation duration
+# TYPE storage_operation_duration_seconds histogram
+storage_operation_duration_seconds_count{migrated="false",operation_name="mount_volume",status="success",volume_plugin="kubernetes.io/fake-plugin"} 1
+storage_operation_duration_seconds_count{migrated="true",operation_name="unmount_volume",status="fail-unknown",volume_plugin="kubernetes.io/fake-plugin"} 1
+`
+	if err := testutil.GatherAndCompare(gatherWithoutBuckets(), strings.NewReader(want), "storage_operation_duration_seconds"); err != nil {
+		t.Fatalf("unexpected metrics output: %v", err)
+	}
+}
+
+func TestRecordOperationLatencyMetric_VolumeOperationTotalSeconds_CollectAndCompare(t *testing.T) {
+	storageOperationEndToEndLatencyMetric.Reset()
+	RecordOperationLatencyMetric("kubernetes.io/fake-plugin", "mount_volume", 0.5)
+
+	want := `# HELP volume_operation_total_seconds [BETA] Storage operation end to end duration in seconds
+# TYPE volume_operation_total_seconds histogram
+volume_operation_total_seconds_count{operation_name="mount_volume",plugin_name="kubernetes.io/fake-plugin"} 1
+`
+	if err := testutil.GatherAndCompare(gatherWithoutBuckets(), strings.NewReader(want), "volume_operation_total_seconds"); err != nil {
+		t.Fatalf("unexpected metrics output: %v", err)
+	}
+}
+
+func gatherWithoutBuckets() testutil.GathererFunc {
+	return func() ([]*testutil.MetricFamily, error) {
+		got, err := legacyregistry.DefaultGatherer.Gather()
+		for _, mf := range got {
+			for _, m := range mf.Metric {
+				if m.Histogram == nil {
+					continue
+				}
+				m.Histogram.SampleSum = nil
+				m.Histogram.Bucket = nil
+			}
+		}
+		return got, err
 	}
 }


### PR DESCRIPTION
/kind feature
/kind api-change

#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes a small set of **kubelet volume metrics** from Alpha to Beta stability as part of the metrics graduation effort tracked in #136107.

These metrics are widely used by operators to monitor storage reliability and performance. Graduating them to Beta provides stronger compatibility guarantees for dashboards and alerts, specifically that existing label sets will not be removed while the metrics are in Beta.

This PR is intentionally scoped to volume metrics only and follow-up PRs handle other components.

Metrics promoted in this PR:
- `storage_operation_duration_seconds`
- `volume_operation_total_seconds`

#### Which issue(s) this PR is related to:
Related https://github.com/kubernetes/kubernetes/issues/136107

#### Special notes for your reviewer:
- Follows the Kubernetes metrics stability policy for Alpha to Beta graduation.
- Added focused unit tests validating metric registration, emission, and expected labels/values.
- No metric names or label keys were changed; only stability was promoted to Beta.

#### Does this PR introduce a user-facing change?
Yes. The listed volume metrics are now **Beta** -  meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted kubelet volume metrics (`storage_operation_duration_seconds`, `volume_operation_total_seconds`) from Alpha to Beta stability, providing stronger API and label stability guarantees for metric consumers.
```