### PR TITLE
ipaddress: migrate parentref validation to DV

### DIFF
--- a/pkg/apis/networking/v1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1/zz_generated.validations.go
@@ -66,32 +66,6 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	return nil
 }
 
-// Validate_IPBlock validates an instance of IPBlock according
-// to declarative validation rules in the API schema.
-func Validate_IPBlock(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *networkingv1.IPBlock) (errs field.ErrorList) {
-	// field networkingv1.IPBlock.CIDR
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
-			return
-		}(fldPath.Child("cidr"), &obj.CIDR, safe.Field(oldObj, func(oldObj *networkingv1.IPBlock) *string { return &oldObj.CIDR }), oldObj != nil)...)
-
-	// field networkingv1.IPBlock.Except has no validation
-	return errs
-}
-
 // Validate_IPAddress validates an instance of IPAddress according
 // to declarative validation rules in the API schema.
 func Validate_IPAddress(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *networkingv1.IPAddress) (errs field.ErrorList) {
@@ -141,6 +115,32 @@ func Validate_IPAddressSpec(ctx context.Context, op operation.Operation, fldPath
 			return
 		}(fldPath.Child("parentRef"), obj.ParentRef, safe.Field(oldObj, func(oldObj *networkingv1.IPAddressSpec) *networkingv1.ParentReference { return oldObj.ParentRef }), oldObj != nil)...)
 
+	return errs
+}
+
+// Validate_IPBlock validates an instance of IPBlock according
+// to declarative validation rules in the API schema.
+func Validate_IPBlock(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *networkingv1.IPBlock) (errs field.ErrorList) {
+	// field networkingv1.IPBlock.CIDR
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("cidr"), &obj.CIDR, safe.Field(oldObj, func(oldObj *networkingv1.IPBlock) *string { return &oldObj.CIDR }), oldObj != nil)...)
+
+	// field networkingv1.IPBlock.Except has no validation
 	return errs
 }
 

--- a/pkg/apis/networking/v1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1/zz_generated.validations.go
@@ -39,6 +39,14 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type IPAddress
+	scheme.AddValidationFunc((*networkingv1.IPAddress)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_IPAddress(ctx, op, nil /* fldPath */, obj.(*networkingv1.IPAddress), safe.Cast[*networkingv1.IPAddress](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type IngressClass
 	scheme.AddValidationFunc((*networkingv1.IngressClass)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -81,6 +89,58 @@ func Validate_IPBlock(ctx context.Context, op operation.Operation, fldPath *fiel
 		}(fldPath.Child("cidr"), &obj.CIDR, safe.Field(oldObj, func(oldObj *networkingv1.IPBlock) *string { return &oldObj.CIDR }), oldObj != nil)...)
 
 	// field networkingv1.IPBlock.Except has no validation
+	return errs
+}
+
+// Validate_IPAddress validates an instance of IPAddress according
+// to declarative validation rules in the API schema.
+func Validate_IPAddress(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *networkingv1.IPAddress) (errs field.ErrorList) {
+	// field networkingv1.IPAddress.TypeMeta has no validation
+	// field networkingv1.IPAddress.ObjectMeta has no validation
+
+	// field networkingv1.IPAddress.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *networkingv1.IPAddressSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_IPAddressSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *networkingv1.IPAddress) *networkingv1.IPAddressSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_IPAddressSpec validates an instance of IPAddressSpec according
+// to declarative validation rules in the API schema.
+func Validate_IPAddressSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *networkingv1.IPAddressSpec) (errs field.ErrorList) {
+	// field networkingv1.IPAddressSpec.ParentRef
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *networkingv1.ParentReference, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ParentReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("parentRef"), obj.ParentRef, safe.Field(oldObj, func(oldObj *networkingv1.IPAddressSpec) *networkingv1.ParentReference { return oldObj.ParentRef }), oldObj != nil)...)
+
 	return errs
 }
 
@@ -309,5 +369,53 @@ func Validate_NetworkPolicySpec(ctx context.Context, op operation.Operation, fld
 		}), oldObj != nil)...)
 
 	// field networkingv1.NetworkPolicySpec.PolicyTypes has no validation
