### PR TITLE
Remove unused PodStatusResult type

### DIFF
--- a/pkg/apis/core/register.go
+++ b/pkg/apis/core/register.go
@@ -54,7 +54,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Pod{},
 		&PodList{},
-		&PodStatusResult{},
 		&PodTemplate{},
 		&PodTemplateList{},
 		&ReplicationControllerList{},

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4655,18 +4655,6 @@ type PodStatus struct {
 	Resources *ResourceRequirements
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
-type PodStatusResult struct {
-	metav1.TypeMeta
-	// +optional
-	metav1.ObjectMeta
-	// Status represents the current information about a pod. This data may not be up
-	// to date.
-	// +optional
-	Status PodStatus
-}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/staging/src/k8s.io/api/core/v1/register.go
+++ b/staging/src/k8s.io/api/core/v1/register.go
@@ -46,7 +46,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Pod{},
 		&PodList{},
-		&PodStatusResult{},
 		&PodTemplate{},
 		&PodTemplateList{},
 		&ReplicationController{},

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5439,24 +5439,6 @@ type PodStatus struct {
 	Resources *ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,20,opt,name=resources"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:prerelease-lifecycle-gen:introduced=1.0
-
-// PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
-type PodStatusResult struct {
-	metav1.TypeMeta `json:",inline"`
-	// Standard object's metadata.
-	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	// Most recently observed status of the pod.
-	// This data may not be up to date.
-	// Populated by the system.
-	// Read-only.
-	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
-	Status PodStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
-}
 
 // +genclient
 // +genclient:method=UpdateEphemeralContainers,verb=update,subresource=ephemeralcontainers

--- a/test/integration/apiserver/cel/typeresolution_test.go
+++ b/test/integration/apiserver/cel/typeresolution_test.go
@@ -348,7 +348,7 @@ func TestBuiltinResolution(t *testing.T) {
 					continue
 				}
 				// skip private, reference, and alias types that cannot appear in the wild
-				if gvk.Kind == "SerializedReference" || gvk.Kind == "List" || gvk.Kind == "RangeAllocation" || gvk.Kind == "PodStatusResult" {
+				if gvk.Kind == "SerializedReference" || gvk.Kind == "List" || gvk.Kind == "RangeAllocation" {
 					continue
 				}
 				// skip internal types

--- a/test/integration/apiserver/print_test.go
+++ b/test/integration/apiserver/print_test.go
@@ -61,7 +61,6 @@ var kindAllowList = sets.NewString(
 	"PodPortForwardOptions",
 	"PodLogOptions",
 	"PodProxyOptions",
-	"PodStatusResult",
 	"RangeAllocation",
 	"ServiceProxyOptions",
 	"SerializedReference",


### PR DESCRIPTION
## Summary

The `PodStatusResult` type was introduced in 2015 (PR #3565) but has never been used anywhere in the codebase. This PR removes it to reduce maintenance burden when modifying pod status fields.

Changes:
- Remove `PodStatusResult` type definition from `staging/src/k8s.io/api/core/v1/types.go`
- Remove `PodStatusResult` type definition from `pkg/apis/core/types.go`  
- Remove type registration from both `register.go` files
- Update test files that were explicitly skipping this unused type

Fixes #136250

/sig node
/kind cleanup