### PR TITLE
Simplify pkg/volume with slices.Contains.

### DIFF
--- a/pkg/util/tolerations/tolerations_test.go
+++ b/pkg/util/tolerations/tolerations_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strings"
 	"testing"
 
@@ -176,19 +177,11 @@ func TestIsSuperset(t *testing.T) {
 		assert.False(t, isSuperset(tolerations[super], tolerations[sub]),
 			"%s should NOT be a superset of %s", super, sub)
 	}
-	contains := func(ss []string, s string) bool {
-		for _, str := range ss {
-			if str == s {
-				return true
-			}
-		}
-		return false
-	}
 
 	for _, test := range tests {
 		t.Run(test.toleration, func(t *testing.T) {
 			for name := range tolerations {
-				if name == test.toleration || contains(test.ss, name) {
+				if name == test.toleration || slices.Contains(test.ss, name) {
 					assertSuperset(t, test.toleration, name)
 				} else {
 					assertNotSuperset(t, test.toleration, name)

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	api "k8s.io/api/core/v1"
@@ -560,12 +561,7 @@ func (c *csiMountMgr) supportsVolumeLifecycleMode() error {
 
 // containsVolumeMode checks whether the given volume mode is listed.
 func containsVolumeMode(modes []storage.VolumeLifecycleMode, mode storage.VolumeLifecycleMode) bool {
-	for _, m := range modes {
-		if m == mode {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(modes, mode)
 }
 
 // isDirMounted returns the !notMounted result from IsLikelyNotMountPoint check

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 
@@ -297,12 +298,7 @@ func (plugin *flexVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (
 func (plugin *flexVolumePlugin) isUnsupported(command string) bool {
 	plugin.Lock()
 	defer plugin.Unlock()
-	for _, unsupportedCommand := range plugin.unsupportedCommands {
-		if command == unsupportedCommand {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(plugin.unsupportedCommands, command)
 }
 
 func (plugin *flexVolumePlugin) GetDeviceMountRefs(deviceMountPath string) ([]string, error) {

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	goruntime "runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1748,10 +1749,5 @@ func MetricsEqualIgnoreTimestamp(a *volume.Metrics, b *volume.Metrics) bool {
 }
 
 func ContainsAccessMode(modes []v1.PersistentVolumeAccessMode, mode v1.PersistentVolumeAccessMode) bool {
-	for _, m := range modes {
-		if m == mode {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(modes, mode)
 }

--- a/pkg/volume/util/hostutil/hostutil_linux.go
+++ b/pkg/volume/util/hostutil/hostutil_linux.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -244,17 +245,7 @@ func GetSELinux(path string, mountInfoFilename string, selinuxEnabled seLinuxEna
 	}
 
 	// "seclabel" can be both in mount options and super options.
-	for _, opt := range info.SuperOptions {
-		if opt == "seclabel" {
-			return true, nil
-		}
-	}
-	for _, opt := range info.MountOptions {
-		if opt == "seclabel" {
-			return true, nil
-		}
-	}
-	return false, nil
+	return slices.Contains(info.SuperOptions, "seclabel") || slices.Contains(info.MountOptions, "seclabel"), nil
 }
 
 // GetSELinuxSupport returns true if given path is on a mount that supports

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -1500,12 +1501,10 @@ func (og *operationGenerator) verifyVolumeIsSafeToDetach(
 		return volumeToDetach.GenerateErrorDetailed("DetachVolume failed fetching node from API server", fetchErr)
 	}
 
-	for _, inUseVolume := range node.Status.VolumesInUse {
-		if inUseVolume == volumeToDetach.VolumeName {
-			return volumeToDetach.GenerateErrorDetailed(
-				"DetachVolume failed",
-				fmt.Errorf("volume is still in use by node, according to Node status"))
-		}
+	if slices.Contains(node.Status.VolumesInUse, volumeToDetach.VolumeName) {
+		return volumeToDetach.GenerateErrorDetailed(
+			"DetachVolume failed",
+			fmt.Errorf("volume is still in use by node, according to Node status"))
 	}
 
 	// Volume is not marked as in use by node

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -220,12 +221,7 @@ func JoinMountOptions(userOptions []string, systemOptions []string) []string {
 
 // ContainsAccessMode returns whether the requested mode is contained by modes
 func ContainsAccessMode(modes []v1.PersistentVolumeAccessMode, mode v1.PersistentVolumeAccessMode) bool {
-	for _, m := range modes {
-		if m == mode {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(modes, mode)
 }
 
 // ContainsAllAccessModes returns whether all of the requested modes are contained by modes

--- a/pkg/volume/validation/pv_validation.go
+++ b/pkg/volume/validation/pv_validation.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"errors"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -61,10 +62,8 @@ func checkMountOption(pv *api.PersistentVolume) field.ErrorList {
 // ValidatePathNoBacksteps will make sure the targetPath does not have any element which is ".."
 func ValidatePathNoBacksteps(targetPath string) error {
 	parts := strings.Split(filepath.ToSlash(targetPath), "/")
-	for _, item := range parts {
-		if item == ".." {
-			return errors.New("must not contain '..'")
-		}
+	if slices.Contains(parts, "..") {
+		return errors.New("must not contain '..'")
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

Intentionally, I have limited to `pkg/volume` and a single file in `pkg/util/tolerations`.

A bit follow-up to #136292 

/kind cleanup

#### What this PR does / why we need it:

It removes a few internal helper functions that after applying [modernize/slicescontains](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_slicescontains) only called `slices.Contains`

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: