### PR TITLE
test: update code to use GlibcDnsTesting image

### DIFF
--- a/test/e2e/common/node/pod_hostnameoverride.go
+++ b/test/e2e/common/node/pod_hostnameoverride.go
@@ -43,7 +43,7 @@ func newTestPod(namespace string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:    "test-pod-hostname-override",
-					Image:   imageutils.GetE2EImage(imageutils.JessieDnsutils),
+					Image:   imageutils.GetE2EImage(imageutils.GlibcDnsTesting),
 					Command: []string{"sh", "-c", "echo $(hostname)';'$(hostname -f)';'"},
 				},
 			},

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -65,7 +65,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, nil, "", "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, nil, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -89,7 +89,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, nil, "", "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, nil, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -112,7 +112,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, hostEntries, "", "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, hostEntries, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -134,7 +134,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(nil, hostEntries, "", "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(nil, hostEntries, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -187,7 +187,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, nil, regularService.Spec.ClusterIP, "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, nil, regularService.Spec.ClusterIP, "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -242,7 +242,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, nil, regularService.Spec.ClusterIP, "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, nil, regularService.Spec.ClusterIP, "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -284,7 +284,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(nil, hostNames, "", "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(nil, hostNames, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -329,7 +329,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, nil, "", "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, nil, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -366,7 +366,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileName := createTargetedProbeCommand(hostFQDN, "CNAME", "agnhost")
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileName := createTargetedProbeCommand(hostFQDN, "CNAME", "jessie")
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -385,7 +385,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileName = createTargetedProbeCommand(hostFQDN, "CNAME", "agnhost")
 		agnhostProber = dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileName = createTargetedProbeCommand(hostFQDN, "CNAME", "jessie")
-		jessieProber = dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber = dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -413,7 +413,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileName = createTargetedProbeCommand(hostFQDN, targetRecord, "agnhost")
 		agnhostProber = dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileName = createTargetedProbeCommand(hostFQDN, targetRecord, "jessie")
-		jessieProber = dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber = dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -599,7 +599,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, hostEntries, "", "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, hostEntries, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -639,7 +639,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, hostEntries, "", "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, hostEntries, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -676,7 +676,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, nil, "", "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, nil, "", "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 
@@ -720,7 +720,7 @@ var _ = common.SIGDescribe("DNS HostNetwork", func() {
 		agnhostProbeCmd, agnhostFileNames := createProbeCommand(namesToResolve, nil, regularService.Spec.ClusterIP, "agnhost", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
 		agnhostProber := dnsQuerier{name: "agnhost", image: imageutils.Agnhost, cmd: agnhostProbeCmd}
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, nil, regularService.Spec.ClusterIP, "jessie", f.Namespace.Name, framework.TestContext.ClusterDNSDomain, framework.TestContext.ClusterIsIPv6())
-		jessieProber := dnsQuerier{name: "jessie", image: imageutils.JessieDnsutils, cmd: jessieProbeCmd}
+		jessieProber := dnsQuerier{name: "jessie", image: imageutils.GlibcDnsTesting, cmd: jessieProbeCmd}
 		ginkgo.By("Running these commands on agnhost: " + agnhostProbeCmd + "\n")
 		ginkgo.By("Running these commands on jessie: " + jessieProbeCmd + "\n")
 

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -573,7 +573,7 @@ func TestConcurrentAccessToSingleVolume(ctx context.Context, f *framework.Framew
 			SeLinuxLabel:  e2epod.GetLinuxLabel(),
 			NodeSelection: node,
 			PVCsReadOnly:  readOnly,
-			ImageID:       e2epod.GetTestImageID(imageutils.JessieDnsutils),
+			ImageID:       e2epod.GetTestImageID(imageutils.GlibcDnsTesting),
 		}
 		pod, err := e2epod.CreateSecPodWithNodeSelection(ctx, cs, &podConfig, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
@@ -697,7 +697,7 @@ func TestConcurrentAccessToRelatedVolumes(ctx context.Context, f *framework.Fram
 			SeLinuxLabel:  e2epod.GetLinuxLabel(),
 			NodeSelection: node,
 			PVCsReadOnly:  false,
-			ImageID:       e2epod.GetTestImageID(imageutils.JessieDnsutils),
+			ImageID:       e2epod.GetTestImageID(imageutils.GlibcDnsTesting),
 		}
 		pod, err := e2epod.CreateSecPodWithNodeSelection(ctx, cs, &podConfig, f.Timeouts.PodStart)
 		defer func() {

--- a/test/e2e_node/pod_hostnamefqdn_test.go
+++ b/test/e2e_node/pod_hostnamefqdn_test.go
@@ -63,7 +63,7 @@ func testPod(podnamebase string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "test-container",
-					Image: imageutils.GetE2EImage(imageutils.JessieDnsutils),
+					Image: imageutils.GetE2EImage(imageutils.GlibcDnsTesting),
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,

--- a/test/images/.permitted-images
+++ b/test/images/.permitted-images
@@ -14,8 +14,8 @@ registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
 registry.k8s.io/e2e-test-images/agnhost
 registry.k8s.io/e2e-test-images/apparmor-loader
 registry.k8s.io/e2e-test-images/busybox
+registry.k8s.io/e2e-test-images/glibc-dns-testing
 registry.k8s.io/e2e-test-images/ipc-utils
-registry.k8s.io/e2e-test-images/jessie-dnsutils
 registry.k8s.io/e2e-test-images/kitten
 registry.k8s.io/e2e-test-images/nautilus
 registry.k8s.io/e2e-test-images/nginx

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -169,8 +169,8 @@ const (
 	InvalidRegistryImage
 	// IpcUtils image
 	IpcUtils
-	// JessieDnsutils image
-	JessieDnsutils
+	// GlibcDnsTesting image (formerly JessieDnsutils)
+	GlibcDnsTesting
 	// Kitten image
 	Kitten
 	// Nautilus image
@@ -218,7 +218,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.6.7-0"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{list.PromoterE2eRegistry, "ipc-utils", "1.3"}
-	configs[JessieDnsutils] = Config{list.PromoterE2eRegistry, "jessie-dnsutils", "1.7"}
+	configs[GlibcDnsTesting] = Config{list.PromoterE2eRegistry, "glibc-dns-testing", "2.0.0"}
 	configs[Kitten] = Config{list.PromoterE2eRegistry, "kitten", "1.7"}
 	configs[Nautilus] = Config{list.PromoterE2eRegistry, "nautilus", "1.7"}
 	configs[NFSProvisioner] = Config{list.SigStorageRegistry, "nfs-provisioner", "v4.0.8"}


### PR DESCRIPTION
Updates the codebase to use the new glibc-dns-testing image which replaces the deprecated jessie-dnsutils image.

This PR depends on the glibc-dns-testing image being available in the registry (registry.k8s.io/e2e-test-images/glibc-dns-testing:2.0).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

xref: https://github.com/kubernetes/kubernetes/pull/136358 (has to land first!)
xref: https://github.com/kubernetes/kubernetes/issues/136357

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