+	return errs
+}
+
+// Validate_ParentReference validates an instance of ParentReference according
+// to declarative validation rules in the API schema.
+func Validate_ParentReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *networkingv1.ParentReference) (errs field.ErrorList) {
+	// field networkingv1.ParentReference.Group has no validation
+
+	// field networkingv1.ParentReference.Resource
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("resource"), &obj.Resource, safe.Field(oldObj, func(oldObj *networkingv1.ParentReference) *string { return &oldObj.Resource }), oldObj != nil)...)
+
+	// field networkingv1.ParentReference.Namespace has no validation
+
+	// field networkingv1.ParentReference.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *networkingv1.ParentReference) *string { return &oldObj.Name }), oldObj != nil)...)
+
 	return errs
 }

--- a/pkg/apis/networking/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1beta1/zz_generated.validations.go
@@ -39,6 +39,14 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type IPAddress
+	scheme.AddValidationFunc((*networkingv1beta1.IPAddress)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_IPAddress(ctx, op, nil /* fldPath */, obj.(*networkingv1beta1.IPAddress), safe.Cast[*networkingv1beta1.IPAddress](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type IngressClass
 	scheme.AddValidationFunc((*networkingv1beta1.IngressClass)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -48,6 +56,56 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_IPAddress validates an instance of IPAddress according
+// to declarative validation rules in the API schema.
+func Validate_IPAddress(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *networkingv1beta1.IPAddress) (errs field.ErrorList) {
+	// field networkingv1beta1.IPAddress.TypeMeta has no validation
+	// field networkingv1beta1.IPAddress.ObjectMeta has no validation
+
+	// field networkingv1beta1.IPAddress.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *networkingv1beta1.IPAddressSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_IPAddressSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *networkingv1beta1.IPAddress) *networkingv1beta1.IPAddressSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_IPAddressSpec validates an instance of IPAddressSpec according
+// to declarative validation rules in the API schema.
+func Validate_IPAddressSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *networkingv1beta1.IPAddressSpec) (errs field.ErrorList) {
+	// field networkingv1beta1.IPAddressSpec.ParentRef
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *networkingv1beta1.ParentReference, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ParentReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("parentRef"), obj.ParentRef, safe.Field(oldObj, func(oldObj *networkingv1beta1.IPAddressSpec) *networkingv1beta1.ParentReference {
+			return oldObj.ParentRef
+		}), oldObj != nil)...)
+
+	return errs
 }
 
 // Validate_IngressClass validates an instance of IngressClass according
@@ -145,6 +203,54 @@ func Validate_IngressClassSpec(ctx context.Context, op operation.Operation, fldP
 		}(fldPath.Child("parameters"), obj.Parameters, safe.Field(oldObj, func(oldObj *networkingv1beta1.IngressClassSpec) *networkingv1beta1.IngressClassParametersReference {
 			return oldObj.Parameters
 		}), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_ParentReference validates an instance of ParentReference according
+// to declarative validation rules in the API schema.
+func Validate_ParentReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *networkingv1beta1.ParentReference) (errs field.ErrorList) {
+	// field networkingv1beta1.ParentReference.Group has no validation
+
+	// field networkingv1beta1.ParentReference.Resource
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("resource"), &obj.Resource, safe.Field(oldObj, func(oldObj *networkingv1beta1.ParentReference) *string { return &oldObj.Resource }), oldObj != nil)...)
+
+	// field networkingv1beta1.ParentReference.Namespace has no validation
+
+	// field networkingv1beta1.ParentReference.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *networkingv1beta1.ParentReference) *string { return &oldObj.Name }), oldObj != nil)...)
 
 	return errs
 }

--- a/pkg/apis/networking/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1beta1/zz_generated.validations.go
@@ -91,6 +91,10 @@ func Validate_IPAddressSpec(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -785,7 +785,7 @@ func validateIPAddressParentReference(params *networking.ParentReference, fldPat
 	allErrs := field.ErrorList{}
 
 	if params == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("parentRef"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("parentRef"), "").MarkCoveredByDeclarative())
 		return allErrs
 	}
 
@@ -799,7 +799,7 @@ func validateIPAddressParentReference(params *networking.ParentReference, fldPat
 
 	// resource is required
 	if params.Resource == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("resource"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resource"), "").MarkCoveredByDeclarative())
 	} else {
 		for _, msg := range content.IsPathSegmentName(params.Resource) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("resource"), params.Resource, msg))
