### PR TITLE
ns role labels to system ns

### DIFF
--- a/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller.go
+++ b/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller.go
@@ -34,6 +34,13 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	// NamespaceRoleLabel is the label key used to identify system namespaces
+	NamespaceRoleLabel = "kubernetes.io/namespace-role"
+	// NamespaceRoleSystem is the label value for system namespaces
+	NamespaceRoleSystem = "system"
+)
+
 // Controller ensure system namespaces exist.
 type Controller struct {
 	client kubernetes.Interface
@@ -91,8 +98,10 @@ func (c *Controller) createNamespaceIfNeeded(ns string) error {
 	}
 	newNs := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ns,
-			Namespace: "",
+			Name: ns,
+			Labels: map[string]string{
+				NamespaceRoleLabel: NamespaceRoleSystem,
+			},
 		},
 	}
 	_, err := c.client.CoreV1().Namespaces().Create(context.TODO(), newNs, metav1.CreateOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this? 
feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable: 
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
Adds automatic labeling of system namespaces with `kubernetes.io/namespace-role=system` to enable portable `ClusterNetworkPolicy` targeting and policy-based namespace classification across distributions.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/enhancements/issues/5708#issuecomment-3771691025
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Open for upcoming reviews.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
System namespaces (`kube-system`, `kube-public`, `kube-node-lease`, `default`) are now automatically labeled with `kubernetes.io/namespace-role=system` to enable portable policy targeting across distributions. Administrators can use this label in `ClusterNetworkPolicies` and other configurations to distinguish system infrastructure from user workloads.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
