### PR TITLE
Eliminate duplicate scale methods deployment controller in favor of a parameter

### DIFF
--- a/pkg/controller/deployment/recreate.go
+++ b/pkg/controller/deployment/recreate.go
@@ -83,7 +83,7 @@ func (dc *DeploymentController) scaleDownOldReplicaSetsForRecreate(ctx context.C
 		if *(rs.Spec.Replicas) == 0 {
 			continue
 		}
-		scaledRS, updatedRS, err := dc.scaleReplicaSetWithLazyAnnotationUpdate(ctx, rs, 0, deployment)
+		scaledRS, updatedRS, err := dc.scaleReplicaSet(ctx, rs, 0, deployment, false)
 		if err != nil {
 			return false, err
 		}
@@ -127,6 +127,6 @@ func oldPodsRunning(newRS *apps.ReplicaSet, oldRSs []*apps.ReplicaSet, podMap ma
 
 // scaleUpNewReplicaSetForRecreate scales up new replica set when deployment strategy is "Recreate".
 func (dc *DeploymentController) scaleUpNewReplicaSetForRecreate(ctx context.Context, newRS *apps.ReplicaSet, deployment *apps.Deployment) (bool, error) {
-	scaled, _, err := dc.scaleReplicaSetWithLazyAnnotationUpdate(ctx, newRS, *(deployment.Spec.Replicas), deployment)
+	scaled, _, err := dc.scaleReplicaSet(ctx, newRS, *(deployment.Spec.Replicas), deployment, false)
 	return scaled, err
 }

--- a/pkg/controller/deployment/rolling.go
+++ b/pkg/controller/deployment/rolling.go
@@ -72,14 +72,14 @@ func (dc *DeploymentController) reconcileNewReplicaSet(ctx context.Context, allR
 	}
 	if *(newRS.Spec.Replicas) > *(deployment.Spec.Replicas) {
 		// Scale down.
-		scaled, _, err := dc.scaleReplicaSetWithLazyAnnotationUpdate(ctx, newRS, *(deployment.Spec.Replicas), deployment)
+		scaled, _, err := dc.scaleReplicaSet(ctx, newRS, *(deployment.Spec.Replicas), deployment, false)
 		return scaled, err
 	}
 	newReplicasCount, err := deploymentutil.NewRSNewReplicas(deployment, allRSs, newRS)
 	if err != nil {
 		return false, err
 	}
-	scaled, _, err := dc.scaleReplicaSetWithLazyAnnotationUpdate(ctx, newRS, newReplicasCount, deployment)
+	scaled, _, err := dc.scaleReplicaSet(ctx, newRS, newReplicasCount, deployment, false)
 	return scaled, err
 }
 
@@ -178,7 +178,7 @@ func (dc *DeploymentController) cleanupUnhealthyReplicas(ctx context.Context, ol
 		if newReplicasCount > *(targetRS.Spec.Replicas) {
 			return nil, 0, fmt.Errorf("when cleaning up unhealthy replicas, got invalid request to scale down %s/%s %d -> %d", targetRS.Namespace, targetRS.Name, *(targetRS.Spec.Replicas), newReplicasCount)
 		}
-		_, updatedOldRS, err := dc.scaleReplicaSetWithLazyAnnotationUpdate(ctx, targetRS, newReplicasCount, deployment)
+		_, updatedOldRS, err := dc.scaleReplicaSet(ctx, targetRS, newReplicasCount, deployment, false)
 		if err != nil {
 			return nil, totalScaledDown, err
 		}
@@ -223,7 +223,7 @@ func (dc *DeploymentController) scaleDownOldReplicaSetsForRollingUpdate(ctx cont
 		if newReplicasCount > *(targetRS.Spec.Replicas) {
 			return 0, fmt.Errorf("when scaling down old RS, got invalid request to scale down %s/%s %d -> %d", targetRS.Namespace, targetRS.Name, *(targetRS.Spec.Replicas), newReplicasCount)
 		}
-		_, _, err := dc.scaleReplicaSetWithLazyAnnotationUpdate(ctx, targetRS, newReplicasCount, deployment)
+		_, _, err := dc.scaleReplicaSet(ctx, targetRS, newReplicasCount, deployment, false)
 		if err != nil {
 			return totalScaledDown, err
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps

#### What this PR does / why we need it:
This initially was attempted in [5f083e3b9f59e27029c08f8f79f70fa809909160](https://github.com/kubernetes/kubernetes/pull/134840/commits) but it caused e2e failing heavily (see
https://github.com/kubernetes/kubernetes/issues/135222 for more details). The changes proposed in https://github.com/kubernetes/kubernetes/pull/135234 clarified the naming of the two existing scale methods but they still leave both of them as is.

This PR goes a step further by combining both into a single method with a parameter `forceUpdate` which is responsible for driving the mode of execution between lazy update and a forced update.

#### Which issue(s) this PR is related to:
None

#### Special notes for your reviewer:
/assign @atiratree 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
