### PR TITLE
Remove obsolete `// +build` instruction.

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -227,6 +227,7 @@ linters:
     - ineffassign
     - kubeapilinter
     - logcheck
+    - modernize
     - revive
     - sorted
     - staticcheck
@@ -501,6 +502,47 @@ linters:
         - pattern: ^gomega\.BeFalse$
           pkg: ^github.com/onsi/gomega$
           msg: "it does not produce a good failure message - use BeFalseBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"
+    modernize:
+      # List of analyzers to disable.
+      # By default, all analyzers are enabled but in
+      # Kubernetes we want to be more selective and
+      # disable those which are not useful for it.
+      disable:
+        # Replace interface{} with any.
+        - any
+        # Replace for-range over b.N with b.Loop.
+        - bloop
+        # Replace []byte(fmt.Sprintf) with fmt.Appendf.
+        - fmtappendf
+        # Remove redundant re-declaration of loop variables.
+        - forvar
+        # Replace explicit loops over maps with calls to maps package.
+        - mapsloop
+        # Replace if/else statements with calls to min or max.
+        - minmax
+        # Suggest replacing omitempty with omitzero for struct fields.
+        - omitzero
+        # Replace 3-clause for loops with for-range over integers.
+        - rangeint
+        # Replace reflect.TypeOf(x) with TypeFor[T]().
+        - reflecttypefor
+        # Replace loops with slices.Contains or slices.ContainsFunc.
+        - slicescontains
+        # Replace sort.Slice with slices.Sort for basic types.
+        - slicessort
+        # Use iterators instead of Len/At-style APIs.
+        - stditerators
+        # Replace HasPrefix/TrimPrefix with CutPrefix.
+        - stringscutprefix
+        # Replace ranging over Split/Fields with SplitSeq/FieldsSeq.
+        - stringsseq
+        # Replace += with strings.Builder.
+        - stringsbuilder
+        # Replace context.WithCancel with t.Context in tests.
+        - testingcontext
+        # Replace wg.Add(1)/go/wg.Done() with wg.Go.
+        - waitgroup
+
     revive:
       # Only these rules are enabled.
       rules:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -237,6 +237,7 @@ linters:
     - ineffassign
     - kubeapilinter
     - logcheck
+    - modernize
     - revive
     - sorted
     - staticcheck
@@ -522,6 +523,47 @@ linters:
         - typeSwitchVar
         - underef
         - unslice
+    modernize:
+      # List of analyzers to disable.
+      # By default, all analyzers are enabled but in
+      # Kubernetes we want to be more selective and
+      # disable those which are not useful for it.
+      disable:
+        # Replace interface{} with any.
+        - any
+        # Replace for-range over b.N with b.Loop.
+        - bloop
+        # Replace []byte(fmt.Sprintf) with fmt.Appendf.
+        - fmtappendf
+        # Remove redundant re-declaration of loop variables.
+        - forvar
+        # Replace explicit loops over maps with calls to maps package.
+        - mapsloop
+        # Replace if/else statements with calls to min or max.
+        - minmax
+        # Suggest replacing omitempty with omitzero for struct fields.
+        - omitzero
+        # Replace 3-clause for loops with for-range over integers.
+        - rangeint
+        # Replace reflect.TypeOf(x) with TypeFor[T]().
+        - reflecttypefor
+        # Replace loops with slices.Contains or slices.ContainsFunc.
+        - slicescontains
+        # Replace sort.Slice with slices.Sort for basic types.
+        - slicessort
+        # Use iterators instead of Len/At-style APIs.
+        - stditerators
+        # Replace HasPrefix/TrimPrefix with CutPrefix.
+        - stringscutprefix
+        # Replace ranging over Split/Fields with SplitSeq/FieldsSeq.
+        - stringsseq
+        # Replace += with strings.Builder.
+        - stringsbuilder
+        # Replace context.WithCancel with t.Context in tests.
+        - testingcontext
+        # Replace wg.Add(1)/go/wg.Done() with wg.Go.
+        - waitgroup
+
     revive:
       # Only these rules are enabled.
       rules:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -169,6 +169,7 @@ linters:
     - ineffassign
     - kubeapilinter
     - logcheck
