### PR TITLE
clenup(kubelet/test):Add test cases

### DIFF
--- a/pkg/kubelet/apis/podresources/client_test.go
+++ b/pkg/kubelet/apis/podresources/client_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podresources
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+	"k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+)
+
+func TestGetClient(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupFunc func(*grpc.Server)
+		getClient func(string, time.Duration, int) (interface{}, *grpc.ClientConn, error)
+	}{
+		{
+			name: "v1alpha1",
+			setupFunc: func(server *grpc.Server) {
+				v1alpha1.RegisterPodResourcesListerServer(server, &mockV1alpha1Server{})
+			},
+			getClient: func(socket string, timeout time.Duration, maxSize int) (interface{}, *grpc.ClientConn, error) {
+				return GetV1alpha1Client(socket, timeout, maxSize)
+			},
+		},
+		{
+			name: "v1",
+			setupFunc: func(server *grpc.Server) {
+				v1.RegisterPodResourcesListerServer(server, &mockV1Server{})
+			},
+			getClient: func(socket string, timeout time.Duration, maxSize int) (interface{}, *grpc.ClientConn, error) {
+				return GetV1Client(socket, timeout, maxSize)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			socketPath := filepath.Join(t.TempDir(), "podresources.sock")
+			listener, err := net.Listen("unix", socketPath)
+			require.NoError(t, err)
+			defer listener.Close()
+
+			cleanup := startTestServer(t, listener, tt.setupFunc)
+			defer cleanup()
+
+			client, conn, err := tt.getClient(socketPath, 10*time.Second, 1024*1024)
+			require.NoError(t, err)
+			defer conn.Close()
+
+			require.NotNil(t, client)
+		})
+	}
+}
+
+func TestGetV1alpha1ClientError(t *testing.T) {
+	_, _, err := GetV1alpha1Client("unix:///invalid\x00path", 100*time.Millisecond, 1024*1024)
+	if err == nil {
+		t.Fatal("expected error for invalid socket path")
+	}
+}
+
+func TestGetV1ClientError(t *testing.T) {
+	_, _, err := GetV1Client("unix:///invalid\x00path", 100*time.Millisecond, 1024*1024)
+	if err == nil {
+		t.Fatal("expected error for invalid socket path")
+	}
+}
+
+type mockV1alpha1Server struct {
+	v1alpha1.UnimplementedPodResourcesListerServer
+}
+
+func (m *mockV1alpha1Server) List(context.Context, *v1alpha1.ListPodResourcesRequest) (*v1alpha1.ListPodResourcesResponse, error) {
+	return &v1alpha1.ListPodResourcesResponse{}, nil
+}
+
+type mockV1Server struct {
+	v1.UnimplementedPodResourcesListerServer
+}
+
+func (m *mockV1Server) List(context.Context, *v1.ListPodResourcesRequest) (*v1.ListPodResourcesResponse, error) {
+	return &v1.ListPodResourcesResponse{}, nil
+}
+
+func (m *mockV1Server) GetAllocatableResources(context.Context, *v1.AllocatableResourcesRequest) (*v1.AllocatableResourcesResponse, error) {
+	return &v1.AllocatableResourcesResponse{}, nil
+}
+
+func (m *mockV1Server) Get(context.Context, *v1.GetPodResourcesRequest) (*v1.GetPodResourcesResponse, error) {
+	return &v1.GetPodResourcesResponse{}, nil
+}
+
+func startTestServer(t *testing.T, listener net.Listener, registerFunc func(server *grpc.Server)) func() {
+	server := grpc.NewServer()
+	registerFunc(server)
+	go func() {
+		if err := server.Serve(listener); err != nil {
+			t.Logf("server stopped: %v", err)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	return func() {
+		server.Stop()
+	}
+}

--- a/pkg/kubelet/apis/podresources/server_v1_test.go
+++ b/pkg/kubelet/apis/podresources/server_v1_test.go
@@ -1269,3 +1269,217 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 		})
 	}
 }
