### PR TITLE
Skip Scale in versioned declarative validation fuzzing

### DIFF
--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -64,6 +64,11 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 
 	for _, gv := range typesWithDeclarativeValidation {
 		for kind := range legacyscheme.Scheme.KnownTypes(gv) {
+			// Scale is a virtual subresource and does not have declarative
+			// validation implemented in any API group.
+			if kind == "Scale" {
+				continue
+			}
 			gvk := gv.WithKind(kind)
 			t.Run(gvk.String(), func(t *testing.T) {
 				for i := 0; i < fuzzIters; i++ {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes intermittent failures in TestVersionedValidationByFuzzing caused by the Scale kind.
This happens because Scale is a shared subresource type that exists in multiple API groups/versions (autoscaling, apps, extensions) and does not currently have declarative validation registered.

Additionally, conversion for Scale across versions may succeed or fail depending on fuzzed ScaleStatus.Selector values (it is parsed during conversion), making the failure non-deterministic.

If conversion for Scale fails then those are seen as Parsing errors, but when conversion passes, then it looks for Validation and fails as declarative validation is not found for Scale.

And not sure of adding Declarative validation for Scale subresource as per this PR - https://github.com/kubernetes/kubernetes/pull/136058, I think similar to List objects, Scale is a special shared subresource type and not a normal user-authored API object so thought tp skip it for this.


failures- https://storage.googleapis.com/k8s-triage/index.html?text=TestVersionedValidationByFuzzing&xjob=s3
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
