### PR TITLE
Promote apiserver and aggregator metrics to beta

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -118,6 +118,7 @@ type AdmissionMetrics struct {
 	controller                      *metricSet
 	webhook                         *metricSet
 	webhookRejection                *metrics.CounterVec
+	webhookRejectionDeprecated      *metrics.CounterVec
 	webhookFailOpen                 *metrics.CounterVec
 	webhookRequest                  *metrics.CounterVec
 	matchConditionEvalErrors        *metrics.CounterVec
@@ -196,9 +197,20 @@ func newAdmissionMetrics() *AdmissionMetrics {
 		&metrics.CounterOpts{
 			Namespace:      namespace,
 			Subsystem:      subsystem,
-			Name:           "webhook_rejection_count",
+			Name:           "webhook_rejections_total",
 			Help:           "Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.",
 			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"name", "type", "operation", "error_type", "rejection_code"})
+
+	webhookRejectionDeprecated := metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:         namespace,
+			Subsystem:         subsystem,
+			Name:              "webhook_rejection_count",
+			Help:              "Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.36.0",
 		},
 		[]string{"name", "type", "operation", "error_type", "rejection_code"})
 
@@ -218,7 +230,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 			Subsystem:      subsystem,
 			Name:           "webhook_request_total",
 			Help:           "Admission webhook request total, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify whether the request was rejected or not and an HTTP status code. Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"name", "type", "operation", "code", "rejected"})
 
@@ -262,11 +274,12 @@ func newAdmissionMetrics() *AdmissionMetrics {
 	webhook.mustRegister()
 	matchConditionEvaluationSeconds.mustRegister()
 	legacyregistry.MustRegister(webhookRejection)
+	legacyregistry.MustRegister(webhookRejectionDeprecated)
 	legacyregistry.MustRegister(webhookFailOpen)
 	legacyregistry.MustRegister(webhookRequest)
 	legacyregistry.MustRegister(matchConditionEvalError)
 	legacyregistry.MustRegister(matchConditionExclusions)
-	return &AdmissionMetrics{step: step, controller: controller, webhook: webhook, webhookRejection: webhookRejection, webhookFailOpen: webhookFailOpen, webhookRequest: webhookRequest, matchConditionEvalErrors: matchConditionEvalError, matchConditionExclusions: matchConditionExclusions, matchConditionEvaluationSeconds: matchConditionEvaluationSeconds}
+	return &AdmissionMetrics{step: step, controller: controller, webhook: webhook, webhookRejection: webhookRejection, webhookRejectionDeprecated: webhookRejectionDeprecated, webhookFailOpen: webhookFailOpen, webhookRequest: webhookRequest, matchConditionEvalErrors: matchConditionEvalError, matchConditionExclusions: matchConditionExclusions, matchConditionEvaluationSeconds: matchConditionEvaluationSeconds}
 }
 
 func (m *AdmissionMetrics) reset() {
@@ -303,6 +316,7 @@ func (m *AdmissionMetrics) ObserveWebhookRejection(ctx context.Context, name, st
 		rejectionCode = 600
 	}
 	m.webhookRejection.WithContext(ctx).WithLabelValues(name, stepType, operation, string(errorType), strconv.Itoa(rejectionCode)).Inc()
+	m.webhookRejectionDeprecated.WithContext(ctx).WithLabelValues(name, stepType, operation, string(errorType), strconv.Itoa(rejectionCode)).Inc()
 }
 
 // WebhookRejectionGathererForTest exposes admission webhook rejection metric for access by unit test.

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -153,10 +153,10 @@ func TestObserveWebhookRejection(t *testing.T) {
 		"error_type":     "apiserver_internal_error",
 		"rejection_code": "0",
 	}
-	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabels, 1)
-	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabels600, 1)
-	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabelsCallingWebhookError, 1)
-	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabelsAPIServerInternalError, 1)
+	expectCounterValue(t, "apiserver_admission_webhook_rejections_total", wantLabels, 1)
+	expectCounterValue(t, "apiserver_admission_webhook_rejections_total", wantLabels600, 1)
+	expectCounterValue(t, "apiserver_admission_webhook_rejections_total", wantLabelsCallingWebhookError, 1)
+	expectCounterValue(t, "apiserver_admission_webhook_rejections_total", wantLabelsAPIServerInternalError, 1)
 }
 
 func TestObserveWebhookFailOpen(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -185,10 +185,10 @@ func TestAdmit(t *testing.T) {
 			}
 			if len(tt.ExpectRejectionMetrics) > 0 {
 				expectedMetrics := `
-# HELP apiserver_admission_webhook_rejection_count [ALPHA] Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.
-# TYPE apiserver_admission_webhook_rejection_count counter
+# HELP apiserver_admission_webhook_rejections_total [ALPHA] Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.
+# TYPE apiserver_admission_webhook_rejections_total counter
 ` + tt.ExpectRejectionMetrics + "\n"
-				if err := testutil.CollectAndCompare(admissionmetrics.Metrics.WebhookRejectionGathererForTest(), strings.NewReader(expectedMetrics), "apiserver_admission_webhook_rejection_count"); err != nil {
+				if err := testutil.CollectAndCompare(admissionmetrics.Metrics.WebhookRejectionGathererForTest(), strings.NewReader(expectedMetrics), "apiserver_admission_webhook_rejections_total"); err != nil {
 					t.Errorf("unexpected collecting result:\n%s", err)
 				}
 			}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
@@ -521,7 +521,7 @@ func NewNonMutatingTestCases(url *url.URL) []ValidatingTest {
 				AdmissionReviewVersions: []string{"v1beta1"},
 			}},
 			ExpectStatusCode:       http.StatusInternalServerError,
-			ExpectRejectionMetrics: `apiserver_admission_webhook_rejection_count{error_type="calling_webhook_error",name="invalidClientConfig",operation="UPDATE",rejection_code="500",type="validating"} 1`,
+			ExpectRejectionMetrics: `apiserver_admission_webhook_rejections_total{error_type="calling_webhook_error",name="invalidClientConfig",operation="UPDATE",rejection_code="500",type="validating"} 1`,
 			ErrorContains:          "could not get REST client",
 		},
 		{
@@ -535,7 +535,7 @@ func NewNonMutatingTestCases(url *url.URL) []ValidatingTest {
 				AdmissionReviewVersions: []string{"v1beta1"},
 			}},
 			ExpectStatusCode:       http.StatusInternalServerError,
