### PR TITLE
Skip memory pressure PSI test for CRI-O

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -405,6 +405,21 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		})
 
 		ginkgo.It("should report Memory pressure in PSI metrics", func(ctx context.Context) {
+			runtime, _, err := getCRIClient()
+			framework.ExpectNoError(err)
+			resp, err := runtime.Version(ctx, "")
+			framework.ExpectNoError(err)
+
+			if resp.GetRuntimeName() == "cri-o" {
+				// Skip this test for CRI-O (used on Fedora CoreOS in test CI) until automatic
+				// memory.high configuration is available. The test fails on Fedora CoreOS due to
+				// different page cache reclaim behavior. CRI-O is implementing a fix to automatically
+				// set memory.high to 95% of memory.max for cgroup v2 containers.
+				// See: https://github.com/cri-o/cri-o/pull/9714
+				// See: https://github.com/coreos/fedora-coreos-tracker/issues/2094
+				ginkgo.Skip("Skipping for CRI-O until automatic memory.high configuration is available")
+			}
+
 			podName := "memory-pressure-pod"
 			ginkgo.By("Creating a pod to generate Memory pressure")
 			// Create a pod that generates memory pressure by continuously writing to files,


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Skip the memory pressure PSI test when running with CRI-O (used on Fedora CoreOS in test CI) until automatic memory.high configuration is available in the runtime.

The test fails on Fedora CoreOS due to different page cache reclaim behavior between kernels. In cgroup v2, memory.max is a hard limit that triggers OOM kills, while memory.high is a soft limit that triggers aggressive reclaim. Without memory.high configured, Fedora CoreOS doesn't reclaim page cache fast enough, causing instant OOM instead of sustained memory pressure.

CRI-O is implementing a fix to automatically set memory.high to 95% of memory.max for cgroup v2 containers, which will resolve this issue. Once that's available, this skip can be removed.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/134141

#### Special notes for your reviewer:

Testgrid: https://testgrid.k8s.io/sig-node-cri-o#node-kubelet-serial-crio

Related:
- CRI-O fix: https://github.com/cri-o/cri-o/pull/9714
- CoreOS tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2094

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```