### PR TITLE
cleanup: improve darwin error messages

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -1467,7 +1467,7 @@ if [[ "${START_MODE}" != *"nokubelet"* ]]; then
   # Detect the OS name/arch and display appropriate error.
     case "$(uname -s)" in
       Darwin)
-        print_color "kubelet is not currently supported in darwin, kubelet aborted."
+        print_color "kubelet is not supported on macOS. Please use https://sigs.k8s.io/kind"
         KUBELET_LOG=""
         ;;
       Linux)
@@ -1487,7 +1487,7 @@ if [[ "${START_MODE}" != "kubeletonly" ]]; then
     # Detect the OS name/arch and display appropriate error.
     case "$(uname -s)" in
       Darwin)
-        print_color "kubelet is not currently supported in darwin, kube-proxy aborted."
+        print_color "kube-proxy is not supported on macOS. Please use https://sigs.k8s.io/kind."
         ;;
       Linux)
         start_kubeproxy


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
While reviewing the `hack/` directory, I noticed stale TODOs regarding Kubelet and kube-proxy support on Darwin. Since native support is not planned and the community standard has shifted to tools like `kind` for macOS development, I have removed these TODOs and updated the error messages to provide more helpful guidance to users.

#### Which issue(s) this PR is related to:

Fixes #NONE
N/A

#### Special notes for your reviewer:
This is my first contribution to the Kubernetes project. As a Senior DevOps Engineer, I wanted to start by cleaning up technical debt in the internal tooling scripts used for local development.

#### Does this PR introduce a user-facing change?

```release-note
NONE