### PR TITLE
Automated cherry pick of #135918: kubectl: Fix panic in exec terminal size queue

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -411,6 +411,10 @@ type terminalSizeQueueAdapter struct {
 }
 
 func (a *terminalSizeQueueAdapter) Next() *remotecommand.TerminalSize {
+	if a.delegate == nil {
+		return nil
+	}
+
 	next := a.delegate.Next()
 	if next == nil {
 		return nil


### PR DESCRIPTION
Cherry pick of #135918 on release-1.35.

#135918: kubectl: Fix panic in exec terminal size queue

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a panic in `kubectl exec` when the terminal size queue delegate is uninitialized.
```