### PR TITLE
Promote controller metrics to beta

### DIFF
--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -109,13 +109,10 @@ var (
 	//   action: FailJob, Ignore, Count
 	PodFailuresHandledByFailurePolicy = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Subsystem: JobControllerSubsystem,
-			Name:      "pod_failures_handled_by_failure_policy_total",
-			Help: `The number of failed Pods handled by failure policy with
-			respect to the failure policy action applied based on the matched
-			rule. Possible values of the action label correspond to the
-			possible values for the failure policy rule action, which are:
-			"FailJob", "Ignore" and "Count".`,
+			Subsystem:      JobControllerSubsystem,
+			Name:           "pod_failures_handled_by_failure_policy_total",
+			Help:           `The number of failed Pods handled by failure policy with respect to the failure policy action applied based on the matched rule. Possible values of the action label correspond to the possible values for the failure policy rule action, which are: "FailJob", "Ignore" and "Count".`,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"action"})
 
@@ -124,11 +121,10 @@ var (
 	// regardless of whether they are owned by a Job.
 	TerminatedPodsTrackingFinalizerTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Subsystem: JobControllerSubsystem,
-			Name:      "terminated_pods_tracking_finalizer_total",
-			Help: `The number of terminated pods (phase=Failed|Succeeded)
-that have the finalizer batch.kubernetes.io/job-tracking
-The event label can be "add" or "delete".`,
+			Subsystem:      JobControllerSubsystem,
+			Name:           "terminated_pods_tracking_finalizer_total",
+			Help:           `The number of terminated pods (phase=Failed|Succeeded) that have the finalizer batch.kubernetes.io/job-tracking. The event label can be "add" or "delete".`,
+			StabilityLevel: metrics.BETA,
 		}, []string{"event"})
 
 	// JobFinishedIndexesTotal records the number of finished indexes.

--- a/pkg/controller/job/metrics/metrics_test.go
+++ b/pkg/controller/job/metrics/metrics_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestPodFailuresHandledByFailurePolicy(t *testing.T) {
+	// Reset the metric to ensure clean state
+	PodFailuresHandledByFailurePolicy.Reset()
+
+	// Register the metric
+	Register()
+
+	// Test with different action labels
+	PodFailuresHandledByFailurePolicy.WithLabelValues("FailJob").Inc()
+	PodFailuresHandledByFailurePolicy.WithLabelValues("Ignore").Inc()
+	PodFailuresHandledByFailurePolicy.WithLabelValues("Count").Inc()
+
+	want := `
+		# HELP job_controller_pod_failures_handled_by_failure_policy_total [BETA] The number of failed Pods handled by failure policy with respect to the failure policy action applied based on the matched rule. Possible values of the action label correspond to the possible values for the failure policy rule action, which are: "FailJob", "Ignore" and "Count".
+		# TYPE job_controller_pod_failures_handled_by_failure_policy_total counter
+		job_controller_pod_failures_handled_by_failure_policy_total{action="Count"} 1
+		job_controller_pod_failures_handled_by_failure_policy_total{action="FailJob"} 1
+		job_controller_pod_failures_handled_by_failure_policy_total{action="Ignore"} 1
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "job_controller_pod_failures_handled_by_failure_policy_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTerminatedPodsTrackingFinalizerTotal(t *testing.T) {
+	// Reset the metric to ensure clean state
+	TerminatedPodsTrackingFinalizerTotal.Reset()
+
+	// Register the metric
+	Register()
+
+	// Test with add event
+	TerminatedPodsTrackingFinalizerTotal.WithLabelValues("add").Inc()
+	TerminatedPodsTrackingFinalizerTotal.WithLabelValues("add").Inc()
+
+	// Test with delete event
+	TerminatedPodsTrackingFinalizerTotal.WithLabelValues("delete").Inc()
+
+	want := `
+		# HELP job_controller_terminated_pods_tracking_finalizer_total [BETA] The number of terminated pods (phase=Failed|Succeeded) that have the finalizer batch.kubernetes.io/job-tracking. The event label can be "add" or "delete".
+		# TYPE job_controller_terminated_pods_tracking_finalizer_total counter
+		job_controller_terminated_pods_tracking_finalizer_total{event="add"} 2
+		job_controller_terminated_pods_tracking_finalizer_total{event="delete"} 1
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "job_controller_terminated_pods_tracking_finalizer_total"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/controller/resourceclaim/metrics/metrics.go
+++ b/pkg/controller/resourceclaim/metrics/metrics.go
@@ -56,7 +56,7 @@ var (
 			"Source can be 'resource_claim_template' (created from a template), "+
 			"'extended_resource' (extended resources), or empty (manually created by a user).",
 		[]string{"allocated", "admin_access", "source"}, nil,
-		metrics.ALPHA, "")
+		metrics.BETA, "")
 )
 
 var registerMetrics sync.Once

