### PR TITLE
Use Go 1.22 for-range in test/{utils,integrations}

### DIFF
--- a/test/integration/apiserver/admissionwebhook/load_balance_test.go
+++ b/test/integration/apiserver/admissionwebhook/load_balance_test.go
@@ -209,7 +209,7 @@ func TestWebhookLoadBalance(t *testing.T) {
 
 			// Submit 10 parallel requests
 			wg := &sync.WaitGroup{}
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
@@ -232,7 +232,7 @@ func TestWebhookLoadBalance(t *testing.T) {
 
 			// Submit 10 more parallel requests
 			wg = &sync.WaitGroup{}
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()

--- a/test/integration/apiserver/admissionwebhook/match_conditions_test.go
+++ b/test/integration/apiserver/admissionwebhook/match_conditions_test.go
@@ -1086,7 +1086,7 @@ func newMarkerPod(namespace string) *corev1.Pod {
 
 func repeatedMatchConditions(size int) []admissionregistrationv1.MatchCondition {
 	matchConditions := make([]admissionregistrationv1.MatchCondition, 0, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		matchConditions = append(matchConditions, admissionregistrationv1.MatchCondition{
 			Name:       "repeated-" + strconv.Itoa(i),
 			Expression: "true",
@@ -1098,7 +1098,7 @@ func repeatedMatchConditions(size int) []admissionregistrationv1.MatchCondition 
 // generate n matchConditions with provided expression
 func generateMatchConditionsWithAuthzCheck(num int, exp string) []admissionregistrationv1.MatchCondition {
 	var conditions = make([]admissionregistrationv1.MatchCondition, num)
-	for i := 0; i < num; i++ {
+	for i := range num {
 		conditions[i].Name = "test" + strconv.Itoa(i)
 		conditions[i].Expression = exp
 	}

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -422,7 +422,7 @@ func testListOptions(t *testing.T, watchCacheEnabled bool) {
 
 	var compactedRv string
 	var oldestUncompactedRv int64
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		rs := newRS("default")
 		rs.Name = fmt.Sprintf("test-%d", i)
 		serializer := protobuf.NewSerializer(nil, nil)
@@ -661,7 +661,7 @@ func TestListResourceVersion0(t *testing.T) {
 
 			rsClient := clientSet.AppsV1().ReplicaSets(ns.Name)
 
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				rs := newRS(ns.Name)
 				rs.Name = fmt.Sprintf("test-%d", i)
 				if _, err := rsClient.Create(tCtx, rs, metav1.CreateOptions{}); err != nil {
@@ -713,7 +713,7 @@ func TestAPIListChunking(t *testing.T) {
 
 	rsClient := clientSet.AppsV1().ReplicaSets(ns.Name)
 
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		rs := newRS(ns.Name)
 		rs.Name = fmt.Sprintf("test-%d", i)
 		if _, err := rsClient.Create(ctx, rs, metav1.CreateOptions{}); err != nil {
@@ -780,7 +780,7 @@ func TestAPIListChunkingWithLabelSelector(t *testing.T) {
 
 	rsClient := clientSet.AppsV1().ReplicaSets(ns.Name)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		rs := newRS(ns.Name)
 		rs.Name = fmt.Sprintf("test-%d", i)
 		odd := i%2 != 0
@@ -849,7 +849,7 @@ func TestNameInFieldSelector(t *testing.T) {
 	defer tearDownFn()
 
 	numNamespaces := 3
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		ns := framework.CreateNamespaceOrDie(clientSet, fmt.Sprintf("ns%d", i), t)
 		defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
 
@@ -2751,7 +2751,7 @@ func expectTableWatchEventsWithTypes(t *testing.T, count, columns int, policy me
 
 	var events []streamedEvent
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		var evt metav1.WatchEvent
 		if err := d.Decode(&evt); err != nil {
 			t.Fatal(err)
@@ -2874,7 +2874,7 @@ func expectTableV1WatchEvents(t *testing.T, count, columns int, policy metav1.In
 
 	var objects [][]byte
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		var evt metav1.WatchEvent
 		if err := d.Decode(&evt); err != nil {
 			t.Fatal(err)

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -855,7 +855,7 @@ func TestApplyGroupsManySeparateUpdates(t *testing.T) {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
 	}
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		unique := fmt.Sprintf("updater%v", i)
 		object, err = client.CoreV1().RESTClient().Patch(types.MergePatchType).
 			AbsPath("/apis/admissionregistration.k8s.io/v1").
@@ -906,7 +906,7 @@ func TestCreateVeryLargeObject(t *testing.T) {
 		Data: map[string]string{},
 	}
 
-	for i := 0; i < 9999; i++ {
+	for i := range 9999 {
 		unique := fmt.Sprintf("this-key-is-very-long-so-as-to-create-a-very-large-serialized-fieldset-%v", i)
 		cfg.Data[unique] = "A"
 	}
@@ -965,7 +965,7 @@ func TestUpdateVeryLargeObject(t *testing.T) {
 		}
 
 		// Apply the large update, then attempt to push it to the apiserver.
-		for i := 0; i < 9999; i++ {
+		for i := range 9999 {
 			unique := fmt.Sprintf("this-key-is-very-long-so-as-to-create-a-very-large-serialized-fieldset-%v", i)
 			updateCfg.Data[unique] = "A"
 		}
@@ -1020,7 +1020,7 @@ func TestPatchVeryLargeObject(t *testing.T) {
 	}
 
 	patchString := `{"data":{"k":"v"`
-	for i := 0; i < 9999; i++ {
+	for i := range 9999 {
 		unique := fmt.Sprintf("this-key-is-very-long-so-as-to-create-a-very-large-serialized-fieldset-%v", i)
 		patchString = fmt.Sprintf("%s,%q:%q", patchString, unique, "A")
 	}
@@ -1081,7 +1081,7 @@ func TestPatchVeryLargeObjectCBORApply(t *testing.T) {
 	}
 
 	patchString := `{"data":{"k":"v"`
-	for i := 0; i < 9999; i++ {
+	for i := range 9999 {
 		unique := fmt.Sprintf("this-key-is-very-long-so-as-to-create-a-very-large-serialized-fieldset-%v", i)
 		patchString = fmt.Sprintf("%s,%q:%q", patchString, unique, "A")
 	}
@@ -3015,7 +3015,7 @@ func benchPostPod(client clientset.Interface, pod v1.Pod, parallel int) func(*te
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			c := make(chan error)
-			for j := 0; j < parallel; j++ {
+			for j := range parallel {
 				j := j
 				i := i
 				go func(pod v1.Pod) {
@@ -3028,7 +3028,7 @@ func benchPostPod(client clientset.Interface, pod v1.Pod, parallel int) func(*te
 					c <- err
 				}(pod)
 			}
-			for j := 0; j < parallel; j++ {
+			for range parallel {
 				err := <-c
 				if err != nil {
 					b.Fatal(err)
@@ -3062,7 +3062,7 @@ func benchListPod(client clientset.Interface, pod v1.Pod, num int) func(*testing
 			b.Fatal(err)
 		}
 		// Create pods
-		for i := 0; i < num; i++ {
+		for i := range num {
 			pod.Name = fmt.Sprintf("get-%d-%d", b.N, i)
 			pod.Namespace = namespace
 			_, err := client.CoreV1().RESTClient().Post().

--- a/test/integration/apiserver/cel/admission_policy_test.go
+++ b/test/integration/apiserver/cel/admission_policy_test.go
@@ -705,7 +705,7 @@ func (p *policyExpectationHolder) verify(t *testing.T) {
 					header = record
 				} else {
 					line := map[string]string{}
-					for i := 0; i < len(record); i++ {
+					for i := range record {
 						line[header[i]] = record[i]
 					}
 					mappedCSV = append(mappedCSV, line)

--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -2230,7 +2230,7 @@ func Test_CostLimitForValidation(t *testing.T) {
 // generate n validation rules with provided expression
 func generateValidationsWithAuthzCheck(num int, exp string) []admissionregistrationv1.Validation {
 	var validations = make([]admissionregistrationv1.Validation, num)
-	for i := 0; i < num; i++ {
+	for i := range num {
 		validations[i].Expression = exp
 	}
 	return validations
@@ -2609,7 +2609,7 @@ func TestCRDsOnStartup(t *testing.T) {
 	}
 
 	// Create a bunch of fake CRDs to make the initial startup sync take a long time
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		crd := myCRD.DeepCopy()
 		crd.Name = fmt.Sprintf("foos%d.cr.bar.com", i)
 		crd.Spec.Names.Plural = fmt.Sprintf("foos%d", i)
@@ -3219,7 +3219,7 @@ func withBindingExistsLabels(labels []string, policy *admissionregistrationv1.Va
 
 func buildExistsSelector(labels []string) []metav1.LabelSelectorRequirement {
 	matchExprs := make([]metav1.LabelSelectorRequirement, len(labels))
-	for i := 0; i < len(labels); i++ {
+	for i := range labels {
 		matchExprs[i].Key = labels[i]
 		matchExprs[i].Operator = metav1.LabelSelectorOpExists
 	}

--- a/test/integration/apiserver/crd_regression_test.go
+++ b/test/integration/apiserver/crd_regression_test.go
@@ -126,7 +126,7 @@ func TestCRDExponentialRecursionBug(t *testing.T) {
 	// create a object with nested fields to trigger the bug
 	var m map[string]interface{}
 	m = instance.Object["spec"].(map[string]interface{})
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		m[fmt.Sprintf("field%d", i)] = map[string]interface{}{}
 		m = m[fmt.Sprintf("field%d", i)].(map[string]interface{})
 	}

--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -774,7 +774,7 @@ func nonStructuralCrdWithValidations() *apiextensionsv1beta1.CustomResourceDefin
 
 func genLargeArray(n, x int64) []int64 {
 	arr := make([]int64, n)
-	for i := int64(0); i < n; i++ {
+	for i := range n {
 		arr[i] = x
 	}
 	return arr

--- a/test/integration/apiserver/flowcontrol/concurrency_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_test.go
@@ -314,7 +314,7 @@ func createPriorityLevelAndBindingFlowSchemaForUser(c clientset.Interface, usern
 }
 
 func streamRequests(parallel int, request func(), wg *sync.WaitGroup, stopCh <-chan struct{}) {
-	for i := 0; i < parallel; i++ {
+	for range parallel {
 		go func() {
 			defer wg.Done()
 			for {

--- a/test/integration/apiserver/patch_test.go
+++ b/test/integration/apiserver/patch_test.go
@@ -46,7 +46,7 @@ func TestPatchConflicts(t *testing.T) {
 
 	UIDs := make([]types.UID, numOfConcurrentPatches)
 	ownerRefs := []metav1.OwnerReference{}
-	for i := 0; i < numOfConcurrentPatches; i++ {
+	for i := range numOfConcurrentPatches {
 		uid := types.UID(uuid.New().String())
 		ownerName := fmt.Sprintf("owner-%d", i)
 		UIDs[i] = uid
@@ -76,7 +76,7 @@ func TestPatchConflicts(t *testing.T) {
 	// Run a lot of simultaneous patch operations to exercise internal API server retry of application of patches that do not specify resourceVersion.
 	// They should all succeed.
 	wg := sync.WaitGroup{}
-	for i := 0; i < numOfConcurrentPatches; i++ {
+	for i := range numOfConcurrentPatches {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/test/integration/apiserver/watchcache_test.go
+++ b/test/integration/apiserver/watchcache_test.go
@@ -180,7 +180,7 @@ func BenchmarkListFromWatchCache(b *testing.B) {
 	wg := sync.WaitGroup{}
 
 	errCh := make(chan error, namespaces)
-	for i := 0; i < namespaces; i++ {
+	for i := range namespaces {
 		wg.Add(1)
 		index := i
 		go func() {
@@ -195,7 +195,7 @@ func BenchmarkListFromWatchCache(b *testing.B) {
 				return
 			}
 
-			for j := 0; j < secretsPerNamespace; j++ {
+			for j := range secretsPerNamespace {
 				secret := &v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: fmt.Sprintf("secret-%d", j),

--- a/test/integration/client/client_test.go
+++ b/test/integration/client/client_test.go
@@ -197,7 +197,7 @@ func TestAtomicPut(t *testing.T) {
 	testLabels := labels.Set{
 		"foo": "bar",
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		// a: z, b: y, etc...
 		testLabels[string([]byte{byte('a' + i)})] = string([]byte{byte('z' - i)})
 	}
@@ -731,7 +731,7 @@ func TestSingleWatch(t *testing.T) {
 	}
 
 	rv1 := ""
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		event := mkEvent(i)
 		got, err := client.CoreV1().Events("default").Create(context.TODO(), event, metav1.CreateOptions{})
 		if err != nil {
@@ -823,7 +823,7 @@ func TestMultiWatch(t *testing.T) {
 	watchesStarted := sync.WaitGroup{}
 
 	// make a bunch of pods and watch them
-	for i := 0; i < watcherCount; i++ {
+	for i := range watcherCount {
 		watchesStarted.Add(1)
 		name := fmt.Sprintf("multi-watch-%v", i)
 		got, err := client.CoreV1().Pods("default").Create(context.TODO(), &v1.Pod{
@@ -882,12 +882,12 @@ func TestMultiWatch(t *testing.T) {
 		changeToMake := make(chan int, unrelatedCount*2)
 		changeMade := make(chan int, unrelatedCount*2)
 		go func() {
-			for i := 0; i < unrelatedCount; i++ {
+			for i := range unrelatedCount {
 				changeToMake <- i
 			}
 			close(changeToMake)
 		}()
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -904,7 +904,7 @@ func TestMultiWatch(t *testing.T) {
 			}()
 		}
 
-		for i := 0; i < 2000; i++ {
+		for i := range 2000 {
 			<-changeMade
 			if (i+1)%50 == 0 {
 				log.Printf("%v: %v unrelated changes made", time.Now(), i+1)
@@ -918,12 +918,12 @@ func TestMultiWatch(t *testing.T) {
 		changeToMake := make(chan int, unrelatedCount*2)
 		changeMade := make(chan int, unrelatedCount*2)
 		go func() {
-			for i := 0; i < unrelatedCount; i++ {
+			for i := range unrelatedCount {
 				changeToMake <- i
 			}
 			close(changeToMake)
 		}()
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -953,7 +953,7 @@ func TestMultiWatch(t *testing.T) {
 			}()
 		}
 
-		for i := 0; i < 2000; i++ {
+		for i := range 2000 {
 			<-changeMade
 			if (i+1)%50 == 0 {
 				log.Printf("%v: %v unrelated changes made", time.Now(), i+1)
@@ -964,7 +964,7 @@ func TestMultiWatch(t *testing.T) {
 	// Now we still have changes being made in parallel, but at least 1000 have been made.
 	// Make some updates to send down the watches.
 	sentTimes := make(chan timePair, watcherCount*2)
-	for i := 0; i < watcherCount; i++ {
+	for i := range watcherCount {
 		go func(i int) {
 			name := fmt.Sprintf("multi-watch-%v", i)
 			pod, err := client.CoreV1().Pods("default").Get(context.TODO(), name, metav1.GetOptions{})
@@ -980,13 +980,13 @@ func TestMultiWatch(t *testing.T) {
 	}
 
 	sent := map[string]time.Time{}
-	for i := 0; i < watcherCount; i++ {
+	for range watcherCount {
 		tp := <-sentTimes
 		sent[tp.name] = tp.t
 	}
 	log.Printf("all changes made")
 	dur := map[string]time.Duration{}
-	for i := 0; i < watcherCount; i++ {
+	for range watcherCount {
 		tp := <-receivedTimes
 		delta := tp.t.Sub(sent[tp.name])
 		dur[tp.name] = delta

--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -217,7 +217,7 @@ func testDynamicClientWatch(t *testing.T, client clientset.Interface, dynamicCli
 	}
 
 	rv1 := ""
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		event := mkEvent(i)
 		got, err := client.CoreV1().Events("default").Create(context.TODO(), event, metav1.CreateOptions{})
 		if err != nil {

--- a/test/integration/client/metrics/metrics_test.go
+++ b/test/integration/client/metrics/metrics_test.go
@@ -90,7 +90,7 @@ func TestAPIServerTransportMetrics(t *testing.T) {
 
 	requests := 30
 	errors := 0
-	for i := 0; i < requests; i++ {
+	for i := range requests {
 		apiService, err := aggregatorClient.ApiregistrationV1().APIServices().Get(context.Background(), "v1alpha1.wardle.example.com", metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)

--- a/test/integration/controlplane/kube_apiserver_test.go
+++ b/test/integration/controlplane/kube_apiserver_test.go
@@ -705,7 +705,7 @@ func testReconcilersAPIServerLease(t *testing.T, leaseCount int, apiServerCount 
 	instanceOptions := kubeapiservertesting.NewDefaultTestServerOptions()
 
 	// 1. start apiServerCount api servers
-	for i := 0; i < apiServerCount; i++ {
+	for i := range apiServerCount {
 		// start count api server
 		server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{
 			"--endpoint-reconciler-type", "master-count",
@@ -733,7 +733,7 @@ func testReconcilersAPIServerLease(t *testing.T, leaseCount int, apiServerCount 
 	}
 
 	// 3. start lease api servers
-	for i := 0; i < leaseCount; i++ {
+	for i := range leaseCount {
 		options := []string{
 			"--endpoint-reconciler-type", "lease",
 			"--advertise-address", fmt.Sprintf("10.0.1.%v", i+10),
@@ -743,7 +743,7 @@ func testReconcilersAPIServerLease(t *testing.T, leaseCount int, apiServerCount 
 	}
 
 	defer func() {
-		for i := 0; i < leaseCount; i++ {
+		for i := range leaseCount {
 			leaseServers[i].TearDownFn()
 		}
 	}()
@@ -793,7 +793,7 @@ func TestMultiAPIServerNodePortAllocation(t *testing.T) {
 	instanceOptions := kubeapiservertesting.NewDefaultTestServerOptions()
 
 	// create 2 api servers and 2 clients
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		// start count api server
 		t.Logf("starting api server: %d", i)
 		server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{
@@ -842,7 +842,7 @@ func TestMultiAPIServerNodePortAllocation(t *testing.T) {
 
 	// create and delete the same nodePortservice using different APIservers
 	// to check that API servers are using the same port allocation bitmap
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		// Create the service using the first API server
 		_, err := clientAPIServers[0].CoreV1().Services(metav1.NamespaceDefault).Create(context.TODO(), serviceObject, metav1.CreateOptions{})
 		if err != nil {

--- a/test/integration/controlplane/synthetic_controlplane_test.go
+++ b/test/integration/controlplane/synthetic_controlplane_test.go
@@ -293,21 +293,21 @@ func constructBody(val string, size int, field string, t *testing.T) *appsv1.Dep
 	switch field {
 	case "labels":
 		labelsMap := map[string]string{}
-		for i := 0; i < size; i++ {
+		for i := range size {
 			key := val + strconv.Itoa(i)
 			labelsMap[key] = val
 		}
 		deploymentObject.ObjectMeta.Labels = labelsMap
 	case "annotations":
 		annotationsMap := map[string]string{}
-		for i := 0; i < size; i++ {
+		for i := range size {
 			key := val + strconv.Itoa(i)
 			annotationsMap[key] = val
 		}
 		deploymentObject.ObjectMeta.Annotations = annotationsMap
 	case "finalizers":
 		finalizerString := []string{}
-		for i := 0; i < size; i++ {
+		for range size {
 			finalizerString = append(finalizerString, val)
 		}
 		deploymentObject.ObjectMeta.Finalizers = finalizerString
@@ -732,9 +732,9 @@ func TestUpdateNodeObjects(t *testing.T) {
 		}
 	}
 
-	for k := 0; k < listers; k++ {
+	for k := range listers {
 		go func(lister int) {
-			for i := 0; i < iterations; i++ {
+			for i := range iterations {
 				_, err := c.Nodes().List(context.TODO(), metav1.ListOptions{})
 				if err != nil {
 					fmt.Printf("[list:%d] error after %d: %v\n", lister, i, err)
@@ -745,7 +745,7 @@ func TestUpdateNodeObjects(t *testing.T) {
 		}(k)
 	}
 
-	for k := 0; k < watchers; k++ {
+	for k := range watchers {
 		go func(lister int) {
 			w, err := c.Nodes().Watch(context.TODO(), metav1.ListOptions{})
 			if err != nil {
@@ -769,10 +769,10 @@ func TestUpdateNodeObjects(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(nodes - listers)
 
-	for j := 0; j < nodes; j++ {
+	for j := range nodes {
 		go func(node int) {
 			var lastCount int
-			for i := 0; i < iterations; i++ {
+			for i := range iterations {
 				if i%100 == 0 {
 					fmt.Printf("[%d] iteration %d ...\n", node, i)
 				}

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -741,7 +741,7 @@ resources:
 
 	const podCount = 1_000
 
-	for i := 0; i < podCount; i++ {
+	for i := range podCount {
 		if _, err := client.CoreV1().Pods(testNamespace).Create(ctx, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("dek-reuse-%04d", i+1), // making creation order match returned list order / nonce counter
@@ -1147,7 +1147,7 @@ resources:
 
 	secrets := make([]*api.Secret, dataLen)
 
-	for i := 0; i < dataLen; i++ {
+	for i := range dataLen {
 		secrets[i] = &api.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("test-secret-%d", i),
@@ -1166,7 +1166,7 @@ resources:
 			b.Fatal(err)
 		}
 
-		for i := 0; i < dataLen; i++ {
+		for i := range dataLen {
 			out, err := secretStorage.Create(ctx, secrets[i], noValidation, &metav1.CreateOptions{})
 			if err != nil {
 				b.Fatal(err)
@@ -1294,7 +1294,7 @@ resources:
 
 	secrets := make([]*corev1.Secret, dataLen)
 
-	for i := 0; i < dataLen; i++ {
+	for i := range dataLen {
 		secrets[i] = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("test-secret-%d", i),
@@ -1313,7 +1313,7 @@ resources:
 			b.Fatal(err)
 		}
 
-		for i := 0; i < dataLen; i++ {
+		for i := range dataLen {
 			out, err := secretStorage.Create(ctx, secrets[i], metav1.CreateOptions{})
 			if err != nil {
 				b.Fatal(err)

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -1238,7 +1238,7 @@ func TestDaemonSetRollingUpdateWithTolerations(t *testing.T) {
 	}
 
 	// Add six nodes with zone-y, zone-z or common taint
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		if i < 2 {
 			taints = []v1.Taint{
 				{Key: "zone-y", Effect: v1.TaintEffectNoSchedule},

--- a/test/integration/disruption/disruption_test.go
+++ b/test/integration/disruption/disruption_test.go
@@ -161,7 +161,7 @@ func TestPDBWithScaleSubresource(t *testing.T) {
 			Controller: &trueValue,
 		},
 	}
-	for i := 0; i < replicas; i++ {
+	for i := range replicas {
 		createPod(tCtx, t, fmt.Sprintf("pod-%d", i), nsName, map[string]string{"app": "test-crd"}, clientSet, ownerRefs)
 	}
 
@@ -260,7 +260,7 @@ func TestEmptySelector(t *testing.T) {
 			replicas := 4
 			minAvailable := intstr.FromInt32(2)
 
-			for j := 0; j < replicas; j++ {
+			for j := range replicas {
 				createPod(tCtx, t, fmt.Sprintf("pod-%d", j), nsName, map[string]string{"app": "test-crd"},
 					clientSet, []metav1.OwnerReference{})
 			}

--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -308,7 +308,7 @@ func TestDRA(t *testing.T) {
 }
 
 func createNodes(tCtx ktesting.TContext) {
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		nodeName := fmt.Sprintf("worker-%d", i)
 		// Create node.
 		node := &v1.Node{
@@ -546,7 +546,7 @@ func testFilterTimeout(tCtx ktesting.TContext, devicesPerSlice int) {
 	namespace := createTestNamespace(tCtx, nil)
 	class, driverName := createTestClass(tCtx, namespace)
 	deviceNames := make([]string, devicesPerSlice)
-	for i := 0; i < devicesPerSlice; i++ {
+	for i := range devicesPerSlice {
 		deviceNames[i] = fmt.Sprintf("dev-%d", i)
 	}
 	slice := st.MakeResourceSlice("worker-0", driverName).Devices(deviceNames...)
@@ -1167,7 +1167,7 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 		// Stress the controller by repeatedly deleting the slices.
 		// One delete occurs after the sync period is over (because of the Consistently),
 		// the second before (because it's done as quickly as possible).
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			tCtx.Log("deleting ResourceSlices")
 			tCtx.ExpectNoError(tCtx.Client().ResourceV1().ResourceSlices().DeleteCollection(tCtx, metav1.DeleteOptions{}, listDriverSlices), "delete driver slices")
 			expectedStats.NumCreates += int64(len(expectedSlices))
@@ -1180,7 +1180,7 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 		_, getStats, expectedStats := setup(tCtx)
 
 		// Stress the controller by repeatedly updatings the slices.
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			slices, err := tCtx.Client().ResourceV1().ResourceSlices().List(tCtx, listDriverSlices)
 			tCtx.ExpectNoError(err, "list slices")
 			for _, slice := range slices.Items {
@@ -1691,7 +1691,7 @@ func testInvalidResourceSlices(tCtx ktesting.TContext) {
 		"invalid-for-all-nodes": {
 			slices: func() []*st.ResourceSliceWrapper {
 				var slices []*st.ResourceSliceWrapper
-				for i := 0; i < 8; i++ {
+				for i := range 8 {
 					nodeName := fmt.Sprintf("worker-%d", i)
 					invalidPoolSlice1 := st.MakeResourceSlice(nodeName, driverNamePlaceholder).Devices("device-1")
 					invalidPoolSlice1.Name += "-1"

--- a/test/integration/dra/objects.go
+++ b/test/integration/dra/objects.go
@@ -43,7 +43,7 @@ func NewMaxResourceSlices() map[string]*resourceapi.ResourceSlice {
 func newResourceSliceWithTaintsAndConsumesCounters() *resourceapi.ResourceSlice {
 	slice := newBasicResourceSlice(resourceapi.ResourceSliceMaxDevicesWithTaintsOrConsumesCounters)
 	for i := range slice.Spec.Devices {
-		for j := 0; j < resourceapi.DeviceTaintsMaxLength; j++ {
+		for range resourceapi.DeviceTaintsMaxLength {
 			slice.Spec.Devices[i].Taints = append(slice.Spec.Devices[i].Taints,
 				resourceapi.DeviceTaint{
 					Key:       maxLabelName(i),
@@ -55,12 +55,12 @@ func newResourceSliceWithTaintsAndConsumesCounters() *resourceapi.ResourceSlice 
 		}
 		slice.Spec.Devices[i].ConsumesCounters = func() []resourceapi.DeviceCounterConsumption {
 			var consumesCounters []resourceapi.DeviceCounterConsumption
-			for i := 0; i < resourceapi.ResourceSliceMaxDeviceCounterConsumptionsPerDevice; i++ {
+			for i := range resourceapi.ResourceSliceMaxDeviceCounterConsumptionsPerDevice {
 				consumesCounters = append(consumesCounters, resourceapi.DeviceCounterConsumption{
 					CounterSet: maxDNSLabel(i),
 					Counters: func() map[string]resourceapi.Counter {
 						counters := make(map[string]resourceapi.Counter)
-						for i := 0; i < resourceapi.ResourceSliceMaxCountersPerDeviceCounterConsumption; i++ {
+						for i := range resourceapi.ResourceSliceMaxCountersPerDeviceCounterConsumption {
 							counters[maxDNSLabel(i)] = resourceapi.Counter{
 								Value: resource.MustParse("80Gi"),
 							}
@@ -79,13 +79,13 @@ func newBasicResourceSlice(numDevices int) *resourceapi.ResourceSlice {
 	slice := commonResourceSlice()
 	slice.Spec.PerDeviceNodeSelection = ptr.To(true)
 	var devices []resourceapi.Device
-	for i := 0; i < numDevices; i++ {
+	for i := range numDevices {
 		devices = append(devices, resourceapi.Device{
 			Name: maxDNSLabel(i),
 			// Use attributes rather than capacity since it is more expensive.
 			Attributes: func() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 				attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
-				for i := 0; i < resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice; i++ {
+				for i := range resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice {
 					attributes[maxResourceQualifiedName(i)] = resourceapi.DeviceAttribute{
 						StringValue: ptr.To(maxDNSLabel(i)),
 					}
@@ -103,12 +103,12 @@ func newSharedCountersResourceSlice() *resourceapi.ResourceSlice {
 	slice := commonResourceSlice()
 	slice.Spec.NodeName = ptr.To(maxSubDomain(0))
 	var counterSets []resourceapi.CounterSet
-	for i := 0; i < resourceapi.ResourceSliceMaxCounterSets; i++ {
+	for i := range resourceapi.ResourceSliceMaxCounterSets {
 		counterSets = append(counterSets, resourceapi.CounterSet{
 			Name: maxDNSLabel(i),
 			Counters: func() map[string]resourceapi.Counter {
 				counters := make(map[string]resourceapi.Counter)
-				for i := 0; i < resourceapi.ResourceSliceMaxCountersPerCounterSet; i++ {
+				for i := range resourceapi.ResourceSliceMaxCountersPerCounterSet {
 					counters[maxDNSLabel(i)] = resourceapi.Counter{
 						Value: resource.MustParse("80Gi"),
 					}
@@ -146,7 +146,7 @@ func commonResourceSlice() *resourceapi.ResourceSlice {
 // maxKeyValueMap produces a map for labels or annotations.
 func maxKeyValueMap(n int) map[string]string {
 	m := make(map[string]string)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		m[maxQualifiedName(i)] = maxLabelValue(0)
 	}
 	return m

--- a/test/integration/dra/resourceslicecontroller.go
+++ b/test/integration/dra/resourceslicecontroller.go
@@ -45,15 +45,15 @@ func TestCreateResourceSlices(tCtx ktesting.TContext, numSlices int) {
 		Slices: make([]resourceslice.Slice, numSlices),
 	}
 	numDevices := 0
-	for i := 0; i < numSlices; i++ {
+	for i := range numSlices {
 		devices := make([]resourceapi.Device, resourceapi.ResourceSliceMaxDevices)
-		for e := 0; e < resourceapi.ResourceSliceMaxDevices; e++ {
+		for e := range resourceapi.ResourceSliceMaxDevices {
 			device := resourceapi.Device{
 				Name:       devicePrefix + strings.Repeat("x", validation.DNS1035LabelMaxLength-len(devicePrefix)-6) + fmt.Sprintf("%06d", numDevices),
 				Attributes: make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice),
 			}
 			numDevices++
-			for j := 0; j < resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice; j++ {
+			for j := range resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice {
 				name := resourceapi.QualifiedName(domain + "/" + strings.Repeat("x", resourceapi.DeviceMaxIDLength-4) + fmt.Sprintf("%04d", j))
 				device.Attributes[name] = resourceapi.DeviceAttribute{
 					StringValue: &stringValue,

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -230,7 +230,7 @@ func TestEndpointWithMultiplePodUpdates(t *testing.T) {
 
 	var services []*v1.Service
 	// Create services associated to the pod
-	for i := 0; i < concurrency; i++ {
+	for i := range concurrency {
 		svc := newService(ns.Name, fmt.Sprintf("foo%d", i))
 		_, err = client.CoreV1().Services(ns.Name).Create(tCtx, svc, metav1.CreateOptions{})
 		if err != nil {
@@ -678,7 +678,7 @@ func TestEndpointTruncate(t *testing.T) {
 	// create 1001 Pods to reach endpoint max capacity that is set to 1000
 	allPodNames := sets.New[string]()
 	baseIP := netutils.BigForIP(netutils.ParseIPSloppy("10.0.0.1"))
-	for i := 0; i < 1001; i++ {
+	for i := range 1001 {
 		pod := basePod.DeepCopy()
 		pod.Name = fmt.Sprintf("%s-%d", basePod.Name, i)
 		allPodNames.Insert(pod.Name)
@@ -755,7 +755,7 @@ func TestEndpointTruncate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get pod %s: %v", truncatedPodName, err)
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		truncatedPod.Status.Conditions[0].Status = v1.ConditionFalse
 		truncatedPod, err = client.CoreV1().Pods(ns.Name).UpdateStatus(tCtx, truncatedPod, metav1.UpdateOptions{})
 		if err != nil {

--- a/test/integration/evictions/evictions_test.go
+++ b/test/integration/evictions/evictions_test.go
@@ -83,7 +83,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 	}
 
 	// Generate numOfEvictions pods to evict
-	for i := 0; i < numOfEvictions; i++ {
+	for i := range numOfEvictions {
 		podName := fmt.Sprintf(podNameFormat, i)
 		pod := newPod(podName)
 
@@ -110,7 +110,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 	errCh := make(chan error, 3*numOfEvictions)
 	var wg sync.WaitGroup
 	// spawn numOfEvictions goroutines to concurrently evict the pods
-	for i := 0; i < numOfEvictions; i++ {
+	for i := range numOfEvictions {
 		wg.Add(1)
 		go func(id int, errCh chan error) {
 			defer wg.Done()

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -201,7 +201,7 @@ func TestAPIServiceWaitOnStart(t *testing.T) {
 	aggregatorClient := aggregatorclient.NewForConfigOrDie(kubeClientConfig)
 
 	t.Log("Ensure both APIService objects remain")
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		if _, err := aggregatorClient.ApiregistrationV1().APIServices().Get(ctx, "v1.valid.example.com", metav1.GetOptions{}); err != nil {
 			t.Fatal(err)
 		}
@@ -232,7 +232,7 @@ func TestAPIServiceWaitOnStart(t *testing.T) {
 	}
 
 	t.Log("Ensure the valid APIService object remains")
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		time.Sleep(time.Second)
 		if _, err := aggregatorClient.ApiregistrationV1().APIServices().Get(ctx, "v1.valid.example.com", metav1.GetOptions{}); err != nil {
 			t.Fatal(err)

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -2338,7 +2338,7 @@ func TestImmediateJobRecreation(t *testing.T) {
 	// more Jobs than the number of Job controller workers to make it very unlikely
 	// that syncJob executes (and cleans the in-memory state) before the corresponding
 	// replacement Jobs are created.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		jobObj, err := createJobWithDefaults(ctx, clientSet, ns.Name, ptr.To(jobSpec(i)))
 		if err != nil {
 			t.Fatalf("Error %v when creating the job %q", err, klog.KObj(jobObj))

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -81,11 +81,11 @@ func TestWatchBasedManager(t *testing.T) {
 	t.Log(time.Now(), "creating 1000 secrets")
 	wg := sync.WaitGroup{}
 	errCh := make(chan error, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				name := fmt.Sprintf("s%d", i*100+j)
 				if _, err := client.CoreV1().Secrets(testNamespace).Create(ctx, &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name}}, metav1.CreateOptions{}); err != nil {
 					select {
@@ -109,11 +109,11 @@ func TestWatchBasedManager(t *testing.T) {
 	// fetch all secrets
 	wg = sync.WaitGroup{}
 	errCh = make(chan error, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				name := fmt.Sprintf("s%d", i*100+j)
 				start := time.Now()
 				store.AddReference(testNamespace, name, types.UID(name))

--- a/test/integration/logs/benchmark/benchmark_test.go
+++ b/test/integration/logs/benchmark/benchmark_test.go
@@ -317,7 +317,7 @@ func generateOutput(b *testing.B, config loadGeneratorConfig, files ...*os.File)
 			defer wg.Done()
 
 			acc := 0.0
-			for i := 0; i < n; i++ {
+			for range n {
 				if acc > 100 {
 					klog.ErrorS(err, msg, "key", "value")
 					acc -= 100

--- a/test/integration/node/lifecycle_test.go
+++ b/test/integration/node/lifecycle_test.go
@@ -77,7 +77,7 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			var nodes []*v1.Node
-			for i := 0; i < nodeCount; i++ {
+			for i := range nodeCount {
 				node := &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   fmt.Sprintf("testnode-%d", i),
@@ -390,7 +390,7 @@ func TestTaintBasedEvictions(t *testing.T) {
 			}
 
 			var nodes []*v1.Node
-			for i := 0; i < nodeCount; i++ {
+			for i := range nodeCount {
 				node := &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: fmt.Sprintf("node-%d", i),

--- a/test/integration/replicaset/replicaset_test.go
+++ b/test/integration/replicaset/replicaset_test.go
@@ -729,7 +729,7 @@ func TestOverlappingRSs(t *testing.T) {
 	defer stopControllers()
 
 	// Create 2 RSs with identical selectors
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		// One RS has 1 replica, and another has 2 replicas
 		rs := newRS(fmt.Sprintf("rs-%d", i+1), ns.Name, i+1)
 		rss, _ := createRSsPods(t, c, []*apps.ReplicaSet{rs}, []*v1.Pod{})
@@ -744,7 +744,7 @@ func TestOverlappingRSs(t *testing.T) {
 	}
 
 	// Expect both RSs have .status.replicas = .spec.replicas
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		newRS, err := c.AppsV1().ReplicaSets(ns.Name).Get(tCtx, fmt.Sprintf("rs-%d", i+1), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("failed to obtain rs rs-%d: %v", i+1, err)
@@ -945,7 +945,7 @@ func TestExtraPodsAdoptionAndDeletion(t *testing.T) {
 	rs := newRS("rs", ns.Name, 2)
 	// Create 3 pods, RS should adopt only 2 of them
 	podList := []*v1.Pod{}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		pod := newMatchingPod(fmt.Sprintf("pod-%d", i+1), ns.Name)
 		pod.Labels = labelMap()
 		podList = append(podList, pod)

--- a/test/integration/replicationcontroller/replicationcontroller_test.go
+++ b/test/integration/replicationcontroller/replicationcontroller_test.go
@@ -614,7 +614,7 @@ func TestOverlappingRCs(t *testing.T) {
 	defer stopControllers()
 
 	// Create 2 RCs with identical selectors
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		// One RC has 1 replica, and another has 2 replicas
 		rc := newRC(fmt.Sprintf("rc-%d", i+1), ns.Name, i+1)
 		rcs, _ := createRCsPods(t, c, []*v1.ReplicationController{rc}, []*v1.Pod{})
@@ -629,7 +629,7 @@ func TestOverlappingRCs(t *testing.T) {
 	}
 
 	// Expect both RCs have .status.replicas = .spec.replicas
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		newRC, err := c.CoreV1().ReplicationControllers(ns.Name).Get(tCtx, fmt.Sprintf("rc-%d", i+1), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("failed to obtain rc rc-%d: %v", i+1, err)
@@ -830,7 +830,7 @@ func TestExtraPodsAdoptionAndDeletion(t *testing.T) {
 	rc := newRC("rc", ns.Name, 2)
 	// Create 3 pods, RC should adopt only 2 of them
 	podList := []*v1.Pod{}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		pod := newMatchingPod(fmt.Sprintf("pod-%d", i+1), ns.Name)
 		pod.Labels = labelMap()
 		podList = append(podList, pod)

--- a/test/integration/scheduler/extender/extender_test.go
+++ b/test/integration/scheduler/extender/extender_test.go
@@ -381,7 +381,7 @@ func DoTestPodScheduling(ns *v1.Namespace, t *testing.T, cs clientset.Interface)
 		},
 	}
 
-	for ii := 0; ii < 5; ii++ {
+	for ii := range 5 {
 		node.Name = fmt.Sprintf("machine%d", ii+1)
 		if _, err := createNode(cs, node); err != nil {
 			t.Fatalf("Failed to create nodes: %v", err)

--- a/test/integration/scheduler/preemption/misc/miscpreemption_test.go
+++ b/test/integration/scheduler/preemption/misc/miscpreemption_test.go
@@ -410,7 +410,7 @@ func TestPreemptionStarvation(t *testing.T) {
 					numRunningPods := test.numExistingPod - test.numExpectedPending
 					runningPods := make([]*v1.Pod, numRunningPods)
 					// Create and run existingPods.
-					for i := 0; i < numRunningPods; i++ {
+					for i := range numRunningPods {
 						runningPods[i], err = createPausePod(cs, mkPriorityPodWithGrace(testCtx, fmt.Sprintf("rpod-%v", i), mediumPriority, 0))
 						if err != nil {
 							t.Fatalf("Error creating pause pod: %v", err)

--- a/test/integration/scheduler/scoring/priorities_test.go
+++ b/test/integration/scheduler/scoring/priorities_test.go
@@ -356,7 +356,7 @@ func TestPodAffinityScoring(t *testing.T) {
 	labelValue := "S1"
 	topologyKey := "node-topologykey"
 	topologyValues := []string{}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		topologyValues = append(topologyValues, fmt.Sprintf("topologyvalue%d", i))
 	}
 	tests := []struct {
@@ -1187,7 +1187,7 @@ func TestDefaultPodTopologySpreadScoring(t *testing.T) {
 	nodeNum := 300
 
 	zoneForNode := make(map[string]string)
-	for i := 0; i < nodeNum; i++ {
+	for i := range nodeNum {
 		nodeName := fmt.Sprintf("node-%d", i)
 		zone := fmt.Sprintf("zone-%d", i%3)
 		zoneForNode[nodeName] = zone
@@ -1226,7 +1226,7 @@ func TestDefaultPodTopologySpreadScoring(t *testing.T) {
 	for _, nPods := range []int{3, 9, 15} {
 		// Append nPods each iteration.
 		t.Run(fmt.Sprintf("%d-pods", totalPodCnt+nPods), func(t *testing.T) {
-			for i := 0; i < nPods; i++ {
+			for range nPods {
 				p := st.MakePod().Name(fmt.Sprintf("p-%d", totalPodCnt)).Label("service", serviceName).Container(pause).Obj()
 				_, err = cs.CoreV1().Pods(ns).Create(testCtx.Ctx, p, metav1.CreateOptions{})
 				if err != nil {

--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -229,7 +229,7 @@ func resourceSlice(driverName, nodeName string, capacity int) *resourceapi.Resou
 		},
 	}
 
-	for i := 0; i < capacity; i++ {
+	for i := range capacity {
 		slice.Spec.Devices = append(slice.Spec.Devices,
 			resourceapi.Device{
 				Name: fmt.Sprintf("instance-%d", i),

--- a/test/integration/scheduler_perf/node_util.go
+++ b/test/integration/scheduler_perf/node_util.go
@@ -95,7 +95,7 @@ func (p *IntegrationTestNodePreparer) PrepareNodes(ctx context.Context, nextNode
 		if err != nil {
 			return fmt.Errorf("failed to get node template: %w", err)
 		}
-		for retry := 0; retry < createNodeRetries; retry++ {
+		for range createNodeRetries {
 			// Create nodes with the usual kubernetes.io/hostname label.
 			// For that we need to know the name in advance, if we want to
 			// do it in one request.

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -1842,7 +1842,7 @@ func (e *WorkloadExecutor) runDeletePodsOp(opIndex int, op *deletePodsOp) error 
 			ticker := time.NewTicker(time.Second / time.Duration(op.DeletePodsPerSecond))
 			defer ticker.Stop()
 
-			for i := 0; i < len(podsToDelete); i++ {
+			for i := range podsToDelete {
 				select {
 				case <-ticker.C:
 					if err := e.tCtx.Client().CoreV1().Pods(op.Namespace).Delete(e.tCtx, podsToDelete[i].Name, metav1.DeleteOptions{}); err != nil {

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -278,7 +278,7 @@ func TestLegacyServiceAccountTokenTracking(t *testing.T) {
 
 			var wg sync.WaitGroup
 			concurrency := 5
-			for i := 0; i < concurrency; i++ {
+			for range concurrency {
 				wg.Add(1)
 				go func() {
 					doServiceAccountAPIRequests(t, roClient, myns, true, true, false)

--- a/test/integration/servicecidr/allocator_test.go
+++ b/test/integration/servicecidr/allocator_test.go
@@ -111,7 +111,7 @@ func TestServiceAllocation(t *testing.T) {
 			}
 
 			// make 5 more services to take up all IPs
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				if _, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(context.TODO(), svc(i), metav1.CreateOptions{}); err != nil {
 					t.Error(err)
 				}
@@ -194,7 +194,7 @@ func TestServiceAllocIPAddressLargeCIDR(t *testing.T) {
 	}
 
 	// create 5 random services and check that the Services have an IP associated
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		svc, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(tCtx, svc(i), metav1.CreateOptions{})
 		if err != nil {
 			t.Error(err)
@@ -326,7 +326,7 @@ func TestSkewedAllocatorsRollback(t *testing.T) {
 	}
 
 	// create 5 random services and check that the Services have an IP associated
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		service, err := kubeclient1.CoreV1().Services(metav1.NamespaceDefault).Create(context.TODO(), svc(i), metav1.CreateOptions{})
 		if err != nil {
 			t.Error(err)
@@ -561,7 +561,7 @@ func TestFlagsIPAllocator(t *testing.T) {
 	}
 
 	// create 5 random services and check that the Services have an IP associated
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		service, err := kubeclient1.CoreV1().Services(metav1.NamespaceDefault).Create(context.TODO(), svc(i), metav1.CreateOptions{})
 		if err != nil {
 			t.Error(err)

--- a/test/integration/servicecidr/feature_enable_disable_test.go
+++ b/test/integration/servicecidr/feature_enable_disable_test.go
@@ -63,7 +63,7 @@ func TestEnableDisableServiceCIDR(t *testing.T) {
 
 	ns := framework.CreateNamespaceOrDie(client1, "test-enable-disable-service-cidr", t)
 	// make 2 services , there will be 3 services counting the kubernetes.default
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if _, err := client1.CoreV1().Services(ns.Name).Create(context.TODO(), svc(i), metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/servicecidr/migration_test.go
+++ b/test/integration/servicecidr/migration_test.go
@@ -114,7 +114,7 @@ func TestMigrateServiceCIDR(t *testing.T) {
 	}
 
 	// make 2 services , there will be still 3 free addresses
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if _, err := client1.CoreV1().Services(ns.Name).Create(context.TODO(), svc(i), metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/servicecidr/perf_test.go
+++ b/test/integration/servicecidr/perf_test.go
@@ -110,18 +110,18 @@ func TestServiceAllocPerformance(t *testing.T) {
 			results := make(chan error, nservices)
 			t.Log("Starting workers to create ClusterIP Service")
 			now := time.Now()
-			for w := 0; w < nworkers; w++ {
+			for w := range nworkers {
 				t.Logf("Starting worker %d", w)
 				go worker(client, w, jobs, results)
 			}
-			for i := 0; i < nservices; i++ {
+			for i := range nservices {
 				t.Logf("Sending job %d", i)
 				jobs <- i
 			}
 			t.Log("All jobs processed")
 			close(jobs)
 
-			for c := 0; c < nservices; c++ {
+			for c := range nservices {
 				t.Logf("Getting results %d", c)
 				err := <-results
 				if err != nil {

--- a/test/integration/servicecidr/servicecidr_test.go
+++ b/test/integration/servicecidr/servicecidr_test.go
@@ -74,7 +74,7 @@ func TestServiceAllocNewServiceCIDR(t *testing.T) {
 
 	// /29 = 6 services, kubernetes.default takes the first address
 	// make 5 more services to take up all IPs
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if _, err := client.CoreV1().Services(metav1.NamespaceDefault).Create(context.Background(), makeService(fmt.Sprintf("service-%d", i)), metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
@@ -174,7 +174,7 @@ func TestServiceCIDRDeletion(t *testing.T) {
 
 	// /29 = 6 services, kubernetes.default takes the first address
 	// make 5 more services to take up all IPs
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if _, err := client.CoreV1().Services(ns.Name).Create(context.Background(), makeService(fmt.Sprintf("service-%d", i)), metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -775,7 +775,7 @@ func CreateNode(cs clientset.Interface, node *v1.Node) (*v1.Node, error) {
 
 func createNodes(cs clientset.Interface, prefix string, wrapper *st.NodeWrapper, numNodes int) ([]*v1.Node, error) {
 	nodes := make([]*v1.Node, numNodes)
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		nodeName := fmt.Sprintf("%v-%d", prefix, i)
 		node, err := CreateNode(cs, wrapper.Name(nodeName).Label("kubernetes.io/hostname", nodeName).Obj())
 		if err != nil {

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -614,7 +614,7 @@ func TestPVCBoundWithADC(t *testing.T) {
 
 	// pods with pvc not bound
 	pvcs := []*v1.PersistentVolumeClaim{}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		pod, pvc := fakePodWithPVC(fmt.Sprintf("fakepod-pvcnotbound-%d", i), fmt.Sprintf("fakepvc-%d", i), namespaceName)
 		if _, err := testClient.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
 			t.Errorf("Failed to create pod : %v", err)

--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -511,7 +511,7 @@ func TestPersistentVolumeMultiPVs(t *testing.T) {
 
 	maxPVs := getObjectCount()
 	pvs := make([]*v1.PersistentVolume, maxPVs)
-	for i := 0; i < maxPVs; i++ {
+	for i := range maxPVs {
 		// This PV will be claimed, released, and deleted
 		pvs[i] = createPV("pv-"+strconv.Itoa(i), "/tmp/foo"+strconv.Itoa(i), strconv.Itoa(i+1)+"G",
 			[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}, v1.PersistentVolumeReclaimRetain)
@@ -519,7 +519,7 @@ func TestPersistentVolumeMultiPVs(t *testing.T) {
 
 	pvc := createPVC("pvc-2", ns.Name, strconv.Itoa(maxPVs/2)+"G", []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}, "")
 
-	for i := 0; i < maxPVs; i++ {
+	for i := range maxPVs {
 		_, err := testClient.CoreV1().PersistentVolumes().Create(context.TODO(), pvs[i], metav1.CreateOptions{})
 		if err != nil {
 			t.Errorf("Failed to create PersistentVolume %d: %v", i, err)
@@ -542,7 +542,7 @@ func TestPersistentVolumeMultiPVs(t *testing.T) {
 
 	// only one PV is bound
 	bound := 0
-	for i := 0; i < maxPVs; i++ {
+	for i := range maxPVs {
 		pv, err := testClient.CoreV1().PersistentVolumes().Get(context.TODO(), pvs[i].Name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Unexpected error getting pv: %v", err)
@@ -780,7 +780,7 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 	objCount := getObjectCount()
 	pvs := make([]*v1.PersistentVolume, objCount)
 	pvcs := make([]*v1.PersistentVolumeClaim, objCount)
-	for i := 0; i < objCount; i++ {
+	for i := range objCount {
 		// This PV will be claimed, released, and deleted
 		pvs[i] = createPV("pv-"+strconv.Itoa(i), "/tmp/foo"+strconv.Itoa(i), "1G",
 			[]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}, v1.PersistentVolumeReclaimRetain)
@@ -794,12 +794,12 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 	// watchPV early - it seems it has limited capacity and it gets stuck
 	// with >3000 volumes.
 	go func() {
-		for i := 0; i < objCount; i++ {
+		for i := range objCount {
 			_, _ = testClient.CoreV1().PersistentVolumes().Create(context.TODO(), pvs[i], metav1.CreateOptions{})
 		}
 	}()
 	// Wait for them to get Available
-	for i := 0; i < objCount; i++ {
+	for i := range objCount {
 		waitForAnyPersistentVolumePhase(watchPV, v1.VolumeAvailable)
 		klog.V(1).Infof("%d volumes available", i+1)
 	}
@@ -873,7 +873,7 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 
 	// Create the claims, again in a separate goroutine.
 	go func() {
-		for i := 0; i < objCount; i++ {
+		for i := range objCount {
 			_, _ = testClient.CoreV1().PersistentVolumeClaims(ns.Name).Create(context.TODO(), pvcs[i], metav1.CreateOptions{})
 		}
 	}()
@@ -885,7 +885,7 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 	}
 
 	// wait until the binder pairs all volumes
-	for i := 0; i < objCount; i++ {
+	for i := range objCount {
 		waitForPersistentVolumePhase(testClient, pvs[i].Name, watchPV, v1.VolumeBound)
 		klog.V(1).Infof("%d claims bound", i+1)
 	}
@@ -894,7 +894,7 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 	close(stopCh)
 
 	// check that everything is bound to something
-	for i := 0; i < objCount; i++ {
+	for i := range objCount {
 		pv, err := testClient.CoreV1().PersistentVolumes().Get(context.TODO(), pvs[i].Name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Unexpected error getting pv: %v", err)
@@ -940,7 +940,7 @@ func TestPersistentVolumeControllerStartup(t *testing.T) {
 	// Create *bound* volumes and PVCs
 	pvs := make([]*v1.PersistentVolume, objCount)
 	pvcs := make([]*v1.PersistentVolumeClaim, objCount)
-	for i := 0; i < objCount; i++ {
+	for i := range objCount {
 		pvName := "pv-startup-" + strconv.Itoa(i)
 		pvcName := "pvc-startup-" + strconv.Itoa(i)
 
@@ -1027,7 +1027,7 @@ func TestPersistentVolumeControllerStartup(t *testing.T) {
 	}
 
 	// check that everything is bound to something
-	for i := 0; i < objCount; i++ {
+	for i := range objCount {
 		pv, err := testClient.CoreV1().PersistentVolumes().Get(context.TODO(), pvs[i].Name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Unexpected error getting pv: %v", err)
@@ -1085,7 +1085,7 @@ func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
 
 	objCount := getObjectCount()
 	pvcs := make([]*v1.PersistentVolumeClaim, objCount)
-	for i := 0; i < objCount; i++ {
+	for i := range objCount {
 		pvc := createPVC("pvc-provision-"+strconv.Itoa(i), ns.Name, "1G", []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}, "gold")
 		pvcs[i] = pvc
 	}
@@ -1094,7 +1094,7 @@ func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
 	// Create the claims in a separate goroutine to pop events from watchPVC
 	// early. It gets stuck with >3000 claims.
 	go func() {
-		for i := 0; i < objCount; i++ {
+		for i := range objCount {
 			_, _ = testClient.CoreV1().PersistentVolumeClaims(ns.Name).Create(context.TODO(), pvcs[i], metav1.CreateOptions{})
 		}
 	}()
@@ -1114,7 +1114,7 @@ func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
 	if len(pvList.Items) != objCount {
 		t.Fatalf("Expected to get %d volumes, got %d", objCount, len(pvList.Items))
 	}
-	for i := 0; i < objCount; i++ {
+	for i := range objCount {
 		pv := &pvList.Items[i]
 		if pv.Status.Phase != v1.VolumeBound {
 			t.Fatalf("Expected volume %s to be bound, is %s instead", pv.Name, pv.Status.Phase)
@@ -1123,7 +1123,7 @@ func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
 	}
 
 	// Delete the claims
-	for i := 0; i < objCount; i++ {
+	for i := range objCount {
 		_ = testClient.CoreV1().PersistentVolumeClaims(ns.Name).Delete(context.TODO(), pvcs[i].Name, metav1.DeleteOptions{})
 	}
 
@@ -1481,7 +1481,7 @@ func waitForSomePersistentVolumeClaimPhase(ctx context.Context, testClient clien
 	}()
 
 	return wait.ExponentialBackoffWithContext(ctx, retry.DefaultBackoff, func(ctx context.Context) (bool, error) {
-		for i := 0; i < objCount; i++ {
+		for i := range objCount {
 			err := waitForAnyPersistentVolumeClaimPhase(watchPVC, v1.ClaimBound)
 			if err != nil {
 				klog.Errorf("Failed to wait for a claim (%d/%d) to be bound: %v", i+1, objCount, err)

--- a/test/integration/volumescheduling/volume_binding_test.go
+++ b/test/integration/volumescheduling/volume_binding_test.go
@@ -522,7 +522,7 @@ func testVolumeBindingWithAffinity(t *testing.T, anti bool, numNodes, numPods, n
 	pvcs := []*v1.PersistentVolumeClaim{}
 
 	// Create PVs for the first node
-	for i := 0; i < numPVsFirstNode; i++ {
+	for i := range numPVsFirstNode {
 		pv := makePV(fmt.Sprintf("pv-node1-%v", i), classWait, "", "", node1)
 		if pv, err := config.client.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create PersistentVolume %q: %v", pv.Name, err)
@@ -538,7 +538,7 @@ func testVolumeBindingWithAffinity(t *testing.T, anti bool, numNodes, numPods, n
 	}
 
 	// Create pods
-	for i := 0; i < numPods; i++ {
+	for i := range numPods {
 		// Create one pvc per pod
 		pvc := makePVC(fmt.Sprintf("pvc-%v", i), config.ns, &classWait, "")
 		if pvc, err := config.client.CoreV1().PersistentVolumeClaims(config.ns).Create(context.TODO(), pvc, metav1.CreateOptions{}); err != nil {
@@ -662,7 +662,7 @@ func TestPVAffinityConflict(t *testing.T) {
 		markNodeAffinity,
 		markNodeSelector,
 	}
-	for i := 0; i < len(nodeMarkers); i++ {
+	for i := range nodeMarkers {
 		podName := "local-pod-" + strconv.Itoa(i+1)
 		pod := makePod(podName, config.ns, []string{"local-pvc"})
 		nodeMarkers[i].(func(*v1.Pod, string))(pod, "node-2")
@@ -1057,7 +1057,7 @@ func setupCluster(t *testing.T, nsName string, numberOfNodes int, resyncPeriod t
 
 	// Create shared objects
 	// Create nodes
-	for i := 0; i < numberOfNodes; i++ {
+	for i := range numberOfNodes {
 		testNode := makeNode(i + 1)
 		if _, err := clientset.CoreV1().Nodes().Create(context.TODO(), testNode, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create Node %q: %v", testNode.Name, err)

--- a/test/utils/density_utils.go
+++ b/test/utils/density_utils.go
@@ -43,7 +43,7 @@ func AddLabelsToNode(c clientset.Interface, nodeName string, labels map[string]s
 	labelString := "{" + strings.Join(tokens, ",") + "}"
 	patch := fmt.Sprintf(`{"metadata":{"labels":%v}}`, labelString)
 	var err error
-	for attempt := 0; attempt < retries; attempt++ {
+	for range retries {
 		_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
 		if err != nil {
 			if !apierrors.IsConflict(err) {
@@ -62,7 +62,7 @@ func AddLabelsToNode(c clientset.Interface, nodeName string, labels map[string]s
 func RemoveLabelOffNode(c clientset.Interface, nodeName string, labelKeys []string) error {
 	var node *v1.Node
 	var err error
-	for attempt := 0; attempt < retries; attempt++ {
+	for range retries {
 		node, err = c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if err != nil {
 			return err

--- a/test/utils/hermeticpodcertificatesigner/hermeticpodcertificatesigner.go
+++ b/test/utils/hermeticpodcertificatesigner/hermeticpodcertificatesigner.go
@@ -353,7 +353,7 @@ func GenerateCAHierarchy(numIntermediates int) ([]crypto.PrivateKey, [][]byte, e
 	caKeys = append(caKeys, rootPrivKey)
 	caCerts = append(caCerts, rootDER)
 
-	for i := 0; i < numIntermediates; i++ {
+	for range numIntermediates {
 		pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 		if err != nil {
 			return nil, nil, fmt.Errorf("while generating intermediate key: %w", err)

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -734,7 +734,7 @@ func StartPods(c clientset.Interface, replicas int, namespace string, podNamePre
 		panic("StartPods: number of replicas must be non-zero")
 	}
 	startPodsID := string(uuid.NewUUID()) // So that we can label and find them
-	for i := 0; i < replicas; i++ {
+	for i := range replicas {
 		podName := fmt.Sprintf("%v-%v", podNamePrefix, i)
 		pod.ObjectMeta.Name = podName
 		pod.ObjectMeta.Labels["name"] = podName
@@ -1048,7 +1048,7 @@ func DoPrepareNode(ctx context.Context, client clientset.Interface, node *v1.Nod
 	if len(patch) == 0 {
 		return nil
 	}
-	for attempt := 0; attempt < retries; attempt++ {
+	for range retries {
 		if _, err = client.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{}); err == nil {
 			break
 		}
@@ -1061,7 +1061,7 @@ func DoPrepareNode(ctx context.Context, client clientset.Interface, node *v1.Nod
 		return fmt.Errorf("too many conflicts when applying patch %v to Node %v: %s", string(patch), node.Name, err)
 	}
 
-	for attempt := 0; attempt < retries; attempt++ {
+	for range retries {
 		if err = strategy.PrepareDependentObjects(ctx, node, client); err == nil {
 			break
 		}


### PR DESCRIPTION
#### What type of PR is this?

This was changed using [modernize/rangeint](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_rangeint) I didn't use this on everything in the code base. Note that in certain cases, the intermediate variable is not needed, so `for range <number>` can be used instead.

/kind cleanup

#### What this PR does / why we need it:

It's clean-up. My gut feeling is that `for i := range <whatever>` is marginally faster than `for i := 0 ...`

#### Which issue(s) this PR is related to:

N/A.

#### Special notes for your reviewer:

You can reproduce my changes with:

```sh
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -rangeint -fix -test ./test/utils/... 
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -rangeint -fix -test ./test/integration/... 
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
