### PR TITLE
fake client: delete pod when eviction subresource is created

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
@@ -31,14 +31,13 @@ import (
 func TestNewSimpleClientset(t *testing.T) {
 	client := NewSimpleClientset()
 
-	pod, err := client.CoreV1().Pods("default").Create(context.Background(), &v1.Pod{
+	_, err := client.CoreV1().Pods("default").Create(context.Background(), &v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "pod-1",
 			Namespace: "default",
 		},
 	}, meta_v1.CreateOptions{})
 	require.NoError(t, err)
-	require.NotNil(t, pod)
 
 	_, err = client.CoreV1().Pods("default").Create(context.Background(), &v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -175,6 +175,13 @@ func (o objectTrackerReact) Create(action CreateActionImpl) (runtime.Object, err
 			})
 		} else {
 			// If the historical object type is different from the current object type, need to make sure we return the object submitted,don't persist the submitted object in the tracker.
+			// Special case: eviction subresource should delete the pod
+			if action.GetSubresource() == "eviction" && gvr.Resource == "pods" {
+				err = o.tracker.Delete(gvr, ns, objMeta.GetName())
+				if err != nil {
+					return nil, err
+				}
+			}
 			return action.GetObject(), nil
 		}
 	}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

When using the fake client's `Evict()` method, the pod was not being removed from the object tracker. This caused pods to remain in the tracker after eviction, which is inconsistent with real API server behavior.

The fix adds special handling in `ObjectReaction`'s Create method to detect eviction subresource actions on pods and delete the corresponding pod from the tracker.

## Which issue(s) this PR fixes:

Fixes #112168

## Special notes for your reviewer:

The existing test `TestNewSimpleClientset` was improved to actually verify that the evicted pod is deleted. Additional explicit tests were added for both the low-level `ObjectReaction` and the high-level fake clientset.

## Does this PR introduce a user-facing change?

```release-note
NONE
```