-			ExpectRejectionMetrics: `apiserver_admission_webhook_rejection_count{error_type="calling_webhook_error",name="nonStatusError",operation="UPDATE",rejection_code="503",type="validating"} 1`,
+			ExpectRejectionMetrics: `apiserver_admission_webhook_rejections_total{error_type="calling_webhook_error",name="nonStatusError",operation="UPDATE",rejection_code="503",type="validating"} 1`,
 			ErrorContains:          "failed to call webhook",
 		},
 		{
@@ -974,7 +974,7 @@ func NewMutatingTestCases(url *url.URL, configurationName string) []MutatingTest
 				AdmissionReviewVersions: []string{"v1beta1"},
 			}},
 			ExpectStatusCode:       http.StatusInternalServerError,
-			ExpectRejectionMetrics: `apiserver_admission_webhook_rejection_count{error_type="calling_webhook_error",name="invalidClientConfig",operation="UPDATE",rejection_code="500",type="admit"} 1`,
+			ExpectRejectionMetrics: `apiserver_admission_webhook_rejections_total{error_type="calling_webhook_error",name="invalidClientConfig",operation="UPDATE",rejection_code="500",type="admit"} 1`,
 			ErrorContains:          "could not get REST client",
 			ExpectAnnotations: map[string]string{
 				"mutation.webhook.admission.k8s.io/round_0_index_0": mutationAnnotationValue(configurationName, "invalidClientConfig", false),
@@ -991,7 +991,7 @@ func NewMutatingTestCases(url *url.URL, configurationName string) []MutatingTest
 				AdmissionReviewVersions: []string{"v1beta1"},
 			}},
 			ExpectStatusCode:       http.StatusInternalServerError,
