### PR TITLE
[InPlacePodVerticalScaling] retry pending pod resizes when another pod terminates

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -58,10 +58,11 @@ const (
 	initialRetryDelay = 30 * time.Second
 	retryDelay        = 3 * time.Minute
 
-	TriggerReasonPodResized  = "pod_resized"
-	TriggerReasonPodUpdated  = "pod_updated"
-	TriggerReasonPodsAdded   = "pods_added"
-	TriggerReasonPodsRemoved = "pods_removed"
+	TriggerReasonPodResized    = "pod_resized"
+	TriggerReasonPodUpdated    = "pod_updated"
+	TriggerReasonPodsAdded     = "pods_added"
+	TriggerReasonPodsRemoved   = "pods_removed"
+	TriggerReasonPodTerminated = "pod_terminated"
 
 	triggerReasonPeriodic = "periodic_retry"
 )

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2853,9 +2853,8 @@ func (kl *Kubelet) HandlePodUpdates(pods []*v1.Pod) {
 	}
 }
 
-// recordResizeOperaations records if any of the pod level resources or
-// containers need to be resized, and returns
-// true if so
+// recordResizeOperations records if any of the pod level resources or
+// containers need to be resized, and returns true if so
 func recordResizeOperations(oldPod, newPod *v1.Pod) bool {
 	if oldPod == nil {
 		// This should never happen.
@@ -2864,7 +2863,6 @@ func recordResizeOperations(oldPod, newPod *v1.Pod) bool {
 
 	hasResize := recordContainerResizeOperations(oldPod, newPod) || recordPodLevelResourceResizeOperations(oldPod, newPod)
 	return hasResize
-
 }
 
 // recordPodLevelResourceResizeOperations records if any of the pod level resources need to be resized, and returns
@@ -2981,6 +2979,7 @@ func (kl *Kubelet) HandlePodRemoves(pods []*v1.Pod) {
 func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 	start := kl.clock.Now()
 	retryPendingResizes := false
+	var triggerReason string
 	hasPendingResizes := kl.allocationManager.HasPendingResizes()
 	for _, pod := range pods {
 		// Update the pod in pod manager, status manager will do periodically reconcile according
@@ -2998,9 +2997,15 @@ func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 		}
 
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-			// If there are pending resizes, check whether the requests shrank as a result of the status
-			// resources changing.
 			if hasPendingResizes && !retryPendingResizes && oldPod != nil {
+				// If the pod has reached a terminal phase, we retry all pending resizes.
+				if podutil.IsPodTerminal(pod) && !podutil.IsPodTerminal(oldPod) {
+					retryPendingResizes = true
+					triggerReason = allocation.TriggerReasonPodTerminated
+				}
+
+				// If there are pending resizes, check whether the requests shrank as a result of the status
+				// resources changing.
 				opts := resourcehelper.PodResourcesOptions{
 					UseStatusResources:                             true,
 					SkipPodLevelResources:                          !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources),
@@ -3015,8 +3020,11 @@ func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 				newRequest := resourcehelper.PodRequests(allocatedPod, opts)
 
 				// If cpu or memory requests shrank, then retry the pending resizes.
-				retryPendingResizes = newRequest.Memory().Cmp(*oldRequest.Memory()) < 0 ||
-					newRequest.Cpu().Cmp(*oldRequest.Cpu()) < 0
+				if newRequest.Memory().Cmp(*oldRequest.Memory()) < 0 ||
+					newRequest.Cpu().Cmp(*oldRequest.Cpu()) < 0 {
+					retryPendingResizes = true
+					triggerReason = allocation.TriggerReasonPodResized
+				}
 			}
 		}
 
@@ -3051,7 +3059,7 @@ func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		if retryPendingResizes {
-			kl.allocationManager.RetryPendingResizes(allocation.TriggerReasonPodResized)
+			kl.allocationManager.RetryPendingResizes(triggerReason)
 		}
 	}
 }

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -4620,6 +4620,9 @@ func TestHandlePodReconcile_RetryPendingResizes(t *testing.T) {
 		}
 	}
 
+	terminalPod := makePodWithResources("terminal-pod", v1.ResourceList{v1.ResourceCPU: lowCPU, v1.ResourceMemory: lowMem}, v1.ResourceList{v1.ResourceCPU: lowCPU, v1.ResourceMemory: lowMem})
+	terminalPod.Status.Phase = v1.PodFailed
+
 	pendingResizeAllocated := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pod-pending-resize",
@@ -4678,6 +4681,12 @@ func TestHandlePodReconcile_RetryPendingResizes(t *testing.T) {
 			name:                     "requests are decreasing",
 			oldPod:                   makePodWithResources("updated-pod", v1.ResourceList{v1.ResourceCPU: lowCPU, v1.ResourceMemory: lowMem}, v1.ResourceList{v1.ResourceCPU: highCPU, v1.ResourceMemory: highMem}),
 			newPod:                   makePodWithResources("updated-pod", v1.ResourceList{v1.ResourceCPU: enormousCPU, v1.ResourceMemory: enormousMem}, v1.ResourceList{v1.ResourceCPU: lowCPU, v1.ResourceMemory: lowMem}),
+			shouldRetryPendingResize: true,
+		},
+		{
+			name:                     "pod is marked as terminal",
+			oldPod:                   makePodWithResources("terminal-pod", v1.ResourceList{v1.ResourceCPU: lowCPU, v1.ResourceMemory: lowMem}, v1.ResourceList{v1.ResourceCPU: lowCPU, v1.ResourceMemory: lowMem}),
+			newPod:                   terminalPod,
 			shouldRetryPendingResize: true,
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind bug

#### What this PR does / why we need it:

Today, when a pod is deleted, pending resizes are not re-attempted until they are garbage collected in `HandlePodRemoves`. This PR is a small optimization that moves the call to `retryPendingResizes` to `HandlePodReconcile`, so that they can be retried as soon as the pod reaches a terminal state, rather than waiting for the pod to be removed entirely. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/assign @tallclair
/priority important-soon
