### PR TITLE
Add serathius as approver for apiserver storage

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
@@ -3,6 +3,7 @@
 approvers:
   - liggitt
   - wojtek-t
+  - serathius
 reviewers:
   - smarterclayton
   - wojtek-t
@@ -14,6 +15,7 @@ reviewers:
   - enj
   - stevekuznetsov
   - MadhavJivrajani
+  - serathius
 emeritus_approvers:
   - xiang90
   - timothysc


### PR DESCRIPTION
In last 2 years I have been actively driving storage layer of Kubernetes by proposing and implementing multiple strategic KEPs.

List of contributions to staging/src/k8s.io/apiserver/pkg/storage in last 2 years ordered by date:
- #136066
- #135961
- #132259
- #134041
- #134109
- #134067
- #134065
- #134015
- #133624
- #134012
- #133871
- #133991
- #133886
- #133868
- #133873
- #133817
- #133604
- #133053
- #132965
- #132893
- #132901
- #132944
- #132884
- #132645
- #132915
- #132876
- #132848
- #132813
- #132355
- #132150
- #132454
- #132253
- #131979
- #131845
- #131766
- #130937
- #130423
- #130925
- #130924
- #130922
- #130899
- #130863
- #130873
- #130866
- #130688
- #130811
- #130815
- #130813
- #130588
- #130775
- #130777
- #130752
- #130475
- #130637
- #130417
- #130589
- #130587
- #130443
- #130400
- #130412
- #130399
- #130279
- #130242
- #130280
- #129930
- #129547
- #129443
- #129439
- #129540
- #129542
- #129441
- #129440
- #128415
- #126875
- #126754
- #125258
- #126968
- #125884
- #126854
- #126329
- #126467
- #125722
- #123513
- #125584
- #125441
- #125115
- #124466
- #124513
- #124469
- #123994
- #123935
- #123676
- #123674
- #123732
- #123532

```release-note
NONE
```
/cc @liggitt @wojtek-t @jpbetz @deads2k 
