### PR TITLE
DRA tests: stop using deprecated ktesting functions

### DIFF
--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -664,7 +664,7 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 
 	// Wait for registration.
 	tCtx.Log("wait for plugin registration")
-	ktesting.Eventually(tCtx, func(tCtx ktesting.TContext) map[string][]app.GRPCCall {
+	tCtx.Eventually(func(tCtx ktesting.TContext) map[string][]app.GRPCCall {
 		notRegistered := make(map[string][]app.GRPCCall)
 		for nodename, plugin := range d.Nodes {
 			calls := plugin.GetGRPCCalls()
@@ -995,7 +995,7 @@ func (d *Driver) TearDown(tCtx ktesting.TContext) {
 // Only use this in tests where kubelet support for DRA is guaranteed.
 func (d *Driver) IsGone(tCtx ktesting.TContext) {
 	tCtx.Logf("Waiting for ResourceSlices of driver %s to be removed...", d.Name)
-	ktesting.Eventually(tCtx, d.NewGetSlices()).WithTimeout(2 * time.Minute).Should(gomega.HaveField("Items", gomega.BeEmpty()))
+	tCtx.Eventually(d.NewGetSlices()).WithTimeout(2 * time.Minute).Should(gomega.HaveField("Items", gomega.BeEmpty()))
 }
 
 func (d *Driver) interceptor(nodename string, ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {

--- a/test/e2e_dra/coredra_test.go
+++ b/test/e2e_dra/coredra_test.go
@@ -56,13 +56,13 @@ func coreDRA(tCtx ktesting.TContext, b *drautils.Builder) upgradedTestFunc {
 			// to the restarted apiserver. Sometimes, attempts fail with "EOF" as error
 			// or (even weirder) with
 			//     getting *v1.Pod: pods "tester-2" is forbidden: User "kubernetes-admin" cannot get resource "pods" in API group "" in the namespace "dra-9021"
-			ktesting.Eventually(tCtx, func(tCtx ktesting.TContext) error {
+			tCtx.Eventually(func(tCtx ktesting.TContext) error {
 				return tCtx.Client().ResourceV1beta1().ResourceClaims(namespace).Delete(tCtx, claim.Name, metav1.DeleteOptions{})
 			}).Should(gomega.Succeed(), "delete claim after downgrade")
-			ktesting.Eventually(tCtx, func(tCtx ktesting.TContext) error {
+			tCtx.Eventually(func(tCtx ktesting.TContext) error {
 				return tCtx.Client().CoreV1().Pods(namespace).Delete(tCtx, pod.Name, metav1.DeleteOptions{})
 			}).Should(gomega.Succeed(), "delete pod after downgrade")
-			ktesting.Eventually(tCtx, func(tCtx ktesting.TContext) *v1.Pod {
+			tCtx.Eventually(func(tCtx ktesting.TContext) *v1.Pod {
 				pod, err := tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					return nil

--- a/test/e2e_dra/upgradedowngrade_test.go
+++ b/test/e2e_dra/upgradedowngrade_test.go
@@ -255,7 +255,7 @@ func testUpgradeDowngrade(tCtx ktesting.TContext) {
 
 	// The kubelet wipes all ResourceSlices on a restart because it doesn't know which drivers were running.
 	// Wait for the ResourceSlice controller in the driver to notice and recreate the ResourceSlices.
-	ktesting.Eventually(tCtx.WithStep("wait for ResourceSlices"), driver.NewGetSlices()).WithTimeout(5 * time.Minute).Should(gomega.HaveField("Items", gomega.HaveLen(len(nodes.NodeNames))))
+	tCtx.WithStep("wait for ResourceSlices").Eventually(driver.NewGetSlices()).WithTimeout(5 * time.Minute).Should(gomega.HaveField("Items", gomega.HaveLen(len(nodes.NodeNames))))
 
 	downgradedTestFuncs := make(map[string]downgradedTestFunc, len(subTests))
 	tCtx.Run("after-cluster-upgrade", func(tCtx ktesting.TContext) {

--- a/test/integration/dra/binding_conditions_test.go
+++ b/test/integration/dra/binding_conditions_test.go
@@ -444,10 +444,8 @@ profiles:
 
 	// The scheduler should hit the binding timeout and surface that on the pod.
 	// We poll the pod's conditions until we see a message containing "binding timeout".
-	tCtx.Eventually(func(tCtx ktesting.TContext) *v1.Pod {
-		p, err := tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-		tCtx.ExpectNoError(err, "get pod")
-		return p
+	tCtx.Eventually(func(tCtx ktesting.TContext) (*v1.Pod, error) {
+		return tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
 	}).WithTimeout(maxTO).WithPolling(300*time.Millisecond).Should(
 		gomega.HaveField("Status.Conditions",
 			gomega.ContainElement(
@@ -465,10 +463,8 @@ profiles:
 		"bindingTimeout should trigger roughly near %s (observed %v)", wantTO, elapsed,
 	)
 	// Verify that the pod remains unscheduled after the binding timeout.
-	tCtx.Eventually(func(tCtx ktesting.TContext) *v1.Pod {
-		pod, err := tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-		tCtx.ExpectNoError(err, "get pod")
-		return pod
+	tCtx.Eventually(func(tCtx ktesting.TContext) (*v1.Pod, error) {
+		return tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
 	}).WithTimeout(wantTO).WithPolling(200 * time.Millisecond).Should(gomega.SatisfyAll(
 		gomega.HaveField("Spec.NodeName", gomega.BeEmpty()),
 
@@ -570,10 +566,8 @@ profiles:
 		gomega.Succeed(), "slice must be created before binding timeout")
 
 	// Wait until the binding timeout occurs.
-	tCtx.Eventually(func(tCtx ktesting.TContext) *v1.Pod {
-		p, err := tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-		tCtx.ExpectNoError(err, "get pod")
-		return p
+	tCtx.Eventually(func(tCtx ktesting.TContext) (*v1.Pod, error) {
+		return tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
 	}).WithTimeout(20*time.Second).WithPolling(300*time.Millisecond).Should(
 		gomega.HaveField("Status.Conditions",
 			gomega.ContainElement(
@@ -586,10 +580,8 @@ profiles:
 	)
 
 	// Verify recovery to the newly added device without BindingConditions through rescheduling triggered by binding timeout.
-	tCtx.Eventually(func(tCtx ktesting.TContext) *resourceapi.ResourceClaim {
-		c, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim1.Name, metav1.GetOptions{})
-		tCtx.ExpectNoError(err)
-		return c
+	tCtx.Eventually(func(tCtx ktesting.TContext) (*resourceapi.ResourceClaim, error) {
+		return tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim1.Name, metav1.GetOptions{})
 	}).WithTimeout(10*time.Second).WithPolling(1*time.Second).Should(gomega.HaveField(
 		"Status.Allocation",
 		gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{

--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -618,10 +618,8 @@ func testPrioritizedList(tCtx ktesting.TContext, enabled bool) {
 			"Message": gomega.Equal("0/8 nodes are available: 8 cannot allocate all claims. still not schedulable, preemption: 0/8 nodes are available: 8 Preemption is not helpful for scheduling."),
 		}),
 	))
-	tCtx.Eventually(func(tCtx ktesting.TContext) *v1.Pod {
-		pod, err := tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-		tCtx.ExpectNoError(err, "get pod")
-		return pod
+	tCtx.Eventually(func(tCtx ktesting.TContext) (*v1.Pod, error) {
+		return tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
 	}).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(schedulingAttempted)
 }
 
@@ -689,10 +687,8 @@ func testPrioritizedListScoring(tCtx ktesting.TContext) {
 
 		_ = createPod(tCtx, namespace, "-pl-single-claim", podWithClaimName, claim)
 		expectedSelectedRequest := fmt.Sprintf("%s/%s", claim.Spec.Devices.Requests[0].Name, claim.Spec.Devices.Requests[0].FirstAvailable[0].Name)
-		tCtx.Eventually(func(tCtx ktesting.TContext) *resourceapi.ResourceClaim {
-			c, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim.Name, metav1.GetOptions{})
-			tCtx.ExpectNoError(err)
-			return c
+		tCtx.Eventually(func(tCtx ktesting.TContext) (*resourceapi.ResourceClaim, error) {
+			return tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim.Name, metav1.GetOptions{})
 		}).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(expectedAllocatedClaim(expectedSelectedRequest, nodeInfos[0]))
 	})
 
@@ -751,18 +747,14 @@ func testPrioritizedListScoring(tCtx ktesting.TContext) {
 
 		// The second subrequest in claim1 is for nodeInfos[2], so it should be chosen.
 		expectedSelectedRequest := fmt.Sprintf("%s/%s", claim1.Spec.Devices.Requests[0].Name, claim1.Spec.Devices.Requests[0].FirstAvailable[1].Name)
-		tCtx.Eventually(func(tCtx ktesting.TContext) *resourceapi.ResourceClaim {
-			c, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claimPrioritizedList1.Name, metav1.GetOptions{})
-			tCtx.ExpectNoError(err)
-			return c
+		tCtx.Eventually(func(tCtx ktesting.TContext) (*resourceapi.ResourceClaim, error) {
+			return tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claimPrioritizedList1.Name, metav1.GetOptions{})
 		}).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(expectedAllocatedClaim(expectedSelectedRequest, nodeInfos[2]))
 
 		// The first subrequest in claim2 is for nodeInfos[2], so it should be chosen.
 		expectedSelectedRequest = fmt.Sprintf("%s/%s", claim2.Spec.Devices.Requests[0].Name, claim2.Spec.Devices.Requests[0].FirstAvailable[0].Name)
-		tCtx.Eventually(func(tCtx ktesting.TContext) *resourceapi.ResourceClaim {
-			c, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claimPrioritizedList2.Name, metav1.GetOptions{})
-			tCtx.ExpectNoError(err)
-			return c
+		tCtx.Eventually(func(tCtx ktesting.TContext) (*resourceapi.ResourceClaim, error) {
+			return tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claimPrioritizedList2.Name, metav1.GetOptions{})
 		}).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(expectedAllocatedClaim(expectedSelectedRequest, nodeInfos[2]))
 	})
 }
@@ -833,10 +825,8 @@ func testExtendedResource(tCtx ktesting.TContext, enabled bool) {
 				}),
 			))
 		}
-		tCtx.Eventually(func(tCtx ktesting.TContext) *v1.Pod {
-			pod, err := tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-			tCtx.ExpectNoError(err, "get pod")
-			return pod
+		tCtx.Eventually(func(tCtx ktesting.TContext) (*v1.Pod, error) {
+			return tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
 		}).WithTimeout(time.Minute).WithPolling(time.Second).Should(schedulingAttempted)
 	})
 }
@@ -1716,18 +1706,14 @@ func testInvalidResourceSlices(tCtx ktesting.TContext) {
 			schedulingAttempted := gomega.HaveField("Status.Conditions", gomega.ContainElement(
 				gstruct.MatchFields(gstruct.IgnoreExtras, tc.expectedPodScheduledCondition),
 			))
-			tCtx.Eventually(func(tCtx ktesting.TContext) *v1.Pod {
-				pod, err := tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-				tCtx.ExpectNoError(err, "get pod")
-				return pod
+			tCtx.Eventually(func(tCtx ktesting.TContext) (*v1.Pod, error) {
+				return tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
 			}).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(schedulingAttempted)
 
 			// Only check the ResourceClaim if we expected the Pod to schedule.
 			if tc.expectPodToSchedule {
-				tCtx.Eventually(func(tCtx ktesting.TContext) *resourceapi.ResourceClaim {
-					c, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim.Name, metav1.GetOptions{})
-					tCtx.ExpectNoError(err)
-					return c
+				tCtx.Eventually(func(tCtx ktesting.TContext) (*resourceapi.ResourceClaim, error) {
+					return tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim.Name, metav1.GetOptions{})
 				}).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(gomega.HaveField("Status.Allocation", gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 					"Devices": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 						"Results": gomega.HaveExactElements(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{

--- a/test/integration/dra/helpers_test.go
+++ b/test/integration/dra/helpers_test.go
@@ -165,8 +165,8 @@ func createPod(tCtx ktesting.TContext, namespace string, suffix string, pod *v1.
 func waitForPodScheduled(tCtx ktesting.TContext, namespace, podName string) {
 	tCtx.Helper()
 
-	tCtx.Eventually(func(tCtx ktesting.TContext) *v1.Pod {
-		return must(tCtx, tCtx.Client().CoreV1().Pods(namespace).Get, podName, metav1.GetOptions{})
+	tCtx.Eventually(func(tCtx ktesting.TContext) (*v1.Pod, error) {
+		return tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, podName, metav1.GetOptions{})
 	}).WithTimeout(60*time.Second).Should(
 		gomega.HaveField("Status.Conditions", gomega.ContainElement(
 			gomega.And(
@@ -207,11 +207,10 @@ func waitForNotFound[T any](tCtx ktesting.TContext, get func(context.Context, st
 func waitForClaim(tCtx ktesting.TContext, namespace, claimName string, timeout time.Duration, match gtypes.GomegaMatcher, description ...any) *resourceapi.ResourceClaim {
 	tCtx.Helper()
 	var latestClaim *resourceapi.ResourceClaim
-	tCtx.Eventually(func(tCtx ktesting.TContext) *resourceapi.ResourceClaim {
+	tCtx.Eventually(func(tCtx ktesting.TContext) (*resourceapi.ResourceClaim, error) {
 		c, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claimName, metav1.GetOptions{})
-		tCtx.ExpectNoError(err, "get claim")
 		latestClaim = c
-		return latestClaim
+		return c, err
 	}).WithTimeout(timeout).WithPolling(time.Second).Should(match, description...)
 	return latestClaim
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Some of them were already converted previously, but didn't take full advantage of the more flexible methods: errors can be checked again by Gomega.


#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:


This is a follow-up for https://github.com/kubernetes/kubernetes/pull/136156.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @bart0sh 