### PR TITLE
fix cli throwing an error when trying to tail the logs for a Pod

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -32,6 +32,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest"
@@ -405,17 +406,11 @@ func (o LogsOptions) parallelConsumeRequest(ctx context.Context, requests map[co
 		go func(objRef corev1.ObjectReference, request rest.ResponseWrapper) {
 			defer wg.Done()
 			out := o.addPrefixIfNeeded(objRef, writer)
-			if err := o.ConsumeRequestFn(ctx, request, out); err != nil {
-				if !o.IgnoreLogErrors {
-					writer.CloseWithError(err)
-
-					// It's important to return here to propagate the error via the pipe
-					return
-				}
-
-				fmt.Fprintf(writer, "error: %v\n", err)
+			if err := o.consumeWithRetry(ctx, request, out, writer); err != nil {
+				writer.CloseWithError(err)
+				// It's important to return here to propagate the error via the pipe
+				return
 			}
-
 		}(objRef, request)
 	}
 
@@ -431,16 +426,43 @@ func (o LogsOptions) parallelConsumeRequest(ctx context.Context, requests map[co
 func (o LogsOptions) sequentialConsumeRequest(ctx context.Context, requests map[corev1.ObjectReference]rest.ResponseWrapper) error {
 	for objRef, request := range requests {
 		out := o.addPrefixIfNeeded(objRef, o.Out)
-		if err := o.ConsumeRequestFn(ctx, request, out); err != nil {
-			if !o.IgnoreLogErrors {
-				return err
-			}
-
-			fmt.Fprintf(o.Out, "error: %v\n", err)
+		if err := o.consumeWithRetry(ctx, request, out, o.Out); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+func (o LogsOptions) consumeWithRetry(ctx context.Context, request rest.ResponseWrapper, out io.Writer, internalErrOut io.Writer) error {
+	if !o.Follow {
+		err := o.ConsumeRequestFn(ctx, request, out)
+		if err != nil && o.IgnoreLogErrors {
+			_, _ = fmt.Fprint(internalErrOut, "error: "+err.Error()+"\n")
+			return nil
+		}
+		return err
+	}
+
+	return wait.PollUntilContextTimeout(ctx, 1*time.Second, o.GetPodTimeout, true, func(_ context.Context) (bool, error) {
+		err := o.ConsumeRequestFn(ctx, request, out)
+		if err == nil {
+			return true, nil
+		}
+
+		if o.IgnoreLogErrors {
+			_, _ = fmt.Fprint(internalErrOut, "error: "+err.Error()+"\n")
+			return true, nil
+		}
+
+		_, _ = o.ErrOut.Write([]byte(err.Error() + "\n"))
+
+		if _, ok := err.(apierrors.APIStatus); ok {
+			return false, nil
+		}
+
+		return false, err
+	})
 }
 
 func (o LogsOptions) addPrefixIfNeeded(ref corev1.ObjectReference, writer io.Writer) io.Writer {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -64,6 +64,7 @@ func TestLog(t *testing.T) {
 				}
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 
@@ -85,6 +86,7 @@ func TestLog(t *testing.T) {
 				}
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -112,6 +114,7 @@ func TestLog(t *testing.T) {
 				}
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -136,6 +139,7 @@ func TestLog(t *testing.T) {
 				}
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -158,6 +162,7 @@ func TestLog(t *testing.T) {
 				}
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -190,6 +195,7 @@ func TestLog(t *testing.T) {
 				}
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				return o
@@ -210,23 +216,36 @@ func TestLog(t *testing.T) {
 							Kind:      "Pod",
 							Name:      "some-pod-1",
 							FieldPath: "spec.containers{some-container-1}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 1\n")},
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{data: strings.NewReader("test log content from source 1\n")},
+							},
+						},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-2",
 							FieldPath: "spec.containers{some-container-2}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 2\n")},
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{data: strings.NewReader("test log content from source 2\n")},
+							},
+						},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-3",
 							FieldPath: "spec.containers{some-container-3}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 3\n")},
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{data: strings.NewReader("test log content from source 3\n")},
+							},
+						},
 					},
 					wg: wg,
 				}
 				wg.Add(3)
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Follow = true
@@ -268,6 +287,7 @@ func TestLog(t *testing.T) {
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.MaxFollowConcurrency = 2
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.Follow = true
 				return o
 			},
