### PR TITLE
fix(apiserver): convert V().Error() to V().Info()

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
@@ -415,7 +415,7 @@ func authorizeUnsafeDelete(ctx context.Context, attr admission.Attributes, authz
 	decision, reason, err := authz.Authorize(ctx, record)
 	if err != nil {
 		err = fmt.Errorf("error while checking permission for %q, %w", record.Verb, err)
-		klog.FromContext(ctx).V(1).Error(err, "failed to authorize")
+		klog.FromContext(ctx).V(1).Info("failed to authorize", "err", err)
 		return admission.NewForbidden(attr, err)
 	}
 	if decision == authorizer.DecisionAllow {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR corrects the log verbosity behavior in the `authorizeUnsafeDelete` function within the apiserver's delete handler.

The `go-logr/logr` package ignores verbosity levels when using the `Error` method. This means `logger.V(1).Error()` will always log regardless of the verbosity setting, which contradicts the developer's original intent to only log at verbosity level 1 or higher.

**Change:**
```diff
- klog.FromContext(ctx).V(1).Error(err, "failed to authorize")
+ klog.FromContext(ctx).V(1).Info("failed to authorize", "err", err)
```

#### Which issue(s) this PR is related to:

Ref #136027

This issue was identified by @pohly in PR #136190, which adds a `logcheck` linter rule to detect this pattern.

#### Special notes for your reviewer:

- This is a minimal, single-line fix following the same pattern used in the merged PR #136046
- The existing unit tests (`TestAuthorizeUnsafeDelete`) pass without modification
- This fix aligns with the [Kubernetes logging conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md)

Thank you for taking the time to review this PR. I appreciate any feedback or suggestions!

#### Does this PR introduce a user-facing change?

```release-note
Fix log verbosity level in apiserver's unsafe delete authorization check that was incorrectly using Error level instead of Info level
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/sig api-machinery
/area apiserver