+
+// TestGetPodResourcesV1FeatureGateDisabled tests Get() when the feature gate is disabled
+func TestGetPodResourcesV1FeatureGateDisabled(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.KubeletPodResourcesGet, false)
+
+	tCtx := ktesting.Init(t)
+	podName := "pod-name"
+	podNamespace := "pod-namespace"
+
+	mockDevicesProvider := podresourcetest.NewMockDevicesProvider(t)
+	mockPodsProvider := podresourcetest.NewMockPodsProvider(t)
+	mockCPUsProvider := podresourcetest.NewMockCPUsProvider(t)
+	mockMemoryProvider := podresourcetest.NewMockMemoryProvider(t)
+	mockDynamicResourcesProvider := podresourcetest.NewMockDynamicResourcesProvider(t)
+
+	providers := PodResourcesProviders{
+		Pods:             mockPodsProvider,
+		Devices:          mockDevicesProvider,
+		Cpus:             mockCPUsProvider,
+		Memory:           mockMemoryProvider,
+		DynamicResources: mockDynamicResourcesProvider,
+	}
+	server := NewV1PodResourcesServer(tCtx, providers)
+	podReq := &podresourcesapi.GetPodResourcesRequest{PodName: podName, PodNamespace: podNamespace}
+	_, err := server.Get(tCtx, podReq)
+	if err == nil {
+		t.Errorf("expected error when feature gate is disabled, got nil")
+	}
+	expectedErr := "PodResources API Get method disabled"
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+}
+
+// TestListPodResourcesV1WithTerminalPods tests List() with terminal pods when useActivePods=false
+func TestListPodResourcesV1WithTerminalPods(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.KubeletPodResourcesListUseActivePods, false)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.KubeletPodResourcesDynamicResources, true)
+
+	tCtx := ktesting.Init(t)
+	containerName := "container-name"
+
+	// Create pods with different phases
+	runningPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "running-pod",
+			Namespace: "default",
+			UID:       types.UID("running-uid"),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: containerName}},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+
+	failedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "failed-pod",
+			Namespace: "default",
+			UID:       types.UID("failed-uid"),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: containerName}},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodFailed,
+		},
+	}
+
+	succeededPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "succeeded-pod",
+			Namespace: "default",
+			UID:       types.UID("succeeded-uid"),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: containerName}},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodSucceeded,
+		},
+	}
+
+	pendingPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-pod",
+			Namespace: "default",
+			UID:       types.UID("pending-uid"),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: containerName}},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodPending,
+		},
+	}
+
+	allPods := []*v1.Pod{runningPod, failedPod, succeededPod, pendingPod}
+
+	mockDevicesProvider := podresourcetest.NewMockDevicesProvider(t)
+	mockPodsProvider := podresourcetest.NewMockPodsProvider(t)
+	mockCPUsProvider := podresourcetest.NewMockCPUsProvider(t)
+	mockMemoryProvider := podresourcetest.NewMockMemoryProvider(t)
+	mockDynamicResourcesProvider := podresourcetest.NewMockDynamicResourcesProvider(t)
+
+	mockPodsProvider.EXPECT().GetPods().Return(allPods)
+	mockDevicesProvider.EXPECT().UpdateAllocatedDevices().Return()
+
+	// Only non-terminal pods should have their resources queried
+	for _, pod := range []*v1.Pod{runningPod, pendingPod} {
+		mockDevicesProvider.EXPECT().GetDevices(string(pod.UID), containerName).Return([]*podresourcesapi.ContainerDevices{})
+		mockCPUsProvider.EXPECT().GetCPUs(string(pod.UID), containerName).Return([]int64{})
+		mockMemoryProvider.EXPECT().GetMemory(string(pod.UID), containerName).Return([]*podresourcesapi.ContainerMemory{})
+		mockDynamicResourcesProvider.EXPECT().GetDynamicResources(pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{})
+	}
+
+	providers := PodResourcesProviders{
+		Pods:             mockPodsProvider,
+		Devices:          mockDevicesProvider,
+		Cpus:             mockCPUsProvider,
+		Memory:           mockMemoryProvider,
+		DynamicResources: mockDynamicResourcesProvider,
+	}
+	server := NewV1PodResourcesServer(tCtx, providers)
+	resp, err := server.List(tCtx, &podresourcesapi.ListPodResourcesRequest{})
+	if err != nil {
+		t.Errorf("want err = %v, got %q", nil, err)
+	}
+
+	// Verify only non-terminal pods are in the response
+	if len(resp.PodResources) != 2 {
+		t.Errorf("expected 2 pods in response (running and pending), got %d", len(resp.PodResources))
+	}
+
+	podNames := make(map[string]bool)
+	for _, pr := range resp.PodResources {
+		podNames[pr.Name] = true
+	}
+
+	if !podNames["running-pod"] {
+		t.Errorf("expected running-pod in response")
+	}
+	if !podNames["pending-pod"] {
+		t.Errorf("expected pending-pod in response")
+	}
+	if podNames["failed-pod"] {
+		t.Errorf("did not expect failed-pod in response")
+	}
+	if podNames["succeeded-pod"] {
+		t.Errorf("did not expect succeeded-pod in response")
+	}
+}
+
+// TestListPodResourcesV1WithActivePodsEnabled tests List() with useActivePods=true
+func TestListPodResourcesV1WithActivePodsEnabled(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.KubeletPodResourcesListUseActivePods, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.KubeletPodResourcesDynamicResources, true)
+
+	tCtx := ktesting.Init(t)
+	containerName := "container-name"
+
+	activePod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "active-pod",
+			Namespace: "default",
+			UID:       types.UID("active-uid"),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: containerName}},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+
+	activePods := []*v1.Pod{activePod}
+
+	mockDevicesProvider := podresourcetest.NewMockDevicesProvider(t)
+	mockPodsProvider := podresourcetest.NewMockPodsProvider(t)
+	mockCPUsProvider := podresourcetest.NewMockCPUsProvider(t)
+	mockMemoryProvider := podresourcetest.NewMockMemoryProvider(t)
+	mockDynamicResourcesProvider := podresourcetest.NewMockDynamicResourcesProvider(t)
+
+	// When useActivePods=true, GetActivePods should be called
+	mockPodsProvider.EXPECT().GetActivePods().Return(activePods)
+	mockDevicesProvider.EXPECT().UpdateAllocatedDevices().Return()
+	mockDevicesProvider.EXPECT().GetDevices(string(activePod.UID), containerName).Return([]*podresourcesapi.ContainerDevices{})
+	mockCPUsProvider.EXPECT().GetCPUs(string(activePod.UID), containerName).Return([]int64{})
+	mockMemoryProvider.EXPECT().GetMemory(string(activePod.UID), containerName).Return([]*podresourcesapi.ContainerMemory{})
+	mockDynamicResourcesProvider.EXPECT().GetDynamicResources(activePod, &activePod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{})
+
+	providers := PodResourcesProviders{
+		Pods:             mockPodsProvider,
+		Devices:          mockDevicesProvider,
+		Cpus:             mockCPUsProvider,
+		Memory:           mockMemoryProvider,
+		DynamicResources: mockDynamicResourcesProvider,
+	}
+	server := NewV1PodResourcesServer(tCtx, providers)
+	resp, err := server.List(tCtx, &podresourcesapi.ListPodResourcesRequest{})
+	if err != nil {
+		t.Errorf("want err = %v, got %q", nil, err)
+	}
+
+	if len(resp.PodResources) != 1 {
+		t.Errorf("expected 1 pod in response, got %d", len(resp.PodResources))
+	}
+
+	if resp.PodResources[0].Name != "active-pod" {
+		t.Errorf("expected active-pod in response, got %s", resp.PodResources[0].Name)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
﻿
#### What this PR does / why we need it:
Additional testing items:
Test the normal connection of V1alpha1 client
Test the normal connection of V1 client
Test error handling of V1alpha1 client
Error handling for testing V1 client
Test the behavior of the Get() method when feature gate is disabled
Test List() method to filter terminated Pods when useActivePods=false
Test the List() method to use FHIR ActivePods() when useActivePods()=true
﻿
Improve unit testing coverage from 71% to 97%

Uncovered code:
Error return path for grpc. DialContext() in client. go
Reason: gRPC clients almost never fail in the dial phase without the grpc. WhatBlock() option

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/126268
﻿
```release-note
NONE
```