@@ -277,6 +297,7 @@ func TestLog(t *testing.T) {
 			name: "fail if LogsForObject fails",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) (map[corev1.ObjectReference]restclient.ResponseWrapper, error) {
 					return nil, errors.New("Error from the LogsForObject")
 				}
@@ -303,6 +324,7 @@ func TestLog(t *testing.T) {
 				}
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = func(ctx context.Context, req restclient.ResponseWrapper, out io.Writer) error {
 					return errors.New("Error from the ConsumeRequestFn")
@@ -321,17 +343,29 @@ func TestLog(t *testing.T) {
 							Kind:      "Pod",
 							Name:      "test-pod-1",
 							FieldPath: "spec.containers{test-container-1}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 1\n")},
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{data: strings.NewReader("test log content from source 1\n")},
+							},
+						},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-2",
 							FieldPath: "spec.containers{test-container-2}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 2\n")},
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{data: strings.NewReader("test log content from source 2\n")},
+							},
+						},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-3",
 							FieldPath: "spec.containers{test-container-3}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 3\n")},
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{data: strings.NewReader("test log content from source 3\n")},
+							},
+						},
 					},
 					wg: wg,
 				}
@@ -340,6 +374,7 @@ func TestLog(t *testing.T) {
 				o := NewLogsOptions(streams)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.Follow = true
 				o.Prefix = true
 				return o
@@ -360,17 +395,29 @@ func TestLog(t *testing.T) {
 							Kind:      "Pod",
 							Name:      "test-pod-1",
 							FieldPath: "spec.containers{test-container-1}",
-						}: &responseWrapperMock{},
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{},
+							},
+						},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-2",
 							FieldPath: "spec.containers{test-container-2}",
-						}: &responseWrapperMock{},
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{},
+							},
+						},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-3",
 							FieldPath: "spec.containers{test-container-3}",
-						}: &responseWrapperMock{},
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{},
+							},
+						},
 					},
 					wg: wg,
 				}
@@ -382,6 +429,7 @@ func TestLog(t *testing.T) {
 					return errors.New("Error from the ConsumeRequestFn")
 				}
 				o.Follow = true
+				o.GetPodTimeout = 5 * time.Millisecond
 				return o
 			},
 			expectedErr: "Error from the ConsumeRequestFn",
@@ -405,6 +453,7 @@ func TestLog(t *testing.T) {
 					return errors.New("Error from the ConsumeRequestFn")
 				}
 				o.Follow = true
+				o.GetPodTimeout = 5 * time.Millisecond
 				return o
 			},
 			expectedErr: "Error from the ConsumeRequestFn",
