### PR TITLE
Fixed load balancer status issue when cleared

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -613,6 +613,15 @@ func needsUpdate(oldService *v1.Service, newService *v1.Service) bool {
 		return true
 	}
 
+	// If the service wants a load balancer and the ingress status has been cleared,
+	// we need to reconcile to restore the status from the cloud provider.
+	if wantsLoadBalancer(newService) {
+		if len(oldService.Status.LoadBalancer.Ingress) > 0 && len(newService.Status.LoadBalancer.Ingress) == 0 {
+			klog.V(2).Infof("Service %s LoadBalancer ingress status was cleared (had %d entries)", klog.KObj(newService), len(oldService.Status.LoadBalancer.Ingress))
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -1493,6 +1493,83 @@ func TestNeedsUpdate(t *testing.T) {
 			return
 		},
 		expectedNeedsUpdate: true,
+	}, {
+		testName: "If LoadBalancer status ingress is cleared",
+		updateFn: func() (oldSvc *v1.Service, newSvc *v1.Service) {
+			oldSvc = defaultExternalService()
+			oldSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: "1.2.3.4"}}
+			newSvc = defaultExternalService()
+			newSvc.Status.LoadBalancer.Ingress = nil
+			return
+		},
+		expectedNeedsUpdate: true,
+	}, {
+		testName: "If LoadBalancer status was already empty",
+		updateFn: func() (oldSvc *v1.Service, newSvc *v1.Service) {
+			oldSvc = defaultExternalService()
+			oldSvc.Status.LoadBalancer.Ingress = nil
+			newSvc = defaultExternalService()
+			newSvc.Status.LoadBalancer.Ingress = nil
+			return
+		},
+		expectedNeedsUpdate: false,
+	}, {
+		testName: "If LoadBalancer status hostname ingress is cleared",
+		updateFn: func() (oldSvc *v1.Service, newSvc *v1.Service) {
+			oldSvc = defaultExternalService()
+			oldSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "lb.example.com"}}
+			newSvc = defaultExternalService()
+			newSvc.Status.LoadBalancer.Ingress = nil
+			return
+		},
+		expectedNeedsUpdate: true,
+	}, {
+		testName: "If LoadBalancer status with multiple ingress entries is cleared",
+		updateFn: func() (oldSvc *v1.Service, newSvc *v1.Service) {
+			oldSvc = defaultExternalService()
+			oldSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{
+				{IP: "1.2.3.4"},
+				{IP: "5.6.7.8"},
+				{Hostname: "lb.example.com"},
+			}
+			newSvc = defaultExternalService()
+			newSvc.Status.LoadBalancer.Ingress = nil
+			return
+		},
+		expectedNeedsUpdate: true,
+	}, {
+		testName: "If LoadBalancer status ingress is cleared to empty slice",
+		updateFn: func() (oldSvc *v1.Service, newSvc *v1.Service) {
+			oldSvc = defaultExternalService()
+			oldSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: "1.2.3.4"}}
+			newSvc = defaultExternalService()
+			newSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{}
+			return
+		},
+		expectedNeedsUpdate: true,
+	}, {
+		testName: "If LoadBalancer status unchanged with populated ingress",
+		updateFn: func() (oldSvc *v1.Service, newSvc *v1.Service) {
+			oldSvc = defaultExternalService()
+			oldSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: "1.2.3.4"}}
+			newSvc = defaultExternalService()
+			newSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: "1.2.3.4"}}
+			return
+		},
+		expectedNeedsUpdate: false,
+	}, {
+		testName: "If service with LoadBalancerClass has status cleared",
+		updateFn: func() (oldSvc *v1.Service, newSvc *v1.Service) {
+			lbClass := "custom-lb-class"
+			oldSvc = defaultExternalService()
+			oldSvc.Spec.LoadBalancerClass = &lbClass
+			oldSvc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: "1.2.3.4"}}
+			newSvc = defaultExternalService()
+			newSvc.Spec.LoadBalancerClass = &lbClass
+			newSvc.Status.LoadBalancer.Ingress = nil
+			return
+		},
+		expectedNeedsUpdate: false,
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
  #### What type of PR is this?                                                                                                                                  
                                                                                                                                                                 
  /kind bug                                                                                                                                                      
  /sig cloud-provider                                                                                                                                            
                                                                                                                                                                 
  #### What this PR does / why we need it:                                                                                                                       
                                                                                                                                                                 
  The cloud-provider service controller doesn't trigger reconciliation when a LoadBalancer Service's `status.loadBalancer.ingress` is cleared by external tools  
  (e.g., GitOps tools like ArgoCD or FluxCD).                                                                                                                    
                                                                                                                                                                 
  When GitOps tools apply a Service manifest, they typically clear the `status` field since status is not stored in Git. The service controller's `needsUpdate()`
   function only checks for Spec changes (ports, IPs, annotations, etc.) and does not detect when the LoadBalancer status has been cleared. This causes the      
  Service to show a pending status indefinitely even though the cloud load balancer continues to function normally.                                              
                                                                                                                                                                 
  This PR adds a check in `needsUpdate()` to detect when `status.loadBalancer.ingress` has been cleared and trigger reconciliation to restore the correct status 
  from the cloud provider.                                                                                                                                       
                                                                                                                                                                 
  **Changes:**                                                                                                                                                   
  - Modified `needsUpdate()` in `controller.go` to detect when LoadBalancer ingress status is cleared                                                            
  - Added 7 comprehensive test cases covering:                                                                                                                   
    - IP-based ingress clearing                                                                                                                                  
    - Hostname-based ingress clearing                                                                                                                            
    - Multiple ingress entries clearing                                                                                                                          
    - Empty slice vs nil handling                                                                                                                                
    - No false positives when status is already empty or unchanged                                                                                               
    - Services with `LoadBalancerClass` are correctly ignored (handled by different controller)                                                                  
                                                                                                                                                                 
  #### Which issue(s) this PR is related to:                                                                                                                     
                                                                                                                                                                 
  Fixes #136316                                                                                                                                                  
                                                                                                                                                                 
  #### Special notes for your reviewer:                                                                                                                          
                                                                                                                                                                 
  The fix is minimal and surgical - only 9 lines of production code added. Key design decisions:                                                                 
                                                                                                                                                                 
  1. **Only detects clearing, not any status change**: The check `len(old) > 0 && len(new) == 0` specifically detects when status goes from populated to empty,  
  not general status changes. This prevents unnecessary reconciliation when status is unchanged.                                                                 
                                                                                                                                                                 
  2. **Protected by `wantsLoadBalancer()` guard**: Services with `LoadBalancerClass` set are correctly ignored since they're managed by a different controller.  
                                                                                                                                                                 
  3. **No infinite loops**: After reconciliation restores the status, the next update will have `len(new) > 0`, so no further reconciliation is triggered.       
                                                                                                                                                                 
  4. **Works with periodic resync**: The fix integrates correctly with the existing 30-second resync period.                                                     
                                                                                                                                                                 
  #### Does this PR introduce a user-facing change?                                                                                                              
                                                                                                                                                                 
  ```release-note                                                                                                                                                
  Fixed a bug where the cloud-provider service controller would not reconcile LoadBalancer Services when the status was cleared by external tools (e.g., GitOps  
  tools). The controller now detects when `status.loadBalancer.ingress` is cleared and reconciles to restore the correct status from the cloud provider.         
                                                                                                                                                                 
  ```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:                                                                      
                                                                                                                                                                 
  NONE