### PR TITLE
Make sure errors present in declarative validation test files are DV …

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -282,7 +282,7 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 	var imperativeErrs field.ErrorList
 
 	// The errOutputMatcher is used to verify the output matches the expected errors in test cases.
-	errOutputMatcher := field.ErrorMatcher{}.ByType().ByOrigin().ByFieldNormalized(opt.NormalizationRules)
+	errOutputMatcher := field.ErrorMatcher{}.ByType().ByOrigin().ByFieldNormalized(opt.NormalizationRules).ByDeclarativeNative()
 
 	// We only need to test both gate enabled and disabled together, because
 	// 1) the DeclarativeValidationTakeover won't take effect if DeclarativeValidation is disabled.
@@ -298,6 +298,13 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 			errOutputMatcher.Test(t, expectedErrs, declarativeTakeoverErrs)
 		} else if len(declarativeTakeoverErrs) != 0 {
 			t.Errorf("expected no errors, but got: %v", declarativeTakeoverErrs)
+		}
+
+		// make sure all errors marked by covered by declarative validations, are actually covered.
+		for _, err := range declarativeTakeoverErrs {
+			if err.CoveredByDeclarative {
+				t.Errorf("error %v should be covered by declarative validation", err)
+			}
 		}
 	})
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR enhances the testing framework for **Declarative Validation (KEP-5073)** by updating the shared validation testing utilities in `pkg/api/testing/validation.go`.

Specifically, it:
1.  **Refines Error Matching**: Updates the `errOutputMatcher` to include `.ByDeclarativeNative()`. This allows the testing framework to distinguish and verify errors produced by native declarative validation rules, which are programmatically identified via the `.MarkDeclarativeOnly()` method.
2.  **Strengthens Equivalence Testing**: Adds a verification loop to the `verifyValidationEquivalence` process to ensure that errors generated during the declarative "takeover" path are correctly accounted for and covered.



#### Which issue(s) this PR is related to:
*   Related to **KEP-5073**: [Declarative Validation of Kubernetes Native Types With validation-gen](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md)

#### Special notes for your reviewer:
The updated matcher now enforces that errors marked with the `+k8s:declarativeValidationNative` tag (or equivalent) are correctly identified by the test suite. The added check in `pkg/api/testing/validation.go` serves as a safeguard to ensure that no errors intended to be covered by the declarative path are missed during the "soak" and verification period.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
*   [KEP-5073]