### PR TITLE
Automated cherry pick of #136014: kubeadm: waiting for etcd learner member to be started before promoting during 'kubeadm join'

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -637,18 +637,19 @@ func TestListMembers(t *testing.T) {
 	}
 }
 
-func TestIsLearner(t *testing.T) {
+func TestGetMemberStatus(t *testing.T) {
 	type fields struct {
 		Endpoints       []string
 		newEtcdClient   func(endpoints []string) (etcdClient, error)
 		listMembersFunc func(timeout time.Duration) (*clientv3.MemberListResponse, error)
 	}
 	tests := []struct {
-		name      string
-		fields    fields
-		memberID  uint64
-		want      bool
-		wantError bool
+		name        string
+		fields      fields
+		memberID    uint64
+		wantLearner bool
+		wantStarted bool
+		wantError   bool
 	}{
 		{
 			name: "The specified member is not a learner",
@@ -670,8 +671,9 @@ func TestIsLearner(t *testing.T) {
 					return f, nil
 				},
 			},
-			memberID: 1,
-			want:     false,
+			memberID:    1,
+			wantLearner: false,
+			wantStarted: true,
 		},
 		{
 			name: "The specified member is a learner",
@@ -700,8 +702,9 @@ func TestIsLearner(t *testing.T) {
 					return f, nil
 				},
 			},
-			memberID: 1,
-			want:     true,
+			memberID:    1,
+			wantLearner: true,
+			wantStarted: true,
 		},
 		{
 			name: "The specified member does not exist",
@@ -714,8 +717,10 @@ func TestIsLearner(t *testing.T) {
 					return f, nil
 				},
 			},
-			memberID: 3,
-			want:     false,
+			memberID:    3,
+			wantLearner: false,
+			wantStarted: false,
+			wantError:   true,
 		},
 		{
 			name: "Learner ID is empty",
@@ -736,7 +741,32 @@ func TestIsLearner(t *testing.T) {
 					return f, nil
 				},
 			},
-			want: true,
+			wantLearner: true,
+			wantStarted: true,
+		},
+		{
+			name: "Learner member is not started (no name)",
+			fields: fields{
+				Endpoints: []string{},
+				newEtcdClient: func(endpoints []string) (etcdClient, error) {
+					f := &fakeEtcdClient{
+						members: []*pb.Member{
+							{
+								ID:   1,
+								Name: "",
+								PeerURLs: []string{
+									"https://member2:2380",
+								},
+								IsLearner: true,
+							},
+						},
+					}
+					return f, nil
+				},
+			},
+			memberID:    1,
+			wantLearner: true,
+			wantStarted: false,
 		},
 		{
 			name: "ListMembers returns an error",
@@ -760,8 +790,10 @@ func TestIsLearner(t *testing.T) {
 					return nil, errNotImplemented
 				},
 			},
-			want:      false,
-			wantError: true,
+			memberID:    1,
+			wantLearner: false,
+			wantStarted: false,
+			wantError:   true,
 		},
 	}
 	for _, tt := range tests {
@@ -778,12 +810,15 @@ func TestIsLearner(t *testing.T) {
 					return resp, nil
 				}
 			}
-			got, err := c.isLearner(tt.memberID)
-			if got != tt.want {
-				t.Errorf("isLearner() = %v, want %v", got, tt.want)
+			gotLearner, gotStarted, err := c.getMemberStatus(tt.memberID)
+			if gotLearner != tt.wantLearner {
+				t.Errorf("getMemberStatus() isLearner = %v, want %v", gotLearner, tt.wantLearner)
 			}
-			if (err != nil) != (tt.wantError) {
-				t.Errorf("isLearner() error = %v, wantError %v", err, tt.wantError)
+			if gotStarted != tt.wantStarted {
+				t.Errorf("getMemberStatus() started = %v, want %v", gotStarted, tt.wantStarted)
+			}
+			if (err != nil) != tt.wantError {
+				t.Errorf("getMemberStatus() error = %v, wantError %v", err, tt.wantError)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #136014 on release-1.34.

#136014: kubeadm: waiting for etcd learner member to be started before promoting during 'kubeadm join'

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: waiting for etcd learner member to be started before promoting during 'kubeadm join'
```