### PR TITLE
Update scheduler_perf test throughput thresholds

### DIFF
--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -167,14 +167,15 @@ Most test cases have a threshold set for the largest `performance` workloads.
 By default, these are defined for the `Average` statistic of the `SchedulingThroughput` metric. 
 It is possible to use other metric by configuring `thresholdMetricSelector` per test case or workload. 
 
+If the actual metric value is below the threshold, the test will fail.
+
 ### How to calculate the threshold
 
-The initial values for scheduling throughput thresholds were calculated through an analysis of historical data, 
-specifically focusing on the minimum, average, and standard deviation values for each workload 
-(see [#126871](https://github.com/kubernetes/kubernetes/pull/126871)). 
-Our goal is to set the thresholds somewhat pessimistically to minimize flakiness, 
-so it's recommended to set the threshold slightly below the observed historical minimum. 
-Depending on variability of data, the threshold can be lowered more. 
+The current values for scheduling throughput thresholds were calculated through an analysis of historical data, taking the minimum average value from the most recent 250 test runs.
+
+It's important to note that any test failure will result in a workflow failure,
+and consecutive workflow failures will raise an alert.
+Our goal is to set the thresholds somewhat pessimistically to minimize flakiness.
 
 Thresholds should be adjusted based on the flakiness level and minima observed in the future. 
 Remember to set the value for newly added test cases as well, 

--- a/test/integration/scheduler_perf/affinity/performance-config.yaml
+++ b/test/integration/scheduler_perf/affinity/performance-config.yaml
@@ -63,7 +63,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 60
+    threshold: 180
     params:
       initNodes: 5000
       initPods: 1000
@@ -72,7 +72,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 60
+    threshold: 180
     params:
       initNodes: 5000
       initPods: 1000
@@ -186,7 +186,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 35
+    threshold: 70
     params:
       initNodes: 5000
       initPods: 5000
@@ -195,7 +195,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 35
+    threshold: 70
     params:
       initNodes: 5000
       initPods: 5000
@@ -247,7 +247,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 90
+    threshold: 160
     params:
       initNodes: 5000
       initPods: 5000
@@ -256,7 +256,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 90
+    threshold: 160
     params:
       initNodes: 5000
       initPods: 5000
@@ -309,7 +309,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 90
+    threshold: 190
     params:
       initNodes: 5000
       initPods: 5000
@@ -318,7 +318,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 90
+    threshold: 190
     params:
       initNodes: 5000
       initPods: 5000
@@ -369,7 +369,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 220
+    threshold: 540
     params:
       initNodes: 5000
       initPods: 5000
@@ -378,7 +378,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 220
+    threshold: 540
     params:
       initNodes: 5000
       initPods: 5000
@@ -449,7 +449,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 140
+    threshold: 540
     params:
       initNodes: 5000
       initPods: 2000
@@ -458,7 +458,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 140
+    threshold: 540
     params:
       initNodes: 5000
       initPods: 2000
@@ -523,7 +523,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 24
+    threshold: 140
     params:
       initNodes: 6000
       initPodsPerNamespace: 40
@@ -533,7 +533,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 24
+    threshold: 140
     params:
       initNodes: 6000
       initPodsPerNamespace: 40
@@ -599,7 +599,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 55
+    threshold: 180
     params:
       initNodes: 5000
       initPodsPerNamespace: 40
@@ -609,7 +609,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 55
+    threshold: 180
     params:
       initNodes: 5000
       initPodsPerNamespace: 40
@@ -678,7 +678,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 35
+    threshold: 180
     params:
       initNodes: 5000
       initPodsPerNamespace: 50
@@ -688,7 +688,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 35
+    threshold: 180
     params:
       initNodes: 5000
       initPodsPerNamespace: 50
@@ -753,7 +753,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 90
+    threshold: 190
     params:
       initNodes: 5000
       initPodsPerNamespace: 50
@@ -763,7 +763,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 90
+    threshold: 190
     params:
       initNodes: 5000
       initPodsPerNamespace: 50
@@ -807,7 +807,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 110
+    threshold: 750
     params:
       gatedPods: 10000
       measurePods: 20000
@@ -815,7 +815,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 110
+    threshold: 750
     params:
       gatedPods: 10000
       measurePods: 20000

--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -68,7 +68,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 270
+    threshold: 680
     params:
       initNodes: 5000
       initPods: 1000
@@ -77,7 +77,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 270
+    threshold: 680
     params:
       initNodes: 5000
       initPods: 1000
@@ -113,8 +113,8 @@
 - name: SchedulingDaemonset
   defaultPodTemplatePath: ../templates/daemonset-pod.yaml
   workloadTemplate:
-    # Create one node with a specific name (scheduler-perf-node),
-    # which is supposed to get all Pods created in this test case.
+  # Create one node with a specific name (scheduler-perf-node),
+  # which is supposed to get all Pods created in this test case.
   - opcode: createNodes
     count: 1
     nodeTemplatePath: ../templates/node-with-name.yaml
@@ -147,7 +147,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 390
+    threshold: 1100
     params:
       initNodes: 15000
       measurePods: 30000
@@ -155,7 +155,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 390
+    threshold: 1100
     params:
       initNodes: 15000
       measurePods: 30000
@@ -289,7 +289,7 @@
       measurePods: 500
   - name: 5000Nodes
     labels: [performance]
-    threshold: 160
+    threshold: 570
     featureGates:
       SchedulerQueueingHints: false
       SchedulerAsyncPreemption: false
@@ -298,7 +298,7 @@
       initPods: 20000
       measurePods: 5000
   - name: 5000Nodes_AsyncPreemptionEnabled
-    threshold: 160
+    threshold: 570
     labels: [performance]
     featureGates:
       SchedulerAsyncPreemption: true
@@ -312,7 +312,7 @@
       SchedulerQueueingHints: true
       SchedulerAsyncAPICalls: false
     labels: [performance]
-    threshold: 160
+    threshold: 570
     params:
       initNodes: 5000
       initPods: 20000
@@ -322,7 +322,7 @@
       SchedulerQueueingHints: true
       SchedulerAsyncAPICalls: true
     labels: [performance]
-    threshold: 160
+    threshold: 570
     params:
       initNodes: 5000
       initPods: 20000
@@ -386,7 +386,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 140
+    threshold: 590
     params:
       initNodes: 5000
       initPods: 100
@@ -396,7 +396,7 @@
       SchedulerQueueingHints: true
       SchedulerAsyncAPICalls: false
     labels: [performance]
-    threshold: 170
+    threshold: 590
     params:
       initNodes: 5000
       initPods: 100
@@ -406,7 +406,7 @@
       SchedulerQueueingHints: true
       SchedulerAsyncAPICalls: true
     labels: [performance]
-    threshold: 170
+    threshold: 590
     params:
       initNodes: 5000
       initPods: 100
@@ -481,7 +481,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 265
+    threshold: 710
     params:
       initNodes: 5000
       measurePods: 10000
@@ -489,7 +489,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 265
+    threshold: 710
     params:
       initNodes: 5000
       measurePods: 10000
@@ -544,7 +544,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 130
+    threshold: 910
     params:
       gatedPods: 10000
       deletingPods: 20000
@@ -553,7 +553,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 130
+    threshold: 910
     params:
       gatedPods: 10000
       deletingPods: 20000

--- a/test/integration/scheduler_perf/topology_spreading/performance-config.yaml
+++ b/test/integration/scheduler_perf/topology_spreading/performance-config.yaml
@@ -64,7 +64,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 85
+    threshold: 480
     params:
       initNodes: 5000
       initPods: 5000
@@ -73,7 +73,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 85
+    threshold: 480
     params:
       initNodes: 5000
       initPods: 5000
@@ -126,7 +126,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 125
+    threshold: 340
     params:
       initNodes: 5000
       initPods: 5000
@@ -135,7 +135,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 125
+    threshold: 340
     params:
       initNodes: 5000
       initPods: 5000
@@ -246,7 +246,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance, short]
-    threshold: 68
+    threshold: 270
     params:
       taintNodes: 1000
       normalNodes: 4000
@@ -255,7 +255,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance, short]
-    threshold: 68
+    threshold: 270
     params:
       taintNodes: 1000
       normalNodes: 4000

