### PR TITLE
scheduler: optimize podGroupInfo to minimize the lock time

### DIFF
--- a/pkg/scheduler/backend/podgroupmanager/podgroupmanager_test.go
+++ b/pkg/scheduler/backend/podgroupmanager/podgroupmanager_test.go
@@ -269,7 +269,7 @@ func TestPodGroupManager_DeletePod(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error getting pod group state: %v", err)
 			}
-			if len(state.AllPods()) == 0 {
+			if state.AllPodsCount() == 0 {
 				t.Errorf("Expected AllPods to be non-empty")
 			}
 			if state.AllPods().Has(p1.UID) {

--- a/pkg/scheduler/backend/podgroupmanager/podgroupstate.go
+++ b/pkg/scheduler/backend/podgroupmanager/podgroupstate.go
@@ -124,8 +124,8 @@ func (pgs *podGroupState) deletePod(podUID types.UID) {
 
 // empty returns true when the group is empty.
 func (pgs *podGroupState) empty() bool {
-	pgs.lock.Lock()
-	defer pgs.lock.Unlock()
+	pgs.lock.RLock()
+	defer pgs.lock.RUnlock()
 
 	return len(pgs.allPods) == 0
 }
@@ -136,6 +136,14 @@ func (pgs *podGroupState) AllPods() sets.Set[types.UID] {
 	defer pgs.lock.RUnlock()
 
 	return sets.KeySet(pgs.allPods)
+}
+
+// AllPodsCount returns the number of all pods known to the scheduler for this group.
+func (pgs *podGroupState) AllPodsCount() int {
+	pgs.lock.RLock()
+	defer pgs.lock.RUnlock()
+
+	return len(pgs.allPods)
 }
 
 // UnscheduledPods returns all pods that are unscheduled for this group,
@@ -170,6 +178,14 @@ func (pgs *podGroupState) AssignedPods() sets.Set[types.UID] {
 	return pgs.assignedPods.Clone()
 }
 
+// ScheduledPodsCount returns the number of pods for this group that are either assumed or assigned.
+func (pgs *podGroupState) ScheduledPodsCount() int {
+	pgs.lock.RLock()
+	defer pgs.lock.RUnlock()
+
+	return len(pgs.assumedPods) + len(pgs.assignedPods)
+}
+
 // SchedulingTimeout returns the remaining time until the pod group scheduling times out.
 // A new deadline is created if one doesn't exist, or if the previous one has expired.
 func (pgs *podGroupState) SchedulingTimeout() time.Duration {
@@ -190,7 +206,21 @@ func (pgs *podGroupState) AssumePod(podUID types.UID) {
 	pgs.lock.Lock()
 	defer pgs.lock.Unlock()
 
-	pgs.assumedPods.Insert(podUID)
+	pod := pgs.allPods[podUID]
+	// A scheduling pod may be removed from the cluster.
+	// In that case, we just ignore it.
+	if pod == nil {
+		return
+	}
+
+	// If the pod is already assigned, put it into assignedPods.
+	// Otherwise put it to assumedPods.
+	if pod.Spec.NodeName != "" {
+		pgs.assignedPods.Insert(podUID)
+	} else {
+		pgs.assumedPods.Insert(podUID)
+	}
+
 	pgs.unscheduledPods.Delete(podUID)
 }
 
@@ -199,6 +229,20 @@ func (pgs *podGroupState) ForgetPod(podUID types.UID) {
 	pgs.lock.Lock()
 	defer pgs.lock.Unlock()
 
-	pgs.unscheduledPods.Insert(podUID)
+	pod := pgs.allPods[podUID]
+	// A scheduling pod may be removed from the cluster.
+	// In that case, we just ignore it.
+	if pod == nil {
+		return
+	}
+
 	pgs.assumedPods.Delete(podUID)
+
+	// If the pod is already assigned, put it into assignedPods.
+	// Otherwise, put it into unscheduledPods.
+	if pod.Spec.NodeName != "" {
+		pgs.assignedPods.Insert(podUID)
+	} else {
+		pgs.unscheduledPods.Insert(podUID)
+	}
 }

--- a/pkg/scheduler/backend/podgroupmanager/podgroupstate_test.go
+++ b/pkg/scheduler/backend/podgroupmanager/podgroupstate_test.go
@@ -90,3 +90,106 @@ func TestPodGroupState_SchedulingTimeout(t *testing.T) {
 		t.Errorf("Expected positive timeout duration after reset, got %v", timeout)
 	}
 }
+
+func TestPodGroupState_PodCounts(t *testing.T) {
+	pgs := newPodGroupState()
+	pod1 := st.MakePod().Namespace("ns1").Name("p1").UID("p1").
+		PodGroupName("pg1").Obj()
+	pod2 := st.MakePod().Namespace("ns1").Name("p2").UID("p2").
+		PodGroupName("pg1").Obj()
+	pod3 := st.MakePod().Namespace("ns1").Name("p3").UID("p3").Node("node1").
+		PodGroupName("pg1").Obj()
+	pod4 := st.MakePod().Namespace("ns1").Name("p4").UID("p4").
+		PodGroupName("pg1").Obj()
+
+	if count := pgs.AllPodsCount(); count != 0 {
+		t.Errorf("Expected AllPodsCount to be 0, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 0 {
+		t.Errorf("Expected ScheduledPodsCount to be 0, got %d", count)
+	}
+
+	pgs.addPod(pod1)
+	pgs.addPod(pod2)
+	pgs.addPod(pod3)
+
+	if count := pgs.AllPodsCount(); count != 3 {
+		t.Errorf("Expected AllPodsCount to be 3, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 1 {
+		t.Errorf("Expected ScheduledPodsCount to be 1, got %d", count)
+	}
+
+	// Assuming a pod should move it from unscheduled to assumed, increasing the count of scheduled pods.
+	pgs.AssumePod(pod1.UID)
+	if count := pgs.AllPodsCount(); count != 3 {
+		t.Errorf("Expected AllPodsCount to be 3, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 2 {
+		t.Errorf("Expected ScheduledPodsCount to be 2, got %d", count)
+	}
+
+	// Assuming a pod that is already scheduled should not change the counts.
+	pgs.AssumePod(pod3.UID)
+	if count := pgs.AllPodsCount(); count != 3 {
+		t.Errorf("Expected AllPodsCount to be 3, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 2 {
+		t.Errorf("Expected ScheduledPodsCount to be 2, got %d", count)
+	}
+
+	// Assuming a pod that is not in the state should not change the counts.
+	pgs.AssumePod(pod4.UID)
+	if count := pgs.AllPodsCount(); count != 3 {
+		t.Errorf("Expected AllPodsCount to be 3, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 2 {
+		t.Errorf("Expected ScheduledPodsCount to be 2, got %d", count)
+	}
+
+	// Forgetting a pod that is already scheduled should not change the counts.
+	pgs.ForgetPod(pod3.UID)
+	if count := pgs.AllPodsCount(); count != 3 {
+		t.Errorf("Expected AllPodsCount to be 3, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 2 {
+		t.Errorf("Expected ScheduledPodsCount to be 2, got %d", count)
+	}
+
+	// Forgetting a pod that is in the assumed state should move it back to unscheduled,
+	// decreasing the count of scheduled pods.
+	pgs.ForgetPod(pod1.UID)
+	if count := pgs.AllPodsCount(); count != 3 {
+		t.Errorf("Expected AllPodsCount to be 3, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 1 {
+		t.Errorf("Expected ScheduledPodsCount to be 1, got %d", count)
+	}
+
+	// Forgetting a pod that is not assumed should not change the counts.
+	pgs.ForgetPod(pod1.UID)
+	if count := pgs.AllPodsCount(); count != 3 {
+		t.Errorf("Expected AllPodsCount to be 3, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 1 {
+		t.Errorf("Expected ScheduledPodsCount to be 1, got %d", count)
+	}
+
+	// Assuming a pod again should move it back to assumed, increasing the count of scheduled pods.
+	pgs.AssumePod(pod2.UID)
+	if count := pgs.AllPodsCount(); count != 3 {
+		t.Errorf("Expected AllPodsCount to be 3, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 2 {
+		t.Errorf("Expected ScheduledPodsCount to be 2, got %d", count)
+	}
+
+	// Forgetting a pod that is not in the state should not change the counts.
+	pgs.ForgetPod(pod4.UID)
+	if count := pgs.AllPodsCount(); count != 3 {
+		t.Errorf("Expected AllPodsCount to be 3, got %d", count)
+	}
+	if count := pgs.ScheduledPodsCount(); count != 2 {
+		t.Errorf("Expected ScheduledPodsCount to be 2, got %d", count)
+	}
+}

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -141,8 +141,8 @@ func (pl *GangScheduling) PreEnqueue(ctx context.Context, pod *v1.Pod) *fwk.Stat
 	if err != nil {
 		return fwk.AsStatus(err)
 	}
-	allPods := podGroupState.AllPods()
-	if len(allPods) < int(policy.Gang.MinCount) {
+	allPodsCount := podGroupState.AllPodsCount()
+	if allPodsCount < int(policy.Gang.MinCount) {
 		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue")
 	}
 
@@ -207,9 +207,8 @@ func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod 
 	if err != nil {
 		return fwk.AsStatus(err), 0
 	}
-	assumedPods := podGroupState.AssumedPods()
-	assumedOrAssignedPods := assumedPods.Union(podGroupState.AssignedPods())
-	if len(assumedOrAssignedPods) < int(policy.Gang.MinCount) {
+	scheduledPodsCount := podGroupState.ScheduledPodsCount()
+	if scheduledPodsCount < int(policy.Gang.MinCount) {
 		// Activate unscheduled pods from this pod group in case they were waiting for this pod to be scheduled.
 		unscheduledPods := podGroupState.UnscheduledPods()
 		pl.handle.Activate(klog.FromContext(ctx), unscheduledPods)
@@ -217,6 +216,7 @@ func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod 
 		return fwk.NewStatus(fwk.Wait, "waiting for minCount pods from a gang to be scheduled"), podGroupState.SchedulingTimeout()
 	}
 
+	assumedPods := podGroupState.AssumedPods()
 	logger.V(4).Info("Quorum is met for a gang. Allowing other pods from a gang waiting on permit", "pod", klog.KObj(pod), "schedulingGroup", schedulingGroup, "allowedPods", len(assumedPods))
 
 	// The quorum is met. Allow this pod and signal all other waiting pods from the same gang to proceed.

--- a/staging/src/k8s.io/kube-scheduler/framework/listers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/listers.go
@@ -157,6 +157,8 @@ type PodGroupManager interface {
 type PodGroupState interface {
 	// AllPods returns the UIDs of all pods known to the scheduler for this group.
 	AllPods() sets.Set[types.UID]
+	// AllPodsCount returns the number of all pods known to the scheduler for this group.
+	AllPodsCount() int
 	// UnscheduledPods returns all pods that are unscheduled for this group,
 	// i.e., are neither assumed nor assigned.
 	// The returned map type corresponds to the argument of the PodActivator.Activate method.
@@ -166,6 +168,8 @@ type PodGroupState interface {
 	AssumedPods() sets.Set[types.UID]
 	// AssignedPods returns the UIDs of all pods already assigned (bound) for this group.
 	AssignedPods() sets.Set[types.UID]
+	// ScheduledPodsCount returns the number of pods for this group that are either assumed or assigned.
+	ScheduledPodsCount() int
 	// AssumePod marks a pod as having reached the Reserve stage.
 	AssumePod(podUID types.UID)
 	// ForgetPod removes a pod from the assumed state.


### PR DESCRIPTION
Gang scheduler will add the pod into the podGroupInfo before pod enqueue, if there are thousands of pods in a podGroupInfo, The call of AssumedPods, AssignedPods and AllPods will hold the lock and clone the map, so that new Pods should wait there for a long time to add into the podGroupInfo, also it will be a long wait to enqueue the pod.

In our test, a pod will wait seconds to enqueue if we have 5000 pod in a gang group.

In this PR, we can avoid the traverse and clone of the map by adding AllPodsCount and ScheduledPodsCount method. Actually in most of the time, what the scheduler needs to know is the count of them but not the contents.

We also combined the Assumed and Assigned pods into a set named "scheduledPods" so we can quickly get the count of them, which is also scheduler really needs to get.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind api-change


#### What this PR does / why we need it:
This PR can optimize the gang scheduler efficiency, in our test, the schedule time of 5000 pods per gang is reduced from more than 30min to less than 3min.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