@@ -808,7 +808,7 @@ func validateIPAddressParentReference(params *networking.ParentReference, fldPat
 
 	// name is required
 	if params.Name == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "").MarkCoveredByDeclarative())
 	} else {
 		for _, msg := range content.IsPathSegmentName(params.Name) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), params.Name, msg))
@@ -828,7 +828,7 @@ func validateIPAddressParentReference(params *networking.ParentReference, fldPat
 func ValidateIPAddressUpdate(update, old *networking.IPAddress) field.ErrorList {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&update.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(update.Spec.ParentRef, old.Spec.ParentRef, field.NewPath("spec").Child("parentRef"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(update.Spec.ParentRef, old.Spec.ParentRef, field.NewPath("spec").Child("parentRef")).MarkCoveredByDeclarative().WithOrigin("immutable")...)
 	return allErrs
 }
 

--- a/pkg/registry/networking/ipaddress/declarative_validation_test.go
+++ b/pkg/registry/networking/ipaddress/declarative_validation_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipaddress

--- a/pkg/registry/networking/ipaddress/declarative_validation_test.go
+++ b/pkg/registry/networking/ipaddress/declarative_validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,3 +15,208 @@ limitations under the License.
 */
 
 package ipaddress
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	networking "k8s.io/kubernetes/pkg/apis/networking"
+)
+
+var apiVersions = []string{"v1beta1", "v1"}
+
+func TestDeclarativeValidateIPAddress(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(
+				genericapirequest.NewDefaultContext(),
+				&genericapirequest.RequestInfo{
+					APIGroup:          "networking.k8s.io",
+					APIVersion:        apiVersion,
+					Resource:          "ipaddresses",
+					IsResourceRequest: true,
+					Verb:              "create",
+				},
+			)
+
+			testCases := map[string]struct {
+				input        networking.IPAddress
+				expectedErrs field.ErrorList
+			}{
+				"valid": {
+					input: mkValidIPAddress(),
+				},
+				"missing parentRef": {
+					input: mkValidIPAddress(withNilParentRef),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "parentRef"), ""),
+					},
+				},
+				"missing parentRef resource": {
+					input: mkValidIPAddress(withEmptyParentRefResource),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "parentRef", "resource"), ""),
+					},
+				},
+				"missing parentRef name": {
+					input: mkValidIPAddress(withEmptyParentRefName),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "parentRef", "name"), ""),
+					},
+				},
+			}
+			for name, tc := range testCases {
+				t.Run(name, func(t *testing.T) {
+					apitesting.VerifyValidationEquivalence(
+						t,
+						ctx,
+						&tc.input,
+						Strategy.Validate,
+						tc.expectedErrs,
+					)
+				})
+			}
+		})
+	}
+}
+
+func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testCases := map[string]struct {
+				oldObj       networking.IPAddress
+				updateObj    networking.IPAddress
+				expectedErrs field.ErrorList
+			}{
+				"valid update": {
+					oldObj:    mkValidIPAddress(withResourceVersion("1")),
+					updateObj: mkValidIPAddress(withResourceVersion("1")),
+				},
+				"immutable parentRef": {
+					oldObj: mkValidIPAddress(withResourceVersion("1")),
+					updateObj: mkValidIPAddress(
+						withResourceVersion("1"),
+						withParentRefName("new-name"),
+					),
+					expectedErrs: field.ErrorList{
+						func() *field.Error {
+							e := field.Invalid(field.NewPath("spec", "parentRef"), &networking.ParentReference{
+								Group:    "apps",
+								Resource: "deployments",
+								Name:     "new-name",
+							}, "field is immutable")
+							e.Origin = "immutable"
+							return e
+						}(),
+					},
+				},
+				"set parentRef": {
+					oldObj: mkValidIPAddress(withResourceVersion("1"), withNilParentRef),
+					updateObj: mkValidIPAddress(
+						withResourceVersion("2"),
+						withParentRefName("new-name"),
+					),
+					expectedErrs: field.ErrorList{
+						func() *field.Error {
+							e := field.Invalid(field.NewPath("spec", "parentRef"), &networking.ParentReference{
+								Group:    "apps",
+								Resource: "deployments",
+								Name:     "new-name",
+							}, "field is immutable")
+							e.Origin = "immutable"
+							return e
+						}(),
+					},
+				},
+				"unset parentRef": {
+					oldObj: mkValidIPAddress(withResourceVersion("1")),
+					updateObj: mkValidIPAddress(
+						withResourceVersion("1"),
+						withNilParentRef,
+					),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "parentRef"), ""),
+						func() *field.Error {
+							e := field.Invalid(field.NewPath("spec", "parentRef"), nil, "field is immutable")
+							e.Origin = "immutable"
+							return e
+						}(),
+					},
+				},
+			}
+
+			for name, tc := range testCases {
+				t.Run(name, func(t *testing.T) {
+					ctx := genericapirequest.WithRequestInfo(
+						genericapirequest.NewDefaultContext(),
+						&genericapirequest.RequestInfo{
+							APIPrefix:         "apis",
+							APIGroup:          "networking.k8s.io",
+							APIVersion:        apiVersion,
+							Resource:          "ipaddresses",
+							Name:              "192.168.1.1",
+							IsResourceRequest: true,
+							Verb:              "update",
+						},
+					)
+
+					apitesting.VerifyUpdateValidationEquivalence(
+						t,
+						ctx,
+						&tc.updateObj,
+						&tc.oldObj,
+						Strategy.ValidateUpdate,
+						tc.expectedErrs,
+					)
+				})
+			}
+		})
+	}
+}
+
+func mkValidIPAddress(tweaks ...func(obj *networking.IPAddress)) networking.IPAddress {
+	obj := networking.IPAddress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "192.168.1.1",
+		},
+		Spec: networking.IPAddressSpec{
+			ParentRef: &networking.ParentReference{
+				Group:    "apps",
+				Resource: "deployments",
+				Name:     "my-deployment",
+			},
+		},
+	}
+
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}
+
+func withNilParentRef(obj *networking.IPAddress) {
+	obj.Spec.ParentRef = nil
+}
+
+func withEmptyParentRefResource(obj *networking.IPAddress) {
+	obj.Spec.ParentRef.Resource = ""
+}
+
+func withEmptyParentRefName(obj *networking.IPAddress) {
+	obj.Spec.ParentRef.Name = ""
+}
+
+func withResourceVersion(rv string) func(*networking.IPAddress) {
+	return func(obj *networking.IPAddress) {
+		obj.ResourceVersion = rv
+	}
+}
+
+func withParentRefName(name string) func(*networking.IPAddress) {
+	return func(obj *networking.IPAddress) {
+		obj.Spec.ParentRef.Name = name
+	}
+}

