### PR TITLE
cleanup(kubelet/test):Add test cases

### DIFF
--- a/pkg/kubelet/apis/podresources/client_test.go
+++ b/pkg/kubelet/apis/podresources/client_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podresources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	fakeremote "k8s.io/cri-client/pkg/fake"
+)
+
+func TestGetClient(t *testing.T) {
+	testCases := map[string]func(string, time.Duration, int) (any, *grpc.ClientConn, error){
+		"v1alpha1": func(socket string, timeout time.Duration, maxSize int) (any, *grpc.ClientConn, error) {
+			return GetV1alpha1Client(socket, timeout, maxSize)
+		},
+		"v1": func(socket string, timeout time.Duration, maxSize int) (any, *grpc.ClientConn, error) {
+			return GetV1Client(socket, timeout, maxSize)
+		},
+	}
+
+	for version, getClientFn := range testCases {
+		t.Run(version, func(t *testing.T) {
+			socketPath, err := fakeremote.GenerateEndpoint()
+			require.NoError(t, err)
+
+			client, conn, err := getClientFn(socketPath, 10*time.Second, 1024*1024)
+			require.NoError(t, err)
+			require.NotNil(t, client)
+			require.NoError(t, conn.Close())
+
+			client, conn, err = getClientFn("invalid\x00endpoint", 100*time.Millisecond, 1024*1024)
+			require.Error(t, err)
+			assert.Nil(t, client)
+			assert.Nil(t, conn)
+		})
+	}
+}

--- a/pkg/kubelet/apis/podresources/server_v1_test.go
+++ b/pkg/kubelet/apis/podresources/server_v1_test.go
@@ -952,11 +952,14 @@ func TestGetPodResourcesV1(t *testing.T) {
 	}
 
 	pluginCDIDevices := []*podresourcesapi.CDIDevice{{Name: "dra-dev0"}, {Name: "dra-dev1"}}
+	draDriverName := "dra.example.com"
+	poolName := "worker-1-pool"
+	deviceName := "gpu-1"
 	draDevs := []*podresourcesapi.DynamicResource{
 		{
 			ClaimName:      "claim-name",
 			ClaimNamespace: "default",
-			ClaimResources: []*podresourcesapi.ClaimResource{{CdiDevices: pluginCDIDevices}},
+			ClaimResources: []*podresourcesapi.ClaimResource{{CdiDevices: pluginCDIDevices, DriverName: draDriverName, PoolName: poolName, DeviceName: deviceName}},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
﻿
#### What this PR does / why we need it:
Adds unit tests for the podresources client creation functions:
- Test GetV1alpha1Client with valid and invalid socket paths
- Test GetV1Client with valid and invalid socket paths
- Verify proper error handling when socket path is invalid
- Ensure client and connection are properly created on success

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/126268
﻿
```release-note
NONE
```