### PR TITLE
add SIG-Node approvers to DRA dirs

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/OWNERS
+++ b/staging/src/k8s.io/dynamic-resource-allocation/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - sig-node-approvers
   - klueska
   - pohly
 reviewers:

--- a/staging/src/k8s.io/dynamic-resource-allocation/api/OWNERS
+++ b/staging/src/k8s.io/dynamic-resource-allocation/api/OWNERS
@@ -9,6 +9,7 @@ reviewers:
   - bart0sh
   - klueska
   - pohly
+  - sig-node-reviewers
 labels:
   - sig/node
   - wg/device-management

--- a/test/e2e/dra/OWNERS
+++ b/test/e2e/dra/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - sig-node-approvers
   - klueska
   - pohly
 reviewers:

--- a/test/e2e/testing-manifests/dra/OWNERS
+++ b/test/e2e/testing-manifests/dra/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - sig-node-approvers
   - klueska
   - pohly
 reviewers:

--- a/test/integration/dra/OWNERS
+++ b/test/integration/dra/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - sig-node-approvers
   - johnbelamaric
   - klueska
   - pohly


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Add sig-node approvers to DRA folders as suggested [here](https://github.com/kubernetes/kubernetes/pull/136168#issuecomment-3739446015).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
