### PR TITLE
e2e(node): avoid noisy SSH retries on nonexistent host

### DIFF
--- a/test/e2e/node/ssh.go
+++ b/test/e2e/node/ssh.go
@@ -110,9 +110,9 @@ var _ = SIGDescribe("SSH", func() {
 		}
 
 		// Quickly test that SSH itself errors correctly.
-		ginkgo.By("SSH'ing to a nonexistent host")
-		if _, err = e2essh.SSH(ctx, `echo "hello"`, "i.do.not.exist", framework.TestContext.Provider); err == nil {
-			framework.Failf("Expected error trying to SSH to nonexistent host.")
-		}
+		ginkgo.By("SSH'ing to a nonexistent host (expect single failure)")
+		_, err = e2essh.SSH(ctx, `echo "hello"`, "i.do.not.exist:22", framework.TestContext.Provider)
+		framework.ExpectError(err, "expected SSH to fail for nonexistent host")
+
 	})
 })


### PR DESCRIPTION
This PR reduces noise in the SSH e2e test by avoiding repeated retry attempts
against a deliberately invalid host.

Previously, the test attempted to SSH to "i.do.not.exist" without a port,
which caused repeated retries and noisy error output in CI logs.

This change:

- Preserves the intent of validating SSH error handling
- Uses an explicit invalid host:port to produce a single expected failure
- Improves signal-to-noise in e2e output without changing coverage

Fixes #136260

