### PR TITLE
golangci-lint: enforce control over ginkgo.ReportBeforeSuite/ReportAfterSuite

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -212,6 +212,10 @@ linters:
       - text: "field (CapacityRequirements.Requests|DeviceRequestAllocationResult.ConsumedCapacity) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
 
+      - linters:
+        - forbidigo
+        path: test/e2e/e2e_test\.go|test/e2e/framework/internal/.*|test/e2e/framework/[^/]*\.go|test/e2e/invariants/.*
+
   default: standard
   enable: # please keep this alphabetized
     - depguard
@@ -487,6 +491,10 @@ linters:
         - pattern: \.Add$
           pkg: ^k8s\.io/component-base/featuregate$         
           msg: should not use Add, use AddVersioned instead
+        - pattern: \.(ReportBeforeSuite|ReportAfterSuite)
+          pkg: ^github\.com/onsi/ginkgo/v2$
+          msg: usage is restricted to code under control of SIG Testing
+          # Exceptions are listed above under rules.
         - pattern: ^gomega\.BeTrue$
           pkg: ^github.com/onsi/gomega$
           msg: "it does not produce a good failure message - use BeTrueBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -223,6 +223,10 @@ linters:
       - text: "field (CapacityRequirements.Requests|DeviceRequestAllocationResult.ConsumedCapacity) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
 
+      - linters:
+        - forbidigo
+        path: test/e2e/e2e_test\.go|test/e2e/framework/internal/.*|test/e2e/framework/[^/]*\.go|test/e2e/invariants/.*
+
   default: none
   enable: # please keep this alphabetized
     - depguard
@@ -496,6 +500,10 @@ linters:
         - pattern: \.Add$
           pkg: ^k8s\.io/component-base/featuregate$         
           msg: should not use Add, use AddVersioned instead
+        - pattern: \.(ReportBeforeSuite|ReportAfterSuite)
+          pkg: ^github\.com/onsi/ginkgo/v2$
+          msg: usage is restricted to code under control of SIG Testing
+          # Exceptions are listed above under rules.
     gocritic:
       enabled-checks: # These are in addition to the default checks - see https://golangci-lint.run/docs/linters/configuration/#gocritic
         - boolExprSimplify

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -152,6 +152,10 @@ linters:
         
       {{include "hack/kube-api-linter/exceptions.yaml" | indent 6 | trim}}
 
+      - linters:
+        - forbidigo
+        path: test/e2e/e2e_test\.go|test/e2e/framework/internal/.*|test/e2e/framework/[^/]*\.go|test/e2e/invariants/.*
+
   default: {{if .Base -}} none {{- else -}} standard {{- end}}
   enable: # please keep this alphabetized
     - depguard
@@ -231,7 +235,11 @@ linters:
           msg: should not be used because managedFields was removed
         - pattern: \.Add$
           pkg: ^k8s\.io/component-base/featuregate$         
-          msg: should not use Add, use AddVersioned instead 
+          msg: should not use Add, use AddVersioned instead
+        - pattern: \.(ReportBeforeSuite|ReportAfterSuite)
+          pkg: ^github\.com/onsi/ginkgo/v2$
+          msg: usage is restricted to code under control of SIG Testing
+          # Exceptions are listed above under rules.
       {{- if .Hints}}
         - pattern: ^gomega\.BeTrue$
           pkg: ^github.com/onsi/gomega$


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://git.k8s.io/enhancements/keps/sig-testing/5468-invariant-testing introduced a mechanism for tests which hook into the test suite run via ginkgo.ReportAfterSuite. Usage was limited to code in test/e2e/invariants with stricter reviews.

However, this was not enforced mechanically. With forbidigo we can be sure that nothing slips through.

ginkgo.ReportBeforeSuite has similar restrictions.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/133844 is meant to be flagged by this check.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @BenTheElder 
/sig testing
