### PR TITLE
[release-1.34] fix(kubelet): convert V().Error() to V().Info() for verbosity-aware logging

### DIFF
--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
@@ -395,7 +395,7 @@ func (pm *DRAPluginManager) add(driverName string, endpoint string, chosenServic
 				logger.V(4).Info("Attempting to start WatchResources health stream")
 				stream, err := p.NodeWatchResources(ctx)
 				if err != nil {
-					logger.V(3).Error(err, "Failed to establish WatchResources stream, will retry")
+					logger.V(3).Info("Failed to establish WatchResources stream, will retry", "err", err)
 					return
 				}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -430,7 +430,7 @@ func checkSwapControllerAvailability(ctx context.Context) bool {
 		// memory.swap.max does not exist in the cgroup root, so we check /sys/fs/cgroup/<SELF>/memory.swap.max
 		cm, err := libcontainercgroups.ParseCgroupFile("/proc/self/cgroup")
 		if err != nil {
-			logger.V(5).Error(fmt.Errorf("failed to parse /proc/self/cgroup: %w", err), warn)
+			logger.V(5).Info(warn, "err", fmt.Errorf("failed to parse /proc/self/cgroup: %w", err))
 			return false
 		}
 		// For cgroup v2 unified hierarchy, there are no per-controller
@@ -441,7 +441,7 @@ func checkSwapControllerAvailability(ctx context.Context) bool {
 	}
 	if _, err := os.Stat(p); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			logger.V(5).Error(err, warn)
+			logger.V(5).Info(warn, "err", err)
 		}
 		return false
 	}

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -79,7 +79,7 @@ func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.Cont
 		output, err := hr.commandRunner.RunInContainer(ctx, containerID, handler.Exec.Command, 0)
 		if err != nil {
 			msg = fmt.Sprintf("Exec lifecycle hook (%v) for Container %q in Pod %q failed - error: %v, message: %q", handler.Exec.Command, container.Name, format.Pod(pod), err, string(output))
-			logger.V(1).Error(err, "Exec lifecycle hook for Container in Pod failed", "execCommand", handler.Exec.Command, "containerName", container.Name, "pod", klog.KObj(pod), "message", string(output))
+			logger.V(1).Info("Exec lifecycle hook for Container in Pod failed", "execCommand", handler.Exec.Command, "containerName", container.Name, "pod", klog.KObj(pod), "message", string(output), "err", err)
 		}
 		return msg, err
 	case handler.HTTPGet != nil:
@@ -87,7 +87,7 @@ func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.Cont
 		var msg string
 		if err != nil {
 			msg = fmt.Sprintf("HTTP lifecycle hook (%s) for Container %q in Pod %q failed - error: %v", handler.HTTPGet.Path, container.Name, format.Pod(pod), err)
-			logger.V(1).Error(err, "HTTP lifecycle hook for Container in Pod failed", "path", handler.HTTPGet.Path, "containerName", container.Name, "pod", klog.KObj(pod))
+			logger.V(1).Info("HTTP lifecycle hook for Container in Pod failed", "path", handler.HTTPGet.Path, "containerName", container.Name, "pod", klog.KObj(pod), "err", err)
 		}
 		return msg, err
 	case handler.Sleep != nil:
@@ -95,7 +95,7 @@ func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.Cont
 		var msg string
 		if err != nil {
 			msg = fmt.Sprintf("Sleep lifecycle hook (%d) for Container %q in Pod %q failed - error: %v", handler.Sleep.Seconds, container.Name, format.Pod(pod), err)
-			logger.V(1).Error(err, "Sleep lifecycle hook for Container in Pod failed", "sleepSeconds", handler.Sleep.Seconds, "containerName", container.Name, "pod", klog.KObj(pod))
+			logger.V(1).Info("Sleep lifecycle hook for Container in Pod failed", "sleepSeconds", handler.Sleep.Seconds, "containerName", container.Name, "pod", klog.KObj(pod), "err", err)
 		}
 		return msg, err
 	default:
@@ -169,7 +169,7 @@ func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, contai
 	discardHTTPRespBody(resp)
 
 	if isHTTPResponseError(err) {
-		logger.V(1).Error(err, "HTTPS request to lifecycle hook got HTTP response, retrying with HTTP.", "pod", klog.KObj(pod), "host", req.URL.Host)
+		logger.V(1).Info("HTTPS request to lifecycle hook got HTTP response, retrying with HTTP.", "pod", klog.KObj(pod), "host", req.URL.Host, "err", err)
 
 		req := req.Clone(ctx)
 		req.URL.Scheme = "http"

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -297,7 +297,7 @@ func (g *GenericPLEG) Relist() {
 		status, updated, err := g.updateCache(ctx, pod, pid)
 		if err != nil {
 			// Rely on updateCache calling GetPodStatus to log the actual error.
-			g.logger.V(4).Error(err, "PLEG: Ignoring events for pod", "pod", klog.KRef(pod.Namespace, pod.Name))
+			g.logger.V(4).Info("PLEG: Ignoring events for pod", "pod", klog.KRef(pod.Namespace, pod.Name), "err", err)
 
 			// make sure we try to reinspect the pod during the next relisting
 			needsReinspection[pid] = pod

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -649,7 +649,7 @@ func handleSELinuxMetricError(logger klog.Logger, err error, seLinuxSupported bo
 
 	// This is not an error yet, but it will be when support for other access modes is added.
 	warningMetric.Add(1.0)
-	logger.V(4).Error(err, "Please report this error in https://github.com/kubernetes/enhancements/issues/1710, together with full Pod yaml file")
+	logger.V(4).Info("Please report this error in https://github.com/kubernetes/enhancements/issues/1710, together with full Pod yaml file", "err", err)
 	return nil
 }
 
@@ -664,7 +664,7 @@ func getVolumePluginNameWithDriver(logger klog.Logger, plugin volume.VolumePlugi
 	driverName, err := csi.GetCSIDriverName(spec)
 	if err != nil {
 		// In theory this is unreachable - such volume would not pass validation.
-		logger.V(4).Error(err, "failed to get CSI driver name from volume spec")
+		logger.V(4).Info("failed to get CSI driver name from volume spec", "err", err)
 		driverName = "unknown"
 	}
 	// `/` is used to separate plugin + CSI driver in util.GetUniqueVolumeName() too

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -186,7 +186,7 @@ func (rc *reconciler) updateReconstructedFromNodeStatus(ctx context.Context) {
 	node, fetchErr := rc.kubeClient.CoreV1().Nodes().Get(ctx, string(rc.nodeName), metav1.GetOptions{})
 	if fetchErr != nil {
 		// This may repeat few times per second until kubelet is able to read its own status for the first time.
-		logger.V(4).Error(fetchErr, "Failed to get Node status to reconstruct device paths")
+		logger.V(4).Info("Failed to get Node status to reconstruct device paths", "err", fetchErr)
 		return
 	}
 


### PR DESCRIPTION
Cherry-pick of #136028 for release-1.34.

## What type of PR is this?

/kind bug

## What this PR does / why we need it:

This PR fixes incorrect usage of `logger.V(N).Error()` and `klog.V(N).ErrorS()` across the kubelet package. The go-logr package design causes `Error()` calls to bypass verbosity level checks entirely, meaning these logs are always printed regardless of the configured verbosity level.

## Which issue(s) this PR fixes:

Fixes #136027

xref: #136028 (original PR for master)
xref: #136432 (cherry-pick for release-1.35)

## Special notes for your reviewer:

This is a manual cherry-pick because the automated cherry-pick bot doesn't work in k/k repo.

**Files modified (13 files, 22 instances):**
- `pkg/kubelet/allocation/allocation_manager.go`
- `pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go`
- `pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go`
- `pkg/kubelet/kuberuntime/kuberuntime_container_linux.go`
- `pkg/kubelet/lifecycle/handlers.go`
- `pkg/kubelet/metrics/collectors/cri_metrics.go`
- `pkg/kubelet/pleg/generic.go`
- `pkg/kubelet/prober/prober.go`
- `pkg/kubelet/prober/prober_manager.go`
- `pkg/kubelet/stats/cri_stats_provider.go`
- `pkg/kubelet/stats/helper.go`
- `pkg/kubelet/volumemanager/cache/desired_state_of_world.go`
- `pkg/kubelet/volumemanager/reconciler/reconstruct.go`

## Does this PR introduce a user-facing change?

```release-note
Fixed kubelet logging to properly respect verbosity levels. Previously, some debug/info messages using V().Error() would always be printed regardless of the configured log verbosity.
```

/sig node
/area kubelet