### PR TITLE
Fix the bug where the timeout setting in WaitForAPIServer does not take effect

### DIFF
--- a/staging/src/k8s.io/controller-manager/app/helper.go
+++ b/staging/src/k8s.io/controller-manager/app/helper.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kubernetes/kubernetes/vendor/k8s.io/klog/v2"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
@@ -31,23 +32,26 @@ import (
 // WaitForAPIServer waits for the API Server's /healthz endpoint to report "ok" with timeout.
 func WaitForAPIServer(client clientset.Interface, timeout time.Duration) error {
 	var lastErr error
+	timeoutCtx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
 
-	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		healthStatus := 0
-		result := client.Discovery().RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).StatusCode(&healthStatus)
-		if result.Error() != nil {
-			lastErr = fmt.Errorf("failed to get apiserver /healthz status: %v", result.Error())
-			return false, nil
-		}
-		if healthStatus != http.StatusOK {
-			content, _ := result.Raw()
-			lastErr = fmt.Errorf("APIServer isn't healthy: %v", string(content))
-			klog.Warningf("APIServer isn't healthy yet: %v. Waiting a little while.", string(content))
-			return false, nil
-		}
+	err := wait.PollImmediateWithContext(timeoutCtx, time.Second, timeout,
+		func(ctx context.Context) (done bool, err error) {
+			healthStatus := 0
+			result := client.Discovery().RESTClient().Get().AbsPath("/healthz").Do(ctx).StatusCode(&healthStatus)
+			if result.Error() != nil {
+				lastErr = fmt.Errorf("failed to get apiserver /healthz status: %v", result.Error())
+				return false, nil
+			}
+			if healthStatus != http.StatusOK {
+				content, _ := result.Raw()
+				lastErr = fmt.Errorf("APIServer isn't healthy: %v", string(content))
+				klog.Warningf("APIServer isn't healthy yet: %v. Waiting a little while.", string(content))
+				return false, nil
+			}
 
-		return true, nil
-	})
+			return true, nil
+		})
 
 	if err != nil {
 		return fmt.Errorf("%v: %v", err, lastErr)


### PR DESCRIPTION

fix issue: https://github.com/kubernetes/kubernetes/issues/136237

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #136237 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix the bug where the timeout setting in WaitForAPIServer does not take effect
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
