### PR TITLE
Add github.com/google/btree to unwanted dependencies

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -42,6 +42,7 @@
       "github.com/golang/mock": "unmaintained, archive mode",
       "github.com/golang/protobuf": "replace with google.golang.org/protobuf",
       "github.com/golang/groupcache": "unmaintained",
+      "github.com/google/btree": "unmaintained, archive mode",
       "github.com/google/gofuzz": "unmaintained, use sigs.k8s.io/randfill",
       "github.com/google/s2a-go": "cloud dependency, unstable",
       "github.com/google/shlex": "unmaintained, archive mode",
@@ -172,6 +173,10 @@
         "google.golang.org/protobuf",
         "sigs.k8s.io/apiserver-network-proxy/konnectivity-client"
       ],
+      "github.com/google/btree": [
+        "go.etcd.io/etcd/server/v3",
+        "k8s.io/apiserver"
+      ],
       "github.com/google/gofuzz": [
         "github.com/json-iterator/go"
       ],
@@ -268,6 +273,7 @@
       "github.com/davecgh/go-spew",
       "github.com/gogo/protobuf",
       "github.com/golang/protobuf",
+      "github.com/google/btree",
       "github.com/json-iterator/go",
       "github.com/mailru/easyjson",
       "github.com/modern-go/concurrent",


### PR DESCRIPTION
This PR adds github.com/google/btree to the unwanted dependencies list.

## Changes
- Added github.com/google/btree to unwantedModules with reason: "unmaintained, archive mode"
- Added unwantedReferences tracking for github.com/google/btree:
  - go.etcd.io/etcd/server/v3
  - k8s.io/apiserver
- Added github.com/google/btree to unwantedVendored list

xref https://github.com/kubernetes/kubernetes/issues/136415

/kind cleanup

## Reason
The github.com/google/btree module is unmaintained and in archive mode, making it unsuitable for continued use in Kubernetes.

## Verification
- ✅ hack/lint-dependencies.sh passes successfully
- ✅ JSON format is valid

```release-note
NONE
```