### PR TITLE
Rename metric `volume_operation_total_errors` to `volume_operation_errors_total`

### DIFF
--- a/pkg/controller/volume/persistentvolume/metrics/metrics_test.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+// TestVolumeOperationError tests recording metric when operation has error
+func TestVolumeOperationError(t *testing.T) {
+	registry := metrics.NewKubeRegistry()
+	defer registry.Reset()
+	registry.MustRegister(volumeOperationErrorMetric)
+
+	RecordVolumeOperationErrorMetric("kubernetes.io/fake-plugin", "deletion")
+
+	want := `# HELP volume_operation_errors_total [ALPHA] Total volume operation errors
+# TYPE volume_operation_errors_total counter
+volume_operation_errors_total{operation_name="deletion",plugin_name="kubernetes.io/fake-plugin"} 1
+`
+
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(want), "volume_operation_errors_total"); err != nil {
+		t.Errorf("failed to gather metrics: %v", err)
+	}
+}

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -891,6 +891,17 @@
   componentEndpoints:
   - component: kube-controller-manager
     endpoint: /metrics
+- name: stale_sync_skips_total
+  subsystem: statefulset_controller
+  help: Total number of StatefulSet syncs skipped due to a stale watch cache.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: statefulset_max_unavailable
   subsystem: statefulset_controller
   help: Maximum number of unavailable pods allowed during StatefulSet rolling updates
@@ -978,9 +989,20 @@
   componentEndpoints:
   - component: kube-controller-manager
     endpoint: /metrics
+- name: volume_operation_errors_total
+  help: Total volume operation errors
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - operation_name
+  - plugin_name
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: volume_operation_total_errors
   help: Total volume operation errors
   type: Counter
+  deprecatedVersion: 1.36.0
   stabilityLevel: ALPHA
   labels:
   - operation_name


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Rename metric `volume_operation_total_errors` to `volume_operation_errors_total`, and add the test.

Marked `volume_operation_total_errors` as deprecated.

#### Which issue(s) this PR is related to:

Related #136310

#### Special notes for your reviewer:

If I write the test with `volume_operation_total_errors`, it will return

```
failed to gather metrics: lint error: volume_operation_total_errors:counter metrics should have "_total" suffix
```

#### Does this PR introduce a user-facing change?

```release-note
ACTION REQUIRED:
kube-controller-manager: renamed metric 'volume_operation_total_errors' to 'volume_operation_errors_total'. If you are using custom monitoring dashboards or alerting rules based on the 'volume_operation_total_errors' metric, please update them to use the new 'volume_operation_errors_total' metric.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
