### PR TITLE
Mark PodGroupPolicy up with openapi union member tags

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19121,7 +19121,15 @@
           "description": "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics."
         }
       },
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-unions": [
+        {
+          "fields-to-discriminateBy": {
+            "basic": "Basic",
+            "gang": "Gang"
+          }
+        }
+      ]
     },
     "io.k8s.api.scheduling.v1alpha1.TypedLocalObjectReference": {
       "description": "TypedLocalObjectReference allows to reference typed object inside the same namespace.",

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha1_openapi.json
@@ -64,7 +64,15 @@
             "description": "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics."
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-kubernetes-unions": [
+          {
+            "fields-to-discriminateBy": {
+              "basic": "Basic",
+              "gang": "Gang"
+            }
+          }
+        ]
       },
       "io.k8s.api.scheduling.v1alpha1.TypedLocalObjectReference": {
         "description": "TypedLocalObjectReference allows to reference typed object inside the same namespace.",

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -53350,6 +53350,18 @@ func schema_k8sio_api_scheduling_v1alpha1_PodGroupPolicy(ref common.ReferenceCal
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-unions": []interface{}{
+						map[string]interface{}{
+							"fields-to-discriminateBy": map[string]interface{}{
+								"basic": "Basic",
+								"gang":  "Gang",
+							},
+						},
+					},
+				},
+			},
 		},
 		Dependencies: []string{
 			schedulingv1alpha1.BasicSchedulingPolicy{}.OpenAPIModelName(), schedulingv1alpha1.GangSchedulingPolicy{}.OpenAPIModelName()},

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -63,6 +63,7 @@ message PodGroup {
 }
 
 // PodGroupPolicy defines the scheduling configuration for a PodGroup.
+// +union
 message PodGroupPolicy {
   // Basic specifies that the pods in this group should be scheduled using
   // standard Kubernetes scheduling behavior.

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -181,6 +181,7 @@ type PodGroup struct {
 }
 
 // PodGroupPolicy defines the scheduling configuration for a PodGroup.
+// +union
 type PodGroupPolicy struct {
 	// Basic specifies that the pods in this group should be scheduled using
 	// standard Kubernetes scheduling behavior.

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -14363,6 +14363,12 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: gang
       type:
         namedType: io.k8s.api.scheduling.v1alpha1.GangSchedulingPolicy
+    unions:
+    - fields:
+      - fieldName: basic
+        discriminatorValue: Basic
+      - fieldName: gang
+        discriminatorValue: Gang
 - name: io.k8s.api.scheduling.v1alpha1.PriorityClass
   map:
     fields:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change

#### What this PR does / why we need it:

The PodGroupPolicy struct is validated as a union, one of the two member fields must be present, and, they are both marked up as `+k8s:unionMember`. However, the struct itself isn't marked as a union, nor are the fields marked with the `+unionMember` tags that are supported by the openapi generator.

This PR adds them to keep the openapi in sync

I'm not entirely sure that this is correct, since the openapi I believe expects a discriminated union, but figured this was quick to raise for discussion - should we presently require `+k8s:unionMember` and `+unionMember` together until we teach the openapi generator to understand the new `+k8s` style tags?

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Correct openapi schema union validation for the PodGroupPolicy struct in scheduling v1alpha1
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
