### PR TITLE
Addon: add udp-conntrack-cleaner to mitigate issue #136213

### DIFF
--- a/cluster/addons/udp-conntrack-cleaner/README.md
+++ b/cluster/addons/udp-conntrack-cleaner/README.md
@@ -1,0 +1,18 @@
+# UDP Conntrack Cleaner
+
+## Description
+This addon provides a mitigation for **Issue #136213** (UDP Blackhole). 
+
+In scenarios where a UDP client persists traffic during a network partition, the Linux kernel `conntrack` table may mark the flow as `[UNREPLIED]` and persist this state even after connectivity is restored. This prevents the traffic from being re-routed correctly by `kube-proxy`.
+
+## How it works
+This DaemonSet:
+1. Runs on every node with `hostNetwork: true`.
+2. Grants `NET_ADMIN` capabilities to interact with the kernel network stack.
+3. Periodically (every 60s) flushes UDP conntrack entries marked as `UNREPLIED`.
+
+## Usage
+Apply this manifest if you experience UDP connectivity drops after network flaps.
+
+```bash
+kubectl apply -f udp-conntrack-cleaner.yaml

--- a/cluster/addons/udp-conntrack-cleaner/udp-conntrack-cleaner.yaml
+++ b/cluster/addons/udp-conntrack-cleaner/udp-conntrack-cleaner.yaml
@@ -1,0 +1,74 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: udp-conntrack-cleaner
+  namespace: kube-system
+  labels:
+    k8s-app: udp-conntrack-cleaner
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      k8s-app: udp-conntrack-cleaner
+  template:
+    metadata:
+      labels:
+        k8s-app: udp-conntrack-cleaner
+    spec:
+      # HostNetwork is required to access the Node's conntrack table
+      hostNetwork: true
+      # Run on control plane and worker nodes alike
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: cleaner
+        # Alpine is minimal (~5MB). We install conntrack-tools at runtime.
+        image: alpine:3.19
+        securityContext:
+          capabilities:
+            # NET_ADMIN is strictly required to run 'conntrack -D'
+            add: ["NET_ADMIN"]
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Install conntrack-tools (suppress output for cleaner logs)
+            apk add --no-cache conntrack-tools > /dev/null 2>&1;
+            
+            echo "INFO: Starting UDP Conntrack Cleaner loop...";
+            
+            while true; do
+              # Delete UDP entries with [UNREPLIED] state.
+              # This clears "blackholed" connections where the backend is gone 
+              # but the client keeps sending.
+              count=$(conntrack -D -p udp --state UNREPLIED 2>/dev/null);
+              
+              if [ -n "$count" ]; then
+                 echo "$(date): Cleaned stale UNREPLIED UDP entries.";
+              fi
+              
+              # Sleep 60s to minimize CPU usage while maintaining responsiveness
+              sleep 60;
+            done
+        resources:
+          # Minimal resource footprint
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces a new optional addon located at `cluster/addons/udp-conntrack-cleaner`.

**The Problem:**
As described in issue #136213, Kubernetes clusters can experience a "UDP blackhole" scenario. This occurs when a client continues sending UDP packets during a network partition (e.g., a temporary link failure). The Linux kernel marks these packets as `[UNREPLIED]` in the conntrack table. Even after the network recovers, the kernel persists this invalid state, preventing the traffic from being correctly routed to the backend Pods.

**The Solution:**
This addon deploys a lightweight DaemonSet (`udp-conntrack-cleaner`) that runs on all nodes.
1. It runs a minimal shell loop using `conntrack-tools`.
2. It detects UDP conntrack entries with the state `UNREPLIED`.
3. It flushes *only* these specific stale entries.
4. This forces the kernel to establish a new, valid connection tracking entry, instantly restoring connectivity.

This approach is preferred over modifying `kube-proxy` internals as it provides a safe, opt-in mitigation for specific edge cases without risking regression in core networking logic.

#### Which issue(s) this PR is related to:
Fixes #136213
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
I have implemented this as an **Addon** rather than a core code change to minimize risk and invasiveness.

**Key Technical Details:**
* **Safety:** The script executes `conntrack -D -p udp --state UNREPLIED`. It is strictly scoped to UDP packets that are already in a broken state. It does **not** affect active, valid TCP or UDP connections.
* **Resources:** The DaemonSet is configured with minimal limits (10m CPU, 20Mi Memory) to ensure no impact on node performance.
* **Image:** Uses `alpine:3.19` for a minimal footprint, installing `conntrack-tools` at runtime.
* **Permissions:** Requires `NET_ADMIN` capability and `hostNetwork: true` to interact with the node's conntrack table.

**Directory Structure:**
New files added:
* `cluster/addons/udp-conntrack-cleaner/udp-conntrack-cleaner.yaml`
* `cluster/addons/udp-conntrack-cleaner/README.md`


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Feature: Added a new addon `udp-conntrack-cleaner` to mitigate stale UDP conntrack entries (UDP blackholing) that can occur after network partitions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
