### PR TITLE
perf: optimize state cloning in addGENominatedPods to reduce unnecessary overhead

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1215,16 +1215,23 @@ func addGENominatedPods(ctx context.Context, fh fwk.Handle, pod *v1.Pod, state f
 		return false, state, nodeInfo, nil
 	}
 	nodeInfoOut := nodeInfo.Snapshot()
-	stateOut := state.Clone()
+	stateOut := state
 	podsAdded := false
+	podsToAdd := []fwk.PodInfo{}
 	for _, pi := range nominatedPodInfos {
 		if corev1.PodPriority(pi.GetPod()) >= corev1.PodPriority(pod) && pi.GetPod().UID != pod.UID {
-			nodeInfoOut.AddPodInfo(pi)
-			status := fh.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
-			if !status.IsSuccess() {
-				return false, state, nodeInfo, status.AsError()
+			podsToAdd = append(podsToAdd, pi)
+			if !podsAdded {
+				stateOut = state.Clone()
 			}
 			podsAdded = true
+		}
+	}
+	for _, pi := range podsToAdd {
+		nodeInfoOut.AddPodInfo(pi)
+		status := fh.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
+		if !status.IsSuccess() {
+			return false, state, nodeInfo, status.AsError()
 		}
 	}
 	return podsAdded, stateOut, nodeInfoOut, nil

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -2310,12 +2310,13 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 	tests := []struct {
 		name            string
 		preFilterPlugin *TestPlugin
-		filterPlugin    *TestPlugin
+		filterPlugin    fwk.Plugin
 		pod             *v1.Pod
 		nominatedPod    *v1.Pod
 		node            *v1.Node
 		nodeInfo        *framework.NodeInfo
 		wantStatus      *fwk.Status
+		wantStateKey    fwk.StateKey // if non-empty, verify this key exists in CycleState after run
 	}{
 		{
 			name:            "node has no nominated pod",
@@ -2402,6 +2403,24 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			nodeInfo:     framework.NewNodeInfo(pod),
 			wantStatus:   nil,
 		},
+		{
+			name: "filter plugin writes state with nominated pods and pre filters return unschedulable",
+			preFilterPlugin: &TestPlugin{
+				name: "TestPlugin1",
+				inj: injectedResult{
+					PreFilterAddPodStatus: int(fwk.Unschedulable),
+				},
+			},
+			filterPlugin: &TestPluginToWriteState{
+				name: "TestPlugin2",
+			},
+			pod:          highPriorityPod,
+			nominatedPod: lowPriorityPod,
+			node:         node,
+			nodeInfo:     framework.NewNodeInfo(pod),
+			wantStatus:   nil,
+			wantStateKey: testPluginToWriteState,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2423,15 +2442,15 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 				)
 			}
 			if tt.filterPlugin != nil {
-				if err := registry.Register(tt.filterPlugin.name,
+				if err := registry.Register(tt.filterPlugin.Name(),
 					func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 						return tt.filterPlugin, nil
 					}); err != nil {
-					t.Fatalf("fail to register filter plugin (%s)", tt.filterPlugin.name)
+					t.Fatalf("fail to register filter plugin (%s)", tt.filterPlugin.Name())
 				}
 				cfgPls.Filter.Enabled = append(
 					cfgPls.Filter.Enabled,
-					config.Plugin{Name: tt.filterPlugin.name},
+					config.Plugin{Name: tt.filterPlugin.Name()},
 				)
 			}
 
@@ -2470,106 +2489,10 @@ func TestFilterPluginsWithNominatedPods(t *testing.T) {
 			if diff := cmp.Diff(tt.wantStatus, gotStatus, statusCmpOpts...); diff != "" {
 				t.Errorf("Unexpected status: (-want,+got):\n%s", diff)
 			}
-		})
-	}
-}
-
-func TestFilterPluginsWriteStateWithNominatedPods(t *testing.T) {
-	tests := []struct {
-		name            string
-		preFilterPlugin *TestPlugin
-		filterPlugin    *TestPluginToWriteState
-		pod             *v1.Pod
-		nominatedPod    *v1.Pod
-		node            *v1.Node
-		nodeInfo        *framework.NodeInfo
-		wantStatus      *fwk.Status
-	}{
-		{
-			name: "node has a low-priority nominated pod and pre filters return unschedulable",
-			preFilterPlugin: &TestPlugin{
-				name: "TestPlugin1",
-				inj: injectedResult{
-					PreFilterAddPodStatus: int(fwk.Unschedulable),
-				},
-			},
-			filterPlugin: &TestPluginToWriteState{
-				name: "TestPlugin2",
-			},
-			pod:          highPriorityPod,
-			nominatedPod: lowPriorityPod,
-			node:         node,
-			nodeInfo:     framework.NewNodeInfo(pod),
-			wantStatus:   nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
-			registry := Registry{}
-			cfgPls := &config.Plugins{}
-
-			if tt.preFilterPlugin != nil {
-				if err := registry.Register(tt.preFilterPlugin.name,
-					func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-						return tt.preFilterPlugin, nil
-					}); err != nil {
-					t.Fatalf("fail to register preFilter plugin (%s)", tt.preFilterPlugin.name)
+			if tt.wantStateKey != "" {
+				if _, err := state.Read(tt.wantStateKey); err != nil {
+					t.Errorf("Expected state key %q to exist, but got error: %v", tt.wantStateKey, err)
 				}
-				cfgPls.PreFilter.Enabled = append(
-					cfgPls.PreFilter.Enabled,
-					config.Plugin{Name: tt.preFilterPlugin.name},
-				)
-			}
-			if tt.filterPlugin != nil {
-				if err := registry.Register(tt.filterPlugin.name,
-					func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-						return tt.filterPlugin, nil
-					}); err != nil {
-					t.Fatalf("fail to register filter plugin (%s)", tt.filterPlugin.name)
-				}
-				cfgPls.Filter.Enabled = append(
-					cfgPls.Filter.Enabled,
-					config.Plugin{Name: tt.filterPlugin.name},
-				)
-			}
-
-			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(), 0)
-			podInformer := informerFactory.Core().V1().Pods().Informer()
-			err := podInformer.GetStore().Add(tt.pod)
-			if err != nil {
-				t.Fatalf("Error adding pod to podInformer: %s", err)
-			}
-			if tt.nominatedPod != nil {
-				err = podInformer.GetStore().Add(tt.nominatedPod)
-				if err != nil {
-					t.Fatalf("Error adding nominated pod to podInformer: %s", err)
-				}
-			}
-
-			podNominator := internalqueue.NewSchedulingQueue(nil, informerFactory)
-			if tt.nominatedPod != nil {
-				podNominator.AddNominatedPod(
-					logger,
-					mustNewPodInfo(t, tt.nominatedPod),
-					&fwk.NominatingInfo{NominatingMode: fwk.ModeOverride, NominatedNodeName: nodeName})
-			}
-			profile := config.KubeSchedulerProfile{Plugins: cfgPls}
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			f, err := newFrameworkWithQueueSortAndBind(ctx, registry, profile, WithPodNominator(podNominator))
-			if err != nil {
-				t.Fatalf("fail to create framework: %s", err)
-			}
-			defer func() {
-				_ = f.Close()
-			}()
-			tt.nodeInfo.SetNode(tt.node)
-			f.RunFilterPluginsWithNominatedPods(ctx, state, tt.pod, tt.nodeInfo)
-			_, err = state.Read(testPluginToWriteState)
-			if err != nil {
-				t.Fatalf("Error reading state: %s", err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

Modify addGENominatedPods function to avoid unnecessary state cloning when
there are no nominated pods to add. Previously, state was cloned regardless
of whether any nominated pods met the criteria. Now, state is only cloned
when actually needed, reducing performance overhead in common cases.

Normally, Filter is expected to be executed at least once with CycleState, 
but this expectation doesn't hold when all NominatedPods have lower priority 
than the current Pod. This code modification fixes that scenario by ensuring 
proper state handling only when necessary.

Also add new test case to verify state writing behavior with nominated pods.

My use case can be found in the test I added.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

I am a developer working on custom kube-scheduler. My plugins save some state in Filter to avoid duplicate computation in Reserve, but sometimes the cyclestae cannot be found in Reserve even I already write the cyclestate in Filter.

Finally I found the reason: cycleState passed into the Filter is the copy one so the state change is dropped after the Filter.
I think this behavior is unexpected. I hope the Filter can be executed at least once with the origin CycleState.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
