### PR TITLE
E2E framework: fix nil pointer crash in TContext

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -187,7 +187,9 @@ func (f *Framework) TContext(ctx context.Context) ktesting.TContext {
 	}
 	tCtx := ktesting.InitCtx(ctx, f /* intentionally using f here and not f.TB because f overrides some methods */)
 	tCtx = tCtx.WithClients(f.clientConfig, f.restMapper, f.ClientSet, f.DynamicClient, apiextensions.NewForConfigOrDie(f.clientConfig))
-	tCtx = tCtx.WithNamespace(f.Namespace.Name)
+	if f.Namespace != nil {
+		tCtx = tCtx.WithNamespace(f.Namespace.Name)
+	}
 	tCtx = ensureLogger(tCtx)
 	return tCtx
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Not all framework instances have a default namespace. TContext crashed for those.

(cherry picked from commit 80cc14831edefcb889ebaeeb1bddda698415dbc8)

#### Which issue(s) this PR is related to:

https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20nftables,%20master

#### Special notes for your reviewer:

This got merged in https://github.com/kubernetes/kubernetes/pull/136140, then reverted in https://github.com/kubernetes/kubernetes/pull/136151 and was not brought back in https://github.com/kubernetes/kubernetes/pull/136156.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 