### PR TITLE
Fix potential double-locking of RWMutex in device manager

### DIFF
--- a/pkg/kubelet/cm/devicemanager/pod_devices.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices.go
@@ -36,12 +36,14 @@ type deviceAllocateInfo struct {
 	allocResp *pluginapi.ContainerAllocateResponse
 }
 
-type resourceAllocateInfo map[string]deviceAllocateInfo // Keyed by resourceName.
-type containerDevices map[string]resourceAllocateInfo   // Keyed by containerName.
-type podDevices struct {
-	sync.RWMutex
-	devs map[string]containerDevices // Keyed by podUID.
-}
+type (
+	resourceAllocateInfo map[string]deviceAllocateInfo   // Keyed by resourceName.
+	containerDevices     map[string]resourceAllocateInfo // Keyed by containerName.
+	podDevices           struct {
+		sync.RWMutex
+		devs map[string]containerDevices // Keyed by podUID.
+	}
+)
 
 // NewPodDevices is a function that returns object of podDevices type with its own guard
 // RWMutex and a map where key is a pod UID and value contains
@@ -104,16 +106,15 @@ func (pdev *podDevices) podDevices(podUID, resource string) sets.Set[string] {
 
 	ret := sets.New[string]()
 	for contName := range pdev.devs[podUID] {
-		ret = ret.Union(pdev.containerDevices(podUID, contName, resource))
+		ret = ret.Union(pdev.containerDevicesLocked(podUID, contName, resource))
 	}
 	return ret
 }
 
-// Returns list of device Ids allocated to the given container for the given resource.
+// containerDevicesLocked returns list of device Ids allocated to the given container for the given resource.
 // Returns nil if we don't have cached state for the given <podUID, contName, resource>.
-func (pdev *podDevices) containerDevices(podUID, contName, resource string) sets.Set[string] {
-	pdev.RLock()
-	defer pdev.RUnlock()
+// Caller must hold pdev.RLock().
+func (pdev *podDevices) containerDevicesLocked(podUID, contName, resource string) sets.Set[string] {
 	if _, podExists := pdev.devs[podUID]; !podExists {
 		return nil
 	}
@@ -125,6 +126,14 @@ func (pdev *podDevices) containerDevices(podUID, contName, resource string) sets
 		return nil
 	}
 	return devs.deviceIds.Devices()
+}
+
+// Returns list of device Ids allocated to the given container for the given resource.
+// Returns nil if we don't have cached state for the given <podUID, contName, resource>.
+func (pdev *podDevices) containerDevices(podUID, contName, resource string) sets.Set[string] {
+	pdev.RLock()
+	defer pdev.RUnlock()
+	return pdev.containerDevicesLocked(podUID, contName, resource)
 }
 
 // Populates allocatedResources with the device resources allocated to the specified <podUID, contName>.
@@ -220,7 +229,8 @@ func (pdev *podDevices) toCheckpointData(logger klog.Logger) []checkpoint.PodDev
 					ContainerName: conName,
 					ResourceName:  resource,
 					DeviceIDs:     devices.deviceIds,
-					AllocResp:     allocResp})
+					AllocResp:     allocResp,
+				})
 			}
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `podDevices()` function was calling `containerDevices()` while holding the read lock, but `containerDevices()` also attempts to acquire the same lock. This could cause a deadlock when a writer tries to acquire the lock between the two `RLock()` calls.

Introduce `containerDevicesLocked()` that expects the caller to already hold the lock, and use it from `podDevices()` to avoid nested locking.

#### Which issue(s) this PR is related to:

Fixes #127826

#### Special notes for your reviewer:

The fix follows the standard Go pattern of having a `*Locked` variant of a function that expects the caller to hold the lock.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```