--- a/pkg/controller/resourceclaim/metrics/metrics_test.go
+++ b/pkg/controller/resourceclaim/metrics/metrics_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+// Mock collector for testing NumResourceClaimsDesc
+type mockResourceClaimCollector struct {
+	metrics.BaseStableCollector
+	allocated   string
+	adminAccess string
+	source      string
+	value       float64
+}
+
+func (m *mockResourceClaimCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
+	ch <- NumResourceClaimsDesc
+}
+
+func (m *mockResourceClaimCollector) CollectWithStability(ch chan<- metrics.Metric) {
+	ch <- metrics.NewLazyConstMetric(
+		NumResourceClaimsDesc,
+		metrics.GaugeValue,
+		m.value,
+		m.allocated,
+		m.adminAccess,
+		m.source,
+	)
+}
+
+func TestResourceClaimMetrics(t *testing.T) {
+	// Reset metrics to ensure clean state
+	ResourceClaimCreate.Reset()
+
+	// Register metrics
+	SetTestMode(false)
+	collector := &mockResourceClaimCollector{
+		allocated:   "true",
+		adminAccess: "true",
+		source:      "resource_claim_template",
+		value:       5.0,
+	}
+	RegisterMetrics(collector)
+
+	// Test ResourceClaimCreate
+	ResourceClaimCreate.WithLabelValues("success", "true").Inc()
+	ResourceClaimCreate.WithLabelValues("error", "false").Inc()
+
+	wantCreate := `
+		# HELP resourceclaim_controller_creates_total [ALPHA] Number of ResourceClaims creation requests, categorized by creation status and admin access
+		# TYPE resourceclaim_controller_creates_total counter
+		resourceclaim_controller_creates_total{admin_access="false",status="error"} 1
+		resourceclaim_controller_creates_total{admin_access="true",status="success"} 1
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantCreate), "resourceclaim_controller_creates_total"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test NumResourceClaimsDesc (resource_claims)
+	wantResourceClaims := `
+		# HELP resourceclaim_controller_resource_claims [BETA] Number of ResourceClaims, categorized by allocation status, admin access, and source. Source can be 'resource_claim_template' (created from a template), 'extended_resource' (extended resources), or empty (manually created by a user).
+		# TYPE resourceclaim_controller_resource_claims gauge
+		resourceclaim_controller_resource_claims{admin_access="true",allocated="true",source="resource_claim_template"} 5
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantResourceClaims), "resourceclaim_controller_resource_claims"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/staging/src/k8s.io/endpointslice/metrics/metrics.go
+++ b/staging/src/k8s.io/endpointslice/metrics/metrics.go
@@ -34,7 +34,7 @@ var (
 			Subsystem:      EndpointSliceSubsystem,
 			Name:           "endpoints_added_per_sync",
 			Help:           "Number of endpoints added on each Service sync",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 			Buckets:        metrics.ExponentialBuckets(2, 2, 15),
 		},
 		[]string{},
@@ -46,7 +46,7 @@ var (
 			Subsystem:      EndpointSliceSubsystem,
 			Name:           "endpoints_removed_per_sync",
 			Help:           "Number of endpoints removed on each Service sync",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 			Buckets:        metrics.ExponentialBuckets(2, 2, 15),
 		},
 		[]string{},
@@ -57,7 +57,7 @@ var (
 			Subsystem:      EndpointSliceSubsystem,
 			Name:           "endpoints_desired",
 			Help:           "Number of endpoints desired",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{},
 	)
@@ -67,7 +67,7 @@ var (
 			Subsystem:      EndpointSliceSubsystem,
 			Name:           "num_endpoint_slices",
 			Help:           "Number of EndpointSlices",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{},
 	)
@@ -78,7 +78,7 @@ var (
 			Subsystem:      EndpointSliceSubsystem,
 			Name:           "desired_endpoint_slices",
 			Help:           "Number of EndpointSlices that would exist with perfect endpoint allocation",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{},
 	)
@@ -127,7 +127,7 @@ var (
 			Subsystem:      EndpointSliceSubsystem,
 			Name:           "services_count_by_traffic_distribution",
 			Help:           "Number of Services using some specific trafficDistribution",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"traffic_distribution"}, // A trafficDistribution value
 	)

