### PR TITLE
Add metric component and endpoint to metric reference docs

### DIFF
--- a/test/instrumentation/README.md
+++ b/test/instrumentation/README.md
@@ -1,3 +1,5 @@
+## Stable Metric Regression Testing
+
 This directory contains the regression test for controlling the list of stable metrics
 
 If you add or remove a stable metric, this test will fail and you will need
@@ -50,3 +52,51 @@ And then from the root of the k8s/k8s repository, please run this command:
 ```shell
 cp ./test/instrumentation/documentation/documentation.md $WEBSITE_ROOT/content/en/docs/reference/instrumentation/metrics.md
 ```
+
+## Component Endpoint Mapping ([endpoint-mappings.yaml](endpoint-mappings.yaml))
+
+### Purpose
+
+Part of the generated documentation lists the component(s) and endpoint where
+each metric is exported. The association of metrics source file paths to
+components and endpoints is stored in [endpoint-mappings.yaml](endpoint-mappings.yaml).
+
+### Schema
+
+#### Components
+
+Metrics are discovered through static analysis of the codebase. As each metric
+is found, a match to its source file path is attempted based on the lists found
+under `coreComponents` and `standaloneComponents` within the YAML file.
+
+All "core" components are assumed to inherit common metrics, such as
+`kubernetes_healthcheck`, this includes components such as `kube-apiserver` and
+`kubelet`. The directories defined as containing the common metrics are be
+listed under `sharedPaths`.
+
+A "standalone" component only exports the metrics it defines, this includes
+components such as `etcd-version-monitor`. Common metrics will not be associated
+with standalone components.
+
+Both types of component can have multiple paths, and it is assumed that each
+component will be defined only once.
+
+#### Endpoints
+
+The default metrics endpoint is assumed to be `/metrics`. To
+register exceptions to this rule, `endpointMappings` should be used to override
+an endpoint for a particular path. This is useful for examples like the
+`/metrics/resource` endpoint. These mappings are evaluated in the order defined
+in the YAML file, from top to bottom, where the first match wins.
+
+### Registering new metric directories
+
+When generating documentation, you may see a warning if metrics were detected in
+unmapped directories:
+
+```shell
+WARNING: found 1 metric(s) in "cluster/images/etcd-version-monitor/etcd-version-monitor.go" but could not infer component endpoints. Consider updating endpoint-mappings.yaml.
+```
+
+In this example, the directory `cluster/images/etcd-version-monitor/` should be
+added under the relevant component, as explained above under Schema > Components.

--- a/test/instrumentation/README.md
+++ b/test/instrumentation/README.md
@@ -1,9 +1,9 @@
 ## Stable Metric Regression Testing
 
-This directory contains the regression test for controlling the list of stable metrics
+This directory contains the regression test for controlling the list of stable metrics.
 
 If you add or remove a stable metric, this test will fail and you will need
-to update the golden list of tests stored in `testdata/`.  Changes to that file
+to update the golden list of tests stored in `testdata/`. Changes to that file
 require review by sig-instrumentation.
 
 To update the list, run
@@ -71,8 +71,8 @@ under `coreComponents` and `standaloneComponents` within the YAML file.
 
 All "core" components are assumed to inherit common metrics, such as
 `kubernetes_healthcheck`, this includes components such as `kube-apiserver` and
-`kubelet`. The directories defined as containing the common metrics are be
-listed under `sharedPaths`.
+`kubelet`. The directories defined as containing the common metrics are listed
+under `sharedPaths`.
 
 A "standalone" component only exports the metrics it defines, this includes
 components such as `etcd-version-monitor`. Common metrics will not be associated

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -54,6 +54,17 @@
   componentEndpoints:
   - component: kube-controller-manager
     endpoint: /metrics
+- name: stale_sync_skips_total
+  subsystem: daemonset_controller
+  help: Total number of DaemonSet syncs skipped due to a stale watch cache.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: sync_duration_seconds
   subsystem: root_ca_cert_publisher
   help: Number of namespace syncs happened in root ca cert publisher.
@@ -466,6 +477,17 @@
   componentEndpoints:
   - component: kube-controller-manager
     endpoint: /metrics
+- name: stale_sync_skips_total
+  subsystem: job_controller
+  help: Total number of Job syncs skipped due to a stale watch cache.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: terminated_pods_tracking_finalizer_total
   subsystem: job_controller
   help: |-
@@ -639,6 +661,17 @@
   - 2
   - 4
   - 8
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
+- name: stale_sync_skips_total
+  subsystem: replicaset_controller
+  help: Total number of ReplicaSet syncs skipped due to a stale watch cache.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
   componentEndpoints:
   - component: kube-controller-manager
     endpoint: /metrics
@@ -4208,6 +4241,30 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
+- name: apiextensions_openapi_v2_regeneration_count
+  help: Counter of OpenAPI v2 spec regeneration count broken down by causing CRD name
+    and reason.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - crd
+  - reason
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiextensions_openapi_v3_regeneration_count
+  help: Counter of OpenAPI v3 spec regeneration count broken down by group, version,
+    causing CRD and reason.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - crd
+  - group
+  - reason
+  - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: conversion_webhook_duration_seconds
   namespace: apiserver
   help: Conversion webhook request latency
@@ -4272,30 +4329,6 @@
   - 4.096
   - 8.192
   - 16.384
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiextensions_openapi_v2_regeneration_count
-  help: Counter of OpenAPI v2 spec regeneration count broken down by causing CRD name
-    and reason.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - crd
-  - reason
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiextensions_openapi_v3_regeneration_count
-  help: Counter of OpenAPI v3 spec regeneration count broken down by group, version,
-    causing CRD and reason.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - crd
-  - group
-  - reason
-  - version
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
@@ -4423,73 +4456,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: controller_admission_duration_seconds
-  subsystem: admission
-  namespace: apiserver
-  help: Admission controller latency histogram in seconds, identified by name and
-    broken out for each operation and API resource and type (validate or admit).
-  type: Histogram
-  stabilityLevel: STABLE
-  labels:
-  - name
-  - operation
-  - rejected
-  - type
-  buckets:
-  - 0.005
-  - 0.025
-  - 0.1
-  - 0.5
-  - 1
-  - 2.5
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: step_admission_duration_seconds
-  subsystem: admission
-  namespace: apiserver
-  help: Admission sub-step latency histogram in seconds, broken out for each operation
-    and API resource and step type (validate or admit).
-  type: Histogram
-  stabilityLevel: STABLE
-  labels:
-  - operation
-  - rejected
-  - type
-  buckets:
-  - 0.005
-  - 0.025
-  - 0.1
-  - 0.5
-  - 1
-  - 2.5
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: webhook_admission_duration_seconds
-  subsystem: admission
-  namespace: apiserver
-  help: Admission webhook latency histogram in seconds, identified by name and broken
-    out for each operation and API resource and type (validate or admit).
-  type: Histogram
-  stabilityLevel: STABLE
-  labels:
-  - name
-  - operation
-  - rejected
-  - type
-  buckets:
-  - 0.005
-  - 0.025
-  - 0.1
-  - 0.5
-  - 1
-  - 2.5
-  - 10
-  - 25
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: check_duration_seconds
   subsystem: mutating_admission_policy
   namespace: apiserver
@@ -4560,35 +4526,70 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: aggregation_count_total
-  subsystem: aggregator_discovery
-  help: Counter of number of times discovery was aggregated
-  type: Counter
-  stabilityLevel: ALPHA
+- name: controller_admission_duration_seconds
+  subsystem: admission
+  namespace: apiserver
+  help: Admission controller latency histogram in seconds, identified by name and
+    broken out for each operation and API resource and type (validate or admit).
+  type: Histogram
+  stabilityLevel: STABLE
+  labels:
+  - name
+  - operation
+  - rejected
+  - type
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.5
+  - 1
+  - 2.5
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: nopeer_requests_total
-  subsystem: aggregator_discovery
-  help: Counter of number of times no-peer (non peer-aggregated) discovery was requested
-  type: Counter
-  stabilityLevel: ALPHA
+- name: step_admission_duration_seconds
+  subsystem: admission
+  namespace: apiserver
+  help: Admission sub-step latency histogram in seconds, broken out for each operation
+    and API resource and step type (validate or admit).
+  type: Histogram
+  stabilityLevel: STABLE
+  labels:
+  - operation
+  - rejected
+  - type
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.5
+  - 1
+  - 2.5
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: peer_aggregated_cache_hits_total
-  subsystem: aggregator_discovery
-  help: Counter of number of times discovery was served from peer-aggregated cache
-  type: Counter
-  stabilityLevel: ALPHA
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: peer_aggregated_cache_misses_total
-  subsystem: aggregator_discovery
-  help: Counter of number of times discovery was aggregated across all API servers
-  type: Counter
-  stabilityLevel: ALPHA
+- name: webhook_admission_duration_seconds
+  subsystem: admission
+  namespace: apiserver
+  help: Admission webhook latency histogram in seconds, identified by name and broken
+    out for each operation and API resource and type (validate or admit).
+  type: Histogram
+  stabilityLevel: STABLE
+  labels:
+  - name
+  - operation
+  - rejected
+  - type
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.5
+  - 1
+  - 2.5
+  - 10
+  - 25
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
@@ -4715,17 +4716,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: current_inqueue_requests
-  subsystem: apiserver
-  help: Maximal number of queued requests in this apiserver per request kind in last
-    second.
-  type: Gauge
-  stabilityLevel: ALPHA
-  labels:
-  - request_kind
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: apiserver_delegated_authn_request_duration_seconds
   help: Request latency in seconds. Broken down by status code.
   type: Histogram
@@ -4777,6 +4767,137 @@
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: active_fetch_count
+  subsystem: token_cache
+  namespace: authentication
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: fetch_total
+  subsystem: token_cache
+  namespace: authentication
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: request_duration_seconds
+  subsystem: token_cache
+  namespace: authentication
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: request_total
+  subsystem: token_cache
+  namespace: authentication
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: aggregation_count_total
+  subsystem: aggregator_discovery
+  help: Counter of number of times discovery was aggregated
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: nopeer_requests_total
+  subsystem: aggregator_discovery
+  help: Counter of number of times no-peer (non peer-aggregated) discovery was requested
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: peer_aggregated_cache_hits_total
+  subsystem: aggregator_discovery
+  help: Counter of number of times discovery was served from peer-aggregated cache
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: peer_aggregated_cache_misses_total
+  subsystem: aggregator_discovery
+  help: Counter of number of times discovery was aggregated across all API servers
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: current_inqueue_requests
+  subsystem: apiserver
+  help: Maximal number of queued requests in this apiserver per request kind in last
+    second.
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - request_kind
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: dial_duration_seconds
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial latency histogram in seconds, labeled by the protocol (http-connect or
+    grpc), transport (tcp or uds)
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - protocol
+  - transport
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.5
+  - 2.5
+  - 12.5
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: dial_failure_count
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial failure count, labeled by the protocol (http-connect or grpc), transport
+    (tcp or uds), and stage (connect or proxy). The stage indicates at which stage
+    the dial failed
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - protocol
+  - stage
+  - transport
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: dial_start_total
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial starts, labeled by the protocol (http-connect or grpc) and transport
+    (tcp or uds).
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - protocol
+  - transport
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
@@ -5093,46 +5214,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: active_fetch_count
-  subsystem: token_cache
-  namespace: authentication
-  type: Gauge
-  stabilityLevel: ALPHA
-  labels:
-  - status
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: fetch_total
-  subsystem: token_cache
-  namespace: authentication
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - status
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: request_duration_seconds
-  subsystem: token_cache
-  namespace: authentication
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - status
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: request_total
-  subsystem: token_cache
-  namespace: authentication
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - status
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: authorization_attempts_total
   help: Counter of authorization attempts broken down by result. It can be either
     'allowed', 'denied', 'no-opinion' or 'error'.
@@ -5435,54 +5516,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: dial_duration_seconds
-  subsystem: egress_dialer
-  namespace: apiserver
-  help: Dial latency histogram in seconds, labeled by the protocol (http-connect or
-    grpc), transport (tcp or uds)
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - protocol
-  - transport
-  buckets:
-  - 0.005
-  - 0.025
-  - 0.1
-  - 0.5
-  - 2.5
-  - 12.5
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: dial_failure_count
-  subsystem: egress_dialer
-  namespace: apiserver
-  help: Dial failure count, labeled by the protocol (http-connect or grpc), transport
-    (tcp or uds), and stage (connect or proxy). The stage indicates at which stage
-    the dial failed
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - protocol
-  - stage
-  - transport
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: dial_start_total
-  subsystem: egress_dialer
-  namespace: apiserver
-  help: Dial starts, labeled by the protocol (http-connect or grpc) and transport
-    (tcp or uds).
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - protocol
-  - transport
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: automatic_reload_last_timestamp_seconds
   subsystem: encryption_config_controller
   namespace: apiserver
@@ -5650,613 +5683,6 @@
   - 13.1072
   - 26.2144
   - 52.4288
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: init_events_total
-  namespace: apiserver
-  help: Counter of init events processed in watch cache broken by resource type.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiserver_resource_objects
-  help: Number of stored objects at the time of last check split by kind. In case
-    of a fetching error, the value will be -1.
-  type: Gauge
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiserver_resource_size_estimate_bytes
-  help: Estimated size of stored objects in database. Estimate is based on sum of
-    last observed sizes of serialized objects. In case of a fetching error, the value
-    will be -1.
-  type: Gauge
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: storage_consistency_checks_total
-  namespace: apiserver
-  help: Counter for status of consistency checks between etcd and watch cache
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  - status
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: data_key_generation_duration_seconds
-  subsystem: storage
-  namespace: apiserver
-  help: Latencies in seconds of data encryption key(DEK) generation operations.
-  type: Histogram
-  stabilityLevel: ALPHA
-  buckets:
-  - 5e-06
-  - 1e-05
-  - 2e-05
-  - 4e-05
-  - 8e-05
-  - 0.00016
-  - 0.00032
-  - 0.00064
-  - 0.00128
-  - 0.00256
-  - 0.00512
-  - 0.01024
-  - 0.02048
-  - 0.04096
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: data_key_generation_failures_total
-  subsystem: storage
-  namespace: apiserver
-  help: Total number of failed data encryption key(DEK) generation operations.
-  type: Counter
-  stabilityLevel: ALPHA
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: storage_db_total_size_in_bytes
-  subsystem: apiserver
-  help: Total size of the storage database file physically allocated in bytes.
-  type: Gauge
-  deprecatedVersion: 1.28.0
-  stabilityLevel: ALPHA
-  labels:
-  - endpoint
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: storage_decode_errors_total
-  namespace: apiserver
-  help: Number of stored object decode errors split by object type
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: envelope_transformation_cache_misses_total
-  subsystem: storage
-  namespace: apiserver
-  help: Total number of cache misses while accessing key decryption key(KEK).
-  type: Counter
-  stabilityLevel: ALPHA
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: storage_events_received_total
-  subsystem: apiserver
-  help: Number of etcd events received split by kind.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiserver_storage_list_evaluated_objects_total
-  help: Number of objects tested in the course of serving a LIST request from storage
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiserver_storage_list_fetched_objects_total
-  help: Number of objects read from storage in the course of serving a LIST request
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiserver_storage_list_returned_objects_total
-  help: Number of objects returned for a LIST request from storage
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiserver_storage_list_total
-  help: Number of LIST requests served from storage
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: transformation_duration_seconds
-  subsystem: storage
-  namespace: apiserver
-  help: Latencies in seconds of value transformation operations.
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - transformation_type
-  - transformer_prefix
-  buckets:
-  - 5e-06
-  - 1e-05
-  - 2e-05
-  - 4e-05
-  - 8e-05
-  - 0.00016
-  - 0.00032
-  - 0.00064
-  - 0.00128
-  - 0.00256
-  - 0.00512
-  - 0.01024
-  - 0.02048
-  - 0.04096
-  - 0.08192
-  - 0.16384
-  - 0.32768
-  - 0.65536
-  - 1.31072
-  - 2.62144
-  - 5.24288
-  - 10.48576
-  - 20.97152
-  - 41.94304
-  - 83.88608
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: transformation_operations_total
-  subsystem: storage
-  namespace: apiserver
-  help: Total number of transformations. Successful transformation will have a status
-    'OK' and a varied status string when the transformation fails. The status, resource,
-    and transformation_type fields can be used for alerting purposes. For example,
-    you can monitor for encryption/decryption failures using the transformation_type
-    (e.g., from_storage for decryption and to_storage for encryption). Additionally,
-    these fields can be used to ensure that the correct transformers are applied to
-    each resource.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - resource
-  - status
-  - transformation_type
-  - transformer_prefix
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: terminated_watchers_total
-  namespace: apiserver
-  help: Counter of watchers closed due to unresponsiveness broken by resource type.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: consistent_read_total
-  subsystem: watch_cache
-  namespace: apiserver
-  help: Counter for consistent reads from cache.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - fallback
-  - group
-  - resource
-  - success
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: events_dispatched_total
-  subsystem: watch_cache
-  namespace: apiserver
-  help: Counter of events dispatched in watch cache broken by resource type.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: events_received_total
-  subsystem: watch_cache
-  namespace: apiserver
-  help: Counter of events received in watch cache broken by resource type.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: initializations_total
-  subsystem: watch_cache
-  namespace: apiserver
-  help: Counter of watch cache initializations broken by resource type.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: read_wait_seconds
-  subsystem: watch_cache
-  namespace: apiserver
-  help: Histogram of time spent waiting for a watch cache to become fresh.
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  buckets:
-  - 0.005
-  - 0.025
-  - 0.05
-  - 0.1
-  - 0.2
-  - 0.4
-  - 0.6
-  - 0.8
-  - 1
-  - 1.25
-  - 1.5
-  - 2
-  - 3
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: resource_version
-  subsystem: watch_cache
-  namespace: apiserver
-  help: Current resource version of watch cache broken by resource type.
-  type: Gauge
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: etcd_bookmark_counts
-  help: Number of etcd bookmarks (progress notify events) split by kind.
-  type: Gauge
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: etcd_lease_object_counts
-  help: Number of objects attached to a single etcd lease.
-  type: Histogram
-  stabilityLevel: ALPHA
-  buckets:
-  - 10
-  - 50
-  - 100
-  - 500
-  - 1000
-  - 2500
-  - 5000
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: etcd_request_duration_seconds
-  help: Etcd request latency in seconds for each operation and object type.
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - operation
-  - resource
-  buckets:
-  - 0.005
-  - 0.025
-  - 0.05
-  - 0.1
-  - 0.2
-  - 0.4
-  - 0.6
-  - 0.8
-  - 1
-  - 1.25
-  - 1.5
-  - 2
-  - 3
-  - 4
-  - 5
-  - 6
-  - 8
-  - 10
-  - 15
-  - 20
-  - 30
-  - 45
-  - 60
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: etcd_request_errors_total
-  help: Etcd failed request counts for each operation and object type.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - operation
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: etcd_requests_total
-  help: Etcd request counts for each operation and object type.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - operation
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: capacity
-  subsystem: watch_cache
-  help: Total capacity of watch cache broken by resource type.
-  type: Gauge
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: capacity_decrease_total
-  subsystem: watch_cache
-  help: Total number of watch cache capacity decrease events broken by resource type.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: capacity_increase_total
-  subsystem: watch_cache
-  help: Total number of watch cache capacity increase events broken by resource type.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: automatic_reload_last_timestamp_seconds
-  subsystem: authentication_config_controller
-  namespace: apiserver
-  help: Timestamp of the last automatic reload of authentication configuration split
-    by status and apiserver identity.
-  type: Gauge
-  stabilityLevel: BETA
-  labels:
-  - apiserver_id_hash
-  - status
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: automatic_reloads_total
-  subsystem: authentication_config_controller
-  namespace: apiserver
-  help: Total number of automatic reloads of authentication configuration split by
-    status and apiserver identity.
-  type: Counter
-  stabilityLevel: BETA
-  labels:
-  - apiserver_id_hash
-  - status
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: automatic_reload_last_timestamp_seconds
-  subsystem: authorization_config_controller
-  namespace: apiserver
-  help: Timestamp of the last automatic reload of authorization configuration split
-    by status and apiserver identity.
-  type: Gauge
-  stabilityLevel: BETA
-  labels:
-  - apiserver_id_hash
-  - status
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: automatic_reloads_total
-  subsystem: authorization_config_controller
-  namespace: apiserver
-  help: Total number of automatic reloads of authorization configuration split by
-    status and apiserver identity.
-  type: Counter
-  stabilityLevel: BETA
-  labels:
-  - apiserver_id_hash
-  - status
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiserver_storage_objects
-  help: '[DEPRECATED, consider using apiserver_resource_objects instead] Number of
-    stored objects at the time of last check split by kind. In case of a fetching
-    error, the value will be -1.'
-  type: Gauge
-  deprecatedVersion: 1.34.0
-  stabilityLevel: STABLE
-  labels:
-  - resource
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiserver_storage_size_bytes
-  help: Size of the storage database file physically allocated in bytes.
-  type: Custom
-  stabilityLevel: STABLE
-  labels:
-  - storage_cluster_id
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: apiserver_authentication_jwt_authenticator_jwks_fetch_last_key_set_info
-  help: Information about the last JWKS fetched by the JWT authenticator with hash
-    as label, split by api server identity and jwt issuer.
-  type: Custom
-  stabilityLevel: ALPHA
-  labels:
-  - jwt_issuer_hash
-  - apiserver_id_hash
-  - hash
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: jwt_authenticator_jwks_fetch_last_timestamp_seconds
-  subsystem: authentication
-  namespace: apiserver
-  help: Timestamp of the last successful or failed JWKS fetch split by result, api
-    server identity and jwt issuer for the JWT authenticator.
-  type: Gauge
-  stabilityLevel: ALPHA
-  labels:
-  - apiserver_id_hash
-  - jwt_issuer_hash
-  - result
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: jwt_authenticator_latency_seconds
-  subsystem: authentication
-  namespace: apiserver
-  help: Latency of jwt authentication operations in seconds. This is the time spent
-    authenticating a token for cache miss only (i.e. when the token is not found in
-    the cache).
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - jwt_issuer_hash
-  - result
-  buckets:
-  - 0.001
-  - 0.005
-  - 0.01
-  - 0.025
-  - 0.05
-  - 0.1
-  - 0.25
-  - 0.5
-  - 1
-  - 2.5
-  - 5
-  - 10
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: webhook_duration_seconds
-  subsystem: authorization
-  namespace: apiserver
-  help: Request latency in seconds.
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - name
-  - result
-  buckets:
-  - 0.005
-  - 0.01
-  - 0.025
-  - 0.05
-  - 0.1
-  - 0.25
-  - 0.5
-  - 1
-  - 2.5
-  - 5
-  - 10
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: webhook_evaluations_fail_open_total
-  subsystem: authorization
-  namespace: apiserver
-  help: NoOpinion results due to webhook timeout or error.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - name
-  - result
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: webhook_evaluations_total
-  subsystem: authorization
-  namespace: apiserver
-  help: Round-trips to authorization webhooks.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - name
-  - result
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
@@ -6681,6 +6107,42 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
+- name: init_events_total
+  namespace: apiserver
+  help: Counter of init events processed in watch cache broken by resource type.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: peer_discovery_sync_errors_total
+  subsystem: apiserver
+  help: Total number of errors encountered while syncing discovery information from
+    a peer kube-apiserver
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: peer_proxy_errors_total
+  subsystem: apiserver
+  help: Total number of errors encountered while proxying requests to a peer kube
+    apiserver
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  - type
+  - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: rerouted_request_total
   subsystem: apiserver
   help: '`Total number of requests that were proxied to a peer kube-apiserver because
@@ -6694,6 +6156,214 @@
   - group
   - resource
   - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiserver_resource_objects
+  help: Number of stored objects at the time of last check split by kind. In case
+    of a fetching error, the value will be -1.
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiserver_resource_size_estimate_bytes
+  help: Estimated size of stored objects in database. Estimate is based on sum of
+    last observed sizes of serialized objects. In case of a fetching error, the value
+    will be -1.
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: storage_consistency_checks_total
+  namespace: apiserver
+  help: Counter for status of consistency checks between etcd and watch cache
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: data_key_generation_duration_seconds
+  subsystem: storage
+  namespace: apiserver
+  help: Latencies in seconds of data encryption key(DEK) generation operations.
+  type: Histogram
+  stabilityLevel: ALPHA
+  buckets:
+  - 5e-06
+  - 1e-05
+  - 2e-05
+  - 4e-05
+  - 8e-05
+  - 0.00016
+  - 0.00032
+  - 0.00064
+  - 0.00128
+  - 0.00256
+  - 0.00512
+  - 0.01024
+  - 0.02048
+  - 0.04096
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: data_key_generation_failures_total
+  subsystem: storage
+  namespace: apiserver
+  help: Total number of failed data encryption key(DEK) generation operations.
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: storage_db_total_size_in_bytes
+  subsystem: apiserver
+  help: Total size of the storage database file physically allocated in bytes.
+  type: Gauge
+  deprecatedVersion: 1.28.0
+  stabilityLevel: ALPHA
+  labels:
+  - endpoint
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: storage_decode_errors_total
+  namespace: apiserver
+  help: Number of stored object decode errors split by object type
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: envelope_transformation_cache_misses_total
+  subsystem: storage
+  namespace: apiserver
+  help: Total number of cache misses while accessing key decryption key(KEK).
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: storage_events_received_total
+  subsystem: apiserver
+  help: Number of etcd events received split by kind.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiserver_storage_list_evaluated_objects_total
+  help: Number of objects tested in the course of serving a LIST request from storage
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiserver_storage_list_fetched_objects_total
+  help: Number of objects read from storage in the course of serving a LIST request
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiserver_storage_list_returned_objects_total
+  help: Number of objects returned for a LIST request from storage
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiserver_storage_list_total
+  help: Number of LIST requests served from storage
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: transformation_duration_seconds
+  subsystem: storage
+  namespace: apiserver
+  help: Latencies in seconds of value transformation operations.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - transformation_type
+  - transformer_prefix
+  buckets:
+  - 5e-06
+  - 1e-05
+  - 2e-05
+  - 4e-05
+  - 8e-05
+  - 0.00016
+  - 0.00032
+  - 0.00064
+  - 0.00128
+  - 0.00256
+  - 0.00512
+  - 0.01024
+  - 0.02048
+  - 0.04096
+  - 0.08192
+  - 0.16384
+  - 0.32768
+  - 0.65536
+  - 1.31072
+  - 2.62144
+  - 5.24288
+  - 10.48576
+  - 20.97152
+  - 41.94304
+  - 83.88608
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: transformation_operations_total
+  subsystem: storage
+  namespace: apiserver
+  help: Total number of transformations. Successful transformation will have a status
+    'OK' and a varied status string when the transformation fails. The status, resource,
+    and transformation_type fields can be used for alerting purposes. For example,
+    you can monitor for encryption/decryption failures using the transformation_type
+    (e.g., from_storage for decryption and to_storage for encryption). Additionally,
+    these fields can be used to ensure that the correct transformers are applied to
+    each resource.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - resource
+  - status
+  - transformation_type
+  - transformer_prefix
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
@@ -6719,26 +6389,102 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: declarative_validation_panics_total
-  subsystem: validation
+- name: terminated_watchers_total
   namespace: apiserver
-  help: Number of panics in declarative validation, broken down by validation identifier.
+  help: Counter of watchers closed due to unresponsiveness broken by resource type.
   type: Counter
   stabilityLevel: ALPHA
   labels:
-  - validation_identifier
+  - group
+  - resource
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: declarative_validation_parity_discrepancies_total
-  subsystem: validation
+- name: consistent_read_total
+  subsystem: watch_cache
   namespace: apiserver
-  help: Number of discrepancies between declarative and handwritten validation, broken
-    down by validation identifier.
+  help: Counter for consistent reads from cache.
   type: Counter
   stabilityLevel: ALPHA
   labels:
-  - validation_identifier
+  - fallback
+  - group
+  - resource
+  - success
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: events_dispatched_total
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Counter of events dispatched in watch cache broken by resource type.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: events_received_total
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Counter of events received in watch cache broken by resource type.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: initializations_total
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Counter of watch cache initializations broken by resource type.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: read_wait_seconds
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Histogram of time spent waiting for a watch cache to become fresh.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.4
+  - 0.6
+  - 0.8
+  - 1
+  - 1.25
+  - 1.5
+  - 2
+  - 3
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: resource_version
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Current resource version of watch cache broken by resource type.
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
@@ -6761,6 +6507,173 @@
     SAN extension missing (either/or, based on the runtime environment)
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: etcd_bookmark_counts
+  help: Number of etcd bookmarks (progress notify events) split by kind.
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: etcd_lease_object_counts
+  help: Number of objects attached to a single etcd lease.
+  type: Histogram
+  stabilityLevel: ALPHA
+  buckets:
+  - 10
+  - 50
+  - 100
+  - 500
+  - 1000
+  - 2500
+  - 5000
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: etcd_request_duration_seconds
+  help: Etcd request latency in seconds for each operation and object type.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - operation
+  - resource
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.4
+  - 0.6
+  - 0.8
+  - 1
+  - 1.25
+  - 1.5
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 8
+  - 10
+  - 15
+  - 20
+  - 30
+  - 45
+  - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: etcd_request_errors_total
+  help: Etcd failed request counts for each operation and object type.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - operation
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: etcd_requests_total
+  help: Etcd request counts for each operation and object type.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - operation
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: capacity
+  subsystem: watch_cache
+  help: Total capacity of watch cache broken by resource type.
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: capacity_decrease_total
+  subsystem: watch_cache
+  help: Total number of watch cache capacity decrease events broken by resource type.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: capacity_increase_total
+  subsystem: watch_cache
+  help: Total number of watch cache capacity increase events broken by resource type.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: automatic_reload_last_timestamp_seconds
+  subsystem: authentication_config_controller
+  namespace: apiserver
+  help: Timestamp of the last automatic reload of authentication configuration split
+    by status and apiserver identity.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - apiserver_id_hash
+  - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: automatic_reloads_total
+  subsystem: authentication_config_controller
+  namespace: apiserver
+  help: Total number of automatic reloads of authentication configuration split by
+    status and apiserver identity.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - apiserver_id_hash
+  - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: automatic_reload_last_timestamp_seconds
+  subsystem: authorization_config_controller
+  namespace: apiserver
+  help: Timestamp of the last automatic reload of authorization configuration split
+    by status and apiserver identity.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - apiserver_id_hash
+  - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: automatic_reloads_total
+  subsystem: authorization_config_controller
+  namespace: apiserver
+  help: Total number of automatic reloads of authorization configuration split by
+    status and apiserver identity.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - apiserver_id_hash
+  - status
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
@@ -6864,6 +6777,151 @@
   - 10
   - 15
   - 30
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiserver_storage_objects
+  help: '[DEPRECATED, consider using apiserver_resource_objects instead] Number of
+    stored objects at the time of last check split by kind. In case of a fetching
+    error, the value will be -1.'
+  type: Gauge
+  deprecatedVersion: 1.34.0
+  stabilityLevel: STABLE
+  labels:
+  - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiserver_storage_size_bytes
+  help: Size of the storage database file physically allocated in bytes.
+  type: Custom
+  stabilityLevel: STABLE
+  labels:
+  - storage_cluster_id
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiserver_authentication_jwt_authenticator_jwks_fetch_last_key_set_info
+  help: Information about the last JWKS fetched by the JWT authenticator with hash
+    as label, split by api server identity and jwt issuer.
+  type: Custom
+  stabilityLevel: ALPHA
+  labels:
+  - jwt_issuer_hash
+  - apiserver_id_hash
+  - hash
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: jwt_authenticator_jwks_fetch_last_timestamp_seconds
+  subsystem: authentication
+  namespace: apiserver
+  help: Timestamp of the last successful or failed JWKS fetch split by result, api
+    server identity and jwt issuer for the JWT authenticator.
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - apiserver_id_hash
+  - jwt_issuer_hash
+  - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: jwt_authenticator_latency_seconds
+  subsystem: authentication
+  namespace: apiserver
+  help: Latency of jwt authentication operations in seconds. This is the time spent
+    authenticating a token for cache miss only (i.e. when the token is not found in
+    the cache).
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - jwt_issuer_hash
+  - result
+  buckets:
+  - 0.001
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: webhook_duration_seconds
+  subsystem: authorization
+  namespace: apiserver
+  help: Request latency in seconds.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - name
+  - result
+  buckets:
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: webhook_evaluations_fail_open_total
+  subsystem: authorization
+  namespace: apiserver
+  help: NoOpinion results due to webhook timeout or error.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - name
+  - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: webhook_evaluations_total
+  subsystem: authorization
+  namespace: apiserver
+  help: Round-trips to authorization webhooks.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - name
+  - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: declarative_validation_panics_total
+  subsystem: validation
+  namespace: apiserver
+  help: Number of panics in declarative validation, broken down by validation identifier.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - validation_identifier
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: declarative_validation_parity_discrepancies_total
+  subsystem: validation
+  namespace: apiserver
+  help: Number of discrepancies between declarative and handwritten validation, broken
+    down by validation identifier.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - validation_identifier
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
@@ -7024,6 +7082,42 @@
   - 16384
   componentEndpoints:
   - component: cloud-controller-manager
+    endpoint: /metrics
+- name: processing_latency_seconds
+  subsystem: informer
+  help: Time taken to process events after popping from the queue.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - name
+  - resource
+  - version
+  buckets:
+  - 0.001
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
     endpoint: /metrics
 - name: queued_items
   subsystem: informer
@@ -7780,6 +7874,28 @@
     endpoint: /metrics/slis
   - component: kubelet
     endpoint: /metrics/slis
