### PR TITLE
cluster/autoscaler: update version to v1.34.2 and grant RBAC permissions

### DIFF
--- a/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
+++ b/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
@@ -25,7 +25,7 @@ rules:
     verbs: ["create"]
   # read-only access to cluster state
   - apiGroups: [""]
-    resources: ["services", "replicationcontrollers", "persistentvolumes", "persistentvolumeclaims"]
+    resources: ["namespaces", "services", "replicationcontrollers", "persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["daemonsets", "replicasets"]
@@ -40,7 +40,7 @@ rules:
     resources: ["poddisruptionbudgets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"]
     verbs: ["get", "list", "watch"]
   # misc access
   - apiGroups: [""]

--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -22,7 +22,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.1",
+                "image": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",

--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -41,6 +41,7 @@
                     "--write-status-configmap=true",
                     "--balance-similar-node-groups=true",
                     "--expendable-pods-priority-cutoff=-10",
+                    "--bypassed-scheduler-names=non-existing-bypassed-scheduler",
                     {{params}}
                 ],
                 "env": [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This patch updates the cluster-autoscaler configuration and version to ensure compatibility and support for e2e tests.

#### Which issue(s) this PR is related to:
Relates to kubernetes/autoscaler#9023
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

It has been decided to move the associated [e2e tests](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/autoscaling/cluster_size_autoscaling.go) from  the kubernetes/kubernetes to the kubernetes/autoscaler repository. 
This patch will **not** fix `"ci-kubernetes-e2e-gci-gce-autoscaling"` that have been failing for over 200 days, but it is necessary and serves as a preparatory step to facilitate that migration. We are currently working on the remaining transition tasks. 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