--- a/staging/src/k8s.io/endpointslice/metrics/metrics_test.go
+++ b/staging/src/k8s.io/endpointslice/metrics/metrics_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestEndpointSliceMetrics(t *testing.T) {
+	// Reset metrics to ensure clean state
+	EndpointsAddedPerSync.Reset()
+	EndpointsRemovedPerSync.Reset()
+	EndpointsDesired.Reset()
+	NumEndpointSlices.Reset()
+	DesiredEndpointSlices.Reset()
+	ServicesCountByTrafficDistribution.Reset()
+
+	// Register metrics
+	RegisterMetrics()
+
+	// Test EndpointsAddedPerSync
+	EndpointsAddedPerSync.WithLabelValues().Observe(5.0)
+	wantAdded := `
+		# HELP endpoint_slice_controller_endpoints_added_per_sync [BETA] Number of endpoints added on each Service sync
+		# TYPE endpoint_slice_controller_endpoints_added_per_sync histogram
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="2"} 0
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="4"} 0
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="8"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="16"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="32"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="64"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="128"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="256"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="512"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="1024"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="2048"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="4096"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="8192"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="16384"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="32768"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_bucket{le="+Inf"} 1
+		endpoint_slice_controller_endpoints_added_per_sync_sum 5
+		endpoint_slice_controller_endpoints_added_per_sync_count 1
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantAdded), "endpoint_slice_controller_endpoints_added_per_sync"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test EndpointsRemovedPerSync
+	EndpointsRemovedPerSync.WithLabelValues().Observe(3.0)
+	wantRemoved := `
+		# HELP endpoint_slice_controller_endpoints_removed_per_sync [BETA] Number of endpoints removed on each Service sync
+		# TYPE endpoint_slice_controller_endpoints_removed_per_sync histogram
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="2"} 0
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="4"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="8"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="16"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="32"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="64"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="128"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="256"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="512"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="1024"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="2048"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="4096"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="8192"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="16384"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="32768"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_bucket{le="+Inf"} 1
+		endpoint_slice_controller_endpoints_removed_per_sync_sum 3
+		endpoint_slice_controller_endpoints_removed_per_sync_count 1
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantRemoved), "endpoint_slice_controller_endpoints_removed_per_sync"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test EndpointsDesired
+	EndpointsDesired.WithLabelValues().Set(10.0)
+	wantDesired := `
+		# HELP endpoint_slice_controller_endpoints_desired [BETA] Number of endpoints desired
+		# TYPE endpoint_slice_controller_endpoints_desired gauge
+		endpoint_slice_controller_endpoints_desired 10
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantDesired), "endpoint_slice_controller_endpoints_desired"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test NumEndpointSlices
+	NumEndpointSlices.WithLabelValues().Set(5.0)
+	wantNumSlices := `
+		# HELP endpoint_slice_controller_num_endpoint_slices [BETA] Number of EndpointSlices
+		# TYPE endpoint_slice_controller_num_endpoint_slices gauge
+		endpoint_slice_controller_num_endpoint_slices 5
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantNumSlices), "endpoint_slice_controller_num_endpoint_slices"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test DesiredEndpointSlices
+	DesiredEndpointSlices.WithLabelValues().Set(3.0)
+	wantDesiredSlices := `
+		# HELP endpoint_slice_controller_desired_endpoint_slices [BETA] Number of EndpointSlices that would exist with perfect endpoint allocation
+		# TYPE endpoint_slice_controller_desired_endpoint_slices gauge
+		endpoint_slice_controller_desired_endpoint_slices 3
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantDesiredSlices), "endpoint_slice_controller_desired_endpoint_slices"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test ServicesCountByTrafficDistribution
+	ServicesCountByTrafficDistribution.WithLabelValues("PreferClose").Set(2.0)
+	wantServicesCount := `
+		# HELP endpoint_slice_controller_services_count_by_traffic_distribution [BETA] Number of Services using some specific trafficDistribution
+		# TYPE endpoint_slice_controller_services_count_by_traffic_distribution gauge
+		endpoint_slice_controller_services_count_by_traffic_distribution{traffic_distribution="PreferClose"} 2
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantServicesCount), "endpoint_slice_controller_services_count_by_traffic_distribution"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -179,10 +179,92 @@
   help: The count of disabled metrics.
   type: Counter
   stabilityLevel: BETA