--- a/pkg/registry/networking/ipaddress/strategy.go
+++ b/pkg/registry/networking/ipaddress/strategy.go
@@ -19,6 +19,7 @@ package ipaddress
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -73,7 +74,7 @@ func (ipAddressStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.
 func (ipAddressStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	ipAddress := obj.(*networking.IPAddress)
 	err := validation.ValidateIPAddress(ipAddress)
-	return err
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, ipAddress, nil, err, operation.Create)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -91,7 +92,7 @@ func (ipAddressStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Ob
 	oldIPAddress := old.(*networking.IPAddress)
 	errList := validation.ValidateIPAddress(newIPAddress)
 	errList = append(errList, validation.ValidateIPAddressUpdate(newIPAddress, oldIPAddress)...)
-	return errList
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newIPAddress, oldIPAddress, errList, operation.Update)
 }
 
 // AllowUnconditionalUpdate is the default update policy for IPAddress objects.

--- a/pkg/registry/networking/ipaddress/strategy_test.go
+++ b/pkg/registry/networking/ipaddress/strategy_test.go
@@ -42,7 +42,17 @@ func newIPAddress() networking.IPAddress {
 }
 
 func TestIPAddressStrategy(t *testing.T) {
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.WithRequestInfo(
+		genericapirequest.NewDefaultContext(),
+		&genericapirequest.RequestInfo{
+			APIGroup:          "networking.k8s.io",
+			APIVersion:        "v1",
+			Resource:          "ipaddresses",
+			Name:              "192.168.1.1",
+			IsResourceRequest: true,
+			Verb:              "create",
+		},
+	)
 	if Strategy.NamespaceScoped() {
 		t.Errorf("ipAddress must not be namespace scoped")
 	}

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -107,6 +107,8 @@ message IPAddressSpec {
   // ParentRef references the resource that an IPAddress is attached to.
   // An IPAddress must reference a parent object.
   // +required
+  // +k8s:required
+  // +k8s:immutable
   optional ParentReference parentRef = 1;
 }
 
@@ -595,6 +597,7 @@ message ParentReference {
 
   // Resource is the resource of the object being referenced.
   // +required
+  // +k8s:required
   optional string resource = 2;
 
   // Namespace is the namespace of the object being referenced.
@@ -603,6 +606,7 @@ message ParentReference {
 
   // Name is the name of the object being referenced.
   // +required
+  // +k8s:required
   optional string name = 4;
 }
 

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -675,6 +675,7 @@ type IPAddressSpec struct {
 	// An IPAddress must reference a parent object.
 	// +required
 	// +k8s:required
+	// +k8s:immutable
 	ParentRef *ParentReference `json:"parentRef,omitempty" protobuf:"bytes,1,opt,name=parentRef"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -674,6 +674,7 @@ type IPAddressSpec struct {
 	// ParentRef references the resource that an IPAddress is attached to.
 	// An IPAddress must reference a parent object.
 	// +required
+	// +k8s:required
 	ParentRef *ParentReference `json:"parentRef,omitempty" protobuf:"bytes,1,opt,name=parentRef"`
 }
 
@@ -684,12 +685,14 @@ type ParentReference struct {
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the resource of the object being referenced.
 	// +required
+	// +k8s:required
 	Resource string `json:"resource,omitempty" protobuf:"bytes,2,opt,name=resource"`
 	// Namespace is the namespace of the object being referenced.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
 	// Name is the name of the object being referenced.
 	// +required
+	// +k8s:required
 	Name string `json:"name,omitempty" protobuf:"bytes,4,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -108,6 +108,8 @@ message IPAddressSpec {
   // ParentRef references the resource that an IPAddress is attached to.
   // An IPAddress must reference a parent object.
   // +required
+  // +k8s:required
+  // +k8s:immutable
   optional ParentReference parentRef = 1;
 }
 
@@ -402,6 +404,7 @@ message ParentReference {
 
   // Resource is the resource of the object being referenced.
   // +required
+  // +k8s:required
   optional string resource = 2;
 
   // Namespace is the namespace of the object being referenced.
@@ -410,6 +413,7 @@ message ParentReference {
 
   // Name is the name of the object being referenced.
   // +required
+  // +k8s:required
   optional string name = 4;
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -457,6 +457,7 @@ type IPAddressSpec struct {
 	// An IPAddress must reference a parent object.
 	// +required
 	// +k8s:required
+	// +k8s:immutable
 	ParentRef *ParentReference `json:"parentRef,omitempty" protobuf:"bytes,1,opt,name=parentRef"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -456,6 +456,7 @@ type IPAddressSpec struct {
 	// ParentRef references the resource that an IPAddress is attached to.
 	// An IPAddress must reference a parent object.
 	// +required
+	// +k8s:required
 	ParentRef *ParentReference `json:"parentRef,omitempty" protobuf:"bytes,1,opt,name=parentRef"`
 }
 
@@ -466,12 +467,14 @@ type ParentReference struct {
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the resource of the object being referenced.
 	// +required
+	// +k8s:required
 	Resource string `json:"resource,omitempty" protobuf:"bytes,2,opt,name=resource"`
 	// Namespace is the namespace of the object being referenced.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
 	// Name is the name of the object being referenced.
 	// +required
+	// +k8s:required
 	Name string `json:"name,omitempty" protobuf:"bytes,4,opt,name=name"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Migrates ipaddress.ParentRef validation to Declarative Validation (DV), keeping behavior aligned with existing hand-written validation.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Part of [Umbrella][Declarative Validation] Enable Declarative Validation for APIs https://github.com/kubernetes/kubernetes/issues/134280

#### Special notes for your reviewer:
Scope is limited to ipaddress.ParentRef (name and resource sub-fields). No behavior change is intended.

#### Test Plan
Unit tests validating ipaddress create and update with DV are included and enabled

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE