### PR TITLE
Add tmpfs detection to mounttest and unit tests

### DIFF
--- a/test/images/agnhost/mounttest/mt_utils.go
+++ b/test/images/agnhost/mounttest/mt_utils.go
@@ -39,7 +39,7 @@ func fsType(path string) error {
 		return err
 	}
 
-	fmt.Printf("mount type of %q: %v\n", path, buf.Type)
+	fmt.Printf("mount type of %q: %s\n", path, formatFsType(int64(buf.Type)))
 
 	return nil
 }

--- a/test/images/agnhost/mounttest/mt_utils_linux.go
+++ b/test/images/agnhost/mounttest/mt_utils_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mounttest
+
+import (
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// formatFsType returns a string representation of the filesystem type.
+// It translates known filesystem magic numbers to human-readable names.
+func formatFsType(fsType int64) string {
+	if fsType == unix.TMPFS_MAGIC {
+		return "tmpfs"
+	}
+	return strconv.FormatInt(fsType, 10)
+}

--- a/test/images/agnhost/mounttest/mt_utils_other.go
+++ b/test/images/agnhost/mounttest/mt_utils_other.go
@@ -1,0 +1,26 @@
+//go:build !linux && !windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mounttest
+
+import "strconv"
+
+// formatFsType returns a string representation of the filesystem type.
+func formatFsType(fsType int64) string {
+	return strconv.FormatInt(fsType, 10)
+}

--- a/test/images/agnhost/mounttest/mt_utils_test.go
+++ b/test/images/agnhost/mounttest/mt_utils_test.go
@@ -1,0 +1,117 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mounttest
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func captureStdout(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestFsType_EmptyPath(t *testing.T) {
+	output := captureStdout(func() {
+		err := fsType("")
+		if err != nil {
+			t.Errorf("fsType(\"\") returned error: %v", err)
+		}
+	})
+
+	if output != "" {
+		t.Errorf("fsType(\"\") should not print anything, got: %q", output)
+	}
+}
+
+func TestFsType_ValidPath(t *testing.T) {
+	// Use a path that exists on the system
+	testPath := os.TempDir()
+
+	output := captureStdout(func() {
+		err := fsType(testPath)
+		if err != nil {
+			t.Errorf("fsType(%q) returned error: %v", testPath, err)
+		}
+	})
+
+	// Verify the output format
+	expectedPrefix := fmt.Sprintf("mount type of %q:", testPath)
+	if !strings.HasPrefix(output, expectedPrefix) {
+		t.Errorf("fsType(%q) output should start with %q, got: %q", testPath, expectedPrefix, output)
+	}
+
+	// Verify the output is printed exactly once (not duplicated)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Errorf("fsType(%q) should print exactly one line, got %d lines: %q", testPath, len(lines), output)
+	}
+}
+
+func TestFsType_NonExistentPath(t *testing.T) {
+	testPath := "/nonexistent/path/that/does/not/exist"
+
+	output := captureStdout(func() {
+		err := fsType(testPath)
+		if err == nil {
+			t.Errorf("fsType(%q) should return error for non-existent path", testPath)
+		}
+	})
+
+	// Should print an error message
+	if !strings.Contains(output, "error from statfs") {
+		t.Errorf("fsType(%q) should print error message, got: %q", testPath, output)
+	}
+}
+
+func TestFormatFsType_Tmpfs(t *testing.T) {
+	result := formatFsType(unix.TMPFS_MAGIC)
+
+	expected := "tmpfs"
+	if result != expected {
+		t.Errorf("formatFsType(TMPFS_MAGIC) = %q, want %q", result, expected)
+	}
+}
+
+func TestFormatFsType_OtherType(t *testing.T) {
+	otherType := int64(0x12345678)
+	result := formatFsType(otherType)
+
+	expected := "305419896"
+	if result != expected {
+		t.Errorf("formatFsType(%v) = %q, want %q", otherType, result, expected)
+	}
+}


### PR DESCRIPTION
Refactor fsType() to use a platform-specific formatFsType() helper that translates filesystem magic numbers to human-readable names. On Linux, tmpfs filesystems now display as "tmpfs" instead of the raw magic number.

Context:
- https://github.com/kubernetes/kubernetes/pull/136234#issuecomment-3753567071
- https://github.com/kubernetes/kubernetes/pull/134243/changes#diff-8d8ec4f6804e0353a6da68d2da21dc358ecc926e64a4eb16a9362b94e0b93dc3R42-R43

Added some unit tests to remind ourselves for next time.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
