### PR TITLE
Fix Job Controller Metric Double-Counting on Pod Creation Failure

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1816,8 +1816,9 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 						atomic.AddInt32(&active, -1)
 						errCh <- err
 						atomic.AddInt32(&creationsFailed, 1)
+					} else {
+						atomic.AddInt32(&creationsSucceeded, 1)
 					}
-					atomic.AddInt32(&creationsSucceeded, 1)
 				}()
 			}
 			wait.Wait()


### PR DESCRIPTION
## Summary

This PR fixes a **silent metrics correctness bug** in the Kubernetes Job controller where **failed pod creation attempts were incorrectly counted as successful**.

Due to an unconditional increment of the success counter, the Job controller recorded **both a success and a failure** for the same failed pod creation attempt. This resulted in **inflated success metrics**, misleading monitoring dashboards, and unreliable alerting in production clusters.

The fix ensures that **successful pod creation is recorded only when pod creation actually succeeds**.

---

## Impact

### Before This Fix
- `job_pods_creation_total{result="succeeded"}` was incremented even when pod creation failed
- Failed pod creations were counted as both success and failure
- Dashboards showed healthy pod creation while Jobs were actually failing
- Alerts based on success/failure ratios were unreliable
- Debugging stuck Jobs was confusing due to contradictory metrics

### After This Fix
- Success and failure metrics are mutually exclusive
- `job_pods_creation_total` accurately reflects real pod creation outcomes
- Monitoring and alerting correctly surface pod creation failures
- Job controller observability matches actual Job behavior

---

## Root Cause

In `manageJob`, pod creation occurs inside a goroutine. When pod creation failed, the failure counter was incremented correctly, but the success counter was incremented **unconditionally** due to missing control flow separation.

This caused the code to fall through and record a successful creation even when an error occurred.

---

## Fix

The fix ensures that `creationsSucceeded` is incremented **only when `err == nil`**, by introducing an explicit `else` branch.

### Code Change

#### Before
```go
if err != nil {
    defer utilruntime.HandleError(err)
    logger.V(2).Info("Failed creation, decrementing expectations", "job", klog.KObj(job))
    jm.expectations.CreationObserved(logger, jobKey)
    atomic.AddInt32(&active, -1)
    errCh <- err
    atomic.AddInt32(&creationsFailed, 1)
}
atomic.AddInt32(&creationsSucceeded, 1)
if err != nil {
    defer utilruntime.HandleError(err)
    logger.V(2).Info("Failed creation, decrementing expectations", "job", klog.KObj(job))
    jm.expectations.CreationObserved(logger, jobKey)
    atomic.AddInt32(&active, -1)
    errCh <- err
    atomic.AddInt32(&creationsFailed, 1)
} else {
    atomic.AddInt32(&creationsSucceeded, 1)
}
Create a namespace with a strict pod quota
kubectl create namespace test-quota

kubectl apply -f - <<EOF
apiVersion: v1
kind: ResourceQuota
metadata:
  name: pod-quota
  namespace: test-quota
spec:
  hard:
    pods: "2"
EOF