### PR TITLE
kubectl: backport exec terminal size nil check

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -411,6 +411,10 @@ type terminalSizeQueueAdapter struct {
 }
 
 func (a *terminalSizeQueueAdapter) Next() *remotecommand.TerminalSize {
+	if a.delegate == nil {
+		return nil
+	}
+
 	next := a.delegate.Next()
 	if next == nil {
 		return nil


### PR DESCRIPTION
/kind bug
/sig cli
/area kubectl

#### What this PR does / why we need it:
Issue link: https://github.com/kubernetes/kubernetes/issues/136222
Summary: backport the nil-check in terminalSizeQueueAdapter to prevent a panic when TTY is requested but stdout is redirected.
Motivation: v1.35.0 panics in `kubectl exec -ti ... > file` because the terminal size queue delegate can be nil when stdout is not a terminal; this change avoids the nil dereference and exits resize handling safely.
Validation:
- `go test ./staging/src/k8s.io/kubectl/pkg/cmd/exec`

#### Which issue(s) this PR is related to:
Fixes #136222

#### Special notes for your reviewer:
- Backport of 5f675740442e (kubectl: Fix panic in exec terminal size queue).

#### Does this PR introduce a user-facing change?
```release-note
Fixed a `kubectl exec` panic when `-i` and `-t` flags are used and where stdout is also redirected to a file.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
