### PR TITLE
Fix credential test by setting `AlwaysVerify` policy

### DIFF
--- a/test/e2e_node/image_credential_pulls.go
+++ b/test/e2e_node/image_credential_pulls.go
@@ -28,6 +28,7 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/features"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	e2ecommonnode "k8s.io/kubernetes/test/e2e/common/node"
@@ -44,6 +45,11 @@ var _ = SIGDescribe("Ensure Credential Pulled Images", func() {
 		var testImage string
 		var testSecret *v1.Secret
 		var testNode string
+
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.ImagePullCredentialsVerificationPolicy = string(kubeletconfig.AlwaysVerify)
+		})
+
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			var err error
 			_, is, err = getCRIClient()


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

The test expects unauthorized pods to be blocked from accessing cached private images, but the default policy (NeverVerifyPreloadedImages) allows access to any image previously pulled by the kubelet.

Configure the kubelet to use `AlwaysVerify` policy for this test, which enforces credential checks for all images regardless of pull history.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/135703

#### Special notes for your reviewer:

Failing test:
```
E2eNode Suite: [It] [sig-node] Ensure Credential Pulled Images pulling images with credentials [FeatureGate:KubeletEnsureSecretPulledImages] [Beta] [Serial] Never pod without PullSecret cannot access previously pulled private image
```

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```
