### PR TITLE
[WIP] test: add RWXFilesystemOnly capability for multiVolumeTestSuite

### DIFF
--- a/test/e2e/storage/external/README.md
+++ b/test/e2e/storage/external/README.md
@@ -51,3 +51,31 @@ supports them, for example snapshotting:
            e2e.test \
            -- \
            -storage.testdriver=/tmp/hostpath-testdriver.yaml
+
+**ReadWriteMany (RWX) Capabilities**
+
+For drivers that support ReadWriteMany access mode, use one of the following capabilities:
+
+- **`RWX`**: Driver supports RWX on all volume modes it supports (filesystem and block).
+  - Use for drivers like NFS, Azure File that universally support RWX.
+  - Backward compatible with existing test configurations.
+  - Note: Filesystem RWX volumes don't support specifying `fsType` - tests with non-empty fsType will be skipped.
+
+- **`RWXFilesystemOnly`**: Driver supports RWX only on filesystem volumes.
+  - Use for drivers that support for filesystem and block volumes (e.g., vSphere CSI) where only filesystem volumes support RWX.
+  - Block volume RWX tests will be skipped automatically.
+  - Tests with non-empty `fsType` will be skipped (filesystem format is pre-determined by the storage backend).
+
+- **`RWXBlockOnly`**: Driver supports RWX only on block volumes.
+  - Use for drivers that support both filesystem and block volumes where only block volumes support RWX.
+  - Filesystem volume RWX tests will be skipped automatically.
+
+Example for vSphere CSI with filesystem RWX support:
+```yaml
+DriverInfo:
+  Name: vsphere.csi.k8s.io
+  Capabilities:
+    persistence: true
+    block: true
+    RWXFilesystemOnly: true
+```

--- a/test/e2e/storage/framework/testdriver.go
+++ b/test/e2e/storage/framework/testdriver.go
@@ -181,7 +181,23 @@ const (
 	// - NodeStageVolume in the spec
 	CapMultiPODs Capability = "multipods"
 
-	CapRWX                 Capability = "RWX"                 // support ReadWriteMany access modes
+	// CapRWX indicates the driver supports ReadWriteMany access mode.
+	// When set alone without CapRWXFilesystemOnly or CapRWXBlockOnly, it means the driver supports
+	// RWX for all volume modes it supports (backward compatible with existing drivers like NFS, Azure File).
+	// For drivers that support RWX only on specific volume modes, use CapRWXFilesystemOnly or CapRWXBlockOnly.
+	CapRWX Capability = "RWX"
+
+	// CapRWXFilesystemOnly indicates the driver supports ReadWriteMany only on filesystem volumes.
+	// Use this for drivers that support both filesystem and block volumes (e.g., vSphere CSI) where only
+	// filesystem volumes support RWX. Block volume RWX tests will be skipped.
+	// Note: RWX filesystem volumes don't support specifying fsType - tests with non-empty fsType will be skipped.
+	CapRWXFilesystemOnly Capability = "RWXFilesystemOnly"
+
+	// CapRWXBlockOnly indicates the driver supports ReadWriteMany only on block volumes.
+	// Use this for drivers that support both filesystem and block volumes where only block volumes support RWX.
+	// Filesystem volume RWX tests will be skipped.
+	CapRWXBlockOnly Capability = "RWXBlockOnly"
+
 	CapControllerExpansion Capability = "controllerExpansion" // support volume expansion for controller
 	CapNodeExpansion       Capability = "nodeExpansion"       // support volume expansion for node
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Some CSI drivers(e.g. vSphere csi driver) support both block and fileshare which made the test manifest contains both `block: true` and `RWX: true`, with this test patterns combine has some conflicts. Make the tests opt-in, i.e. add test capability RWXFilesystemOnly that's disabled by default. In addition there's also some other csi drivers support block RWX(e.g. iSCSI) only iSCSI, so we need the `CapRWXBlockOnly` capability as well.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/105626
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
