### PR TITLE
Fix sample-apiserver image build failure

### DIFF
--- a/test/images/sample-apiserver/Makefile
+++ b/test/images/sample-apiserver/Makefile
@@ -27,15 +27,11 @@ export
 bin:
 	docker run --rm -i -v "${TARGET}:${TARGET}:Z" registry.k8s.io/build-image/kube-cross:${KUBE_CROSS_VERSION} \
 		/bin/bash -c "\
-			mkdir -p /go/src /go/bin && \
+			mkdir -p /go/src && \
 			git clone https://github.com/kubernetes/sample-apiserver /go/src/k8s.io/sample-apiserver && \
 			cd /go/src/k8s.io/sample-apiserver && \
 			git checkout tags/v0.33.7 && \
 			go mod tidy && \
-			GO111MODULE=on CGO_ENABLED=0 GOARM=${GOARM} GOOS=${OS} GOARCH=${ARCH} go install . && \
-			find /go/bin -name sample-apiserver* -exec cp {} ${TARGET}/sample-apiserver \;"
-			# for arm, go install uses /go/bin/linux_arm, so just find the file and copy it to the
-			# root so we can copy it out from this throw away container image from a standard location.
-			# Windows executables have .exe extension, which is why we're searching sample-apiserver*
+			GO111MODULE=on CGO_ENABLED=0 GOARM=${GOARM} GOOS=${OS} GOARCH=${ARCH} go build -o ${TARGET}/sample-apiserver ."
 
 .PHONY: bin


### PR DESCRIPTION
The kube-cross image has GOPATH=/usr/local/go and GOROOT=/usr/local/go (same directory). When `go install .` runs, the binary is placed in /usr/local/go/bin/, but the Makefile was searching for it in /go/bin/ which is empty.

Fix by using `go build -o` to place the binary directly at the target location instead of relying on go install + find.

Trying to fix failure in:
https://storage.googleapis.com/kubernetes-ci-logs/logs/post-kubernetes-push-e2e-sample-apiserver-test-images/2013777049507860480/build-log.txt

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