@@ -433,6 +482,7 @@ func TestLog(t *testing.T) {
 				}
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.IgnoreLogErrors = true
@@ -463,6 +513,7 @@ func TestLog(t *testing.T) {
 				}
 
 				o := NewLogsOptions(streams)
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				return o
@@ -494,6 +545,7 @@ func TestLog(t *testing.T) {
 
 				o := NewLogsOptions(streams)
 				o.LogsForObject = mock.mockLogsForObject
+				o.GetPodTimeout = 5 * time.Millisecond
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.IgnoreLogErrors = true
 				o.Follow = true
@@ -527,9 +579,72 @@ func TestLog(t *testing.T) {
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Follow = true
+				o.GetPodTimeout = 5 * time.Second
 				return o
 			},
 			expectedErr: "error-container",
+		},
+		{
+			name: "follow logs with retry on waiting container",
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
+				mock := &logTestMock{
+					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+						{
+							Kind:      "Pod",
+							Name:      "some-pod",
+							FieldPath: "spec.containers{some-container}",
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{
+									err: apierrors.NewBadRequest("container \"some-container\" in pod \"some-pod\" is waiting to start: ContainerCreating"),
+								},
+								{
+									data: strings.NewReader("test log content\n"),
+								},
+							},
+						},
+					},
+				}
+				o := NewLogsOptions(streams)
+				o.LogsForObject = mock.mockLogsForObject
+				o.ConsumeRequestFn = mock.mockConsumeRequest
+				o.Follow = true
+				o.GetPodTimeout = 5 * time.Second
+				return o
+			},
+			expectedOutSubstrings: []string{
+				"test log content\n",
+			},
+		},
+		{
+			name: "follow logs with retry and timeout",
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
+				mock := &logTestMock{
+					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+						{
+							Kind:      "Pod",
+							Name:      "some-pod",
+							FieldPath: "spec.containers{some-container}",
+						}: &statefulResponseWrapperMock{
+							results: []mockResult{
+								{
+									err: apierrors.NewBadRequest("container \"some-container\" in pod \"some-pod\" is waiting to start: ContainerCreating"),
+								},
+								{
+									err: apierrors.NewBadRequest("container \"some-container\" in pod \"some-pod\" is waiting to start: ContainerCreating"),
+								},
+							},
+						},
+					},
+				}
+				o := NewLogsOptions(streams)
+				o.LogsForObject = mock.mockLogsForObject
+				o.ConsumeRequestFn = mock.mockConsumeRequest
+				o.Follow = true
+				o.GetPodTimeout = 1 * time.Millisecond
+				return o
+			},
+			expectedErr: "context deadline exceeded",
 		},
 	}
 	for _, test := range tests {
@@ -538,6 +653,7 @@ func TestLog(t *testing.T) {
 			defer tf.Cleanup()
 
 			streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+			streams.ErrOut = &threadSafeWriter{writer: streams.ErrOut}
 
 			opts := test.opts(streams)
 			opts.Namespace = "test"
@@ -967,4 +1083,44 @@ func (l *logTestMock) mockLogsForObject(restClientGetter genericclioptions.RESTC
 	default:
 		return nil, fmt.Errorf("cannot get the logs from %T", object)
 	}
+}
+
+type mockResult struct {
+	err  error
+	data io.Reader
+}
+
+type statefulResponseWrapperMock struct {
+	lock    sync.Mutex
+	calls   int
+	results []mockResult
+}
+
+func (r *statefulResponseWrapperMock) DoRaw(context.Context) ([]byte, error) {
+	return nil, nil
+}
+
+func (r *statefulResponseWrapperMock) Stream(context.Context) (io.ReadCloser, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.calls >= len(r.results) {
+		return nil, fmt.Errorf("unexpected call %d", r.calls)
+	}
+	res := r.results[r.calls]
+	r.calls++
+	if res.err != nil {
+		return nil, res.err
+	}
+	return io.NopCloser(res.data), nil
+}
+
+type threadSafeWriter struct {
+	mu     sync.Mutex
+	writer io.Writer
+}
+
+func (tsw *threadSafeWriter) Write(p []byte) (n int, err error) {
+	tsw.mu.Lock()
+	defer tsw.mu.Unlock()
+	return tsw.writer.Write(p)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
```
This PR fixes "kubectl logs -f" by waiting for containers to start instead of failing immediately 
when a pod is in a "waiting to start" state (e.g., `ContainerCreating`, `PodInitializing`).

**Before**: "kubectl logs -f" would fail with an error like "container is waiting to start." 
when run against pods that haven't fully started yet.

**After**: "kubectl logs -f" will retry until the container starts and logs 
become available, then stream the logs as expected.

This improves the user experience when debugging slow-starting pods, 
as users no longer need to manually retry the command or wait for the pod to be ready 
before running `kubectl logs -f`.
```
**Single Container Pod**:
<img width="1200" height="217" alt="image" src="https://github.com/user-attachments/assets/16b255eb-fc69-4a5e-bdcc-fab6a640a6b9" />


**Multi-Container Pod**:
<img width="1176" height="469" alt="image" src="https://github.com/user-attachments/assets/fc72b57e-9410-4329-a405-1c5da227ab97" />



#### Which issue(s) this PR is related to:
Fixes [28746](https://github.com/kubernetes/kubernetes/issues/28746)

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes [28746](https://github.com/kubernetes/kubernetes/issues/28746)
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed kubectl logs -f to wait for containers to start instead of failing 
immediately when pods are in ContainerCreating or PodInitializing states
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