+- name: desired_endpoint_slices
+  subsystem: endpoint_slice_controller
+  help: Number of EndpointSlices that would exist with perfect endpoint allocation
+  type: Gauge
+  stabilityLevel: BETA
+- name: endpoints_added_per_sync
+  subsystem: endpoint_slice_controller
+  help: Number of endpoints added on each Service sync
+  type: Histogram
+  stabilityLevel: BETA
+  buckets:
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 512
+  - 1024
+  - 2048
+  - 4096
+  - 8192
+  - 16384
+  - 32768
+- name: endpoints_desired
+  subsystem: endpoint_slice_controller
+  help: Number of endpoints desired
+  type: Gauge
+  stabilityLevel: BETA
+- name: endpoints_removed_per_sync
+  subsystem: endpoint_slice_controller
+  help: Number of endpoints removed on each Service sync
+  type: Histogram
+  stabilityLevel: BETA
+  buckets:
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 512
+  - 1024
+  - 2048
+  - 4096
+  - 8192
+  - 16384
+  - 32768
+- name: num_endpoint_slices
+  subsystem: endpoint_slice_controller
+  help: Number of EndpointSlices
+  type: Gauge
+  stabilityLevel: BETA
+- name: services_count_by_traffic_distribution
+  subsystem: endpoint_slice_controller
+  help: Number of Services using some specific trafficDistribution
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - traffic_distribution
 - name: hidden_metrics_total
   help: The count of hidden metrics.
   type: Counter
   stabilityLevel: BETA
+- name: pod_failures_handled_by_failure_policy_total
+  subsystem: job_controller
+  help: '`The number of failed Pods handled by failure policy with respect to the
+    failure policy action applied based on the matched rule. Possible values of the
+    action label correspond to the possible values for the failure policy rule action,
+    which are: "FailJob", "Ignore" and "Count".`'
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - action
+- name: terminated_pods_tracking_finalizer_total
+  subsystem: job_controller
+  help: '`The number of terminated pods (phase=Failed|Succeeded) that have the finalizer
+    batch.kubernetes.io/job-tracking. The event label can be "add" or "delete".`'
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - event
 - name: image_volume_mounted_errors_total
   subsystem: kubelet
   help: Number of failed image volume mounts.
@@ -227,6 +309,16 @@
   labels:
   - deprecated_version
   - stability_level
+- name: resourceclaim_controller_resource_claims
+  help: Number of ResourceClaims, categorized by allocation status, admin access,
+    and source. Source can be 'resource_claim_template' (created from a template),
+    'extended_resource' (extended resources), or empty (manually created by a user).
+  type: Custom
+  stabilityLevel: BETA
+  labels:
+  - allocated
+  - admin_access
+  - source
 - name: pod_scheduling_sli_duration_seconds
   subsystem: scheduler
   help: E2e latency for a pod being scheduled, from the time the pod enters the scheduling


### PR DESCRIPTION
/kind feature
/kind api-change

#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes a set of **controller-manager related metrics** from **Alpha to Beta** stability as part of the metrics graduation effort tracked in #136107.

Graduating these metrics to **Beta** provides stronger compatibility guarantees for dashboards and alerts, ensuring that existing label sets will not be removed while the metrics are in Beta.

This PR is intentionally scoped to controller-manager components only (EndpointSlice, Job, and ResourceClaim controllers).

#### Metrics promoted in this PR

**EndpointSlice controller**
- `endpoint_slice_controller_endpoints_added_per_sync`
- `endpoint_slice_controller_endpoints_removed_per_sync`
- `endpoint_slice_controller_endpoints_desired`
- `endpoint_slice_controller_num_endpoint_slices`
- `endpoint_slice_controller_desired_endpoint_slices`
- `endpoint_slice_controller_services_count_by_traffic_distribution`

**Job controller**
- `job_controller_pod_failures_handled_by_failure_policy_total`
- `job_controller_terminated_pods_tracking_finalizer_total`

**ResourceClaim controller**
- `resourceclaim_controller_resource_claims`

#### Which issue(s) this PR is related to:
Part of #136107

#### Special notes for your reviewer:
- Follows the Kubernetes metrics stability policy for Alpha → Beta graduation.
- Added focused unit tests validating metric registration, emission, and expected labels/values.
- No metric names or label keys were changed; only stability was promoted to Beta.
- `endpoint_slice_controller_changes` is intentionally not promoted in this PR due to counter naming lint requirements (`_total` suffix).
- PV controller metric `volume_operation_total_errors` is also excluded for the same reason and will require a separate rename/deprecation plan before graduation.
- This is PR 4 in the metrics graduation series for #136107 (PRs 1–3 covered component-base, scheduler, and kubelet volume metrics).

#### Does this PR introduce a user-facing change?

```release-note
Promoted several controller-manager metrics (EndpointSlice, Job, and ResourceClaim controllers) from Alpha to Beta stability, providing stronger API and label stability guarantees for metric consumers.
```
