### PR TITLE
Skip gcloud version check to remove dependency on deprecated distutils

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2138,18 +2138,14 @@ function update-or-verify-gcloud() {
     version=$(gcloud version --format=json)
     python3 -c"
 import json,sys
-from packaging import version
 
-minVersion = version.parse('1.3.0')
 required = [ 'alpha', 'beta', 'core' ]
 data = json.loads(sys.argv[1])
 rel = data.get('Google Cloud SDK')
 if 'CL @' in rel:
   print('Using dev version of gcloud: %s' %rel)
   exit(0)
-if rel != 'HEAD' and version.parse(rel) < minVersion:
-  print('gcloud version out of date ( < %s )' % minVersion)
-  exit(1)
+
 missing = []
 for c in required:
   if not data.get(c):

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2138,16 +2138,16 @@ function update-or-verify-gcloud() {
     version=$(gcloud version --format=json)
     python3 -c"
 import json,sys
-from distutils import version
+from packaging import version
 
-minVersion = version.LooseVersion('1.3.0')
+minVersion = version.parse('1.3.0')
 required = [ 'alpha', 'beta', 'core' ]
 data = json.loads(sys.argv[1])
 rel = data.get('Google Cloud SDK')
 if 'CL @' in rel:
   print('Using dev version of gcloud: %s' %rel)
   exit(0)
-if rel != 'HEAD' and version.LooseVersion(rel) < minVersion:
+if rel != 'HEAD' and version.parse(rel) < minVersion:
   print('gcloud version out of date ( < %s )' % minVersion)
   exit(1)
 missing = []


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Since `distutils` package was removed in `python3.12`, the script generated by `util.sh` - more specifically `update-or-verify-gcloud()` - no longer works with recent python versions. This may cause issues long term when users will start to upgrade to the latest versions of python.

The original idea was to replace the use of `datautils.version` with `packaging.version`, which is part of the standard library, but it turned out that older versions of python do not have `packaging` library. After doing some research I came to a conclusion that we may not need this check at all so I ended up removing it completely.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