--- a/test/integration/scheduler_perf/volumes/performance-config.yaml
+++ b/test/integration/scheduler_perf/volumes/performance-config.yaml
@@ -58,7 +58,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 260
+    threshold: 790
     params:
       initNodes: 5000
       initPods: 1000
@@ -67,7 +67,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 260
+    threshold: 790
     params:
       initNodes: 5000
       initPods: 1000
@@ -118,7 +118,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 90
+    threshold: 290
     params:
       initNodes: 5000
       initPods: 1000
@@ -127,7 +127,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 90
+    threshold: 290
     params:
       initNodes: 5000
       initPods: 1000
@@ -187,7 +187,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 35
+    threshold: 100
     params:
       initNodes: 5000
       initPods: 5000
@@ -196,7 +196,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 35
+    threshold: 100
     params:
       initNodes: 5000
       initPods: 5000
@@ -254,7 +254,7 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    threshold: 48
+    threshold: 100
     params:
       initNodes: 5000
       initPods: 5000
@@ -263,7 +263,7 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    threshold: 48
+    threshold: 100
     params:
       initNodes: 5000
       initPods: 5000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

The throughput thresholds set in #126871 can now be increased significantly. The thresholds are computed from the minimum average value for a given test from the last 250 runs.

I also included the formula for computing the thresholds and the caveats in the readme.

Methodology:

I've taken the results from the last 540 runs, then tried various formulas for computing thresholds from the most recent 250 runs and checked how many times we get 3 consecutive failures across the whole dataset which would result in an alert.

I tried various formulas including bottom 10%, bottom 1% and minimum value. Only the minimum value resulted in reasonable alert frequency (0 alerts in the last 400 builds). For tests that have multiple variants, I used `max(variant thresholds)` as the final threshold for all variants.

You can find the data and the analysis in https://docs.google.com/spreadsheets/d/1Ronfj9VuX2a-l3c5XRGcakldLNjLVFmsUdTxY_mfJSs/edit?usp=sharing

Note that we would be able to set much more aggressive thresholds (e.g. p10) if each test was considered separately for the alerts.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
