### PR TITLE
DRA E2E: use image utils to manage hostpath image

### DIFF
--- a/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
+++ b/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: pause
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
+          image: registry.k8s.io/sig-storage/hostpathplugin # Version and actual registry get patched in during deployment.
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When testing in an air-gapped cluster, users of the e2e.test depend on -list-images and KUBE_TEST_REPO_LIST to pre-populate a local registry with required images.

The hostpath image used by DRA was not part of that process (not getting patched with local registry) and the version fell behind what SIG Storage was using at least once. Now the registry and version are derived from what is being tested elsewhere, using the latest available image if there is more than one.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Previous attempt to solve this differently in https://github.com/kubernetes/kubernetes/pull/131698.

/assign @tkashem 

Does this solve the problem for you/Red Hat?

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