+- name: x509_insecure_sha1_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers with insecure SHA1 signatures in
+    their serving certificate OR the number of connection failures due to the insecure
+    SHA1 signatures (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: x509_missing_san_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers missing SAN extension in their serving
+    certificate OR the number of connection failures due to the lack of x509 certificate
+    SAN extension missing (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: changes
   subsystem: endpoint_slice_controller
   help: Number of EndpointSlice changes
@@ -7931,28 +8047,6 @@
   labels:
   - name
   - reason
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: x509_insecure_sha1_total
-  subsystem: kube_aggregator
-  namespace: apiserver
-  help: Counts the number of requests to servers with insecure SHA1 signatures in
-    their serving certificate OR the number of connection failures due to the insecure
-    SHA1 signatures (either/or, based on the runtime environment)
-  type: Counter
-  stabilityLevel: ALPHA
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: x509_missing_san_total
-  subsystem: kube_aggregator
-  namespace: apiserver
-  help: Counts the number of requests to servers missing SAN extension in their serving
-    certificate OR the number of connection failures due to the lack of x509 certificate
-    SAN extension missing (either/or, based on the runtime environment)
-  type: Counter
-  stabilityLevel: ALPHA
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -5,6 +5,9 @@
   stabilityLevel: ALPHA
   labels:
   - binary_version
+  componentEndpoints:
+  - component: etcd-version-monitor
+    endpoint: /metrics
 - name: certificate_manager_client_ttl_seconds
   subsystem: kubelet
   help: Gauge of the TTL (time-to-live) of the Kubelet's client certificate. The value
@@ -12,6 +15,9 @@
     certificate is invalid or unused, the value will be +INF.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: sync_duration_seconds
   subsystem: clustertrustbundle_publisher
   help: The time it took to sync a cluster trust bundle.
@@ -35,6 +41,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: sync_total
   subsystem: clustertrustbundle_publisher
   help: Number of syncs that occurred in cluster trust bundle publisher.
@@ -42,6 +51,9 @@
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: sync_duration_seconds
   subsystem: root_ca_cert_publisher
   help: Number of namespace syncs happened in root ca cert publisher.
@@ -65,6 +77,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: sync_total
   subsystem: root_ca_cert_publisher
   help: Number of namespace syncs happened in root ca cert publisher.
@@ -72,6 +87,9 @@
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: job_creation_skew_duration_seconds
   subsystem: cronjob_controller
   help: Time between when a cronjob is scheduled to be run, and when the corresponding
@@ -89,6 +107,9 @@
   - 128
   - 256
   - 512
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pod_deletion_duration_seconds
   subsystem: device_taint_eviction_controller
   help: Latency, in seconds, between the time when a device taint effect has been
@@ -108,11 +129,17 @@
   - 120
   - 180
   - 240
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pod_deletions_total
   subsystem: device_taint_eviction_controller
   help: Total number of Pods deleted by DeviceTaintEvictionController since its start.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: addresses_skipped_per_sync
   subsystem: endpoint_slice_mirroring_controller
   help: Number of addresses skipped on each Endpoints sync due to being invalid or
@@ -135,6 +162,9 @@
   - 8192
   - 16384
   - 32768
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: changes
   subsystem: endpoint_slice_mirroring_controller
   help: Number of EndpointSlice changes
@@ -142,11 +172,17 @@
   stabilityLevel: ALPHA
   labels:
   - operation
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: desired_endpoint_slices
   subsystem: endpoint_slice_mirroring_controller
   help: Number of EndpointSlices that would exist with perfect endpoint allocation
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: endpoints_added_per_sync
   subsystem: endpoint_slice_mirroring_controller
   help: Number of endpoints added on each Endpoints sync
@@ -168,11 +204,17 @@
   - 8192
   - 16384
   - 32768
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: endpoints_desired
   subsystem: endpoint_slice_mirroring_controller
   help: Number of endpoints desired
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: endpoints_removed_per_sync
   subsystem: endpoint_slice_mirroring_controller
   help: Number of endpoints removed on each Endpoints sync
@@ -194,6 +236,9 @@
   - 8192
   - 16384
   - 32768
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: endpoints_sync_duration
   subsystem: endpoint_slice_mirroring_controller
   help: Duration of syncEndpoints() in seconds
@@ -215,6 +260,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: endpoints_updated_per_sync
   subsystem: endpoint_slice_mirroring_controller
   help: Number of endpoints updated on each Endpoints sync
@@ -236,16 +284,25 @@
   - 8192
   - 16384
   - 32768
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: num_endpoint_slices
   subsystem: endpoint_slice_mirroring_controller
   help: Number of EndpointSlices
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: resources_sync_error_total
   subsystem: garbagecollector_controller
   help: Number of garbage collector resources sync errors
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: desired_replicas
   subsystem: horizontal_pod_autoscaler_controller
   help: Current desired replica count for HPA objects.
@@ -254,6 +311,9 @@
   labels:
   - hpa_name
   - namespace
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: metric_computation_duration_seconds
   subsystem: horizontal_pod_autoscaler_controller
   help: The time(seconds) that the HPA controller takes to calculate one metric. The
@@ -282,6 +342,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: metric_computation_total
   subsystem: horizontal_pod_autoscaler_controller
   help: Number of metric computations. The label 'action' should be either 'scale_down',
@@ -293,11 +356,17 @@
   - action
   - error
   - metric_type
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: num_horizontal_pod_autoscalers
   subsystem: horizontal_pod_autoscaler_controller
   help: Current number of controlled HPA objects.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: reconciliation_duration_seconds
   subsystem: horizontal_pod_autoscaler_controller
   help: The time(seconds) that the HPA controller takes to reconcile once. The label
@@ -326,6 +395,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: reconciliations_total
   subsystem: horizontal_pod_autoscaler_controller
   help: Number of reconciliations of HPA controller. The label 'action' should be
@@ -338,6 +410,9 @@
   labels:
   - action
   - error
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: job_finished_indexes_total
   subsystem: job_controller
   help: "`The number of finished indexes. Possible values for the\n\t\t\tstatus label
@@ -348,6 +423,9 @@
   labels:
   - backoffLimit
   - status
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: job_pods_creation_total
   subsystem: job_controller
   help: |-
@@ -362,6 +440,9 @@
   labels:
   - reason
   - status
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: jobs_by_external_controller_total
   subsystem: job_controller
   help: The number of Jobs managed by an external controller
@@ -369,6 +450,9 @@
   stabilityLevel: ALPHA
   labels:
   - controller_name
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pod_failures_handled_by_failure_policy_total
   subsystem: job_controller
   help: "`The number of failed Pods handled by failure policy with\n\t\t\trespect
@@ -379,6 +463,9 @@
   stabilityLevel: ALPHA
   labels:
   - action
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: terminated_pods_tracking_finalizer_total
   subsystem: job_controller
   help: |-
@@ -389,6 +476,9 @@
   stabilityLevel: ALPHA
   labels:
   - event
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: unhealthy_nodes_in_zone
   subsystem: node_collector
   help: Gauge measuring number of not Ready Nodes per zones.
@@ -396,6 +486,9 @@
   stabilityLevel: ALPHA
   labels:
   - zone
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: update_all_nodes_health_duration_seconds
   subsystem: node_collector
   help: Duration in seconds for NodeController to update the health of all nodes.
@@ -410,6 +503,9 @@
   - 10.24
   - 40.96
   - 163.84
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: update_node_health_duration_seconds
   subsystem: node_collector
   help: Duration in seconds for NodeController to update the health of a single node.
@@ -424,6 +520,9 @@
   - 1.024
   - 4.096
   - 16.384
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: zone_health
   subsystem: node_collector
   help: Gauge measuring percentage of healthy nodes per zone.
@@ -431,6 +530,9 @@
   stabilityLevel: ALPHA
   labels:
   - zone
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: zone_size
   subsystem: node_collector
   help: Gauge measuring number of registered Nodes per zones.
@@ -438,6 +540,9 @@
   stabilityLevel: ALPHA
   labels:
   - zone
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: cidrset_allocation_tries_per_request
   subsystem: node_ipam_controller
   help: Number of endpoints added on each Service sync
@@ -451,6 +556,9 @@
   - 25
   - 125
   - 625
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: cidrset_cidrs_allocations_total
   subsystem: node_ipam_controller
   help: Counter measuring total number of CIDR allocations.
@@ -458,6 +566,9 @@
   stabilityLevel: ALPHA
   labels:
   - clusterCIDR
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: cidrset_cidrs_releases_total
   subsystem: node_ipam_controller
   help: Counter measuring total number of CIDR releases.
@@ -465,6 +576,9 @@
   stabilityLevel: ALPHA
   labels:
   - clusterCIDR
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: cidrset_usage_cidrs
   subsystem: node_ipam_controller
   help: Gauge measuring percentage of allocated CIDRs.
@@ -472,6 +586,9 @@
   stabilityLevel: ALPHA
   labels:
   - clusterCIDR
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: cirdset_max_cidrs
   subsystem: node_ipam_controller
   help: Maximum number of CIDRs that can be allocated.
@@ -479,6 +596,9 @@
   stabilityLevel: ALPHA
   labels:
   - clusterCIDR
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: force_delete_pod_errors_total
   subsystem: pod_gc_collector
   help: Number of errors encountered when forcefully deleting the pods since the Pod
@@ -488,6 +608,9 @@
   labels:
   - namespace
   - reason
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: force_delete_pods_total
   subsystem: pod_gc_collector
   help: Number of pods that are being forcefully deleted since the Pod GC Controller
@@ -497,6 +620,9 @@
   labels:
   - namespace
   - reason
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: sorting_deletion_age_ratio
   subsystem: replicaset_controller
   help: The ratio of chosen deleted pod's ages to the current youngest pod's age (at
@@ -513,6 +639,9 @@
   - 2
   - 4
   - 8
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: job_pods_finished_total
   subsystem: job_controller
   help: The number of finished Pods that are fully tracked
@@ -521,6 +650,9 @@
   labels:
   - completion_mode
   - result
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: job_sync_duration_seconds
   subsystem: job_controller
   help: The time it took to sync a job
@@ -546,6 +678,9 @@
   - 16.384
   - 32.768
   - 65.536
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: job_syncs_total
   subsystem: job_controller
   help: The number of job syncs
@@ -555,6 +690,9 @@
   - action
   - completion_mode
   - result
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: jobs_finished_total
   subsystem: job_controller
   help: The number of finished jobs
@@ -564,6 +702,9 @@
   - completion_mode
   - reason
   - result
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: evictions_total
   subsystem: node_collector
   help: Number of Node evictions that happened since current instance of NodeController
@@ -572,6 +713,9 @@
   stabilityLevel: STABLE
   labels:
   - zone
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: attachdetach_controller_forced_detaches
   subsystem: attach_detach_controller
   help: Number of times the A/D Controller performed a forced detach
@@ -579,6 +723,9 @@
   stabilityLevel: ALPHA
   labels:
   - reason
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: attachdetach_controller_total_volumes
   help: Number of volumes in A/D Controller
   type: Custom
@@ -586,55 +733,34 @@
   labels:
   - plugin_name
   - state
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: create_failures_total
   subsystem: ephemeral_volume_controller
   help: Number of PersistentVolumeClaim creation requests
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: create_total
   subsystem: ephemeral_volume_controller
   help: Number of PersistentVolumeClaim creation requests
   type: Counter
   stabilityLevel: ALPHA
-- name: kubelet_credential_provider_config_info
-  help: Information about the last applied credential provider configuration with
-    hash as label
-  type: Custom
-  stabilityLevel: ALPHA
-  labels:
-  - hash
-- name: credential_provider_plugin_duration
-  subsystem: kubelet
-  help: Duration of execution in seconds for credential provider plugin
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - plugin_name
-  buckets:
-  - 0.005
-  - 0.01
-  - 0.025
-  - 0.05
-  - 0.1
-  - 0.25
-  - 0.5
-  - 1
-  - 2.5
-  - 5
-  - 10
-- name: credential_provider_plugin_errors_total
-  subsystem: kubelet
-  help: Number of errors from credential provider plugin
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - plugin_name
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pv_collector_bound_pv_count
   help: Gauge measuring number of persistent volume currently bound
   type: Custom
   stabilityLevel: ALPHA
   labels:
   - storage_class
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pv_collector_bound_pvc_count
   help: Gauge measuring number of persistent volume claim currently bound
   type: Custom
@@ -643,6 +769,9 @@
   - namespace
   - storage_class
   - volume_attributes_class
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pv_collector_total_pv_count
   help: Gauge measuring total number of persistent volumes
   type: Custom
@@ -650,12 +779,18 @@
   labels:
   - plugin_name
   - volume_mode
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pv_collector_unbound_pv_count
   help: Gauge measuring number of persistent volume currently unbound
   type: Custom
   stabilityLevel: ALPHA
   labels:
   - storage_class
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pv_collector_unbound_pvc_count
   help: Gauge measuring number of persistent volume claim currently unbound
   type: Custom
@@ -664,6 +799,9 @@
   - namespace
   - storage_class
   - volume_attributes_class
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: creates_total
   subsystem: resourceclaim_controller
   help: Number of ResourceClaims creation requests, categorized by creation status
@@ -673,6 +811,9 @@
   labels:
   - admin_access
   - status
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: resourceclaim_controller_resource_claims
   help: Number of ResourceClaims, categorized by allocation status, admin access,
     and source. Source can be 'resource_claim_template' (created from a template),
@@ -683,16 +824,25 @@
   - allocated
   - admin_access
   - source
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: retroactive_storageclass_errors_total
   help: Total number of failed retroactive StorageClass assignments to persistent
     volume claim
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: retroactive_storageclass_total
   help: Total number of retroactive StorageClass assignments to persistent volume
     claim
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: selinux_warning_controller_selinux_volume_conflict
   help: Conflict between two Pods using the same volume
   type: Custom
@@ -705,6 +855,9 @@
   - pod2_namespace
   - pod2_name
   - pod2_value
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: statefulset_max_unavailable
   subsystem: statefulset_controller
   help: Maximum number of unavailable pods allowed during StatefulSet rolling updates
@@ -714,6 +867,9 @@
   - pod_management_policy
   - statefulset_name
   - statefulset_namespace
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: statefulset_unavailable_replicas
   subsystem: statefulset_controller
   help: Current number of unavailable pods in StatefulSet
@@ -723,6 +879,9 @@
   - pod_management_policy
   - statefulset_name
   - statefulset_namespace
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: storage_count_attachable_volumes_in_use
   help: Measure number of volumes in use
   type: Custom
@@ -730,6 +889,9 @@
   labels:
   - node
   - volume_plugin
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pod_deletion_duration_seconds
   subsystem: taint_eviction_controller
   help: Latency, in seconds, between the time when a taint effect has been activated
@@ -749,11 +911,17 @@
   - 120
   - 180
   - 240
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: pod_deletions_total
   subsystem: taint_eviction_controller
   help: Total number of Pods deleted by TaintEvictionController since its start.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: job_deletion_duration_seconds
   subsystem: ttl_after_finished_controller
   help: The time it took to delete the job since it became eligible for deletion
@@ -774,6 +942,9 @@
   - 204.8
   - 409.6
   - 819.2
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: volume_operation_total_errors
   help: Total volume operation errors
   type: Counter
@@ -781,12 +952,18 @@
   labels:
   - operation_name
   - plugin_name
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: client_expiration_renew_errors
   subsystem: certificate_manager
   namespace: kubelet
   help: Counter of certificate renewal errors.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: certificate_manager_server_rotation_seconds
   subsystem: kubelet
   help: Histogram of the number of seconds the previous certificate lived before being
@@ -804,6 +981,9 @@
   - 1.5552e+07
   - 3.1104e+07
   - 1.24416e+08
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: certificate_manager_server_ttl_seconds
   subsystem: kubelet
   help: Gauge of the shortest TTL (time-to-live) of the Kubelet's serving certificate.
@@ -811,11 +991,59 @@
     If serving certificate is invalid or unused, the value will be +INF.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
+- name: kubelet_credential_provider_config_info
+  help: Information about the last applied credential provider configuration with
+    hash as label
+  type: Custom
+  stabilityLevel: ALPHA
+  labels:
+  - hash
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
+- name: credential_provider_plugin_duration
+  subsystem: kubelet
+  help: Duration of execution in seconds for credential provider plugin
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - plugin_name
+  buckets:
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
+- name: credential_provider_plugin_errors_total
+  subsystem: kubelet
+  help: Number of errors from credential provider plugin
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - plugin_name
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: server_expiration_renew_errors
   subsystem: kubelet
   help: Counter of certificate renewal errors.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: container_swap_limit_bytes
   help: Current amount of the container swap limit in bytes. Reported only on non-windows
     systems
@@ -825,6 +1053,9 @@
   - container
   - pod
   - namespace
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: container_swap_usage_bytes
   help: Current amount of the container swap usage in bytes. Reported only on non-windows
     systems
@@ -834,6 +1065,9 @@
   - container
   - pod
   - namespace
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: grpc_operations_duration_seconds
   subsystem: dra
   help: Duration in seconds of the DRA gRPC operations
@@ -859,6 +1093,9 @@
   - 16.995624819678714
   - 26.07345379475354
   - 39.99999999999997
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: operations_duration_seconds
   subsystem: dra
   help: Latency histogram in seconds for the duration of handling all ResourceClaims
@@ -887,6 +1124,9 @@
   - 16.995624819678714
   - 26.07345379475354
   - 39.99999999999997
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: dra_resource_claims_in_use
   help: The number of ResourceClaims that are currently in use on the node, by driver
     name (driver_name label value) and across all drivers (special value <any> for
@@ -897,6 +1137,9 @@
   stabilityLevel: ALPHA
   labels:
   - driver_name
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: active_pods
   subsystem: kubelet
   help: The number of pods the kubelet considers active and which are being considered
@@ -905,6 +1148,9 @@
   stabilityLevel: ALPHA
   labels:
   - static
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: admission_rejections_total
   subsystem: kubelet
   help: Cumulative number pod admission rejections by the Kubelet.
@@ -912,6 +1158,9 @@
   stabilityLevel: ALPHA
   labels:
   - reason
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: cgroup_manager_duration_seconds
   subsystem: kubelet
   help: Duration in seconds for cgroup manager operations. Broken down by method.
@@ -931,11 +1180,17 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: cgroup_version
   subsystem: kubelet
   help: cgroup version on the hosts.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: container_aligned_compute_resources_count
   subsystem: kubelet
   help: Cumulative number of aligned compute resources allocated to containers by
@@ -945,6 +1200,9 @@
   labels:
   - boundary
   - scope
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: container_aligned_compute_resources_failure_count
   subsystem: kubelet
   help: Cumulative number of failures to allocate aligned compute resources to containers
@@ -954,6 +1212,9 @@
   labels:
   - boundary
   - scope
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: kubelet_container_log_filesystem_used_bytes
   help: Bytes used by the container's logs on the filesystem.
   type: Custom
@@ -963,6 +1224,9 @@
   - namespace
   - pod
   - container
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: container_requested_resizes_total
   subsystem: kubelet
   help: Number of requested resizes, counted at the container level. Different resources
@@ -975,6 +1239,9 @@
   - operation
   - requirement
   - resource
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: containers_per_pod_count
   subsystem: kubelet
   help: The number of containers per pod.
@@ -986,6 +1253,9 @@
   - 4
   - 8
   - 16
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: cpu_manager_allocation_per_numa
   subsystem: kubelet
   help: Number of CPUs allocated per NUMA node
@@ -993,27 +1263,42 @@
   stabilityLevel: ALPHA
   labels:
   - numa_node
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: cpu_manager_exclusive_cpu_allocation_count
   subsystem: kubelet
   help: The total number of CPUs exclusively allocated to containers running on this
     node
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: cpu_manager_pinning_errors_total
   subsystem: kubelet
   help: The number of cpu core allocations which required pinning failed.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: cpu_manager_pinning_requests_total
   subsystem: kubelet
   help: The number of cpu core allocations which required pinning.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: cpu_manager_shared_pool_size_millicores
   subsystem: kubelet
   help: The size of the shared CPU pool for non-guaranteed QoS pods, in millicores.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: cri_losing_support
   subsystem: kubelet
   help: the Kubernetes version that the currently running CRI implementation will
@@ -1022,6 +1307,9 @@
   stabilityLevel: ALPHA
   labels:
   - version
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: desired_pods
   subsystem: kubelet
   help: The number of pods the kubelet is being instructed to run. static is true
@@ -1030,6 +1318,9 @@
   stabilityLevel: ALPHA
   labels:
   - static
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: device_plugin_alloc_duration_seconds
   subsystem: kubelet
   help: Duration in seconds to serve a device plugin Allocation request. Broken down
@@ -1050,6 +1341,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: device_plugin_registration_total
   subsystem: kubelet
   help: Cumulative number of device plugin registrations. Broken down by resource
@@ -1058,12 +1352,18 @@
   stabilityLevel: ALPHA
   labels:
   - resource_name
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: evented_pleg_connection_error_count
   subsystem: kubelet
   help: The number of errors encountered during the establishment of streaming connection
     with the CRI runtime.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: evented_pleg_connection_latency_seconds
   subsystem: kubelet
   help: The latency of streaming connection with the CRI runtime, measured in seconds.
@@ -1081,11 +1381,17 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: evented_pleg_connection_success_count
   subsystem: kubelet
   help: The number of times a streaming client was obtained to receive CRI Events.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: eviction_stats_age_seconds
   subsystem: kubelet
   help: Time between when stats are collected, and when pod is evicted based on those
@@ -1106,6 +1412,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: evictions
   subsystem: kubelet
   help: Cumulative number of pod evictions by eviction signal
@@ -1113,16 +1422,25 @@
   stabilityLevel: ALPHA
   labels:
   - eviction_signal
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: graceful_shutdown_end_time_seconds
   subsystem: kubelet
   help: Last graceful shutdown end time since unix epoch in seconds
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: graceful_shutdown_start_time_seconds
   subsystem: kubelet
   help: Last graceful shutdown start time since unix epoch in seconds
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: http_inflight_requests
   subsystem: kubelet
   help: Number of the inflight http requests
@@ -1133,6 +1451,9 @@
   - method
   - path
   - server_type
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: http_requests_duration_seconds
   subsystem: kubelet
   help: Duration in seconds to serve http requests
@@ -1155,6 +1476,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: http_requests_total
   subsystem: kubelet
   help: Number of the http requests received since the server started
@@ -1165,6 +1489,9 @@
   - method
   - path
   - server_type
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: image_garbage_collected_total
   subsystem: kubelet
   help: Total number of images garbage collected by the kubelet, whether through disk
@@ -1173,6 +1500,9 @@
   stabilityLevel: ALPHA
   labels:
   - reason
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: image_manager_ensure_image_requests_total
   subsystem: kubelet
   help: Number of ensure-image requests processed by the kubelet.
@@ -1182,6 +1512,9 @@
   - present_locally
   - pull_policy
   - pull_required
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: image_pull_duration_seconds
   subsystem: kubelet
   help: Duration in seconds to pull an image.
@@ -1208,6 +1541,9 @@
   - 1800
   - 2700
   - 3600
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: imagemanager_image_mustpull_checks_total
   subsystem: kubelet
   help: Counter for how many times kubelet checked whether credentials need to be
@@ -1216,53 +1552,94 @@
   stabilityLevel: ALPHA
   labels:
   - result
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: imagemanager_inmemory_pulledrecords_usage_percent
   subsystem: kubelet
   help: The ImagePulledRecords in-memory cache usage in percent.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: imagemanager_inmemory_pullintents_usage_percent
   subsystem: kubelet
   help: The ImagePullIntents in-memory cache usage in percent.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: imagemanager_ondisk_pulledrecords
   subsystem: kubelet
   help: Number of ImagePulledRecords stored on disk.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: imagemanager_ondisk_pullintents
   subsystem: kubelet
   help: Number of ImagePullIntents stored on disk.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: lifecycle_handler_http_fallbacks_total
   subsystem: kubelet
   help: The number of times lifecycle handlers successfully fell back to http from
     https.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: managed_ephemeral_containers
   subsystem: kubelet
   help: Current number of ephemeral containers in pods managed by this kubelet.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: memory_manager_pinning_errors_total
   subsystem: kubelet
   help: The number of memory pages allocations which required pinning that failed.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: memory_manager_pinning_requests_total
   subsystem: kubelet
   help: The number of memory pages allocations which required pinning.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
+- name: metrics_provider
+  subsystem: kubelet
+  help: Metrics provider used by kubelet to collect container stats. Values can be
+    'cadvisor' and 'cri'
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - provider
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: mirror_pods
   subsystem: kubelet
   help: The number of mirror pods the kubelet will try to create (one per admitted
     static pod)
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: node_name
   subsystem: kubelet
   help: The node's name. The count is always 1.
@@ -1270,43 +1647,67 @@
   stabilityLevel: ALPHA
   labels:
   - node
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: node_startup_duration_seconds
   subsystem: kubelet
   help: Duration in seconds of node startup in total.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: node_startup_post_registration_duration_seconds
   subsystem: kubelet
   help: Duration in seconds of node startup after registration.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: node_startup_pre_kubelet_duration_seconds
   subsystem: kubelet
   help: Duration in seconds of node startup before kubelet starts.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: node_startup_pre_registration_duration_seconds
   subsystem: kubelet
   help: Duration in seconds of node startup before registration.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: node_startup_registration_duration_seconds
   subsystem: kubelet
   help: Duration in seconds of node startup during registration.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: orphan_pod_cleaned_volumes
   subsystem: kubelet
   help: The total number of orphaned Pods whose volumes were cleaned in the last periodic
     sweep.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: orphan_pod_cleaned_volumes_errors
   subsystem: kubelet
   help: The number of orphaned Pods whose volumes failed to be cleaned in the last
     periodic sweep.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: orphaned_runtime_pods_total
   subsystem: kubelet
   help: Number of pods that have been detected in the container runtime without being
@@ -1315,16 +1716,25 @@
     is unusual.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pleg_discard_events
   subsystem: kubelet
   help: The number of discard events in PLEG.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pleg_last_seen_seconds
   subsystem: kubelet
   help: Timestamp in seconds when PLEG was last seen active.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pleg_relist_duration_seconds
   subsystem: kubelet
   help: Duration in seconds for relisting pods in PLEG.
@@ -1342,6 +1752,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pleg_relist_interval_seconds
   subsystem: kubelet
   help: Interval in seconds between relisting in PLEG.
@@ -1359,6 +1772,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_deferred_accepted_resizes_total
   subsystem: kubelet
   help: Cumulative number of resizes that were accepted after being deferred.
@@ -1366,11 +1782,17 @@
   stabilityLevel: ALPHA
   labels:
   - retry_trigger
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_in_progress_resizes
   subsystem: kubelet
   help: Number of in-progress resizes for pods.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_infeasible_resizes_total
   subsystem: kubelet
   help: Number of infeasible resizes for pods.
@@ -1378,6 +1800,9 @@
   stabilityLevel: ALPHA
   labels:
   - reason_detail
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_pending_resizes
   subsystem: kubelet
   help: Number of pending resizes for pods.
@@ -1385,6 +1810,9 @@
   stabilityLevel: ALPHA
   labels:
   - reason
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_resize_duration_milliseconds
   subsystem: kubelet
   help: Duration in milliseconds to actuate a pod resize
@@ -1407,6 +1835,9 @@
   - 120000
   - 300000
   - 600000
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_resources_endpoint_errors_get
   subsystem: kubelet
   help: Number of requests to the PodResource Get endpoint which returned error. Broken
@@ -1415,6 +1846,9 @@
   stabilityLevel: ALPHA
   labels:
   - server_api_version
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_resources_endpoint_errors_get_allocatable
   subsystem: kubelet
   help: Number of requests to the PodResource GetAllocatableResources endpoint which
@@ -1423,6 +1857,9 @@
   stabilityLevel: ALPHA
   labels:
   - server_api_version
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_resources_endpoint_errors_list
   subsystem: kubelet
   help: Number of requests to the PodResource List endpoint which returned error.
@@ -1431,6 +1868,9 @@
   stabilityLevel: ALPHA
   labels:
   - server_api_version
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_resources_endpoint_requests_get
   subsystem: kubelet
   help: Number of requests to the PodResource Get endpoint. Broken down by server
@@ -1439,6 +1879,9 @@
   stabilityLevel: ALPHA
   labels:
   - server_api_version
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_resources_endpoint_requests_get_allocatable
   subsystem: kubelet
   help: Number of requests to the PodResource GetAllocatableResources endpoint. Broken
@@ -1447,6 +1890,9 @@
   stabilityLevel: ALPHA
   labels:
   - server_api_version
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_resources_endpoint_requests_list
   subsystem: kubelet
   help: Number of requests to the PodResource List endpoint. Broken down by server
@@ -1455,6 +1901,9 @@
   stabilityLevel: ALPHA
   labels:
   - server_api_version
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_resources_endpoint_requests_total
   subsystem: kubelet
   help: Cumulative number of requests to the PodResource endpoint. Broken down by
@@ -1463,6 +1912,9 @@
   stabilityLevel: ALPHA
   labels:
   - server_api_version
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_start_duration_seconds
   subsystem: kubelet
   help: Duration in seconds from kubelet seeing a pod for the first time to the pod
@@ -1495,6 +1947,9 @@
   - 1800
   - 2700
   - 3600
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_start_sli_duration_seconds
   subsystem: kubelet
   help: Duration in seconds to start a pod, excluding time to pull images and run
@@ -1528,6 +1983,9 @@
   - 1800
   - 2700
   - 3600
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_start_total_duration_seconds
   subsystem: kubelet
   help: Duration in seconds to start a pod since creation, including time to pull
@@ -1561,6 +2019,9 @@
   - 1800
   - 2700
   - 3600
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_status_sync_duration_seconds
   subsystem: kubelet
   help: Duration in seconds to sync a pod status update. Measures time from detection
@@ -1580,6 +2041,9 @@
   - 30
   - 45
   - 60
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_worker_duration_seconds
   subsystem: kubelet
   help: 'Duration in seconds to sync a single pod. Broken down by operation type:
@@ -1600,6 +2064,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_worker_start_duration_seconds
   subsystem: kubelet
   help: Duration in seconds from kubelet seeing a pod to starting a worker.
@@ -1617,6 +2084,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: kubelet_podcertificate_states
   help: Gauge vector reporting the number of pod certificate projected volume sources,
     faceted by signer_name and state.
@@ -1625,6 +2095,9 @@
   labels:
   - signer_name
   - state
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: preemptions
   subsystem: kubelet
   help: Cumulative number of pod preemptions by preemption resource
@@ -1632,6 +2105,9 @@
   stabilityLevel: ALPHA
   labels:
   - preemption_signal
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: restarted_pods_total
   subsystem: kubelet
   help: Number of pods that have been restarted because they were deleted and recreated
@@ -1641,6 +2117,9 @@
   stabilityLevel: ALPHA
   labels:
   - static
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: run_podsandbox_duration_seconds
   subsystem: kubelet
   help: Duration in seconds of the run_podsandbox operations. Broken down by RuntimeClass.Handler.
@@ -1660,6 +2139,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: run_podsandbox_errors_total
   subsystem: kubelet
   help: Cumulative number of the run_podsandbox operation errors by RuntimeClass.Handler.
@@ -1667,6 +2149,9 @@
   stabilityLevel: ALPHA
   labels:
   - runtime_handler
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: running_containers
   subsystem: kubelet
   help: Number of containers currently running
@@ -1674,11 +2159,17 @@
   stabilityLevel: ALPHA
   labels:
   - container_state
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: running_pods
   subsystem: kubelet
   help: Number of pods that have a running pod sandbox
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: runtime_operations_duration_seconds
   subsystem: kubelet
   help: Duration in seconds of runtime operations. Broken down by operation type.
@@ -1701,6 +2192,9 @@
   - 119.20928955078125
   - 298.0232238769531
   - 745.0580596923828
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: runtime_operations_errors_total
   subsystem: kubelet
   help: Cumulative number of runtime operation errors by operation type.
@@ -1708,6 +2202,9 @@
   stabilityLevel: ALPHA
   labels:
   - operation_type
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: runtime_operations_total
   subsystem: kubelet
   help: Cumulative number of runtime operations by operation type.
@@ -1715,11 +2212,17 @@
   stabilityLevel: ALPHA
   labels:
   - operation_type
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: sleep_action_terminated_early_total
   subsystem: kubelet
   help: The number of times lifecycle sleep handler got terminated before it finishes
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: started_containers_errors_total
   subsystem: kubelet
   help: Cumulative number of errors when starting containers
@@ -1728,6 +2231,9 @@
   labels:
   - code
   - container_type
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: started_containers_total
   subsystem: kubelet
   help: Cumulative number of containers started
@@ -1735,6 +2241,9 @@
   stabilityLevel: ALPHA
   labels:
   - container_type
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: started_host_process_containers_errors_total
   subsystem: kubelet
   help: Cumulative number of errors when starting hostprocess containers. This metric
@@ -1744,6 +2253,9 @@
   labels:
   - code
   - container_type
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: started_host_process_containers_total
   subsystem: kubelet
   help: Cumulative number of hostprocess containers started. This metric will only
@@ -1752,28 +2264,43 @@
   stabilityLevel: ALPHA
   labels:
   - container_type
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: started_pods_errors_total
   subsystem: kubelet
   help: Cumulative number of errors when starting pods
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: started_pods_total
   subsystem: kubelet
   help: Cumulative number of pods started
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: started_user_namespaced_pods_errors_total
   subsystem: kubelet
   help: Cumulative number of errors when starting pods with user namespaces. This
     metric will only be collected on Linux.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: started_user_namespaced_pods_total
   subsystem: kubelet
   help: Cumulative number of pods with user namespaces started. This metric will only
     be collected on Linux.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: topology_manager_admission_duration_ms
   subsystem: kubelet
   help: Duration in milliseconds to serve a pod admission request.
@@ -1795,16 +2322,25 @@
   - 204.8
   - 409.6
   - 819.2
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: topology_manager_admission_errors_total
   subsystem: kubelet
   help: The number of admission request failures where resources could not be aligned.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: topology_manager_admission_requests_total
   subsystem: kubelet
   help: The number of admission requests where resources have to be aligned.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_metric_collection_duration_seconds
   subsystem: kubelet
   help: Duration in seconds to calculate volume stats
@@ -1824,6 +2360,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: kubelet_volume_stats_available_bytes
   help: Number of available bytes in the volume
   type: Custom
@@ -1831,6 +2370,9 @@
   labels:
   - namespace
   - persistentvolumeclaim
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: kubelet_volume_stats_capacity_bytes
   help: Capacity in bytes of the volume
   type: Custom
@@ -1838,6 +2380,9 @@
   labels:
   - namespace
   - persistentvolumeclaim
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: kubelet_volume_stats_health_status_abnormal
   help: Abnormal volume health status. The count is either 1 or 0. 1 indicates the
     volume is unhealthy, 0 indicates volume is healthy
@@ -1846,6 +2391,9 @@
   labels:
   - namespace
   - persistentvolumeclaim
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: kubelet_volume_stats_inodes
   help: Maximum number of inodes in the volume
   type: Custom
@@ -1853,6 +2401,9 @@
   labels:
   - namespace
   - persistentvolumeclaim
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: kubelet_volume_stats_inodes_free
   help: Number of free inodes in the volume
   type: Custom
@@ -1860,6 +2411,9 @@
   labels:
   - namespace
   - persistentvolumeclaim
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: kubelet_volume_stats_inodes_used
   help: Number of used inodes in the volume
   type: Custom
@@ -1867,6 +2421,9 @@
   labels:
   - namespace
   - persistentvolumeclaim
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: kubelet_volume_stats_used_bytes
   help: Number of used bytes in the volume
   type: Custom
@@ -1874,6 +2431,9 @@
   labels:
   - namespace
   - persistentvolumeclaim
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: working_pods
   subsystem: kubelet
   help: Number of pods the kubelet is actually running, broken down by lifecycle phase,
@@ -1886,10 +2446,16 @@
   - config
   - lifecycle
   - static
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: node_swap_usage_bytes
   help: Current swap usage of the node in bytes. Reported only on non-windows systems
   type: Custom
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: plugin_manager_total_plugins
   help: Number of plugins in Plugin Manager
   type: Custom
@@ -1897,6 +2463,9 @@
   labels:
   - socket_path
   - state
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: pod_swap_usage_bytes
   help: Current amount of the pod swap usage in bytes. Reported only on non-windows
     systems
@@ -1905,6 +2474,9 @@
   labels:
   - pod
   - namespace
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: probe_duration_seconds
   subsystem: prober
   help: Duration in seconds for a probe response.
@@ -1915,26 +2487,41 @@
   - namespace
   - pod
   - probe_type
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/probes
 - name: scrape_error
   help: 1 if there was an error while getting container metrics, 0 otherwise
   type: Custom
   deprecatedVersion: 1.29.0
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: image_volume_mounted_errors_total
   subsystem: kubelet
   help: Number of failed image volume mounts.
   type: Counter
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: image_volume_mounted_succeed_total
   subsystem: kubelet
   help: Number of successful image volume mounts.
   type: Counter
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: image_volume_requested_total
   subsystem: kubelet
   help: Number of requested image volumes.
   type: Counter
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: probe_total
   subsystem: prober
   help: Cumulative number of a liveness, readiness or startup probe for a container
@@ -1948,6 +2535,9 @@
   - pod_uid
   - probe_type
   - result
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/probes
 - name: container_cpu_usage_seconds_total
   help: Cumulative cpu time consumed by the container in core-seconds
   type: Custom
@@ -1956,6 +2546,9 @@
   - container
   - pod
   - namespace
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: container_memory_working_set_bytes
   help: Current working set of the container in bytes
   type: Custom
@@ -1964,6 +2557,9 @@
   - container
   - pod
   - namespace
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: container_start_time_seconds
   help: Start time of the container since unix epoch in seconds
   type: Custom
@@ -1972,14 +2568,23 @@
   - container
   - pod
   - namespace
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: node_cpu_usage_seconds_total
   help: Cumulative cpu time consumed by the node in core-seconds
   type: Custom
   stabilityLevel: STABLE
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: node_memory_working_set_bytes
   help: Current working set of the node in bytes
   type: Custom
   stabilityLevel: STABLE
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: pod_cpu_usage_seconds_total
   help: Cumulative cpu time consumed by the pod in core-seconds
   type: Custom
@@ -1987,6 +2592,9 @@
   labels:
   - pod
   - namespace
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: pod_memory_working_set_bytes
   help: Current working set of the pod in bytes
   type: Custom
@@ -1994,20 +2602,32 @@
   labels:
   - pod
   - namespace
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: resource_scrape_error
   help: 1 if there was an error while getting container metrics, 0 otherwise
   type: Custom
   stabilityLevel: STABLE
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics/resource
 - name: force_cleaned_failed_volume_operation_errors_total
   help: The number of volumes that failed force cleanup after their reconstruction
     failed during kubelet startup.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: force_cleaned_failed_volume_operations_total
   help: The number of volumes that were force cleaned after their reconstruction failed
     during kubelet startup. This includes both successful and failed cleanups.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: conntrack_reconciler_deleted_entries_total
   subsystem: kubeproxy
   help: Cumulative conntrack flows deleted by conntrack reconciler
@@ -2015,6 +2635,9 @@
   stabilityLevel: ALPHA
   labels:
   - ip_family
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: conntrack_reconciler_sync_duration_seconds
   subsystem: kubeproxy
   help: ReconcileConntrackFlowsLatency latency in seconds
@@ -2038,14 +2661,23 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: kubeproxy_iptables_ct_state_invalid_dropped_packets_total
   help: packets dropped by iptables to work around conntrack problems
   type: Custom
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: kubeproxy_iptables_localhost_nodeports_accepted_packets_total
   help: Number of packets accepted on nodeports of loopback interface
   type: Custom
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: network_programming_duration_seconds
   subsystem: kubeproxy
   help: In Cluster Network Programming Latency in seconds
@@ -2134,6 +2766,9 @@
   - 240
   - 270
   - 300
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: proxy_healthz_total
   subsystem: kubeproxy
   help: Cumulative proxy healthz HTTP status
@@ -2141,6 +2776,9 @@
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: proxy_livez_total
   subsystem: kubeproxy
   help: Cumulative proxy livez HTTP status
@@ -2148,6 +2786,9 @@
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_full_proxy_rules_duration_seconds
   subsystem: kubeproxy
   help: SyncProxyRules latency in seconds for full resyncs
@@ -2171,6 +2812,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_partial_proxy_rules_duration_seconds
   subsystem: kubeproxy
   help: SyncProxyRules latency in seconds for partial resyncs
@@ -2194,6 +2838,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_duration_seconds
   subsystem: kubeproxy
   help: SyncProxyRules latency in seconds
@@ -2217,16 +2864,25 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_endpoint_changes_pending
   subsystem: kubeproxy
   help: Pending proxy rules Endpoint changes
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_endpoint_changes_total
   subsystem: kubeproxy
   help: Cumulative proxy rules Endpoint changes
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_iptables_last
   subsystem: kubeproxy
   help: Number of iptables rules written by kube-proxy in last sync
@@ -2235,6 +2891,9 @@
   labels:
   - ip_family
   - table
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_iptables_partial_restore_failures_total
   subsystem: kubeproxy
   help: Cumulative proxy iptables partial restore failures
@@ -2242,6 +2901,9 @@
   stabilityLevel: ALPHA
   labels:
   - ip_family
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_iptables_restore_failures_total
   subsystem: kubeproxy
   help: Cumulative proxy iptables restore failures
@@ -2249,6 +2911,9 @@
   stabilityLevel: ALPHA
   labels:
   - ip_family
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_iptables_total
   subsystem: kubeproxy
   help: Total number of iptables rules owned by kube-proxy
@@ -2257,6 +2922,9 @@
   labels:
   - ip_family
   - table
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_last_queued_timestamp_seconds
   subsystem: kubeproxy
   help: The last time a sync of proxy rules was queued
@@ -2264,6 +2932,9 @@
   stabilityLevel: ALPHA
   labels:
   - ip_family
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_last_timestamp_seconds
   subsystem: kubeproxy
   help: The last time proxy rules were successfully synced
@@ -2271,6 +2942,9 @@
   stabilityLevel: ALPHA
   labels:
   - ip_family
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_nftables_cleanup_failures_total
   subsystem: kubeproxy
   help: Cumulative proxy nftables cleanup failures
@@ -2278,6 +2952,9 @@
   stabilityLevel: ALPHA
   labels:
   - ip_family
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_nftables_sync_failures_total
   subsystem: kubeproxy
   help: Cumulative proxy nftables sync failures
@@ -2285,6 +2962,9 @@
   stabilityLevel: ALPHA
   labels:
   - ip_family
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_no_local_endpoints_total
   subsystem: kubeproxy
   help: Number of services with a Local traffic policy and no endpoints
@@ -2293,26 +2973,41 @@
   labels:
   - ip_family
   - traffic_policy
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_service_changes_pending
   subsystem: kubeproxy
   help: Pending proxy rules Service changes
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: sync_proxy_rules_service_changes_total
   subsystem: kubeproxy
   help: Cumulative proxy rules Service changes
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: reconstruct_volume_operations_errors_total
   help: The number of volumes that failed reconstruction from the operating system
     during kubelet startup.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: reconstruct_volume_operations_total
   help: The number of volumes that were attempted to be reconstructed from the operating
     system during kubelet startup. This includes both successful and failed reconstruction.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_manager_selinux_container_errors_total
   help: Number of errors when kubelet cannot compute SELinux context for a container.
     Kubelet can't start such a Pod then and it will retry, therefore value of this
@@ -2321,6 +3016,9 @@
   stabilityLevel: ALPHA
   labels:
   - access_mode
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_manager_selinux_container_warnings_total
   help: Number of errors when kubelet cannot compute SELinux context for a container
     that are ignored. They will become real errors when SELinuxMountReadWriteOncePod
@@ -2329,6 +3027,9 @@
   stabilityLevel: ALPHA
   labels:
   - access_mode
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_manager_selinux_pod_context_mismatch_errors_total
   help: Number of errors when a Pod defines different SELinux contexts for its containers
     that use the same volume. Kubelet can't start such a Pod then and it will retry,
@@ -2337,6 +3038,9 @@
   stabilityLevel: ALPHA
   labels:
   - access_mode
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_manager_selinux_pod_context_mismatch_warnings_total
   help: Number of errors when a Pod defines different SELinux contexts for its containers
     that use the same volume. They are not errors yet, but they will become real errors
@@ -2345,6 +3049,9 @@
   stabilityLevel: ALPHA
   labels:
   - access_mode
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_manager_selinux_volume_context_mismatch_errors_total
   help: Number of errors when a Pod uses a volume that is already mounted with a different
     SELinux context than the Pod needs. Kubelet can't start such a Pod then and it
@@ -2355,6 +3062,9 @@
   labels:
   - access_mode
   - volume_plugin
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_manager_selinux_volume_context_mismatch_warnings_total
   help: Number of errors when a Pod uses a volume that is already mounted with a different
     SELinux context than the Pod needs. They are not errors yet, but they will become
@@ -2365,6 +3075,9 @@
   labels:
   - access_mode
   - volume_plugin
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_manager_selinux_volumes_admitted_total
   help: Number of volumes whose SELinux context was fine and will be mounted with
     mount -o context option.
@@ -2373,6 +3086,9 @@
   labels:
   - access_mode
   - volume_plugin
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_manager_total_volumes
   help: Number of volumes in Volume Manager
   type: Custom
@@ -2380,6 +3096,9 @@
   labels:
   - plugin_name
   - state
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: csr_honored_duration_total
   subsystem: certificates_registry
   namespace: apiserver
@@ -2389,6 +3108,9 @@
   stabilityLevel: ALPHA
   labels:
   - signerName
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: csr_requested_duration_total
   subsystem: certificates_registry
   namespace: apiserver
@@ -2398,6 +3120,9 @@
   stabilityLevel: ALPHA
   labels:
   - signerName
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: ip_errors_total
   subsystem: clusterip_repair
   namespace: apiserver
@@ -2407,12 +3132,18 @@
   stabilityLevel: ALPHA
   labels:
   - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: reconcile_errors_total
   subsystem: clusterip_repair
   namespace: apiserver
   help: Number of reconciliation failures on the clusterip repair reconcile loop
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: port_errors_total
   subsystem: nodeport_repair
   namespace: apiserver
@@ -2422,12 +3153,18 @@
   stabilityLevel: ALPHA
   labels:
   - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: reconcile_errors_total
   subsystem: nodeport_repair
   namespace: apiserver
   help: Number of reconciliation failures on the nodeport repair reconcile loop
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: allocated_ips
   subsystem: clusterip_allocator
   namespace: kube_apiserver
@@ -2436,6 +3173,9 @@
   stabilityLevel: ALPHA
   labels:
   - cidr
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: allocation_duration_seconds
   subsystem: clusterip_allocator
   namespace: kube_apiserver
@@ -2456,6 +3196,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: allocation_errors_total
   subsystem: clusterip_allocator
   namespace: kube_apiserver
@@ -2465,6 +3208,9 @@
   labels:
   - cidr
   - scope
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: allocation_total
   subsystem: clusterip_allocator
   namespace: kube_apiserver
@@ -2474,6 +3220,9 @@
   labels:
   - cidr
   - scope
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: available_ips
   subsystem: clusterip_allocator
   namespace: kube_apiserver
@@ -2482,12 +3231,18 @@
   stabilityLevel: ALPHA
   labels:
   - cidr
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: allocated_ports
   subsystem: nodeport_allocator
   namespace: kube_apiserver
   help: Gauge measuring the number of allocated NodePorts for Services
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: allocation_errors_total
   subsystem: nodeport_allocator
   namespace: kube_apiserver
@@ -2496,6 +3251,9 @@
   stabilityLevel: ALPHA
   labels:
   - scope
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: allocation_total
   subsystem: nodeport_allocator
   namespace: kube_apiserver
@@ -2504,12 +3262,18 @@
   stabilityLevel: ALPHA
   labels:
   - scope
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: available_ports
   subsystem: nodeport_allocator
   namespace: kube_apiserver
   help: Gauge measuring the number of available NodePorts for Services
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: backend_tls_failure_total
   subsystem: pod_logs
   namespace: kube_apiserver
@@ -2517,6 +3281,9 @@
     verification
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: insecure_backend_total
   subsystem: pod_logs
   namespace: kube_apiserver
@@ -2526,6 +3293,9 @@
   stabilityLevel: ALPHA
   labels:
   - usage
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: pods_logs_backend_tls_failure_total
   subsystem: pod_logs
   namespace: kube_apiserver
@@ -2534,6 +3304,9 @@
   type: Counter
   deprecatedVersion: 1.27.0
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: pods_logs_insecure_backend_total
   subsystem: pod_logs
   namespace: kube_apiserver
@@ -2544,6 +3317,9 @@
   stabilityLevel: ALPHA
   labels:
   - usage
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: async_api_call_execution_duration_seconds
   subsystem: scheduler
   help: Duration in seconds for executing API call in the async dispatcher.
@@ -2568,6 +3344,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: async_api_call_execution_total
   subsystem: scheduler
   help: Total number of API calls executed by the async dispatcher.
@@ -2576,6 +3355,9 @@
   labels:
   - call_type
   - result
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: batch_attempts_total
   subsystem: scheduler
   help: Counts of results when we attempt to use batching.
@@ -2584,6 +3366,9 @@
   labels:
   - profile
   - result
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: batch_cache_flushed_total
   subsystem: scheduler
   help: Counts of cache flushes by reason.
@@ -2592,6 +3377,9 @@
   labels:
   - profile
   - reason
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: cache_size
   subsystem: scheduler
   help: Number of nodes, pods, and assumed (bound) pods in the scheduler cache.
@@ -2599,6 +3387,9 @@
   stabilityLevel: ALPHA
   labels:
   - type
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: event_handling_duration_seconds
   subsystem: scheduler
   help: Event handling latency in seconds.
@@ -2619,6 +3410,9 @@
   - 0.0512
   - 0.1024
   - 0.2048
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: get_node_hint_duration_seconds
   subsystem: scheduler
   help: Latency for getting a node hint.
@@ -2640,6 +3434,9 @@
   - 0.00512
   - 0.01024
   - 0.02048
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: goroutines
   subsystem: scheduler
   help: Number of running goroutines split by the work they do such as binding.
@@ -2647,6 +3444,9 @@
   stabilityLevel: ALPHA
   labels:
   - operation
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: inflight_events
   subsystem: scheduler
   help: Number of events currently tracked in the scheduling queue.
@@ -2654,6 +3454,9 @@
   stabilityLevel: ALPHA
   labels:
   - event
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: pending_async_api_calls
   subsystem: scheduler
   help: Number of API calls currently pending in the async queue.
@@ -2661,6 +3464,9 @@
   stabilityLevel: ALPHA
   labels:
   - call_type
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: permit_wait_duration_seconds
   subsystem: scheduler
   help: Duration of waiting on permit.
@@ -2684,6 +3490,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: plugin_evaluation_total
   subsystem: scheduler
   help: Number of attempts to schedule pods by each plugin and the extension point
@@ -2694,6 +3503,9 @@
   - extension_point
   - plugin
   - profile
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: plugin_execution_duration_seconds
   subsystem: scheduler
   help: Duration for running a plugin at a specific extension point.
@@ -2724,6 +3536,9 @@
   - 0.009852612533569338
   - 0.014778918800354007
   - 0.02216837820053101
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: pod_scheduled_after_flush_total
   subsystem: scheduler
   help: Number of pods that were successfully scheduled after being flushed from unschedulablePods
@@ -2731,6 +3546,73 @@
     or event handling issues.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: podgroup_schedule_attempts_total
+  subsystem: scheduler
+  help: Number of attempts to schedule pod group, by the result. 'unschedulable' means
+    a pod group could not be scheduled, while 'error' means an internal scheduler
+    problem.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - profile
+  - result
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: podgroup_scheduling_algorithm_duration_seconds
+  subsystem: scheduler
+  help: Pod group scheduling algorithm latency in seconds
+  type: Histogram
+  stabilityLevel: ALPHA
+  buckets:
+  - 0.001
+  - 0.002
+  - 0.004
+  - 0.008
+  - 0.016
+  - 0.032
+  - 0.064
+  - 0.128
+  - 0.256
+  - 0.512
+  - 1.024
+  - 2.048
+  - 4.096
+  - 8.192
+  - 16.384
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: podgroup_scheduling_attempt_duration_seconds
+  subsystem: scheduler
+  help: Pod group scheduling attempt latency in seconds (scheduling algorithm + binding)
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - profile
+  - result
+  buckets:
+  - 0.001
+  - 0.002
+  - 0.004
+  - 0.008
+  - 0.016
+  - 0.032
+  - 0.064
+  - 0.128
+  - 0.256
+  - 0.512
+  - 1.024
+  - 2.048
+  - 4.096
+  - 8.192
+  - 16.384
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: preemption_goroutines_duration_seconds
   subsystem: scheduler
   help: Duration in seconds for running goroutines for the preemption.
@@ -2759,6 +3641,9 @@
   - 1310.72
   - 2621.44
   - 5242.88
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: preemption_goroutines_execution_total
   subsystem: scheduler
   help: Number of preemption goroutines executed.
@@ -2766,6 +3651,9 @@
   stabilityLevel: ALPHA
   labels:
   - result
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: queueing_hint_execution_duration_seconds
   subsystem: scheduler
   help: Duration for running a queueing hint function of a plugin.
@@ -2796,6 +3684,9 @@
   - 0.009852612533569338
   - 0.014778918800354007
   - 0.02216837820053101
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: resourceclaim_creates_total
   subsystem: scheduler
   help: Number of ResourceClaims creation requests within scheduler
@@ -2803,6 +3694,9 @@
   stabilityLevel: ALPHA
   labels:
   - status
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: scheduling_algorithm_duration_seconds
   subsystem: scheduler
   help: Scheduling algorithm latency in seconds
@@ -2824,6 +3718,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: store_schedule_results_duration_seconds
   subsystem: scheduler
   help: Latency for getting a no.
@@ -2844,6 +3741,9 @@
   - 0.00512
   - 0.01024
   - 0.02048
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: unschedulable_pods
   subsystem: scheduler
   help: The number of unschedulable pods broken down by plugin name. A pod will increment
@@ -2854,6 +3754,9 @@
   labels:
   - plugin
   - profile
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: binder_cache_requests_total
   subsystem: scheduler_volume
   help: Total number for request volume binding cache
@@ -2861,6 +3764,9 @@
   stabilityLevel: ALPHA
   labels:
   - operation
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: scheduling_stage_error_total
   subsystem: scheduler_volume
   help: Volume scheduling stage error count
@@ -2868,6 +3774,9 @@
   stabilityLevel: ALPHA
   labels:
   - operation
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: pod_scheduling_sli_duration_seconds
   subsystem: scheduler
   help: E2e latency for a pod being scheduled, from the time the pod enters the scheduling
@@ -2897,6 +3806,9 @@
   - 1310.72
   - 2621.44
   - 5242.88
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: kube_pod_resource_limit
   help: Resources limit for workloads on the cluster, broken down by pod. This shows
     the resource usage the scheduler and kubelet expect per pod for resources along
@@ -2911,6 +3823,9 @@
   - priority
   - resource
   - unit
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: kube_pod_resource_request
   help: Resources requested by workloads on the cluster, broken down by pod. This
     shows the resource usage the scheduler and kubelet expect per pod for resources
@@ -2925,6 +3840,9 @@
   - priority
   - resource
   - unit
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: framework_extension_point_duration_seconds
   subsystem: scheduler
   help: Latency for running all plugins of a specific extension point.
@@ -2947,6 +3865,9 @@
   - 0.0512
   - 0.1024
   - 0.2048
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: pending_pods
   subsystem: scheduler
   help: Number of pending pods, by the queue type. 'active' means number of pods in
@@ -2958,6 +3879,9 @@
   stabilityLevel: STABLE
   labels:
   - queue
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: pod_scheduling_attempts
   subsystem: scheduler
   help: Number of attempts to successfully schedule a pod.
@@ -2969,11 +3893,17 @@
   - 4
   - 8
   - 16
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: preemption_attempts_total
   subsystem: scheduler
   help: Total preemption attempts in the cluster till now
   type: Counter
   stabilityLevel: STABLE
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: preemption_victims
   subsystem: scheduler
   help: Number of selected preemption victims
@@ -2987,6 +3917,9 @@
   - 16
   - 32
   - 64
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: queue_incoming_pods_total
   subsystem: scheduler
   help: Number of pods added to scheduling queues by event and queue type.
@@ -2995,6 +3928,9 @@
   labels:
   - event
   - queue
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: schedule_attempts_total
   subsystem: scheduler
   help: Number of attempts to schedule pods, by the result. 'unschedulable' means
@@ -3004,6 +3940,9 @@
   labels:
   - profile
   - result
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: scheduling_attempt_duration_seconds
   subsystem: scheduler
   help: Scheduling attempt latency in seconds (scheduling algorithm + binding)
@@ -3028,6 +3967,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: fetch_keys_data_timestamp
   subsystem: externaljwt
   namespace: apiserver
@@ -3035,6 +3977,9 @@
     value returned by the external signer
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: fetch_keys_request_total
   subsystem: externaljwt
   namespace: apiserver
@@ -3043,12 +3988,18 @@
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: fetch_keys_success_timestamp
   subsystem: externaljwt
   namespace: apiserver
   help: Unix Timestamp in seconds of the last successful FetchKeys request
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_duration_seconds
   subsystem: externaljwt
   namespace: apiserver
@@ -3073,6 +4024,9 @@
   - 10
   - 30
   - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: sign_request_total
   subsystem: externaljwt
   namespace: apiserver
@@ -3081,6 +4035,9 @@
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: operations_seconds
   subsystem: csi
   help: Container Storage Interface operation duration with gRPC error code status
@@ -3106,36 +4063,57 @@
   - 120
   - 300
   - 600
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: invalid_legacy_auto_token_uses_total
   subsystem: serviceaccount
   help: Cumulative invalid auto-generated legacy tokens used
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: legacy_auto_token_uses_total
   subsystem: serviceaccount
   help: Cumulative auto-generated legacy tokens used
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: legacy_manual_token_uses_total
   subsystem: serviceaccount
   help: Cumulative manually created legacy tokens used
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: legacy_tokens_total
   subsystem: serviceaccount
   help: Cumulative legacy service account tokens used
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: stale_tokens_total
   subsystem: serviceaccount
   help: Cumulative stale projected service account tokens used
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: valid_tokens_total
   subsystem: serviceaccount
   help: Cumulative valid projected service account tokens used
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: storage_operation_duration_seconds
   help: Storage operation duration
   type: Histogram
@@ -3159,6 +4137,9 @@
   - 120
   - 300
   - 600
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: volume_operation_total_seconds
   help: Storage operation end to end duration in seconds
   type: Histogram
@@ -3180,6 +4161,9 @@
   - 120
   - 300
   - 600
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: graph_actions_duration_seconds
   subsystem: node_authorizer
   help: Histogram of duration of graph actions in node authorizer.
@@ -3200,6 +4184,9 @@
   - 0.0512
   - 0.1024
   - 0.2048
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: ratcheting_seconds
   subsystem: validation
   namespace: apiextensions_apiserver
@@ -3218,24 +4205,9 @@
   - 0.16384
   - 0.65536
   - 2.62144
-- name: apiextensions_openapi_v2_regeneration_count
-  help: Counter of OpenAPI v2 spec regeneration count broken down by causing CRD name
-    and reason.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - crd
-  - reason
-- name: apiextensions_openapi_v3_regeneration_count
-  help: Counter of OpenAPI v3 spec regeneration count broken down by group, version,
-    causing CRD and reason.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - crd
-  - group
-  - reason
-  - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: conversion_webhook_duration_seconds
   namespace: apiserver
   help: Conversion webhook request latency
@@ -3260,6 +4232,9 @@
   - 30
   - 45
   - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: conversion_webhook_request_total
   namespace: apiserver
   help: Counter for conversion webhook requests with success/failure and failure error
@@ -3269,6 +4244,9 @@
   labels:
   - failure_type
   - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_crd_conversion_webhook_duration_seconds
   help: CRD webhook conversion duration in seconds
   type: Histogram
@@ -3294,6 +4272,33 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiextensions_openapi_v2_regeneration_count
+  help: Counter of OpenAPI v2 spec regeneration count broken down by causing CRD name
+    and reason.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - crd
+  - reason
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: apiextensions_openapi_v3_regeneration_count
+  help: Counter of OpenAPI v3 spec regeneration count broken down by group, version,
+    causing CRD and reason.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - crd
+  - group
+  - reason
+  - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: match_condition_evaluation_errors_total
   subsystem: admission
   namespace: apiserver
@@ -3307,6 +4312,9 @@
   - name
   - operation
   - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: match_condition_evaluation_seconds
   subsystem: admission
   namespace: apiserver
@@ -3328,6 +4336,9 @@
   - 0.1
   - 0.2
   - 0.25
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: match_condition_exclusions_total
   subsystem: admission
   namespace: apiserver
@@ -3342,6 +4353,9 @@
   - name
   - operation
   - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: step_admission_duration_seconds_summary
   subsystem: admission
   namespace: apiserver
@@ -3354,6 +4368,9 @@
   - rejected
   - type
   maxAge: 18000000000000
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: webhook_fail_open_count
   subsystem: admission
   namespace: apiserver
@@ -3364,6 +4381,9 @@
   labels:
   - name
   - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: webhook_rejection_count
   subsystem: admission
   namespace: apiserver
@@ -3382,6 +4402,9 @@
   - operation
   - rejection_code
   - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: webhook_request_total
   subsystem: admission
   namespace: apiserver
@@ -3397,34 +4420,9 @@
   - operation
   - rejected
   - type
-- name: check_duration_seconds
-  subsystem: mutating_admission_policy
-  namespace: apiserver
-  help: Mutation admission latency for individual mutation expressions in seconds,
-    labeled by policy and binding.
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - error_type
-  - policy
-  - policy_binding
-  buckets:
-  - 5e-07
-  - 0.001
-  - 0.01
-  - 0.1
-  - 1
-- name: check_total
-  subsystem: mutating_admission_policy
-  namespace: apiserver
-  help: Mutation admission policy check total, labeled by policy and further identified
-    by binding.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - error_type
-  - policy
-  - policy_binding
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: controller_admission_duration_seconds
   subsystem: admission
   namespace: apiserver
@@ -3444,6 +4442,9 @@
   - 0.5
   - 1
   - 2.5
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: step_admission_duration_seconds
   subsystem: admission
   namespace: apiserver
@@ -3462,6 +4463,9 @@
   - 0.5
   - 1
   - 2.5
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: webhook_admission_duration_seconds
   subsystem: admission
   namespace: apiserver
@@ -3483,31 +4487,43 @@
   - 2.5
   - 10
   - 25
-- name: error_total
-  subsystem: apiserver_audit
-  help: Counter of audit events that failed to be audited properly. Plugin identifies
-    the plugin affected by the error.
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: check_duration_seconds
+  subsystem: mutating_admission_policy
+  namespace: apiserver
+  help: Mutation admission latency for individual mutation expressions in seconds,
+    labeled by policy and binding.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - error_type
+  - policy
+  - policy_binding
+  buckets:
+  - 5e-07
+  - 0.001
+  - 0.01
+  - 0.1
+  - 1
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: check_total
+  subsystem: mutating_admission_policy
+  namespace: apiserver
+  help: Mutation admission policy check total, labeled by policy and further identified
+    by binding.
   type: Counter
   stabilityLevel: ALPHA
   labels:
-  - plugin
-- name: event_total
-  subsystem: apiserver_audit
-  help: Counter of audit events generated and sent to the audit backend.
-  type: Counter
-  stabilityLevel: ALPHA
-- name: level_total
-  subsystem: apiserver_audit
-  help: Counter of policy levels for audit events (1 per request).
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - level
-- name: requests_rejected_total
-  subsystem: apiserver_audit
-  help: Counter of apiserver requests rejected due to an error in audit logging backend.
-  type: Counter
-  stabilityLevel: ALPHA
+  - error_type
+  - policy
+  - policy_binding
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: check_duration_seconds
   subsystem: validating_admission_policy
   namespace: apiserver
@@ -3526,6 +4542,9 @@
   - 0.01
   - 0.1
   - 1
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: check_total
   subsystem: validating_admission_policy
   namespace: apiserver
@@ -3538,26 +4557,78 @@
   - error_type
   - policy
   - policy_binding
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: aggregation_count_total
   subsystem: aggregator_discovery
   help: Counter of number of times discovery was aggregated
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: nopeer_requests_total
   subsystem: aggregator_discovery
   help: Counter of number of times no-peer (non peer-aggregated) discovery was requested
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: peer_aggregated_cache_hits_total
   subsystem: aggregator_discovery
   help: Counter of number of times discovery was served from peer-aggregated cache
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: peer_aggregated_cache_misses_total
   subsystem: aggregator_discovery
   help: Counter of number of times discovery was aggregated across all API servers
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: error_total
+  subsystem: apiserver_audit
+  help: Counter of audit events that failed to be audited properly. Plugin identifies
+    the plugin affected by the error.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - plugin
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: event_total
+  subsystem: apiserver_audit
+  help: Counter of audit events generated and sent to the audit backend.
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: level_total
+  subsystem: apiserver_audit
+  help: Counter of policy levels for audit events (1 per request).
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: requests_rejected_total
+  subsystem: apiserver_audit
+  help: Counter of apiserver requests rejected due to an error in audit logging backend.
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: decisions_total
   subsystem: authorization
   namespace: apiserver
@@ -3569,6 +4640,9 @@
   - decision
   - name
   - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: match_condition_evaluation_errors_total
   subsystem: authorization
   namespace: apiserver
@@ -3579,6 +4653,9 @@
   labels:
   - name
   - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: match_condition_evaluation_seconds
   subsystem: authorization
   namespace: apiserver
@@ -3597,6 +4674,9 @@
   - 0.1
   - 0.2
   - 0.25
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: match_condition_exclusions_total
   subsystem: authorization
   namespace: apiserver
@@ -3607,6 +4687,9 @@
   labels:
   - name
   - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: certificate_expiration_seconds
   subsystem: client
   namespace: apiserver
@@ -3629,6 +4712,9 @@
   - 7.776e+06
   - 1.5552e+07
   - 3.1104e+07
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: current_inqueue_requests
   subsystem: apiserver
   help: Maximal number of queued requests in this apiserver per request kind in last
@@ -3637,6 +4723,9 @@
   stabilityLevel: ALPHA
   labels:
   - request_kind
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_delegated_authn_request_duration_seconds
   help: Request latency in seconds. Broken down by status code.
   type: Histogram
@@ -3652,12 +4741,18 @@
   - 3
   - 5
   - 10
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_delegated_authn_request_total
   help: Number of HTTP requests partitioned by status code.
   type: Counter
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_delegated_authz_request_duration_seconds
   help: Request latency in seconds. Broken down by status code.
   type: Histogram
@@ -3673,12 +4768,18 @@
   - 3
   - 5
   - 10
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_delegated_authz_request_total
   help: Number of HTTP requests partitioned by status code.
   type: Counter
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_aborts_total
   subsystem: apiserver
   help: Number of requests which apiserver aborted possibly due to a timeout, for
@@ -3692,6 +4793,9 @@
   - subresource
   - verb
   - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_body_size_bytes
   subsystem: apiserver
   help: Apiserver request body size in bytes broken out by resource and verb.
@@ -3733,6 +4837,9 @@
   - 2.85e+06
   - 2.95e+06
   - 3.05e+06
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_filter_duration_seconds
   subsystem: apiserver
   help: Request filter latency distribution in seconds, for each filter type
@@ -3754,6 +4861,9 @@
   - 10
   - 15
   - 30
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_post_timeout_total
   subsystem: apiserver
   help: Tracks the activity of the request handlers after the associated requests
@@ -3763,6 +4873,9 @@
   labels:
   - source
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_sli_duration_seconds
   subsystem: apiserver
   help: Response latency distribution (not counting webhook duration and priority
@@ -3800,6 +4913,9 @@
   - 30
   - 45
   - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_slo_duration_seconds
   subsystem: apiserver
   help: Response latency distribution (not counting webhook duration and priority
@@ -3838,6 +4954,9 @@
   - 30
   - 45
   - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_terminations_total
   subsystem: apiserver
   help: Number of requests which apiserver terminated in self-defense.
@@ -3852,6 +4971,9 @@
   - subresource
   - verb
   - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_timestamp_comparison_time
   subsystem: apiserver
   help: Time taken for comparison of old vs new objects in UPDATE or PATCH requests
@@ -3870,6 +4992,9 @@
   - 0.3
   - 1
   - 5
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: selfrequest_total
   subsystem: apiserver
   help: Counter of apiserver self-requests broken out for each verb, API resource
@@ -3881,11 +5006,17 @@
   - resource
   - subresource
   - verb
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: tls_handshake_errors_total
   subsystem: apiserver
   help: Number of requests dropped with 'TLS handshake error from' error
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: watch_events_sizes
   subsystem: apiserver
   help: Watch event size distribution in bytes
@@ -3904,6 +5035,9 @@
   - 32768
   - 65536
   - 131072
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: watch_events_total
   subsystem: apiserver
   help: Number of events sent in watch clients
@@ -3913,18 +5047,27 @@
   - group
   - resource
   - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: authenticated_user_requests
   help: Counter of authenticated requests broken out by username.
   type: Counter
   stabilityLevel: ALPHA
   labels:
   - username
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: authentication_attempts
   help: Counter of authenticated attempts.
   type: Counter
   stabilityLevel: ALPHA
   labels:
   - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: authentication_duration_seconds
   help: Authentication duration in seconds broken out by result.
   type: Histogram
@@ -3947,6 +5090,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: active_fetch_count
   subsystem: token_cache
   namespace: authentication
@@ -3954,6 +5100,9 @@
   stabilityLevel: ALPHA
   labels:
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: fetch_total
   subsystem: token_cache
   namespace: authentication
@@ -3961,6 +5110,9 @@
   stabilityLevel: ALPHA
   labels:
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_duration_seconds
   subsystem: token_cache
   namespace: authentication
@@ -3968,6 +5120,9 @@
   stabilityLevel: ALPHA
   labels:
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_total
   subsystem: token_cache
   namespace: authentication
@@ -3975,6 +5130,9 @@
   stabilityLevel: ALPHA
   labels:
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: authorization_attempts_total
   help: Counter of authorization attempts broken down by result. It can be either
     'allowed', 'denied', 'no-opinion' or 'error'.
@@ -3982,6 +5140,9 @@
   stabilityLevel: ALPHA
   labels:
   - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: authorization_duration_seconds
   help: Authorization duration in seconds broken out by result.
   type: Histogram
@@ -4004,6 +5165,9 @@
   - 4.096
   - 8.192
   - 16.384
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: field_validation_request_duration_seconds
   help: Response latency distribution in seconds for each field validation value
   type: Histogram
@@ -4032,18 +5196,27 @@
   - 30
   - 45
   - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: compilation_duration_seconds
   subsystem: cel
   namespace: apiserver
   help: CEL compilation time in seconds.
   type: Histogram
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: evaluation_duration_seconds
   subsystem: cel
   namespace: apiserver
   help: CEL evaluation time in seconds.
   type: Histogram
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: watch_list_duration_seconds
   subsystem: apiserver
   help: Response latency distribution in seconds for watch list requests broken by
@@ -4073,6 +5246,9 @@
   - 30
   - 45
   - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: current_inflight_requests
   subsystem: apiserver
   help: Maximal number of currently used inflight request limit of this apiserver
@@ -4081,6 +5257,9 @@
   stabilityLevel: STABLE
   labels:
   - request_kind
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: longrunning_requests
   subsystem: apiserver
   help: Gauge of all active long-running apiserver requests broken out by verb, group,
@@ -4095,6 +5274,9 @@
   - subresource
   - verb
   - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_duration_seconds
   subsystem: apiserver
   help: Response latency distribution in seconds for each verb, dry run value, group,
@@ -4134,6 +5316,9 @@
   - 30
   - 45
   - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_total
   subsystem: apiserver
   help: Counter of apiserver requests broken out for each verb, dry run value, group,
@@ -4150,6 +5335,9 @@
   - subresource
   - verb
   - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: requested_deprecated_apis
   subsystem: apiserver
   help: Gauge of deprecated APIs that have been requested, broken out by API group,
@@ -4162,6 +5350,9 @@
   - resource
   - subresource
   - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: response_sizes
   subsystem: apiserver
   help: Response size distribution in bytes for each group, version, verb, resource,
@@ -4184,6 +5375,9 @@
   - 1e+07
   - 1e+08
   - 1e+09
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_authentication_config_controller_last_config_info
   help: Information about the last applied authentication configuration with hash
     as label, split by apiserver identity.
@@ -4192,6 +5386,9 @@
   labels:
   - apiserver_id_hash
   - hash
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_authorization_config_controller_last_config_info
   help: Information about the last applied authorization configuration with hash as
     label, split by apiserver identity.
@@ -4200,6 +5397,9 @@
   labels:
   - apiserver_id_hash
   - hash
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: cache_list_fetched_objects_total
   namespace: apiserver
   help: Number of objects read from watch cache in the course of serving a LIST request
@@ -4209,6 +5409,9 @@
   - group
   - index
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: cache_list_returned_objects_total
   namespace: apiserver
   help: Number of objects returned for a LIST request from watch cache
@@ -4217,6 +5420,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: cache_list_total
   namespace: apiserver
   help: Number of LIST requests served from watch cache
@@ -4226,6 +5432,9 @@
   - group
   - index
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: dial_duration_seconds
   subsystem: egress_dialer
   namespace: apiserver
@@ -4243,6 +5452,9 @@
   - 0.5
   - 2.5
   - 12.5
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: dial_failure_count
   subsystem: egress_dialer
   namespace: apiserver
@@ -4255,6 +5467,9 @@
   - protocol
   - stage
   - transport
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: dial_start_total
   subsystem: egress_dialer
   namespace: apiserver
@@ -4265,6 +5480,9 @@
   labels:
   - protocol
   - transport
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: automatic_reload_last_timestamp_seconds
   subsystem: encryption_config_controller
   namespace: apiserver
@@ -4275,6 +5493,9 @@
   labels:
   - apiserver_id_hash
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: automatic_reloads_total
   subsystem: encryption_config_controller
   namespace: apiserver
@@ -4285,6 +5506,9 @@
   labels:
   - apiserver_id_hash
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_encryption_config_controller_last_config_info
   help: Information about the last applied encryption configuration with hash as label,
     split by apiserver identity.
@@ -4293,12 +5517,18 @@
   labels:
   - apiserver_id_hash
   - hash
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: dek_cache_fill_percent
   subsystem: envelope_encryption
   namespace: apiserver
   help: Percent of the cache slots currently occupied by cached DEKs.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: dek_cache_inter_arrival_time_seconds
   subsystem: envelope_encryption
   namespace: apiserver
@@ -4318,6 +5548,9 @@
   - 7680
   - 15360
   - 30720
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: dek_source_cache_size
   subsystem: envelope_encryption
   namespace: apiserver
@@ -4328,6 +5561,9 @@
   stabilityLevel: ALPHA
   labels:
   - provider_name
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: invalid_key_id_from_status_total
   subsystem: envelope_encryption
   namespace: apiserver
@@ -4338,6 +5574,9 @@
   labels:
   - error
   - provider_name
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: key_id_hash_last_timestamp_seconds
   subsystem: envelope_encryption
   namespace: apiserver
@@ -4349,6 +5588,9 @@
   - key_id_hash
   - provider_name
   - transformation_type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: key_id_hash_status_last_timestamp_seconds
   subsystem: envelope_encryption
   namespace: apiserver
@@ -4359,6 +5601,9 @@
   - apiserver_id_hash
   - key_id_hash
   - provider_name
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: key_id_hash_total
   subsystem: envelope_encryption
   namespace: apiserver
@@ -4371,6 +5616,9 @@
   - key_id_hash
   - provider_name
   - transformation_type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: kms_operations_latency_seconds
   subsystem: envelope_encryption
   namespace: apiserver
@@ -4402,6 +5650,9 @@
   - 13.1072
   - 26.2144
   - 52.4288
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: init_events_total
   namespace: apiserver
   help: Counter of init events processed in watch cache broken by resource type.
@@ -4410,6 +5661,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_resource_objects
   help: Number of stored objects at the time of last check split by kind. In case
     of a fetching error, the value will be -1.
@@ -4418,6 +5672,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_resource_size_estimate_bytes
   help: Estimated size of stored objects in database. Estimate is based on sum of
     last observed sizes of serialized objects. In case of a fetching error, the value
@@ -4427,6 +5684,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: storage_consistency_checks_total
   namespace: apiserver
   help: Counter for status of consistency checks between etcd and watch cache
@@ -4436,6 +5696,9 @@
   - group
   - resource
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: data_key_generation_duration_seconds
   subsystem: storage
   namespace: apiserver
@@ -4457,12 +5720,18 @@
   - 0.01024
   - 0.02048
   - 0.04096
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: data_key_generation_failures_total
   subsystem: storage
   namespace: apiserver
   help: Total number of failed data encryption key(DEK) generation operations.
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: storage_db_total_size_in_bytes
   subsystem: apiserver
   help: Total size of the storage database file physically allocated in bytes.
@@ -4471,6 +5740,9 @@
   stabilityLevel: ALPHA
   labels:
   - endpoint
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: storage_decode_errors_total
   namespace: apiserver
   help: Number of stored object decode errors split by object type
@@ -4479,12 +5751,18 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: envelope_transformation_cache_misses_total
   subsystem: storage
   namespace: apiserver
   help: Total number of cache misses while accessing key decryption key(KEK).
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: storage_events_received_total
   subsystem: apiserver
   help: Number of etcd events received split by kind.
@@ -4493,6 +5771,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_storage_list_evaluated_objects_total
   help: Number of objects tested in the course of serving a LIST request from storage
   type: Counter
@@ -4500,6 +5781,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_storage_list_fetched_objects_total
   help: Number of objects read from storage in the course of serving a LIST request
   type: Counter
@@ -4507,6 +5791,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_storage_list_returned_objects_total
   help: Number of objects returned for a LIST request from storage
   type: Counter
@@ -4514,6 +5801,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_storage_list_total
   help: Number of LIST requests served from storage
   type: Counter
@@ -4521,6 +5811,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: transformation_duration_seconds
   subsystem: storage
   namespace: apiserver
@@ -4556,6 +5849,9 @@
   - 20.97152
   - 41.94304
   - 83.88608
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: transformation_operations_total
   subsystem: storage
   namespace: apiserver
@@ -4573,6 +5869,9 @@
   - status
   - transformation_type
   - transformer_prefix
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: terminated_watchers_total
   namespace: apiserver
   help: Counter of watchers closed due to unresponsiveness broken by resource type.
@@ -4581,6 +5880,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: consistent_read_total
   subsystem: watch_cache
   namespace: apiserver
@@ -4592,6 +5894,9 @@
   - group
   - resource
   - success
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: events_dispatched_total
   subsystem: watch_cache
   namespace: apiserver
@@ -4601,6 +5906,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: events_received_total
   subsystem: watch_cache
   namespace: apiserver
@@ -4610,6 +5918,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: initializations_total
   subsystem: watch_cache
   namespace: apiserver
@@ -4619,6 +5930,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: read_wait_seconds
   subsystem: watch_cache
   namespace: apiserver
@@ -4642,6 +5956,9 @@
   - 1.5
   - 2
   - 3
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: resource_version
   subsystem: watch_cache
   namespace: apiserver
@@ -4651,6 +5968,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: etcd_bookmark_counts
   help: Number of etcd bookmarks (progress notify events) split by kind.
   type: Gauge
@@ -4658,6 +5978,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: etcd_lease_object_counts
   help: Number of objects attached to a single etcd lease.
   type: Histogram
@@ -4670,6 +5993,9 @@
   - 1000
   - 2500
   - 5000
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: etcd_request_duration_seconds
   help: Etcd request latency in seconds for each operation and object type.
   type: Histogram
@@ -4702,6 +6028,9 @@
   - 30
   - 45
   - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: etcd_request_errors_total
   help: Etcd failed request counts for each operation and object type.
   type: Counter
@@ -4710,6 +6039,9 @@
   - group
   - operation
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: etcd_requests_total
   help: Etcd request counts for each operation and object type.
   type: Counter
@@ -4718,6 +6050,9 @@
   - group
   - operation
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: capacity
   subsystem: watch_cache
   help: Total capacity of watch cache broken by resource type.
@@ -4726,6 +6061,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: capacity_decrease_total
   subsystem: watch_cache
   help: Total number of watch cache capacity decrease events broken by resource type.
@@ -4734,6 +6072,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: capacity_increase_total
   subsystem: watch_cache
   help: Total number of watch cache capacity increase events broken by resource type.
@@ -4742,6 +6083,9 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: automatic_reload_last_timestamp_seconds
   subsystem: authentication_config_controller
   namespace: apiserver
@@ -4752,6 +6096,9 @@
   labels:
   - apiserver_id_hash
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: automatic_reloads_total
   subsystem: authentication_config_controller
   namespace: apiserver
@@ -4762,6 +6109,9 @@
   labels:
   - apiserver_id_hash
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: automatic_reload_last_timestamp_seconds
   subsystem: authorization_config_controller
   namespace: apiserver
@@ -4772,6 +6122,9 @@
   labels:
   - apiserver_id_hash
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: automatic_reloads_total
   subsystem: authorization_config_controller
   namespace: apiserver
@@ -4782,6 +6135,9 @@
   labels:
   - apiserver_id_hash
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_storage_objects
   help: '[DEPRECATED, consider using apiserver_resource_objects instead] Number of
     stored objects at the time of last check split by kind. In case of a fetching
@@ -4791,12 +6147,18 @@
   stabilityLevel: STABLE
   labels:
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_storage_size_bytes
   help: Size of the storage database file physically allocated in bytes.
   type: Custom
   stabilityLevel: STABLE
   labels:
   - storage_cluster_id
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_authentication_jwt_authenticator_jwks_fetch_last_key_set_info
   help: Information about the last JWKS fetched by the JWT authenticator with hash
     as label, split by api server identity and jwt issuer.
@@ -4806,6 +6168,9 @@
   - jwt_issuer_hash
   - apiserver_id_hash
   - hash
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: jwt_authenticator_jwks_fetch_last_timestamp_seconds
   subsystem: authentication
   namespace: apiserver
@@ -4817,6 +6182,9 @@
   - apiserver_id_hash
   - jwt_issuer_hash
   - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: jwt_authenticator_latency_seconds
   subsystem: authentication
   namespace: apiserver
@@ -4841,6 +6209,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: webhook_duration_seconds
   subsystem: authorization
   namespace: apiserver
@@ -4862,6 +6233,9 @@
   - 2.5
   - 5
   - 10
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: webhook_evaluations_fail_open_total
   subsystem: authorization
   namespace: apiserver
@@ -4871,6 +6245,9 @@
   labels:
   - name
   - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: webhook_evaluations_total
   subsystem: authorization
   namespace: apiserver
@@ -4880,6 +6257,9 @@
   labels:
   - name
   - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: current_inqueue_seats
   subsystem: flowcontrol
   namespace: apiserver
@@ -4890,6 +6270,9 @@
   labels:
   - flow_schema
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: current_limit_seats
   subsystem: flowcontrol
   namespace: apiserver
@@ -4898,6 +6281,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: current_r
   subsystem: flowcontrol
   namespace: apiserver
@@ -4906,6 +6292,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: demand_seats
   subsystem: flowcontrol
   namespace: apiserver
@@ -4928,6 +6317,9 @@
   - 2.8
   - 4
   - 6
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: demand_seats_average
   subsystem: flowcontrol
   namespace: apiserver
@@ -4936,6 +6328,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: demand_seats_high_watermark
   subsystem: flowcontrol
   namespace: apiserver
@@ -4944,6 +6339,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: demand_seats_smoothed
   subsystem: flowcontrol
   namespace: apiserver
@@ -4952,6 +6350,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: demand_seats_stdev
   subsystem: flowcontrol
   namespace: apiserver
@@ -4960,6 +6361,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: dispatch_r
   subsystem: flowcontrol
   namespace: apiserver
@@ -4968,6 +6372,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: epoch_advance_total
   subsystem: flowcontrol
   namespace: apiserver
@@ -4977,6 +6384,9 @@
   labels:
   - priority_level
   - success
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: latest_s
   subsystem: flowcontrol
   namespace: apiserver
@@ -4985,6 +6395,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: lower_limit_seats
   subsystem: flowcontrol
   namespace: apiserver
@@ -4994,6 +6407,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: next_discounted_s_bounds
   subsystem: flowcontrol
   namespace: apiserver
@@ -5004,6 +6420,9 @@
   labels:
   - bound
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: next_s_bounds
   subsystem: flowcontrol
   namespace: apiserver
@@ -5013,6 +6432,9 @@
   labels:
   - bound
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: priority_level_request_utilization
   subsystem: flowcontrol
   namespace: apiserver
@@ -5035,6 +6457,9 @@
   - 0.5
   - 0.75
   - 1
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: priority_level_seat_utilization
   subsystem: flowcontrol
   namespace: apiserver
@@ -5060,6 +6485,9 @@
   - 1
   constLabels:
     phase: executing
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: read_vs_write_current_requests
   subsystem: flowcontrol
   namespace: apiserver
@@ -5086,6 +6514,9 @@
   - 0.95
   - 0.99
   - 1
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_concurrency_in_use
   subsystem: flowcontrol
   namespace: apiserver
@@ -5098,6 +6529,9 @@
   labels:
   - flow_schema
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_concurrency_limit
   subsystem: flowcontrol
   namespace: apiserver
@@ -5107,6 +6541,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_dispatch_no_accommodation_total
   subsystem: flowcontrol
   namespace: apiserver
@@ -5117,6 +6554,9 @@
   labels:
   - flow_schema
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_execution_seconds
   subsystem: flowcontrol
   namespace: apiserver
@@ -5142,6 +6582,9 @@
   - 10
   - 15
   - 30
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_queue_length_after_enqueue
   subsystem: flowcontrol
   namespace: apiserver
@@ -5161,6 +6604,9 @@
   - 250
   - 500
   - 1000
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: seat_fair_frac
   subsystem: flowcontrol
   namespace: apiserver
@@ -5168,6 +6614,9 @@
     can use it
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: target_seats
   subsystem: flowcontrol
   namespace: apiserver
@@ -5176,6 +6625,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: upper_limit_seats
   subsystem: flowcontrol
   namespace: apiserver
@@ -5185,6 +6637,9 @@
   stabilityLevel: ALPHA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: watch_count_samples
   subsystem: flowcontrol
   namespace: apiserver
@@ -5201,6 +6656,9 @@
   - 100
   - 1000
   - 10000
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: work_estimated_seats
   subsystem: flowcontrol
   namespace: apiserver
@@ -5220,14 +6678,25 @@
   - 32
   - 64
   - 100
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: rerouted_request_total
   subsystem: apiserver
-  help: Total number of requests that were proxied to a peer kube apiserver because
-    the local apiserver was not capable of serving it
+  help: '`Total number of requests that were proxied to a peer kube-apiserver because
+    the local apiserver was not capable of serving it, broken down by ''group'', ''version'',
+    and ''resource'' indicating the GVR of the request. If all three are empty (""),
+    the request is a discovery request.`'
   type: Counter
   stabilityLevel: ALPHA
   labels:
   - code
+  - group
+  - resource
+  - version
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: stream_translator_requests_total
   subsystem: apiserver
   help: Total number of requests that were handled by the StreamTranslatorProxy, which
@@ -5236,6 +6705,9 @@
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: stream_tunnel_requests_total
   subsystem: apiserver
   help: Total number of requests that were handled by the StreamTunnelProxy, which
@@ -5244,6 +6716,9 @@
   stabilityLevel: ALPHA
   labels:
   - code
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: declarative_validation_panics_total
   subsystem: validation
   namespace: apiserver
@@ -5252,6 +6727,9 @@
   stabilityLevel: ALPHA
   labels:
   - validation_identifier
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: declarative_validation_parity_discrepancies_total
   subsystem: validation
   namespace: apiserver
@@ -5261,6 +6739,9 @@
   stabilityLevel: ALPHA
   labels:
   - validation_identifier
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: x509_insecure_sha1_total
   subsystem: webhooks
   namespace: apiserver
@@ -5269,6 +6750,9 @@
     SHA1 signatures (either/or, based on the runtime environment)
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: x509_missing_san_total
   subsystem: webhooks
   namespace: apiserver
@@ -5277,6 +6761,9 @@
     SAN extension missing (either/or, based on the runtime environment)
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: current_executing_requests
   subsystem: flowcontrol
   namespace: apiserver
@@ -5287,6 +6774,9 @@
   labels:
   - flow_schema
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: current_executing_seats
   subsystem: flowcontrol
   namespace: apiserver
@@ -5298,6 +6788,9 @@
   labels:
   - flow_schema
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: current_inqueue_requests
   subsystem: flowcontrol
   namespace: apiserver
@@ -5308,6 +6801,9 @@
   labels:
   - flow_schema
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: dispatched_requests_total
   subsystem: flowcontrol
   namespace: apiserver
@@ -5317,6 +6813,9 @@
   labels:
   - flow_schema
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: nominal_limit_seats
   subsystem: flowcontrol
   namespace: apiserver
@@ -5325,6 +6824,9 @@
   stabilityLevel: BETA
   labels:
   - priority_level
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: rejected_requests_total
   subsystem: flowcontrol
   namespace: apiserver
@@ -5335,6 +6837,9 @@
   - flow_schema
   - priority_level
   - reason
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_wait_duration_seconds
   subsystem: flowcontrol
   namespace: apiserver
@@ -5359,6 +6864,9 @@
   - 10
   - 15
   - 30
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: declarative_validation_mismatch_total
   subsystem: validation
   namespace: apiserver
@@ -5366,12 +6874,18 @@
     results for core types.
   type: Counter
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: declarative_validation_panic_total
   subsystem: validation
   namespace: apiserver
   help: Number of times declarative validation has panicked during validation.
   type: Counter
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: request_duration_seconds
   subsystem: cloud_provider_webhook
   help: Request latency in seconds. Broken down by status code.
@@ -5389,6 +6903,9 @@
   - 3
   - 5
   - 10
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
 - name: request_total
   subsystem: cloud_provider_webhook
   help: Number of HTTP requests partitioned by status code.
@@ -5397,6 +6914,9 @@
   labels:
   - code
   - webhook
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
 - name: cloud_provider_taint_removal_delay_seconds
   subsystem: node_controller
   help: Number of seconds after node creation when NodeController removed the cloud-provider
@@ -5410,6 +6930,9 @@
   - 64
   - 256
   - 1024
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
 - name: initial_node_sync_delay_seconds
   subsystem: node_controller
   help: Number of seconds after node creation when NodeController finished the initial
@@ -5423,18 +6946,36 @@
   - 64
   - 256
   - 1024
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+- name: route_sync_total
+  subsystem: route_controller
+  help: A metric counting the amount of times routes have been synced with the cloud
+    provider.
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
 - name: loadbalancer_sync_total
   subsystem: service_controller
   help: A metric counting the amount of times any load balancer has been configured,
     as an effect of service/node changes on the cluster
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
 - name: nodesync_error_total
   subsystem: service_controller
   help: A metric counting the amount of times any load balancer has been configured
     and errored, as an effect of node changes on the cluster
   type: Counter
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
 - name: nodesync_latency_seconds
   subsystem: service_controller
   help: A metric measuring the latency for nodesync which updates loadbalancer hosts
@@ -5457,6 +6998,9 @@
   - 4096
   - 8192
   - 16384
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
 - name: update_loadbalancer_host_latency_seconds
   subsystem: service_controller
   help: A metric measuring the latency for updating each load balancer hosts.
@@ -5478,22 +7022,32 @@
   - 4096
   - 8192
   - 16384
-- name: kubernetes_build_info
-  help: A metric with a constant '1' value labeled by major, minor, git version, git
-    commit, git tree state, build date, Go version, and compiler from which Kubernetes
-    was built, and platform on which it is running.
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+- name: queued_items
+  subsystem: informer
+  help: Number of items currently queued in the FIFO.
   type: Gauge
-  stabilityLevel: BETA
+  stabilityLevel: ALPHA
   labels:
-  - build_date
-  - compiler
-  - git_commit
-  - git_tree_state
-  - git_version
-  - go_version
-  - major
-  - minor
-  - platform
+  - group
+  - name
+  - resource
+  - version
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: leader_election_master_status
   help: Gauge of if the reporting system is master of the relevant lease, 0 indicates
     backup, 1 indicates master. 'name' is the string used to identify the lease. Please
@@ -5502,6 +7056,19 @@
   stabilityLevel: ALPHA
   labels:
   - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: leader_election_slowpath_total
   help: Total number of slow path exercised in renewing leader leases. 'name' is the
     string used to identify the lease. Please make sure to group by name.
@@ -5509,6 +7076,19 @@
   stabilityLevel: ALPHA
   labels:
   - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_dns_resolution_duration_seconds
   help: DNS resolver latency in seconds. Broken down by host.
   type: Histogram
@@ -5527,6 +7107,19 @@
   - 8
   - 15
   - 30
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_exec_plugin_call_total
   help: Number of calls to an exec plugin, partitioned by the type of event encountered
     (no_error, plugin_execution_error, plugin_not_found_error, client_internal_error)
@@ -5537,6 +7130,19 @@
   labels:
   - call_status
   - code
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_exec_plugin_certificate_rotation_age
   help: Histogram of the number of seconds the last auth exec plugin client certificate
     lived before being rotated. If auth exec plugin client certificates are unused,
@@ -5555,6 +7161,19 @@
   - 1.5552e+07
   - 3.1104e+07
   - 1.24416e+08
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_exec_plugin_policy_call_total
   help: Number of comparisons of an exec plugin to the plugin policy and allowlist
     (if any), partitioned by whether or not the policy permits the plugin
@@ -5563,6 +7182,19 @@
   labels:
   - allowed
   - denied
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_exec_plugin_ttl_seconds
   help: Gauge of the shortest TTL (time-to-live) of the client certificate(s) managed
     by the auth exec plugin. The value is in seconds until certificate expiry (negative
@@ -5570,6 +7202,19 @@
     the value will be +INF.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_rate_limiter_duration_seconds
   help: Client side rate limiter latency in seconds. Broken down by verb, and host.
   type: Histogram
@@ -5590,6 +7235,19 @@
   - 15
   - 30
   - 60
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_request_duration_seconds
   help: Request latency in seconds. Broken down by verb, and host.
   type: Histogram
@@ -5610,6 +7268,19 @@
   - 15
   - 30
   - 60
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_request_retries_total
   help: Number of request retries, partitioned by status code, verb, and host.
   type: Counter
@@ -5618,6 +7289,19 @@
   - code
   - host
   - verb
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_request_size_bytes
   help: Request size in bytes. Broken down by verb and host.
   type: Histogram
@@ -5637,6 +7321,19 @@
   - 1.048576e+06
   - 4.194304e+06
   - 1.6777216e+07
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_requests_total
   help: Number of HTTP requests, partitioned by status code, method, and host.
   type: Counter
@@ -5645,6 +7342,19 @@
   - code
   - host
   - method
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_response_size_bytes
   help: Response size in bytes. Broken down by verb and host.
   type: Histogram
@@ -5664,10 +7374,36 @@
   - 1.048576e+06
   - 4.194304e+06
   - 1.6777216e+07
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_transport_cache_entries
   help: Number of transport entries in the internal cache.
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: rest_client_transport_create_calls_total
   help: 'Number of calls to get a new transport, partitioned by the result of the
     operation hit: obtained from the cache, miss: created and added to the cache,
@@ -5676,13 +7412,19 @@
   stabilityLevel: ALPHA
   labels:
   - result
-- name: running_managed_controllers
-  help: Indicates where instances of a controller are currently running
-  type: Gauge
-  stabilityLevel: ALPHA
-  labels:
-  - manager
-  - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: version_info
   help: Provides the compatibility version info of the component. The component label
     is the name of the component, usually kube, but is relevant for aggregated-apiservers.
@@ -5693,14 +7435,82 @@
   - component
   - emulation
   - min_compat
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: disabled_metrics_total
   help: The count of disabled metrics.
   type: Counter
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: hidden_metrics_total
   help: The count of hidden metrics.
   type: Counter
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
+- name: kubernetes_build_info
+  help: A metric with a constant '1' value labeled by major, minor, git version, git
+    commit, git tree state, build date, Go version, and compiler from which Kubernetes
+    was built, and platform on which it is running.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - build_date
+  - compiler
+  - git_commit
+  - git_tree_state
+  - git_version
+  - go_version
+  - major
+  - minor
+  - platform
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: feature_enabled
   namespace: kubernetes
   help: This metric records the data about the stage and enablement of a k8s feature.
@@ -5709,6 +7519,19 @@
   labels:
   - name
   - stage
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: registered_metrics_total
   help: The count of registered metrics broken by stability level and deprecation
     version.
@@ -5717,6 +7540,39 @@
   labels:
   - deprecated_version
   - stability_level
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
+- name: running_managed_controllers
+  help: Indicates where instances of a controller are currently running
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - manager
+  - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: adds_total
   subsystem: workqueue
   help: Total number of adds handled by workqueue
@@ -5724,6 +7580,19 @@
   stabilityLevel: BETA
   labels:
   - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: depth
   subsystem: workqueue
   help: Current depth of workqueue
@@ -5731,6 +7600,19 @@
   stabilityLevel: BETA
   labels:
   - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: longest_running_processor_seconds
   subsystem: workqueue
   help: How many seconds has the longest running processor for workqueue been running.
@@ -5738,6 +7620,19 @@
   stabilityLevel: BETA
   labels:
   - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: queue_duration_seconds
   subsystem: workqueue
   help: How long in seconds an item stays in workqueue before being requested.
@@ -5756,6 +7651,19 @@
   - 0.1
   - 1
   - 10
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: retries_total
   subsystem: workqueue
   help: Total number of retries handled by workqueue
@@ -5763,6 +7671,19 @@
   stabilityLevel: BETA
   labels:
   - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: unfinished_work_seconds
   subsystem: workqueue
   help: How many seconds of work has done that is in progress and hasn't been observed
@@ -5772,6 +7693,19 @@
   stabilityLevel: BETA
   labels:
   - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: work_duration_seconds
   subsystem: workqueue
   help: How long in seconds processing an item from workqueue takes.
@@ -5790,6 +7724,19 @@
   - 0.1
   - 1
   - 10
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: healthcheck
   namespace: kubernetes
   help: This metric records the result of a single healthcheck.
@@ -5798,6 +7745,19 @@
   labels:
   - name
   - type
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: healthchecks_total
   namespace: kubernetes
   help: This metric records the results of all healthcheck.
@@ -5807,22 +7767,19 @@
   - name
   - status
   - type
-- name: x509_insecure_sha1_total
-  subsystem: kube_aggregator
-  namespace: apiserver
-  help: Counts the number of requests to servers with insecure SHA1 signatures in
-    their serving certificate OR the number of connection failures due to the insecure
-    SHA1 signatures (either/or, based on the runtime environment)
-  type: Counter
-  stabilityLevel: ALPHA
-- name: x509_missing_san_total
-  subsystem: kube_aggregator
-  namespace: apiserver
-  help: Counts the number of requests to servers missing SAN extension in their serving
-    certificate OR the number of connection failures due to the lack of x509 certificate
-    SAN extension missing (either/or, based on the runtime environment)
-  type: Counter
-  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: changes
   subsystem: endpoint_slice_controller
   help: Number of EndpointSlice changes
@@ -5830,11 +7787,17 @@
   stabilityLevel: ALPHA
   labels:
   - operation
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: desired_endpoint_slices
   subsystem: endpoint_slice_controller
   help: Number of EndpointSlices that would exist with perfect endpoint allocation
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: endpoints_added_per_sync
   subsystem: endpoint_slice_controller
   help: Number of endpoints added on each Service sync
@@ -5856,11 +7819,17 @@
   - 8192
   - 16384
   - 32768
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: endpoints_desired
   subsystem: endpoint_slice_controller
   help: Number of endpoints desired
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: endpoints_removed_per_sync
   subsystem: endpoint_slice_controller
   help: Number of endpoints removed on each Service sync
@@ -5882,6 +7851,9 @@
   - 8192
   - 16384
   - 32768
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: endpointslices_changed_per_sync
   subsystem: endpoint_slice_controller
   help: Number of EndpointSlices changed on each Service sync
@@ -5890,11 +7862,17 @@
   labels:
   - topology
   - traffic_distribution
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: num_endpoint_slices
   subsystem: endpoint_slice_controller
   help: Number of EndpointSlices
   type: Gauge
   stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: services_count_by_traffic_distribution
   subsystem: endpoint_slice_controller
   help: Number of Services using some specific trafficDistribution
@@ -5902,6 +7880,9 @@
   stabilityLevel: ALPHA
   labels:
   - traffic_distribution
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: syncs
   subsystem: endpoint_slice_controller
   help: Number of EndpointSlice syncs
@@ -5909,6 +7890,9 @@
   stabilityLevel: ALPHA
   labels:
   - result
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: aggregator_openapi_v2_regeneration_count
   help: Counter of OpenAPI v2 spec regeneration count broken down by causing APIService
     name and reason.
@@ -5917,12 +7901,18 @@
   labels:
   - apiservice
   - reason
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: aggregator_openapi_v2_regeneration_duration
   help: Gauge of OpenAPI v2 spec regeneration duration in seconds.
   type: Gauge
   stabilityLevel: ALPHA
   labels:
   - reason
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: aggregator_unavailable_apiservice
   help: Gauge of APIServices which are marked as unavailable broken down by APIService
     name.
@@ -5930,6 +7920,9 @@
   stabilityLevel: ALPHA
   labels:
   - name
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: aggregator_unavailable_apiservice_total
   help: Counter of APIServices which are marked as unavailable broken down by APIService
     name and reason.
@@ -5938,6 +7931,31 @@
   labels:
   - name
   - reason
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: x509_insecure_sha1_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers with insecure SHA1 signatures in
+    their serving certificate OR the number of connection failures due to the insecure
+    SHA1 signatures (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: x509_missing_san_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers missing SAN extension in their serving
+    certificate OR the number of connection failures due to the lack of x509 certificate
+    SAN extension missing (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: ALPHA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: pod_security_errors_total
   help: Number of errors preventing normal evaluation. Non-fatal errors may result
     in the latest restricted profile being used for evaluation.
@@ -5948,6 +7966,9 @@
   - request_operation
   - resource
   - subresource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: pod_security_evaluations_total
   help: Number of policy evaluations that occurred, not counting ignored or exempt
     requests.
@@ -5961,6 +7982,9 @@
   - request_operation
   - resource
   - subresource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: pod_security_exemptions_total
   help: Number of exempt requests, not counting ignored or out of scope requests.
   type: Counter
@@ -5969,3 +7993,6 @@
   - request_operation
   - resource
   - subresource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -7747,17 +7747,17 @@
   - type
   componentEndpoints:
   - component: cloud-controller-manager
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kube-apiserver
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kube-controller-manager
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kube-proxy
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kube-scheduler
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kubelet
-    endpoint: /metrics
+    endpoint: /metrics/slis
 - name: healthchecks_total
   namespace: kubernetes
   help: This metric records the results of all healthcheck.
@@ -7769,17 +7769,17 @@
   - type
   componentEndpoints:
   - component: cloud-controller-manager
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kube-apiserver
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kube-controller-manager
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kube-proxy
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kube-scheduler
-    endpoint: /metrics
+    endpoint: /metrics/slis
   - component: kubelet
-    endpoint: /metrics
+    endpoint: /metrics/slis
 - name: changes
   subsystem: endpoint_slice_controller
   help: Number of EndpointSlice changes

--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -170,14 +170,14 @@ Stable metrics observe strict API contracts and no labels can be added or remove
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics/slis)</li><li>kube-apiserver (/metrics/slis)</li><li>kube-controller-manager (/metrics/slis)</li><li>kube-proxy (/metrics/slis)</li><li>kube-scheduler (/metrics/slis)</li><li>kubelet (/metrics/slis)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">kubernetes_healthchecks_total</div>
 	<div class="metric_help">This metric records the results of all healthcheck.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">status</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">status</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics/slis)</li><li>kube-apiserver (/metrics/slis)</li><li>kube-controller-manager (/metrics/slis)</li><li>kube-proxy (/metrics/slis)</li><li>kube-scheduler (/metrics/slis)</li><li>kubelet (/metrics/slis)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">node_collector_evictions_total</div>
 	<div class="metric_help">Number of Node evictions that happened since current instance of NodeController started.</div>

--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Metrics (v1.36)
 
-<!-- (auto-generated 2026 Feb 18) -->
+<!-- (auto-generated 2026 Feb 27) -->
 <!-- (auto-generated v1.36) -->
 This page details the metrics that different Kubernetes components export. You can query the metrics endpoint for these 
 components using an HTTP scrape, and fetch the current metrics data in Prometheus format.
@@ -1264,6 +1264,20 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">apiserver_peer_discovery_sync_errors_total</div>
+	<div class="metric_help">Total number of errors encountered while syncing discovery information from a peer kube-apiserver</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">apiserver_peer_proxy_errors_total</div>
+	<div class="metric_help">Total number of errors encountered while proxying requests to a peer kube apiserver</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">type</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_aborts_total</div>
 	<div class="metric_help">Number of requests which apiserver aborted possibly due to a timeout, for each group, version, verb, resource, subresource and scope</div>
 	<ul>
@@ -1677,6 +1691,13 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">driver_name</span><span class="metric_label">grpc_status_code</span><span class="metric_label">method_name</span><span class="metric_label">migrated</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">daemonset_controller_stale_sync_skips_total</div>
+	<div class="metric_help">Total number of DaemonSet syncs skipped due to a stale watch cache.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">device_taint_eviction_controller_pod_deletion_duration_seconds</div>
 	<div class="metric_help">Latency, in seconds, between the time when a device taint effect has been activated and a Pod's deletion via DeviceTaintEvictionController.</div>
 	<ul>
@@ -1964,6 +1985,13 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">error</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">informer_processing_latency_seconds</div>
+	<div class="metric_help">Time taken to process events after popping from the queue.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">name</span><span class="metric_label">resource</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">informer_queued_items</div>
 	<div class="metric_help">Number of items currently queued in the FIFO.</div>
 	<ul>
@@ -1998,6 +2026,13 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">job_controller_stale_sync_skips_total</div>
+	<div class="metric_help">Total number of Job syncs skipped due to a stale watch cache.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">job_controller_terminated_pods_tracking_finalizer_total</div>
 	<div class="metric_help">`The number of terminated pods (phase=Failed|Succeeded), that have the finalizer batch.kubernetes.io/job-tracking, The event label can be "add" or "delete".`</div>
@@ -3265,6 +3300,13 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">replicaset_controller_stale_sync_skips_total</div>
+	<div class="metric_help">Total number of ReplicaSet syncs skipped due to a stale watch cache.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">resourceclaim_controller_creates_total</div>
 	<div class="metric_help">Number of ResourceClaims creation requests, categorized by creation status and admin access</div>

--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Metrics (v1.36)
 
-<!-- (auto-generated 2026 Jan 09) -->
+<!-- (auto-generated 2026 Feb 18) -->
 <!-- (auto-generated v1.36) -->
 This page details the metrics that different Kubernetes components export. You can query the metrics endpoint for these 
 components using an HTTP scrape, and fetch the current metrics data in Prometheus format.
@@ -23,259 +23,259 @@ Stable metrics observe strict API contracts and no labels can be added or remove
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_admission_step_admission_duration_seconds</div>
 	<div class="metric_help">Admission sub-step latency histogram in seconds, broken out for each operation and API resource and step type (validate or admit).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_admission_webhook_admission_duration_seconds</div>
 	<div class="metric_help">Admission webhook latency histogram in seconds, identified by name and broken out for each operation and API resource and type (validate or admit).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_current_inflight_requests</div>
 	<div class="metric_help">Maximal number of currently used inflight request limit of this apiserver per request kind in last second.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">request_kind</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">request_kind</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_longrunning_requests</div>
 	<div class="metric_help">Gauge of all active long-running apiserver requests broken out by verb, group, version, resource, scope and component. Not all requests are tracked this way.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_request_duration_seconds</div>
 	<div class="metric_help">Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">dry_run</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">dry_run</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_request_total</div>
 	<div class="metric_help">Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">component</span><span class="metric_label">dry_run</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">component</span><span class="metric_label">dry_run</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_requested_deprecated_apis</div>
 	<div class="metric_help">Gauge of deprecated APIs that have been requested, broken out by API group, version, resource, subresource, and removed_release.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">removed_release</span><span class="metric_label">resource</span><span class="metric_label">subresource</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">removed_release</span><span class="metric_label">resource</span><span class="metric_label">subresource</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_response_sizes</div>
 	<div class="metric_help">Response size distribution in bytes for each group, version, verb, resource, subresource, scope and component.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_storage_objects</div>
 	<div class="metric_help">[DEPRECATED, consider using apiserver_resource_objects instead] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource</span></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.34.0</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.34.0</span></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">apiserver_storage_size_bytes</div>
 	<div class="metric_help">Size of the storage database file physically allocated in bytes.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">storage_cluster_id</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">storage_cluster_id</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">container_cpu_usage_seconds_total</div>
 	<div class="metric_help">Cumulative cpu time consumed by the container in core-seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">container_memory_working_set_bytes</div>
 	<div class="metric_help">Current working set of the container in bytes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">container_start_time_seconds</div>
 	<div class="metric_help">Start time of the container since unix epoch in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">cronjob_controller_job_creation_skew_duration_seconds</div>
 	<div class="metric_help">Time between when a cronjob is scheduled to be run, and when the corresponding job is created</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">job_controller_job_pods_finished_total</div>
 	<div class="metric_help">The number of finished Pods that are fully tracked</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">completion_mode</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">completion_mode</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">job_controller_job_sync_duration_seconds</div>
 	<div class="metric_help">The time it took to sync a job</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">completion_mode</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">completion_mode</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">job_controller_job_syncs_total</div>
 	<div class="metric_help">The number of job syncs</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">completion_mode</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">completion_mode</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">job_controller_jobs_finished_total</div>
 	<div class="metric_help">The number of finished jobs</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">completion_mode</span><span class="metric_label">reason</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">completion_mode</span><span class="metric_label">reason</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">kube_pod_resource_limit</div>
 	<div class="metric_help">Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">node</span><span class="metric_label">scheduler</span><span class="metric_label">priority</span><span class="metric_label">resource</span><span class="metric_label">unit</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">node</span><span class="metric_label">scheduler</span><span class="metric_label">priority</span><span class="metric_label">resource</span><span class="metric_label">unit</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">kube_pod_resource_request</div>
 	<div class="metric_help">Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">node</span><span class="metric_label">scheduler</span><span class="metric_label">priority</span><span class="metric_label">resource</span><span class="metric_label">unit</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">node</span><span class="metric_label">scheduler</span><span class="metric_label">priority</span><span class="metric_label">resource</span><span class="metric_label">unit</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">kubernetes_healthcheck</div>
 	<div class="metric_help">This metric records the result of a single healthcheck.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">kubernetes_healthchecks_total</div>
 	<div class="metric_help">This metric records the results of all healthcheck.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">status</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">status</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">node_collector_evictions_total</div>
 	<div class="metric_help">Number of Node evictions that happened since current instance of NodeController started.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">zone</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">zone</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">node_cpu_usage_seconds_total</div>
 	<div class="metric_help">Cumulative cpu time consumed by the node in core-seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">node_memory_working_set_bytes</div>
 	<div class="metric_help">Current working set of the node in bytes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">pod_cpu_usage_seconds_total</div>
 	<div class="metric_help">Cumulative cpu time consumed by the pod in core-seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod</span><span class="metric_label">namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod</span><span class="metric_label">namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">pod_memory_working_set_bytes</div>
 	<div class="metric_help">Current working set of the pod in bytes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod</span><span class="metric_label">namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod</span><span class="metric_label">namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">resource_scrape_error</div>
 	<div class="metric_help">1 if there was an error while getting container metrics, 0 otherwise</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">scheduler_framework_extension_point_duration_seconds</div>
 	<div class="metric_help">Latency for running all plugins of a specific extension point.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">extension_point</span><span class="metric_label">profile</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">extension_point</span><span class="metric_label">profile</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">scheduler_pending_pods</div>
 	<div class="metric_help">Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">queue</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">queue</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">scheduler_pod_scheduling_attempts</div>
 	<div class="metric_help">Number of attempts to successfully schedule a pod.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">scheduler_preemption_attempts_total</div>
 	<div class="metric_help">Total preemption attempts in the cluster till now</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">scheduler_preemption_victims</div>
 	<div class="metric_help">Number of selected preemption victims</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">scheduler_queue_incoming_pods_total</div>
 	<div class="metric_help">Number of pods added to scheduling queues by event and queue type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span><span class="metric_label">queue</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span><span class="metric_label">queue</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">scheduler_schedule_attempts_total</div>
 	<div class="metric_help">Number of attempts to schedule pods, by the result. 'unschedulable' means a pod could not be scheduled, while 'error' means an internal scheduler problem.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="stable">
 	<div class="metric_name">scheduler_scheduling_attempt_duration_seconds</div>
 	<div class="metric_help">Scheduling attempt latency in seconds (scheduling algorithm + binding)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">STABLE</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div>
 </div>
 
@@ -289,238 +289,252 @@ Beta metrics observe a looser API contract than its stable counterparts. No labe
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_authentication_config_controller_automatic_reloads_total</div>
 	<div class="metric_help">Total number of automatic reloads of authentication configuration split by status and apiserver identity.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds</div>
 	<div class="metric_help">Timestamp of the last automatic reload of authorization configuration split by status and apiserver identity.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_authorization_config_controller_automatic_reloads_total</div>
 	<div class="metric_help">Total number of automatic reloads of authorization configuration split by status and apiserver identity.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_cel_compilation_duration_seconds</div>
 	<div class="metric_help">CEL compilation time in seconds.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_cel_evaluation_duration_seconds</div>
 	<div class="metric_help">CEL evaluation time in seconds.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_flowcontrol_current_executing_requests</div>
 	<div class="metric_help">Number of requests in initial (for a WATCH) or any (for a non-WATCH) execution stage in the API Priority and Fairness subsystem</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_flowcontrol_current_executing_seats</div>
 	<div class="metric_help">Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_flowcontrol_current_inqueue_requests</div>
 	<div class="metric_help">Number of requests currently pending in queues of the API Priority and Fairness subsystem</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_flowcontrol_dispatched_requests_total</div>
 	<div class="metric_help">Number of requests executed by API Priority and Fairness subsystem</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_flowcontrol_nominal_limit_seats</div>
 	<div class="metric_help">Nominal number of execution seats configured for each priority level</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_flowcontrol_rejected_requests_total</div>
 	<div class="metric_help">Number of requests rejected by API Priority and Fairness subsystem</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_flowcontrol_request_wait_duration_seconds</div>
 	<div class="metric_help">Length of time a request spent waiting in its queue</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">execute</span><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">execute</span><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_validating_admission_policy_check_duration_seconds</div>
 	<div class="metric_help">Validation admission latency for individual validation expressions in seconds, labeled by policy and further including binding and enforcement action taken.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">enforcement_action</span><span class="metric_label">error_type</span><span class="metric_label">policy</span><span class="metric_label">policy_binding</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">enforcement_action</span><span class="metric_label">error_type</span><span class="metric_label">policy</span><span class="metric_label">policy_binding</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_validating_admission_policy_check_total</div>
 	<div class="metric_help">Validation admission policy check total, labeled by policy and further identified by binding and enforcement action taken.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">enforcement_action</span><span class="metric_label">error_type</span><span class="metric_label">policy</span><span class="metric_label">policy_binding</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">enforcement_action</span><span class="metric_label">error_type</span><span class="metric_label">policy</span><span class="metric_label">policy_binding</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_validation_declarative_validation_mismatch_total</div>
 	<div class="metric_help">Number of times declarative validation results differed from handwritten validation results for core types.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_validation_declarative_validation_panic_total</div>
 	<div class="metric_help">Number of times declarative validation has panicked during validation.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">apiserver_watch_list_duration_seconds</div>
 	<div class="metric_help">Response latency distribution in seconds for watch list requests broken by group, version, resource and scope.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">disabled_metrics_total</div>
 	<div class="metric_help">The count of disabled metrics.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">hidden_metrics_total</div>
 	<div class="metric_help">The count of hidden metrics.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">kubelet_image_volume_mounted_errors_total</div>
 	<div class="metric_help">Number of failed image volume mounts.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">kubelet_image_volume_mounted_succeed_total</div>
 	<div class="metric_help">Number of successful image volume mounts.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">kubelet_image_volume_requested_total</div>
 	<div class="metric_help">Number of requested image volumes.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="beta">
+	<div class="metric_name">kubernetes_build_info</div>
+	<div class="metric_help">A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
+	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">build_date</span><span class="metric_label">compiler</span><span class="metric_label">git_commit</span><span class="metric_label">git_tree_state</span><span class="metric_label">git_version</span><span class="metric_label">go_version</span><span class="metric_label">major</span><span class="metric_label">minor</span><span class="metric_label">platform</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">kubernetes_feature_enabled</div>
 	<div class="metric_help">This metric records the data about the stage and enablement of a k8s feature.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">stage</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">stage</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">prober_probe_total</div>
 	<div class="metric_help">Cumulative number of a liveness, readiness or startup probe for a container by result.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">pod_uid</span><span class="metric_label">probe_type</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">pod_uid</span><span class="metric_label">probe_type</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/probes)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">registered_metrics_total</div>
 	<div class="metric_help">The count of registered metrics broken by stability level and deprecation version.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">deprecated_version</span><span class="metric_label">stability_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">deprecated_version</span><span class="metric_label">stability_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="beta">
+	<div class="metric_name">running_managed_controllers</div>
+	<div class="metric_help">Indicates where instances of a controller are currently running</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
+	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">manager</span><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">scheduler_pod_scheduling_sli_duration_seconds</div>
 	<div class="metric_help">E2e latency for a pod being scheduled, from the time the pod enters the scheduling queue and might involve multiple scheduling attempts.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">attempts</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">attempts</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_adds_total</div>
 	<div class="metric_help">Total number of adds handled by workqueue</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_depth</div>
 	<div class="metric_help">Current depth of workqueue</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_longest_running_processor_seconds</div>
 	<div class="metric_help">How many seconds has the longest running processor for workqueue been running.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_queue_duration_seconds</div>
 	<div class="metric_help">How long in seconds an item stays in workqueue before being requested.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_retries_total</div>
 	<div class="metric_help">Total number of retries handled by workqueue</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_unfinished_work_seconds</div>
 	<div class="metric_help">How many seconds of work has done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_work_duration_seconds</div>
 	<div class="metric_help">How long in seconds processing an item from workqueue takes.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div>
 </div>
 
@@ -534,3247 +548,3275 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">aggregator_discovery_nopeer_requests_total</div>
 	<div class="metric_help">Counter of number of times no-peer (non peer-aggregated) discovery was requested</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">aggregator_discovery_peer_aggregated_cache_hits_total</div>
 	<div class="metric_help">Counter of number of times discovery was served from peer-aggregated cache</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">aggregator_discovery_peer_aggregated_cache_misses_total</div>
 	<div class="metric_help">Counter of number of times discovery was aggregated across all API servers</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">aggregator_openapi_v2_regeneration_count</div>
 	<div class="metric_help">Counter of OpenAPI v2 spec regeneration count broken down by causing APIService name and reason.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiservice</span><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiservice</span><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">aggregator_openapi_v2_regeneration_duration</div>
 	<div class="metric_help">Gauge of OpenAPI v2 spec regeneration duration in seconds.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">aggregator_unavailable_apiservice</div>
 	<div class="metric_help">Gauge of APIServices which are marked as unavailable broken down by APIService name.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">aggregator_unavailable_apiservice_total</div>
 	<div class="metric_help">Counter of APIServices which are marked as unavailable broken down by APIService name and reason.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiextensions_apiserver_validation_ratcheting_seconds</div>
 	<div class="metric_help">Time for comparison of old to new for the purposes of CRDValidationRatcheting during an UPDATE in seconds.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiextensions_openapi_v2_regeneration_count</div>
 	<div class="metric_help">Counter of OpenAPI v2 spec regeneration count broken down by causing CRD name and reason.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">crd</span><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">crd</span><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiextensions_openapi_v3_regeneration_count</div>
 	<div class="metric_help">Counter of OpenAPI v3 spec regeneration count broken down by group, version, causing CRD and reason.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">crd</span><span class="metric_label">group</span><span class="metric_label">reason</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">crd</span><span class="metric_label">group</span><span class="metric_label">reason</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_admission_match_condition_evaluation_errors_total</div>
 	<div class="metric_help">Admission match condition evaluation errors count, identified by name of resource containing the match condition and broken out for each kind containing matchConditions (webhook or policy), operation and admission type (validate or admit).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">kind</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">kind</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_admission_match_condition_evaluation_seconds</div>
 	<div class="metric_help">Admission match condition evaluation time in seconds, identified by name and broken out for each kind containing matchConditions (webhook or policy), operation and type (validate or admit).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">kind</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">kind</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_admission_match_condition_exclusions_total</div>
 	<div class="metric_help">Admission match condition evaluation exclusions count, identified by name of resource containing the match condition and broken out for each kind containing matchConditions (webhook or policy), operation and admission type (validate or admit).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">kind</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">kind</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_admission_step_admission_duration_seconds_summary</div>
 	<div class="metric_help">Admission sub-step latency summary in seconds, broken out for each operation and API resource and step type (validate or admit).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="summary"><label class="metric_detail">Type:</label> <span class="metric_type">Summary</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_admission_webhook_fail_open_count</div>
 	<div class="metric_help">Admission webhook fail open count, identified by name and broken out for each admission type (validating or admit).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_admission_webhook_rejection_count</div>
 	<div class="metric_help">Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error_type</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">rejection_code</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error_type</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">rejection_code</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_admission_webhook_request_total</div>
 	<div class="metric_help">Admission webhook request total, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify whether the request was rejected or not and an HTTP status code. Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">name</span><span class="metric_label">operation</span><span class="metric_label">rejected</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_audit_error_total</div>
 	<div class="metric_help">Counter of audit events that failed to be audited properly. Plugin identifies the plugin affected by the error.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_audit_event_total</div>
 	<div class="metric_help">Counter of audit events generated and sent to the audit backend.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_audit_level_total</div>
 	<div class="metric_help">Counter of policy levels for audit events (1 per request).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_audit_requests_rejected_total</div>
 	<div class="metric_help">Counter of apiserver requests rejected due to an error in audit logging backend.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authentication_config_controller_last_config_info</div>
 	<div class="metric_help">Information about the last applied authentication configuration with hash as label, split by apiserver identity.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">hash</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">hash</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authentication_jwt_authenticator_jwks_fetch_last_key_set_info</div>
 	<div class="metric_help">Information about the last JWKS fetched by the JWT authenticator with hash as label, split by api server identity and jwt issuer.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">jwt_issuer_hash</span><span class="metric_label">apiserver_id_hash</span><span class="metric_label">hash</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">jwt_issuer_hash</span><span class="metric_label">apiserver_id_hash</span><span class="metric_label">hash</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authentication_jwt_authenticator_jwks_fetch_last_timestamp_seconds</div>
 	<div class="metric_help">Timestamp of the last successful or failed JWKS fetch split by result, api server identity and jwt issuer for the JWT authenticator.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">jwt_issuer_hash</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">jwt_issuer_hash</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authentication_jwt_authenticator_latency_seconds</div>
 	<div class="metric_help">Latency of jwt authentication operations in seconds. This is the time spent authenticating a token for cache miss only (i.e. when the token is not found in the cache).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">jwt_issuer_hash</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">jwt_issuer_hash</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authorization_config_controller_last_config_info</div>
 	<div class="metric_help">Information about the last applied authorization configuration with hash as label, split by apiserver identity.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">hash</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">hash</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authorization_decisions_total</div>
 	<div class="metric_help">Total number of terminal decisions made by an authorizer split by authorizer type, name, and decision.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">decision</span><span class="metric_label">name</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">decision</span><span class="metric_label">name</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authorization_match_condition_evaluation_errors_total</div>
 	<div class="metric_help">Total number of errors when an authorization webhook encounters a match condition error split by authorizer type and name.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authorization_match_condition_evaluation_seconds</div>
 	<div class="metric_help">Authorization match condition evaluation time in seconds, split by authorizer type and name.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authorization_match_condition_exclusions_total</div>
 	<div class="metric_help">Total number of exclusions when an authorization webhook is skipped because match conditions exclude it.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authorization_webhook_duration_seconds</div>
 	<div class="metric_help">Request latency in seconds.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authorization_webhook_evaluations_fail_open_total</div>
 	<div class="metric_help">NoOpinion results due to webhook timeout or error.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_authorization_webhook_evaluations_total</div>
 	<div class="metric_help">Round-trips to authorization webhooks.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_cache_list_fetched_objects_total</div>
 	<div class="metric_help">Number of objects read from watch cache in the course of serving a LIST request</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">index</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">index</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_cache_list_returned_objects_total</div>
 	<div class="metric_help">Number of objects returned for a LIST request from watch cache</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_cache_list_total</div>
 	<div class="metric_help">Number of LIST requests served from watch cache</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">index</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">index</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_certificates_registry_csr_honored_duration_total</div>
 	<div class="metric_help">Total number of issued CSRs with a requested duration that was honored, sliced by signer (only kubernetes.io signer names are specifically identified)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">signerName</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">signerName</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_certificates_registry_csr_requested_duration_total</div>
 	<div class="metric_help">Total number of issued CSRs with a requested duration, sliced by signer (only kubernetes.io signer names are specifically identified)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">signerName</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">signerName</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_client_certificate_expiration_seconds</div>
 	<div class="metric_help">Distribution of the remaining lifetime on the certificate used to authenticate a request.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_clusterip_repair_ip_errors_total</div>
 	<div class="metric_help">Number of errors detected on clusterips by the repair loop broken down by type of error: leak, repair, full, outOfRange, duplicate, unknown, invalid</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_clusterip_repair_reconcile_errors_total</div>
 	<div class="metric_help">Number of reconciliation failures on the clusterip repair reconcile loop</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_conversion_webhook_duration_seconds</div>
 	<div class="metric_help">Conversion webhook request latency</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">failure_type</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">failure_type</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_conversion_webhook_request_total</div>
 	<div class="metric_help">Counter for conversion webhook requests with success/failure and failure error type</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">failure_type</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">failure_type</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_crd_conversion_webhook_duration_seconds</div>
 	<div class="metric_help">CRD webhook conversion duration in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">crd_name</span><span class="metric_label">from_version</span><span class="metric_label">succeeded</span><span class="metric_label">to_version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">crd_name</span><span class="metric_label">from_version</span><span class="metric_label">succeeded</span><span class="metric_label">to_version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_current_inqueue_requests</div>
 	<div class="metric_help">Maximal number of queued requests in this apiserver per request kind in last second.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">request_kind</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">request_kind</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_delegated_authn_request_duration_seconds</div>
 	<div class="metric_help">Request latency in seconds. Broken down by status code.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_delegated_authn_request_total</div>
 	<div class="metric_help">Number of HTTP requests partitioned by status code.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_delegated_authz_request_duration_seconds</div>
 	<div class="metric_help">Request latency in seconds. Broken down by status code.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_delegated_authz_request_total</div>
 	<div class="metric_help">Number of HTTP requests partitioned by status code.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_egress_dialer_dial_duration_seconds</div>
 	<div class="metric_help">Dial latency histogram in seconds, labeled by the protocol (http-connect or grpc), transport (tcp or uds)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">protocol</span><span class="metric_label">transport</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">protocol</span><span class="metric_label">transport</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_egress_dialer_dial_failure_count</div>
 	<div class="metric_help">Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">protocol</span><span class="metric_label">stage</span><span class="metric_label">transport</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">protocol</span><span class="metric_label">stage</span><span class="metric_label">transport</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_egress_dialer_dial_start_total</div>
 	<div class="metric_help">Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">protocol</span><span class="metric_label">transport</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">protocol</span><span class="metric_label">transport</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds</div>
 	<div class="metric_help">Timestamp of the last successful or failed automatic reload of encryption configuration split by apiserver identity.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_encryption_config_controller_automatic_reloads_total</div>
 	<div class="metric_help">Total number of reload successes and failures of encryption configuration split by apiserver identity.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_encryption_config_controller_last_config_info</div>
 	<div class="metric_help">Information about the last applied encryption configuration with hash as label, split by apiserver identity.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">hash</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">hash</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_envelope_encryption_dek_cache_fill_percent</div>
 	<div class="metric_help">Percent of the cache slots currently occupied by cached DEKs.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_envelope_encryption_dek_cache_inter_arrival_time_seconds</div>
 	<div class="metric_help">Time (in seconds) of inter arrival of transformation requests.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">transformation_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">transformation_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_envelope_encryption_dek_source_cache_size</div>
 	<div class="metric_help">Number of records in data encryption key (DEK) source cache. On a restart, this value is an approximation of the number of decrypt RPC calls the server will make to the KMS plugin.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">provider_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">provider_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_envelope_encryption_invalid_key_id_from_status_total</div>
 	<div class="metric_help">Number of times an invalid keyID is returned by the Status RPC call split by error.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error</span><span class="metric_label">provider_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error</span><span class="metric_label">provider_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_envelope_encryption_key_id_hash_last_timestamp_seconds</div>
 	<div class="metric_help">The last time in seconds when a keyID was used.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">key_id_hash</span><span class="metric_label">provider_name</span><span class="metric_label">transformation_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">key_id_hash</span><span class="metric_label">provider_name</span><span class="metric_label">transformation_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_envelope_encryption_key_id_hash_status_last_timestamp_seconds</div>
 	<div class="metric_help">The last time in seconds when a keyID was returned by the Status RPC call.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">key_id_hash</span><span class="metric_label">provider_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">key_id_hash</span><span class="metric_label">provider_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_envelope_encryption_key_id_hash_total</div>
 	<div class="metric_help">Number of times a keyID is used split by transformation type, provider, and apiserver identity.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">key_id_hash</span><span class="metric_label">provider_name</span><span class="metric_label">transformation_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">apiserver_id_hash</span><span class="metric_label">key_id_hash</span><span class="metric_label">provider_name</span><span class="metric_label">transformation_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_envelope_encryption_kms_operations_latency_seconds</div>
 	<div class="metric_help">KMS operation duration with gRPC error code status total.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">grpc_status_code</span><span class="metric_label">method_name</span><span class="metric_label">provider_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">grpc_status_code</span><span class="metric_label">method_name</span><span class="metric_label">provider_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_externaljwt_fetch_keys_data_timestamp</div>
 	<div class="metric_help">Unix Timestamp in seconds of the last successful FetchKeys data_timestamp value returned by the external signer</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_externaljwt_fetch_keys_request_total</div>
 	<div class="metric_help">Total attempts at syncing supported JWKs</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_externaljwt_fetch_keys_success_timestamp</div>
 	<div class="metric_help">Unix Timestamp in seconds of the last successful FetchKeys request</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_externaljwt_request_duration_seconds</div>
 	<div class="metric_help">Request duration and time for calls to external-jwt-signer</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">method</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">method</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_externaljwt_sign_request_total</div>
 	<div class="metric_help">Total attempts at signing JWT</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_current_inqueue_seats</div>
 	<div class="metric_help">Number of seats currently pending in queues of the API Priority and Fairness subsystem</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_current_limit_seats</div>
 	<div class="metric_help">current derived number of execution seats available to each priority level</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_current_r</div>
 	<div class="metric_help">R(time of last change)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_demand_seats</div>
 	<div class="metric_help">Observations, at the end of every nanosecond, of (the number of seats each priority level could use) / (nominal number of seats for that level)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="timingratiohistogram"><label class="metric_detail">Type:</label> <span class="metric_type">TimingRatioHistogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_demand_seats_average</div>
 	<div class="metric_help">Time-weighted average, over last adjustment period, of demand_seats</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_demand_seats_high_watermark</div>
 	<div class="metric_help">High watermark, over last adjustment period, of demand_seats</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_demand_seats_smoothed</div>
 	<div class="metric_help">Smoothed seat demands</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_demand_seats_stdev</div>
 	<div class="metric_help">Time-weighted standard deviation, over last adjustment period, of demand_seats</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_dispatch_r</div>
 	<div class="metric_help">R(time of last dispatch)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_epoch_advance_total</div>
 	<div class="metric_help">Number of times the queueset's progress meter jumped backward</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span><span class="metric_label">success</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span><span class="metric_label">success</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_latest_s</div>
 	<div class="metric_help">S(most recently dispatched request)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_lower_limit_seats</div>
 	<div class="metric_help">Configured lower bound on number of execution seats available to each priority level</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_next_discounted_s_bounds</div>
 	<div class="metric_help">min and max, over queues, of S(oldest waiting request in queue) - estimated work in progress</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">bound</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">bound</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_next_s_bounds</div>
 	<div class="metric_help">min and max, over queues, of S(oldest waiting request in queue)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">bound</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">bound</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_priority_level_request_utilization</div>
 	<div class="metric_help">Observations, at the end of every nanosecond, of number of requests (as a fraction of the relevant limit) waiting or in any stage of execution (but only initial stage for WATCHes)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="timingratiohistogram"><label class="metric_detail">Type:</label> <span class="metric_type">TimingRatioHistogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">phase</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">phase</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_priority_level_seat_utilization</div>
 	<div class="metric_help">Observations, at the end of every nanosecond, of utilization of seats for any stage of execution (but only initial stage for WATCHes)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="timingratiohistogram"><label class="metric_detail">Type:</label> <span class="metric_type">TimingRatioHistogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_labels_constant"><label class="metric_detail">Const Labels:</label><span class="metric_label">phase:executing</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_labels_constant"><label class="metric_detail">Const Labels:</label><span class="metric_label">phase:executing</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_read_vs_write_current_requests</div>
 	<div class="metric_help">Observations, at the end of every nanosecond, of the number of requests (as a fraction of the relevant limit) waiting or in regular stage of execution</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="timingratiohistogram"><label class="metric_detail">Type:</label> <span class="metric_type">TimingRatioHistogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">phase</span><span class="metric_label">request_kind</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">phase</span><span class="metric_label">request_kind</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_request_concurrency_in_use</div>
 	<div class="metric_help">Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.31.0</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.31.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_request_concurrency_limit</div>
 	<div class="metric_help">Nominal number of execution seats configured for each priority level</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.30.0</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.30.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_request_dispatch_no_accommodation_total</div>
 	<div class="metric_help">Number of times a dispatch attempt resulted in a non accommodation due to lack of available seats</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_request_execution_seconds</div>
 	<div class="metric_help">Duration of initial stage (for a WATCH) or any (for a non-WATCH) stage of request execution in the API Priority and Fairness subsystem</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_request_queue_length_after_enqueue</div>
 	<div class="metric_help">Length of queue in the API Priority and Fairness subsystem, as seen by each request after it is enqueued</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_seat_fair_frac</div>
 	<div class="metric_help">Fair fraction of server's concurrency to allocate to each priority level that can use it</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_target_seats</div>
 	<div class="metric_help">Seat allocation targets</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_upper_limit_seats</div>
 	<div class="metric_help">Configured upper bound on number of execution seats available to each priority level</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_watch_count_samples</div>
 	<div class="metric_help">count of watchers for mutating requests in API Priority and Fairness</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_flowcontrol_work_estimated_seats</div>
 	<div class="metric_help">Number of estimated seats (maximum of initial and final seats) associated with requests in API Priority and Fairness</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">flow_schema</span><span class="metric_label">priority_level</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_init_events_total</div>
 	<div class="metric_help">Counter of init events processed in watch cache broken by resource type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_kube_aggregator_x509_insecure_sha1_total</div>
 	<div class="metric_help">Counts the number of requests to servers with insecure SHA1 signatures in their serving certificate OR the number of connection failures due to the insecure SHA1 signatures (either/or, based on the runtime environment)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_kube_aggregator_x509_missing_san_total</div>
 	<div class="metric_help">Counts the number of requests to servers missing SAN extension in their serving certificate OR the number of connection failures due to the lack of x509 certificate SAN extension missing (either/or, based on the runtime environment)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_mutating_admission_policy_check_duration_seconds</div>
 	<div class="metric_help">Mutation admission latency for individual mutation expressions in seconds, labeled by policy and binding.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error_type</span><span class="metric_label">policy</span><span class="metric_label">policy_binding</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error_type</span><span class="metric_label">policy</span><span class="metric_label">policy_binding</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_mutating_admission_policy_check_total</div>
 	<div class="metric_help">Mutation admission policy check total, labeled by policy and further identified by binding.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error_type</span><span class="metric_label">policy</span><span class="metric_label">policy_binding</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error_type</span><span class="metric_label">policy</span><span class="metric_label">policy_binding</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_nodeport_repair_port_errors_total</div>
 	<div class="metric_help">Number of errors detected on ports by the repair loop broken down by type of error: leak, repair, full, outOfRange, duplicate, unknown</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_nodeport_repair_reconcile_errors_total</div>
 	<div class="metric_help">Number of reconciliation failures on the nodeport repair reconcile loop</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_aborts_total</div>
 	<div class="metric_help">Number of requests which apiserver aborted possibly due to a timeout, for each group, version, verb, resource, subresource and scope</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_body_size_bytes</div>
 	<div class="metric_help">Apiserver request body size in bytes broken out by resource and verb.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">verb</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">verb</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_filter_duration_seconds</div>
 	<div class="metric_help">Request filter latency distribution in seconds, for each filter type</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">filter</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">filter</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_post_timeout_total</div>
 	<div class="metric_help">Tracks the activity of the request handlers after the associated requests have been timed out by the apiserver</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">source</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">source</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_sli_duration_seconds</div>
 	<div class="metric_help">Response latency distribution (not counting webhook duration and priority & fairness queue wait times) in seconds for each verb, group, version, resource, subresource, scope and component.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_slo_duration_seconds</div>
 	<div class="metric_help">Response latency distribution (not counting webhook duration and priority & fairness queue wait times) in seconds for each verb, group, version, resource, subresource, scope and component.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.27.0</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.27.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_terminations_total</div>
 	<div class="metric_help">Number of requests which apiserver terminated in self-defense.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">component</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">scope</span><span class="metric_label">subresource</span><span class="metric_label">verb</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_request_timestamp_comparison_time</div>
 	<div class="metric_help">Time taken for comparison of old vs new objects in UPDATE or PATCH requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code_path</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code_path</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_rerouted_request_total</div>
-	<div class="metric_help">Total number of requests that were proxied to a peer kube apiserver because the local apiserver was not capable of serving it</div>
+	<div class="metric_help">`Total number of requests that were proxied to a peer kube-apiserver because the local apiserver was not capable of serving it, broken down by 'group', 'version', and 'resource' indicating the GVR of the request. If all three are empty (""), the request is a discovery request.`</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_resource_objects</div>
 	<div class="metric_help">Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_resource_size_estimate_bytes</div>
 	<div class="metric_help">Estimated size of stored objects in database. Estimate is based on sum of last observed sizes of serialized objects. In case of a fetching error, the value will be -1.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_selfrequest_total</div>
 	<div class="metric_help">Counter of apiserver self-requests broken out for each verb, API resource and subresource.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">subresource</span><span class="metric_label">verb</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">subresource</span><span class="metric_label">verb</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_consistency_checks_total</div>
 	<div class="metric_help">Counter for status of consistency checks between etcd and watch cache</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_data_key_generation_duration_seconds</div>
 	<div class="metric_help">Latencies in seconds of data encryption key(DEK) generation operations.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_data_key_generation_failures_total</div>
 	<div class="metric_help">Total number of failed data encryption key(DEK) generation operations.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_db_total_size_in_bytes</div>
 	<div class="metric_help">Total size of the storage database file physically allocated in bytes.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">endpoint</span></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.28.0</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">endpoint</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.28.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_decode_errors_total</div>
 	<div class="metric_help">Number of stored object decode errors split by object type</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_envelope_transformation_cache_misses_total</div>
 	<div class="metric_help">Total number of cache misses while accessing key decryption key(KEK).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_events_received_total</div>
 	<div class="metric_help">Number of etcd events received split by kind.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_list_evaluated_objects_total</div>
 	<div class="metric_help">Number of objects tested in the course of serving a LIST request from storage</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_list_fetched_objects_total</div>
 	<div class="metric_help">Number of objects read from storage in the course of serving a LIST request</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_list_returned_objects_total</div>
 	<div class="metric_help">Number of objects returned for a LIST request from storage</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_list_total</div>
 	<div class="metric_help">Number of LIST requests served from storage</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_transformation_duration_seconds</div>
 	<div class="metric_help">Latencies in seconds of value transformation operations.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">transformation_type</span><span class="metric_label">transformer_prefix</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">transformation_type</span><span class="metric_label">transformer_prefix</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_storage_transformation_operations_total</div>
 	<div class="metric_help">Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource</span><span class="metric_label">status</span><span class="metric_label">transformation_type</span><span class="metric_label">transformer_prefix</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource</span><span class="metric_label">status</span><span class="metric_label">transformation_type</span><span class="metric_label">transformer_prefix</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_stream_translator_requests_total</div>
 	<div class="metric_help">Total number of requests that were handled by the StreamTranslatorProxy, which processes streaming RemoteCommand/V5</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_stream_tunnel_requests_total</div>
 	<div class="metric_help">Total number of requests that were handled by the StreamTunnelProxy, which processes streaming PortForward/V2</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_terminated_watchers_total</div>
 	<div class="metric_help">Counter of watchers closed due to unresponsiveness broken by resource type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_tls_handshake_errors_total</div>
 	<div class="metric_help">Number of requests dropped with 'TLS handshake error from' error</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_validation_declarative_validation_panics_total</div>
 	<div class="metric_help">Number of panics in declarative validation, broken down by validation identifier.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">validation_identifier</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">validation_identifier</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_validation_declarative_validation_parity_discrepancies_total</div>
 	<div class="metric_help">Number of discrepancies between declarative and handwritten validation, broken down by validation identifier.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">validation_identifier</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">validation_identifier</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_watch_cache_consistent_read_total</div>
 	<div class="metric_help">Counter for consistent reads from cache.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">fallback</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">success</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">fallback</span><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">success</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_watch_cache_events_dispatched_total</div>
 	<div class="metric_help">Counter of events dispatched in watch cache broken by resource type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_watch_cache_events_received_total</div>
 	<div class="metric_help">Counter of events received in watch cache broken by resource type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_watch_cache_initializations_total</div>
 	<div class="metric_help">Counter of watch cache initializations broken by resource type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_watch_cache_read_wait_seconds</div>
 	<div class="metric_help">Histogram of time spent waiting for a watch cache to become fresh.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_watch_cache_resource_version</div>
 	<div class="metric_help">Current resource version of watch cache broken by resource type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_watch_events_sizes</div>
 	<div class="metric_help">Watch event size distribution in bytes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_watch_events_total</div>
 	<div class="metric_help">Number of events sent in watch clients</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_webhooks_x509_insecure_sha1_total</div>
 	<div class="metric_help">Counts the number of requests to servers with insecure SHA1 signatures in their serving certificate OR the number of connection failures due to the insecure SHA1 signatures (either/or, based on the runtime environment)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">apiserver_webhooks_x509_missing_san_total</div>
 	<div class="metric_help">Counts the number of requests to servers missing SAN extension in their serving certificate OR the number of connection failures due to the lack of x509 certificate SAN extension missing (either/or, based on the runtime environment)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">attach_detach_controller_attachdetach_controller_forced_detaches</div>
 	<div class="metric_help">Number of times the A/D Controller performed a forced detach</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">attachdetach_controller_total_volumes</div>
 	<div class="metric_help">Number of volumes in A/D Controller</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span><span class="metric_label">state</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span><span class="metric_label">state</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">authenticated_user_requests</div>
 	<div class="metric_help">Counter of authenticated requests broken out by username.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">username</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">username</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">authentication_attempts</div>
 	<div class="metric_help">Counter of authenticated attempts.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">authentication_duration_seconds</div>
 	<div class="metric_help">Authentication duration in seconds broken out by result.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">authentication_token_cache_active_fetch_count</div>
 	<div class="metric_help"></div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">authentication_token_cache_fetch_total</div>
 	<div class="metric_help"></div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">authentication_token_cache_request_duration_seconds</div>
 	<div class="metric_help"></div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">authentication_token_cache_request_total</div>
 	<div class="metric_help"></div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">authorization_attempts_total</div>
 	<div class="metric_help">Counter of authorization attempts broken down by result. It can be either 'allowed', 'denied', 'no-opinion' or 'error'.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">authorization_duration_seconds</div>
 	<div class="metric_help">Authorization duration in seconds broken out by result.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">cloud_provider_webhook_request_duration_seconds</div>
 	<div class="metric_help">Request latency in seconds. Broken down by status code.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">webhook</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">webhook</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">cloud_provider_webhook_request_total</div>
 	<div class="metric_help">Number of HTTP requests partitioned by status code.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">webhook</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">webhook</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">clustertrustbundle_publisher_sync_duration_seconds</div>
 	<div class="metric_help">The time it took to sync a cluster trust bundle.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">clustertrustbundle_publisher_sync_total</div>
 	<div class="metric_help">Number of syncs that occurred in cluster trust bundle publisher.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">container_swap_limit_bytes</div>
 	<div class="metric_help">Current amount of the container swap limit in bytes. Reported only on non-windows systems</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">container_swap_usage_bytes</div>
 	<div class="metric_help">Current amount of the container swap usage in bytes. Reported only on non-windows systems</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">pod</span><span class="metric_label">namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">csi_operations_seconds</div>
 	<div class="metric_help">Container Storage Interface operation duration with gRPC error code status total</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">driver_name</span><span class="metric_label">grpc_status_code</span><span class="metric_label">method_name</span><span class="metric_label">migrated</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">driver_name</span><span class="metric_label">grpc_status_code</span><span class="metric_label">method_name</span><span class="metric_label">migrated</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">device_taint_eviction_controller_pod_deletion_duration_seconds</div>
 	<div class="metric_help">Latency, in seconds, between the time when a device taint effect has been activated and a Pod's deletion via DeviceTaintEvictionController.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">device_taint_eviction_controller_pod_deletions_total</div>
 	<div class="metric_help">Total number of Pods deleted by DeviceTaintEvictionController since its start.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">dra_grpc_operations_duration_seconds</div>
 	<div class="metric_help">Duration in seconds of the DRA gRPC operations</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">driver_name</span><span class="metric_label">grpc_status_code</span><span class="metric_label">method_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">driver_name</span><span class="metric_label">grpc_status_code</span><span class="metric_label">method_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">dra_operations_duration_seconds</div>
 	<div class="metric_help">Latency histogram in seconds for the duration of handling all ResourceClaims referenced by a pod when the pod starts or stops. Identified by the name of the operation (PrepareResources or UnprepareResources) and separated by the success of the operation. The number of failed operations is provided through the histogram's overall count.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">is_error</span><span class="metric_label">operation_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">is_error</span><span class="metric_label">operation_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">dra_resource_claims_in_use</div>
 	<div class="metric_help">The number of ResourceClaims that are currently in use on the node, by driver name (driver_name label value) and across all drivers (special value <any> for driver_name). Note that the sum of all by-driver counts is not the total number of in-use ResourceClaims because the same ResourceClaim might use devices from different drivers. Instead, use the count for the <any> driver_name.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">driver_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">driver_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_changes</div>
 	<div class="metric_help">Number of EndpointSlice changes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_desired_endpoint_slices</div>
 	<div class="metric_help">Number of EndpointSlices that would exist with perfect endpoint allocation</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_endpoints_added_per_sync</div>
 	<div class="metric_help">Number of endpoints added on each Service sync</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_endpoints_desired</div>
 	<div class="metric_help">Number of endpoints desired</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_endpoints_removed_per_sync</div>
 	<div class="metric_help">Number of endpoints removed on each Service sync</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_endpointslices_changed_per_sync</div>
 	<div class="metric_help">Number of EndpointSlices changed on each Service sync</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">topology</span><span class="metric_label">traffic_distribution</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">topology</span><span class="metric_label">traffic_distribution</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_num_endpoint_slices</div>
 	<div class="metric_help">Number of EndpointSlices</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_services_count_by_traffic_distribution</div>
 	<div class="metric_help">Number of Services using some specific trafficDistribution</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">traffic_distribution</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">traffic_distribution</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_controller_syncs</div>
 	<div class="metric_help">Number of EndpointSlice syncs</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_mirroring_controller_addresses_skipped_per_sync</div>
 	<div class="metric_help">Number of addresses skipped on each Endpoints sync due to being invalid or exceeding MaxEndpointsPerSubset</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_mirroring_controller_changes</div>
 	<div class="metric_help">Number of EndpointSlice changes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_mirroring_controller_desired_endpoint_slices</div>
 	<div class="metric_help">Number of EndpointSlices that would exist with perfect endpoint allocation</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_mirroring_controller_endpoints_added_per_sync</div>
 	<div class="metric_help">Number of endpoints added on each Endpoints sync</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_mirroring_controller_endpoints_desired</div>
 	<div class="metric_help">Number of endpoints desired</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_mirroring_controller_endpoints_removed_per_sync</div>
 	<div class="metric_help">Number of endpoints removed on each Endpoints sync</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_mirroring_controller_endpoints_sync_duration</div>
 	<div class="metric_help">Duration of syncEndpoints() in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_mirroring_controller_endpoints_updated_per_sync</div>
 	<div class="metric_help">Number of endpoints updated on each Endpoints sync</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">endpoint_slice_mirroring_controller_num_endpoint_slices</div>
 	<div class="metric_help">Number of EndpointSlices</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">ephemeral_volume_controller_create_failures_total</div>
 	<div class="metric_help">Number of PersistentVolumeClaim creation requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">ephemeral_volume_controller_create_total</div>
 	<div class="metric_help">Number of PersistentVolumeClaim creation requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">etcd_bookmark_counts</div>
 	<div class="metric_help">Number of etcd bookmarks (progress notify events) split by kind.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">etcd_lease_object_counts</div>
 	<div class="metric_help">Number of objects attached to a single etcd lease.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">etcd_request_duration_seconds</div>
 	<div class="metric_help">Etcd request latency in seconds for each operation and object type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">operation</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">operation</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">etcd_request_errors_total</div>
 	<div class="metric_help">Etcd failed request counts for each operation and object type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">operation</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">operation</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">etcd_requests_total</div>
 	<div class="metric_help">Etcd request counts for each operation and object type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">operation</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">operation</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">etcd_version_info</div>
 	<div class="metric_help">Etcd server's binary version</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">binary_version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">binary_version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>etcd-version-monitor (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">field_validation_request_duration_seconds</div>
 	<div class="metric_help">Response latency distribution in seconds for each field validation value</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">field_validation</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">field_validation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">force_cleaned_failed_volume_operation_errors_total</div>
 	<div class="metric_help">The number of volumes that failed force cleanup after their reconstruction failed during kubelet startup.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">force_cleaned_failed_volume_operations_total</div>
 	<div class="metric_help">The number of volumes that were force cleaned after their reconstruction failed during kubelet startup. This includes both successful and failed cleanups.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">garbagecollector_controller_resources_sync_error_total</div>
 	<div class="metric_help">Number of garbage collector resources sync errors</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">horizontal_pod_autoscaler_controller_desired_replicas</div>
 	<div class="metric_help">Current desired replica count for HPA objects.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">hpa_name</span><span class="metric_label">namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">hpa_name</span><span class="metric_label">namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">horizontal_pod_autoscaler_controller_metric_computation_duration_seconds</div>
 	<div class="metric_help">The time(seconds) that the HPA controller takes to calculate one metric. The label 'action' should be either 'scale_down', 'scale_up', or 'none'. The label 'error' should be either 'spec', 'internal', or 'none'. The label 'metric_type' corresponds to HPA.spec.metrics[*].type</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">error</span><span class="metric_label">metric_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">error</span><span class="metric_label">metric_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">horizontal_pod_autoscaler_controller_metric_computation_total</div>
 	<div class="metric_help">Number of metric computations. The label 'action' should be either 'scale_down', 'scale_up', or 'none'. Also, the label 'error' should be either 'spec', 'internal', or 'none'. The label 'metric_type' corresponds to HPA.spec.metrics[*].type</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">error</span><span class="metric_label">metric_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">error</span><span class="metric_label">metric_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">horizontal_pod_autoscaler_controller_num_horizontal_pod_autoscalers</div>
 	<div class="metric_help">Current number of controlled HPA objects.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">horizontal_pod_autoscaler_controller_reconciliation_duration_seconds</div>
 	<div class="metric_help">The time(seconds) that the HPA controller takes to reconcile once. The label 'action' should be either 'scale_down', 'scale_up', or 'none'. Also, the label 'error' should be either 'spec', 'internal', or 'none'. Note that if both spec and internal errors happen during a reconciliation, the first one to occur is reported in `error` label.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">error</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">error</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">horizontal_pod_autoscaler_controller_reconciliations_total</div>
 	<div class="metric_help">Number of reconciliations of HPA controller. The label 'action' should be either 'scale_down', 'scale_up', or 'none'. Also, the label 'error' should be either 'spec', 'internal', or 'none'. Note that if both spec and internal errors happen during a reconciliation, the first one to occur is reported in `error` label.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">error</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span><span class="metric_label">error</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">informer_queued_items</div>
+	<div class="metric_help">Number of items currently queued in the FIFO.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">name</span><span class="metric_label">resource</span><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">job_controller_job_finished_indexes_total</div>
 	<div class="metric_help">`The number of finished indexes. Possible values for the, 			status label are: "succeeded", "failed". Possible values for the, 			backoffLimit label are: "perIndex" and "global"`</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">backoffLimit</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">backoffLimit</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">job_controller_job_pods_creation_total</div>
 	<div class="metric_help">`The number of Pods created by the Job controller labelled with a reason for the Pod creation., This metric also distinguishes between Pods created using different PodReplacementPolicy settings., Possible values of the "reason" label are:, "new", "recreate_terminating_or_failed", "recreate_failed"., Possible values of the "status" label are:, "succeeded", "failed".`</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">job_controller_jobs_by_external_controller_total</div>
 	<div class="metric_help">The number of Jobs managed by an external controller</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">controller_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">controller_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">job_controller_pod_failures_handled_by_failure_policy_total</div>
 	<div class="metric_help">`The number of failed Pods handled by failure policy with, 			respect to the failure policy action applied based on the matched, 			rule. Possible values of the action label correspond to the, 			possible values for the failure policy rule action, which are:, 			"FailJob", "Ignore" and "Count".`</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">action</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">job_controller_terminated_pods_tracking_finalizer_total</div>
 	<div class="metric_help">`The number of terminated pods (phase=Failed|Succeeded), that have the finalizer batch.kubernetes.io/job-tracking, The event label can be "add" or "delete".`</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_clusterip_allocator_allocated_ips</div>
 	<div class="metric_help">Gauge measuring the number of allocated IPs for Services</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_clusterip_allocator_allocation_duration_seconds</div>
 	<div class="metric_help">Duration in seconds to allocate a Cluster IP by ServiceCIDR</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_clusterip_allocator_allocation_errors_total</div>
 	<div class="metric_help">Number of errors trying to allocate Cluster IPs</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span><span class="metric_label">scope</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span><span class="metric_label">scope</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_clusterip_allocator_allocation_total</div>
 	<div class="metric_help">Number of Cluster IPs allocations</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span><span class="metric_label">scope</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span><span class="metric_label">scope</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_clusterip_allocator_available_ips</div>
 	<div class="metric_help">Gauge measuring the number of available IPs for Services</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">cidr</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_nodeport_allocator_allocated_ports</div>
 	<div class="metric_help">Gauge measuring the number of allocated NodePorts for Services</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_nodeport_allocator_allocation_errors_total</div>
 	<div class="metric_help">Number of errors trying to allocate NodePort</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">scope</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">scope</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_nodeport_allocator_allocation_total</div>
 	<div class="metric_help">Number of NodePort allocations</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">scope</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">scope</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_nodeport_allocator_available_ports</div>
 	<div class="metric_help">Gauge measuring the number of available NodePorts for Services</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_pod_logs_backend_tls_failure_total</div>
 	<div class="metric_help">Total number of requests for pods/logs that failed due to kubelet server TLS verification</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_pod_logs_insecure_backend_total</div>
 	<div class="metric_help">Total number of requests for pods/logs sliced by usage type: enforce_tls, skip_tls_allowed, skip_tls_denied</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">usage</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">usage</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_pod_logs_pods_logs_backend_tls_failure_total</div>
 	<div class="metric_help">Total number of requests for pods/logs that failed due to kubelet server TLS verification</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.27.0</span></li></ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.27.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kube_apiserver_pod_logs_pods_logs_insecure_backend_total</div>
 	<div class="metric_help">Total number of requests for pods/logs sliced by usage type: enforce_tls, skip_tls_allowed, skip_tls_denied</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">usage</span></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.27.0</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">usage</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.27.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_active_pods</div>
 	<div class="metric_help">The number of pods the kubelet considers active and which are being considered when admitting new pods. static is true if the pod is not from the apiserver.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">static</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">static</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_admission_rejections_total</div>
 	<div class="metric_help">Cumulative number pod admission rejections by the Kubelet.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_certificate_manager_client_expiration_renew_errors</div>
 	<div class="metric_help">Counter of certificate renewal errors.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_certificate_manager_client_ttl_seconds</div>
 	<div class="metric_help">Gauge of the TTL (time-to-live) of the Kubelet's client certificate. The value is in seconds until certificate expiry (negative if already expired). If client certificate is invalid or unused, the value will be +INF.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_certificate_manager_server_rotation_seconds</div>
 	<div class="metric_help">Histogram of the number of seconds the previous certificate lived before being rotated.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_certificate_manager_server_ttl_seconds</div>
 	<div class="metric_help">Gauge of the shortest TTL (time-to-live) of the Kubelet's serving certificate. The value is in seconds until certificate expiry (negative if already expired). If serving certificate is invalid or unused, the value will be +INF.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_cgroup_manager_duration_seconds</div>
 	<div class="metric_help">Duration in seconds for cgroup manager operations. Broken down by method.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_cgroup_version</div>
 	<div class="metric_help">cgroup version on the hosts.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_container_aligned_compute_resources_count</div>
 	<div class="metric_help">Cumulative number of aligned compute resources allocated to containers by alignment type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">boundary</span><span class="metric_label">scope</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">boundary</span><span class="metric_label">scope</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_container_aligned_compute_resources_failure_count</div>
 	<div class="metric_help">Cumulative number of failures to allocate aligned compute resources to containers by alignment type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">boundary</span><span class="metric_label">scope</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">boundary</span><span class="metric_label">scope</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_container_log_filesystem_used_bytes</div>
 	<div class="metric_help">Bytes used by the container's logs on the filesystem.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">uid</span><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">container</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">uid</span><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">container</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_container_requested_resizes_total</div>
 	<div class="metric_help">Number of requested resizes, counted at the container level. Different resources on the same container are counted separately. The 'requirement' label refers to 'memory' or 'limits'; the 'operation' label can be one of 'add', 'remove', 'increase' or 'decrease'.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span><span class="metric_label">requirement</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span><span class="metric_label">requirement</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_containers_per_pod_count</div>
 	<div class="metric_help">The number of containers per pod.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_cpu_manager_allocation_per_numa</div>
 	<div class="metric_help">Number of CPUs allocated per NUMA node</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">numa_node</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">numa_node</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_cpu_manager_exclusive_cpu_allocation_count</div>
 	<div class="metric_help">The total number of CPUs exclusively allocated to containers running on this node</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_cpu_manager_pinning_errors_total</div>
 	<div class="metric_help">The number of cpu core allocations which required pinning failed.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_cpu_manager_pinning_requests_total</div>
 	<div class="metric_help">The number of cpu core allocations which required pinning.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_cpu_manager_shared_pool_size_millicores</div>
 	<div class="metric_help">The size of the shared CPU pool for non-guaranteed QoS pods, in millicores.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_credential_provider_config_info</div>
 	<div class="metric_help">Information about the last applied credential provider configuration with hash as label</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">hash</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">hash</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_credential_provider_plugin_duration</div>
 	<div class="metric_help">Duration of execution in seconds for credential provider plugin</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_credential_provider_plugin_errors_total</div>
 	<div class="metric_help">Number of errors from credential provider plugin</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_cri_losing_support</div>
 	<div class="metric_help">the Kubernetes version that the currently running CRI implementation will lose support on if not upgraded.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_desired_pods</div>
 	<div class="metric_help">The number of pods the kubelet is being instructed to run. static is true if the pod is not from the apiserver.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">static</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">static</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_device_plugin_alloc_duration_seconds</div>
 	<div class="metric_help">Duration in seconds to serve a device plugin Allocation request. Broken down by resource name.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_device_plugin_registration_total</div>
 	<div class="metric_help">Cumulative number of device plugin registrations. Broken down by resource name.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_evented_pleg_connection_error_count</div>
 	<div class="metric_help">The number of errors encountered during the establishment of streaming connection with the CRI runtime.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_evented_pleg_connection_latency_seconds</div>
 	<div class="metric_help">The latency of streaming connection with the CRI runtime, measured in seconds.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_evented_pleg_connection_success_count</div>
 	<div class="metric_help">The number of times a streaming client was obtained to receive CRI Events.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_eviction_stats_age_seconds</div>
 	<div class="metric_help">Time between when stats are collected, and when pod is evicted based on those stats by eviction signal</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">eviction_signal</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">eviction_signal</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_evictions</div>
 	<div class="metric_help">Cumulative number of pod evictions by eviction signal</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">eviction_signal</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">eviction_signal</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_graceful_shutdown_end_time_seconds</div>
 	<div class="metric_help">Last graceful shutdown end time since unix epoch in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_graceful_shutdown_start_time_seconds</div>
 	<div class="metric_help">Last graceful shutdown start time since unix epoch in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_http_inflight_requests</div>
 	<div class="metric_help">Number of the inflight http requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">long_running</span><span class="metric_label">method</span><span class="metric_label">path</span><span class="metric_label">server_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">long_running</span><span class="metric_label">method</span><span class="metric_label">path</span><span class="metric_label">server_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_http_requests_duration_seconds</div>
 	<div class="metric_help">Duration in seconds to serve http requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">long_running</span><span class="metric_label">method</span><span class="metric_label">path</span><span class="metric_label">server_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">long_running</span><span class="metric_label">method</span><span class="metric_label">path</span><span class="metric_label">server_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_http_requests_total</div>
 	<div class="metric_help">Number of the http requests received since the server started</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">long_running</span><span class="metric_label">method</span><span class="metric_label">path</span><span class="metric_label">server_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">long_running</span><span class="metric_label">method</span><span class="metric_label">path</span><span class="metric_label">server_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_image_garbage_collected_total</div>
 	<div class="metric_help">Total number of images garbage collected by the kubelet, whether through disk usage or image age.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_image_manager_ensure_image_requests_total</div>
 	<div class="metric_help">Number of ensure-image requests processed by the kubelet.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">present_locally</span><span class="metric_label">pull_policy</span><span class="metric_label">pull_required</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">present_locally</span><span class="metric_label">pull_policy</span><span class="metric_label">pull_required</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_image_pull_duration_seconds</div>
 	<div class="metric_help">Duration in seconds to pull an image.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">image_size_in_bytes</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">image_size_in_bytes</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_imagemanager_image_mustpull_checks_total</div>
 	<div class="metric_help">Counter for how many times kubelet checked whether credentials need to be re-verified to access an image</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_imagemanager_inmemory_pulledrecords_usage_percent</div>
 	<div class="metric_help">The ImagePulledRecords in-memory cache usage in percent.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_imagemanager_inmemory_pullintents_usage_percent</div>
 	<div class="metric_help">The ImagePullIntents in-memory cache usage in percent.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_imagemanager_ondisk_pulledrecords</div>
 	<div class="metric_help">Number of ImagePulledRecords stored on disk.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_imagemanager_ondisk_pullintents</div>
 	<div class="metric_help">Number of ImagePullIntents stored on disk.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_lifecycle_handler_http_fallbacks_total</div>
 	<div class="metric_help">The number of times lifecycle handlers successfully fell back to http from https.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_managed_ephemeral_containers</div>
 	<div class="metric_help">Current number of ephemeral containers in pods managed by this kubelet.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_memory_manager_pinning_errors_total</div>
 	<div class="metric_help">The number of memory pages allocations which required pinning that failed.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_memory_manager_pinning_requests_total</div>
 	<div class="metric_help">The number of memory pages allocations which required pinning.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">kubelet_metrics_provider</div>
+	<div class="metric_help">Metrics provider used by kubelet to collect container stats. Values can be 'cadvisor' and 'cri'</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">provider</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_mirror_pods</div>
 	<div class="metric_help">The number of mirror pods the kubelet will try to create (one per admitted static pod)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_node_name</div>
 	<div class="metric_help">The node's name. The count is always 1.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">node</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">node</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_node_startup_duration_seconds</div>
 	<div class="metric_help">Duration in seconds of node startup in total.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_node_startup_post_registration_duration_seconds</div>
 	<div class="metric_help">Duration in seconds of node startup after registration.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_node_startup_pre_kubelet_duration_seconds</div>
 	<div class="metric_help">Duration in seconds of node startup before kubelet starts.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_node_startup_pre_registration_duration_seconds</div>
 	<div class="metric_help">Duration in seconds of node startup before registration.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_node_startup_registration_duration_seconds</div>
 	<div class="metric_help">Duration in seconds of node startup during registration.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_orphan_pod_cleaned_volumes</div>
 	<div class="metric_help">The total number of orphaned Pods whose volumes were cleaned in the last periodic sweep.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_orphan_pod_cleaned_volumes_errors</div>
 	<div class="metric_help">The number of orphaned Pods whose volumes failed to be cleaned in the last periodic sweep.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_orphaned_runtime_pods_total</div>
 	<div class="metric_help">Number of pods that have been detected in the container runtime without being already known to the pod worker. This typically indicates the kubelet was restarted while a pod was force deleted in the API or in the local configuration, which is unusual.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pleg_discard_events</div>
 	<div class="metric_help">The number of discard events in PLEG.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pleg_last_seen_seconds</div>
 	<div class="metric_help">Timestamp in seconds when PLEG was last seen active.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pleg_relist_duration_seconds</div>
 	<div class="metric_help">Duration in seconds for relisting pods in PLEG.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pleg_relist_interval_seconds</div>
 	<div class="metric_help">Interval in seconds between relisting in PLEG.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_deferred_accepted_resizes_total</div>
 	<div class="metric_help">Cumulative number of resizes that were accepted after being deferred.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">retry_trigger</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">retry_trigger</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_in_progress_resizes</div>
 	<div class="metric_help">Number of in-progress resizes for pods.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_infeasible_resizes_total</div>
 	<div class="metric_help">Number of infeasible resizes for pods.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason_detail</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason_detail</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_pending_resizes</div>
 	<div class="metric_help">Number of pending resizes for pods.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_resize_duration_milliseconds</div>
 	<div class="metric_help">Duration in milliseconds to actuate a pod resize</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">success</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">success</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_resources_endpoint_errors_get</div>
 	<div class="metric_help">Number of requests to the PodResource Get endpoint which returned error. Broken down by server api version.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_resources_endpoint_errors_get_allocatable</div>
 	<div class="metric_help">Number of requests to the PodResource GetAllocatableResources endpoint which returned error. Broken down by server api version.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_resources_endpoint_errors_list</div>
 	<div class="metric_help">Number of requests to the PodResource List endpoint which returned error. Broken down by server api version.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_resources_endpoint_requests_get</div>
 	<div class="metric_help">Number of requests to the PodResource Get endpoint. Broken down by server api version.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_resources_endpoint_requests_get_allocatable</div>
 	<div class="metric_help">Number of requests to the PodResource GetAllocatableResources endpoint. Broken down by server api version.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_resources_endpoint_requests_list</div>
 	<div class="metric_help">Number of requests to the PodResource List endpoint. Broken down by server api version.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_resources_endpoint_requests_total</div>
 	<div class="metric_help">Cumulative number of requests to the PodResource endpoint. Broken down by server api version.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">server_api_version</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_start_duration_seconds</div>
 	<div class="metric_help">Duration in seconds from kubelet seeing a pod for the first time to the pod starting to run</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_start_sli_duration_seconds</div>
 	<div class="metric_help">Duration in seconds to start a pod, excluding time to pull images and run init containers, measured from pod creation timestamp to when all its containers are reported as started and observed via watch</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_start_total_duration_seconds</div>
 	<div class="metric_help">Duration in seconds to start a pod since creation, including time to pull images and run init containers, measured from pod creation timestamp to when all its containers are reported as started and observed via watch</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_status_sync_duration_seconds</div>
 	<div class="metric_help">Duration in seconds to sync a pod status update. Measures time from detection of a change to pod status until the API is successfully updated for that pod, even if multiple intevening changes to pod status occur.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_worker_duration_seconds</div>
 	<div class="metric_help">Duration in seconds to sync a single pod. Broken down by operation type: create, update, or sync</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_pod_worker_start_duration_seconds</div>
 	<div class="metric_help">Duration in seconds from kubelet seeing a pod to starting a worker.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_podcertificate_states</div>
 	<div class="metric_help">Gauge vector reporting the number of pod certificate projected volume sources, faceted by signer_name and state.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">signer_name</span><span class="metric_label">state</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">signer_name</span><span class="metric_label">state</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_preemptions</div>
 	<div class="metric_help">Cumulative number of pod preemptions by preemption resource</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">preemption_signal</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">preemption_signal</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_restarted_pods_total</div>
 	<div class="metric_help">Number of pods that have been restarted because they were deleted and recreated with the same UID while the kubelet was watching them (common for static pods, extremely uncommon for API pods)</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">static</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">static</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_run_podsandbox_duration_seconds</div>
 	<div class="metric_help">Duration in seconds of the run_podsandbox operations. Broken down by RuntimeClass.Handler.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">runtime_handler</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">runtime_handler</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_run_podsandbox_errors_total</div>
 	<div class="metric_help">Cumulative number of the run_podsandbox operation errors by RuntimeClass.Handler.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">runtime_handler</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">runtime_handler</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_running_containers</div>
 	<div class="metric_help">Number of containers currently running</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container_state</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container_state</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_running_pods</div>
 	<div class="metric_help">Number of pods that have a running pod sandbox</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_runtime_operations_duration_seconds</div>
 	<div class="metric_help">Duration in seconds of runtime operations. Broken down by operation type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_runtime_operations_errors_total</div>
 	<div class="metric_help">Cumulative number of runtime operation errors by operation type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_runtime_operations_total</div>
 	<div class="metric_help">Cumulative number of runtime operations by operation type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_server_expiration_renew_errors</div>
 	<div class="metric_help">Counter of certificate renewal errors.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_sleep_action_terminated_early_total</div>
 	<div class="metric_help">The number of times lifecycle sleep handler got terminated before it finishes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_started_containers_errors_total</div>
 	<div class="metric_help">Cumulative number of errors when starting containers</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">container_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">container_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_started_containers_total</div>
 	<div class="metric_help">Cumulative number of containers started</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_started_host_process_containers_errors_total</div>
 	<div class="metric_help">Cumulative number of errors when starting hostprocess containers. This metric will only be collected on Windows.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">container_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">container_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_started_host_process_containers_total</div>
 	<div class="metric_help">Cumulative number of hostprocess containers started. This metric will only be collected on Windows.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_started_pods_errors_total</div>
 	<div class="metric_help">Cumulative number of errors when starting pods</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_started_pods_total</div>
 	<div class="metric_help">Cumulative number of pods started</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_started_user_namespaced_pods_errors_total</div>
 	<div class="metric_help">Cumulative number of errors when starting pods with user namespaces. This metric will only be collected on Linux.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_started_user_namespaced_pods_total</div>
 	<div class="metric_help">Cumulative number of pods with user namespaces started. This metric will only be collected on Linux.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_topology_manager_admission_duration_ms</div>
 	<div class="metric_help">Duration in milliseconds to serve a pod admission request.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_topology_manager_admission_errors_total</div>
 	<div class="metric_help">The number of admission request failures where resources could not be aligned.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_topology_manager_admission_requests_total</div>
 	<div class="metric_help">The number of admission requests where resources have to be aligned.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_volume_metric_collection_duration_seconds</div>
 	<div class="metric_help">Duration in seconds to calculate volume stats</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">metric_source</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">metric_source</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_volume_stats_available_bytes</div>
 	<div class="metric_help">Number of available bytes in the volume</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_volume_stats_capacity_bytes</div>
 	<div class="metric_help">Capacity in bytes of the volume</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_volume_stats_health_status_abnormal</div>
 	<div class="metric_help">Abnormal volume health status. The count is either 1 or 0. 1 indicates the volume is unhealthy, 0 indicates volume is healthy</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_volume_stats_inodes</div>
 	<div class="metric_help">Maximum number of inodes in the volume</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_volume_stats_inodes_free</div>
 	<div class="metric_help">Number of free inodes in the volume</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_volume_stats_inodes_used</div>
 	<div class="metric_help">Number of used inodes in the volume</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_volume_stats_used_bytes</div>
 	<div class="metric_help">Number of used bytes in the volume</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">persistentvolumeclaim</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_working_pods</div>
 	<div class="metric_help">Number of pods the kubelet is actually running, broken down by lifecycle phase, whether the pod is desired, orphaned, or runtime only (also orphaned), and whether the pod is static. An orphaned pod has been removed from local configuration or force deleted in the API and consumes resources that are not otherwise visible.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">config</span><span class="metric_label">lifecycle</span><span class="metric_label">static</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">config</span><span class="metric_label">lifecycle</span><span class="metric_label">static</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_conntrack_reconciler_deleted_entries_total</div>
 	<div class="metric_help">Cumulative conntrack flows deleted by conntrack reconciler</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_conntrack_reconciler_sync_duration_seconds</div>
 	<div class="metric_help">ReconcileConntrackFlowsLatency latency in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_iptables_ct_state_invalid_dropped_packets_total</div>
 	<div class="metric_help">packets dropped by iptables to work around conntrack problems</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_iptables_localhost_nodeports_accepted_packets_total</div>
 	<div class="metric_help">Number of packets accepted on nodeports of loopback interface</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_network_programming_duration_seconds</div>
 	<div class="metric_help">In Cluster Network Programming Latency in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_proxy_healthz_total</div>
 	<div class="metric_help">Cumulative proxy healthz HTTP status</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_proxy_livez_total</div>
 	<div class="metric_help">Cumulative proxy livez HTTP status</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_full_proxy_rules_duration_seconds</div>
 	<div class="metric_help">SyncProxyRules latency in seconds for full resyncs</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_partial_proxy_rules_duration_seconds</div>
 	<div class="metric_help">SyncProxyRules latency in seconds for partial resyncs</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_duration_seconds</div>
 	<div class="metric_help">SyncProxyRules latency in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_endpoint_changes_pending</div>
 	<div class="metric_help">Pending proxy rules Endpoint changes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_endpoint_changes_total</div>
 	<div class="metric_help">Cumulative proxy rules Endpoint changes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_iptables_last</div>
 	<div class="metric_help">Number of iptables rules written by kube-proxy in last sync</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span><span class="metric_label">table</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span><span class="metric_label">table</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_iptables_partial_restore_failures_total</div>
 	<div class="metric_help">Cumulative proxy iptables partial restore failures</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_iptables_restore_failures_total</div>
 	<div class="metric_help">Cumulative proxy iptables restore failures</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_iptables_total</div>
 	<div class="metric_help">Total number of iptables rules owned by kube-proxy</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span><span class="metric_label">table</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span><span class="metric_label">table</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_last_queued_timestamp_seconds</div>
 	<div class="metric_help">The last time a sync of proxy rules was queued</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_last_timestamp_seconds</div>
 	<div class="metric_help">The last time proxy rules were successfully synced</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_nftables_cleanup_failures_total</div>
 	<div class="metric_help">Cumulative proxy nftables cleanup failures</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_nftables_sync_failures_total</div>
 	<div class="metric_help">Cumulative proxy nftables sync failures</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_no_local_endpoints_total</div>
 	<div class="metric_help">Number of services with a Local traffic policy and no endpoints</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span><span class="metric_label">traffic_policy</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">ip_family</span><span class="metric_label">traffic_policy</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_service_changes_pending</div>
 	<div class="metric_help">Pending proxy rules Service changes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubeproxy_sync_proxy_rules_service_changes_total</div>
 	<div class="metric_help">Cumulative proxy rules Service changes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
-	</div><div class="metric" data-stability="beta">
-	<div class="metric_name">kubernetes_build_info</div>
-	<div class="metric_help">A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
-	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">build_date</span><span class="metric_label">compiler</span><span class="metric_label">git_commit</span><span class="metric_label">git_tree_state</span><span class="metric_label">git_version</span><span class="metric_label">go_version</span><span class="metric_label">major</span><span class="metric_label">minor</span><span class="metric_label">platform</span></li></ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">leader_election_master_status</div>
 	<div class="metric_help">Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">leader_election_slowpath_total</div>
 	<div class="metric_help">Total number of slow path exercised in renewing leader leases. 'name' is the string used to identify the lease. Please make sure to group by name.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_authorizer_graph_actions_duration_seconds</div>
 	<div class="metric_help">Histogram of duration of graph actions in node authorizer.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_collector_unhealthy_nodes_in_zone</div>
 	<div class="metric_help">Gauge measuring number of not Ready Nodes per zones.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">zone</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">zone</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_collector_update_all_nodes_health_duration_seconds</div>
 	<div class="metric_help">Duration in seconds for NodeController to update the health of all nodes.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_collector_update_node_health_duration_seconds</div>
 	<div class="metric_help">Duration in seconds for NodeController to update the health of a single node.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_collector_zone_health</div>
 	<div class="metric_help">Gauge measuring percentage of healthy nodes per zone.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">zone</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">zone</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_collector_zone_size</div>
 	<div class="metric_help">Gauge measuring number of registered Nodes per zones.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">zone</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">zone</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_controller_cloud_provider_taint_removal_delay_seconds</div>
 	<div class="metric_help">Number of seconds after node creation when NodeController removed the cloud-provider taint of a single node.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_controller_initial_node_sync_delay_seconds</div>
 	<div class="metric_help">Number of seconds after node creation when NodeController finished the initial synchronization of a single node.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_ipam_controller_cidrset_allocation_tries_per_request</div>
 	<div class="metric_help">Number of endpoints added on each Service sync</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_ipam_controller_cidrset_cidrs_allocations_total</div>
 	<div class="metric_help">Counter measuring total number of CIDR allocations.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_ipam_controller_cidrset_cidrs_releases_total</div>
 	<div class="metric_help">Counter measuring total number of CIDR releases.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_ipam_controller_cidrset_usage_cidrs</div>
 	<div class="metric_help">Gauge measuring percentage of allocated CIDRs.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_ipam_controller_cirdset_max_cidrs</div>
 	<div class="metric_help">Maximum number of CIDRs that can be allocated.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">clusterCIDR</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">node_swap_usage_bytes</div>
 	<div class="metric_help">Current swap usage of the node in bytes. Reported only on non-windows systems</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">plugin_manager_total_plugins</div>
 	<div class="metric_help">Number of plugins in Plugin Manager</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">socket_path</span><span class="metric_label">state</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">socket_path</span><span class="metric_label">state</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pod_gc_collector_force_delete_pod_errors_total</div>
 	<div class="metric_help">Number of errors encountered when forcefully deleting the pods since the Pod GC Controller started.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pod_gc_collector_force_delete_pods_total</div>
 	<div class="metric_help">Number of pods that are being forcefully deleted since the Pod GC Controller started.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pod_security_errors_total</div>
 	<div class="metric_help">Number of errors preventing normal evaluation. Non-fatal errors may result in the latest restricted profile being used for evaluation.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">fatal</span><span class="metric_label">request_operation</span><span class="metric_label">resource</span><span class="metric_label">subresource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">fatal</span><span class="metric_label">request_operation</span><span class="metric_label">resource</span><span class="metric_label">subresource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pod_security_evaluations_total</div>
 	<div class="metric_help">Number of policy evaluations that occurred, not counting ignored or exempt requests.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">decision</span><span class="metric_label">mode</span><span class="metric_label">policy_level</span><span class="metric_label">policy_version</span><span class="metric_label">request_operation</span><span class="metric_label">resource</span><span class="metric_label">subresource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">decision</span><span class="metric_label">mode</span><span class="metric_label">policy_level</span><span class="metric_label">policy_version</span><span class="metric_label">request_operation</span><span class="metric_label">resource</span><span class="metric_label">subresource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pod_security_exemptions_total</div>
 	<div class="metric_help">Number of exempt requests, not counting ignored or out of scope requests.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">request_operation</span><span class="metric_label">resource</span><span class="metric_label">subresource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">request_operation</span><span class="metric_label">resource</span><span class="metric_label">subresource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pod_swap_usage_bytes</div>
 	<div class="metric_help">Current amount of the pod swap usage in bytes. Reported only on non-windows systems</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod</span><span class="metric_label">namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod</span><span class="metric_label">namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">prober_probe_duration_seconds</div>
 	<div class="metric_help">Duration in seconds for a probe response.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">probe_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">container</span><span class="metric_label">namespace</span><span class="metric_label">pod</span><span class="metric_label">probe_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/probes)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pv_collector_bound_pv_count</div>
 	<div class="metric_help">Gauge measuring number of persistent volume currently bound</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">storage_class</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">storage_class</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pv_collector_bound_pvc_count</div>
 	<div class="metric_help">Gauge measuring number of persistent volume claim currently bound</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">storage_class</span><span class="metric_label">volume_attributes_class</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">storage_class</span><span class="metric_label">volume_attributes_class</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pv_collector_total_pv_count</div>
 	<div class="metric_help">Gauge measuring total number of persistent volumes</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span><span class="metric_label">volume_mode</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span><span class="metric_label">volume_mode</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pv_collector_unbound_pv_count</div>
 	<div class="metric_help">Gauge measuring number of persistent volume currently unbound</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">storage_class</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">storage_class</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">pv_collector_unbound_pvc_count</div>
 	<div class="metric_help">Gauge measuring number of persistent volume claim currently unbound</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">storage_class</span><span class="metric_label">volume_attributes_class</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">namespace</span><span class="metric_label">storage_class</span><span class="metric_label">volume_attributes_class</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">reconstruct_volume_operations_errors_total</div>
 	<div class="metric_help">The number of volumes that failed reconstruction from the operating system during kubelet startup.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">reconstruct_volume_operations_total</div>
 	<div class="metric_help">The number of volumes that were attempted to be reconstructed from the operating system during kubelet startup. This includes both successful and failed reconstruction.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">replicaset_controller_sorting_deletion_age_ratio</div>
 	<div class="metric_help">The ratio of chosen deleted pod's ages to the current youngest pod's age (at the time). Should be <2. The intent of this metric is to measure the rough efficacy of the LogarithmicScaleDown feature gate's effect on the sorting (and deletion) of pods when a replicaset scales down. This only considers Ready pods when calculating and reporting.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">resourceclaim_controller_creates_total</div>
 	<div class="metric_help">Number of ResourceClaims creation requests, categorized by creation status and admin access</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">admin_access</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">admin_access</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">resourceclaim_controller_resource_claims</div>
 	<div class="metric_help">Number of ResourceClaims, categorized by allocation status, admin access, and source. Source can be 'resource_claim_template' (created from a template), 'extended_resource' (extended resources), or empty (manually created by a user).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">allocated</span><span class="metric_label">admin_access</span><span class="metric_label">source</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">allocated</span><span class="metric_label">admin_access</span><span class="metric_label">source</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_dns_resolution_duration_seconds</div>
 	<div class="metric_help">DNS resolver latency in seconds. Broken down by host.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_exec_plugin_call_total</div>
 	<div class="metric_help">Number of calls to an exec plugin, partitioned by the type of event encountered (no_error, plugin_execution_error, plugin_not_found_error, client_internal_error) and an optional exit code. The exit code will be set to 0 if and only if the plugin call was successful.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">call_status</span><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">call_status</span><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_exec_plugin_certificate_rotation_age</div>
 	<div class="metric_help">Histogram of the number of seconds the last auth exec plugin client certificate lived before being rotated. If auth exec plugin client certificates are unused, histogram will contain no data.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_exec_plugin_policy_call_total</div>
 	<div class="metric_help">Number of comparisons of an exec plugin to the plugin policy and allowlist (if any), partitioned by whether or not the policy permits the plugin</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">allowed</span><span class="metric_label">denied</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">allowed</span><span class="metric_label">denied</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_exec_plugin_ttl_seconds</div>
 	<div class="metric_help">Gauge of the shortest TTL (time-to-live) of the client certificate(s) managed by the auth exec plugin. The value is in seconds until certificate expiry (negative if already expired). If auth exec plugins are unused or manage no TLS certificates, the value will be +INF.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_rate_limiter_duration_seconds</div>
 	<div class="metric_help">Client side rate limiter latency in seconds. Broken down by verb, and host.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span><span class="metric_label">verb</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span><span class="metric_label">verb</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_request_duration_seconds</div>
 	<div class="metric_help">Request latency in seconds. Broken down by verb, and host.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span><span class="metric_label">verb</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span><span class="metric_label">verb</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_request_retries_total</div>
 	<div class="metric_help">Number of request retries, partitioned by status code, verb, and host.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">host</span><span class="metric_label">verb</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">host</span><span class="metric_label">verb</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_request_size_bytes</div>
 	<div class="metric_help">Request size in bytes. Broken down by verb and host.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span><span class="metric_label">verb</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span><span class="metric_label">verb</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_requests_total</div>
 	<div class="metric_help">Number of HTTP requests, partitioned by status code, method, and host.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">host</span><span class="metric_label">method</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span><span class="metric_label">host</span><span class="metric_label">method</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_response_size_bytes</div>
 	<div class="metric_help">Response size in bytes. Broken down by verb and host.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span><span class="metric_label">verb</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">host</span><span class="metric_label">verb</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_transport_cache_entries</div>
 	<div class="metric_help">Number of transport entries in the internal cache.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">rest_client_transport_create_calls_total</div>
 	<div class="metric_help">Number of calls to get a new transport, partitioned by the result of the operation hit: obtained from the cache, miss: created and added to the cache, uncacheable: created and not cached</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">retroactive_storageclass_errors_total</div>
 	<div class="metric_help">Total number of failed retroactive StorageClass assignments to persistent volume claim</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">retroactive_storageclass_total</div>
 	<div class="metric_help">Total number of retroactive StorageClass assignments to persistent volume claim</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">root_ca_cert_publisher_sync_duration_seconds</div>
 	<div class="metric_help">Number of namespace syncs happened in root ca cert publisher.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">root_ca_cert_publisher_sync_total</div>
 	<div class="metric_help">Number of namespace syncs happened in root ca cert publisher.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">code</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">running_managed_controllers</div>
-	<div class="metric_help">Indicates where instances of a controller are currently running</div>
+	<div class="metric_name">route_controller_route_sync_total</div>
+	<div class="metric_help">A metric counting the amount of times routes have been synced with the cloud provider.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">manager</span><span class="metric_label">name</span></li></ul>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_async_api_call_execution_duration_seconds</div>
 	<div class="metric_help">Duration in seconds for executing API call in the async dispatcher.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">call_type</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">call_type</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_async_api_call_execution_total</div>
 	<div class="metric_help">Total number of API calls executed by the async dispatcher.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">call_type</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">call_type</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_batch_attempts_total</div>
 	<div class="metric_help">Counts of results when we attempt to use batching.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_batch_cache_flushed_total</div>
 	<div class="metric_help">Counts of cache flushes by reason.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">reason</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">reason</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_cache_size</div>
 	<div class="metric_help">Number of nodes, pods, and assumed (bound) pods in the scheduler cache.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_event_handling_duration_seconds</div>
 	<div class="metric_help">Event handling latency in seconds.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_get_node_hint_duration_seconds</div>
 	<div class="metric_help">Latency for getting a node hint.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">hinted</span><span class="metric_label">profile</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">hinted</span><span class="metric_label">profile</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_goroutines</div>
 	<div class="metric_help">Number of running goroutines split by the work they do such as binding.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_inflight_events</div>
 	<div class="metric_help">Number of events currently tracked in the scheduling queue.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_pending_async_api_calls</div>
 	<div class="metric_help">Number of API calls currently pending in the async queue.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">call_type</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">call_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_permit_wait_duration_seconds</div>
 	<div class="metric_help">Duration of waiting on permit.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_plugin_evaluation_total</div>
 	<div class="metric_help">Number of attempts to schedule pods by each plugin and the extension point (available only in PreFilter, Filter, PreScore, and Score).</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">extension_point</span><span class="metric_label">plugin</span><span class="metric_label">profile</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">extension_point</span><span class="metric_label">plugin</span><span class="metric_label">profile</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_plugin_execution_duration_seconds</div>
 	<div class="metric_help">Duration for running a plugin at a specific extension point.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">extension_point</span><span class="metric_label">plugin</span><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">extension_point</span><span class="metric_label">plugin</span><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_pod_scheduled_after_flush_total</div>
 	<div class="metric_help">Number of pods that were successfully scheduled after being flushed from unschedulablePods due to timeout. This metric helps detect potential queueing hint misconfigurations or event handling issues.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">scheduler_podgroup_schedule_attempts_total</div>
+	<div class="metric_help">Number of attempts to schedule pod group, by the result. 'unschedulable' means a pod group could not be scheduled, while 'error' means an internal scheduler problem.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">scheduler_podgroup_scheduling_algorithm_duration_seconds</div>
+	<div class="metric_help">Pod group scheduling algorithm latency in seconds</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">scheduler_podgroup_scheduling_attempt_duration_seconds</div>
+	<div class="metric_help">Pod group scheduling attempt latency in seconds (scheduling algorithm + binding)</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_preemption_goroutines_duration_seconds</div>
 	<div class="metric_help">Duration in seconds for running goroutines for the preemption.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_preemption_goroutines_execution_total</div>
 	<div class="metric_help">Number of preemption goroutines executed.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_queueing_hint_execution_duration_seconds</div>
 	<div class="metric_help">Duration for running a queueing hint function of a plugin.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span><span class="metric_label">hint</span><span class="metric_label">plugin</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">event</span><span class="metric_label">hint</span><span class="metric_label">plugin</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_resourceclaim_creates_total</div>
 	<div class="metric_help">Number of ResourceClaims creation requests within scheduler</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">status</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_scheduling_algorithm_duration_seconds</div>
 	<div class="metric_help">Scheduling algorithm latency in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_store_schedule_results_duration_seconds</div>
 	<div class="metric_help">Latency for getting a no.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">profile</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_unschedulable_pods</div>
 	<div class="metric_help">The number of unschedulable pods broken down by plugin name. A pod will increment the gauge for all plugins that caused it to not schedule and so this metric have meaning only when broken down by plugin.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin</span><span class="metric_label">profile</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin</span><span class="metric_label">profile</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_volume_binder_cache_requests_total</div>
 	<div class="metric_help">Total number for request volume binding cache</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_volume_scheduling_stage_error_total</div>
 	<div class="metric_help">Volume scheduling stage error count</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scrape_error</div>
 	<div class="metric_help">1 if there was an error while getting container metrics, 0 otherwise</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.29.0</span></li></ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics/resource)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.29.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">selinux_warning_controller_selinux_volume_conflict</div>
 	<div class="metric_help">Conflict between two Pods using the same volume</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">property</span><span class="metric_label">pod1_namespace</span><span class="metric_label">pod1_name</span><span class="metric_label">pod1_value</span><span class="metric_label">pod2_namespace</span><span class="metric_label">pod2_name</span><span class="metric_label">pod2_value</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">property</span><span class="metric_label">pod1_namespace</span><span class="metric_label">pod1_name</span><span class="metric_label">pod1_value</span><span class="metric_label">pod2_namespace</span><span class="metric_label">pod2_name</span><span class="metric_label">pod2_value</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">service_controller_loadbalancer_sync_total</div>
 	<div class="metric_help">A metric counting the amount of times any load balancer has been configured, as an effect of service/node changes on the cluster</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">service_controller_nodesync_error_total</div>
 	<div class="metric_help">A metric counting the amount of times any load balancer has been configured and errored, as an effect of node changes on the cluster</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">service_controller_nodesync_latency_seconds</div>
 	<div class="metric_help">A metric measuring the latency for nodesync which updates loadbalancer hosts on cluster node updates.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">service_controller_update_loadbalancer_host_latency_seconds</div>
 	<div class="metric_help">A metric measuring the latency for updating each load balancer hosts.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">serviceaccount_invalid_legacy_auto_token_uses_total</div>
 	<div class="metric_help">Cumulative invalid auto-generated legacy tokens used</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">serviceaccount_legacy_auto_token_uses_total</div>
 	<div class="metric_help">Cumulative auto-generated legacy tokens used</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">serviceaccount_legacy_manual_token_uses_total</div>
 	<div class="metric_help">Cumulative manually created legacy tokens used</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">serviceaccount_legacy_tokens_total</div>
 	<div class="metric_help">Cumulative legacy service account tokens used</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">serviceaccount_stale_tokens_total</div>
 	<div class="metric_help">Cumulative stale projected service account tokens used</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">serviceaccount_valid_tokens_total</div>
 	<div class="metric_help">Cumulative valid projected service account tokens used</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">statefulset_controller_statefulset_max_unavailable</div>
 	<div class="metric_help">Maximum number of unavailable pods allowed during StatefulSet rolling updates</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod_management_policy</span><span class="metric_label">statefulset_name</span><span class="metric_label">statefulset_namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod_management_policy</span><span class="metric_label">statefulset_name</span><span class="metric_label">statefulset_namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">statefulset_controller_statefulset_unavailable_replicas</div>
 	<div class="metric_help">Current number of unavailable pods in StatefulSet</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod_management_policy</span><span class="metric_label">statefulset_name</span><span class="metric_label">statefulset_namespace</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">pod_management_policy</span><span class="metric_label">statefulset_name</span><span class="metric_label">statefulset_namespace</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">storage_count_attachable_volumes_in_use</div>
 	<div class="metric_help">Measure number of volumes in use</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">node</span><span class="metric_label">volume_plugin</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">node</span><span class="metric_label">volume_plugin</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">storage_operation_duration_seconds</div>
 	<div class="metric_help">Storage operation duration</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">migrated</span><span class="metric_label">operation_name</span><span class="metric_label">status</span><span class="metric_label">volume_plugin</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">migrated</span><span class="metric_label">operation_name</span><span class="metric_label">status</span><span class="metric_label">volume_plugin</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">taint_eviction_controller_pod_deletion_duration_seconds</div>
 	<div class="metric_help">Latency, in seconds, between the time when a taint effect has been activated for the Pod and its deletion via TaintEvictionController.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">taint_eviction_controller_pod_deletions_total</div>
 	<div class="metric_help">Total number of Pods deleted by TaintEvictionController since its start.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">ttl_after_finished_controller_job_deletion_duration_seconds</div>
 	<div class="metric_help">The time it took to delete the job since it became eligible for deletion</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	</ul>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">version_info</div>
 	<div class="metric_help">Provides the compatibility version info of the component. The component label is the name of the component, usually kube, but is relevant for aggregated-apiservers.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">binary</span><span class="metric_label">component</span><span class="metric_label">emulation</span><span class="metric_label">min_compat</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">binary</span><span class="metric_label">component</span><span class="metric_label">emulation</span><span class="metric_label">min_compat</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li><li>kube-apiserver (/metrics)</li><li>kube-controller-manager (/metrics)</li><li>kube-proxy (/metrics)</li><li>kube-scheduler (/metrics)</li><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_manager_selinux_container_errors_total</div>
 	<div class="metric_help">Number of errors when kubelet cannot compute SELinux context for a container. Kubelet can't start such a Pod then and it will retry, therefore value of this metric may not represent the actual nr. of containers.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_manager_selinux_container_warnings_total</div>
 	<div class="metric_help">Number of errors when kubelet cannot compute SELinux context for a container that are ignored. They will become real errors when SELinuxMountReadWriteOncePod feature is expanded to all volume access modes.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_manager_selinux_pod_context_mismatch_errors_total</div>
 	<div class="metric_help">Number of errors when a Pod defines different SELinux contexts for its containers that use the same volume. Kubelet can't start such a Pod then and it will retry, therefore value of this metric may not represent the actual nr. of Pods.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_manager_selinux_pod_context_mismatch_warnings_total</div>
 	<div class="metric_help">Number of errors when a Pod defines different SELinux contexts for its containers that use the same volume. They are not errors yet, but they will become real errors when SELinuxMountReadWriteOncePod feature is expanded to all volume access modes.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_manager_selinux_volume_context_mismatch_errors_total</div>
 	<div class="metric_help">Number of errors when a Pod uses a volume that is already mounted with a different SELinux context than the Pod needs. Kubelet can't start such a Pod then and it will retry, therefore value of this metric may not represent the actual nr. of Pods.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span><span class="metric_label">volume_plugin</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span><span class="metric_label">volume_plugin</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_manager_selinux_volume_context_mismatch_warnings_total</div>
 	<div class="metric_help">Number of errors when a Pod uses a volume that is already mounted with a different SELinux context than the Pod needs. They are not errors yet, but they will become real errors when SELinuxMountReadWriteOncePod feature is expanded to all volume access modes.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span><span class="metric_label">volume_plugin</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span><span class="metric_label">volume_plugin</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_manager_selinux_volumes_admitted_total</div>
 	<div class="metric_help">Number of volumes whose SELinux context was fine and will be mounted with mount -o context option.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span><span class="metric_label">volume_plugin</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">access_mode</span><span class="metric_label">volume_plugin</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_manager_total_volumes</div>
 	<div class="metric_help">Number of volumes in Volume Manager</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="custom"><label class="metric_detail">Type:</label> <span class="metric_type">Custom</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span><span class="metric_label">state</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">plugin_name</span><span class="metric_label">state</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_operation_total_errors</div>
 	<div class="metric_help">Total volume operation errors</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_name</span><span class="metric_label">plugin_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_name</span><span class="metric_label">plugin_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">volume_operation_total_seconds</div>
 	<div class="metric_help">Storage operation end to end duration in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_name</span><span class="metric_label">plugin_name</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation_name</span><span class="metric_label">plugin_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">watch_cache_capacity</div>
 	<div class="metric_help">Total capacity of watch cache broken by resource type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">watch_cache_capacity_decrease_total</div>
 	<div class="metric_help">Total number of watch cache capacity decrease events broken by resource type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">watch_cache_capacity_increase_total</div>
 	<div class="metric_help">Total number of watch cache capacity increase events broken by resource type.</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div>
 </div>

--- a/test/instrumentation/documentation/main.go
+++ b/test/instrumentation/documentation/main.go
@@ -71,6 +71,7 @@ Stable metrics observe strict API contracts and no labels can be added or remove
 	<li data-type="{{$metric.Type | ToLower}}"><label class="metric_detail">Type:</label> <span class="metric_type">{{- $metric.Type -}}</span></li>
 	{{if $metric.Labels }}<li class="metric_labels_varying"><label class="metric_detail">Labels:</label>{{range $label := $metric.Labels}}<span class="metric_label">{{- $label -}}</span>{{- end -}}</li>{{- end -}}
 	{{if $metric.ConstLabels }}<li class="metric_labels_constant"><label class="metric_detail">Const Labels:</label>{{range $key, $value := $metric.ConstLabels}}<span class="metric_label">{{$key}}:{{$value}}</span>{{- end -}}</li>{{- end -}}
+	{{if $metric.ComponentEndpoints }}<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul>{{range $ce := $metric.ComponentEndpoints}}<li>{{$ce.Component}} ({{$ce.Endpoint}})</li>{{- end -}}</ul></li>{{- end -}}
 	{{if $metric.DeprecatedVersion }}<li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>{{- $metric.DeprecatedVersion -}}</span></li>{{- end -}}
 	</ul>
 	</div>{{end}}
@@ -90,6 +91,7 @@ Beta metrics observe a looser API contract than its stable counterparts. No labe
 	<li data-type="{{$metric.Type | ToLower}}"><label class="metric_detail">Type:</label> <span class="metric_type">{{- $metric.Type -}}</span></li>
 	{{if $metric.Labels }}<li class="metric_labels_varying"><label class="metric_detail">Labels:</label>{{range $label := $metric.Labels}}<span class="metric_label">{{- $label -}}</span>{{- end -}}</li>{{- end -}}
 	{{if $metric.ConstLabels }}<li class="metric_labels_constant"><label class="metric_detail">Const Labels:</label>{{range $key, $value := $metric.ConstLabels}}<span class="metric_label">{{$key}}:{{$value}}</span>{{- end -}}</li>{{- end -}}
+	{{if $metric.ComponentEndpoints }}<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul>{{range $ce := $metric.ComponentEndpoints}}<li>{{$ce.Component}} ({{$ce.Endpoint}})</li>{{- end -}}</ul></li>{{- end -}}
 	{{if $metric.DeprecatedVersion }}<li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>{{- $metric.DeprecatedVersion -}}</span></li>{{- end -}}
 	</ul>
 	</div>{{end}}
@@ -109,6 +111,7 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="{{$metric.Type | ToLower}}"><label class="metric_detail">Type:</label> <span class="metric_type">{{- $metric.Type -}}</span></li>
 	{{if $metric.Labels }}<li class="metric_labels_varying"><label class="metric_detail">Labels:</label>{{range $label := $metric.Labels}}<span class="metric_label">{{- $label -}}</span>{{- end -}}</li>{{- end -}}
 	{{if $metric.ConstLabels }}<li class="metric_labels_constant"><label class="metric_detail">Const Labels:</label>{{range $key, $value := $metric.ConstLabels}}<span class="metric_label">{{$key}}:{{$value}}</span>{{- end -}}</li>{{- end -}}
+	{{if $metric.ComponentEndpoints }}<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul>{{range $ce := $metric.ComponentEndpoints}}<li>{{$ce.Component}} ({{$ce.Endpoint}})</li>{{- end -}}</ul></li>{{- end -}}
 	{{if $metric.DeprecatedVersion }}<li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>{{- $metric.DeprecatedVersion -}}</span></li>{{- end -}}
 	</ul>
 	</div>{{end}}

--- a/test/instrumentation/endpoint-mappings.yaml
+++ b/test/instrumentation/endpoint-mappings.yaml
@@ -50,6 +50,8 @@ sharedPaths:
 
 # Endpoint mappings: override the default endpoint for specific paths.
 endpointMappings:
+  - pathContains: "staging/src/k8s.io/component-base/metrics/slis"
+    endpoint: /metrics/slis
   - pathContains: "pkg/kubelet/metrics/collectors/resource_metrics.go"
     endpoint: /metrics/resource
   - pathContains: "pkg/kubelet/prober/"

--- a/test/instrumentation/endpoint-mappings.yaml
+++ b/test/instrumentation/endpoint-mappings.yaml
@@ -50,7 +50,7 @@ sharedPaths:
 
 # Endpoint mappings: override the default endpoint for specific paths.
 endpointMappings:
-  - pathContains: "staging/src/k8s.io/component-base/metrics/slis"
+  - pathContains: "staging/src/k8s.io/component-base/metrics/prometheus/slis"
     endpoint: /metrics/slis
   - pathContains: "pkg/kubelet/metrics/collectors/resource_metrics.go"
     endpoint: /metrics/resource

--- a/test/instrumentation/endpoint-mappings.yaml
+++ b/test/instrumentation/endpoint-mappings.yaml
@@ -1,0 +1,59 @@
+# Endpoint mappings for Kubernetes metrics documentation generation.
+#
+# This file maps source file paths to the component and endpoint where metrics are exposed.
+# Rules are evaluated in order; first match wins for endpoint mappings.
+
+# Core components: these share common infrastructure (client-go, component-base).
+# Metrics from sharedPaths will be attributed to ALL of these components.
+coreComponents:
+  kube-apiserver:
+    - "cmd/kube-apiserver/"
+    - "pkg/controlplane/"
+    - "pkg/registry/"
+    - "pkg/serviceaccount/"
+    - "plugin/pkg/admission/"
+    - "plugin/pkg/auth/"
+    - "staging/src/k8s.io/apiserver/"
+    - "staging/src/k8s.io/apiextensions-apiserver/"
+    - "staging/src/k8s.io/kube-aggregator/"
+    - "staging/src/k8s.io/pod-security-admission/"
+  kube-controller-manager:
+    - "cmd/kube-controller-manager/"
+    - "pkg/controller/"
+    - "staging/src/k8s.io/controller-manager/"
+    - "staging/src/k8s.io/endpointslice/"
+  kube-scheduler:
+    - "cmd/kube-scheduler/"
+    - "pkg/scheduler/"
+    - "staging/src/k8s.io/kube-scheduler/"
+  kube-proxy:
+    - "cmd/kube-proxy/"
+    - "pkg/proxy/"
+  kubelet:
+    - "cmd/kubelet/"
+    - "pkg/kubelet/"
+    - "pkg/credentialprovider/"
+    - "pkg/volume/"
+  cloud-controller-manager:
+    - "staging/src/k8s.io/cloud-provider/"
+
+# Standalone components: these have their own specific metrics and do NOT
+# share the common infrastructure metrics.
+standaloneComponents:
+  etcd-version-monitor:
+    - "cluster/images/etcd-version-monitor/"
+
+# Shared paths: metrics from these paths are available across ALL core components.
+sharedPaths:
+  - "staging/src/k8s.io/client-go/"
+  - "staging/src/k8s.io/component-base/"
+
+# Endpoint mappings: override the default endpoint for specific paths.
+endpointMappings:
+  - pathContains: "pkg/kubelet/metrics/collectors/resource_metrics.go"
+    endpoint: /metrics/resource
+  - pathContains: "pkg/kubelet/prober/"
+    endpoint: /metrics/probes
+
+# Default endpoint when no endpointMappings rule matches.
+defaultEndpoint: /metrics

--- a/test/instrumentation/endpoint-mappings.yaml
+++ b/test/instrumentation/endpoint-mappings.yaml
@@ -45,7 +45,6 @@ standaloneComponents:
 
 # Shared paths: metrics from these paths are available across ALL core components.
 sharedPaths:
-  - "staging/src/k8s.io/client-go/"
   - "staging/src/k8s.io/component-base/"
 
 # Endpoint mappings: override the default endpoint for specific paths.

--- a/test/instrumentation/endpoint_mapping.go
+++ b/test/instrumentation/endpoint_mapping.go
@@ -91,7 +91,15 @@ func (c *endpointMappingConfig) isSharedPath(filePath string) bool {
 }
 
 func (c *endpointMappingConfig) inferComponent(filePath string, components map[string][]string) string {
-	for component, patterns := range components {
+	// Sort component names for deterministic iteration order
+	componentNames := make([]string, 0, len(components))
+	for name := range components {
+		componentNames = append(componentNames, name)
+	}
+	sort.Strings(componentNames)
+
+	for _, component := range componentNames {
+		patterns := components[component]
 		for _, pattern := range patterns {
 			if strings.Contains(filePath, pattern) {
 				return component

--- a/test/instrumentation/endpoint_mapping.go
+++ b/test/instrumentation/endpoint_mapping.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/instrumentation/endpoint_mapping.go
+++ b/test/instrumentation/endpoint_mapping.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v2"
+
+	"k8s.io/kubernetes/test/instrumentation/internal/metric"
+)
+
+type endpointMappingConfig struct {
+	CoreComponents       map[string][]string `yaml:"coreComponents"`
+	StandaloneComponents map[string][]string `yaml:"standaloneComponents"`
+	SharedPaths          []string            `yaml:"sharedPaths"`
+	EndpointMappings     []endpointMapping   `yaml:"endpointMappings"`
+	DefaultEndpoint      string              `yaml:"defaultEndpoint"`
+}
+
+type endpointMapping struct {
+	PathContains string `yaml:"pathContains"`
+	Endpoint     string `yaml:"endpoint"`
+}
+
+func loadEndpointMappingConfig(path string) (*endpointMappingConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var config endpointMappingConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+	if config.DefaultEndpoint == "" {
+		config.DefaultEndpoint = "/metrics"
+	}
+	return &config, nil
+}
+
+// inferComponentEndpoints determines the component(s) and endpoint for a metric based on its source file path.
+func (c *endpointMappingConfig) inferComponentEndpoints(filePath string) []metric.ComponentEndpoint {
+	endpoint := c.inferEndpoint(filePath)
+
+	if c.isSharedPath(filePath) {
+		return c.allCoreComponentEndpoints(endpoint)
+	}
+
+	component := c.inferComponent(filePath, c.CoreComponents)
+	if component != "" {
+		return []metric.ComponentEndpoint{{
+			Component: component,
+			Endpoint:  endpoint,
+		}}
+	}
+
+	component = c.inferComponent(filePath, c.StandaloneComponents)
+	if component != "" {
+		return []metric.ComponentEndpoint{{
+			Component: component,
+			Endpoint:  endpoint,
+		}}
+	}
+
+	return nil
+}
+
+func (c *endpointMappingConfig) isSharedPath(filePath string) bool {
+	for _, pattern := range c.SharedPaths {
+		if strings.Contains(filePath, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *endpointMappingConfig) inferComponent(filePath string, components map[string][]string) string {
+	for component, patterns := range components {
+		for _, pattern := range patterns {
+			if strings.Contains(filePath, pattern) {
+				return component
+			}
+		}
+	}
+	return ""
+}
+
+func (c *endpointMappingConfig) inferEndpoint(filePath string) string {
+	for _, mapping := range c.EndpointMappings {
+		if strings.Contains(filePath, mapping.PathContains) {
+			return mapping.Endpoint
+		}
+	}
+	return c.DefaultEndpoint
+}
+
+// allCoreComponentEndpoints returns a ComponentEndpoint for each core component with the given endpoint.
+func (c *endpointMappingConfig) allCoreComponentEndpoints(endpoint string) []metric.ComponentEndpoint {
+	result := make([]metric.ComponentEndpoint, 0, len(c.CoreComponents))
+	for component := range c.CoreComponents {
+		result = append(result, metric.ComponentEndpoint{
+			Component: component,
+			Endpoint:  endpoint,
+		})
+	}
+	// Sort for deterministic output
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Component < result[j].Component
+	})
+	return result
+}

--- a/test/instrumentation/internal/metric/metric.go
+++ b/test/instrumentation/internal/metric/metric.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,22 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package metric
 
 import (
 	"k8s.io/component-base/metrics"
 )
 
+// Metric type constants.
 const (
-	counterMetricType    = "Counter"
-	gaugeMetricType      = "Gauge"
-	histogramMetricType  = "Histogram"
-	summaryMetricType    = "Summary"
-	timingRatioHistogram = "TimingRatioHistogram"
-	customType           = "Custom"
+	TypeCounter              = "Counter"
+	TypeGauge                = "Gauge"
+	TypeHistogram            = "Histogram"
+	TypeSummary              = "Summary"
+	TypeTimingRatioHistogram = "TimingRatioHistogram"
+	TypeCustom               = "Custom"
 )
 
-type metric struct {
+// Metric represents a parsed Kubernetes metric definition.
+type Metric struct {
 	Name              string              `yaml:"name" json:"name"`
 	Subsystem         string              `yaml:"subsystem,omitempty" json:"subsystem,omitempty"`
 	Namespace         string              `yaml:"namespace,omitempty" json:"namespace,omitempty"`
@@ -46,21 +48,23 @@ type metric struct {
 	ConstLabels       map[string]string   `yaml:"constLabels,omitempty" json:"constLabels,omitempty"`
 }
 
-func (m metric) buildFQName() string {
+// BuildFQName returns the fully qualified metric name.
+func (m Metric) BuildFQName() string {
 	return metrics.BuildFQName(m.Namespace, m.Subsystem, m.Name)
 }
 
-type byFQName []metric
+// ByFQName implements sort.Interface for []Metric based on stability level and FQName.
+type ByFQName []Metric
 
-func (ms byFQName) Len() int { return len(ms) }
-func (ms byFQName) Less(i, j int) bool {
+func (ms ByFQName) Len() int { return len(ms) }
+func (ms ByFQName) Less(i, j int) bool {
 	if ms[i].StabilityLevel < ms[j].StabilityLevel {
 		return true
 	} else if ms[i].StabilityLevel > ms[j].StabilityLevel {
 		return false
 	}
-	return ms[i].buildFQName() < ms[j].buildFQName()
+	return ms[i].BuildFQName() < ms[j].BuildFQName()
 }
-func (ms byFQName) Swap(i, j int) {
+func (ms ByFQName) Swap(i, j int) {
 	ms[i], ms[j] = ms[j], ms[i]
 }

--- a/test/instrumentation/internal/metric/metric.go
+++ b/test/instrumentation/internal/metric/metric.go
@@ -30,22 +30,29 @@ const (
 	TypeCustom               = "Custom"
 )
 
+// ComponentEndpoint represents a component and the endpoint where a metric is exposed.
+type ComponentEndpoint struct {
+	Component string `yaml:"component" json:"component"`
+	Endpoint  string `yaml:"endpoint" json:"endpoint"`
+}
+
 // Metric represents a parsed Kubernetes metric definition.
 type Metric struct {
-	Name              string              `yaml:"name" json:"name"`
-	Subsystem         string              `yaml:"subsystem,omitempty" json:"subsystem,omitempty"`
-	Namespace         string              `yaml:"namespace,omitempty" json:"namespace,omitempty"`
-	Help              string              `yaml:"help,omitempty" json:"help,omitempty"`
-	Type              string              `yaml:"type,omitempty" json:"type,omitempty"`
-	DeprecatedVersion string              `yaml:"deprecatedVersion,omitempty" json:"deprecatedVersion,omitempty"`
-	StabilityLevel    string              `yaml:"stabilityLevel,omitempty" json:"stabilityLevel,omitempty"`
-	Labels            []string            `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Buckets           []float64           `yaml:"buckets,omitempty" json:"buckets,omitempty"`
-	Objectives        map[float64]float64 `yaml:"objectives,omitempty" json:"objectives,omitempty"`
-	AgeBuckets        uint32              `yaml:"ageBuckets,omitempty" json:"ageBuckets,omitempty"`
-	BufCap            uint32              `yaml:"bufCap,omitempty" json:"bufCap,omitempty"`
-	MaxAge            int64               `yaml:"maxAge,omitempty" json:"maxAge,omitempty"`
-	ConstLabels       map[string]string   `yaml:"constLabels,omitempty" json:"constLabels,omitempty"`
+	Name               string              `yaml:"name" json:"name"`
+	Subsystem          string              `yaml:"subsystem,omitempty" json:"subsystem,omitempty"`
+	Namespace          string              `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Help               string              `yaml:"help,omitempty" json:"help,omitempty"`
+	Type               string              `yaml:"type,omitempty" json:"type,omitempty"`
+	DeprecatedVersion  string              `yaml:"deprecatedVersion,omitempty" json:"deprecatedVersion,omitempty"`
+	StabilityLevel     string              `yaml:"stabilityLevel,omitempty" json:"stabilityLevel,omitempty"`
+	Labels             []string            `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Buckets            []float64           `yaml:"buckets,omitempty" json:"buckets,omitempty"`
+	Objectives         map[float64]float64 `yaml:"objectives,omitempty" json:"objectives,omitempty"`
+	AgeBuckets         uint32              `yaml:"ageBuckets,omitempty" json:"ageBuckets,omitempty"`
+	BufCap             uint32              `yaml:"bufCap,omitempty" json:"bufCap,omitempty"`
+	MaxAge             int64               `yaml:"maxAge,omitempty" json:"maxAge,omitempty"`
+	ConstLabels        map[string]string   `yaml:"constLabels,omitempty" json:"constLabels,omitempty"`
+	ComponentEndpoints []ComponentEndpoint `yaml:"componentEndpoints,omitempty" json:"componentEndpoints,omitempty"`
 }
 
 // BuildFQName returns the fully qualified metric name.

--- a/test/instrumentation/internal/metric/metric.go
+++ b/test/instrumentation/internal/metric/metric.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/instrumentation/main.go
+++ b/test/instrumentation/main.go
@@ -46,7 +46,7 @@ var (
 	// env configs
 	GOOS                  string = findGOOS()
 	ALL_STABILITY_CLASSES bool
-	ENDPOINT_MAPPINGS     string
+	EndpointMappings      string
 )
 
 func findGOOS() string {
@@ -64,7 +64,7 @@ func findGOOS() string {
 func main() {
 
 	flag.BoolVar(&ALL_STABILITY_CLASSES, "allstabilityclasses", false, "use this flag to enable all stability classes")
-	flag.StringVar(&ENDPOINT_MAPPINGS, "endpoint-mappings", "", "path to endpoint mappings configuration file")
+	flag.StringVar(&EndpointMappings, "endpoint-mappings", "", "path to endpoint mappings configuration file")
 	flag.Parse()
 	if len(flag.Args()) < 1 {
 		fmt.Fprintf(os.Stderr, "USAGE: %s <DIR or FILE or '-'> [...]\n", os.Args[0])
@@ -73,9 +73,9 @@ func main() {
 
 	// Load endpoint mappings configuration if provided
 	var endpointConfig *endpointMappingConfig
-	if ENDPOINT_MAPPINGS != "" {
+	if EndpointMappings != "" {
 		var err error
-		endpointConfig, err = loadEndpointMappingConfig(ENDPOINT_MAPPINGS)
+		endpointConfig, err = loadEndpointMappingConfig(EndpointMappings)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to load endpoint mappings: %s\n", err)
 			os.Exit(1)

--- a/test/instrumentation/main.go
+++ b/test/instrumentation/main.go
@@ -191,6 +191,9 @@ func searchFileForStableMetrics(filename string, src interface{}, endpointConfig
 			for i := range metrics {
 				metrics[i].ComponentEndpoints = ces
 			}
+		} else if len(metrics) > 0 {
+			fmt.Fprintf(os.Stderr, "WARNING: found %d metric(s) in %q but could not infer component endpoints. "+
+				"Consider updating endpoint-mappings.yaml.\n", len(metrics), filename)
 		}
 	}
 

--- a/test/instrumentation/main_test.go
+++ b/test/instrumentation/main_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/component-base/metrics"
+	"k8s.io/kubernetes/test/instrumentation/internal/metric"
 )
 
 const fakeFilename = "testdata/metric.go"
@@ -122,18 +123,18 @@ func TestStableMetric(t *testing.T) {
 	for _, test := range []struct {
 		testName string
 		src      string
-		metric   metric
+		metric   metric.Metric
 	}{
 		{
 			testName: "Counter",
-			metric: metric{
+			metric: metric.Metric{
 				Name:              "metric",
 				Namespace:         "namespace",
 				Subsystem:         "subsystem",
 				StabilityLevel:    "STABLE",
 				DeprecatedVersion: "1.16",
 				Help:              "help",
-				Type:              counterMetricType,
+				Type:              metric.TypeCounter,
 			},
 			src: `
 package test
@@ -151,7 +152,7 @@ var _ = metrics.NewCounter(
 `},
 		{
 			testName: "CounterVec",
-			metric: metric{
+			metric: metric.Metric{
 				Name:              "metric",
 				Namespace:         "namespace",
 				Subsystem:         "subsystem",
@@ -159,7 +160,7 @@ var _ = metrics.NewCounter(
 				StabilityLevel:    "STABLE",
 				DeprecatedVersion: "1.16",
 				Help:              "help",
-				Type:              counterMetricType,
+				Type:              metric.TypeCounter,
 			},
 			src: `
 package test
@@ -178,14 +179,14 @@ var _ = metrics.NewCounterVec(
 `},
 		{
 			testName: "Gauge",
-			metric: metric{
+			metric: metric.Metric{
 				Name:              "gauge",
 				Namespace:         "namespace",
 				Subsystem:         "subsystem",
 				StabilityLevel:    "STABLE",
 				DeprecatedVersion: "1.16",
 				Help:              "help",
-				Type:              gaugeMetricType,
+				Type:              metric.TypeGauge,
 			},
 			src: `
 package test
@@ -203,14 +204,14 @@ var _ = metrics.NewGauge(
 `},
 		{
 			testName: "GaugeVec",
-			metric: metric{
+			metric: metric.Metric{
 				Name:              "gauge",
 				Namespace:         "namespace",
 				Subsystem:         "subsystem",
 				StabilityLevel:    "STABLE",
 				DeprecatedVersion: "1.16",
 				Help:              "help",
-				Type:              gaugeMetricType,
+				Type:              metric.TypeGauge,
 				Labels:            []string{"label-1", "label-2"},
 			},
 			src: `
@@ -230,7 +231,7 @@ var _ = metrics.NewGaugeVec(
 `},
 		{
 			testName: "Histogram",
-			metric: metric{
+			metric: metric.Metric{
 				Name:              "histogram",
 				Namespace:         "namespace",
 				Subsystem:         "subsystem",
@@ -238,7 +239,7 @@ var _ = metrics.NewGaugeVec(
 				StabilityLevel:    "STABLE",
 				Buckets:           []float64{0.001, 0.01, 0.1, 1, 10, 100},
 				Help:              "help",
-				Type:              histogramMetricType,
+				Type:              metric.TypeHistogram,
 			},
 			src: `
 package test
@@ -257,7 +258,7 @@ var _ = metrics.NewHistogram(
 `},
 		{
 			testName: "HistogramVec",
-			metric: metric{
+			metric: metric.Metric{
 				Name:              "histogram",
 				Namespace:         "namespace",
 				Subsystem:         "subsystem",
@@ -265,7 +266,7 @@ var _ = metrics.NewHistogram(
 				StabilityLevel:    "STABLE",
 				Buckets:           []float64{0.001, 0.01, 0.1, 1, 10, 100},
 				Help:              "help",
-				Type:              histogramMetricType,
+				Type:              metric.TypeHistogram,
 				Labels:            []string{"label-1", "label-2"},
 			},
 			src: `
@@ -286,10 +287,10 @@ var _ = metrics.NewHistogramVec(
 `},
 		{
 			testName: "Custom import",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "metric",
 				StabilityLevel: "STABLE",
-				Type:           counterMetricType,
+				Type:           metric.TypeCounter,
 			},
 			src: `
 package test
@@ -303,12 +304,12 @@ var _ = custom.NewCounter(
 `},
 		{
 			testName: "Custom import NewDesc",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "apiserver_storage_size_bytes",
 				Help:           "Size of the storage database file physically allocated in bytes.",
 				Labels:         []string{"server"},
 				StabilityLevel: "STABLE",
-				Type:           customType,
+				Type:           metric.TypeCustom,
 				ConstLabels:    map[string]string{},
 			},
 			src: `
@@ -318,10 +319,10 @@ var _ = custom.NewDesc("apiserver_storage_size_bytes", "Size of the storage data
 `},
 		{
 			testName: "Const",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "metric",
 				StabilityLevel: "STABLE",
-				Type:           counterMetricType,
+				Type:           metric.TypeCounter,
 			},
 			src: `
 package test
@@ -336,10 +337,10 @@ var _ = metrics.NewCounter(
 `},
 		{
 			testName: "Variable",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "metric",
 				StabilityLevel: "STABLE",
-				Type:           counterMetricType,
+				Type:           metric.TypeCounter,
 			},
 			src: `
 package test
@@ -354,10 +355,10 @@ var _ = metrics.NewCounter(
 `},
 		{
 			testName: "Multiple consts in block",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "metric",
 				StabilityLevel: "STABLE",
-				Type:           counterMetricType,
+				Type:           metric.TypeCounter,
 			},
 			src: `
 package test
@@ -376,10 +377,10 @@ var _ = metrics.NewCounter(
 `},
 		{
 			testName: "Multiple variables in Block",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "metric",
 				StabilityLevel: "STABLE",
-				Type:           counterMetricType,
+				Type:           metric.TypeCounter,
 			},
 			src: `
 package test
@@ -397,11 +398,11 @@ var (
 `},
 		{
 			testName: "Histogram with linear buckets",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "histogram",
 				StabilityLevel: "STABLE",
 				Buckets:        metrics.LinearBuckets(1, 1, 3),
-				Type:           histogramMetricType,
+				Type:           metric.TypeHistogram,
 			},
 			src: `
 package test
@@ -416,11 +417,11 @@ var _ = metrics.NewHistogram(
 `},
 		{
 			testName: "Histogram with exponential buckets",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "histogram",
 				StabilityLevel: "STABLE",
 				Buckets:        metrics.ExponentialBuckets(1, 2, 3),
-				Type:           histogramMetricType,
+				Type:           metric.TypeHistogram,
 			},
 			src: `
 package test
@@ -435,11 +436,11 @@ var _ = metrics.NewHistogram(
 `},
 		{
 			testName: "Histogram with default buckets",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "histogram",
 				StabilityLevel: "STABLE",
 				Buckets:        metrics.DefBuckets,
-				Type:           histogramMetricType,
+				Type:           metric.TypeHistogram,
 			},
 			src: `
 package test
@@ -454,11 +455,11 @@ var _ = metrics.NewHistogram(
 `},
 		{
 			testName: "Imported k8s.io constant",
-			metric: metric{
+			metric: metric.Metric{
 				Name:           "importedCounter",
 				StabilityLevel: "STABLE",
 				Subsystem:      "kubelet",
-				Type:           counterMetricType,
+				Type:           metric.TypeCounter,
 			},
 			src: `
 package test

--- a/test/instrumentation/main_test.go
+++ b/test/instrumentation/main_test.go
@@ -108,7 +108,7 @@ var _ = NewCounter(
 `},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			metrics, errors := searchFileForStableMetrics(fakeFilename, test.src)
+			metrics, errors := searchFileForStableMetrics(fakeFilename, test.src, nil)
 			if len(metrics) != 0 {
 				t.Errorf("Didn't expect any stable metrics found, got: %d", len(metrics))
 			}
@@ -475,7 +475,7 @@ var _ = compbasemetrics.NewCounter(
 `},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			metrics, errors := searchFileForStableMetrics(fakeFilename, test.src)
+			metrics, errors := searchFileForStableMetrics(fakeFilename, test.src, nil)
 			if len(errors) != 0 {
 				t.Errorf("Unexpected errors: %s", errors)
 			}
@@ -677,7 +677,7 @@ var _ = metrics.NewHistogram(
 `},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			_, errors := searchFileForStableMetrics(fakeFilename, test.src)
+			_, errors := searchFileForStableMetrics(fakeFilename, test.src, nil)
 			if len(errors) != 1 {
 				t.Errorf("Unexpected number of errors, got %d, want 1", len(errors))
 			}

--- a/test/instrumentation/sort/main.go
+++ b/test/instrumentation/sort/main.go
@@ -23,7 +23,8 @@ import (
 
 	flag "github.com/spf13/pflag"
 	yaml "go.yaml.in/yaml/v2"
-	"k8s.io/component-base/metrics"
+
+	"k8s.io/kubernetes/test/instrumentation/internal/metric"
 )
 
 func main() {
@@ -32,13 +33,13 @@ func main() {
 	flag.Parse()
 	dat, err := os.ReadFile(sortFile)
 	if err == nil {
-		var parsedMetrics []metric
+		var parsedMetrics []metric.Metric
 		err = yaml.Unmarshal(dat, &parsedMetrics)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
 		}
-		sort.Sort(byFQName(parsedMetrics))
+		sort.Sort(metric.ByFQName(parsedMetrics))
 		data, err := yaml.Marshal(parsedMetrics)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
@@ -47,40 +48,4 @@ func main() {
 
 		fmt.Print(string(data))
 	}
-}
-
-type metric struct {
-	Name              string              `yaml:"name" json:"name"`
-	Subsystem         string              `yaml:"subsystem,omitempty" json:"subsystem,omitempty"`
-	Namespace         string              `yaml:"namespace,omitempty" json:"namespace,omitempty"`
-	Help              string              `yaml:"help,omitempty" json:"help,omitempty"`
-	Type              string              `yaml:"type,omitempty" json:"type,omitempty"`
-	DeprecatedVersion string              `yaml:"deprecatedVersion,omitempty" json:"deprecatedVersion,omitempty"`
-	StabilityLevel    string              `yaml:"stabilityLevel,omitempty" json:"stabilityLevel,omitempty"`
-	Labels            []string            `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Buckets           []float64           `yaml:"buckets,omitempty" json:"buckets,omitempty"`
-	Objectives        map[float64]float64 `yaml:"objectives,omitempty" json:"objectives,omitempty"`
-	AgeBuckets        uint32              `yaml:"ageBuckets,omitempty" json:"ageBuckets,omitempty"`
-	BufCap            uint32              `yaml:"bufCap,omitempty" json:"bufCap,omitempty"`
-	MaxAge            int64               `yaml:"maxAge,omitempty" json:"maxAge,omitempty"`
-	ConstLabels       map[string]string   `yaml:"constLabels,omitempty" json:"constLabels,omitempty"`
-}
-
-func (m metric) BuildFQName() string {
-	return metrics.BuildFQName(m.Namespace, m.Subsystem, m.Name)
-}
-
-type byFQName []metric
-
-func (ms byFQName) Len() int { return len(ms) }
-func (ms byFQName) Less(i, j int) bool {
-	if ms[i].StabilityLevel < ms[j].StabilityLevel {
-		return true
-	} else if ms[i].StabilityLevel > ms[j].StabilityLevel {
-		return false
-	}
-	return ms[i].BuildFQName() < ms[j].BuildFQName()
-}
-func (ms byFQName) Swap(i, j int) {
-	ms[i], ms[j] = ms[j], ms[i]
 }

--- a/test/instrumentation/stability-utils.sh
+++ b/test/instrumentation/stability-utils.sh
@@ -68,7 +68,7 @@ function kube::validate::stablemetrics() {
             "test/instrumentation/decode_metric.go" \
             "test/instrumentation/find_stable_metric.go" \
             "test/instrumentation/error.go" \
-            "test/instrumentation/metric.go" \
+            "test/instrumentation/endpoint_mapping.go" \
             -- \
             1>"${temp_file}")
 
@@ -100,7 +100,7 @@ function kube::validate::test::stablemetrics() {
             "test/instrumentation/decode_metric.go" \
             "test/instrumentation/find_stable_metric.go" \
             "test/instrumentation/error.go" \
-            "test/instrumentation/metric.go" \
+            "test/instrumentation/endpoint_mapping.go" \
             -- \
             1>"${temp_file}")
 
@@ -129,7 +129,7 @@ function kube::update::stablemetrics() {
             "test/instrumentation/decode_metric.go" \
             "test/instrumentation/find_stable_metric.go" \
             "test/instrumentation/error.go" \
-            "test/instrumentation/metric.go" \
+            "test/instrumentation/endpoint_mapping.go" \
             -- \
             1>"${temp_file}")
 
@@ -158,8 +158,9 @@ function kube::update::documentation::list() {
             "test/instrumentation/decode_metric.go" \
             "test/instrumentation/find_stable_metric.go" \
             "test/instrumentation/error.go" \
-            "test/instrumentation/metric.go" \
+            "test/instrumentation/endpoint_mapping.go" \
             --allstabilityclasses \
+            --endpoint-mappings="test/instrumentation/endpoint-mappings.yaml" \
             -- \
             1>"${temp_file}")
 
@@ -196,7 +197,7 @@ function kube::update::test::stablemetrics() {
             "test/instrumentation/decode_metric.go" \
             "test/instrumentation/find_stable_metric.go" \
             "test/instrumentation/error.go" \
-            "test/instrumentation/metric.go" \
+            "test/instrumentation/endpoint_mapping.go" \
             -- \
             1>"${temp_file}")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Add metric component and endpoint to [generated metric reference documentation](https://kubernetes.io/docs/reference/instrumentation/metrics/). Commits:

- db1a4d7f574ef52b46c35c4717f60593adfbddea Preliminary refactor: consolidate the `metric` struct, which was duplicated in (3) files, into a new internal package.
- 6e63c941afad16e7762460dc0b9acef29426ec7f Implement component and endpoint mapping
- 7340d7edc25cbafdf063fb43b2dc48922e07508a Re-generate the metric docs

A separate PR for the website repo will be raised if this PR gets accepted and merged, in order to update the public generated documentation.

Design:

**Components** are determined by the metric source file path, where each component can have many paths. A new YAML mapping file was introduced `test/instrumentation/endpoint-mappings.yaml` that captures the component paths under `coreComponents`.

A special case `etcd-version-monitor` was discovered, and is stored separately in the YAML file under `standaloneComponents`.

**Endpoints** are assumed to be `/metrics` by default, with the exception of Kubelet's `/metrics/resource` and `/metrics/probes` endpoints. These exceptions are also captured in the YAML mapping file under `endpointMappings`.

The Go data structure used to store the information from the mapping file is as follows:

```go
type ComponentEndpoint struct {
    Component string `yaml:"component" json:"component"`
    Endpoint  string `yaml:"endpoint" json:"endpoint"`
}

type Metric struct {
    /* existing fields removed for brevity */
    ComponentEndpoints []ComponentEndpoint `yaml:"componentEndpoints,omitempty" json:"componentEndpoints,omitempty"`}
```

**Screenshots**

Top of page, for context, the new "Components" list can be seen:

<img width="833" height="774" alt="Screenshot 2026-01-22 at 13 00 26" src="https://github.com/user-attachments/assets/96954fd2-d689-44f2-8337-21c512e8b1a9" />

A standalone component exception case:

<img width="350" height="338" alt="Screenshot 2026-01-22 at 13 01 35" src="https://github.com/user-attachments/assets/04dda146-4071-4915-a9ed-00f062a19c7e" />

A metric exported by all core components:

<img width="416" height="502" alt="Screenshot 2026-01-22 at 13 20 31" src="https://github.com/user-attachments/assets/dcf22431-5c72-43b1-b280-3826b7590583" />

A Kubelet resource metric exception case:

<img width="512" height="289" alt="Screenshot 2026-01-22 at 13 20 45" src="https://github.com/user-attachments/assets/1deaeada-cb1e-4e55-b8c1-61c746a567fa" />

A Kubelet prober metric exception case:

<img width="692" height="299" alt="Screenshot 2026-01-22 at 13 36 02" src="https://github.com/user-attachments/assets/4d19881a-73f8-44da-838b-95d4d416aa29" />

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/website/issues/43993

#### Special notes for your reviewer:

Recommend review on a commit-by-commit basis.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add metric component and endpoint to generated metric reference documentation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
