### PR TITLE
Ensure latest resource state is fetched consistently in `kubectl describe`

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
@@ -178,6 +178,7 @@ func (o *DescribeOptions) Run() error {
 		ResourceTypeOrNameArgs(true, o.BuilderArgs...).
 		RequestChunksOf(o.DescriberSettings.ChunkSize).
 		Flatten().
+		Latest().
 		Do()
 	err := r.Err()
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR unifies the resource retrieval logic in `kubectl describe` by adding the `.Latest()` call to the resource builder.

Currently, there is an inconsistency in how `kubectl describe` fetches data depending on the input source:
- When running `kubectl describe <type> <name>`, the resource is retrieved directly from the server.
- When running `kubectl describe -f <file>.yaml`, the command relies on the local file content rather than fetching the live state from the cluster.

By adding `.Latest()` to the builder chain, we ensure that even when a resource is initialized from a local file, `kubectl` will perform a request to the API server to retrieve the most up-to-date version of that object before describing it. This ensures that the output of describe always reflects the actual state of the cluster.

The included test case verifies that an API call is made when describing a resource provided via a file path.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubectl/issues/1769

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
