### PR TITLE
e2e(node): avoid noisy SSH retries on nonexistent host

### DIFF
--- a/test/e2e/node/ssh.go
+++ b/test/e2e/node/ssh.go
@@ -110,9 +110,9 @@ var _ = SIGDescribe("SSH", func() {
 		}
 
 		// Quickly test that SSH itself errors correctly.
-		ginkgo.By("SSH'ing to a nonexistent host")
-		if _, err = e2essh.SSH(ctx, `echo "hello"`, "i.do.not.exist", framework.TestContext.Provider); err == nil {
-			framework.Failf("Expected error trying to SSH to nonexistent host.")
-		}
-	})
-})
+                ginkgo.By("SSH'ing to a nonexistent host")
+                _, err = e2essh.SSH(ctx, `echo "hello"`, "i.do.not.exist", framework.TestContext.Provider)
+                if err == nil {
+                        framework.Failf("Expected error trying to SSH to nonexistent host")
+                }
+


### PR DESCRIPTION
This tightens the negative SSH test in test/e2e/node/ssh.go by removing
retry behavior for an intentionally invalid host.

The test still validates SSH error handling for other e2e cases, but
avoids repeated error logs in CI for the expected failure path.
Fixes #136260

```release-note
NONE
```
