### PR TITLE
volume and proxy: switch tests to NewClientset

### DIFF
--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -330,7 +330,7 @@ func TestPlugin(t *testing.T) {
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
 		configMap     = configMap(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&configMap)
+		client        = fake.NewClientset(&configMap)
 		pluginMgr     = volume.VolumePluginMgr{}
 		tempDir, host = newTestHost(t, client)
 	)
@@ -396,7 +396,7 @@ func TestPluginReboot(t *testing.T) {
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
 		configMap     = configMap(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&configMap)
+		client        = fake.NewClientset(&configMap)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
@@ -453,7 +453,7 @@ func TestPluginOptional(t *testing.T) {
 		trueVal        = true
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
-		client        = fake.NewSimpleClientset()
+		client        = fake.NewClientset()
 		pluginMgr     = volume.VolumePluginMgr{}
 		tempDir, host = newTestHost(t, client)
 	)
@@ -546,7 +546,7 @@ func TestPluginKeysOptional(t *testing.T) {
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
 		configMap     = configMap(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&configMap)
+		client        = fake.NewClientset(&configMap)
 		pluginMgr     = volume.VolumePluginMgr{}
 		tempDir, host = newTestHost(t, client)
 	)
@@ -630,7 +630,7 @@ func TestInvalidConfigMapSetup(t *testing.T) {
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
 		configMap     = configMap(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&configMap)
+		client        = fake.NewClientset(&configMap)
 		pluginMgr     = volume.VolumePluginMgr{}
 		tempDir, host = newTestHost(t, client)
 	)

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -203,7 +203,7 @@ func TestAttacherAttach(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("test case: %s", tc.name)
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewClientset()
 			plug, tmpDir := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 			defer os.RemoveAll(tmpDir)
 
@@ -290,7 +290,7 @@ func TestAttacherAttachWithInline(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("test case: %s", tc.name)
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewClientset()
 			plug, tmpDir := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 			defer os.RemoveAll(tmpDir)
 
@@ -359,7 +359,7 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fakeClient := fakeclient.NewSimpleClientset(
+			fakeClient := fakeclient.NewClientset(
 				getTestCSIDriver("not-attachable", nil, &bFalse, nil),
 				getTestCSIDriver("attachable", nil, &bTrue, nil),
 				getTestCSIDriver("nil", nil, nil, nil),
@@ -446,7 +446,7 @@ func TestAttacherWaitForVolumeAttachmentWithCSIDriver(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fakeClient := fakeclient.NewSimpleClientset(
+			fakeClient := fakeclient.NewClientset(
 				getTestCSIDriver("not-attachable", nil, &bFalse, nil),
 				getTestCSIDriver("attachable", nil, &bTrue, nil),
 				getTestCSIDriver("nil", nil, nil, nil),
@@ -532,7 +532,7 @@ func TestAttacherWaitForAttach(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewClientset()
 			plug, tmpDir := newTestPlugin(t, fakeClient)
 			defer os.RemoveAll(tmpDir)
 
@@ -614,7 +614,7 @@ func TestAttacherWaitForAttachWithInline(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewClientset()
 			plug, tmpDir := newTestPlugin(t, fakeClient)
 			defer os.RemoveAll(tmpDir)
 
@@ -844,7 +844,7 @@ func TestAttacherDetach(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("running test: %v", tc.name)
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewClientset()
 			plug, tmpDir := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 			defer os.RemoveAll(tmpDir)
 
@@ -894,7 +894,7 @@ func TestAttacherDetach(t *testing.T) {
 func TestAttacherGetDeviceMountPath(t *testing.T) {
 	// Setup
 	// Create a new attacher
-	fakeClient := fakeclient.NewSimpleClientset()
+	fakeClient := fakeclient.NewClientset()
 	plug, tmpDir := newTestPlugin(t, fakeClient)
 	defer os.RemoveAll(tmpDir)
 	attacher, err0 := plug.NewAttacher()
@@ -1171,7 +1171,7 @@ func TestAttacherMountDevice(t *testing.T) {
 
 			// Setup
 			// Create a new attacher
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewClientset()
 			plug, tmpDir := newTestPlugin(t, fakeClient)
 			defer os.RemoveAll(tmpDir)
 
@@ -1389,7 +1389,7 @@ func TestAttacherMountDeviceWithInline(t *testing.T) {
 
 			// Setup
 			// Create a new attacher
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewClientset()
 			plug, tmpDir := newTestPlugin(t, fakeClient)
 			defer os.RemoveAll(tmpDir)
 
@@ -1534,7 +1534,7 @@ func TestAttacherUnmountDevice(t *testing.T) {
 			t.Logf("Running test case: %s", tc.testName)
 			// Setup
 			// Create a new attacher
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewClientset()
 			plug, tmpDir := newTestPlugin(t, fakeClient)
 			defer os.RemoveAll(tmpDir)
 			attacher, err0 := plug.NewAttacher()

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -369,7 +369,7 @@ func TestBlockMapperMapPodDevice(t *testing.T) {
 }
 
 func TestBlockMapperMapPodDeviceNotSupportAttach(t *testing.T) {
-	fakeClient := fakeclient.NewSimpleClientset()
+	fakeClient := fakeclient.NewClientset()
 	attachRequired := false
 	fakeDriver := &storagev1.CSIDriver{
 		ObjectMeta: metav1.ObjectMeta{
@@ -408,7 +408,7 @@ func TestBlockMapperMapPodDeviceNotSupportAttach(t *testing.T) {
 }
 
 func TestBlockMapperMapPodDeviceWithPodInfo(t *testing.T) {
-	fakeClient := fakeclient.NewSimpleClientset()
+	fakeClient := fakeclient.NewClientset()
 	attachRequired := false
 	podInfo := true
 	fakeDriver := &storagev1.CSIDriver{

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -221,7 +221,7 @@ func TestMounterSetUp(t *testing.T) {
 			modes := []storage.VolumeLifecycleMode{
 				storage.VolumeLifecyclePersistent,
 			}
-			fakeClient := fakeclient.NewSimpleClientset(
+			fakeClient := fakeclient.NewClientset(
 				getTestCSIDriver("no-info", &noPodMountInfo, nil, modes),
 				getTestCSIDriver("info", &currentPodInfoMount, nil, modes),
 				getTestCSIDriver("nil", nil, nil, modes),
@@ -417,7 +417,7 @@ func TestMounterSetupJsonFileHandling(t *testing.T) {
 			fileFsPolicy := storage.FileFSGroupPolicy
 			csiDriver.Spec.FSGroupPolicy = &fileFsPolicy
 
-			fakeClient := fakeclient.NewSimpleClientset(csiDriver)
+			fakeClient := fakeclient.NewClientset(csiDriver)
 			plug, tmpDir := newTestPlugin(t, fakeClient)
 			defer os.RemoveAll(tmpDir)
 
@@ -490,7 +490,7 @@ func TestMounterSetupJsonFileHandling(t *testing.T) {
 }
 
 func TestMounterSetUpSimple(t *testing.T) {
-	fakeClient := fakeclient.NewSimpleClientset()
+	fakeClient := fakeclient.NewClientset()
 	plug, tmpDir := newTestPlugin(t, fakeClient)
 	transientError := volumetypes.NewTransientOperationFailure("")
 	defer os.RemoveAll(tmpDir)
@@ -680,7 +680,7 @@ func TestMounterSetUpSimple(t *testing.T) {
 }
 
 func TestMounterSetupWithStatusTracking(t *testing.T) {
-	fakeClient := fakeclient.NewSimpleClientset()
+	fakeClient := fakeclient.NewClientset()
 	plug, tmpDir := newTestPlugin(t, fakeClient)
 	defer os.RemoveAll(tmpDir)
 	nonFinalError := volumetypes.NewUncertainProgressError("non-final-error")
@@ -840,7 +840,7 @@ func TestMounterSetUpWithInline(t *testing.T) {
 			storage.VolumeLifecyclePersistent,
 		}
 		driver := getTestCSIDriver(testDriver, nil, nil, volumeLifecycleModes)
-		fakeClient := fakeclient.NewSimpleClientset(driver)
+		fakeClient := fakeclient.NewClientset(driver)
 		plug, tmpDir := newTestPlugin(t, fakeClient)
 		defer os.RemoveAll(tmpDir)
 		registerFakePlugin(testDriver, "endpoint", []string{"1.0.0"}, t)
@@ -925,7 +925,7 @@ func TestMounterSetUpWithInline(t *testing.T) {
 }
 
 func TestMounterSetUpWithFSGroup(t *testing.T) {
-	fakeClient := fakeclient.NewSimpleClientset()
+	fakeClient := fakeclient.NewClientset()
 	plug, tmpDir := newTestPlugin(t, fakeClient)
 	defer os.RemoveAll(tmpDir)
 
@@ -1362,14 +1362,14 @@ func TestPodServiceAccountTokenAttrs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			registerFakePlugin(testDriver, "endpoint", []string{"1.0.0"}, t)
-			client := fakeclient.NewSimpleClientset()
+			client := fakeclient.NewClientset()
 			if test.driver != nil {
 				test.driver.Spec.VolumeLifecycleModes = []storage.VolumeLifecycleMode{
 					storage.VolumeLifecycleEphemeral,
 					storage.VolumeLifecyclePersistent,
 				}
 				scheme.Default(test.driver)
-				client = fakeclient.NewSimpleClientset(test.driver)
+				client = fakeclient.NewClientset(test.driver)
 			}
 			client.PrependReactor("create", "serviceaccounts", clitesting.ReactionFunc(func(action clitesting.Action) (bool, runtime.Object, error) {
 				tr := action.(clitesting.CreateAction).GetObject().(*authenticationv1.TokenRequest)
@@ -1599,7 +1599,7 @@ func TestMounterGetFSGroupPolicy(t *testing.T) {
 		}
 
 		// Create the client and register the resources
-		fakeClient := fakeclient.NewSimpleClientset(driver)
+		fakeClient := fakeclient.NewClientset(driver)
 		plug, tmpDir := newTestPlugin(t, fakeClient)
 		defer os.RemoveAll(tmpDir)
 		registerFakePlugin(testDriver, "endpoint", []string{"1.3.0"}, t)

--- a/pkg/volume/csi/csi_node_updater_test.go
+++ b/pkg/volume/csi/csi_node_updater_test.go
@@ -45,7 +45,7 @@ func setupTest(t *testing.T, driver *v1.CSIDriver) *testFixture {
 		clientObjects = append(clientObjects, driver)
 	}
 
-	client := fakeclient.NewSimpleClientset(clientObjects...)
+	client := fakeclient.NewClientset(clientObjects...)
 	factory := informers.NewSharedInformerFactory(client, 0)
 	driverInformer := factory.Storage().V1().CSIDrivers().Informer()
 

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -63,7 +63,7 @@ func newTestPluginWithVolumeHost(t *testing.T, client *fakeclient.Clientset, hos
 	}
 
 	if client == nil {
-		client = fakeclient.NewSimpleClientset()
+		client = fakeclient.NewClientset()
 	}
 
 	client.Tracker().Add(&api.Node{
@@ -233,7 +233,7 @@ func TestPluginGetVolumeNameWithInline(t *testing.T) {
 		storage.VolumeLifecyclePersistent,
 	}
 	driver := getTestCSIDriver(testDriver, nil, nil, modes)
-	client := fakeclient.NewSimpleClientset(driver)
+	client := fakeclient.NewClientset(driver)
 	plug, tmpDir := newTestPlugin(t, client)
 	defer os.RemoveAll(tmpDir)
 	testCases := []struct {
@@ -502,7 +502,7 @@ func TestPluginConstructVolumeSpecWithInline(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			driver := getTestCSIDriver(testDriver, nil, nil, tc.modes)
-			client := fakeclient.NewSimpleClientset(driver)
+			client := fakeclient.NewClientset(driver)
 			plug, tmpDir := newTestPlugin(t, client)
 			defer os.RemoveAll(tmpDir)
 
@@ -708,7 +708,7 @@ func TestPluginNewMounterWithInline(t *testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				driver := getTestCSIDriver(testDriver, nil, nil, supported)
-				fakeClient := fakeclient.NewSimpleClientset(driver)
+				fakeClient := fakeclient.NewClientset(driver)
 				plug, tmpDir := newTestPlugin(t, fakeClient)
 				defer os.RemoveAll(tmpDir)
 
@@ -896,7 +896,7 @@ func TestPluginCanAttach(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			csiDriver := getTestCSIDriver(test.driverName, nil, &test.canAttach, nil)
-			fakeCSIClient := fakeclient.NewSimpleClientset(csiDriver)
+			fakeCSIClient := fakeclient.NewClientset(csiDriver)
 			plug, tmpDir := newTestPlugin(t, fakeCSIClient)
 			defer os.RemoveAll(tmpDir)
 
@@ -954,7 +954,7 @@ func TestPluginFindAttachablePlugin(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpDir)
 
-			client := fakeclient.NewSimpleClientset(
+			client := fakeclient.NewClientset(
 				getTestCSIDriver(test.driverName, nil, &test.canAttach, nil),
 				&api.Node{
 					ObjectMeta: meta.ObjectMeta{
@@ -1080,7 +1080,7 @@ func TestPluginFindDeviceMountablePluginBySpec(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpDir)
 
-			client := fakeclient.NewSimpleClientset(
+			client := fakeclient.NewClientset(
 				&api.Node{
 					ObjectMeta: meta.ObjectMeta{
 						Name: "fakeNode",

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -245,7 +245,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 				Spec: api.NodeSpec{},
 			})
 
-			client := fakeclient.NewSimpleClientset(objs...)
+			client := fakeclient.NewClientset(objs...)
 
 			factory := informers.NewSharedInformerFactory(client, time.Hour /* disable resync */)
 			csiDriverInformer := factory.Storage().V1().CSIDrivers()

--- a/pkg/volume/csi/testing/testing.go
+++ b/pkg/volume/csi/testing/testing.go
@@ -38,7 +38,7 @@ func NewTestPlugin(t *testing.T, client *fakeclient.Clientset) (*volume.VolumePl
 	}
 
 	if client == nil {
-		client = fakeclient.NewSimpleClientset()
+		client = fakeclient.NewClientset()
 	}
 
 	client.Tracker().Add(&v1.Node{

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -227,7 +227,7 @@ func newDownwardAPITest(t *testing.T, name string, volumeFiles, podLabels, podAn
 		Labels:      podLabels,
 		Annotations: podAnnotations,
 	}
-	clientset := fake.NewSimpleClientset(&v1.Pod{ObjectMeta: podMeta})
+	clientset := fake.NewClientset(&v1.Pod{ObjectMeta: podMeta})
 
 	pluginMgr := volume.VolumePluginMgr{}
 	rootDir, host := newTestHost(t, clientset)

--- a/pkg/volume/fc/fc_test.go
+++ b/pkg/volume/fc/fc_test.go
@@ -375,7 +375,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 		},
 	}
 
-	client := fake.NewSimpleClientset(pv, claim)
+	client := fake.NewClientset(pv, claim)
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(t, tmpDir, client, nil))

--- a/pkg/volume/hostpath/host_path_test.go
+++ b/pkg/volume/hostpath/host_path_test.go
@@ -302,7 +302,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 		},
 	}
 
-	client := fake.NewSimpleClientset(pv, claim)
+	client := fake.NewClientset(pv, claim)
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), nil /* prober */, volumetest.NewFakeKubeletVolumeHost(t, "/tmp/fake", client, nil))

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -280,7 +280,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 		},
 	}
 
-	client := fake.NewSimpleClientset(pv, claim)
+	client := fake.NewClientset(pv, claim)
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(t, tmpDir, client, nil))

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -260,7 +260,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 		},
 	}
 
-	client := fake.NewSimpleClientset(pv, claim)
+	client := fake.NewClientset(pv, claim)
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{}), nil /* prober */, volumetest.NewFakeVolumeHost(t, tmpDir, client, nil))

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -266,7 +266,7 @@ func TestCollectDataWithSecret(t *testing.T) {
 
 			testPodUID := types.UID("test_pod_uid")
 			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
-			client := fake.NewSimpleClientset(tc.secret)
+			client := fake.NewClientset(tc.secret)
 			tempDir, host := newTestHost(t, client)
 			defer os.RemoveAll(tempDir)
 			var myVolumeMounter = projectedVolumeMounter{
@@ -515,7 +515,7 @@ func TestCollectDataWithConfigMap(t *testing.T) {
 
 			testPodUID := types.UID("test_pod_uid")
 			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
-			client := fake.NewSimpleClientset(tc.configMap)
+			client := fake.NewClientset(tc.configMap)
 			tempDir, host := newTestHost(t, client)
 			defer os.RemoveAll(tempDir)
 			var myVolumeMounter = projectedVolumeMounter{
@@ -686,7 +686,7 @@ func TestCollectDataWithDownwardAPI(t *testing.T) {
 			source := makeProjection("", ptr.To[int32](tc.mode), "downwardAPI")
 			source.Sources[0].DownwardAPI.Items = tc.volumeFile
 
-			client := fake.NewSimpleClientset(tc.pod)
+			client := fake.NewClientset(tc.pod)
 			tempDir, host := newTestHost(t, client)
 			defer os.RemoveAll(tempDir)
 			var myVolumeMounter = projectedVolumeMounter{
@@ -1009,7 +1009,7 @@ func TestCollectDataWithClusterTrustBundle(t *testing.T) {
 				Spec: v1.PodSpec{ServiceAccountName: "foo"},
 			}
 
-			client := fake.NewSimpleClientset(tc.bundles...)
+			client := fake.NewClientset(tc.bundles...)
 
 			tempDir, host := newTestHost(t, client)
 			defer os.RemoveAll(tempDir)
@@ -1112,7 +1112,7 @@ func TestCollectDataWithPodCertificate(t *testing.T) {
 				Spec: v1.PodSpec{ServiceAccountName: "foo"},
 			}
 
-			client := fake.NewSimpleClientset(tc.bundles...)
+			client := fake.NewClientset(tc.bundles...)
 
 			tempDir, host := newTestHost(t, client)
 			defer os.RemoveAll(tempDir)
@@ -1180,7 +1180,7 @@ func TestPlugin(t *testing.T) {
 
 		volumeSpec    = makeVolumeSpec(testVolumeName, testName, 0644)
 		secret        = makeSecret(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&secret)
+		client        = fake.NewClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
@@ -1241,7 +1241,7 @@ func TestInvalidPathProjected(t *testing.T) {
 
 		volumeSpec    = makeVolumeSpec(testVolumeName, testName, 0644)
 		secret        = makeSecret(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&secret)
+		client        = fake.NewClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
@@ -1295,7 +1295,7 @@ func TestPluginReboot(t *testing.T) {
 
 		volumeSpec    = makeVolumeSpec(testVolumeName, testName, 0644)
 		secret        = makeSecret(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&secret)
+		client        = fake.NewClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
@@ -1348,7 +1348,7 @@ func TestPluginOptional(t *testing.T) {
 		trueVal        = true
 
 		volumeSpec    = makeVolumeSpec(testVolumeName, testName, 0644)
-		client        = fake.NewSimpleClientset()
+		client        = fake.NewClientset()
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
@@ -1440,7 +1440,7 @@ func TestPluginOptionalKeys(t *testing.T) {
 
 		volumeSpec    = makeVolumeSpec(testVolumeName, testName, 0644)
 		secret        = makeSecret(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&secret)
+		client        = fake.NewClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -301,7 +301,7 @@ func TestPlugin(t *testing.T) {
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
 		secret        = secret(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&secret)
+		client        = fake.NewClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
@@ -371,7 +371,7 @@ func TestInvalidPathSecret(t *testing.T) {
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
 		secret        = secret(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&secret)
+		client        = fake.NewClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
@@ -425,7 +425,7 @@ func TestPluginReboot(t *testing.T) {
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
 		secret        = secret(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&secret)
+		client        = fake.NewClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
@@ -478,7 +478,7 @@ func TestPluginOptional(t *testing.T) {
 		trueVal        = true
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
-		client        = fake.NewSimpleClientset()
+		client        = fake.NewClientset()
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
@@ -570,7 +570,7 @@ func TestPluginOptionalKeys(t *testing.T) {
 
 		volumeSpec    = volumeSpec(testVolumeName, testName, 0644)
 		secret        = secret(testNamespace, testName)
-		client        = fake.NewSimpleClientset(&secret)
+		client        = fake.NewClientset(&secret)
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -595,7 +595,7 @@ func getTestPV(volumeName string, specSize string) *v1.PersistentVolume {
 }
 
 func getTestOperationGenerator(volumePluginMgr *volume.VolumePluginMgr, objects ...runtime.Object) OperationGenerator {
-	fakeKubeClient := fakeclient.NewSimpleClientset(objects...)
+	fakeKubeClient := fakeclient.NewClientset(objects...)
 	fakeRecorder := &record.FakeRecorder{}
 	fakeHandler := volumetesting.NewBlockVolumePathHandler()
 	operationGenerator := NewOperationGenerator(
@@ -607,7 +607,7 @@ func getTestOperationGenerator(volumePluginMgr *volume.VolumePluginMgr, objects 
 }
 
 func getTestOperatorGeneratorWithPVPVC(volumePluginMgr *volume.VolumePluginMgr, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) OperationGenerator {
-	fakeKubeClient := fakeclient.NewSimpleClientset(pvc, pv)
+	fakeKubeClient := fakeclient.NewClientset(pvc, pv)
 	fakeKubeClient.AddReactor("get", "persistentvolumeclaims", func(action core.Action) (bool, runtime.Object, error) {
 		return true, pvc, nil
 	})
@@ -647,7 +647,7 @@ func getTestVolumeToUnmount(pod *v1.Pod, pvSpec v1.PersistentVolumeSpec, pluginN
 }
 
 func initTestPlugins(t *testing.T, plugs []volume.VolumePlugin, pluginName string) (*volume.VolumePluginMgr, string) {
-	client := fakeclient.NewSimpleClientset()
+	client := fakeclient.NewClientset()
 	pluginMgr, _, tmpDir := csitesting.NewTestPlugin(t, client)
 
 	err := pluginMgr.InitPlugins(plugs, nil, pluginMgr.Host)

--- a/pkg/volume/util/resize_util_test.go
+++ b/pkg/volume/util/resize_util_test.go
@@ -224,7 +224,7 @@ func TestResizeFunctions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, true)
 			pvc := tc.pvc
-			kubeClient := fake.NewSimpleClientset(pvc)
+			kubeClient := fake.NewClientset(pvc)
 
 			var err error
 

--- a/staging/src/k8s.io/client-go/testing/helpers.go
+++ b/staging/src/k8s.io/client-go/testing/helpers.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// StripMetadata remove metadata (e.g., ManagedFields) so DeepEqual
+// assertions compare only the ConfigMap content returned by fake clients.
+func StripMetadata[T interface {
+	runtime.Object
+	comparable
+}](cm T) T {
+	var zero T
+	if cm == zero {
+		return cm
+	}
+
+	clone := cm.DeepCopyObject()
+
+	if o, ok := clone.(metav1.Object); ok {
+		o.SetManagedFields(nil)
+	}
+
+	return clone.(T)
+}

--- a/staging/src/k8s.io/client-go/testing/helpers_test.go
+++ b/staging/src/k8s.io/client-go/testing/helpers_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNormalizeConfigMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     runtime.Object
+		expected runtime.Object
+	}{
+		{
+			name:     "nil ConfigMap",
+			expected: nil,
+		},
+		{
+			name: "strips managed fields",
+			data: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:          "test",
+					Namespace:     "default",
+					ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "fake"}},
+				},
+				Data: map[string]string{"key": "value"},
+			},
+			expected: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Data: map[string]string{"key": "value"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			normalized := StripMetadata[runtime.Object](tt.data)
+
+			if !reflect.DeepEqual(normalized, tt.expected) {
+				t.Errorf("StripMetadata() = %v, want %v", normalized, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

1. Move `NormalizeConfigMap` into a global helper file.
2. Replaces deprecated NewSimpleClientset with NewClientset across volume and proxy
3. Fixed a small mistake I made earlier in the dns_test.go file. I forgot to output the updated object to Errorf, which was a problem when trying to find the reason of unequal objects



#### Which issue(s) this PR is related to:

#135980

#### Special notes for your reviewer:

-

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
not needed
```
