### PR TITLE
kubelet: add unit tests for QoS CPU shares update

### DIFF
--- a/pkg/kubelet/cm/qos_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux_test.go
@@ -19,16 +19,23 @@ limitations under the License.
 package cm
 
 import (
+	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	cres "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
+	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 )
 
 func activeTestPods() []*v1.Pod {
@@ -154,4 +161,263 @@ func TestQoSContainerCgroup(t *testing.T) {
 	guaranteedMin := resource.MustParse("128Mi")
 	assert.Equal(t, qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified["memory.min"], strconv.FormatInt(burstableMin.Value()+guaranteedMin.Value(), 10))
 	assert.Equal(t, qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified["memory.min"], strconv.FormatInt(burstableMin.Value(), 10))
+}
+
+
+// fakeCgroupManager is used because Start() requires a functional
+// CgroupManager. All methods are stubbed so that Start() can
+// complete successfully without using real cgroups. 
+type fakeCgroupManager struct {
+	
+	created []*CgroupConfig
+	updates []*CgroupConfig
+}
+
+// Update() is the observation point for this test.
+// Capture the updated cgroup config so it can be validated.
+func (f *fakeCgroupManager) Update(logger klog.Logger, config *CgroupConfig) error{
+	copiedConfig := *config
+	f.updates = append(f.updates, &copiedConfig)
+	return nil
+}
+
+// Create() must succeed for Start() to construct QoS cgroups.
+// We do not assert on Create() behavior in this test.
+func (f *fakeCgroupManager) Create(l klog.Logger, config *CgroupConfig) error {
+	copiedConfig := *config
+	f.created = append(f.created, &copiedConfig)
+	return nil
+}
+
+func (f *fakeCgroupManager)	Destroy(l klog.Logger,config *CgroupConfig) error {return nil}
+func (f *fakeCgroupManager)	Validate(name CgroupName) error {return nil}
+func (f *fakeCgroupManager)	Exists(name CgroupName) bool {return false}
+func (f *fakeCgroupManager)	Name(name CgroupName) string {return name.ToCgroupfs()}
+func (f *fakeCgroupManager)	CgroupName(name string) CgroupName {return ParseCgroupfsToCgroupName(name)}
+func (f *fakeCgroupManager)	Pids(logger klog.Logger, name CgroupName) []int {return nil}
+func (f *fakeCgroupManager)	ReduceCPULimits(logger klog.Logger, cgroupName CgroupName) error {return nil}
+func (f *fakeCgroupManager)	MemoryUsage(name CgroupName) (int64, error) {return int64(0),nil}
+func (f *fakeCgroupManager)	GetCgroupConfig(name CgroupName, resource v1.ResourceName) (*ResourceConfig, error) {return nil,nil}
+func (f *fakeCgroupManager)	SetCgroupConfig(logger klog.Logger, name CgroupName, resourceConfig *ResourceConfig) error {return nil}
+func (f *fakeCgroupManager)	Version() int {return 1}
+
+func expectedCPUShares(activeTestPods ActivePodsFunc) uint64 {
+	var pods []*v1.Pod = activeTestPods()
+
+	burstablePodCPURequest := int64(0)
+	for i := range pods {
+		pod := pods[i]
+		qosClass := v1qos.GetPodQOS(pod)
+		if qosClass != v1.PodQOSBurstable {
+			// we only care about the burstable qos tier
+			continue
+		}	
+		req := cres.PodRequests(pod, cres.PodResourcesOptions{})
+		if request, found := req[v1.ResourceCPU]; found {
+			burstablePodCPURequest += request.MilliValue()
+		}
+	}
+	// set burstable shares based on current observe state
+	burstableCPUShares := MilliCPUToShares(burstablePodCPURequest)
+	return burstableCPUShares
+}
+
+func guaranteedTestPods() []*v1.Pod{
+	return []*v1.Pod{
+		
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(uuid.NewUUID()),
+				Name: "guaranteed-pod",
+				Namespace: "test",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "foo",
+						Image: "busybox",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:resource.MustParse("1"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
+
+	}
+}
+
+func burstableTestPods() []*v1.Pod{
+	return []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(uuid.NewUUID()),
+				Name: "burstable-pod",
+				Namespace: "test",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "foo",
+						Image: "busybox",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:resource.MustParse("1"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:resource.MustParse("2"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func bestEffortTestPods() []*v1.Pod{
+	return []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: types.UID(uuid.NewUUID()),
+				Name: "besteffort-pod",
+				Namespace: "test",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "foo",
+						Image: "busybox",
+					},
+				},
+			},
+		},
+	}
+} 
+
+func guaranteedAndBurstableTestPods() []*v1.Pod {
+	pods := []*v1.Pod{}
+	pods = append(pods, guaranteedTestPods()...)
+	pods = append(pods, burstableTestPods()...)
+	return pods
+}
+func besteffortAndBurstableTestPods() []*v1.Pod {
+	pods := []*v1.Pod{}
+	pods = append(pods, bestEffortTestPods()...)
+	pods = append(pods, burstableTestPods()...)
+	return pods
+}
+
+// TestQOSCPUConfigUpdate verifies that UpdateCgroups() computes and
+// updates the correct CPU shares for each QoS class based on the
+// currently active pods.
+func TestQOSCPUConfigUpdate(t *testing.T){
+
+	tests := []struct{
+		name string
+		testPods ActivePodsFunc
+		expectedCPUShares uint64
+	}{
+		{
+			name: "guaranteed-pods-only",
+			testPods: guaranteedTestPods,
+			expectedCPUShares:expectedCPUShares(guaranteedTestPods),
+		},
+		{
+			name: "burstable-pods-only",
+			testPods: burstableTestPods,
+			expectedCPUShares: expectedCPUShares(burstableTestPods),
+		},
+		{
+			name: "besteffort-pods-only",
+			testPods: bestEffortTestPods,
+			expectedCPUShares: expectedCPUShares(bestEffortTestPods),
+		},
+		{
+			name: "guaranteed-and-burstable-pods",
+			testPods: guaranteedAndBurstableTestPods,
+			expectedCPUShares: expectedCPUShares(guaranteedAndBurstableTestPods),
+		},
+		{
+			name: "besteffort-and-burstable-pods",
+			testPods: besteffortAndBurstableTestPods,
+			expectedCPUShares: expectedCPUShares(besteffortAndBurstableTestPods),
+		},
+	}
+
+	for _,testCase := range tests{
+
+		t.Run(testCase.name, func(t *testing.T) {
+
+	testContainerManager,err := createTestQOSContainerManager(logr.Logger{})
+	if err!=nil{
+		t.Fatalf("Unable to create Test Qos Container Manager: %s", err)
+		return
+	}
+	
+	var fakecgroupManager = &fakeCgroupManager{}
+	testContainerManager.cgroupManager = fakecgroupManager
+
+	err=testContainerManager.Start(context.Background(), func() v1.ResourceList {return v1.ResourceList{}}, testCase.testPods)
+	if err!=nil{
+		t.Fatalf("Start() failed: %s",err)
+	}
+
+	// UpdateCgroups() is expected to update all QoS cgroups on each call
+	// based on the current active pod set.
+	err = testContainerManager.UpdateCgroups(logr.Logger{})
+	if err!=nil{
+		t.Fatalf("Error in UpdateCgroups(): %s", err)
+	}
+
+	//These flags will be used to check whether UpdateCgroups()
+	//is updating the CPU shares for all QoS classes (cgroups) 
+	foundBurstable := false
+	foundBestEffort := false
+	foundGuaranteed := false
+
+	for _,config := range fakecgroupManager.updates {
+
+		if strings.HasSuffix(config.Name.ToCgroupfs(), "burstable"){
+			foundBurstable = true
+			if *config.ResourceParameters.CPUShares != testCase.expectedCPUShares{
+				t.Fatalf("Expected CPU Shares for Burstable: %d. Got: %d",testCase.expectedCPUShares, *config.ResourceParameters.CPUShares)
+			}
+			continue
+		}
+
+		if strings.HasSuffix(config.Name.ToCgroupfs(), "besteffort"){
+			foundBestEffort = true
+			if *config.ResourceParameters.CPUShares != MinShares {
+				t.Fatalf("Expected CPU Shares for BestEffort: %d Got: %d", MinShares, *config.ResourceParameters.CPUShares)
+			}
+			continue
+		}
+
+		if config.Name.ToCgroupfs() == testContainerManager.cgroupRoot.ToCgroupfs() {
+			foundGuaranteed = true
+			if  config.ResourceParameters != nil && config.ResourceParameters.CPUShares != nil{
+				t.Fatalf("Expected CPU Shares for Guaranteed: <nil>, Got: %d", *config.ResourceParameters.CPUShares)
+			}
+		}
+	}
+
+	if !foundBurstable {
+	t.Fatalf("burstable cgroup not found")
+}
+if !foundBestEffort {
+	t.Fatalf("besteffort cgroup not found")
+}
+if !foundGuaranteed {
+	t.Fatalf("guaranteed cgroup not found")
+}
+
+}) 
+
+	}
 }


### PR DESCRIPTION
Add unit test coverage for UpdateCgroups() to verify that CPU shares are correctly computed and applied for Guaranteed, Burstable, and BestEffort QoS classes based on active pods.

This improves test coverage in the QoS container manager area, as suggested in tracker #109717.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:
This PR adds unit test coverage for UpdateCgroups() in the kubelet QoS
container manager.

The test verifies that CPU shares are correctly computed and applied
for Guaranteed, Burstable, and BestEffort QoS classes based on the
currently active pod set.

Improving coverage in this area helps document and preserve existing
QoS resource-management behavior and reduces the risk of regressions
during future refactoring.
#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Part of #109717

#### Special notes for your reviewer:
The test uses a fake CgroupManager to allow Start() and UpdateCgroups()
to execute without relying on real cgroup interactions.

UpdateCgroups() is expected to update all QoS cgroups on each invocation
based on the current active pod set; this assumption is documented and
validated explicitly by the test.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
