### PR TITLE
Migrate kubelet_node_status* to contextual logging

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -49,10 +49,11 @@ import (
 // registerWithAPIServer registers the node with the cluster master. It is safe
 // to call multiple times, but not concurrently (kl.registrationCompleted is
 // not locked).
-func (kl *Kubelet) registerWithAPIServer() {
+func (kl *Kubelet) registerWithAPIServer(ctx context.Context) {
 	if kl.registrationCompleted {
 		return
 	}
+	logger := klog.FromContext(ctx)
 
 	kl.nodeStartupLatencyTracker.RecordAttemptRegisterNode()
 
@@ -65,16 +66,16 @@ func (kl *Kubelet) registerWithAPIServer() {
 			step = 7 * time.Second
 		}
 
-		node, err := kl.initialNode(context.TODO())
+		node, err := kl.initialNode(ctx)
 		if err != nil {
-			klog.ErrorS(err, "Unable to construct v1.Node object for kubelet")
+			logger.Error(err, "Unable to construct v1.Node object for kubelet")
 			continue
 		}
 
-		klog.InfoS("Attempting to register node", "node", klog.KObj(node))
-		registered := kl.tryRegisterWithAPIServer(node)
+		logger.Info("Attempting to register node", "node", klog.KObj(node))
+		registered := kl.tryRegisterWithAPIServer(ctx, node)
 		if registered {
-			klog.InfoS("Successfully registered node", "node", klog.KObj(node))
+			logger.Info("Successfully registered node", "node", klog.KObj(node))
 			kl.registrationCompleted = true
 			return
 		}
@@ -86,8 +87,9 @@ func (kl *Kubelet) registerWithAPIServer() {
 // successful.  If a node with the same name already exists, it reconciles the
 // value of the annotation for controller-managed attach-detach of attachable
 // persistent volumes for the node.
-func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
-	_, err := kl.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+func (kl *Kubelet) tryRegisterWithAPIServer(ctx context.Context, node *v1.Node) bool {
+	logger := klog.FromContext(ctx)
+	_, err := kl.kubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 	if err == nil {
 		kl.nodeStartupLatencyTracker.RecordRegisteredNewNode()
 		return true
@@ -99,39 +101,39 @@ func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
 	case apierrors.IsForbidden(err):
 		// Creating nodes is forbidden, but node may still exist, attempt to get the node.
 		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletRegistrationGetOnExistsOnly) {
-			klog.ErrorS(err, "Unable to register node with API server, reason is forbidden", "node", klog.KObj(node))
+			logger.Error(err, "Unable to register node with API server, reason is forbidden", "node", klog.KObj(node))
 			return false
 		}
 	default:
-		klog.ErrorS(err, "Unable to register node with API server", "node", klog.KObj(node))
+		logger.Error(err, "Unable to register node with API server", "node", klog.KObj(node))
 		return false
 	}
 
-	existingNode, err := kl.kubeClient.CoreV1().Nodes().Get(context.TODO(), string(kl.nodeName), metav1.GetOptions{})
+	existingNode, err := kl.kubeClient.CoreV1().Nodes().Get(ctx, string(kl.nodeName), metav1.GetOptions{})
 	if err != nil {
-		klog.ErrorS(err, "Unable to register node with API server, error getting existing node", "node", klog.KObj(node))
+		logger.Error(err, "Unable to register node with API server, error getting existing node", "node", klog.KObj(node))
 		return false
 	}
 
 	if existingNode == nil {
-		klog.InfoS("Unable to register node with API server, no node instance returned", "node", klog.KObj(node))
+		logger.Info("Unable to register node with API server, no node instance returned", "node", klog.KObj(node))
 		return false
 	}
 
 	originalNode := existingNode.DeepCopy()
 
-	klog.InfoS("Node was previously registered", "node", klog.KObj(node))
+	logger.Info("Node was previously registered", "node", klog.KObj(node))
 
 	// Edge case: the node was previously registered; reconcile
 	// the value of the controller-managed attach-detach
 	// annotation.
-	requiresUpdate := kl.reconcileCMADAnnotationWithExistingNode(node, existingNode)
+	requiresUpdate := kl.reconcileCMADAnnotationWithExistingNode(logger, node, existingNode)
 	requiresUpdate = kl.updateDefaultLabels(node, existingNode) || requiresUpdate
-	requiresUpdate = kl.reconcileExtendedResource(node, existingNode) || requiresUpdate
-	requiresUpdate = kl.reconcileHugePageResource(node, existingNode) || requiresUpdate
+	requiresUpdate = kl.reconcileExtendedResource(logger, node, existingNode) || requiresUpdate
+	requiresUpdate = kl.reconcileHugePageResource(logger, node, existingNode) || requiresUpdate
 	if requiresUpdate {
 		if _, _, err := nodeutil.PatchNodeStatus(kl.kubeClient.CoreV1(), types.NodeName(kl.nodeName), originalNode, existingNode); err != nil {
-			klog.ErrorS(err, "Unable to reconcile node with API server,error updating node", "node", klog.KObj(node))
+			logger.Error(err, "Unable to reconcile node with API server,error updating node", "node", klog.KObj(node))
 			return false
 		}
 	}
@@ -140,7 +142,7 @@ func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
 }
 
 // reconcileHugePageResource will update huge page capacity for each page size and remove huge page sizes no longer supported
-func (kl *Kubelet) reconcileHugePageResource(initialNode, existingNode *v1.Node) bool {
+func (kl *Kubelet) reconcileHugePageResource(logger klog.Logger, initialNode, existingNode *v1.Node) bool {
 	requiresUpdate := updateDefaultResources(initialNode, existingNode)
 	supportedHugePageResources := sets.Set[string]{}
 
@@ -179,7 +181,7 @@ func (kl *Kubelet) reconcileHugePageResource(initialNode, existingNode *v1.Node)
 		if !supportedHugePageResources.Has(string(resourceName)) {
 			delete(existingNode.Status.Capacity, resourceName)
 			delete(existingNode.Status.Allocatable, resourceName)
-			klog.InfoS("Removing huge page resource which is no longer supported", "resourceName", resourceName)
+			logger.Info("Removing huge page resource which is no longer supported", "resourceName", resourceName)
 			requiresUpdate = true
 		}
 	}
@@ -187,13 +189,13 @@ func (kl *Kubelet) reconcileHugePageResource(initialNode, existingNode *v1.Node)
 }
 
 // Zeros out extended resource capacity during reconciliation.
-func (kl *Kubelet) reconcileExtendedResource(initialNode, node *v1.Node) bool {
+func (kl *Kubelet) reconcileExtendedResource(logger klog.Logger, initialNode, node *v1.Node) bool {
 	requiresUpdate := updateDefaultResources(initialNode, node)
 	// Check with the device manager to see if node has been recreated, in which case extended resources should be zeroed until they are available
 	if kl.containerManager.ShouldResetExtendedResourceCapacity() {
 		for k := range node.Status.Capacity {
 			if v1helper.IsExtendedResourceName(k) {
-				klog.InfoS("Zero out resource capacity in existing node", "resourceName", k, "node", klog.KObj(node))
+				logger.Info("Zero out resource capacity in existing node", "resourceName", k, "node", klog.KObj(node))
 				node.Status.Capacity[k] = *resource.NewQuantity(int64(0), resource.DecimalSI)
 				node.Status.Allocatable[k] = *resource.NewQuantity(int64(0), resource.DecimalSI)
 				requiresUpdate = true
@@ -269,7 +271,7 @@ func (kl *Kubelet) updateDefaultLabels(initialNode, existingNode *v1.Node) bool 
 // reconcileCMADAnnotationWithExistingNode reconciles the controller-managed
 // attach-detach annotation on a new node and the existing node, returning
 // whether the existing node must be updated.
-func (kl *Kubelet) reconcileCMADAnnotationWithExistingNode(node, existingNode *v1.Node) bool {
+func (kl *Kubelet) reconcileCMADAnnotationWithExistingNode(logger klog.Logger, node, existingNode *v1.Node) bool {
 	var (
 		existingCMAAnnotation    = existingNode.Annotations[volutil.ControllerManagedAttachAnnotation]
 		newCMAAnnotation, newSet = node.Annotations[volutil.ControllerManagedAttachAnnotation]
@@ -283,10 +285,10 @@ func (kl *Kubelet) reconcileCMADAnnotationWithExistingNode(node, existingNode *v
 	// not have the same value, update the existing node with
 	// the correct value of the annotation.
 	if !newSet {
-		klog.InfoS("Controller attach-detach setting changed to false; updating existing Node")
+		logger.Info("Controller attach-detach setting changed to false; updating existing Node")
 		delete(existingNode.Annotations, volutil.ControllerManagedAttachAnnotation)
 	} else {
-		klog.InfoS("Controller attach-detach setting changed to true; updating existing Node")
+		logger.Info("Controller attach-detach setting changed to true; updating existing Node")
 		if existingNode.Annotations == nil {
 			existingNode.Annotations = make(map[string]string)
 		}
@@ -299,6 +301,7 @@ func (kl *Kubelet) reconcileCMADAnnotationWithExistingNode(node, existingNode *v
 // initialNode constructs the initial v1.Node for this Kubelet, incorporating node
 // labels, information from the cloud provider, and Kubelet configuration.
 func (kl *Kubelet) initialNode(ctx context.Context) (*v1.Node, error) {
+	logger := klog.FromContext(ctx)
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: string(kl.nodeName),
@@ -340,16 +343,16 @@ func (kl *Kubelet) initialNode(ctx context.Context) (*v1.Node, error) {
 			node.Annotations = make(map[string]string)
 		}
 
-		klog.V(2).InfoS("Setting node annotation to enable volume controller attach/detach")
+		logger.V(2).Info("Setting node annotation to enable volume controller attach/detach")
 		node.Annotations[volutil.ControllerManagedAttachAnnotation] = "true"
 	} else {
-		klog.V(2).InfoS("Controller attach/detach is disabled for this node; Kubelet will attach and detach volumes")
+		logger.V(2).Info("Controller attach/detach is disabled for this node; Kubelet will attach and detach volumes")
 	}
 
 	// @question: should this be place after the call to the cloud provider? which also applies labels
 	for k, v := range kl.nodeLabels {
 		if cv, found := node.ObjectMeta.Labels[k]; found {
-			klog.InfoS("the node label will overwrite default setting", "labelKey", k, "labelValue", v, "default", cv)
+			logger.Info("the node label will overwrite default setting", "labelKey", k, "labelValue", v, "default", cv)
 		}
 		node.ObjectMeta.Labels[k] = v
 	}
@@ -425,7 +428,7 @@ func (kl *Kubelet) fastNodeStatusUpdate(ctx context.Context, timeout bool) (comp
 		return false
 	}
 
-	klog.InfoS("Fast updating node status as it just became ready")
+	logger.Info("Fast updating node status as it just became ready")
 	if _, err := kl.patchNodeStatus(originalNode, node); err != nil {
 		// The originalNode is probably stale, but we know that the current state of kubelet would turn
 		// the node to be ready. Retry using syncNodeStatus() which fetches from the apiserver.
@@ -433,7 +436,7 @@ func (kl *Kubelet) fastNodeStatusUpdate(ctx context.Context, timeout bool) (comp
 
 		// The reversed kl.syncNodeStatusMux.Unlock/Lock() below to allow kl.syncNodeStatus() execution.
 		kl.syncNodeStatusMux.Unlock()
-		kl.syncNodeStatus()
+		kl.syncNodeStatus(ctx)
 		// This lock action is unnecessary if we add a flag to check in the defer before unlocking it,
 		// but having it here makes the logic a bit easier to read.
 		kl.syncNodeStatusMux.Lock()
@@ -446,33 +449,34 @@ func (kl *Kubelet) fastNodeStatusUpdate(ctx context.Context, timeout bool) (comp
 // syncNodeStatus should be called periodically from a goroutine.
 // It synchronizes node status to master if there is any change or enough time
 // passed from the last sync, registering the kubelet first if necessary.
-func (kl *Kubelet) syncNodeStatus() {
+func (kl *Kubelet) syncNodeStatus(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	kl.syncNodeStatusMux.Lock()
 	defer kl.syncNodeStatusMux.Unlock()
-	ctx := context.Background()
 
 	if kl.kubeClient == nil || kl.heartbeatClient == nil {
 		return
 	}
 	if kl.registerNode {
 		// This will exit immediately if it doesn't need to do anything.
-		kl.registerWithAPIServer()
+		kl.registerWithAPIServer(ctx)
 	}
 	if err := kl.updateNodeStatus(ctx); err != nil {
-		klog.ErrorS(err, "Unable to update node status")
+		logger.Error(err, "Unable to update node status")
 	}
 }
 
 // updateNodeStatus updates node status to master with retries if there is any
 // change or enough time passed from the last sync.
 func (kl *Kubelet) updateNodeStatus(ctx context.Context) error {
-	klog.V(5).InfoS("Updating node status")
+	logger := klog.FromContext(ctx)
+	logger.V(5).Info("Updating node status")
 	for i := 0; i < nodeStatusUpdateRetry; i++ {
 		if err := kl.tryUpdateNodeStatus(ctx, i); err != nil {
 			if i > 0 && kl.onRepeatedHeartbeatFailure != nil {
 				kl.onRepeatedHeartbeatFailure()
 			}
-			klog.ErrorS(err, "Error updating node status, will retry")
+			logger.Error(err, "Error updating node status, will retry")
 		} else {
 			return nil
 		}
@@ -544,6 +548,7 @@ func (kl *Kubelet) calculateDelay() time.Duration {
 // updateNode creates a copy of originalNode and runs update logic on it.
 // It returns the updated node object and a bool indicating if anything has been changed.
 func (kl *Kubelet) updateNode(ctx context.Context, originalNode *v1.Node) (*v1.Node, bool) {
+	logger := klog.FromContext(ctx)
 	node := originalNode.DeepCopy()
 
 	podCIDRChanged := false
@@ -554,7 +559,7 @@ func (kl *Kubelet) updateNode(ctx context.Context, originalNode *v1.Node) (*v1.N
 		var err error
 		podCIDRs := strings.Join(node.Spec.PodCIDRs, ",")
 		if podCIDRChanged, err = kl.updatePodCIDR(ctx, podCIDRs); err != nil {
-			klog.ErrorS(err, "Error updating pod CIDR")
+			logger.Error(err, "Error updating pod CIDR")
 		}
 	}
 
@@ -630,8 +635,8 @@ func (kl *Kubelet) markVolumesFromNode(node *v1.Node) {
 
 // recordNodeStatusEvent records an event of the given type with the given
 // message for the node.
-func (kl *Kubelet) recordNodeStatusEvent(eventType, event string) {
-	klog.V(2).InfoS("Recording event message for node", "node", klog.KRef("", string(kl.nodeName)), "event", event)
+func (kl *Kubelet) recordNodeStatusEvent(logger klog.Logger, eventType, event string) {
+	logger.V(2).Info("Recording event message for node", "node", klog.KRef("", string(kl.nodeName)), "event", event)
 	kl.recorder.Eventf(kl.nodeRef, eventType, event, "Node %s status is now: %s", kl.nodeName, event)
 }
 
@@ -642,13 +647,14 @@ func (kl *Kubelet) recordEvent(eventType, event, message string) {
 
 // record if node schedulable change.
 func (kl *Kubelet) recordNodeSchedulableEvent(ctx context.Context, node *v1.Node) error {
+	logger := klog.FromContext(ctx)
 	kl.lastNodeUnschedulableLock.Lock()
 	defer kl.lastNodeUnschedulableLock.Unlock()
 	if kl.lastNodeUnschedulable != node.Spec.Unschedulable {
 		if node.Spec.Unschedulable {
-			kl.recordNodeStatusEvent(v1.EventTypeNormal, events.NodeNotSchedulable)
+			kl.recordNodeStatusEvent(logger, v1.EventTypeNormal, events.NodeNotSchedulable)
 		} else {
-			kl.recordNodeStatusEvent(v1.EventTypeNormal, events.NodeSchedulable)
+			kl.recordNodeStatusEvent(logger, v1.EventTypeNormal, events.NodeSchedulable)
 		}
 		kl.lastNodeUnschedulable = node.Spec.Unschedulable
 	}
@@ -660,10 +666,11 @@ func (kl *Kubelet) recordNodeSchedulableEvent(ctx context.Context, node *v1.Node
 // TODO(madhusudancs): Simplify the logic for setting node conditions and
 // refactor the node status condition code out to a different file.
 func (kl *Kubelet) setNodeStatus(ctx context.Context, node *v1.Node) {
+	logger := klog.FromContext(ctx)
 	for i, f := range kl.setNodeStatusFuncs {
-		klog.V(5).InfoS("Setting node status condition code", "position", i, "node", klog.KObj(node))
+		logger.V(5).Info("Setting node status condition code", "position", i, "node", klog.KObj(node))
 		if err := f(ctx, node); err != nil {
-			klog.ErrorS(err, "Failed to set some node status fields", "node", klog.KObj(node))
+			logger.Error(err, "Failed to set some node status fields", "node", klog.KObj(node))
 		}
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.NodeDeclaredFeatures) && kl.nodeDeclaredFeatures != nil {

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -320,14 +320,14 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 			}
 
 			kubelet.updateRuntimeUp(tCtx)
-			assert.NoError(t, kubelet.updateNodeStatus(tCtx))
+			require.NoError(t, kubelet.updateNodeStatus(tCtx))
 			actions := kubeClient.Actions()
 			require.Len(t, actions, 2)
 			require.True(t, actions[1].Matches("patch", "nodes"))
 			require.Equal(t, "status", actions[1].GetSubresource())
 
 			updatedNode, err := applyNodeStatusPatch(&existingNode, actions[1].(core.PatchActionImpl).GetPatch())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			for i, cond := range updatedNode.Status.Conditions {
 				assert.False(t, cond.LastHeartbeatTime.IsZero(), "LastHeartbeatTime for %v condition is zero", cond.Type)
 				assert.False(t, cond.LastTransitionTime.IsZero(), "LastTransitionTime for %v condition is zero", cond.Type)
@@ -510,7 +510,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 	}
 
 	kubelet.updateRuntimeUp(tCtx)
-	assert.NoError(t, kubelet.updateNodeStatus(tCtx))
+	require.NoError(t, kubelet.updateNodeStatus(tCtx))
 
 	actions := kubeClient.Actions()
 	assert.Len(t, actions, 2)
@@ -548,7 +548,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 
 	// set up a listener that hangs connections
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer ln.Close()
 	go func() {
 		// accept connections and just let them hang
@@ -568,7 +568,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 		QPS:     -1,
 		Timeout: time.Second,
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
@@ -592,7 +592,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 	}
 
 	// should return an error, but not hang
-	assert.Error(t, kubelet.updateNodeStatus(tCtx))
+	require.Error(t, kubelet.updateNodeStatus(tCtx))
 
 	// should have attempted multiple times
 	if actualAttempts := atomic.LoadInt64(&attempts); actualAttempts < nodeStatusUpdateRetry {
@@ -1146,7 +1146,7 @@ func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
 			kubelet.nodeLister = delegatingNodeLister{client: kubeClient}
 
 			// Execute
-			assert.NoError(t, kubelet.updateNodeStatus(tCtx))
+			require.NoError(t, kubelet.updateNodeStatus(tCtx))
 
 			// Validate
 			actions := kubeClient.Actions()
@@ -1651,7 +1651,7 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 	require.Equal(t, "status", actions[0].GetSubresource())
 
 	updatedNode, err := applyNodeStatusPatch(&existingNode, actions[0].(core.PatchActionImpl).GetPatch())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, apiequality.Semantic.DeepEqual(expectedNode.Status.Allocatable, updatedNode.Status.Allocatable), "%s", cmp.Diff(expectedNode.Status.Allocatable, updatedNode.Status.Allocatable))
 }
 
@@ -2735,7 +2735,7 @@ func TestValidateNodeIPParam(t *testing.T) {
 	for _, test := range tests {
 		err := validateNodeIP(netutils.ParseIPSloppy(test.nodeIP))
 		if test.success {
-			assert.NoErrorf(t, err, "test %s", test.testName)
+			require.NoErrorf(t, err, "test %s", test.testName)
 		} else {
 			assert.Errorf(t, err, "test %s", test.testName)
 		}
@@ -3076,14 +3076,14 @@ func TestUpdateNodeAddresses(t *testing.T) {
 			}
 
 			_, err := kubeClient.CoreV1().Nodes().Update(tCtx, oldNode, metav1.UpdateOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			kubelet.setNodeStatusFuncs = []func(context.Context, *v1.Node) error{
 				func(_ context.Context, node *v1.Node) error {
 					node.Status.Addresses = expectedNode.Status.Addresses
 					return nil
 				},
 			}
-			assert.NoError(t, kubelet.updateNodeStatus(tCtx))
+			require.NoError(t, kubelet.updateNodeStatus(tCtx))
 
 			actions := kubeClient.Actions()
 			lastAction := actions[len(actions)-1]

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -189,6 +189,7 @@ func (l delegatingNodeLister) List(selector labels.Selector) (ret []*v1.Node, er
 }
 
 func TestUpdateNewNodeStatus(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	cases := []struct {
 		desc                string
 		nodeStatusMaxImages int32
@@ -205,7 +206,6 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
 			// generate one more in inputImageList than we configure the Kubelet to report,
 			// or 5 images if unlimited
 			numTestImages := int(tc.nodeStatusMaxImages) + 1
@@ -319,8 +319,8 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 				},
 			}
 
-			kubelet.updateRuntimeUp(ctx)
-			assert.NoError(t, kubelet.updateNodeStatus(ctx))
+			kubelet.updateRuntimeUp(tCtx)
+			assert.NoError(t, kubelet.updateNodeStatus(tCtx))
 			actions := kubeClient.Actions()
 			require.Len(t, actions, 2)
 			require.True(t, actions[1].Matches("patch", "nodes"))
@@ -345,7 +345,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 }
 
 func TestUpdateExistingNodeStatus(t *testing.T) {
-	ctx := context.Background()
+	tCtx := ktesting.Init(t)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -509,8 +509,8 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 		},
 	}
 
-	kubelet.updateRuntimeUp(ctx)
-	assert.NoError(t, kubelet.updateNodeStatus(ctx))
+	kubelet.updateRuntimeUp(tCtx)
+	assert.NoError(t, kubelet.updateNodeStatus(tCtx))
 
 	actions := kubeClient.Actions()
 	assert.Len(t, actions, 2)
@@ -538,7 +538,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 }
 
 func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
-	ctx := context.Background()
+	tCtx := ktesting.Init(t)
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -592,7 +592,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 	}
 
 	// should return an error, but not hang
-	assert.Error(t, kubelet.updateNodeStatus(ctx))
+	assert.Error(t, kubelet.updateNodeStatus(tCtx))
 
 	// should have attempted multiple times
 	if actualAttempts := atomic.LoadInt64(&attempts); actualAttempts < nodeStatusUpdateRetry {
@@ -1071,6 +1071,7 @@ func TestUpdateNodeStatusWithLease(t *testing.T) {
 }
 
 func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	cases := []struct {
 		desc                  string
 		existingVolumes       []v1.UniqueVolumeName // volumes to initially populate volumeManager
@@ -1119,7 +1120,6 @@ func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
 			// Setup
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
@@ -1146,7 +1146,7 @@ func TestUpdateNodeStatusAndVolumesInUseWithNodeLease(t *testing.T) {
 			kubelet.nodeLister = delegatingNodeLister{client: kubeClient}
 
 			// Execute
-			assert.NoError(t, kubelet.updateNodeStatus(ctx))
+			assert.NoError(t, kubelet.updateNodeStatus(tCtx))
 
 			// Validate
 			actions := kubeClient.Actions()
@@ -1328,6 +1328,7 @@ func TestFastStatusUpdateOnce(t *testing.T) {
 }
 
 func TestRegisterWithApiServer(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -1374,7 +1375,7 @@ func TestRegisterWithApiServer(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		kubelet.registerWithAPIServer()
+		kubelet.registerWithAPIServer(tCtx)
 		done <- struct{}{}
 	}()
 	select {
@@ -1386,6 +1387,7 @@ func TestRegisterWithApiServer(t *testing.T) {
 }
 
 func TestTryRegisterWithApiServer(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	alreadyExists := &apierrors.StatusError{
 		ErrStatus: metav1.Status{Reason: metav1.StatusReasonAlreadyExists},
 	}
@@ -1552,7 +1554,7 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 			})
 			addNotImplatedReaction(kubeClient)
 
-			result := kubelet.tryRegisterWithAPIServer(tc.newNode)
+			result := kubelet.tryRegisterWithAPIServer(tCtx, tc.newNode)
 			require.Equal(t, tc.expectedResult, result, "test [%s]", tc.name)
 
 			actions := kubeClient.Actions()
@@ -2169,6 +2171,7 @@ func TestUpdateDefaultResources(t *testing.T) {
 }
 
 func TestReconcileHugePageResource(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	hugePageResourceName64Ki := v1.ResourceName("hugepages-64Ki")
 	hugePageResourceName2Mi := v1.ResourceName("hugepages-2Mi")
@@ -2453,7 +2456,7 @@ func TestReconcileHugePageResource(t *testing.T) {
 			defer testKubelet.Cleanup()
 			kubelet := testKubelet.kubelet
 
-			needsUpdate := kubelet.reconcileHugePageResource(tc.initialNode, tc.existingNode)
+			needsUpdate := kubelet.reconcileHugePageResource(logger, tc.initialNode, tc.existingNode)
 			assert.Equal(t, tc.needsUpdate, needsUpdate, tc.name)
 			assert.Equal(t, tc.expectedNode, tc.existingNode, tc.name)
 		})
@@ -2461,6 +2464,7 @@ func TestReconcileHugePageResource(t *testing.T) {
 
 }
 func TestReconcileExtendedResource(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	testKubelet.kubelet.kubeClient = nil // ensure only the heartbeat client is used
 	testKubelet.kubelet.containerManager = cm.NewStubContainerManagerWithExtendedResource(true /* shouldResetExtendedResourceCapacity*/)
@@ -2641,7 +2645,7 @@ func TestReconcileExtendedResource(t *testing.T) {
 		defer testKubelet.Cleanup()
 		kubelet := testKubelet.kubelet
 
-		needsUpdate := kubelet.reconcileExtendedResource(tc.initialNode, tc.existingNode)
+		needsUpdate := kubelet.reconcileExtendedResource(logger, tc.initialNode, tc.existingNode)
 		assert.Equal(t, tc.needsUpdate, needsUpdate, tc.name)
 		assert.Equal(t, tc.expectedNode, tc.existingNode, tc.name)
 	}
@@ -2739,6 +2743,7 @@ func TestValidateNodeIPParam(t *testing.T) {
 }
 
 func TestRegisterWithApiServerWithTaint(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -2773,7 +2778,7 @@ func TestRegisterWithApiServerWithTaint(t *testing.T) {
 	kubelet.registrationCompleted = false
 
 	// Register node to apiserver.
-	kubelet.registerWithAPIServer()
+	kubelet.registerWithAPIServer(tCtx)
 
 	// Check the unschedulable taint.
 	got := gotNode.(*v1.Node)
@@ -2940,6 +2945,7 @@ func TestNodeStatusHasChanged(t *testing.T) {
 }
 
 func TestUpdateNodeAddresses(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -3054,7 +3060,6 @@ func TestUpdateNodeAddresses(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			ctx := context.Background()
 			oldNode := &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname},
 				Spec:       v1.NodeSpec{},
@@ -3070,7 +3075,7 @@ func TestUpdateNodeAddresses(t *testing.T) {
 				},
 			}
 
-			_, err := kubeClient.CoreV1().Nodes().Update(ctx, oldNode, metav1.UpdateOptions{})
+			_, err := kubeClient.CoreV1().Nodes().Update(tCtx, oldNode, metav1.UpdateOptions{})
 			assert.NoError(t, err)
 			kubelet.setNodeStatusFuncs = []func(context.Context, *v1.Node) error{
 				func(_ context.Context, node *v1.Node) error {
@@ -3078,7 +3083,7 @@ func TestUpdateNodeAddresses(t *testing.T) {
 					return nil
 				},
 			}
-			assert.NoError(t, kubelet.updateNodeStatus(ctx))
+			assert.NoError(t, kubelet.updateNodeStatus(tCtx))
 
 			actions := kubeClient.Actions()
 			lastAction := actions[len(actions)-1]
@@ -3164,6 +3169,7 @@ func TestCalculateDelay(t *testing.T) {
 }
 
 func TestSetNodeStatusDeclaredFeatures(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		name               string
 		featureGateEnabled bool
@@ -3209,7 +3215,7 @@ func TestSetNodeStatusDeclaredFeatures(t *testing.T) {
 
 			// We need to force a status update, so we make the last status report time old.
 			kubelet.lastStatusReportTime = time.Now().Add(-time.Hour)
-			require.NoError(t, kubelet.updateNodeStatus(context.TODO()))
+			require.NoError(t, kubelet.updateNodeStatus(tCtx))
 
 			actions := kubeClient.Actions()
 			// We expect a get and a patch

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -406,7 +406,7 @@ func newTestKubeletWithImageList(
 		NodeRef:                         nodeRef,
 		GetPodsFunc:                     kubelet.podManager.GetPods,
 		KillPodFunc:                     killPodNow(kubelet.podWorkers, fakeRecorder),
-		SyncNodeStatusFunc:              func() {},
+		SyncNodeStatusFunc:              func(context.Context) {},
 		ShutdownGracePeriodRequested:    0,
 		ShutdownGracePeriodCriticalPods: 0,
 	})
@@ -3062,6 +3062,7 @@ func TestSyncTerminatingPodKillPod(t *testing.T) {
 }
 
 func TestSyncLabels(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tests := []struct {
 		name             string
 		existingNode     *v1.Node
@@ -3099,7 +3100,7 @@ func TestSyncLabels(t *testing.T) {
 			test.existingNode.Name = string(kl.nodeName)
 
 			kl.nodeLister = testNodeLister{nodes: []*v1.Node{test.existingNode}}
-			go func() { kl.syncNodeStatus() }()
+			go func() { kl.syncNodeStatus(tCtx) }()
 
 			err := retryWithExponentialBackOff(
 				100*time.Millisecond,

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -42,7 +42,7 @@ type Manager interface {
 	lifecycle.PodAdmitHandler
 
 	Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult
-	Start() error
+	Start(ctx context.Context) error
 	ShutdownStatus() error
 }
 
@@ -54,7 +54,7 @@ type Config struct {
 	NodeRef                          *v1.ObjectReference
 	GetPodsFunc                      eviction.ActivePodsFunc
 	KillPodFunc                      eviction.KillPodFunc
-	SyncNodeStatusFunc               func()
+	SyncNodeStatusFunc               func(context.Context)
 	ShutdownGracePeriodRequested     time.Duration
 	ShutdownGracePeriodCriticalPods  time.Duration
 	ShutdownGracePeriodByPodPriority []kubeletconfig.ShutdownGracePeriodByPodPriority
@@ -71,7 +71,7 @@ func (managerStub) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmit
 }
 
 // Start is a no-op always returning nil for non linux platforms.
-func (managerStub) Start() error {
+func (managerStub) Start(context.Context) error {
 	return nil
 }
 

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
@@ -20,6 +20,7 @@ limitations under the License.
 package nodeshutdown
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -55,7 +56,7 @@ type managerImpl struct {
 	nodeRef  *v1.ObjectReference
 
 	getPods        eviction.ActivePodsFunc
-	syncNodeStatus func()
+	syncNodeStatus func(context.Context)
 
 	nodeShuttingDownMutex sync.Mutex
 	nodeShuttingDownNow   bool
@@ -135,7 +136,7 @@ func (m *managerImpl) setMetrics() {
 }
 
 // Start starts the node shutdown manager and will start watching the node for shutdown events.
-func (m *managerImpl) Start() error {
+func (m *managerImpl) Start(_ context.Context) error {
 	m.logger.V(1).Info("Shutdown manager get started")
 
 	_, err := m.start()
@@ -246,7 +247,7 @@ func (m *managerImpl) ProcessShutdownEvent() error {
 	m.nodeShuttingDownNow = true
 	m.nodeShuttingDownMutex.Unlock()
 
-	go m.syncNodeStatus()
+	go m.syncNodeStatus(context.TODO())
 
 	m.logger.V(1).Info("Shutdown manager processing preshutdown event")
 	activePods := m.getPods()

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package nodeshutdown
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -90,7 +91,7 @@ func TestFeatureEnabled(t *testing.T) {
 				NodeRef:                         nodeRef,
 				GetPodsFunc:                     activePodsFunc,
 				KillPodFunc:                     killPodsFunc,
-				SyncNodeStatusFunc:              func() {},
+				SyncNodeStatusFunc:              func(context.Context) {},
 				ShutdownGracePeriodRequested:    tc.shutdownGracePeriodRequested,
 				ShutdownGracePeriodCriticalPods: 0,
 				StateDirectory:                  os.TempDir(),
@@ -104,7 +105,7 @@ func Test_managerImpl_ProcessShutdownEvent(t *testing.T) {
 	var (
 		fakeRecorder      = &record.FakeRecorder{}
 		fakeVolumeManager = volumemanager.NewFakeVolumeManager([]v1.UniqueVolumeName{}, 0, nil, false)
-		syncNodeStatus    = func() {}
+		syncNodeStatus    = func(context.Context) {}
 		nodeRef           = &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
 		fakeclock         = testingclock.NewFakeClock(time.Now())
 	)
@@ -116,7 +117,7 @@ func Test_managerImpl_ProcessShutdownEvent(t *testing.T) {
 		shutdownGracePeriodByPodPriority []kubeletconfig.ShutdownGracePeriodByPodPriority
 		getPods                          eviction.ActivePodsFunc
 		killPodFunc                      eviction.KillPodFunc
-		syncNodeStatus                   func()
+		syncNodeStatus                   func(context.Context)
 		nodeShuttingDownNow              bool
 		clock                            clock.Clock
 	}

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -473,10 +473,11 @@ func ReadyCondition(
 	storageErrorsFunc func() error, // typically Kubelet.runtimeState.storageErrors
 	cmStatusFunc func() cm.Status, // typically Kubelet.containerManager.Status
 	nodeShutdownManagerErrorsFunc func() error, // typically kubelet.shutdownManager.errors.
-	recordEventFunc func(eventType, event string), // typically Kubelet.recordNodeStatusEvent
+	recordEventFunc func(logger klog.Logger, eventType, event string), // typically Kubelet.recordNodeStatusEvent
 	localStorageCapacityIsolation bool,
 ) Setter {
 	return func(ctx context.Context, node *v1.Node) error {
+		logger := klog.FromContext(ctx)
 		// NOTE(aaronlevy): NodeReady condition needs to be the last in the list of node conditions.
 		// This is due to an issue with version skewed kubelet and master components.
 		// ref: https://github.com/kubernetes/kubernetes/issues/16961
@@ -539,9 +540,9 @@ func ReadyCondition(
 		}
 		if needToRecordEvent {
 			if newNodeReadyCondition.Status == v1.ConditionTrue {
-				recordEventFunc(v1.EventTypeNormal, events.NodeReady)
+				recordEventFunc(logger, v1.EventTypeNormal, events.NodeReady)
 			} else {
-				recordEventFunc(v1.EventTypeNormal, events.NodeNotReady)
+				recordEventFunc(logger, v1.EventTypeNormal, events.NodeNotReady)
 				logger := klog.FromContext(ctx)
 				logger.Info("Node became not ready", "node", klog.KObj(node), "condition", newNodeReadyCondition)
 			}
@@ -553,9 +554,10 @@ func ReadyCondition(
 // MemoryPressureCondition returns a Setter that updates the v1.NodeMemoryPressure condition on the node.
 func MemoryPressureCondition(nowFunc func() time.Time, // typically Kubelet.clock.Now
 	pressureFunc func() bool, // typically Kubelet.evictionManager.IsUnderMemoryPressure
-	recordEventFunc func(eventType, event string), // typically Kubelet.recordNodeStatusEvent
+	recordEventFunc func(logger klog.Logger, eventType, event string), // typically Kubelet.recordNodeStatusEvent
 ) Setter {
 	return func(ctx context.Context, node *v1.Node) error {
+		logger := klog.FromContext(ctx)
 		currentTime := metav1.NewTime(nowFunc())
 		var condition *v1.NodeCondition
 
@@ -594,14 +596,14 @@ func MemoryPressureCondition(nowFunc func() time.Time, // typically Kubelet.cloc
 				condition.Reason = "KubeletHasInsufficientMemory"
 				condition.Message = "kubelet has insufficient memory available"
 				condition.LastTransitionTime = currentTime
-				recordEventFunc(v1.EventTypeNormal, "NodeHasInsufficientMemory")
+				recordEventFunc(logger, v1.EventTypeNormal, "NodeHasInsufficientMemory")
 			}
 		} else if condition.Status != v1.ConditionFalse {
 			condition.Status = v1.ConditionFalse
 			condition.Reason = "KubeletHasSufficientMemory"
 			condition.Message = "kubelet has sufficient memory available"
 			condition.LastTransitionTime = currentTime
-			recordEventFunc(v1.EventTypeNormal, "NodeHasSufficientMemory")
+			recordEventFunc(logger, v1.EventTypeNormal, "NodeHasSufficientMemory")
 		}
 
 		if newCondition {
@@ -614,9 +616,10 @@ func MemoryPressureCondition(nowFunc func() time.Time, // typically Kubelet.cloc
 // PIDPressureCondition returns a Setter that updates the v1.NodePIDPressure condition on the node.
 func PIDPressureCondition(nowFunc func() time.Time, // typically Kubelet.clock.Now
 	pressureFunc func() bool, // typically Kubelet.evictionManager.IsUnderPIDPressure
-	recordEventFunc func(eventType, event string), // typically Kubelet.recordNodeStatusEvent
+	recordEventFunc func(logger klog.Logger, eventType, event string), // typically Kubelet.recordNodeStatusEvent
 ) Setter {
 	return func(ctx context.Context, node *v1.Node) error {
+		logger := klog.FromContext(ctx)
 		currentTime := metav1.NewTime(nowFunc())
 		var condition *v1.NodeCondition
 
@@ -655,14 +658,14 @@ func PIDPressureCondition(nowFunc func() time.Time, // typically Kubelet.clock.N
 				condition.Reason = "KubeletHasInsufficientPID"
 				condition.Message = "kubelet has insufficient PID available"
 				condition.LastTransitionTime = currentTime
-				recordEventFunc(v1.EventTypeNormal, "NodeHasInsufficientPID")
+				recordEventFunc(logger, v1.EventTypeNormal, "NodeHasInsufficientPID")
 			}
 		} else if condition.Status != v1.ConditionFalse {
 			condition.Status = v1.ConditionFalse
 			condition.Reason = "KubeletHasSufficientPID"
 			condition.Message = "kubelet has sufficient PID available"
 			condition.LastTransitionTime = currentTime
-			recordEventFunc(v1.EventTypeNormal, "NodeHasSufficientPID")
+			recordEventFunc(logger, v1.EventTypeNormal, "NodeHasSufficientPID")
 		}
 
 		if newCondition {
@@ -675,9 +678,10 @@ func PIDPressureCondition(nowFunc func() time.Time, // typically Kubelet.clock.N
 // DiskPressureCondition returns a Setter that updates the v1.NodeDiskPressure condition on the node.
 func DiskPressureCondition(nowFunc func() time.Time, // typically Kubelet.clock.Now
 	pressureFunc func() bool, // typically Kubelet.evictionManager.IsUnderDiskPressure
-	recordEventFunc func(eventType, event string), // typically Kubelet.recordNodeStatusEvent
+	recordEventFunc func(logger klog.Logger, eventType, event string), // typically Kubelet.recordNodeStatusEvent
 ) Setter {
 	return func(ctx context.Context, node *v1.Node) error {
+		logger := klog.FromContext(ctx)
 		currentTime := metav1.NewTime(nowFunc())
 		var condition *v1.NodeCondition
 
@@ -716,14 +720,14 @@ func DiskPressureCondition(nowFunc func() time.Time, // typically Kubelet.clock.
 				condition.Reason = "KubeletHasDiskPressure"
 				condition.Message = "kubelet has disk pressure"
 				condition.LastTransitionTime = currentTime
-				recordEventFunc(v1.EventTypeNormal, "NodeHasDiskPressure")
+				recordEventFunc(logger, v1.EventTypeNormal, "NodeHasDiskPressure")
 			}
 		} else if condition.Status != v1.ConditionFalse {
 			condition.Status = v1.ConditionFalse
 			condition.Reason = "KubeletHasNoDiskPressure"
 			condition.Message = "kubelet has no disk pressure"
 			condition.LastTransitionTime = currentTime
-			recordEventFunc(v1.EventTypeNormal, "NodeHasNoDiskPressure")
+			recordEventFunc(logger, v1.EventTypeNormal, "NodeHasNoDiskPressure")
 		}
 
 		if newCondition {

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/version"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -1342,7 +1343,7 @@ func TestReadyCondition(t *testing.T) {
 				return tc.nodeShutdownManagerErrors
 			}
 			events := []testEvent{}
-			recordEventFunc := func(eventType, event string) {
+			recordEventFunc := func(logger klog.Logger, eventType, event string) {
 				events = append(events, testEvent{
 					eventType: eventType,
 					event:     event,
@@ -1461,7 +1462,7 @@ func TestMemoryPressureCondition(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := ktesting.Init(t)
 			events := []testEvent{}
-			recordEventFunc := func(eventType, event string) {
+			recordEventFunc := func(logger klog.Logger, eventType, event string) {
 				events = append(events, testEvent{
 					eventType: eventType,
 					event:     event,
@@ -1583,7 +1584,7 @@ func TestPIDPressureCondition(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := ktesting.Init(t)
 			events := []testEvent{}
-			recordEventFunc := func(eventType, event string) {
+			recordEventFunc := func(logger klog.Logger, eventType, event string) {
 				events = append(events, testEvent{
 					eventType: eventType,
 					event:     event,
@@ -1705,7 +1706,7 @@ func TestDiskPressureCondition(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := ktesting.Init(t)
 			events := []testEvent{}
-			recordEventFunc := func(eventType, event string) {
+			recordEventFunc := func(logger klog.Logger, eventType, event string) {
 				events = append(events, testEvent{
 					eventType: eventType,
 					event:     event,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

migrate kubelet_node_status*.go and their dependencies to contextual logging

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/wg structured-logging
/area logging
/priority important-longterm
/cc @kubernetes/wg-structured-logging-reviews

/cc @ffromani @swatisehgal @hoteye @SergeyKanzhelev
for review and approval