-			ExpectRejectionMetrics: `apiserver_admission_webhook_rejection_count{error_type="calling_webhook_error",name="nonStatusError",operation="UPDATE",rejection_code="503",type="admit"} 1`,
+			ExpectRejectionMetrics: `apiserver_admission_webhook_rejections_total{error_type="calling_webhook_error",name="nonStatusError",operation="UPDATE",rejection_code="503",type="admit"} 1`,
 			ErrorContains:          "failed to call webhook",
 			ExpectAnnotations: map[string]string{
 				"mutation.webhook.admission.k8s.io/round_0_index_0": mutationAnnotationValue(configurationName, "nonStatusError", false),

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -157,10 +157,10 @@ func TestValidate(t *testing.T) {
 		}
 		if len(tt.ExpectRejectionMetrics) > 0 {
 			expectedMetrics := `
-# HELP apiserver_admission_webhook_rejection_count [ALPHA] Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.
-# TYPE apiserver_admission_webhook_rejection_count counter
+# HELP apiserver_admission_webhook_rejections_total [ALPHA] Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.
+# TYPE apiserver_admission_webhook_rejections_total counter
 ` + tt.ExpectRejectionMetrics + "\n"
-			if err := testutil.CollectAndCompare(admissionmetrics.Metrics.WebhookRejectionGathererForTest(), strings.NewReader(expectedMetrics), "apiserver_admission_webhook_rejection_count"); err != nil {
+			if err := testutil.CollectAndCompare(admissionmetrics.Metrics.WebhookRejectionGathererForTest(), strings.NewReader(expectedMetrics), "apiserver_admission_webhook_rejections_total"); err != nil {
 				t.Errorf("unexpected collecting result:\n%s", err)
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/audit/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/metrics.go
@@ -44,7 +44,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "event_total",
 			Help:           "Counter of audit events generated and sent to the audit backend.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		})
 	errorCounter = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -52,7 +52,7 @@ var (
 			Name:      "error_total",
 			Help: "Counter of audit events that failed to be audited properly. " +
 				"Plugin identifies the plugin affected by the error.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"plugin"},
 	)
@@ -61,7 +61,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "level_total",
 			Help:           "Counter of policy levels for audit events (1 per request).",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"level"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/audit/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/metrics_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+type testError struct {
+	msg string
+}
+
+func (e *testError) Error() string {
+	return e.msg
+}
+
+func TestAuditMetrics(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		metrics []string
+		update  func()
+		want    string
+	}{
+		{
+			desc:    "event_total counter",
+			metrics: []string{"apiserver_audit_event_total"},
+			update: func() {
+				ObserveEvent(context.Background())
+			},
+			want: `
+			# HELP apiserver_audit_event_total [BETA] Counter of audit events generated and sent to the audit backend.
+			# TYPE apiserver_audit_event_total counter
+			apiserver_audit_event_total 1
+			`,
+		},
+		{
+			desc:    "error_total counter",
+			metrics: []string{"apiserver_audit_error_total"},
+			update: func() {
+				// HandlePluginError increments the counter based on the number of impacted events
+				err := &testError{msg: "test error"}
+				impactedEvent := &auditinternal.Event{}
+				HandlePluginError("test-plugin", err, impactedEvent)
+			},
+			want: `
+			# HELP apiserver_audit_error_total [BETA] Counter of audit events that failed to be audited properly. Plugin identifies the plugin affected by the error.
+			# TYPE apiserver_audit_error_total counter
+			apiserver_audit_error_total{plugin="test-plugin"} 1
+			`,
+		},
+		{
+			desc:    "level_total counter",
+			metrics: []string{"apiserver_audit_level_total"},
+			update: func() {
+				ObservePolicyLevel(context.Background(), auditinternal.LevelRequest)
+			},
+			want: `
+			# HELP apiserver_audit_level_total [BETA] Counter of policy levels for audit events (1 per request).
+			# TYPE apiserver_audit_level_total counter
+			apiserver_audit_level_total{level="Request"} 1
+			`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			eventCounter.Reset()
+			errorCounter.Reset()
+			levelCounter.Reset()
+			test.update()
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.want), test.metrics...); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 const (
@@ -1277,4 +1278,42 @@ func TestCertificateIdentifier(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientCertificateExpirationMetric(t *testing.T) {
+	before := certExpirationSampleCount(t)
+
+	a := New(getDefaultVerifyOptions(t), CommonNameUserConversion)
+
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.TLS = &tls.ConnectionState{PeerCertificates: getCerts(t, clientCNCert)}
+
+	_, ok, err := a.AuthenticateRequest(req)
+	if err != nil || !ok {
+		t.Fatalf("Expected successful authentication, got ok=%v err=%v", ok, err)
+	}
+
+	after := certExpirationSampleCount(t)
+	if after-before != 1 {
+		t.Errorf("Expected histogram sample count to increase by 1, got before=%d after=%d", before, after)
+	}
+}
+
+// certExpirationSampleCount returns the total sample count across all label
+// combinations for apiserver_client_certificate_expiration_seconds.
+func certExpirationSampleCount(t *testing.T) uint64 {
+	t.Helper()
+	gathered, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+	var count uint64
+	for _, mf := range gathered {
+		if mf.GetName() == "apiserver_client_certificate_expiration_seconds" {
+			for _, m := range mf.GetMetric() {
+				count += m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return count
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -130,7 +130,7 @@ var (
 			// dependant on user configuration.
 			Buckets: []float64{0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
 				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
 	)
@@ -233,7 +233,7 @@ var (
 			Name:           "request_filter_duration_seconds",
 			Help:           "Request filter latency distribution in seconds, for each filter type",
 			Buckets:        []float64{0.0001, 0.0003, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 5.0, 10.0, 15.0, 30.0},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"filter"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/fields"
@@ -525,5 +526,64 @@ func TestCleanListScope(t *testing.T) {
 				t.Errorf("unexpected scope = %s, expected = %s", actualScope, scenario.expectedScope)
 			}
 		})
+	}
+}
+
+func TestRequestFilterDuration(t *testing.T) {
+	Register()
+	Reset()
+
+	RecordFilterLatency(context.Background(), "test-filter", 10*time.Millisecond)
+
+	want := `
+		# HELP apiserver_request_filter_duration_seconds [BETA] Request filter latency distribution in seconds, for each filter type
+		# TYPE apiserver_request_filter_duration_seconds histogram
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.0001"} 0
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.0003"} 0
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.001"} 0
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.003"} 0
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.01"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.03"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.1"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.3"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="1"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="5"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="10"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="15"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="30"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="+Inf"} 1
+		apiserver_request_filter_duration_seconds_count{filter="test-filter"} 1
+		apiserver_request_filter_duration_seconds_sum{filter="test-filter"} 0.01
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_request_filter_duration_seconds"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestSLIDuration(t *testing.T) {
+	Register()
+	requestSliLatencies.Reset()
+
+	ctx := request.WithLatencyTrackers(context.Background())
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+	req = req.WithContext(ctx)
+
+	MonitorRequest(req, "LIST", "", "v1", "pods", "", "cluster", "apiserver", false, "", 200, 0, 100*time.Millisecond)
+
+	gathered, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	var count uint64
+	for _, mf := range gathered {
+		if mf.GetName() == "apiserver_request_sli_duration_seconds" {
+			for _, m := range mf.GetMetric() {
+				count += m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("Expected 1 sample in apiserver_request_sli_duration_seconds, got %d", count)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -210,7 +210,7 @@ func TestMetrics(t *testing.T) {
 			proxierErr:   true,
 			metrics:      []string{"apiserver_egress_dialer_dial_start_total"},
 			want: `
-	# HELP apiserver_egress_dialer_dial_start_total [ALPHA] Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).
+	# HELP apiserver_egress_dialer_dial_start_total [BETA] Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).
 	# TYPE apiserver_egress_dialer_dial_start_total counter
 	apiserver_egress_dialer_dial_start_total{protocol="fake_protocol",transport="fake_transport"} 1
 `,
@@ -218,21 +218,21 @@ func TestMetrics(t *testing.T) {
 		"connect to proxy server error": {
 			connectorErr: true,
 			proxierErr:   false,
-			metrics:      []string{"apiserver_egress_dialer_dial_failure_count"},
+			metrics:      []string{"apiserver_egress_dialer_dial_failures_total"},
 			want: `
-	# HELP apiserver_egress_dialer_dial_failure_count [ALPHA] Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed
-	# TYPE apiserver_egress_dialer_dial_failure_count counter
-	apiserver_egress_dialer_dial_failure_count{protocol="fake_protocol",stage="connect",transport="fake_transport"} 1
+	# HELP apiserver_egress_dialer_dial_failures_total [ALPHA] Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed
+	# TYPE apiserver_egress_dialer_dial_failures_total counter
+	apiserver_egress_dialer_dial_failures_total{protocol="fake_protocol",stage="connect",transport="fake_transport"} 1
 `,
 		},
 		"connect succeeded, proxy failed": {
 			connectorErr: false,
 			proxierErr:   true,
-			metrics:      []string{"apiserver_egress_dialer_dial_failure_count"},
+			metrics:      []string{"apiserver_egress_dialer_dial_failures_total"},
 			want: `
-	# HELP apiserver_egress_dialer_dial_failure_count [ALPHA] Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed
-	# TYPE apiserver_egress_dialer_dial_failure_count counter
-	apiserver_egress_dialer_dial_failure_count{protocol="fake_protocol",stage="proxy",transport="fake_transport"} 1
+	# HELP apiserver_egress_dialer_dial_failures_total [ALPHA] Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed
+	# TYPE apiserver_egress_dialer_dial_failures_total counter
+	apiserver_egress_dialer_dial_failures_total{protocol="fake_protocol",stage="proxy",transport="fake_transport"} 1
 `,
 		},
 		"successful": {
@@ -240,7 +240,7 @@ func TestMetrics(t *testing.T) {
 			proxierErr:   false,
 			metrics:      []string{"apiserver_egress_dialer_dial_duration_seconds"},
 			want: `
-            # HELP apiserver_egress_dialer_dial_duration_seconds [ALPHA] Dial latency histogram in seconds, labeled by the protocol (http-connect or grpc), transport (tcp or uds)
+            # HELP apiserver_egress_dialer_dial_duration_seconds [BETA] Dial latency histogram in seconds, labeled by the protocol (http-connect or grpc), transport (tcp or uds)
             # TYPE apiserver_egress_dialer_dial_duration_seconds histogram
             apiserver_egress_dialer_dial_duration_seconds_bucket{protocol="fake_protocol",transport="fake_transport",le="0.005"} 1
             apiserver_egress_dialer_dial_duration_seconds_bucket{protocol="fake_protocol",transport="fake_transport",le="0.025"} 1

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/metrics/metrics.go
@@ -52,10 +52,11 @@ var (
 
 // DialMetrics instruments dials to proxy server with prometheus metrics.
 type DialMetrics struct {
-	clock     clock.Clock
-	starts    *metrics.CounterVec
-	latencies *metrics.HistogramVec
-	failures  *metrics.CounterVec
+	clock              clock.Clock
+	starts             *metrics.CounterVec
+	latencies          *metrics.HistogramVec
+	failures           *metrics.CounterVec
+	failuresDeprecated *metrics.CounterVec
 }
 
 // newDialMetrics create a new DialMetrics, configured with default metric names.
@@ -66,7 +67,7 @@ func newDialMetrics() *DialMetrics {
 			Subsystem:      subsystem,
 			Name:           "dial_start_total",
 			Help:           "Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"protocol", "transport"},
 	)
@@ -78,7 +79,7 @@ func newDialMetrics() *DialMetrics {
 			Name:           "dial_duration_seconds",
 			Help:           "Dial latency histogram in seconds, labeled by the protocol (http-connect or grpc), transport (tcp or uds)",
 			Buckets:        latencyBuckets,
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"protocol", "transport"},
 	)
@@ -87,9 +88,21 @@ func newDialMetrics() *DialMetrics {
 		&metrics.CounterOpts{
 			Namespace:      namespace,
 			Subsystem:      subsystem,
-			Name:           "dial_failure_count",
+			Name:           "dial_failures_total",
 			Help:           "Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed",
 			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"protocol", "transport", "stage"},
+	)
+
+	failuresDeprecated := metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:         namespace,
+			Subsystem:         subsystem,
+			Name:              "dial_failure_count",
+			Help:              "Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.36.0",
 		},
 		[]string{"protocol", "transport", "stage"},
 	)
@@ -97,7 +110,8 @@ func newDialMetrics() *DialMetrics {
 	legacyregistry.MustRegister(starts)
 	legacyregistry.MustRegister(latencies)
 	legacyregistry.MustRegister(failures)
-	return &DialMetrics{starts: starts, latencies: latencies, failures: failures, clock: clock.RealClock{}}
+	legacyregistry.MustRegister(failuresDeprecated)
+	return &DialMetrics{starts: starts, latencies: latencies, failures: failures, failuresDeprecated: failuresDeprecated, clock: clock.RealClock{}}
 }
 
 // Clock returns the clock.
@@ -115,6 +129,7 @@ func (m *DialMetrics) Reset() {
 	m.starts.Reset()
 	m.latencies.Reset()
 	m.failures.Reset()
+	m.failuresDeprecated.Reset()
 }
 
 // ObserveDialStart records the start of a dial attempt, labeled by protocol, transport.
@@ -130,4 +145,5 @@ func (m *DialMetrics) ObserveDialLatency(elapsed time.Duration, protocol, transp
 // ObserveDialFailure records a failed dial, labeled by protocol, transport, and the stage the dial failed at.
 func (m *DialMetrics) ObserveDialFailure(protocol, transport, stage string) {
 	m.failures.WithLabelValues(protocol, transport, stage).Inc()
+	m.failuresDeprecated.WithLabelValues(protocol, transport, stage).Inc()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -120,7 +120,7 @@ var (
 		&compbasemetrics.GaugeOpts{
 			Name:           "etcd_bookmark_counts",
 			Help:           "Number of etcd bookmarks (progress notify events) split by kind.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics/metrics.go
@@ -74,7 +74,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "dek_cache_fill_percent",
 			Help:           "Percent of the cache slots currently occupied by cached DEKs.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 	)
 
@@ -85,7 +85,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "dek_cache_inter_arrival_time_seconds",
 			Help:           "Time (in seconds) of inter arrival of transformation requests.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 			Buckets:        metrics.ExponentialBuckets(60, 2, 10),
 		},
 		[]string{"transformation_type"},

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
@@ -118,7 +118,7 @@ var (
 			// Buckets for both 0.99 and 1.0 mean PromQL's histogram_quantile will reveal saturation
 			Buckets:        []float64{0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1},
 			ConstLabels:    map[string]string{phase: "executing"},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		priorityLevel,
 	)
@@ -132,7 +132,7 @@ var (
 			// For executing: the denominator will be seats, so this metric will skew low.
 			// For waiting: total queue capacity is generally quite generous, so this metric will skew low.
 			Buckets:        []float64{0, 0.001, 0.003, 0.01, 0.03, 0.1, 0.25, 0.5, 0.75, 1},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		LabelNamePhase, priorityLevel,
 	)
@@ -293,7 +293,7 @@ var (
 			Name:           "request_execution_seconds",
 			Help:           "Duration of initial stage (for a WATCH) or any (for a non-WATCH) stage of request execution in the API Priority and Fairness subsystem",
 			Buckets:        requestDurationSecondsBuckets,
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{priorityLevel, flowSchema, "type"},
 	)
@@ -327,7 +327,7 @@ var (
 			// the upper bound comes from the maximum number of seats a request
 			// can occupy which is currently set at 10.
 			Buckets:        []float64{1, 2, 4, 8, 16, 32, 64, 100},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{priorityLevel, flowSchema},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestFlowControlBetaMetrics(t *testing.T) {
+	Register()
+
+	tests := []struct {
+		desc    string
+		metrics []string
+		update  func()
+		want    string
+	}{
+		{
+			desc:    "rejected_requests_total increments on AddReject",
+			metrics: []string{"apiserver_flowcontrol_rejected_requests_total"},
+			update: func() {
+				AddReject(context.Background(), "test-pl", "test-fs", "queue-full")
+			},
+			want: `
+			# HELP apiserver_flowcontrol_rejected_requests_total [BETA] Number of requests rejected by API Priority and Fairness subsystem
+			# TYPE apiserver_flowcontrol_rejected_requests_total counter
+			apiserver_flowcontrol_rejected_requests_total{flow_schema="test-fs",priority_level="test-pl",reason="queue-full"} 1
+			`,
+		},
+		{
+			desc:    "dispatched_requests_total increments on AddDispatch",
+			metrics: []string{"apiserver_flowcontrol_dispatched_requests_total"},
+			update: func() {
+				AddDispatch(context.Background(), "test-pl", "test-fs")
+			},
+			want: `
+			# HELP apiserver_flowcontrol_dispatched_requests_total [BETA] Number of requests executed by API Priority and Fairness subsystem
+			# TYPE apiserver_flowcontrol_dispatched_requests_total counter
+			apiserver_flowcontrol_dispatched_requests_total{flow_schema="test-fs",priority_level="test-pl"} 1
+			`,
+		},
+		{
+			desc:    "current_executing_requests updates on AddRequestsExecuting",
+			metrics: []string{"apiserver_flowcontrol_current_executing_requests"},
+			update: func() {
+				AddRequestsExecuting(context.Background(), "test-pl", "test-fs", 2)
+			},
+			want: `
+			# HELP apiserver_flowcontrol_current_executing_requests [BETA] Number of requests in initial (for a WATCH) or any (for a non-WATCH) execution stage in the API Priority and Fairness subsystem
+			# TYPE apiserver_flowcontrol_current_executing_requests gauge
+			apiserver_flowcontrol_current_executing_requests{flow_schema="test-fs",priority_level="test-pl"} 2
+			`,
+		},
+		{
+			desc:    "current_executing_seats updates on AddSeatConcurrencyInUse",
+			metrics: []string{"apiserver_flowcontrol_current_executing_seats"},
+			update: func() {
+				AddSeatConcurrencyInUse("test-pl", "test-fs", 3)
+			},
+			want: `
+			# HELP apiserver_flowcontrol_current_executing_seats [BETA] Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem
+			# TYPE apiserver_flowcontrol_current_executing_seats gauge
+			apiserver_flowcontrol_current_executing_seats{flow_schema="test-fs",priority_level="test-pl"} 3
+			`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			Reset()
+			tc.update()
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.want), tc.metrics...); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestFlowControlHistogramMetrics(t *testing.T) {
+	Register()
+	Reset()
+
+	ObserveWaitingDuration(context.Background(), "test-pl", "test-fs", "true", 50*time.Millisecond)
+	ObserveExecutionDuration(context.Background(), "test-pl", "test-fs", 100*time.Millisecond)
+	ObserveWorkEstimatedSeats("test-pl", "test-fs", 4)
+
+	gathered, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	wantCounts := map[string]uint64{
+		"apiserver_flowcontrol_request_wait_duration_seconds": 1,
+		"apiserver_flowcontrol_request_execution_seconds":     1,
+		"apiserver_flowcontrol_work_estimated_seats":          1,
+	}
+
+	gotCounts := make(map[string]uint64)
+	for _, mf := range gathered {
+		if _, ok := wantCounts[mf.GetName()]; ok {
+			for _, m := range mf.GetMetric() {
+				gotCounts[mf.GetName()] += m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+
+	for name, want := range wantCounts {
+		if got := gotCounts[name]; got != want {
+			t.Errorf("Metric %s: expected %d samples, got %d", name, want, got)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics.go
@@ -113,7 +113,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "webhook_evaluations_total",
 			Help:           "Round-trips to authorization webhooks.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"name", "result"},
 	)
@@ -125,7 +125,7 @@ var (
 			Name:           "webhook_duration_seconds",
 			Help:           "Request latency in seconds.",
 			Buckets:        compbasemetrics.DefBuckets,
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"name", "result"},
 	)
@@ -136,7 +136,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "webhook_evaluations_fail_open_total",
 			Help:           "NoOpinion results due to webhook timeout or error.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"name", "result"},
 	)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics_test.go
@@ -45,7 +45,7 @@ func TestRecordWebhookMetrics(t *testing.T) {
 			result:   "timeout",
 			duration: 1.5,
 			want: `
-			# HELP apiserver_authorization_webhook_duration_seconds [ALPHA] Request latency in seconds.
+			# HELP apiserver_authorization_webhook_duration_seconds [BETA] Request latency in seconds.
 			# TYPE apiserver_authorization_webhook_duration_seconds histogram
             apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.005"} 0
             apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.01"} 0
@@ -61,10 +61,10 @@ func TestRecordWebhookMetrics(t *testing.T) {
             apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="+Inf"} 1
             apiserver_authorization_webhook_duration_seconds_sum{name="wh1.example.com",result="timeout"} 1.5
             apiserver_authorization_webhook_duration_seconds_count{name="wh1.example.com",result="timeout"} 1
-            # HELP apiserver_authorization_webhook_evaluations_fail_open_total [ALPHA] NoOpinion results due to webhook timeout or error.
+            # HELP apiserver_authorization_webhook_evaluations_fail_open_total [BETA] NoOpinion results due to webhook timeout or error.
             # TYPE apiserver_authorization_webhook_evaluations_fail_open_total counter
             apiserver_authorization_webhook_evaluations_fail_open_total{name="wh1.example.com",result="timeout"} 1
-            # HELP apiserver_authorization_webhook_evaluations_total [ALPHA] Round-trips to authorization webhooks.
+            # HELP apiserver_authorization_webhook_evaluations_total [BETA] Round-trips to authorization webhooks.
             # TYPE apiserver_authorization_webhook_evaluations_total counter
             apiserver_authorization_webhook_evaluations_total{name="wh1.example.com",result="timeout"} 1
             `,

--- a/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
@@ -30,9 +30,6 @@ import (
 // We setup this list for allow and not fail on the current violations.
 // Generally speaking, you need to fix the problem for a new metric rather than add it into the list.
 var exceptionMetrics = []string{
-	// k8s.io/apiserver/pkg/server/egressselector
-	"apiserver_egress_dialer_dial_failure_count", // counter metrics should have "_total" suffix
-
 	// k8s.io/apiserver/pkg/server/healthz
 	"apiserver_request_total", // label names should be written in 'snake_case' not 'camelCase'
 
@@ -42,7 +39,6 @@ var exceptionMetrics = []string{
 
 	// kube-apiserver
 	"aggregator_openapi_v2_regeneration_count",
-	"apiserver_admission_webhook_rejection_count", // counter metrics should have "_total" suffix,apiserver_admission_webhook_rejection_count:non-histogram and non-summary metrics should not have "_count" suffix
 	"apiserver_admission_step_admission_duration_seconds_summary",
 	"apiserver_current_inflight_requests",
 	"apiserver_longrunning_gauge",

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
@@ -30,7 +30,7 @@ var x509MissingSANCounter = metrics.NewCounter(
 			"in their serving certificate OR the number of connection failures " +
 			"due to the lack of x509 certificate SAN extension missing " +
 			"(either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 
@@ -42,7 +42,7 @@ var x509InsecureSHA1Counter = metrics.NewCounter(
 		Help: "Counts the number of requests to servers with insecure SHA1 signatures " +
 			"in their serving certificate OR the number of connection failures " +
 			"due to the insecure SHA1 signatures (either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestX509MetricsRegistration(t *testing.T) {
+	x509MissingSANCounter.Reset()
+	x509InsecureSHA1Counter.Reset()
+
+	testCases := []struct {
+		desc    string
+		metrics []string
+		want    string
+	}{
+		{
+			desc:    "x509 missing SAN counter registered with BETA",
+			metrics: []string{"apiserver_kube_aggregator_x509_missing_san_total"},
+			want: `
+			# HELP apiserver_kube_aggregator_x509_missing_san_total [BETA] Counts the number of requests to servers missing SAN extension in their serving certificate OR the number of connection failures due to the lack of x509 certificate SAN extension missing (either/or, based on the runtime environment)
+			# TYPE apiserver_kube_aggregator_x509_missing_san_total counter
+			apiserver_kube_aggregator_x509_missing_san_total 0
+			`,
+		},
+		{
+			desc:    "x509 insecure SHA1 counter registered with BETA",
+			metrics: []string{"apiserver_kube_aggregator_x509_insecure_sha1_total"},
+			want: `
+			# HELP apiserver_kube_aggregator_x509_insecure_sha1_total [BETA] Counts the number of requests to servers with insecure SHA1 signatures in their serving certificate OR the number of connection failures due to the insecure SHA1 signatures (either/or, based on the runtime environment)
+			# TYPE apiserver_kube_aggregator_x509_insecure_sha1_total counter
+			apiserver_kube_aggregator_x509_insecure_sha1_total 0
+			`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.want), test.metrics...); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestX509MetricsRecording(t *testing.T) {
+	x509MissingSANCounter.Inc()
+	x509InsecureSHA1Counter.Inc()
+
+	gathered, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	counts := map[string]float64{}
+	for _, mf := range gathered {
+		switch mf.GetName() {
+		case "apiserver_kube_aggregator_x509_missing_san_total",
+			"apiserver_kube_aggregator_x509_insecure_sha1_total":
+			for _, m := range mf.GetMetric() {
+				counts[mf.GetName()] += m.GetCounter().GetValue()
+			}
+		}
+	}
+
+	for _, name := range []string{
+		"apiserver_kube_aggregator_x509_missing_san_total",
+		"apiserver_kube_aggregator_x509_insecure_sha1_total",
+	} {
+		if counts[name] < 1 {
+			t.Errorf("Metric %s: expected recorded value ≥1, got %v", name, counts[name])
+		}
+	}
+}

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -4439,7 +4439,7 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: webhook_rejection_count
+- name: webhook_rejections_total
   subsystem: admission
   namespace: apiserver
   help: Admission webhook rejection count, identified by name and broken out for each
@@ -4895,7 +4895,7 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: dial_failure_count
+- name: dial_failures_total
   subsystem: egress_dialer
   namespace: apiserver
   help: Dial failure count, labeled by the protocol (http-connect or grpc), transport

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -1,3 +1,38 @@
+- name: webhook_request_total
+  subsystem: admission
+  namespace: apiserver
+  help: Admission webhook request total, identified by name and broken out for each
+    admission type (validating or admit) and operation. Additional labels specify
+    whether the request was rejected or not and an HTTP status code. Codes greater
+    than 600 are truncated to 600, to keep the metrics cardinality bounded.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - code
+  - name
+  - operation
+  - rejected
+  - type
+- name: error_total
+  subsystem: apiserver_audit
+  help: Counter of audit events that failed to be audited properly. Plugin identifies
+    the plugin affected by the error.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - plugin
+- name: event_total
+  subsystem: apiserver_audit
+  help: Counter of audit events generated and sent to the audit backend.
+  type: Counter
+  stabilityLevel: BETA
+- name: level_total
+  subsystem: apiserver_audit
+  help: Counter of policy levels for audit events (1 per request).
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - level
 - name: automatic_reload_last_timestamp_seconds
   subsystem: authentication_config_controller
   namespace: apiserver
@@ -38,6 +73,45 @@
   labels:
   - apiserver_id_hash
   - status
+- name: webhook_duration_seconds
+  subsystem: authorization
+  namespace: apiserver
+  help: Request latency in seconds.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
+  buckets:
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+- name: webhook_evaluations_fail_open_total
+  subsystem: authorization
+  namespace: apiserver
+  help: NoOpinion results due to webhook timeout or error.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
+- name: webhook_evaluations_total
+  subsystem: authorization
+  namespace: apiserver
+  help: Round-trips to authorization webhooks.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
 - name: compilation_duration_seconds
   subsystem: cel
   namespace: apiserver
@@ -50,6 +124,58 @@
   help: CEL evaluation time in seconds.
   type: Histogram
   stabilityLevel: BETA
+- name: dial_duration_seconds
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial latency histogram in seconds, labeled by the protocol (http-connect or
+    grpc), transport (tcp or uds)
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - transport
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.5
+  - 2.5
+  - 12.5
+- name: dial_start_total
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial starts, labeled by the protocol (http-connect or grpc) and transport
+    (tcp or uds).
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - transport
+- name: dek_cache_fill_percent
+  subsystem: envelope_encryption
+  namespace: apiserver
+  help: Percent of the cache slots currently occupied by cached DEKs.
+  type: Gauge
+  stabilityLevel: BETA
+- name: dek_cache_inter_arrival_time_seconds
+  subsystem: envelope_encryption
+  namespace: apiserver
+  help: Time (in seconds) of inter arrival of transformation requests.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - transformation_type
+  buckets:
+  - 60
+  - 120
+  - 240
+  - 480
+  - 960
+  - 1920
+  - 3840
+  - 7680
+  - 15360
+  - 30720
 - name: current_executing_requests
   subsystem: flowcontrol
   namespace: apiserver
@@ -98,6 +224,53 @@
   stabilityLevel: BETA
   labels:
   - priority_level
+- name: priority_level_request_utilization
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Observations, at the end of every nanosecond, of number of requests (as a
+    fraction of the relevant limit) waiting or in any stage of execution (but only
+    initial stage for WATCHes)
+  type: TimingRatioHistogram
+  stabilityLevel: BETA
+  labels:
+  - phase
+  - priority_level
+  buckets:
+  - 0
+  - 0.001
+  - 0.003
+  - 0.01
+  - 0.03
+  - 0.1
+  - 0.25
+  - 0.5
+  - 0.75
+  - 1
+- name: priority_level_seat_utilization
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Observations, at the end of every nanosecond, of utilization of seats for
+    any stage of execution (but only initial stage for WATCHes)
+  type: TimingRatioHistogram
+  stabilityLevel: BETA
+  labels:
+  - priority_level
+  buckets:
+  - 0
+  - 0.1
+  - 0.2
+  - 0.3
+  - 0.4
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - 0.95
+  - 0.99
+  - 1
+  constLabels:
+    phase: executing
 - name: rejected_requests_total
   subsystem: flowcontrol
   namespace: apiserver
@@ -108,6 +281,31 @@
   - flow_schema
   - priority_level
   - reason
+- name: request_execution_seconds
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Duration of initial stage (for a WATCH) or any (for a non-WATCH) stage of
+    request execution in the API Priority and Fairness subsystem
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - flow_schema
+  - priority_level
+  - type
+  buckets:
+  - 0
+  - 0.005
+  - 0.02
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.5
+  - 1
+  - 2
+  - 5
+  - 10
+  - 15
+  - 30
 - name: request_wait_duration_seconds
   subsystem: flowcontrol
   namespace: apiserver
@@ -132,6 +330,99 @@
   - 10
   - 15
   - 30
+- name: work_estimated_seats
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Number of estimated seats (maximum of initial and final seats) associated
+    with requests in API Priority and Fairness
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - flow_schema
+  - priority_level
+  buckets:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 100
+- name: x509_insecure_sha1_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers with insecure SHA1 signatures in
+    their serving certificate OR the number of connection failures due to the insecure
+    SHA1 signatures (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
+- name: x509_missing_san_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers missing SAN extension in their serving
+    certificate OR the number of connection failures due to the lack of x509 certificate
+    SAN extension missing (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
+- name: request_filter_duration_seconds
+  subsystem: apiserver
+  help: Request filter latency distribution in seconds, for each filter type
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - filter
+  buckets:
+  - 0.0001
+  - 0.0003
+  - 0.001
+  - 0.003
+  - 0.01
+  - 0.03
+  - 0.1
+  - 0.3
+  - 1
+  - 5
+  - 10
+  - 15
+  - 30
+- name: request_sli_duration_seconds
+  subsystem: apiserver
+  help: Response latency distribution (not counting webhook duration and priority
+    & fairness queue wait times) in seconds for each verb, group, version, resource,
+    subresource, scope and component.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - component
+  - group
+  - resource
+  - scope
+  - subresource
+  - verb
+  - version
+  buckets:
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.4
+  - 0.6
+  - 0.8
+  - 1
+  - 1.25
+  - 1.5
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 8
+  - 10
+  - 15
+  - 20
+  - 30
+  - 45
+  - 60
 - name: check_duration_seconds
   subsystem: validating_admission_policy
   namespace: apiserver
@@ -272,6 +563,13 @@
   stabilityLevel: BETA
   labels:
   - traffic_distribution
+- name: etcd_bookmark_counts
+  help: Number of etcd bookmarks (progress notify events) split by kind.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
 - name: hidden_metrics_total
   help: The count of hidden metrics.
   type: Counter


### PR DESCRIPTION
/kind feature
/kind api-change

#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes a set of **kube-apiserver** and **kube-aggregator** metrics from Alpha to Beta stability as part of the metrics graduation effort tracked in #136107.

Graduating these metrics to **Beta** provides stronger compatibility guarantees for metric consumers (dashboards/alerts), specifically that existing label sets will not be removed while the metrics are in Beta.

#### Which issue(s) this PR is related to:
Fixes #136107

#### Special notes for your reviewer:
- Promotions are limited to the metrics explicitly listed in #136107 and validated against the “Graduating to Beta” guidance from SIG Instrumentation.
- Added/updated focused tests validating metric registration/emission and expected labels/values using existing patterns.
- No metric names or label keys were changed; only stability was promoted to Beta.
- PR 5 in the metrics graduation series for #136107 (following PRs for component-base, scheduler, kubelet volume, controller metrics). This PR covers apiserver + kube-aggregator metrics only.

#### Does this PR introduce a user-facing change?
Yes. The affected apiserver and aggregator metrics are now **Beta**, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted several kube-apiserver and kube-aggregator metrics from Alpha to Beta stability, providing stronger API and label stability guarantees for metric consumers.
```