### PR TITLE
Automated cherry pick of #135685: Bugfix: calculate request latency properly in audit log filter

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -149,7 +149,6 @@ func evaluatePolicyAndCreateAuditEvent(req *http.Request, policy audit.PolicyRul
 
 // writeLatencyToAnnotation writes the latency incurred in different
 // layers of the apiserver to the annotations of the audit object.
-// it should be invoked after ev.StageTimestamp has been set appropriately.
 func writeLatencyToAnnotation(ctx context.Context) {
 	ac := audit.AuditContextFrom(ctx)
 	// we will track latency in annotation only when the total latency
@@ -157,7 +156,7 @@ func writeLatencyToAnnotation(ctx context.Context) {
 	// traces in rest/handlers for create, delete, update,
 	// get, list, and deletecollection.
 	const threshold = 500 * time.Millisecond
-	latency := ac.GetEventStageTimestamp().Sub(ac.GetEventRequestReceivedTimestamp().Time)
+	latency := time.Since(ac.GetEventRequestReceivedTimestamp().Time)
 	if latency <= threshold {
 		return
 	}


### PR DESCRIPTION
Cherry pick of #135685 on release-1.35.

#135685: Bugfix: calculate request latency properly in audit log filter

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.34+ regression reporting apiserver request latency annotation in the audit log when request took more than 500ms 
```
