### PR TITLE
fix(kubelet):resolve loop variable capture bug in WaitForAllPodsUnmount

### DIFF
--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -516,6 +516,7 @@ func (vm *volumeManager) WaitForAllPodsUnmount(ctx context.Context, pods []*v1.P
 
 	funcs := make([]func() error, 0, len(pods))
 	for _, pod := range pods {
+		pod := pod
 		funcs = append(funcs, func() error {
 			return vm.WaitForUnmount(ctx, pod)
 		})

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -743,6 +743,14 @@ func TestWaitForAllPodsUnmount(t *testing.T) {
 				require.ErrorAs(t, err, &aggErr, "Expected error to be an Aggregate error")
 				errs := aggErr.Errors()
 				require.Len(t, errs, test.numPods, "Expected %d errors but got %d", test.numPods, len(errs))
+
+				// Verify that each pod's volume name appears in the error messages,
+				// which proves different pods are being processed
+				errString := err.Error()
+				for i := 0; i < test.numPods; i++ {
+					volumeName := fmt.Sprintf("fake/fake-device-%d", i)
+					require.Contains(t, errString, volumeName, "Expected error to contain volume name %s for pod-%d", volumeName, i)
+				}
 			} else {
 				require.NoError(t, err, "Expected no error")
 			}


### PR DESCRIPTION
#### What type of PR is this?
﻿
/kind bug
/kind flake
﻿
#### What this PR does / why we need it:
﻿
This PR fixes a goroutine closure bug in `WaitForAllPodsUnmount` where the loop variable `pod` was being captured by reference instead of by value.
﻿
**Problem:**
All goroutines created in the loop were capturing the same `pod` variable reference. When executed concurrently, they would all operate on the last pod in the slice instead of their intended pod. This caused intermittent test failures because some pods' volumes were never properly unmounted.
﻿
**Solution:**
Create a local copy of the loop variable within each iteration using `pod := pod`. This ensures each closure captures a distinct pod instance, allowing all pods to be processed correctly in parallel.
﻿
#### Which issue(s) this PR is related to:
﻿
Fixes #<issue-number>
https://github.com/kubernetes/kubernetes/issues/136255
﻿
﻿
#### Does this PR introduce a user-facing change?
﻿
```release-note
NONE