### PR TITLE
Drop support for corev1.Endpoints in kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -5155,7 +5155,6 @@ func TestDescribeEvents(t *testing.T) {
 		m := map[string]ResourceDescriber{
 			"DaemonSetDescriber":             &DaemonSetDescriber{clientset},
 			"DeploymentDescriber":            &DeploymentDescriber{clientset},
-			"EndpointsDescriber":             &EndpointsDescriber{clientset},
 			"EndpointSliceDescriber":         &EndpointSliceDescriber{clientset},
 			"JobDescriber":                   &JobDescriber{clientset},
 			"IngressDescriber":               &IngressDescriber{clientset},
@@ -5187,12 +5186,6 @@ func TestDescribeEvents(t *testing.T) {
 			Spec: appsv1.DeploymentSpec{
 				Replicas: ptr.To[int32](1),
 				Selector: &metav1.LabelSelector{},
-			},
-		},
-		"EndpointsDescriber": &corev1.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bar",
-				Namespace: "foo",
 			},
 		},
 		"EndpointSliceDescriber": &discoveryv1.EndpointSlice{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
It cleans up deprecated `corev1.Endpoints` so we will not have to modify `ResourceDescriber` logic for it when implementing https://github.com/kubernetes/kubectl/issues/1769 and https://github.com/kubernetes/kubernetes/pull/133498.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubectl/issues/1769

#### Does this PR introduce a user-facing change?
```release-note
Dropped support for core/v1 Endpoints in kubectl
```
