### PR TITLE
Rename PodGroupInfo in preparation for Workload-aware scheduling changes

### DIFF
--- a/pkg/scheduler/backend/workloadmanager/workloadmanager.go
+++ b/pkg/scheduler/backend/workloadmanager/workloadmanager.go
@@ -44,14 +44,14 @@ type WorkloadManager interface {
 type workloadManager struct {
 	lock sync.RWMutex
 
-	// podGroupInfos stores the runtime state for each known pod group.
-	podGroupInfos map[podGroupKey]*podGroupInfo
+	// podGroupStates stores the runtime state for each known pod group.
+	podGroupStates map[podGroupKey]*podGroupState
 }
 
 // New initializes a new workload manager and returns it.
 func New() *workloadManager {
 	return &workloadManager{
-		podGroupInfos: make(map[podGroupKey]*podGroupInfo),
+		podGroupStates: make(map[podGroupKey]*podGroupState),
 	}
 }
 
@@ -65,12 +65,12 @@ func (wm *workloadManager) AddPod(pod *v1.Pod) {
 	defer wm.lock.Unlock()
 
 	key := newPodGroupKey(pod.Namespace, pod.Spec.WorkloadRef)
-	info, ok := wm.podGroupInfos[key]
+	state, ok := wm.podGroupStates[key]
 	if !ok {
-		info = newPodGroupInfo()
-		wm.podGroupInfos[key] = info
+		state = newPodGroupState()
+		wm.podGroupStates[key] = state
 	}
-	info.addPod(pod)
+	state.addPod(pod)
 }
 
 // UpdatePod updates a pod in the workload manager if it has a workload reference.
@@ -83,15 +83,15 @@ func (wm *workloadManager) UpdatePod(oldPod, newPod *v1.Pod) {
 	defer wm.lock.Unlock()
 
 	key := newPodGroupKey(newPod.Namespace, newPod.Spec.WorkloadRef)
-	info, ok := wm.podGroupInfos[key]
+	state, ok := wm.podGroupStates[key]
 	if !ok {
 		// Shouldn't happen, but handling this case gracefully.
-		info = newPodGroupInfo()
-		wm.podGroupInfos[key] = info
-		info.addPod(newPod)
+		state = newPodGroupState()
+		wm.podGroupStates[key] = state
+		state.addPod(newPod)
 		return
 	}
-	info.updatePod(oldPod, newPod)
+	state.updatePod(oldPod, newPod)
 }
 
 // DeletePod removes a pod from the workload manager if it has a workload reference.
@@ -104,24 +104,24 @@ func (wm *workloadManager) DeletePod(pod *v1.Pod) {
 	defer wm.lock.Unlock()
 
 	key := newPodGroupKey(pod.Namespace, pod.Spec.WorkloadRef)
-	info, ok := wm.podGroupInfos[key]
+	state, ok := wm.podGroupStates[key]
 	if !ok {
 		// The pod group may have already been cleaned up, or the pod was never added.
 		return
 	}
-	info.deletePod(pod.UID)
+	state.deletePod(pod.UID)
 	// Clean up the map entry if no pods are left in the group.
-	if info.empty() {
-		delete(wm.podGroupInfos, key)
+	if state.empty() {
+		delete(wm.podGroupStates, key)
 	}
 }
 
-// PodGroupInfo returns the state of a pod group.
-func (wm *workloadManager) PodGroupInfo(namespace string, workloadRef *v1.WorkloadReference) (fwk.PodGroupInfo, error) {
+// PodGroupState returns the runtime state of a pod group.
+func (wm *workloadManager) PodGroupState(namespace string, workloadRef *v1.WorkloadReference) (fwk.PodGroupState, error) {
 	wm.lock.RLock()
 	defer wm.lock.RUnlock()
 
-	state, ok := wm.podGroupInfos[newPodGroupKey(namespace, workloadRef)]
+	state, ok := wm.podGroupStates[newPodGroupKey(namespace, workloadRef)]
 	if !ok {
 		return nil, fmt.Errorf("internal pod group state doesn't exist for a pod's workload")
 	}

--- a/pkg/scheduler/backend/workloadmanager/workloadmanager_test.go
+++ b/pkg/scheduler/backend/workloadmanager/workloadmanager_test.go
@@ -83,24 +83,24 @@ func TestWorkloadManager_AddPod(t *testing.T) {
 
 			manager.AddPod(tt.podToAdd)
 
-			gotPodGroups := len(manager.podGroupInfos)
+			gotPodGroups := len(manager.podGroupStates)
 			if gotPodGroups != tt.expectedPodGroups {
 				t.Fatalf("Expected %v pod group(s), got %v", tt.expectedPodGroups, gotPodGroups)
 			}
 			if gotPodGroups == 0 {
 				return
 			}
-			info, err := manager.PodGroupInfo(tt.podToAdd.Namespace, tt.podToAdd.Spec.WorkloadRef)
+			state, err := manager.PodGroupState(tt.podToAdd.Namespace, tt.podToAdd.Spec.WorkloadRef)
 			if err != nil {
-				t.Fatalf("Unexpected error getting pod group info: %v", err)
+				t.Fatalf("Unexpected error getting pod group state: %v", err)
 			}
-			if inAll := info.AllPods().Has(tt.podToAdd.UID); inAll != tt.expectInAllPods {
+			if inAll := state.AllPods().Has(tt.podToAdd.UID); inAll != tt.expectInAllPods {
 				t.Errorf("Unexpected AllPods state, want: %v, got: %v", tt.expectInAllPods, inAll)
 			}
-			if inAssumed := info.AssumedPods().Has(tt.podToAdd.UID); inAssumed != tt.expectInAssumedPods {
+			if inAssumed := state.AssumedPods().Has(tt.podToAdd.UID); inAssumed != tt.expectInAssumedPods {
 				t.Errorf("Unexpected AssumedPods state, want: %v, got: %v", tt.expectInAssumedPods, inAssumed)
 			}
-			if inAssigned := info.AssignedPods().Has(tt.podToAdd.UID); inAssigned != tt.expectInAssignedPods {
+			if inAssigned := state.AssignedPods().Has(tt.podToAdd.UID); inAssigned != tt.expectInAssignedPods {
 				t.Errorf("Unexpected AssignedPods state, want: %v, got: %v", tt.expectInAssignedPods, inAssigned)
 			}
 		})
@@ -182,16 +182,16 @@ func TestWorkloadManager_UpdatePod(t *testing.T) {
 
 			manager.AddPod(tt.oldPod)
 			if tt.assumePod {
-				info, err := manager.PodGroupInfo(tt.oldPod.Namespace, tt.oldPod.Spec.WorkloadRef)
+				state, err := manager.PodGroupState(tt.oldPod.Namespace, tt.oldPod.Spec.WorkloadRef)
 				if err != nil {
-					t.Fatalf("Unexpected error getting pod group info: %v", err)
+					t.Fatalf("Unexpected error getting pod group state: %v", err)
 				}
-				info.AssumePod(tt.oldPod.UID)
+				state.AssumePod(tt.oldPod.UID)
 			}
 
 			manager.UpdatePod(tt.oldPod, tt.newPod)
 
-			gotPodGroups := len(manager.podGroupInfos)
+			gotPodGroups := len(manager.podGroupStates)
 			if gotPodGroups == 0 {
 				if tt.expectInAllPods {
 					t.Fatalf("Expected pod group, but got none")
@@ -201,17 +201,17 @@ func TestWorkloadManager_UpdatePod(t *testing.T) {
 			if !tt.expectInAllPods {
 				t.Fatalf("Expected no pod groups, but got %v", gotPodGroups)
 			}
-			info, err := manager.PodGroupInfo(tt.newPod.Namespace, tt.newPod.Spec.WorkloadRef)
+			state, err := manager.PodGroupState(tt.newPod.Namespace, tt.newPod.Spec.WorkloadRef)
 			if err != nil {
-				t.Fatalf("Unexpected error getting pod group info: %v", err)
+				t.Fatalf("Unexpected error getting pod group state: %v", err)
 			}
-			if inAll := info.AllPods().Has(tt.newPod.UID); inAll != tt.expectInAllPods {
+			if inAll := state.AllPods().Has(tt.newPod.UID); inAll != tt.expectInAllPods {
 				t.Errorf("Unexpected AllPods state, want: %v, got: %v", tt.expectInAllPods, inAll)
 			}
-			if inAssumed := info.AssumedPods().Has(tt.newPod.UID); inAssumed != tt.expectInAssumedPods {
+			if inAssumed := state.AssumedPods().Has(tt.newPod.UID); inAssumed != tt.expectInAssumedPods {
 				t.Errorf("Unexpected AssumedPods state, want: %v, got: %v", tt.expectInAssumedPods, inAssumed)
 			}
-			if inAssigned := info.AssignedPods().Has(tt.newPod.UID); inAssigned != tt.expectInAssignedPods {
+			if inAssigned := state.AssignedPods().Has(tt.newPod.UID); inAssigned != tt.expectInAssignedPods {
 				t.Errorf("Unexpected AssignedPods state, want: %v, got: %v", tt.expectInAssignedPods, inAssigned)
 			}
 		})
@@ -238,7 +238,7 @@ func TestWorkloadManager_DeletePod(t *testing.T) {
 			expectedPodGroups: 1,
 		},
 		{
-			name:        "deleting the last pod cleans up the info",
+			name:        "deleting the last pod cleans up the state",
 			initPods:    []*v1.Pod{p1},
 			podToDelete: p1,
 		},
@@ -256,21 +256,21 @@ func TestWorkloadManager_DeletePod(t *testing.T) {
 			}
 			manager.DeletePod(tt.podToDelete)
 
-			gotPodGroups := len(manager.podGroupInfos)
+			gotPodGroups := len(manager.podGroupStates)
 			if gotPodGroups != tt.expectedPodGroups {
 				t.Fatalf("Expected %v pod group(s), got %v", tt.expectedPodGroups, gotPodGroups)
 			}
 			if gotPodGroups == 0 {
 				return
 			}
-			info, err := manager.PodGroupInfo(tt.podToDelete.Namespace, tt.podToDelete.Spec.WorkloadRef)
+			state, err := manager.PodGroupState(tt.podToDelete.Namespace, tt.podToDelete.Spec.WorkloadRef)
 			if err != nil {
-				t.Fatalf("Unexpected error getting pod group info: %v", err)
+				t.Fatalf("Unexpected error getting pod group state: %v", err)
 			}
-			if len(info.AllPods()) == 0 {
+			if len(state.AllPods()) == 0 {
 				t.Errorf("Expected AllPods to be non-empty")
 			}
-			if info.AllPods().Has(p1.UID) {
+			if state.AllPods().Has(p1.UID) {
 				t.Errorf("Expected pod to be deleted")
 			}
 		})

--- a/staging/src/k8s.io/kube-scheduler/framework/listers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/listers.go
@@ -149,12 +149,12 @@ type CSIManager interface {
 // WorkloadManager provides an interface for scheduling plugins to provide workload-aware scheduling.
 // It acts as the central source of truth for runtime information about workloads.
 type WorkloadManager interface {
-	// PodGroupInfo retrieves the runtime state for a specific pod group, identified by workload's namespace and reference.
-	PodGroupInfo(namespace string, workloadRef *v1.WorkloadReference) (PodGroupInfo, error)
+	// PodGroupState retrieves the runtime state for a specific pod group, identified by workload's namespace and reference.
+	PodGroupState(namespace string, workloadRef *v1.WorkloadReference) (PodGroupState, error)
 }
 
-// PodGroupInfo provides an interface to view and modify the state of a single pod group.
-type PodGroupInfo interface {
+// PodGroupState provides an interface to view and modify the state of a single pod group.
+type PodGroupState interface {
 	// AllPods returns the UIDs of all pods known to the scheduler for this group.
 	AllPods() sets.Set[types.UID]
 	// UnscheduledPods returns all pods that are unscheduled for this group,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

As mentioned in https://github.com/kubernetes/enhancements/pull/5733/changes#r2610449539, we want to have a more focused PodGroupInfo type than the current implementation.

In this PR I rename PodGroupInfo to PodGroupState.

PodGroupState is used to track live pod state, which is currently used by the GangScheduling plugin.

The new PodGroupInfo type will describe a snapshotted state of a podgroup that will be used in the workload scheduling cycle plugins.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/5732
KEP: https://github.com/kubernetes/enhancements/issues/4671

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Renamed PodGroupInfo to PodGroupState, which can break custom scheduler plugins that use Handle.WorkloadManager
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/5733/changes#diff-7ae886ce193e1c72e6a0673ded84f5552891a2b813918acd8cd5e5a3b6748c06R285
```