+    - modernize
     - revive
     - sorted
     - staticcheck
@@ -268,6 +269,47 @@ linters:
         - underef
         - unslice
     {{- end}}
+    modernize:
+      # List of analyzers to disable.
+      # By default, all analyzers are enabled but in
+      # Kubernetes we want to be more selective and
+      # disable those which are not useful for it.
+      disable:
+        # Replace interface{} with any.
+        - any
+        # Replace for-range over b.N with b.Loop.
+        - bloop
+        # Replace []byte(fmt.Sprintf) with fmt.Appendf.
+        - fmtappendf
+        # Remove redundant re-declaration of loop variables.
+        - forvar
+        # Replace explicit loops over maps with calls to maps package.
+        - mapsloop
+        # Replace if/else statements with calls to min or max.
+        - minmax
+        # Suggest replacing omitempty with omitzero for struct fields.
+        - omitzero
+        # Replace 3-clause for loops with for-range over integers.
+        - rangeint
+        # Replace reflect.TypeOf(x) with TypeFor[T]().
+        - reflecttypefor
+        # Replace loops with slices.Contains or slices.ContainsFunc.
+        - slicescontains
+        # Replace sort.Slice with slices.Sort for basic types.
+        - slicessort
+        # Use iterators instead of Len/At-style APIs.
+        - stditerators
+        # Replace HasPrefix/TrimPrefix with CutPrefix.
+        - stringscutprefix
+        # Replace ranging over Split/Fields with SplitSeq/FieldsSeq.
+        - stringsseq
+        # Replace += with strings.Builder.
+        - stringsbuilder
+        # Replace context.WithCancel with t.Context in tests.
+        - testingcontext
+        # Replace wg.Add(1)/go/wg.Done() with wg.Go.
+        - waitgroup
+
     revive:
       # Only these rules are enabled.
       rules:

--- a/pkg/proxy/conntrack/sysctls.go
+++ b/pkg/proxy/conntrack/sysctls.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2015 The Kubernetes Authors.

--- a/pkg/proxy/conntrack/sysctls_test.go
+++ b/pkg/proxy/conntrack/sysctls_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2025 The Kubernetes Authors.

--- a/pkg/proxy/iptables/cleanup.go
+++ b/pkg/proxy/iptables/cleanup.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2015 The Kubernetes Authors.

--- a/pkg/proxy/iptables/cleanup_test.go
+++ b/pkg/proxy/iptables/cleanup_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2015 The Kubernetes Authors.

--- a/pkg/proxy/ipvs/cleanup.go
+++ b/pkg/proxy/ipvs/cleanup.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/pkg/proxy/ipvs/cleanup_test.go
+++ b/pkg/proxy/ipvs/cleanup_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/pkg/proxy/ipvs/supported.go
+++ b/pkg/proxy/ipvs/supported.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/pkg/proxy/ipvs/supported_test.go
+++ b/pkg/proxy/ipvs/supported_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/pkg/proxy/nftables/cleanup.go
+++ b/pkg/proxy/nftables/cleanup.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2015 The Kubernetes Authors.

--- a/pkg/proxy/nftables/supported.go
+++ b/pkg/proxy/nftables/supported.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2015 The Kubernetes Authors.

--- a/pkg/proxy/winkernel/supported.go
+++ b/pkg/proxy/winkernel/supported.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/test/e2e_node/probe_stress_test.go
+++ b/test/e2e_node/probe_stress_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2025 The Kubernetes Authors.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is obsolete from Go 1.18.
[modernize plusbuild](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_plusbuild)

#### Which issue(s) this PR is related to:

N/A.

#### Special notes for your reviewer:

/assign @endocrimes @robscott

You can reproduce my changes with:

```sh
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -plusbuild -fix -test ./...
```

#### Does this PR introduce a user-facing change?

```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: