### PR TITLE
Clean up kubelet nodeinfo cache

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -2465,8 +2465,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 			},
 		}, nil
 	}
-
-	predicateHandler := lifecycle.NewPredicateAdmitHandler(getNode, lifecycle.NewAdmissionFailureHandlerStub(), containerManager.UpdatePluginResources)
+	predicateHandler := lifecycle.NewPredicateAdmitHandler(getNode, lifecycle.NewAdmissionFailureHandlerStub(), containerManager.UpdatePluginResources, lifecycle.NewNodeInfoProviderStubWithPods(allocatedPods))
 	resizeHandler := NewPodResizesAdmitHandler(containerManager, runtime, allocationManager, logger)
 	allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{resizeHandler, predicateHandler})
 	return allocationManager

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -54,6 +54,7 @@ import (
 	statustest "k8s.io/kubernetes/pkg/kubelet/status/testing"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 	_ "k8s.io/kubernetes/pkg/volume/hostpath"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
@@ -3480,10 +3481,22 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 		}, nil
 	}
 
-	predicateHandler := lifecycle.NewPredicateAdmitHandler(getNode, lifecycle.NewAdmissionFailureHandlerStub(), containerManager.UpdatePluginResources)
+	predicateHandler := lifecycle.NewPredicateAdmitHandler(getNode, lifecycle.NewAdmissionFailureHandlerStub(), containerManager.UpdatePluginResources, allocatedPodsNodeInfoProvider{allocationManager.(*manager)})
 	resizeHandler := NewPodResizesAdmitHandler(containerManager, runtime, allocationManager)
 	allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{resizeHandler, predicateHandler})
 	return allocationManager
+}
+
+// allocatedPodsNodeInfoProvider stands in for the kubelet's NodeInfo cache and
+// holds the same set it does: pods with an allocation. A pod is added to the
+// production cache once admission succeeds, which is also when its allocation
+// is written, so pods still awaiting admission are absent from both.
+type allocatedPodsNodeInfoProvider struct {
+	manager *manager
+}
+
+func (p allocatedPodsNodeInfoProvider) Snapshot() *schedulerframework.NodeInfo {
+	return schedulerframework.NewNodeInfo(p.manager.GetAllocatedPods()...)
 }
 
 func setContainerStatus(podStatus *kubecontainer.PodStatus, c *v1.Container, idx int) {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -110,6 +110,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/metrics/collectors"
 	"k8s.io/kubernetes/pkg/kubelet/network/dns"
+	"k8s.io/kubernetes/pkg/kubelet/nodeinfocache"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown"
 	oomwatcher "k8s.io/kubernetes/pkg/kubelet/oom"
 	"k8s.io/kubernetes/pkg/kubelet/pleg"
@@ -711,6 +712,11 @@ func NewMainKubelet(ctx context.Context,
 		kubeDeps.Recorder,
 	)
 
+	// Initialize NodeInfo cache for efficient pod admission.
+	// The node will be set when GetCachedNode is first called.
+	// Pods will be added incrementally via HandlePodAdditions.
+	klet.nodeInfoCache = nodeinfocache.New()
+
 	klet.resourceAnalyzer = serverstats.NewResourceAnalyzer(ctx, klet, kubeCfg.VolumeStatsAggPeriod.Duration, kubeDeps.Recorder)
 	klet.runtimeService = kubeDeps.RemoteRuntimeService
 
@@ -1115,7 +1121,7 @@ func NewMainKubelet(ctx context.Context,
 	handlers = append(handlers, klet.containerManager.GetAllocateResourcesPodAdmitHandler())
 
 	criticalPodAdmissionHandler := preemption.NewCriticalPodAdmissionHandler(klet.getAllocatedPods, killPodNow(ctx, klet.podWorkers, kubeDeps.Recorder), kubeDeps.Recorder)
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources, klet.nodeInfoCache))
 	// apply functional Option's
 	for _, opt := range kubeDeps.Options {
 		opt(klet)
@@ -1297,6 +1303,10 @@ type Kubelet struct {
 
 	// allocationManager manages allocated resources for pods.
 	allocationManager allocation.Manager
+
+	// nodeInfoCache caches NodeInfo for efficient pod admission.
+	// Updated incrementally when pods are added/removed/updated.
+	nodeInfoCache *nodeinfocache.Cache
 
 	// podCertificateManager is fed updates as pods are added and removed from
 	// the node, and requests certificates for them based on their configured
@@ -2888,6 +2898,15 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 				recordAdmissionRejection(reason)
 				continue
 			}
+			// Update NodeInfo cache after successful admission. Mirror pods
+			// never reach here — the wasMirror continue above filters them out,
+			// so the cache holds only non-mirror admitted pods.
+			// Use allocated resources (not desired) so resource accounting
+			// reflects what is actually committed on the node. The second
+			// return is a "did spec differ from allocation" bool (not an
+			// error); only the resolved pod is needed at the cache sites.
+			allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
+			kl.nodeInfoCache.AddPod(allocatedPod)
 
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 				// Backfill the queue of pending resizes, but only after all the pods have
@@ -2925,6 +2944,16 @@ func (kl *Kubelet) HandlePodUpdates(ctx context.Context, pods []*v1.Pod) {
 	for _, pod := range pods {
 		oldPod, _ := kl.podManager.GetPodByUID(pod.UID)
 		kl.podManager.UpdatePod(pod)
+		// Update NodeInfo cache with allocated resources (not desired) so
+		// resource accounting reflects what is actually committed.
+		// oldPod is nil for mirror pods (stored separately in podManager),
+		// so the cache update is naturally skipped for mirror pod events.
+		// The second return is a "differs from spec" bool, not an error;
+		// only the resolved pod is needed here.
+		if oldPod != nil {
+			allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
+			kl.nodeInfoCache.UpdatePod(logger, oldPod, allocatedPod)
+		}
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
 		if wasMirror {
@@ -3072,6 +3101,13 @@ func (kl *Kubelet) HandlePodRemoves(ctx context.Context, pods []*v1.Pod) {
 	for _, pod := range pods {
 		kl.podCertificateManager.ForgetPod(ctx, pod)
 		kl.podManager.RemovePod(pod)
+		// Remove from the NodeInfo cache. Called unconditionally on the raw
+		// pod: the cache only ever holds non-mirror admitted pods (see
+		// HandlePodAdditions), and a mirror pod's UID is never present, so a
+		// mirror REMOVE event is a tolerated no-op (RemovePod logs at V(4) and
+		// returns). The static pod is removed by its own non-mirror REMOVE,
+		// keyed by the same UID it was added with.
+		kl.nodeInfoCache.RemovePod(logger, pod)
 		kl.allocationManager.RemovePod(pod.UID)
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
@@ -3115,6 +3151,18 @@ func (kl *Kubelet) HandlePodReconcile(ctx context.Context, pods []*v1.Pod) {
 		// to the pod manager.
 		oldPod, _ := kl.podManager.GetPodByUID(pod.UID)
 		kl.podManager.UpdatePod(pod)
+		// Keep NodeInfo cache in sync — reconcile events carry the latest pod
+		// spec from the API server which may include resource changes.
+		// Use allocated resources so accounting reflects actual commitments.
+		// oldPod is nil for mirror pods (podManager stores them separately, so
+		// GetPodByUID never returns them), so the cache update is naturally
+		// skipped for mirror pod events — the cache holds only non-mirror pods.
+		// The second return is a "differs from spec" bool, not an error;
+		// only the resolved pod is needed here.
+		if oldPod != nil {
+			allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
+			kl.nodeInfoCache.UpdatePod(logger, oldPod, allocatedPod)
+		}
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
 		if wasMirror {
@@ -3142,6 +3190,8 @@ func (kl *Kubelet) HandlePodReconcile(ctx context.Context, pods []*v1.Pod) {
 				}
 
 				// Ignore desired resources when aggregating the resources.
+				// The second return is a "differs from spec" bool, not an
+				// error; only the resolved pod is needed here.
 				allocatedOldPod, _ := kl.allocationManager.UpdatePodFromAllocation(oldPod)
 				allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -110,6 +110,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/metrics/collectors"
 	"k8s.io/kubernetes/pkg/kubelet/network/dns"
+	"k8s.io/kubernetes/pkg/kubelet/nodeinfocache"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown"
 	oomwatcher "k8s.io/kubernetes/pkg/kubelet/oom"
 	"k8s.io/kubernetes/pkg/kubelet/pleg"
@@ -739,6 +740,11 @@ func NewMainKubelet(ctx context.Context,
 		logger,
 	)
 
+	// Initialize NodeInfo cache for efficient pod admission.
+	// The node will be set when GetCachedNode is first called.
+	// Pods will be added incrementally via HandlePodAdditions.
+	klet.nodeInfoCache = nodeinfocache.New()
+
 	klet.resourceAnalyzer = serverstats.NewResourceAnalyzer(ctx, klet, kubeCfg.VolumeStatsAggPeriod.Duration, kubeDeps.Recorder)
 	klet.runtimeService = kubeDeps.RemoteRuntimeService
 
@@ -1134,7 +1140,7 @@ func NewMainKubelet(ctx context.Context,
 	handlers = append(handlers, klet.containerManager.GetAllocateResourcesPodAdmitHandler(logger))
 
 	criticalPodAdmissionHandler := preemption.NewCriticalPodAdmissionHandler(klet.getAllocatedPods, killPodNow(ctx, klet.podWorkers, kubeDeps.Recorder), kubeDeps.Recorder)
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources, klet.nodeInfoCache))
 	// apply functional Option's
 	for _, opt := range kubeDeps.Options {
 		opt(klet)
@@ -1316,6 +1322,10 @@ type Kubelet struct {
 
 	// allocationManager manages allocated resources for pods.
 	allocationManager allocation.Manager
+
+	// nodeInfoCache caches NodeInfo for efficient pod admission.
+	// Updated incrementally when pods are added/removed/updated.
+	nodeInfoCache *nodeinfocache.Cache
 
 	// podCertificateManager is fed updates as pods are added and removed from
 	// the node, and requests certificates for them based on their configured
@@ -2931,6 +2941,16 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 			}
 			recordPodLevelResourcesAdmission(pod)
 
+			// Update NodeInfo cache after successful admission. Mirror pods
+			// never reach here — the wasMirror continue above filters them out,
+			// so the cache holds only non-mirror admitted pods.
+			// Use allocated resources (not desired) so resource accounting
+			// reflects what is actually committed on the node. The second
+			// return is a "did spec differ from allocation" bool (not an
+			// error); only the resolved pod is needed at the cache sites.
+			allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
+			kl.nodeInfoCache.AddPod(allocatedPod)
+
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 				// Backfill the queue of pending resizes, but only after all the pods have
 				// been added. This ensures that no resizes get resolved until all the
@@ -2967,6 +2987,16 @@ func (kl *Kubelet) HandlePodUpdates(ctx context.Context, pods []*v1.Pod) {
 	for _, pod := range pods {
 		oldPod, _ := kl.podManager.GetPodByUID(pod.UID)
 		kl.podManager.UpdatePod(pod)
+		// Update NodeInfo cache with allocated resources (not desired) so
+		// resource accounting reflects what is actually committed.
+		// oldPod is nil for mirror pods (stored separately in podManager),
+		// so the cache update is naturally skipped for mirror pod events.
+		// The second return is a "differs from spec" bool, not an error;
+		// only the resolved pod is needed here.
+		if oldPod != nil {
+			allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
+			kl.nodeInfoCache.UpdatePod(logger, oldPod, allocatedPod)
+		}
 
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 			// Skip pods that haven't been allocated yet to avoid counting them against
@@ -3133,6 +3163,13 @@ func (kl *Kubelet) HandlePodRemoves(ctx context.Context, pods []*v1.Pod) {
 	for _, pod := range pods {
 		kl.podCertificateManager.ForgetPod(ctx, pod)
 		kl.podManager.RemovePod(pod)
+		// Remove from the NodeInfo cache. Called unconditionally on the raw
+		// pod: the cache only ever holds non-mirror admitted pods (see
+		// HandlePodAdditions), and a mirror pod's UID is never present, so a
+		// mirror REMOVE event is a tolerated no-op (RemovePod logs at V(4) and
+		// returns). The static pod is removed by its own non-mirror REMOVE,
+		// keyed by the same UID it was added with.
+		kl.nodeInfoCache.RemovePod(logger, pod)
 		kl.allocationManager.RemovePod(logger, pod.UID)
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
@@ -3176,6 +3213,18 @@ func (kl *Kubelet) HandlePodReconcile(ctx context.Context, pods []*v1.Pod) {
 		// to the pod manager.
 		oldPod, _ := kl.podManager.GetPodByUID(pod.UID)
 		kl.podManager.UpdatePod(pod)
+		// Keep NodeInfo cache in sync — reconcile events carry the latest pod
+		// spec from the API server which may include resource changes.
+		// Use allocated resources so accounting reflects actual commitments.
+		// oldPod is nil for mirror pods (podManager stores them separately, so
+		// GetPodByUID never returns them), so the cache update is naturally
+		// skipped for mirror pod events — the cache holds only non-mirror pods.
+		// The second return is a "differs from spec" bool, not an error;
+		// only the resolved pod is needed here.
+		if oldPod != nil {
+			allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
+			kl.nodeInfoCache.UpdatePod(logger, oldPod, allocatedPod)
+		}
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
 		if wasMirror {
@@ -3206,6 +3255,8 @@ func (kl *Kubelet) HandlePodReconcile(ctx context.Context, pods []*v1.Pod) {
 				}
 
 				// Ignore desired resources when aggregating the resources.
+				// The second return is a "differs from spec" bool, not an
+				// error; only the resolved pod is needed here.
 				allocatedOldPod, _ := kl.allocationManager.UpdatePodFromAllocation(oldPod)
 				allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
 

--- a/pkg/kubelet/kubelet_nodecache.go
+++ b/pkg/kubelet/kubelet_nodecache.go
@@ -48,7 +48,7 @@ func (kl *Kubelet) getCachedNode(ctx context.Context) (*v1.Node, error) {
 	}
 
 	if kl.cachedNode == nil {
-		kl.cachedNode = informerNode
+		kl.setCachedNode(informerNode)
 		return informerNode, nil
 	}
 
@@ -56,10 +56,10 @@ func (kl *Kubelet) getCachedNode(ctx context.Context) (*v1.Node, error) {
 	if err != nil {
 		// In error cases, default to the informer node.
 		logger.Error(err, "failed to check if node is newer; using informer node")
-		kl.cachedNode = informerNode
+		kl.setCachedNode(informerNode)
 	}
 	if isNewer {
-		kl.cachedNode = informerNode
+		kl.setCachedNode(informerNode)
 	}
 	return kl.cachedNode, nil
 }
@@ -74,8 +74,14 @@ func (kl *Kubelet) getNodeSync(ctx context.Context) (*v1.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	kl.cachedNode = node
+	kl.setCachedNode(node)
 	return node, nil
+}
+
+// setCachedNode updates both the Node object cache and the NodeInfo cache.
+func (kl *Kubelet) setCachedNode(node *v1.Node) {
+	kl.cachedNode = node
+	kl.nodeInfoCache.SetNode(node)
 }
 
 // isNewer checks if the informer node is newer than the cached node based on the ResourceVersion.

--- a/pkg/kubelet/kubelet_nodecache_test.go
+++ b/pkg/kubelet/kubelet_nodecache_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/kubelet/nodeinfocache"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
@@ -112,9 +113,10 @@ func TestGetCachedNode(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			kl := Kubelet{
-				cachedNode: test.cachedNode,
-				nodeLister: newFakeNodeLister(test.nodeListerErr, test.informerNode),
-				kubeClient: &fake.Clientset{},
+				cachedNode:    test.cachedNode,
+				nodeLister:    newFakeNodeLister(test.nodeListerErr, test.informerNode),
+				kubeClient:    &fake.Clientset{},
+				nodeInfoCache: nodeinfocache.New(),
 			}
 			if test.expectedNode == nil {
 				var err error

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -90,6 +90,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/logs"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/network/dns"
+	"k8s.io/kubernetes/pkg/kubelet/nodeinfocache"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown"
 	"k8s.io/kubernetes/pkg/kubelet/pleg"
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager"
@@ -320,6 +321,7 @@ func newTestKubeletWithImageList(
 	kubelet.reasonCache = NewReasonCache()
 	podCache := containertest.NewFakeCache(kubelet.containerRuntime)
 	kubelet.podCache = podCache
+	kubelet.nodeInfoCache = nodeinfocache.New()
 	kubelet.podWorkers = &fakePodWorkers{
 		syncPodFn: kubelet.SyncPod,
 		cache:     kubelet.podCache,
@@ -425,7 +427,7 @@ func newTestKubeletWithImageList(
 	handlers = append(handlers, shutdownManager)
 
 	// Add this as cleanup predicate pod admitter
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources, kubelet.nodeInfoCache))
 
 	if !excludeAdmitHandlers {
 		kubelet.allocationManager.AddPodAdmitHandlers(handlers)
@@ -999,6 +1001,63 @@ func TestHandlePortConflicts(t *testing.T) {
 	checkPodStatus(t, kl, fittingPod, v1.PodPending)
 }
 
+// TestHandlePodAdditions_MirrorPodNotCached locks in the invariant that the
+// NodeInfo cache holds only non-mirror admitted pods. A mirror pod must never
+// reach the cache: in HandlePodAdditions the wasMirror continue precedes the
+// AddPod, and in HandlePodUpdates/HandlePodReconcile GetPodByUID returns nil for
+// a mirror UID (podManager stores mirror pods separately). A regression would
+// double-count the static pod's resources — once for the static pod, once for
+// its mirror — silently over-counting node usage during admission.
+func TestHandlePodAdditions_MirrorPodNotCached(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	kl.nodeLister = testNodeLister{nodes: []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
+			Status: v1.NodeStatus{
+				Allocatable: v1.ResourceList{
+					v1.ResourcePods: *resource.NewQuantity(110, resource.DecimalSI),
+				},
+			},
+		},
+	}}
+
+	recorder := record.NewFakeRecorder(20)
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "testNode", UID: types.UID("testNode")}
+	kl.dnsConfigurer = dns.NewConfigurer(recorder, nodeRef, nil, nil, "TEST", "")
+
+	spec := v1.PodSpec{NodeName: string(kl.nodeName)}
+
+	// A regular pod is admitted and added to the cache (baseline = 1).
+	regularPod := podWithUIDNameNsSpec("11111111", "static-foo", "ns", spec)
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{regularPod})
+	if got := len(kl.nodeInfoCache.Snapshot().Pods); got != 1 {
+		t.Fatalf("after admitting a regular pod: cache has %d pods, want 1", got)
+	}
+
+	// The mirror pod for that static pod (distinct UID, mirror annotation) must
+	// NOT be added on ADD — the wasMirror continue filters it before AddPod.
+	mirrorPod := podWithUIDNameNsSpec("22222222", "static-foo", "ns", spec)
+	mirrorPod.Annotations = map[string]string{
+		kubetypes.ConfigSourceAnnotationKey: "api",
+		kubetypes.ConfigMirrorAnnotationKey: "mirror",
+	}
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{mirrorPod})
+	if got := len(kl.nodeInfoCache.Snapshot().Pods); got != 1 {
+		t.Fatalf("after a mirror pod ADD: cache has %d pods, want 1 (mirror pod must not be cached)", got)
+	}
+
+	// A mirror pod UPDATE must likewise leave the cache unchanged — GetPodByUID
+	// returns nil for the mirror UID, so the oldPod != nil guard skips it.
+	kl.HandlePodUpdates(tCtx, []*v1.Pod{mirrorPod})
+	if got := len(kl.nodeInfoCache.Snapshot().Pods); got != 1 {
+		t.Fatalf("after a mirror pod UPDATE: cache has %d pods, want 1 (mirror pod must not be cached)", got)
+	}
+}
+
 // Tests that we handle host name conflicts correctly by setting the failed status in status map.
 func TestHandleHostNameConflicts(t *testing.T) {
 	tCtx := ktesting.Init(t)
@@ -1264,7 +1323,7 @@ func TestHandlePluginResources(t *testing.T) {
 	}
 
 	// add updatePluginResourcesFunc to admission handler, to test it's behavior.
-	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc)})
+	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc, lifecycle.NewNodeInfoProviderStub())})
 
 	recorder := record.NewFakeRecorder(20)
 	nodeRef := &v1.ObjectReference{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -90,6 +90,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/logs"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/network/dns"
+	"k8s.io/kubernetes/pkg/kubelet/nodeinfocache"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown"
 	"k8s.io/kubernetes/pkg/kubelet/pleg"
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager"
@@ -319,6 +320,7 @@ func newTestKubeletWithImageList(
 	kubelet.reasonCache = NewReasonCache()
 	podCache := containertest.NewFakeCache(kubelet.containerRuntime)
 	kubelet.podCache = podCache
+	kubelet.nodeInfoCache = nodeinfocache.New()
 	kubelet.podWorkers = &fakePodWorkers{
 		syncPodFn: kubelet.SyncPod,
 		cache:     kubelet.podCache,
@@ -425,7 +427,7 @@ func newTestKubeletWithImageList(
 	handlers = append(handlers, shutdownManager)
 
 	// Add this as cleanup predicate pod admitter
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources, kubelet.nodeInfoCache))
 
 	if !excludeAdmitHandlers {
 		kubelet.allocationManager.AddPodAdmitHandlers(handlers)
@@ -1050,6 +1052,63 @@ func TestHandlePortConflicts(t *testing.T) {
 	checkPodStatus(t, kl, fittingPod, v1.PodPending)
 }
 
+// TestHandlePodAdditions_MirrorPodNotCached locks in the invariant that the
+// NodeInfo cache holds only non-mirror admitted pods. A mirror pod must never
+// reach the cache: in HandlePodAdditions the wasMirror continue precedes the
+// AddPod, and in HandlePodUpdates/HandlePodReconcile GetPodByUID returns nil for
+// a mirror UID (podManager stores mirror pods separately). A regression would
+// double-count the static pod's resources — once for the static pod, once for
+// its mirror — silently over-counting node usage during admission.
+func TestHandlePodAdditions_MirrorPodNotCached(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	kl.nodeLister = testNodeLister{nodes: []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
+			Status: v1.NodeStatus{
+				Allocatable: v1.ResourceList{
+					v1.ResourcePods: *resource.NewQuantity(110, resource.DecimalSI),
+				},
+			},
+		},
+	}}
+
+	recorder := record.NewFakeRecorder(20)
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "testNode", UID: types.UID("testNode")}
+	kl.dnsConfigurer = dns.NewConfigurer(recorder, nodeRef, nil, nil, "TEST", "")
+
+	spec := v1.PodSpec{NodeName: string(kl.nodeName)}
+
+	// A regular pod is admitted and added to the cache (baseline = 1).
+	regularPod := podWithUIDNameNsSpec("11111111", "static-foo", "ns", spec)
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{regularPod})
+	if got := len(kl.nodeInfoCache.Snapshot().Pods); got != 1 {
+		t.Fatalf("after admitting a regular pod: cache has %d pods, want 1", got)
+	}
+
+	// The mirror pod for that static pod (distinct UID, mirror annotation) must
+	// NOT be added on ADD — the wasMirror continue filters it before AddPod.
+	mirrorPod := podWithUIDNameNsSpec("22222222", "static-foo", "ns", spec)
+	mirrorPod.Annotations = map[string]string{
+		kubetypes.ConfigSourceAnnotationKey: "api",
+		kubetypes.ConfigMirrorAnnotationKey: "mirror",
+	}
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{mirrorPod})
+	if got := len(kl.nodeInfoCache.Snapshot().Pods); got != 1 {
+		t.Fatalf("after a mirror pod ADD: cache has %d pods, want 1 (mirror pod must not be cached)", got)
+	}
+
+	// A mirror pod UPDATE must likewise leave the cache unchanged — GetPodByUID
+	// returns nil for the mirror UID, so the oldPod != nil guard skips it.
+	kl.HandlePodUpdates(tCtx, []*v1.Pod{mirrorPod})
+	if got := len(kl.nodeInfoCache.Snapshot().Pods); got != 1 {
+		t.Fatalf("after a mirror pod UPDATE: cache has %d pods, want 1 (mirror pod must not be cached)", got)
+	}
+}
+
 // Tests that we handle host name conflicts correctly by setting the failed status in status map.
 func TestHandleHostNameConflicts(t *testing.T) {
 	tCtx := ktesting.Init(t)
@@ -1283,7 +1342,7 @@ func TestHandlePluginResources(t *testing.T) {
 	}
 
 	// add updatePluginResourcesFunc to admission handler, to test it's behavior.
-	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc)})
+	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc, lifecycle.NewNodeInfoProviderStub())})
 
 	kl.dnsConfigurer = createDNSConfigurer()
 

--- a/pkg/kubelet/lifecycle/node_info_provider_stub.go
+++ b/pkg/kubelet/lifecycle/node_info_provider_stub.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	v1 "k8s.io/api/core/v1"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// NodeInfoProviderStub is a NodeInfoProvider that returns a configurable NodeInfo.
+// Used for testing when the NodeInfo cache behavior is not being tested.
+//
+// This is exported from non-test code (rather than a _test.go file) so that
+// tests in other packages — currently pkg/kubelet and pkg/kubelet/allocation —
+// can construct a predicateAdmitHandler without depending on the production
+// nodeinfocache.Cache. Go's package-test visibility rules require it to live
+// here for those cross-package consumers to reach it.
+type NodeInfoProviderStub struct {
+	pods []*v1.Pod
+}
+
+var _ NodeInfoProvider = &NodeInfoProviderStub{}
+
+// NewNodeInfoProviderStub returns an instance of NodeInfoProviderStub with an empty NodeInfo.
+func NewNodeInfoProviderStub() *NodeInfoProviderStub {
+	return &NodeInfoProviderStub{}
+}
+
+// NewNodeInfoProviderStubWithPods returns an instance of NodeInfoProviderStub
+// pre-populated with the given pods.
+func NewNodeInfoProviderStubWithPods(pods []*v1.Pod) *NodeInfoProviderStub {
+	return &NodeInfoProviderStub{pods: pods}
+}
+
+// Snapshot returns a NodeInfo snapshot containing the configured pods.
+func (n *NodeInfoProviderStub) Snapshot() *schedulerframework.NodeInfo {
+	return schedulerframework.NewNodeInfo(n.pods...)
+}

--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -98,21 +98,31 @@ type AdmissionFailureHandler interface {
 	HandleAdmissionFailure(ctx context.Context, admitPod *v1.Pod, failureReasons []PredicateFailureReason) ([]PredicateFailureReason, error)
 }
 
+// NodeInfoProvider provides NodeInfo snapshots for admission decisions.
+// This interface allows the predicateAdmitHandler to use a cached NodeInfo
+// rather than rebuilding it from scratch on every admission.
+type NodeInfoProvider interface {
+	// Snapshot returns a deep copy of the cached NodeInfo for safe concurrent use.
+	Snapshot() *schedulerframework.NodeInfo
+}
+
 type predicateAdmitHandler struct {
 	getNodeAnyWayFunc        getNodeAnyWayFuncType
 	pluginResourceUpdateFunc pluginResourceUpdateFuncType
 	admissionFailureHandler  AdmissionFailureHandler
+	nodeInfoProvider         NodeInfoProvider
 }
 
 var _ PodAdmitHandler = &predicateAdmitHandler{}
 
-// NewPredicateAdmitHandler returns a PodAdmitHandler which is used to evaluates
+// NewPredicateAdmitHandler returns a PodAdmitHandler which is used to evaluate
 // if a pod can be admitted from the perspective of predicates.
-func NewPredicateAdmitHandler(getNodeAnyWayFunc getNodeAnyWayFuncType, admissionFailureHandler AdmissionFailureHandler, pluginResourceUpdateFunc pluginResourceUpdateFuncType) PodAdmitHandler {
+func NewPredicateAdmitHandler(getNodeAnyWayFunc getNodeAnyWayFuncType, admissionFailureHandler AdmissionFailureHandler, pluginResourceUpdateFunc pluginResourceUpdateFuncType, nodeInfoProvider NodeInfoProvider) PodAdmitHandler {
 	return &predicateAdmitHandler{
-		getNodeAnyWayFunc,
-		pluginResourceUpdateFunc,
-		admissionFailureHandler,
+		getNodeAnyWayFunc:        getNodeAnyWayFunc,
+		pluginResourceUpdateFunc: pluginResourceUpdateFunc,
+		admissionFailureHandler:  admissionFailureHandler,
+		nodeInfoProvider:         nodeInfoProvider,
 	}
 }
 
@@ -155,9 +165,23 @@ func (w *predicateAdmitHandler) Admit(ctx context.Context, attrs *PodAdmitAttrib
 		}
 	}
 
-	pods := attrs.OtherPods
-	nodeInfo := schedulerframework.NewNodeInfo(pods...)
+	// Use cached NodeInfo snapshot instead of rebuilding from scratch.
+	// This is O(n) for the snapshot vs O(n*m) for NewNodeInfo where n=pods, m=containers.
+	nodeInfo := w.nodeInfoProvider.Snapshot()
+	// Ensure node is current (cache may have slightly stale node if updated between events)
 	nodeInfo.SetNode(node)
+	// For resize operations, remove the old version of the pod from the snapshot
+	// so resource accounting reflects only the other pods on the node.
+	// New pods (AddOperation) are not in the cache yet, so no removal is needed.
+	if attrs.Operation == ResizeOperation {
+		if err := nodeInfo.RemovePod(logger, admitPod); err != nil {
+			// We continue despite the error. The snapshot still contains the old
+			// pod, so resource accounting double-counts this pod's resources,
+			// making admission more conservative (may reject a valid resize but
+			// will not admit one that would overcommit the node).
+			logger.Error(err, "Failed to remove pod from NodeInfo snapshot during resize admission; resource accounting may be inaccurate", "pod", klog.KObj(admitPod))
+		}
+	}
 
 	// ensure the node has enough plugin resources for that required in pods
 	if err = w.pluginResourceUpdateFunc(nodeInfo, attrs); err != nil {

--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -98,21 +98,31 @@ type AdmissionFailureHandler interface {
 	HandleAdmissionFailure(ctx context.Context, admitPod *v1.Pod, failureReasons []PredicateFailureReason, operation Operation) ([]PredicateFailureReason, error)
 }
 
+// NodeInfoProvider provides NodeInfo snapshots for admission decisions.
+// This interface allows the predicateAdmitHandler to use a cached NodeInfo
+// rather than rebuilding it from scratch on every admission.
+type NodeInfoProvider interface {
+	// Snapshot returns a deep copy of the cached NodeInfo for safe concurrent use.
+	Snapshot() *schedulerframework.NodeInfo
+}
+
 type predicateAdmitHandler struct {
 	getNodeAnyWayFunc        getNodeAnyWayFuncType
 	pluginResourceUpdateFunc pluginResourceUpdateFuncType
 	admissionFailureHandler  AdmissionFailureHandler
+	nodeInfoProvider         NodeInfoProvider
 }
 
 var _ PodAdmitHandler = &predicateAdmitHandler{}
 
-// NewPredicateAdmitHandler returns a PodAdmitHandler which is used to evaluates
+// NewPredicateAdmitHandler returns a PodAdmitHandler which is used to evaluate
 // if a pod can be admitted from the perspective of predicates.
-func NewPredicateAdmitHandler(getNodeAnyWayFunc getNodeAnyWayFuncType, admissionFailureHandler AdmissionFailureHandler, pluginResourceUpdateFunc pluginResourceUpdateFuncType) PodAdmitHandler {
+func NewPredicateAdmitHandler(getNodeAnyWayFunc getNodeAnyWayFuncType, admissionFailureHandler AdmissionFailureHandler, pluginResourceUpdateFunc pluginResourceUpdateFuncType, nodeInfoProvider NodeInfoProvider) PodAdmitHandler {
 	return &predicateAdmitHandler{
-		getNodeAnyWayFunc,
-		pluginResourceUpdateFunc,
-		admissionFailureHandler,
+		getNodeAnyWayFunc:        getNodeAnyWayFunc,
+		pluginResourceUpdateFunc: pluginResourceUpdateFunc,
+		admissionFailureHandler:  admissionFailureHandler,
+		nodeInfoProvider:         nodeInfoProvider,
 	}
 }
 
@@ -155,9 +165,23 @@ func (w *predicateAdmitHandler) Admit(ctx context.Context, attrs *PodAdmitAttrib
 		}
 	}
 
-	pods := attrs.OtherPods
-	nodeInfo := schedulerframework.NewNodeInfo(pods...)
+	// Use cached NodeInfo snapshot instead of rebuilding from scratch.
+	// This is O(n) for the snapshot vs O(n*m) for NewNodeInfo where n=pods, m=containers.
+	nodeInfo := w.nodeInfoProvider.Snapshot()
+	// Ensure node is current (cache may have slightly stale node if updated between events)
 	nodeInfo.SetNode(node)
+	// For resize operations, remove the old version of the pod from the snapshot
+	// so resource accounting reflects only the other pods on the node.
+	// New pods (AddOperation) are not in the cache yet, so no removal is needed.
+	if attrs.Operation == ResizeOperation {
+		if err := nodeInfo.RemovePod(logger, admitPod); err != nil {
+			// We continue despite the error. The snapshot still contains the old
+			// pod, so resource accounting double-counts this pod's resources,
+			// making admission more conservative (may reject a valid resize but
+			// will not admit one that would overcommit the node).
+			logger.Error(err, "Failed to remove pod from NodeInfo snapshot during resize admission; resource accounting may be inaccurate", "pod", klog.KObj(admitPod))
+		}
+	}
 
 	// ensure the node has enough plugin resources for that required in pods
 	if err = w.pluginResourceUpdateFunc(nodeInfo, attrs); err != nil {

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -22,9 +22,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -36,7 +39,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodename"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
-	"k8s.io/utils/ptr"
 )
 
 var (
@@ -835,6 +837,148 @@ func TestPodAdmissionBasedOnSupplementalGroupsPolicy(t *testing.T) {
 			actualResult := rejectPodAdmissionBasedOnSupplementalGroupsPolicy(test.pod, test.node)
 			if test.expectRejection != actualResult {
 				t.Errorf("unexpected result, expected %v but got %v", test.expectRejection, actualResult)
+			}
+		})
+	}
+}
+
+// newResizablePod builds a pod with stable identity and a single container
+// requesting cpuMilli of CPU. Two pods built with the same name share a UID
+// (and namespace/name), so the scheduler-framework NodeInfo treats them as the
+// same pod. That identity match is what lets NodeInfo.RemovePod recognize an
+// old version of a pod against its resized version during admission.
+func newResizablePod(name string, cpuMilli int64) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       apitypes.UID(name),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name: "c0",
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU: *resource.NewMilliQuantity(cpuMilli, resource.DecimalSI),
+					},
+				},
+			}},
+		},
+	}
+}
+
+// TestAdmitResizeOperation exercises predicateAdmitHandler.Admit() with
+// Operation: ResizeOperation — the branch that calls NodeInfo.RemovePod() on
+// the snapshot before resource fitting, so accounting reflects only the OTHER
+// pods on the node. The existing predicate tests call generalFilter() directly
+// and never go through Admit(), so the Snapshot()/RemovePod path is uncovered.
+//
+// The decisive check is a CONTRAST: with the same NodeInfo snapshot (which
+// already contains the old version of the pod) and the same resized pod,
+// ResizeOperation and AddOperation must reach OPPOSITE admission results. That
+// difference is produced solely by the RemovePod branch — nothing else differs
+// between the two calls.
+//
+// Worked example (single CPU dimension):
+//
+//	node allocatable CPU        = 10
+//	old pod already in snapshot =  6   (NewNodeInfoProviderStubWithPods)
+//	resized pod being admitted  =  8
+//
+//	ResizeOperation: RemovePod subtracts the old 6 -> 0 used -> 8 <= 10 -> ADMIT
+//	AddOperation:    no removal, 6 already used    -> 6 + 8 = 14 > 10  -> REJECT
+//
+// If both operations yield the same result, the RemovePod branch is not being
+// exercised — that means the table numbers are wrong, not the code.
+func TestAdmitResizeOperation(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodeCPUMilli int64     // node allocatable CPU
+		snapshotCPU  int64     // CPU requested by the pod already in the snapshot (old version)
+		admitCPU     int64     // CPU requested by the pod being admitted (resized version)
+		operation    Operation // AddOperation or ResizeOperation
+		wantAdmit    bool
+	}{
+		{
+			// Baseline new-pod admission. Existing pod in the snapshot uses
+			// 4 CPU; admit pod requests 4 CPU. 4 + 4 = 8 <= 10 -> ADMIT.
+			name:         "AddOperation_fits",
+			nodeCPUMilli: 10,
+			snapshotCPU:  4,
+			admitCPU:     4,
+			operation:    AddOperation,
+			wantAdmit:    true,
+		},
+		{
+			// CONTRAST PAIR (1/2): AddOperation does NOT call RemovePod, so
+			// the old version's 6 CPU stays counted: 6 + 8 = 14 > 10 -> REJECT.
+			name:         "AddOperation_double_counts_into_overcommit",
+			nodeCPUMilli: 10,
+			snapshotCPU:  6,
+			admitCPU:     8,
+			operation:    AddOperation,
+			wantAdmit:    false,
+		},
+		{
+			// CONTRAST PAIR (2/2): identical inputs to the case above, but
+			// ResizeOperation triggers RemovePod -> 0 used + 8 requested = 8
+			// <= 10 -> ADMIT. The opposite verdict with identical inputs is
+			// the load-bearing signal that the RemovePod branch is exercised.
+			name:         "ResizeOperation_fits_only_after_removal",
+			nodeCPUMilli: 10,
+			snapshotCPU:  6,
+			admitCPU:     8,
+			operation:    ResizeOperation,
+			wantAdmit:    true,
+		},
+		{
+			// Resize that still exceeds node capacity even after the old
+			// allocation is removed: 0 + 15 > 10 -> REJECT.
+			name:         "ResizeOperation_exceeds_capacity_even_after_removal",
+			nodeCPUMilli: 10,
+			snapshotCPU:  6,
+			admitCPU:     15,
+			operation:    ResizeOperation,
+			wantAdmit:    false,
+		},
+		{
+			// Shrinking resize: new request <= old request <= capacity. Always fits.
+			name:         "ResizeOperation_shrink_fits",
+			nodeCPUMilli: 10,
+			snapshotCPU:  8,
+			admitCPU:     4,
+			operation:    ResizeOperation,
+			wantAdmit:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oldPod := newResizablePod("resize-pod", tc.snapshotCPU)
+			// Same name -> same UID, so NodeInfo.RemovePod can match this
+			// resized pod against oldPod in the snapshot.
+			admitPod := newResizablePod("resize-pod", tc.admitCPU)
+
+			node := makeTestNode(v1.ResourceList{
+				v1.ResourceCPU:  *resource.NewMilliQuantity(tc.nodeCPUMilli, resource.DecimalSI),
+				v1.ResourcePods: *resource.NewQuantity(10, resource.DecimalSI),
+			})
+
+			w := &predicateAdmitHandler{
+				getNodeAnyWayFunc: func(ctx context.Context, useCache bool) (*v1.Node, error) {
+					return node, nil
+				},
+				pluginResourceUpdateFunc: func(*schedulerframework.NodeInfo, *PodAdmitAttributes) error {
+					return nil
+				},
+				admissionFailureHandler: NewAdmissionFailureHandlerStub(),
+				nodeInfoProvider:        NewNodeInfoProviderStubWithPods([]*v1.Pod{oldPod}),
+			}
+
+			result := w.Admit(context.TODO(), &PodAdmitAttributes{Pod: admitPod, Operation: tc.operation})
+			if result.Admit != tc.wantAdmit {
+				t.Errorf("Admit() Admit = %v (reason %q, message %q), want %v",
+					result.Admit, result.Reason, result.Message, tc.wantAdmit)
 			}
 		})
 	}

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -22,9 +22,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -37,7 +40,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	"k8s.io/utils/ptr"
 )
 
 var (
@@ -837,6 +839,148 @@ func TestPodAdmissionBasedOnSupplementalGroupsPolicy(t *testing.T) {
 			actualResult := rejectPodAdmissionBasedOnSupplementalGroupsPolicy(test.pod, test.node)
 			if test.expectRejection != actualResult {
 				t.Errorf("unexpected result, expected %v but got %v", test.expectRejection, actualResult)
+			}
+		})
+	}
+}
+
+// newResizablePod builds a pod with stable identity and a single container
+// requesting cpuMilli of CPU. Two pods built with the same name share a UID
+// (and namespace/name), so the scheduler-framework NodeInfo treats them as the
+// same pod. That identity match is what lets NodeInfo.RemovePod recognize an
+// old version of a pod against its resized version during admission.
+func newResizablePod(name string, cpuMilli int64) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       apitypes.UID(name),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name: "c0",
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU: *resource.NewMilliQuantity(cpuMilli, resource.DecimalSI),
+					},
+				},
+			}},
+		},
+	}
+}
+
+// TestAdmitResizeOperation exercises predicateAdmitHandler.Admit() with
+// Operation: ResizeOperation — the branch that calls NodeInfo.RemovePod() on
+// the snapshot before resource fitting, so accounting reflects only the OTHER
+// pods on the node. The existing predicate tests call generalFilter() directly
+// and never go through Admit(), so the Snapshot()/RemovePod path is uncovered.
+//
+// The decisive check is a CONTRAST: with the same NodeInfo snapshot (which
+// already contains the old version of the pod) and the same resized pod,
+// ResizeOperation and AddOperation must reach OPPOSITE admission results. That
+// difference is produced solely by the RemovePod branch — nothing else differs
+// between the two calls.
+//
+// Worked example (single CPU dimension):
+//
+//	node allocatable CPU        = 10
+//	old pod already in snapshot =  6   (NewNodeInfoProviderStubWithPods)
+//	resized pod being admitted  =  8
+//
+//	ResizeOperation: RemovePod subtracts the old 6 -> 0 used -> 8 <= 10 -> ADMIT
+//	AddOperation:    no removal, 6 already used    -> 6 + 8 = 14 > 10  -> REJECT
+//
+// If both operations yield the same result, the RemovePod branch is not being
+// exercised — that means the table numbers are wrong, not the code.
+func TestAdmitResizeOperation(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodeCPUMilli int64     // node allocatable CPU
+		snapshotCPU  int64     // CPU requested by the pod already in the snapshot (old version)
+		admitCPU     int64     // CPU requested by the pod being admitted (resized version)
+		operation    Operation // AddOperation or ResizeOperation
+		wantAdmit    bool
+	}{
+		{
+			// Baseline new-pod admission. Existing pod in the snapshot uses
+			// 4 CPU; admit pod requests 4 CPU. 4 + 4 = 8 <= 10 -> ADMIT.
+			name:         "AddOperation_fits",
+			nodeCPUMilli: 10,
+			snapshotCPU:  4,
+			admitCPU:     4,
+			operation:    AddOperation,
+			wantAdmit:    true,
+		},
+		{
+			// CONTRAST PAIR (1/2): AddOperation does NOT call RemovePod, so
+			// the old version's 6 CPU stays counted: 6 + 8 = 14 > 10 -> REJECT.
+			name:         "AddOperation_double_counts_into_overcommit",
+			nodeCPUMilli: 10,
+			snapshotCPU:  6,
+			admitCPU:     8,
+			operation:    AddOperation,
+			wantAdmit:    false,
+		},
+		{
+			// CONTRAST PAIR (2/2): identical inputs to the case above, but
+			// ResizeOperation triggers RemovePod -> 0 used + 8 requested = 8
+			// <= 10 -> ADMIT. The opposite verdict with identical inputs is
+			// the load-bearing signal that the RemovePod branch is exercised.
+			name:         "ResizeOperation_fits_only_after_removal",
+			nodeCPUMilli: 10,
+			snapshotCPU:  6,
+			admitCPU:     8,
+			operation:    ResizeOperation,
+			wantAdmit:    true,
+		},
+		{
+			// Resize that still exceeds node capacity even after the old
+			// allocation is removed: 0 + 15 > 10 -> REJECT.
+			name:         "ResizeOperation_exceeds_capacity_even_after_removal",
+			nodeCPUMilli: 10,
+			snapshotCPU:  6,
+			admitCPU:     15,
+			operation:    ResizeOperation,
+			wantAdmit:    false,
+		},
+		{
+			// Shrinking resize: new request <= old request <= capacity. Always fits.
+			name:         "ResizeOperation_shrink_fits",
+			nodeCPUMilli: 10,
+			snapshotCPU:  8,
+			admitCPU:     4,
+			operation:    ResizeOperation,
+			wantAdmit:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oldPod := newResizablePod("resize-pod", tc.snapshotCPU)
+			// Same name -> same UID, so NodeInfo.RemovePod can match this
+			// resized pod against oldPod in the snapshot.
+			admitPod := newResizablePod("resize-pod", tc.admitCPU)
+
+			node := makeTestNode(v1.ResourceList{
+				v1.ResourceCPU:  *resource.NewMilliQuantity(tc.nodeCPUMilli, resource.DecimalSI),
+				v1.ResourcePods: *resource.NewQuantity(10, resource.DecimalSI),
+			})
+
+			w := &predicateAdmitHandler{
+				getNodeAnyWayFunc: func(ctx context.Context, useCache bool) (*v1.Node, error) {
+					return node, nil
+				},
+				pluginResourceUpdateFunc: func(*schedulerframework.NodeInfo, *PodAdmitAttributes) error {
+					return nil
+				},
+				admissionFailureHandler: NewAdmissionFailureHandlerStub(),
+				nodeInfoProvider:        NewNodeInfoProviderStubWithPods([]*v1.Pod{oldPod}),
+			}
+
+			result := w.Admit(context.TODO(), &PodAdmitAttributes{Pod: admitPod, Operation: tc.operation})
+			if result.Admit != tc.wantAdmit {
+				t.Errorf("Admit() Admit = %v (reason %q, message %q), want %v",
+					result.Admit, result.Reason, result.Message, tc.wantAdmit)
 			}
 		})
 	}

--- a/pkg/kubelet/nodeinfocache/benchmark_test.go
+++ b/pkg/kubelet/nodeinfocache/benchmark_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfocache
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/ktesting"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// generatePods creates n pods with realistic resource requests.
+// Each pod has 2 containers to simulate typical workloads.
+func generatePods(count int) []*v1.Pod {
+	pods := make([]*v1.Pod, count)
+	for i := range count {
+		pods[i] = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pod-%d", i),
+				Namespace: "default",
+				UID:       types.UID(fmt.Sprintf("uid-%d", i)),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "main",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:              resource.MustParse("100m"),
+								v1.ResourceMemory:           resource.MustParse("256Mi"),
+								v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					{
+						Name: "sidecar",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("50m"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	return pods
+}
+
+// generatePodsWithPrefix creates pods with a custom name prefix.
+func generatePodsWithPrefix(prefix string, count int) []*v1.Pod {
+	pods := generatePods(count)
+	for i, pod := range pods {
+		pod.Name = fmt.Sprintf("%s-%d", prefix, i)
+		pod.UID = types.UID(fmt.Sprintf("%s-uid-%d", prefix, i))
+	}
+	return pods
+}
+
+// makeNode creates a node with specified resources.
+func makeNode(name, cpu, memory string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse(cpu),
+				v1.ResourceMemory: resource.MustParse(memory),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+		},
+	}
+}
+
+// BenchmarkNewNodeInfo measures the baseline: rebuilding NodeInfo from scratch.
+// This is the OLD approach used before caching.
+func BenchmarkNewNodeInfo(b *testing.B) {
+	pods := generatePods(100)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = schedulerframework.NewNodeInfo(pods...)
+	}
+}
+
+// BenchmarkCacheSnapshot measures the NEW approach: getting a snapshot from cache.
+func BenchmarkCacheSnapshot(b *testing.B) {
+	cache := New()
+	for _, pod := range generatePods(100) {
+		cache.AddPod(pod)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = cache.Snapshot()
+	}
+}
+
+// BenchmarkCacheAddPod measures the cost of adding a pod to the cache.
+func BenchmarkCacheAddPod(b *testing.B) {
+	pod := generatePods(1)[0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	cache := New()
+	for b.Loop() {
+		cache.AddPod(pod)
+	}
+}
+
+// BenchmarkCacheRemovePod measures the cost of removing a pod from the cache.
+func BenchmarkCacheRemovePod(b *testing.B) {
+	logger, _ := ktesting.NewTestContext(b)
+	pod := generatePods(1)[0]
+	cache := New()
+	// Pre-populate with many pods so RemovePod has to search.
+	for _, p := range generatePods(100) {
+		cache.AddPod(p)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		cache.AddPod(pod)
+		cache.RemovePod(logger, pod)
+	}
+}
+
+// BenchmarkAdmissionE2E compares the full admission path: NodeInfo construction + SetNode.
+// This simulates a single pod admission for both new pods and resize operations.
+func BenchmarkAdmissionE2E(b *testing.B) {
+	logger, _ := ktesting.NewTestContext(b)
+	existingPods := generatePods(100)
+	node := makeNode("test-node", "8", "32Gi")
+	// Pick an existing pod to simulate resize admission
+	resizePod := existingPods[50]
+
+	b.Run("NewPod/Current-NewNodeInfo", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			nodeInfo := schedulerframework.NewNodeInfo(existingPods...)
+			nodeInfo.SetNode(node)
+		}
+	})
+
+	b.Run("NewPod/Cached-Snapshot", func(b *testing.B) {
+		cache := New()
+		cache.SetNode(node)
+		for _, pod := range existingPods {
+			cache.AddPod(pod)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			nodeInfo := cache.Snapshot()
+			nodeInfo.SetNode(node)
+		}
+	})
+
+	b.Run("Resize/Current-NewNodeInfo+RemovePod", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			nodeInfo := schedulerframework.NewNodeInfo(existingPods...)
+			nodeInfo.SetNode(node)
+			_ = nodeInfo.RemovePod(logger, resizePod)
+		}
+	})
+
+	b.Run("Resize/Cached-Snapshot+RemovePod", func(b *testing.B) {
+		cache := New()
+		cache.SetNode(node)
+		for _, pod := range existingPods {
+			cache.AddPod(pod)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			nodeInfo := cache.Snapshot()
+			nodeInfo.SetNode(node)
+			_ = nodeInfo.RemovePod(logger, resizePod)
+		}
+	})
+}
+
+// BenchmarkResizeRetryScenario simulates pending resize retries.
+// This is where caching provides the most benefit - the same pod set
+// is evaluated repeatedly while waiting for resources to become available.
+func BenchmarkResizeRetryScenario(b *testing.B) {
+	existingPods := generatePods(100)
+	node := makeNode("test-node", "8", "32Gi")
+	retryCount := 10 // Typical retries before resources free up
+
+	b.Run("Current-RebuildEachRetry", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			// Current: rebuild NodeInfo on every retry
+			for range retryCount {
+				nodeInfo := schedulerframework.NewNodeInfo(existingPods...)
+				nodeInfo.SetNode(node)
+			}
+		}
+	})
+
+	b.Run("Cached-SnapshotEachRetry", func(b *testing.B) {
+		cache := New()
+		cache.SetNode(node)
+		for _, pod := range existingPods {
+			cache.AddPod(pod)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			// New: snapshot from cache on each retry
+			for range retryCount {
+				nodeInfo := cache.Snapshot()
+				nodeInfo.SetNode(node)
+			}
+		}
+	})
+}
+
+// BenchmarkSequentialAdmissions simulates burst pod creation.
+// Tests the incremental update benefit when pods are admitted one after another.
+func BenchmarkSequentialAdmissions(b *testing.B) {
+	node := makeNode("test-node", "8", "32Gi")
+	basePodCount := 50
+	burstSize := 20
+
+	b.Run("Current-RebuildGrowingSet", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			pods := generatePods(basePodCount)
+			newPods := generatePodsWithPrefix("burst", burstSize)
+			// Admit burst pods sequentially
+			for _, newPod := range newPods {
+				nodeInfo := schedulerframework.NewNodeInfo(pods...)
+				nodeInfo.SetNode(node)
+				// After admission, pod joins the set
+				pods = append(pods, newPod)
+			}
+		}
+	})
+
+	b.Run("Cached-IncrementalAdd", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			cache := New()
+			cache.SetNode(node)
+			for _, pod := range generatePods(basePodCount) {
+				cache.AddPod(pod)
+			}
+			newPods := generatePodsWithPrefix("burst", burstSize)
+			// Admit burst pods sequentially
+			for _, newPod := range newPods {
+				_ = cache.Snapshot()
+				// After admission, add to cache (O(1))
+				cache.AddPod(newPod)
+			}
+		}
+	})
+}
+
+// BenchmarkScalingComparison tests performance across different node sizes.
+func BenchmarkScalingComparison(b *testing.B) {
+	node := makeNode("test-node", "96", "384Gi") // Large node
+
+	for _, podCount := range []int{10, 50, 100, 200} {
+		pods := generatePods(podCount)
+
+		b.Run(fmt.Sprintf("NewNodeInfo-%dPods", podCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				nodeInfo := schedulerframework.NewNodeInfo(pods...)
+				nodeInfo.SetNode(node)
+			}
+		})
+
+		b.Run(fmt.Sprintf("CacheSnapshot-%dPods", podCount), func(b *testing.B) {
+			cache := New()
+			cache.SetNode(node)
+			for _, pod := range pods {
+				cache.AddPod(pod)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				nodeInfo := cache.Snapshot()
+				nodeInfo.SetNode(node)
+			}
+		})
+	}
+}
+
+// BenchmarkConcurrentSnapshots tests snapshot performance under concurrent access.
+func BenchmarkConcurrentSnapshots(b *testing.B) {
+	cache := New()
+	cache.SetNode(makeNode("test-node", "8", "32Gi"))
+	for _, pod := range generatePods(100) {
+		cache.AddPod(pod)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = cache.Snapshot()
+		}
+	})
+}

--- a/pkg/kubelet/nodeinfocache/cache.go
+++ b/pkg/kubelet/nodeinfocache/cache.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfocache
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// Cache maintains a cached NodeInfo for the kubelet's node.
+// Thread-safe wrapper around schedulerframework.NodeInfo with incremental updates.
+type Cache struct {
+	lock     sync.RWMutex
+	nodeInfo *schedulerframework.NodeInfo
+}
+
+// New creates a new empty NodeInfo cache with a placeholder Node and zero
+// allocatable resources.
+//
+// Two invariants protect pod admission against an unpopulated cache:
+//
+//  1. SetNode is invoked from the kubelet's node-status update path before
+//     the sync loop starts processing pod events, so by the time admission
+//     calls Snapshot() the cache reflects the real node.
+//  2. Even if Snapshot() ran before SetNode, zero allocatable resources
+//     would reject every pod (fail-closed). Over-admission would require
+//     the cache to under-count requested resources for an admitted pod,
+//     which can only happen if a pod-lifecycle handler forgets to call
+//     AddPod. All four (HandlePodAdditions, HandlePodUpdates,
+//     HandlePodReconcile, HandlePodRemoves) keep the cache in sync.
+func New() *Cache {
+	ni := schedulerframework.NewNodeInfo()
+	// Set a placeholder node so that NodeInfo.RemovePod error messages
+	// can safely access Node().Name before SetNode is called.
+	ni.SetNode(&v1.Node{})
+	return &Cache{
+		nodeInfo: ni,
+	}
+}
+
+// SetNode updates the cached node metadata.
+func (c *Cache) SetNode(node *v1.Node) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.nodeInfo.SetNode(node)
+}
+
+// AddPod adds a pod to the cache incrementally.
+func (c *Cache) AddPod(pod *v1.Pod) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.nodeInfo.AddPod(pod)
+}
+
+// RemovePod removes a pod from the cache.
+// If the pod is not found (e.g. it was rejected during admission), the error is logged and ignored.
+func (c *Cache) RemovePod(logger klog.Logger, pod *v1.Pod) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if err := c.nodeInfo.RemovePod(logger, pod); err != nil {
+		logger.V(4).Info("Pod not found in cache during remove", "pod", klog.KObj(pod), "err", err)
+	}
+}
+
+// UpdatePod updates a pod in the cache (remove old, add new).
+// If the old pod is not found (e.g. it was rejected during admission or is
+// terminating), the update is skipped entirely — only admitted pods belong
+// in the cache.
+func (c *Cache) UpdatePod(logger klog.Logger, oldPod, newPod *v1.Pod) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if err := c.nodeInfo.RemovePod(logger, oldPod); err != nil {
+		logger.V(4).Info("Pod not found in cache during update, skipping add", "pod", klog.KObj(oldPod), "err", err)
+		return
+	}
+	c.nodeInfo.AddPod(newPod)
+}
+
+// Snapshot returns a deep copy of the cached NodeInfo for safe concurrent
+// use. See New() for the invariants that protect admission decisions from
+// observing an unpopulated cache.
+func (c *Cache) Snapshot() *schedulerframework.NodeInfo {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.nodeInfo.SnapshotConcrete()
+}

--- a/pkg/kubelet/nodeinfocache/cache_test.go
+++ b/pkg/kubelet/nodeinfocache/cache_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfocache
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/ktesting"
+)
+
+func TestCacheAddRemovePod(t *testing.T) {
+	cache := New()
+	logger, _ := ktesting.NewTestContext(t)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod", Namespace: "default", UID: types.UID("test-uid"),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100m"),
+						v1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			}},
+		},
+	}
+
+	// Add pod
+	cache.AddPod(pod)
+	snapshot := cache.Snapshot()
+	if got := len(snapshot.Pods); got != 1 {
+		t.Errorf("expected 1 pod, got %d", got)
+	}
+	if snapshot.Requested.MilliCPU != 100 {
+		t.Errorf("expected 100 milliCPU, got %d", snapshot.Requested.MilliCPU)
+	}
+
+	// Remove pod
+	cache.RemovePod(logger, pod)
+	if got := len(cache.Snapshot().Pods); got != 0 {
+		t.Errorf("expected 0 pods, got %d", got)
+	}
+}
+
+func TestCacheSnapshotIsolation(t *testing.T) {
+	cache := New()
+
+	pod1 := makePod("pod1", "100m", "256Mi")
+	cache.AddPod(pod1)
+
+	// Take snapshot
+	snapshot := cache.Snapshot()
+	originalCPU := snapshot.Requested.MilliCPU
+
+	// Add another pod to cache
+	pod2 := makePod("pod2", "200m", "512Mi")
+	cache.AddPod(pod2)
+
+	// Snapshot should be unchanged (deep copy)
+	if snapshot.Requested.MilliCPU != originalCPU {
+		t.Error("snapshot was mutated after cache modification")
+	}
+}
+
+func TestCacheConcurrentAccess(t *testing.T) {
+	cache := New()
+	logger, _ := ktesting.NewTestContext(t)
+
+	done := make(chan bool)
+
+	// Writer goroutine
+	go func() {
+		for i := range 100 {
+			pod := makePod(fmt.Sprintf("pod-%d", i), "10m", "10Mi")
+			cache.AddPod(pod)
+			cache.RemovePod(logger, pod)
+		}
+		done <- true
+	}()
+
+	// Reader goroutine
+	go func() {
+		for range 100 {
+			_ = cache.Snapshot()
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
+}
+
+func TestCacheSetNode(t *testing.T) {
+	cache := New()
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+		},
+	}
+
+	cache.SetNode(node)
+
+	snapshot := cache.Snapshot()
+	if snapshot.Node() == nil {
+		t.Error("expected node to be set")
+	}
+	if snapshot.Node().Name != "test-node" {
+		t.Errorf("expected node name 'test-node', got '%s'", snapshot.Node().Name)
+	}
+}
+
+func TestCacheUpdatePod(t *testing.T) {
+	cache := New()
+	logger, _ := ktesting.NewTestContext(t)
+
+	oldPod := makePod("test-pod", "100m", "256Mi")
+	cache.AddPod(oldPod)
+
+	// Verify initial state
+	snapshot := cache.Snapshot()
+	if snapshot.Requested.MilliCPU != 100 {
+		t.Errorf("expected 100 milliCPU, got %d", snapshot.Requested.MilliCPU)
+	}
+
+	// Update pod with new resources
+	newPod := makePod("test-pod", "200m", "512Mi")
+	cache.UpdatePod(logger, oldPod, newPod)
+
+	// Verify updated state
+	snapshot = cache.Snapshot()
+	if snapshot.Requested.MilliCPU != 200 {
+		t.Errorf("expected 200 milliCPU after update, got %d", snapshot.Requested.MilliCPU)
+	}
+	if got := len(snapshot.Pods); got != 1 {
+		t.Errorf("expected 1 pod after update, got %d", got)
+	}
+}
+
+func TestCacheUpdatePodNotInCache(t *testing.T) {
+	cache := New()
+	logger, _ := ktesting.NewTestContext(t)
+
+	// Pod that was never added to the cache (e.g. rejected during admission).
+	oldPod := makePod("rejected-pod", "100m", "256Mi")
+	newPod := makePod("rejected-pod", "200m", "512Mi")
+
+	// UpdatePod should be a no-op: RemovePod fails, so AddPod must be skipped.
+	cache.UpdatePod(logger, oldPod, newPod)
+
+	snapshot := cache.Snapshot()
+	if got := len(snapshot.Pods); got != 0 {
+		t.Errorf("expected 0 pods after updating a pod not in cache, got %d", got)
+	}
+	if snapshot.Requested.MilliCPU != 0 {
+		t.Errorf("expected 0 milliCPU after updating a pod not in cache, got %d", snapshot.Requested.MilliCPU)
+	}
+}
+
+func makePod(name, cpu, memory string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "default", UID: types.UID(name),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse(cpu),
+						v1.ResourceMemory: resource.MustParse(memory),
+					},
+				},
+			}},
+		},
+	}
+}


### PR DESCRIPTION
## Scope

This PR introduces the `NodeInfo` cache and switches kubelet admission to use it. **Dead-code removal** (removing the now-unused `OtherPods` field, `getAllocatedPods` helper, `getActivePods` threading, and the `activePods` parameter on `Manager.AddPod`) has moved to #138467, stacked on this branch.

After this PR merges, #138467 can be reviewed and merged as a trivial followup.

---

#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it:

Adds an incremental `NodeInfo` cache to the kubelet to eliminate redundant O(pods × containers) `NewNodeInfo(pods...)` rebuilds on every pod admission and resize retry.

**Before:** `predicateAdmitHandler.Admit()` called `schedulerframework.NewNodeInfo(pods...)` on every admission, iterating every resource in every container (requested, actual, allocated) for every pod on the node.

**After:** A `nodeinfocache.Cache` maintains `NodeInfo` incrementally via pod lifecycle events (`HandlePodAdditions/Updates/Removes`) and node updates (`setCachedNode`). Admission calls `Snapshot()` which returns a deep copy — no resource iteration needed.

**Changes:**
- New `pkg/kubelet/nodeinfocache/` package: thread-safe `Cache` with `AddPod`, `RemovePod`, `UpdatePod`, `SetNode`, `Snapshot` methods (86 lines)
- New `NodeInfoProvider` interface in `lifecycle/predicate.go` to decouple admission from the concrete cache (enables test mocking)
- Wired into `kubelet.go` pod lifecycle handlers and `kubelet_nodecache.go` node updates
- Unit tests (5 test cases including concurrent access) and benchmarks (9 scenarios)

**Benchmark results (100 pods, 2 containers each):**

| Metric | Old (rebuild) | New (cached snapshot) | Improvement |
|--------|---------------|----------------------|-------------|
| Time/op | ~180 μs | ~550 ns | **328×** |
| Memory/op | 387 KB | 2.2 KB | **176×** |
| Allocs/op | 1,715 | 8 | **214×** |

#### Which issue(s) this PR is related to:

Ref #132858

#### Special notes for your reviewer:

This follows the `cachedNode` pattern already used in `kubelet_nodecache.go`. The cache is updated synchronously in the kubelet's sync loop, so it stays consistent with the pod manager without risk of stale data.

The `NodeInfoProvider` interface allows `predicate_test.go` to inject test doubles without depending on the concrete cache.

`pluginResourceUpdateFunc` and `SetNode` mutate the NodeInfo during admission — this is safe because `Snapshot()` returns a deep copy via `nodeInfo.SnapshotConcrete()`.

#### AI assistance disclosure

This PR was developed with assistance from Claude (Anthropic). Claude
was used to draft the cache implementation, the admission-path
integration, the benchmark suite, and the test cases. Design decisions
(cache placement, `NodeInfoProvider` interface boundary, allocated-vs-
desired resource accounting, error/log policy) were made by the
author. All changes were reviewed, verified locally and in CI, and
edited where necessary; the author takes responsibility for the
submitted code.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Related PR (earlier hash-based approach): https://github.com/kubernetes/kubernetes/pull/134462

