### PR TITLE
controller-manager: Add ControllerManagerReleaseLeaderElectionLockOnCancel feature gate

### DIFF
--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -40,6 +40,11 @@ const (
 	// kep:  http://kep.k8s.io/2699
 	// Enable webhook in cloud controller manager
 	CloudControllerManagerWebhook featuregate.Feature = "CloudControllerManagerWebhook"
+
+	// owner: @jefftree, @tchap
+	//
+	// Make kube-controller-manager release leader election lock on exit.
+	ControllerManagerReleaseLeaderElectionLockOnExit featuregate.Feature = "ControllerManagerReleaseLeaderElectionLockOnExit"
 )
 
 func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.MutableVersionedFeatureGate) error {
@@ -54,5 +59,8 @@ var versionedCloudPublicFeatureGates = map[featuregate.Feature]featuregate.Versi
 	},
 	CloudControllerManagerWebhook: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	ControllerManagerReleaseLeaderElectionLockOnExit: {
+		{Version: version.MustParse("1.36"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -305,6 +305,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.30"
+- name: ControllerManagerReleaseLeaderElectionLockOnExit
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.36"
 - name: CoordinatedLeaderElection
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The feature gate is needed so that we can conditionally release leader election lock on exit in `kube-controller-manager`.

This is going to be followed by actually conditionally enabling that feature in `kube-controller-manager`.

#### Which issue(s) this PR is related to:

Followup to PR https://github.com/kubernetes/kubernetes/pull/132620

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Added ControllerManagerReleaseLeaderElectionLockOnCancel feature gate to gate leader election lock release on exit for kube-controller-manager
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A