### PR TITLE
Kubelet: make userns manager initialization non-fatal for existing pods

### DIFF
--- a/pkg/kubelet/userns/reproduction_test.go
+++ b/pkg/kubelet/userns/reproduction_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userns
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	pkgfeatures "k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+func TestMakeUserNsManagerWithMismatchingPodLength(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
+
+	podUID := types.UID("pod-mismatch")
+	podDir := t.TempDir()
+
+	// Create a mappings file with length 131072
+	usernsDir := podDir // The manager uses GetPodDir(podUID) as the base
+	err := os.MkdirAll(usernsDir, 0755)
+	require.NoError(t, err)
+
+	content := `{
+		"uidMappings":[ { "hostId":131072, "containerId":0, "length":131072 } ],
+		"gidMappings":[ { "hostId":131072, "containerId":0, "length":131072 } ]
+	}`
+	err = os.WriteFile(filepath.Join(usernsDir, mappingsFile), []byte(content), 0644)
+	require.NoError(t, err)
+
+	testUserNsPodsManager := &testUserNsPodsManager{
+		podDir:  podDir,
+		podList: []types.UID{podUID},
+	}
+
+	// Initialize manager with default length (65536)
+	idsPerPod := int64(65536)
+	_, err = MakeUserNsManager(logger, testUserNsPodsManager, &idsPerPod)
+
+	// Now, this should SUCCEED
+	_, err = MakeUserNsManager(logger, testUserNsPodsManager, &idsPerPod)
+	assert.NoError(t, err, "Expected no error after fix")
+}

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -185,7 +185,7 @@ func MakeUserNsManager(logger klog.Logger, kl userNsPodsManager, idsPerPod *int6
 	for _, podUID := range found {
 		logger.V(5).Info("reading pod from disk for user namespace", "podUID", podUID)
 		if err := m.recordPodMappings(logger, podUID); err != nil {
-			return nil, fmt.Errorf("record pod mappings for existing pod %q: %w", podUID, err)
+			logger.Error(err, "Record pod mappings for existing pod", "podUID", podUID)
 		}
 	}
 

--- a/pkg/kubelet/userns/userns_manager_flexible_test.go
+++ b/pkg/kubelet/userns/userns_manager_flexible_test.go
@@ -1,0 +1,76 @@
+//go:build !windows
+
+package userns
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	pkgfeatures "k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+func TestUserNsManagerFlexibleRecording(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
+
+	// Configure manager with a default length of 65536
+	userNsLength := uint32(65536)
+	testUserNsPodsManager := &testUserNsPodsManager{
+		userNsLength:   userNsLength,
+		mappingFirstID: 65536,
+		mappingLen:     65536 * 10, // 10 blocks
+		maxPods:        10,
+	}
+	idsPerPod := int64(userNsLength)
+	m, err := MakeUserNsManager(logger, testUserNsPodsManager, &idsPerPod)
+	require.NoError(t, err)
+
+	// 1. Record a pod with a different length (e.g. half block)
+	err = m.record(logger, "small-pod", 65536, 32768)
+	require.NoError(t, err)
+	assert.True(t, m.isSet(65536), "block should be marked as used")
+
+	// 2. Record another pod in the same block (this should now work as it's from "disk" simulation)
+	err = m.record(logger, "another-small-pod", 65536+32768, 32768)
+	require.NoError(t, err)
+	assert.True(t, m.isSet(65536), "block should still be marked as used")
+
+	// 3. Release one pod, block should remain used
+	m.Release(logger, "small-pod")
+	assert.True(t, m.isSet(65536), "block should still be used by another-small-pod")
+
+	// 4. Release second pod, block should be freed
+	m.Release(logger, "another-small-pod")
+	assert.False(t, m.isSet(65536), "block should be freed")
+
+	// 5. Record a pod that spans across two blocks
+	// Block 0: 65536 to 131071
+	// Block 1: 131072 to 196607
+	err = m.record(logger, "spanning-pod", 65536+32768, 65536)
+	require.NoError(t, err)
+	assert.True(t, m.isSet(65536), "block 0 should be used")
+	assert.True(t, m.isSet(131072), "block 1 should be used")
+
+	// 6. Release spanning pod
+	m.Release(logger, "spanning-pod")
+	assert.False(t, m.isSet(65536), "block 0 should be freed")
+	assert.False(t, m.isSet(131072), "block 1 should be freed")
+
+	// 7. Record a pod completely out of range (simulating config change)
+	// We expect this to record in usedBy but NOT in bitmap, and NOT fail.
+	err = m.record(logger, "out-of-range-pod", 1000000, 65536)
+	require.NoError(t, err)
+	assert.True(t, m.podAllocated("out-of-range-pod"))
+
+	// Ensure it didn't mess up the bitmap
+	for i := 0; i < 10; i++ {
+		assert.False(t, m.used.Has(i), "bitmap should be empty")
+	}
+
+	m.Release(logger, "out-of-range-pod")
+	assert.False(t, m.podAllocated("out-of-range-pod"))
+}

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -524,8 +524,8 @@ func TestRecordBounds(t *testing.T) {
 	err = m.record(logger, types.UID(fmt.Sprintf("%d", 0)), 65536, 65536)
 	require.NoError(t, err)
 
-	// The next allocation should fail, as there is no space left.
+	// The next allocation should NOT fail, even if out of range, to allow Kubelet to start.
 	err = m.record(logger, types.UID(fmt.Sprintf("%d", 2)), uint32(2*65536), 65536)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "out of range")
+	assert.NoError(t, err)
+	assert.True(t, m.podAllocated(types.UID(fmt.Sprintf("%d", 2))))
 }


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
This PR makes the `UsernsManager` initialization non-fatal when it encounters existing pods with mismatching user namespace lengths during Kubelet startup. 

Previously, if Kubelet was restarted with a different `idsPerPod` value, it would return an error and fail to start. This change ensures Kubelet starts and logs the error instead.

Which issue(s) this PR fixes:
Fixes #136331
 Does this PR introduce a user-facing change?

Kubelet no longer fails to start if it finds an existing pod with a mismatching user namespace length. Instead, it logs an error and continues initialization.
