### PR TITLE
E2E framework ssh: avoid log spam in runSSHCommand

### DIFF
--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -247,16 +247,12 @@ func runSSHCommand(ctx context.Context, cmd, user, host string, signer ssh.Signe
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	client, err := ssh.Dial("tcp", host, config)
-	if err != nil {
-		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
-			fmt.Printf("error dialing %s@%s: '%v', retrying\n", user, host, err)
-			if client, err = ssh.Dial("tcp", host, config); err != nil {
-				return false, nil // retrying, error will be logged above
-			}
-			return true, nil
-		})
-	}
+	var client *ssh.Client
+	err := framework.Gomega().Eventually(ctx, func() error {
+		c, err := ssh.Dial("tcp", host, config)
+		client = c
+		return err
+	}).WithPolling(5 * time.Second).WithTimeout(20 * time.Second).Should(gomega.Succeed())
 	if err != nil {
 		return "", "", 0, fmt.Errorf("error getting SSH client to %s@%s: %w", user, host, err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Emitting "error dialing" on each retry spams the test log output even when the tests succeed.

Using Eventually also has other advantages (better failure message, support for Gingko progress reports when a test is stuck).

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/136260

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
