### PR TITLE
Refactor NewTestContext and instead use ktesting.Init

### DIFF
--- a/cmd/kube-proxy/app/server_linux_test.go
+++ b/cmd/kube-proxy/app/server_linux_test.go
@@ -423,8 +423,8 @@ func Test_getLocalDetectors(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
-			r := getLocalDetectors(logger, c.primaryIPFamily, c.config, c.nodePodCIDRs)
+			tCtx := ktesting.Init(t)
+			r := getLocalDetectors(tCtx.Logger(), c.primaryIPFamily, c.config, c.nodePodCIDRs)
 			if !reflect.DeepEqual(r, c.expected) {
 				t.Errorf("Unexpected detect-local implementation, expected: %q, got: %q", c.expected, r)
 			}
@@ -512,7 +512,7 @@ detectLocalMode: "BridgeInterface"`)
 	}
 
 	for _, tc := range testCases {
-		_, ctx := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
 		file, tempDir, err := setUp()
 		if err != nil {
 			t.Fatalf("unexpected error when setting up environment: %v", err)
@@ -528,7 +528,7 @@ detectLocalMode: "BridgeInterface"`)
 
 		errCh := make(chan error, 1)
 		go func() {
-			errCh <- opt.runLoop(ctx)
+			errCh <- opt.runLoop(tCtx)
 		}()
 
 		if tc.append {

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -225,8 +225,9 @@ func Test_detectNodeIPs(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			primaryFamily, ips := detectNodeIPs(ctx, c.rawNodeIPs, c.bindAddress)
+			tCtx := ktesting.Init(t)
+
+			primaryFamily, ips := detectNodeIPs(tCtx, c.rawNodeIPs, c.bindAddress)
 			if primaryFamily != c.expectedFamily {
 				t.Errorf("Expected family %q got %q", c.expectedFamily, primaryFamily)
 			}

--- a/pkg/api/job/warnings_test.go
+++ b/pkg/api/job/warnings_test.go
@@ -107,8 +107,9 @@ func TestWarningsForJobSpec(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			warnings := WarningsForJobSpec(ctx, nil, tc.spec, nil)
+			tCtx := ktesting.Init(t)
+
+			warnings := WarningsForJobSpec(tCtx, nil, tc.spec, nil)
 			if len(warnings) != tc.wantWarningsCount {
 				t.Errorf("Got %d warnings, want %d.\nWarnings: %v", len(warnings), tc.wantWarningsCount, warnings)
 			}

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -174,7 +174,9 @@ func newReplicaSet(name string, replicas int, rsUuid types.UID) *apps.ReplicaSet
 }
 
 func TestControllerExpectations(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	ttl := 30 * time.Second
 	e, fakeClock := NewFakeControllerExpectationsLookup(ttl)
 	// In practice we can't really have add and delete expectations since we only either create or
@@ -257,7 +259,9 @@ func TestControllerExpectations(t *testing.T) {
 }
 
 func TestUIDExpectations(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	uidExp := NewUIDTrackingControllerExpectations(NewControllerExpectations())
 	type test struct {
 		name        string
@@ -557,7 +561,8 @@ func TestClaimedPodFiltering(t *testing.T) {
 }
 
 func TestActivePodFiltering(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	type podData struct {
 		podName  string
 		podPhase v1.PodPhase
@@ -597,7 +602,7 @@ func TestActivePodFiltering(t *testing.T) {
 			for i := range podList.Items {
 				podPointers = append(podPointers, &podList.Items[i])
 			}
-			got := FilterActivePods(logger, podPointers)
+			got := FilterActivePods(tCtx.Logger(), podPointers)
 			gotNames := sets.NewString()
 			for _, pod := range got {
 				gotNames.Insert(pod.Name)

--- a/pkg/controller/endpointslicemirroring/reconciler_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_test.go
@@ -1315,9 +1315,11 @@ func fetchEndpointSlices(t *testing.T, client *fake.Clientset, namespace string)
 }
 
 func reconcileHelper(t *testing.T, r *reconciler, endpoints *corev1.Endpoints, existingSlices []*discovery.EndpointSlice) {
+	tCtx := ktesting.Init(t)
+
 	t.Helper()
-	logger, _ := ktesting.NewTestContext(t)
-	err := r.reconcile(logger, endpoints, existingSlices)
+	
+	err := r.reconcile(tCtx.Logger(), endpoints, existingSlices)
 	if err != nil {
 		t.Fatalf("Expected no error reconciling Endpoint Slices, got: %v", err)
 	}

--- a/pkg/controller/nodeipam/ipam/range_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator_test.go
@@ -509,7 +509,7 @@ func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
 	}
 
 	// test function
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	testFunc := func(tc testCase) {
 		fakeNodeInformer := test.FakeNodeInformer(tc.fakeNodeHandler)
 		nodeList, _ := tc.fakeNodeHandler.List(tCtx, metav1.ListOptions{})
@@ -610,7 +610,7 @@ func TestAllocateOrOccupyCIDRFailure(t *testing.T) {
 			},
 		},
 	}
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	testFunc := func(tc testCase) {
 		// Initialize the range allocator.
 		allocator, err := NewCIDRRangeAllocator(tCtx, tc.fakeNodeHandler, test.FakeNodeInformer(tc.fakeNodeHandler), tc.allocatorParams, nil)
@@ -755,7 +755,7 @@ func TestReleaseCIDRSuccess(t *testing.T) {
 			},
 		},
 	}
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	testFunc := func(tc releaseTestCase) {
 		// Initialize the range allocator.
 		allocator, _ := NewCIDRRangeAllocator(tCtx, tc.fakeNodeHandler, test.FakeNodeInformer(tc.fakeNodeHandler), tc.allocatorParams, nil)
@@ -807,7 +807,7 @@ func TestReleaseCIDRSuccess(t *testing.T) {
 				},
 			}
 			nodeToRelease.Spec.PodCIDRs = cidrToRelease
-			err = allocator.ReleaseCIDR(logger, &nodeToRelease)
+			err = allocator.ReleaseCIDR(tCtx.Logger(), &nodeToRelease)
 			if err != nil {
 				t.Fatalf("%v: unexpected error in ReleaseCIDR: %v", tc.description, err)
 			}
@@ -908,7 +908,7 @@ func TestNodeDeletionReleaseCIDR(t *testing.T) {
 				Existing:  tc.existingNodes,
 				Clientset: fake.NewSimpleClientset(),
 			}
-			_, tCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
 
 			fakeNodeInformer := test.FakeNodeInformer(fakeNodeHandler)
 			nodeList, err := fakeNodeHandler.List(tCtx, metav1.ListOptions{})

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -2526,6 +2526,8 @@ func TestApplyNoExecuteTaints(t *testing.T) {
 // TestApplyNoExecuteTaintsToUnreachableNode ensures a NoExecute taint is applied to node that hasn't posted the
 // node status for a period greater than nodeMonitorGracePeriod.
 func TestApplyNoExecuteTaintsToUnreachableNode(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
 	// TODO: Remove skip once https://github.com/kubernetes/kubernetes/pull/114607 merges.
 	if goruntime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows.")
@@ -2586,9 +2588,9 @@ func TestApplyNoExecuteTaintsToUnreachableNode(t *testing.T) {
 		},
 		Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
 	}
-	_, ctx := ktesting.NewTestContext(t)
+
 	nodeController, _ := newNodeLifecycleControllerFromClient(
-		ctx,
+		tCtx,
 		fakeNodeHandler,
 		testRateLimiterQPS,
 		testRateLimiterQPS,
@@ -2605,11 +2607,11 @@ func TestApplyNoExecuteTaintsToUnreachableNode(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass(ctx)
-	node0, err := fakeNodeHandler.Get(ctx, "node0", metav1.GetOptions{})
+	nodeController.doNoExecuteTaintingPass(tCtx)
+	node0, err := fakeNodeHandler.Get(tCtx, "node0", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node0...")
 		return
@@ -2617,7 +2619,7 @@ func TestApplyNoExecuteTaintsToUnreachableNode(t *testing.T) {
 	if len(node0.Spec.Taints) > 0 {
 		t.Errorf("Got unexpected taints %v", node0.Spec.Taints)
 	}
-	node1, err := fakeNodeHandler.Get(ctx, "node1", metav1.GetOptions{})
+	node1, err := fakeNodeHandler.Get(tCtx, "node1", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node1...")
 		return
@@ -2639,7 +2641,7 @@ func TestApplyNoExecuteTaintsToUnreachableNode(t *testing.T) {
 			},
 		},
 	}
-	_, err = fakeNodeHandler.UpdateStatus(ctx, node1, metav1.UpdateOptions{})
+	_, err = fakeNodeHandler.UpdateStatus(tCtx, node1, metav1.UpdateOptions{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		return
@@ -2648,15 +2650,15 @@ func TestApplyNoExecuteTaintsToUnreachableNode(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass(ctx)
+	nodeController.doNoExecuteTaintingPass(tCtx)
 
-	node0, err = fakeNodeHandler.Get(ctx, "node0", metav1.GetOptions{})
+	node0, err = fakeNodeHandler.Get(tCtx, "node0", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node0...")
 		return
@@ -2664,7 +2666,7 @@ func TestApplyNoExecuteTaintsToUnreachableNode(t *testing.T) {
 	if !taintutils.TaintExists(node0.Spec.Taints, UnreachableTaintTemplate) {
 		t.Errorf("Can't find taint %v in %v", UnreachableTaintTemplate, node0.Spec.Taints)
 	}
-	node1, err = fakeNodeHandler.Get(ctx, "node1", metav1.GetOptions{})
+	node1, err = fakeNodeHandler.Get(tCtx, "node1", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node1...")
 		return
@@ -2684,7 +2686,7 @@ func TestApplyNoExecuteTaintsToUnreachableNode(t *testing.T) {
 			},
 		},
 	}
-	_, err = fakeNodeHandler.UpdateStatus(ctx, node0, metav1.UpdateOptions{})
+	_, err = fakeNodeHandler.UpdateStatus(tCtx, node0, metav1.UpdateOptions{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		return
@@ -2692,12 +2694,12 @@ func TestApplyNoExecuteTaintsToUnreachableNode(t *testing.T) {
 	if err := nodeController.syncNodeStore(fakeNodeHandler); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if err := nodeController.monitorNodeHealth(ctx); err != nil {
+	if err := nodeController.monitorNodeHealth(tCtx); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	nodeController.doNoExecuteTaintingPass(ctx)
+	nodeController.doNoExecuteTaintingPass(tCtx)
 
-	node0, err = fakeNodeHandler.Get(ctx, "node0", metav1.GetOptions{})
+	node0, err = fakeNodeHandler.Get(tCtx, "node0", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Can't get current node0...")
 		return

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -187,7 +187,9 @@ func init() {
 }
 
 func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfake.Clientset, *cmfake.FakeCustomMetricsClient, *emfake.FakeExternalMetricsClient, *scalefake.FakeScaleClient) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	namespace := "test-namespace"
 	hpaName := "test-hpa"
 	podNamePrefix := "test-pod"

--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -168,8 +168,10 @@ func TestServiceAccountCreation(t *testing.T) {
 			var wg sync.WaitGroup
 			defer wg.Wait()
 
-			logger, ctx := ktesting.NewTestContext(t)
-			defer ctx.Cancel("test case terminating")
+			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
+
+			defer tCtx.Cancel("test case terminating")
 
 			controller, err := NewServiceAccountsController(
 				logger,
@@ -200,7 +202,7 @@ func TestServiceAccountCreation(t *testing.T) {
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 			wg.Go(func() {
-				controller.Run(ctx, 1)
+				controller.Run(tCtx, 1)
 			})
 
 			if tc.ExistingNamespace != nil {

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -432,7 +432,7 @@ func TestTokenCreation(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
 
 			// Re-seed to reset name generation
 			utilrand.Seed(1)
@@ -447,7 +447,7 @@ func TestTokenCreation(t *testing.T) {
 			secretInformer := informers.Core().V1().Secrets().Informer()
 			secrets := secretInformer.GetStore()
 			serviceAccounts := informers.Core().V1().ServiceAccounts().Informer().GetStore()
-			controller, err := NewTokensController(logger, informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), client, TokensControllerOptions{TokenGenerator: generator, RootCA: []byte("CA Data"), MaxRetries: tc.MaxRetries})
+			controller, err := NewTokensController(tCtx.Logger(), informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), client, TokensControllerOptions{TokenGenerator: generator, RootCA: []byte("CA Data"), MaxRetries: tc.MaxRetries})
 			if err != nil {
 				t.Fatalf("error creating Tokens controller: %v", err)
 			}
@@ -490,10 +490,10 @@ func TestTokenCreation(t *testing.T) {
 
 			for {
 				if controller.syncServiceAccountQueue.Len() > 0 {
-					controller.syncServiceAccount(ctx)
+					controller.syncServiceAccount(tCtx)
 				}
 				if controller.syncSecretQueue.Len() > 0 {
-					controller.syncSecret(ctx)
+					controller.syncSecret(tCtx)
 				}
 
 				// The queues still have things to work on

--- a/pkg/controlplane/controller/legacytokentracking/controller_test.go
+++ b/pkg/controlplane/controller/legacytokentracking/controller_test.go
@@ -127,7 +127,8 @@ func TestSyncConfigMap(t *testing.T) {
 			},
 		},
 	}
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(test.clientObjects...)
@@ -137,7 +138,7 @@ func TestSyncConfigMap(t *testing.T) {
 				controller.configMapCache.Add(test.existingConfigMap)
 			}
 
-			if err := controller.syncConfigMap(ctx); err != nil {
+			if err := controller.syncConfigMap(tCtx); err != nil {
 				t.Errorf("Failed to sync ConfigMap, err: %v", err)
 			}
 
@@ -147,7 +148,7 @@ func TestSyncConfigMap(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: ConfigMapName},
 				})
 				controller.clock.(*testingclock.FakeClock).SetTime(createAt)
-				if err := controller.syncConfigMap(ctx); err != nil {
+				if err := controller.syncConfigMap(tCtx); err != nil {
 					t.Errorf("Failed to sync ConfigMap, err: %v", err)
 				}
 			}

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -2328,7 +2328,8 @@ func TestRecordPodDeferredAcceptedResizes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			original := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:       "1111",
@@ -2371,7 +2372,7 @@ func TestRecordPodDeferredAcceptedResizes(t *testing.T) {
 				return resizedPod, true
 			}
 			am.PushPendingResize(original.UID)
-			resizedPods := am.(*manager).retryPendingResizes(logger, tc.trigger)
+			resizedPods := am.(*manager).retryPendingResizes(tCtx.Logger(), tc.trigger)
 
 			require.Len(t, resizedPods, 1)
 			require.Equal(t, original.UID, resizedPods[0].UID)

--- a/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
@@ -273,10 +273,11 @@ users:
 		},
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			certConfig, clientConfig, err := LoadClientConfig(logger, test.kubeconfigPath, test.bootstrapPath, test.certDir)
+			certConfig, clientConfig, err := LoadClientConfig(tCtx.Logger(), test.kubeconfigPath, test.bootstrapPath, test.certDir)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/kubelet/certificate/transport_test.go
+++ b/pkg/kubelet/certificate/transport_test.go
@@ -146,7 +146,7 @@ func TestRotateShutsDownConnections(t *testing.T) {
 	// This test fails if you comment out the t.closeAllConns() call in
 	// transport.go and don't close connections on a rotate.
 
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -193,7 +193,7 @@ func TestRotateShutsDownConnections(t *testing.T) {
 	}
 
 	// Check for a new cert every 10 milliseconds
-	if _, err := updateTransport(logger, stop, 10*time.Millisecond, c, m, 0); err != nil {
+	if _, err := updateTransport(tCtx.Logger(), stop, 10*time.Millisecond, c, m, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
@@ -600,7 +600,7 @@ func TestLazyInformerManager_ensureManagerSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, loggerCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
 
 			fakeDisc := fakeDiscovery{
 				err:         tt.injectError,
@@ -620,8 +620,8 @@ func TestLazyInformerManager_ensureManagerSet(t *testing.T) {
 				managerLock:       sync.RWMutex{},
 				client:            NewFakeClientset(fakeDisc),
 				cacheSize:         128,
-				contextWithLogger: loggerCtx,
-				logger:            logger,
+				contextWithLogger: tCtx,
+				logger:            tCtx.Logger(),
 			}
 			if err := m.ensureManagerSet(); tt.wantError != (err != nil) {
 				t.Errorf("expected error: %t, got %v", tt.wantError, err)

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -27,7 +27,8 @@ import (
 )
 
 func TestCPUAccumulatorFreeSockets(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -116,7 +117,7 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(tCtx.Logger(), tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			result := acc.freeSockets()
 			sort.Ints(result)
 			if !reflect.DeepEqual(result, tc.expect) {
@@ -128,7 +129,7 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 }
 
 func TestCPUAccumulatorFreeNUMANodes(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -217,7 +218,7 @@ func TestCPUAccumulatorFreeNUMANodes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(tCtx.Logger(), tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			result := acc.freeNUMANodes()
 			if !reflect.DeepEqual(result, tc.expect) {
 				t.Errorf("expected %v to equal %v", result, tc.expect)
@@ -227,7 +228,7 @@ func TestCPUAccumulatorFreeNUMANodes(t *testing.T) {
 }
 
 func TestCPUAccumulatorFreeSocketsAndNUMANodes(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		description     string
 		topo            *topology.CPUTopology
@@ -267,7 +268,7 @@ func TestCPUAccumulatorFreeSocketsAndNUMANodes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(tCtx.Logger(), tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			resultNUMANodes := acc.freeNUMANodes()
 			if !reflect.DeepEqual(resultNUMANodes, tc.expectNUMANodes) {
 				t.Errorf("expected NUMA Nodes %v to equal %v", resultNUMANodes, tc.expectNUMANodes)
@@ -281,7 +282,7 @@ func TestCPUAccumulatorFreeSocketsAndNUMANodes(t *testing.T) {
 }
 
 func TestCPUAccumulatorFreeCores(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -340,7 +341,7 @@ func TestCPUAccumulatorFreeCores(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(tCtx.Logger(), tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			result := acc.freeCores()
 			if !reflect.DeepEqual(result, tc.expect) {
 				t.Errorf("expected %v to equal %v", result, tc.expect)
@@ -350,7 +351,7 @@ func TestCPUAccumulatorFreeCores(t *testing.T) {
 }
 
 func TestCPUAccumulatorFreeCPUs(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -397,7 +398,7 @@ func TestCPUAccumulatorFreeCPUs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(tCtx.Logger(), tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			result := acc.freeCPUs()
 			if !reflect.DeepEqual(result, tc.expect) {
 				t.Errorf("expected %v to equal %v", result, tc.expect)
@@ -407,7 +408,7 @@ func TestCPUAccumulatorFreeCPUs(t *testing.T) {
 }
 
 func TestCPUAccumulatorTake(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	testCases := []struct {
 		description     string
 		topo            *topology.CPUTopology
@@ -484,7 +485,7 @@ func TestCPUAccumulatorTake(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, tc.numCPUs, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(tCtx.Logger(), tc.topo, tc.availableCPUs, tc.numCPUs, CPUSortingStrategyPacked)
 			totalTaken := 0
 			for _, cpus := range tc.takeCPUs {
 				acc.take(cpus)
@@ -646,7 +647,7 @@ func commonTakeByTopologyTestCases(t *testing.T) []takeByTopologyTestCase {
 }
 
 func TestTakeByTopologyNUMAPacked(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	testCases := commonTakeByTopologyTestCases(t)
 	testCases = append(testCases, []takeByTopologyTestCase{
 		{
@@ -758,7 +759,7 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 				strategy = CPUSortingStrategySpread
 			}
 
-			result, err := takeByTopologyNUMAPacked(logger, tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption)
+			result, err := takeByTopologyNUMAPacked(tCtx.Logger(), tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption)
 			if tc.expErr != "" && err != nil && err.Error() != tc.expErr {
 				t.Errorf("expected error to be [%v] but it was [%v]", tc.expErr, err)
 			}
@@ -770,7 +771,8 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 }
 
 func TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -860,7 +862,7 @@ func TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption(t *testing.T) {
 		if tc.opts.DistributeCPUsAcrossCores {
 			strategy = CPUSortingStrategySpread
 		}
-		result, err := takeByTopologyNUMAPacked(logger, tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption)
+		result, err := takeByTopologyNUMAPacked(tCtx.Logger(), tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption)
 		if tc.expErr != "" && err.Error() != tc.expErr {
 			t.Errorf("testCase %q failed, expected error to be [%v] but it was [%v]", tc.description, tc.expErr, err)
 		}
@@ -966,7 +968,8 @@ func commonTakeByTopologyExtendedTestCases(t *testing.T) []takeByTopologyExtende
 }
 
 func TestTakeByTopologyNUMADistributed(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	testCases := commonTakeByTopologyExtendedTestCases(t)
 	testCases = append(testCases, []takeByTopologyExtendedTestCase{
 		{
@@ -1063,7 +1066,7 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			result, err := takeByTopologyNUMADistributed(logger, tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked)
+			result, err := takeByTopologyNUMADistributed(tCtx.Logger(), tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked)
 			if err != nil {
 				if tc.expErr == "" {
 					t.Errorf("unexpected error [%v]", err)

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -290,7 +290,8 @@ func TestCPUManagerAdd(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 
 	testPolicy, _ := NewStaticPolicy(
 		logger,
@@ -562,7 +563,9 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		logger, _ := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+		logger := tCtx.Logger()
+
 		policy, _ := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
 
 		mockState := &mockState{
@@ -726,7 +729,9 @@ func TestCPUManagerGenerate(t *testing.T) {
 			}
 			defer os.RemoveAll(sDir)
 
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
+
 			mgr, err := NewManager(logger, testCase.cpuPolicyName, nil, 5*time.Second, machineInfo, cpuset.New(), testCase.nodeAllocatableReservation, sDir, topologymanager.NewFakeManager())
 			if testCase.expectedError != nil {
 				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
@@ -754,7 +759,9 @@ func TestCPUManagerRemove(t *testing.T) {
 	containerID := "fakeID"
 	containerMap := containermap.NewContainerMap()
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	mgr := &manager{
 		policy: &mockPolicy{
 			err: nil,
@@ -799,7 +806,8 @@ func TestReconcileState(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 
 	testPolicy, _ := NewStaticPolicy(
 		logger,
@@ -1256,7 +1264,9 @@ func TestReconcileState(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		logger, _ := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+		logger := tCtx.Logger()
+
 		mgr := &manager{
 			policy: testCase.policy,
 			state: &mockState{
@@ -1330,7 +1340,9 @@ func TestCPUManagerAddWithResvList(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testPolicy, _ := NewStaticPolicy(
 		logger,
 		&topology.CPUTopology{
@@ -1463,7 +1475,9 @@ func TestCPUManagerHandlePolicyOptions(t *testing.T) {
 			}
 			defer os.RemoveAll(sDir)
 
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
+
 			_, err = NewManager(logger, testCase.cpuPolicyName, testCase.cpuPolicyOptions, 5*time.Second, machineInfo, cpuset.New(), nodeAllocatableReservation, sDir, topologymanager.NewFakeManager())
 			if err == nil {
 				t.Errorf("Expected error, but NewManager succeeded")
@@ -1477,7 +1491,9 @@ func TestCPUManagerHandlePolicyOptions(t *testing.T) {
 }
 
 func TestCPUManagerGetAllocatableCPUs(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	if runtime.GOOS == "windows" {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}

--- a/pkg/kubelet/cm/cpumanager/policy_none_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_none_test.go
@@ -35,7 +35,9 @@ func TestNonePolicyName(t *testing.T) {
 }
 
 func TestNonePolicyAllocate(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	policy := &nonePolicy{}
 
 	st := &mockState{
@@ -53,7 +55,9 @@ func TestNonePolicyAllocate(t *testing.T) {
 }
 
 func TestNonePolicyRemove(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	policy := &nonePolicy{}
 
 	st := &mockState{

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -72,8 +72,9 @@ func (spt staticPolicyTest) PseudoClone() staticPolicyTest {
 }
 
 func TestStaticPolicyName(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
-	policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(), nil)
+	tCtx := ktesting.Init(t)
+
+	policy, err := NewStaticPolicy(tCtx.Logger(), topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(), nil)
 	if err != nil {
 		t.Fatalf("NewStaticPolicy() failed: %v", err)
 	}
@@ -173,7 +174,9 @@ func TestStaticPolicyStart(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
+
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
 			p, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), testCase.options)
 			if err != nil {
@@ -647,7 +650,9 @@ func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 	if testCase.reservedCPUs != nil {
 		cpus = testCase.reservedCPUs.Clone()
 	}
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpus, tm, testCase.options)
 	if err != nil {
 		t.Fatalf("NewStaticPolicy() failed: %v", err)
@@ -722,7 +727,9 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		logger, _ := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+		logger := tCtx.Logger()
+
 		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
@@ -779,7 +786,9 @@ func TestStaticPolicyDoNotReuseCPUs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		logger, _ := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+		logger := tCtx.Logger()
+
 		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
@@ -865,7 +874,9 @@ func TestStaticPolicyRemove(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		logger, _ := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+		logger := tCtx.Logger()
+
 		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
@@ -959,7 +970,9 @@ func TestTopologyAwareAllocateCPUs(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		logger, _ := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+		logger := tCtx.Logger()
+
 		p, err := NewStaticPolicy(logger, tc.topo, 0, cpuset.New(), topologymanager.NewFakeManager(), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
@@ -1059,7 +1072,9 @@ func TestStaticPolicyStartWithResvList(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
+
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
 			p, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(), testCase.cpuPolicyOptions)
 			if !reflect.DeepEqual(err, testCase.expNewErr) {
@@ -1138,7 +1153,9 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		logger, _ := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+		logger := tCtx.Logger()
+
 		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
@@ -1907,7 +1924,9 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
+
 			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(), testCase.cpuPolicyOptions)
 			if err != nil {
 				t.Fatalf("NewStaticPolicy() failed with %v", err)

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -210,6 +210,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+
 			// ensure there is no previous checkpoint
 			cpm.RemoveCheckpoint(testingCheckpoint)
 
@@ -220,8 +222,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 				require.NoErrorf(t, err, "could not create testing checkpoint: %v", err)
 			}
 
-			logger, _ := ktesting.NewTestContext(t)
-			restoredState, err := NewCheckpointState(logger, testingDir, testingCheckpoint, tc.policyName, tc.initialContainers)
+			restoredState, err := NewCheckpointState(tCtx.Logger(), testingDir, testingCheckpoint, tc.policyName, tc.initialContainers)
 			if strings.TrimSpace(tc.expectedError) == "" {
 				require.NoError(t, err)
 			} else {
@@ -275,7 +276,9 @@ func TestCheckpointStateStore(t *testing.T) {
 			// ensure there is no previous checkpoint
 			cpm.RemoveCheckpoint(testingCheckpoint)
 
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
+
 			cs1, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
 			if err != nil {
 				t.Fatalf("could not create testing checkpointState instance: %v", err)
@@ -346,11 +349,12 @@ func TestCheckpointStateHelpers(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+
 			// ensure there is no previous checkpoint
 			cpm.RemoveCheckpoint(testingCheckpoint)
 
-			logger, _ := ktesting.NewTestContext(t)
-			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
+			state, err := NewCheckpointState(tCtx.Logger(), testingDir, testingCheckpoint, "none", nil)
 			if err != nil {
 				t.Fatalf("could not create testing checkpointState instance: %v", err)
 			}
@@ -392,6 +396,8 @@ func TestCheckpointStateClear(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+
 			// create temp dir
 			testingDir, err := os.MkdirTemp("", "cpumanager_state_test")
 			if err != nil {
@@ -399,8 +405,7 @@ func TestCheckpointStateClear(t *testing.T) {
 			}
 			defer os.RemoveAll(testingDir)
 
-			logger, _ := ktesting.NewTestContext(t)
-			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
+			state, err := NewCheckpointState(tCtx.Logger(), testingDir, testingCheckpoint, "none", nil)
 			if err != nil {
 				t.Fatalf("could not create testing checkpointState instance: %v", err)
 			}

--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -823,8 +823,9 @@ func Test_Discover(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
-			got, err := Discover(logger, &tt.machineInfo)
+			tCtx := ktesting.Init(t)
+
+			got, err := Discover(tCtx.Logger(), &tt.machineInfo)
 			if err != nil {
 				if tt.wantErr {
 					t.Logf("Discover() expected error = %v", err)

--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -74,7 +74,8 @@ type containerOptions struct {
 }
 
 func TestPodGuaranteedCPUs(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	options := [][]*containerOptions{
 		{
 			{request: "0", limit: "0"},
@@ -202,7 +203,7 @@ func TestPodGuaranteedCPUs(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
-			requestedCPU := p.podGuaranteedCPUs(logger, tc.pod)
+			requestedCPU := p.podGuaranteedCPUs(tCtx.Logger(), tc.pod)
 
 			if requestedCPU != tc.expectedCPU {
 				t.Errorf("Expected in result to be %v , got %v", tc.expectedCPU, requestedCPU)
@@ -212,13 +213,14 @@ func TestPodGuaranteedCPUs(t *testing.T) {
 }
 
 func TestGetTopologyHints(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	machineInfo := returnMachineInfo()
 
 	for _, tc := range returnTestCases() {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, tc.podLevelResourcesEnabled)
 
-		topology, _ := topology.Discover(logger, &machineInfo)
+		topology, _ := topology.Discover(tCtx.Logger(), &machineInfo)
 
 		var activePods []*v1.Pod
 		for p := range tc.assignments {
@@ -263,13 +265,14 @@ func TestGetTopologyHints(t *testing.T) {
 }
 
 func TestGetPodTopologyHints(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	machineInfo := returnMachineInfo()
 
 	for _, tc := range returnTestCases() {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, tc.podLevelResourcesEnabled)
 
-		topology, _ := topology.Discover(logger, &machineInfo)
+		topology, _ := topology.Discover(tCtx.Logger(), &machineInfo)
 
 		var activePods []*v1.Pod
 		for p := range tc.assignments {

--- a/pkg/kubelet/cm/devicemanager/endpoint_test.go
+++ b/pkg/kubelet/cm/devicemanager/endpoint_test.go
@@ -76,7 +76,8 @@ func esocketName() string {
 }
 
 func TestNewEndpoint(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	socket := filepath.Join(os.TempDir(), esocketName())
 
 	devs := []*pluginapi.Device{
@@ -85,13 +86,14 @@ func TestNewEndpoint(t *testing.T) {
 
 	p, e := esetup(tCtx, t, devs, socket, "mock", func(logger klog.Logger, n string, d []*pluginapi.Device) {})
 	defer func() {
-		err := ecleanup(logger, p, e)
+		err := ecleanup(tCtx.Logger(), p, e)
 		require.NoError(t, err)
 	}()
 }
 
 func TestRun(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	socket := filepath.Join(os.TempDir(), esocketName())
 
 	devs := []*pluginapi.Device{
@@ -143,7 +145,7 @@ func TestRun(t *testing.T) {
 
 	p, e := esetup(tCtx, t, devs, socket, "mock", callback)
 	defer func() {
-		err := ecleanup(logger, p, e)
+		err := ecleanup(tCtx.Logger(), p, e)
 		require.NoError(t, err)
 	}()
 
@@ -160,7 +162,8 @@ func TestRun(t *testing.T) {
 }
 
 func TestAllocate(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	socket := filepath.Join(os.TempDir(), esocketName())
 	devs := []*pluginapi.Device{
 		{ID: "ADeviceId", Health: pluginapi.Healthy},
@@ -172,7 +175,7 @@ func TestAllocate(t *testing.T) {
 		callbackChan <- callbackCount
 	})
 	defer func() {
-		err := ecleanup(logger, p, e)
+		err := ecleanup(tCtx.Logger(), p, e)
 		require.NoError(t, err)
 	}()
 
@@ -217,7 +220,8 @@ func TestAllocate(t *testing.T) {
 }
 
 func TestGetPreferredAllocation(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	socket := filepath.Join(os.TempDir(), esocketName())
 	callbackCount := 0
 	callbackChan := make(chan int)
@@ -226,7 +230,7 @@ func TestGetPreferredAllocation(t *testing.T) {
 		callbackChan <- callbackCount
 	})
 	defer func() {
-		err := ecleanup(logger, p, e)
+		err := ecleanup(tCtx.Logger(), p, e)
 		require.NoError(t, err)
 	}()
 

--- a/pkg/kubelet/cm/devicemanager/pod_devices_test.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices_test.go
@@ -158,7 +158,8 @@ func expectResourceDeviceInstances(t *testing.T, resp ResourceDeviceInstances, e
 }
 
 func TestDeviceRunContainerOptions(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	const (
 		podUID        = "pod"
 		containerName = "container"
@@ -241,7 +242,7 @@ func TestDeviceRunContainerOptions(t *testing.T) {
 					response,
 				)
 			}
-			opts := podDevices.deviceRunContainerOptions(logger, podUID, containerName)
+			opts := podDevices.deviceRunContainerOptions(tCtx.Logger(), podUID, containerName)
 
 			// The exact ordering of the options depends on the order of the resources in the map.
 			// We therefore use `ElementsMatch` instead of `Equal` on the member slices.

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -1082,10 +1082,11 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="PrepareRe
 // - first claim already prepared by a previous pod
 // - second claim is new and needs to be prepared
 func TestPrepareResourcesWithPreparedAndNewClaim(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	fakeKubeClient := fake.NewClientset()
 
-	manager, err := NewManager(logger, fakeKubeClient, t.TempDir())
+	manager, err := NewManager(tCtx.Logger(), fakeKubeClient, t.TempDir())
 	require.NoError(t, err)
 	manager.initDRAPluginManager(tCtx, getFakeNode, time.Second)
 

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -492,7 +492,9 @@ func TestGetSystemReservedMemory(t *testing.T) {
 }
 
 func TestRemoveStaleState(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	machineInfo := returnMachineInfo()
 	testCases := []testMemoryManager{
 		{
@@ -932,7 +934,9 @@ func TestRemoveStaleState(t *testing.T) {
 }
 
 func TestAddContainer(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	machineInfo := returnMachineInfo()
 	reserved := systemReservedMemory{
 		0: map[v1.ResourceName]uint64{
@@ -1436,7 +1440,9 @@ func TestAddContainer(t *testing.T) {
 }
 
 func TestRemoveContainer(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	machineInfo := returnMachineInfo()
 	reserved := systemReservedMemory{
 		0: map[v1.ResourceName]uint64{
@@ -1915,7 +1921,9 @@ func getPolicyNameForOs() policyType {
 }
 
 func TestNewManager(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	machineInfo := returnMachineInfo()
 	expectedReserved := systemReservedMemory{
 		0: map[v1.ResourceName]uint64{
@@ -2037,7 +2045,9 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestGetTopologyHints(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testCases := []testMemoryManager{
 		{
 			description: "Successful hint generation",
@@ -2183,7 +2193,9 @@ func TestGetTopologyHints(t *testing.T) {
 }
 
 func TestAllocateAndAddPodWithInitContainers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testCases := []testMemoryManager{
 		{
 			description: "should remove init containers from the state file, once app container started",

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -149,7 +149,9 @@ type testStaticPolicy struct {
 }
 
 func initTests(t *testing.T, testCase *testStaticPolicy, hint *topologymanager.TopologyHint, initContainersReusableMemory reusableMemory) (Policy, state.State, error) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	manager := topologymanager.NewFakeManager()
 	if hint != nil {
 		manager = topologymanager.NewFakeManagerWithHint(hint)
@@ -228,7 +230,9 @@ func TestStaticPolicyName(t *testing.T) {
 }
 
 func TestStaticPolicyStart(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testCases := []testStaticPolicy{
 		{
 			description: "should fail, if machine state is empty, but it has memory assignments",
@@ -1192,7 +1196,9 @@ func TestStaticPolicyStart(t *testing.T) {
 }
 
 func TestStaticPolicyAllocate(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testCases := []testStaticPolicy{
 		{
 			description:         "should do nothing for non-guaranteed pods",
@@ -2112,7 +2118,9 @@ func TestStaticPolicyAllocate(t *testing.T) {
 }
 
 func TestStaticPolicyAllocateWithInitContainers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testCases := []testStaticPolicy{
 		{
 			description: "should re-use init containers memory, init containers requests 1Gi and 2Gi, apps containers 3Gi and 4Gi",
@@ -2841,7 +2849,9 @@ func TestStaticPolicyAllocateWithInitContainers(t *testing.T) {
 }
 
 func TestStaticPolicyAllocateWithRestartableInitContainers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testCases := []testStaticPolicy{
 		{
 			description: "should do nothing once containers already exist under the state file",
@@ -3179,7 +3189,9 @@ func TestStaticPolicyAllocateWithRestartableInitContainers(t *testing.T) {
 }
 
 func TestStaticPolicyRemoveContainer(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testCases := []testStaticPolicy{
 		{
 			description:         "should do nothing when the container does not exist under the state",
@@ -3437,7 +3449,9 @@ func TestStaticPolicyRemoveContainer(t *testing.T) {
 }
 
 func TestStaticPolicyGetTopologyHints(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testCases := []testStaticPolicy{
 		{
 			description: "should not provide topology hints for non-guaranteed pods",
@@ -3836,7 +3850,9 @@ func TestStaticPolicyGetTopologyHints(t *testing.T) {
 }
 
 func TestStaticPolicyGetPodTopologyHints(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testCases := []testStaticPolicy{
 		{
 			description: "should not provide pod topology hints for guaranteed pod with pod level resources",

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -43,7 +43,8 @@ func assertStateEqual(t *testing.T, restoredState, expectedState State) {
 }
 
 func TestCheckpointStateRestore(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	testCases := []struct {
 		description       string
 		checkpointContent string
@@ -133,7 +134,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 				assert.NoError(t, cpm.CreateCheckpoint(testingCheckpoint, checkpoint), "could not create testing checkpoint")
 			}
 
-			restoredState, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
+			restoredState, err := NewCheckpointState(tCtx.Logger(), testingDir, testingCheckpoint, "static")
 			if strings.TrimSpace(tc.expectedError) != "" {
 				assert.Error(t, err)
 				assert.ErrorContains(t, err, "could not restore state from checkpoint: "+tc.expectedError)
@@ -147,7 +148,9 @@ func TestCheckpointStateRestore(t *testing.T) {
 }
 
 func TestCheckpointStateStore(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	expectedState := &stateMemory{
 		assignments: ContainerMemoryAssignments{
 			"pod": map[string][]Block{
@@ -202,7 +205,8 @@ func TestCheckpointStateStore(t *testing.T) {
 }
 
 func TestCheckpointStateHelpers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	testCases := []struct {
 		description  string
 		machineState NUMANodeMap
@@ -310,7 +314,7 @@ func TestCheckpointStateHelpers(t *testing.T) {
 			// ensure there is no previous checkpoint
 			assert.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
 
-			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
+			state, err := NewCheckpointState(tCtx.Logger(), testingDir, testingCheckpoint, "static")
 			assert.NoError(t, err, "could not create testing checkpoint manager")
 
 			state.SetMachineState(tc.machineState)
@@ -330,7 +334,8 @@ func TestCheckpointStateHelpers(t *testing.T) {
 }
 
 func TestCheckpointStateClear(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	testCases := []struct {
 		description  string
 		machineState NUMANodeMap
@@ -374,7 +379,7 @@ func TestCheckpointStateClear(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
+			state, err := NewCheckpointState(tCtx.Logger(), testingDir, testingCheckpoint, "static")
 			assert.NoError(t, err, "could not create testing checkpoint manager")
 
 			state.SetMachineState(tc.machineState)

--- a/pkg/kubelet/cm/topologymanager/policy_none_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_none_test.go
@@ -103,11 +103,11 @@ func TestPolicyNoneMerge(t *testing.T) {
 		},
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	for _, tc := range tcases {
 		policy := NewNonePolicy()
-		result, admit := policy.Merge(logger, tc.providersHints)
+		result, admit := policy.Merge(tCtx.Logger(), tc.providersHints)
 		if !result.IsEqual(tc.expectedHint) || admit != tc.expectedAdmit {
 			t.Errorf("Test Case: %s: Expected merge hint to be %v, got %v", tc.name, tc.expectedHint, result)
 		}

--- a/pkg/kubelet/cm/topologymanager/policy_options_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options_test.go
@@ -130,17 +130,17 @@ func TestNewTopologyManagerOptions(t *testing.T) {
 		},
 	}
 
+	tCtx := ktesting.Init(t)
+
 	setTopologyManagerOptionsDuringTest(t, betaOptions, fancyBetaOption)
 	setTopologyManagerOptionsDuringTest(t, alphaOptions, fancyAlphaOption)
-
-	logger, _ := ktesting.NewTestContext(t)
 
 	for _, tcase := range testCases {
 		t.Run(tcase.description, func(t *testing.T) {
 			if tcase.featureGate != "" {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, tcase.featureGate, tcase.featureGateEnable)
 			}
-			opts, err := NewPolicyOptions(logger, tcase.policyOptions)
+			opts, err := NewPolicyOptions(tCtx.Logger(), tcase.policyOptions)
 			if tcase.expectedErr != nil {
 				if err == nil {
 					t.Errorf("expected error %v, got no error", tcase.expectedErr)

--- a/pkg/kubelet/cm/topologymanager/policy_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_test.go
@@ -1274,7 +1274,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 }
 
 func testPolicyMerge(policy Policy, tcases []policyMergeTestCase, t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	for _, tc := range tcases {
 		var providersHints []map[string][]TopologyHint
@@ -1283,7 +1283,7 @@ func testPolicyMerge(policy Policy, tcases []policyMergeTestCase, t *testing.T) 
 			providersHints = append(providersHints, hints)
 		}
 
-		actual, _ := policy.Merge(logger, providersHints)
+		actual, _ := policy.Merge(tCtx.Logger(), providersHints)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("%v: Expected Topology Hint to be %v, got %v:", tc.name, tc.expected, actual)
 		}

--- a/pkg/kubelet/cm/topologymanager/scope_container_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_container_test.go
@@ -122,7 +122,7 @@ func TestContainerCalculateAffinity(t *testing.T) {
 		},
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	for _, tc := range tcases {
 		ctnScope := &containerScope{
@@ -133,7 +133,7 @@ func TestContainerCalculateAffinity(t *testing.T) {
 			},
 		}
 
-		ctnScope.calculateAffinity(logger, &v1.Pod{}, &v1.Container{})
+		ctnScope.calculateAffinity(tCtx.Logger(), &v1.Pod{}, &v1.Container{})
 		actual := ctnScope.policy.(*mockPolicy).ph
 		if !reflect.DeepEqual(tc.expected, actual) {
 			t.Errorf("Test Case: %s", tc.name)
@@ -257,7 +257,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		},
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	for _, tc := range tcases {
 		ctnScope := containerScope{
@@ -265,7 +265,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 				hintProviders: tc.hp,
 			},
 		}
-		actual := ctnScope.accumulateProvidersHints(logger, &v1.Pod{}, &v1.Container{})
+		actual := ctnScope.accumulateProvidersHints(tCtx.Logger(), &v1.Pod{}, &v1.Container{})
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("Test Case %s: Expected NUMANodeAffinity in result to be %v, got %v", tc.name, tc.expected, actual)
 		}

--- a/pkg/kubelet/cm/topologymanager/scope_pod_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod_test.go
@@ -122,7 +122,7 @@ func TestPodCalculateAffinity(t *testing.T) {
 		},
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	for _, tc := range tcases {
 		podScope := &podScope{
@@ -133,7 +133,7 @@ func TestPodCalculateAffinity(t *testing.T) {
 			},
 		}
 
-		podScope.calculateAffinity(logger, &v1.Pod{})
+		podScope.calculateAffinity(tCtx.Logger(), &v1.Pod{})
 		actual := podScope.policy.(*mockPolicy).ph
 		if !reflect.DeepEqual(tc.expected, actual) {
 			t.Errorf("Test Case: %s", tc.name)
@@ -257,7 +257,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		},
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	for _, tc := range tcases {
 		pScope := podScope{
@@ -265,7 +265,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 				hintProviders: tc.hp,
 			},
 		}
-		actual := pScope.accumulateProvidersHints(logger, &v1.Pod{})
+		actual := pScope.accumulateProvidersHints(tCtx.Logger(), &v1.Pod{})
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("Test Case %s: Expected NUMANodeAffinity in result to be %v, got %v", tc.name, tc.expected, actual)
 		}

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -247,12 +247,14 @@ func TestAddHintProvider(t *testing.T) {
 			},
 		},
 	}
+	tCtx := ktesting.Init(t)
+
 	mngr := manager{}
 	mngr.scope = NewContainerScope(NewNonePolicy())
-	logger, _ := ktesting.NewTestContext(t)
+
 	for _, tc := range tcases {
 		for _, hp := range tc.hp {
-			mngr.AddHintProvider(logger, hp)
+			mngr.AddHintProvider(tCtx.Logger(), hp)
 		}
 		if len(tc.hp) != len(mngr.scope.(*containerScope).hintProviders) {
 			t.Errorf("error")

--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -43,19 +43,21 @@ import (
 )
 
 func TestExtractFromNonExistentFile(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ch := make(chan sourceUpdate, 1)
 	lw := newSourceFile("/some/fake/file", "localhost", time.Millisecond, ch)
-	err := lw.doWatch(logger)
+	err := lw.doWatch(tCtx.Logger())
 	if err == nil {
 		t.Errorf("Expected error")
 	}
 }
 
 func TestUpdateOnNonExistentFile(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ch := make(chan sourceUpdate)
-	NewSourceFile(logger, "random_non_existent_path", "localhost", time.Millisecond, ch)
+	NewSourceFile(tCtx.Logger(), "random_non_existent_path", "localhost", time.Millisecond, ch)
 	select {
 	case update := <-ch:
 		expected := createSourceUpdate() // Expect empty update.
@@ -69,7 +71,8 @@ func TestUpdateOnNonExistentFile(t *testing.T) {
 }
 
 func TestReadPodsFromFileExistAlready(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	hostname := types.NodeName("random-test-hostname")
 	var testCases = getTestCases(hostname)
 
@@ -83,7 +86,7 @@ func TestReadPodsFromFileExistAlready(t *testing.T) {
 			file := testCase.writeToFile(dirName, "test_pod_manifest", t)
 
 			ch := make(chan sourceUpdate)
-			NewSourceFile(logger, file, hostname, time.Millisecond, ch)
+			NewSourceFile(tCtx.Logger(), file, hostname, time.Millisecond, ch)
 			select {
 			case update := <-ch:
 				for _, pod := range update.Pods {
@@ -229,7 +232,9 @@ func createSymbolicLink(link, target, name string, t *testing.T) string {
 }
 
 func watchFileAdded(watchDir bool, symlink bool, t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	hostname := types.NodeName("random-test-hostname")
 	var testCases = getTestCases(hostname)
 
@@ -283,7 +288,9 @@ func watchFileAdded(watchDir bool, symlink bool, t *testing.T) {
 }
 
 func watchFileChanged(watchDir bool, symlink bool, period time.Duration, t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	hostname := types.NodeName("random-test-hostname")
 	var testCases = getTestCases(hostname)
 

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -33,7 +33,8 @@ func TestExtractFromBadDataFile(t *testing.T) {
 	}
 	defer removeAll(dirName, t)
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	fileName := filepath.Join(dirName, "test_pod_config")
 	err = os.WriteFile(fileName, []byte{1, 2, 3}, 0555)
 	if err != nil {
@@ -42,7 +43,7 @@ func TestExtractFromBadDataFile(t *testing.T) {
 
 	ch := make(chan sourceUpdate, 1)
 	lw := newSourceFile(fileName, "localhost", time.Millisecond, ch)
-	err = lw.listConfig(logger)
+	err = lw.listConfig(tCtx.Logger())
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -56,7 +57,9 @@ func TestExtractFromEmptyDir(t *testing.T) {
 	}
 	defer removeAll(dirName, t)
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	ch := make(chan sourceUpdate, 1)
 	lw := newSourceFile(dirName, "localhost", time.Millisecond, ch)
 	err = lw.listConfig(logger)

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -395,7 +395,9 @@ func TestGetContainerSpec(t *testing.T) {
 }
 
 func TestShouldContainerBeRestarted(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",
@@ -548,7 +550,8 @@ func TestHasPrivilegedContainer(t *testing.T) {
 }
 
 func TestMakePortMappings(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	port := func(name string, protocol v1.Protocol, containerPort, hostPort int32, ip string) v1.ContainerPort {
 		return v1.ContainerPort{
 			Name:          name,
@@ -638,7 +641,7 @@ func TestMakePortMappings(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		actual := MakePortMappings(logger, tt.container)
+		actual := MakePortMappings(tCtx.Logger(), tt.container)
 		assert.Equal(t, tt.expectedPortMappings, actual, "[%d]", i)
 	}
 }

--- a/pkg/kubelet/images/pullmanager/fs_pullrecords_test.go
+++ b/pkg/kubelet/images/pullmanager/fs_pullrecords_test.go
@@ -27,7 +27,8 @@ import (
 )
 
 func TestNewFSPullRecordsAccessor(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	tests := []struct {
 		name            string
 		initRoot        bool
@@ -159,7 +160,7 @@ func TestNewFSPullRecordsAccessor(t *testing.T) {
 				}
 			}
 
-			_, err := NewFSPullRecordsAccessor(logger, kubeletDir)
+			_, err := NewFSPullRecordsAccessor(tCtx.Logger(), kubeletDir)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewFSPullRecordsAccessor() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/kubelet/images/pullmanager/image_pull_manager_test.go
+++ b/pkg/kubelet/images/pullmanager/image_pull_manager_test.go
@@ -751,9 +751,10 @@ func TestFileBasedImagePullManager_MustAttemptImagePull(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+
 			encoder, decoder, err := createKubeletConfigSchemeEncoderDecoder()
 			require.NoError(t, err)
-			_, tCtx := ktesting.NewTestContext(t)
 
 			testDir := t.TempDir()
 			pullingDir := filepath.Join(testDir, "pulling")
@@ -825,7 +826,8 @@ func (a *testWriteCountingFSPullRecordsAccessor) WriteImagePulledRecord(logger k
 }
 
 func TestFileBasedImagePullManager_RecordPullIntent(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	tests := []struct {
 		name         string
 		inputImage   string
@@ -871,7 +873,7 @@ func TestFileBasedImagePullManager_RecordPullIntent(t *testing.T) {
 				f.intentCounters.Store(tt.inputImage, tt.startCounter)
 			}
 
-			_ = f.RecordPullIntent(logger, tt.inputImage)
+			_ = f.RecordPullIntent(tCtx.Logger(), tt.inputImage)
 
 			expectFilename := filepath.Join(pullingDir, tt.wantFile)
 			require.FileExists(t, expectFilename)
@@ -1151,7 +1153,8 @@ func TestFileBasedImagePullManager_RecordImagePulled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, tCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			encoder, decoder, err := createKubeletConfigSchemeEncoderDecoder()
 			require.NoError(t, err)
 
@@ -1441,7 +1444,8 @@ func TestFileBasedImagePullManager_PruneUnknownRecords(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, tCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			encoder, decoder, err := createKubeletConfigSchemeEncoderDecoder()
 			require.NoError(t, err)
 

--- a/pkg/kubelet/images/pullmanager/mem_pullrecords_test.go
+++ b/pkg/kubelet/images/pullmanager/mem_pullrecords_test.go
@@ -194,7 +194,8 @@ func (a *recordingPullRecordsAccessor) DeleteImagePulledRecord(logger klog.Logge
 }
 
 func TestNewCachedPullRecordsAccessor(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	manyPullIntents := generateTestPullIntents(51)
 	slices.SortFunc(manyPullIntents, pullIntentsCmp)
 
@@ -299,7 +300,7 @@ func TestNewCachedPullRecordsAccessor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotAccessor := NewCachedPullRecordsAccessor(logger, tt.delegate, 50, 100, 10)
+			gotAccessor := NewCachedPullRecordsAccessor(tCtx.Logger(), tt.delegate, 50, 100, 10)
 			gotMeteredAccessor, ok := gotAccessor.(*meteringRecordsAccessor)
 			if !ok {
 				t.Fatalf("the tested accessor must be a metered records accessor, got %T", gotAccessor)
@@ -629,7 +630,8 @@ func Test_cachedPullRecordsAccessor_ImagePullIntentExists(t *testing.T) {
 }
 
 func Test_cachedPullRecordsAccessor_WriteImagePullIntent(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	justEnoughIntents := generateTestPullIntents(100)
 
 	tests := []struct {
@@ -735,7 +737,7 @@ func Test_cachedPullRecordsAccessor_WriteImagePullIntent(t *testing.T) {
 			}
 			c.intents.authoritative.Store(tt.initAuthoritative)
 
-			if err := c.WriteImagePullIntent(logger, tt.inputImage); !cmpErrorStrings(err, tt.wantErr) {
+			if err := c.WriteImagePullIntent(tCtx.Logger(), tt.inputImage); !cmpErrorStrings(err, tt.wantErr) {
 				t.Errorf("cachedPullRecordsAccessor.WriteImagePullIntent() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -755,7 +757,8 @@ func Test_cachedPullRecordsAccessor_WriteImagePullIntent(t *testing.T) {
 }
 
 func Test_cachedPullRecordsAccessor_WriteImagePulledRecord(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	justEnoughPulledRecords := generateTestPulledRecords(100)
 
 	tests := []struct {
@@ -903,7 +906,7 @@ func Test_cachedPullRecordsAccessor_WriteImagePulledRecord(t *testing.T) {
 			}
 			c.pulledRecords.authoritative.Store(tt.initAuthoritative)
 
-			if err := c.WriteImagePulledRecord(logger, tt.inputRecord); !cmpErrorStrings(err, tt.wantErr) {
+			if err := c.WriteImagePulledRecord(tCtx.Logger(), tt.inputRecord); !cmpErrorStrings(err, tt.wantErr) {
 				t.Errorf("cachedPullRecordsAccessor.WriteImagePulledRecord() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -923,7 +926,8 @@ func Test_cachedPullRecordsAccessor_WriteImagePulledRecord(t *testing.T) {
 }
 
 func Test_cachedPullRecordsAccessor_DeleteImagePullIntent(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	tests := []struct {
 		name         string
 		delegate     *testPullRecordsAccessor
@@ -966,7 +970,7 @@ func Test_cachedPullRecordsAccessor_DeleteImagePullIntent(t *testing.T) {
 				}
 				c.intents.authoritative.Store(initAuthoritative)
 
-				if err := c.DeleteImagePullIntent(logger, tt.inputImage); !cmpErrorStrings(err, tt.wantErr) {
+				if err := c.DeleteImagePullIntent(tCtx.Logger(), tt.inputImage); !cmpErrorStrings(err, tt.wantErr) {
 					t.Errorf("cachedPullRecordsAccessor.DeleteImagePullIntent() error = %v, wantErr %v", err, tt.wantErr)
 				}
 
@@ -992,7 +996,8 @@ func Test_cachedPullRecordsAccessor_DeleteImagePullIntent(t *testing.T) {
 }
 
 func Test_cachedPullRecordsAccessor_DeleteImagePulledRecord(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	tests := []struct {
 		name              string
 		delegate          *testPullRecordsAccessor
@@ -1035,7 +1040,7 @@ func Test_cachedPullRecordsAccessor_DeleteImagePulledRecord(t *testing.T) {
 				}
 				c.pulledRecords.authoritative.Store(initAuthoritative)
 
-				if err := c.DeleteImagePulledRecord(logger, tt.imageRef); !cmpErrorStrings(err, tt.wantErr) {
+				if err := c.DeleteImagePulledRecord(tCtx.Logger(), tt.imageRef); !cmpErrorStrings(err, tt.wantErr) {
 					t.Errorf("cachedPullRecordsAccessor.DeleteImagePulledRecord() error = %v, wantErr %v", err, tt.wantErr)
 				}
 

--- a/pkg/kubelet/kubelet_pods_linux_test.go
+++ b/pkg/kubelet/kubelet_pods_linux_test.go
@@ -41,7 +41,8 @@ import (
 )
 
 func TestMakeMounts(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	bTrue := true
 	propagationHostToContainer := v1.MountPropagationHostToContainer
 	propagationBidirectional := v1.MountPropagationBidirectional
@@ -461,7 +462,7 @@ func TestMakeMounts(t *testing.T) {
 					},
 				}
 
-				mounts, _, err := makeMounts(logger, &pod, "/pod", &tc.container, "fakepodname", "", []string{""}, tc.podVolumes, fhu, fsp, nil, tc.supportsRRO, tc.imageVolumes)
+				mounts, _, err := makeMounts(tCtx.Logger(), &pod, "/pod", &tc.container, "fakepodname", "", []string{""}, tc.podVolumes, fhu, fsp, nil, tc.supportsRRO, tc.imageVolumes)
 
 				// validate only the error if we expect an error
 				if tc.expectErr {
@@ -483,7 +484,8 @@ func TestMakeMounts(t *testing.T) {
 }
 
 func TestMakeMountsEtcHostsFile(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   "test-ns",
@@ -561,7 +563,7 @@ func TestMakeMountsEtcHostsFile(t *testing.T) {
 				tt.containerFn(container)
 			}
 
-			mounts, _, err := makeMounts(logger, pod, t.TempDir(), container, "fakepodname", "fakedomain", tt.podIPs, tt.podVolumes, fhu, fsp, nil, false, nil)
+			mounts, _, err := makeMounts(tCtx.Logger(), pod, t.TempDir(), container, "fakepodname", "fakedomain", tt.podIPs, tt.podVolumes, fhu, fsp, nil, false, nil)
 
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -582,7 +584,8 @@ func TestMakeMountsEtcHostsFile(t *testing.T) {
 }
 
 func TestMakeBlockVolumes(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
@@ -698,7 +701,7 @@ func TestMakeBlockVolumes(t *testing.T) {
 				},
 			}
 			blkutil := volumetest.NewBlockVolumePathHandler()
-			blkVolumes, err := kubelet.makeBlockVolumes(logger, &pod, &tc.container, tc.podVolumes, blkutil)
+			blkVolumes, err := kubelet.makeBlockVolumes(tCtx.Logger(), &pod, &tc.container, tc.podVolumes, blkutil)
 			// validate only the error if we expect an error
 			if tc.expectErr {
 				if err == nil || err.Error() != tc.expectedErrMsg {

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -396,7 +396,8 @@ func buildService(name, namespace, clusterIP, protocol string, port int) *v1.Ser
 }
 
 func TestMakeEnvironmentVariables(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	trueVal := true
 	services := []*v1.Service{
 		buildService("kubernetes", metav1.NamespaceDefault, "1.2.3.1", "TCP", 8081),
@@ -2036,7 +2037,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				testPod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "file"
 			}
 
-			result, err := kl.makeEnvironmentVariables(logger, testPod, tc.container, podIP, tc.podIPs, kubecontainer.VolumeMap{})
+			result, err := kl.makeEnvironmentVariables(tCtx.Logger(), testPod, tc.container, podIP, tc.podIPs, kubecontainer.VolumeMap{})
 			select {
 			case e := <-fakeRecorder.Events:
 				assert.Equal(t, tc.expectedEvent, e)
@@ -2206,7 +2207,8 @@ func withRestartCount(status v1.ContainerStatus, restartCount int32) v1.Containe
 }
 
 func TestPodPhaseWithRestartAlways(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		Containers: []v1.Container{
@@ -2341,13 +2343,14 @@ func TestPodPhaseWithRestartAlways(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		status := getPhase(logger, test.pod, test.pod.Status.ContainerStatuses, test.podIsTerminal, false)
+		status := getPhase(tCtx.Logger(), test.pod, test.pod.Status.ContainerStatuses, test.podIsTerminal, false)
 		assert.Equal(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
 func TestPodPhaseWithRestartAlwaysInitContainers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		InitContainers: []v1.Container{
@@ -2446,13 +2449,14 @@ func TestPodPhaseWithRestartAlwaysInitContainers(t *testing.T) {
 	for _, test := range tests {
 		statusInfo := test.pod.Status.InitContainerStatuses
 		statusInfo = append(statusInfo, test.pod.Status.ContainerStatuses...)
-		status := getPhase(logger, test.pod, statusInfo, false, false)
+		status := getPhase(tCtx.Logger(), test.pod, statusInfo, false, false)
 		assert.Equal(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
 func TestPodPhaseWithRestartAlwaysRestartableInitContainers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		InitContainers: []v1.Container{
@@ -2690,13 +2694,14 @@ func TestPodPhaseWithRestartAlwaysRestartableInitContainers(t *testing.T) {
 	for _, test := range tests {
 		statusInfo := test.pod.Status.InitContainerStatuses
 		statusInfo = append(statusInfo, test.pod.Status.ContainerStatuses...)
-		status := getPhase(logger, test.pod, statusInfo, test.podIsTerminal, test.podHasInitialized)
+		status := getPhase(tCtx.Logger(), test.pod, statusInfo, test.podIsTerminal, test.podHasInitialized)
 		assert.Equal(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
 func TestPodPhaseWithRestartAlwaysAndPodHasRun(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		InitContainers: []v1.Container{
@@ -2804,13 +2809,14 @@ func TestPodPhaseWithRestartAlwaysAndPodHasRun(t *testing.T) {
 	for _, test := range tests {
 		statusInfo := test.pod.Status.InitContainerStatuses
 		statusInfo = append(statusInfo, test.pod.Status.ContainerStatuses...)
-		status := getPhase(logger, test.pod, statusInfo, false, test.podHasInitialized)
+		status := getPhase(tCtx.Logger(), test.pod, statusInfo, false, test.podHasInitialized)
 		assert.Equal(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
 func TestPodPhaseWithRestartNever(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		Containers: []v1.Container{
@@ -2905,13 +2911,14 @@ func TestPodPhaseWithRestartNever(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		status := getPhase(logger, test.pod, test.pod.Status.ContainerStatuses, false, false)
+		status := getPhase(tCtx.Logger(), test.pod, test.pod.Status.ContainerStatuses, false, false)
 		assert.Equal(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
 func TestPodPhaseWithRestartNeverInitContainers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		InitContainers: []v1.Container{
@@ -3010,13 +3017,14 @@ func TestPodPhaseWithRestartNeverInitContainers(t *testing.T) {
 	for _, test := range tests {
 		statusInfo := test.pod.Status.InitContainerStatuses
 		statusInfo = append(statusInfo, test.pod.Status.ContainerStatuses...)
-		status := getPhase(logger, test.pod, statusInfo, false, false)
+		status := getPhase(tCtx.Logger(), test.pod, statusInfo, false, false)
 		assert.Equal(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
 func TestPodPhaseWithRestartNeverRestartableInitContainers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		InitContainers: []v1.Container{
@@ -3223,13 +3231,14 @@ func TestPodPhaseWithRestartNeverRestartableInitContainers(t *testing.T) {
 	for _, test := range tests {
 		statusInfo := test.pod.Status.InitContainerStatuses
 		statusInfo = append(statusInfo, test.pod.Status.ContainerStatuses...)
-		status := getPhase(logger, test.pod, statusInfo, false, test.podHasInitialized)
+		status := getPhase(tCtx.Logger(), test.pod, statusInfo, false, test.podHasInitialized)
 		assert.Equal(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
 func TestPodPhaseWithRestartOnFailure(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
 		Containers: []v1.Container{
@@ -3337,13 +3346,14 @@ func TestPodPhaseWithRestartOnFailure(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		status := getPhase(logger, test.pod, test.pod.Status.ContainerStatuses, false, false)
+		status := getPhase(tCtx.Logger(), test.pod, test.pod.Status.ContainerStatuses, false, false)
 		assert.Equal(t, test.status, status, "[test %s]", test.test)
 	}
 }
 
 func TestPodPhaseWithContainerRestartPolicy(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	var (
 		containerRestartPolicyAlways    = v1.ContainerRestartPolicyAlways
 		containerRestartPolicyOnFailure = v1.ContainerRestartPolicyOnFailure
@@ -3468,14 +3478,15 @@ func TestPodPhaseWithContainerRestartPolicy(t *testing.T) {
 					ContainerStatuses: tc.statuses,
 				},
 			}
-			phase := getPhase(logger, pod, tc.statuses, tc.podIsTerminal, true)
+			phase := getPhase(tCtx.Logger(), pod, tc.statuses, tc.podIsTerminal, true)
 			assert.Equal(t, tc.expectedPhase, phase)
 		})
 	}
 }
 
 func TestPodPhaseWithContainerRestartPolicyInitContainers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	var (
 		containerRestartPolicyAlways    = v1.ContainerRestartPolicyAlways
 		containerRestartPolicyOnFailure = v1.ContainerRestartPolicyOnFailure
@@ -3542,14 +3553,15 @@ func TestPodPhaseWithContainerRestartPolicyInitContainers(t *testing.T) {
 					ContainerStatuses: tc.statuses,
 				},
 			}
-			phase := getPhase(logger, pod, tc.statuses, tc.podIsTerminal, true)
+			phase := getPhase(tCtx.Logger(), pod, tc.statuses, tc.podIsTerminal, true)
 			assert.Equal(t, tc.expectedPhase, phase)
 		})
 	}
 }
 
 func TestPodPhaseWithRestartAllContainers(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 		features.ContainerRestartRules:                true,
 		features.NodeDeclaredFeatures:                 true,
@@ -3794,7 +3806,7 @@ func TestPodPhaseWithRestartAllContainers(t *testing.T) {
 					ContainerStatuses: tc.statuses,
 				},
 			}
-			phase := getPhase(logger, pod, tc.statuses, false, true)
+			phase := getPhase(tCtx.Logger(), pod, tc.statuses, false, true)
 			assert.Equal(t, tc.expectedPhase, phase)
 		})
 	}
@@ -4857,12 +4869,13 @@ func Test_generateAPIPodStatus(t *testing.T) {
 	for _, test := range tests {
 		for _, enablePodReadyToStartContainersCondition := range []bool{false, true} {
 			t.Run(test.name, func(t *testing.T) {
-				logger, tCtx := ktesting.NewTestContext(t)
+				tCtx := ktesting.Init(t)
+
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodReadyToStartContainersCondition, enablePodReadyToStartContainersCondition)
 				testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 				defer testKubelet.Cleanup()
 				kl := testKubelet.kubelet
-				kl.statusManager.SetPodStatus(logger, test.pod, test.previousStatus)
+				kl.statusManager.SetPodStatus(tCtx.Logger(), test.pod, test.previousStatus)
 				for _, name := range test.unreadyContainer {
 					kl.readinessManager.Set(kubecontainer.BuildContainerID("", findContainerStatusByName(test.expected, name).ContainerID), results.Failure, test.pod)
 				}
@@ -4979,13 +4992,13 @@ func Test_generateAPIPodStatusForInPlaceVPAEnabled(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			logger, tCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
 
 			oldStatus := test.pod.Status
-			kl.statusManager.SetPodStatus(logger, test.pod, oldStatus)
+			kl.statusManager.SetPodStatus(tCtx.Logger(), test.pod, oldStatus)
 			actual := kl.generateAPIPodStatus(tCtx, test.pod, &testKubecontainerPodStatus /* criStatus */, false /* test.isPodTerminal */)
 			for _, c := range actual.Conditions {
 				if c.Type == v1.PodResizePending || c.Type == v1.PodResizeInProgress {
@@ -5154,7 +5167,8 @@ func TestGetPortForward(t *testing.T) {
 }
 
 func TestTruncatePodHostname(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	for c, test := range map[string]struct {
 		input  string
 		output string
@@ -5177,7 +5191,7 @@ func TestTruncatePodHostname(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase: %q", c)
-		output, err := truncatePodHostnameIfNeeded(logger, "test-pod", test.input)
+		output, err := truncatePodHostnameIfNeeded(tCtx.Logger(), "test-pod", test.input)
 		assert.NoError(t, err)
 		assert.Equal(t, test.output, output)
 	}
@@ -7516,7 +7530,8 @@ func testMetric(t *testing.T, metricName string, expectedMetric string) {
 }
 
 func TestGetNonExistentImagePullSecret(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	secrets := make([]*v1.Secret, 0)
 	fakeRecorder := record.NewFakeRecorder(1)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
@@ -7539,7 +7554,7 @@ func TestGetNonExistentImagePullSecret(t *testing.T) {
 		},
 	}
 
-	pullSecrets := testKubelet.kubelet.getPullSecretsForPod(logger, testPod)
+	pullSecrets := testKubelet.kubelet.getPullSecretsForPod(tCtx.Logger(), testPod)
 	assert.Empty(t, pullSecrets)
 
 	assert.Len(t, fakeRecorder.Events, 1)
@@ -7770,7 +7785,8 @@ func (tvm *testVolumeMounter) GetPath() string {
 }
 
 func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	// Create a temporary directory for test files
 	tmpDir, err := os.MkdirTemp("", "filekeyref-test")
 	require.NoError(t, err)
@@ -8126,7 +8142,7 @@ func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
 				},
 			}
 
-			envs, err := kl.makeEnvironmentVariables(logger, pod, tc.container, "192.168.1.1", []string{"192.168.1.1"}, tc.podVolumes)
+			envs, err := kl.makeEnvironmentVariables(tCtx.Logger(), pod, tc.container, "192.168.1.1", []string{"192.168.1.1"}, tc.podVolumes)
 
 			if tc.expectedError {
 				require.Error(t, err)
@@ -8153,7 +8169,8 @@ func (e Envs) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
 func (e Envs) Less(i, j int) bool { return e[i].Name < e[j].Name }
 
 func TestGeneratePodHostNameAndDomain(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	kubelet := &Kubelet{}
 	kubelet.dnsConfigurer = &dns.Configurer{
 		ClusterDomain: "cluster.local",
@@ -8287,7 +8304,7 @@ func TestGeneratePodHostNameAndDomain(t *testing.T) {
 				},
 			}
 
-			hostname, domain, err := kubelet.GeneratePodHostNameAndDomain(logger, pod)
+			hostname, domain, err := kubelet.GeneratePodHostNameAndDomain(tCtx.Logger(), pod)
 			if tc.expectError {
 				if err == nil {
 					t.Errorf("expected an error but got none")

--- a/pkg/kubelet/kubelet_pods_windows_test.go
+++ b/pkg/kubelet/kubelet_pods_windows_test.go
@@ -31,7 +31,8 @@ import (
 )
 
 func TestMakeMountsWindows(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	// TODO: remove skip once the failing test has been fixed.
 	t.Skip("Skip failing test on Windows.")
 	container := v1.Container{
@@ -94,7 +95,7 @@ func TestMakeMountsWindows(t *testing.T) {
 	podDir, err := os.MkdirTemp("", "test-rotate-logs")
 	require.NoError(t, err)
 	defer os.RemoveAll(podDir)
-	mounts, _, err := makeMounts(logger, &pod, podDir, &container, "fakepodname", "", []string{""}, podVolumes, fhu, fsp, nil, false, nil)
+	mounts, _, err := makeMounts(tCtx.Logger(), &pod, podDir, &container, "fakepodname", "", []string{""}, podVolumes, fhu, fsp, nil, false, nil)
 	require.NoError(t, err)
 
 	expectedMounts := []kubecontainer.Mount{

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -198,8 +198,9 @@ func TestPodVolumesExist(t *testing.T) {
 		},
 	}
 
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	defer tCtx.Cancel("test has completed")
+
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	kubelet.podManager.SetPods(pods)
@@ -209,7 +210,7 @@ func TestPodVolumesExist(t *testing.T) {
 	}
 
 	for _, pod := range pods {
-		podVolumesExist := kubelet.podVolumesExist(logger, pod.UID)
+		podVolumesExist := kubelet.podVolumesExist(tCtx.Logger(), pod.UID)
 		assert.True(t, podVolumesExist, "pod %q", pod.UID)
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -246,7 +246,9 @@ func TestImageStatsWithError(t *testing.T) {
 }
 
 func TestPullWithSecrets(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	// auth value is equivalent to: "username":"passed-user","password":"passed-password"
 	dockerCfg := map[string]map[string]string{"index.docker.io/v1/": {"email": "passed-email", "auth": "cGFzc2VkLXVzZXI6cGFzc2VkLXBhc3N3b3Jk"}}
 	dockercfgContent, err := json.Marshal(dockerCfg)
@@ -359,7 +361,8 @@ func TestPullWithSecrets(t *testing.T) {
 }
 
 func TestPullWithSecretsWithError(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 
 	dockerCfg := map[string]map[string]map[string]string{
 		"auths": {

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -78,7 +78,8 @@ func (f podStatusProviderFunc) GetPodStatus(_ context.Context, uid types.UID, na
 }
 
 func TestRunHandlerExec(t *testing.T) {
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	fakeCommandRunner := fakeContainerCommandRunner{}
 	handlerRunner := NewHandlerRunner(&fakeHTTP{}, &fakeCommandRunner, nil, nil)
 
@@ -124,7 +125,8 @@ func (f *fakeHTTP) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestRunHandlerHttp(t *testing.T) {
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	fakeHTTPGetter := fakeHTTP{}
 	fakePodStatusProvider := stubPodStatusProvider("127.0.0.1")
 	handlerRunner := NewHandlerRunner(&fakeHTTPGetter, &fakeContainerCommandRunner{}, fakePodStatusProvider, nil)
@@ -160,7 +162,8 @@ func TestRunHandlerHttp(t *testing.T) {
 }
 
 func TestRunHandlerHttpWithHeaders(t *testing.T) {
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	fakeHTTPDoer := fakeHTTP{}
 	fakePodStatusProvider := stubPodStatusProvider("127.0.0.1")
 
@@ -202,7 +205,8 @@ func TestRunHandlerHttpWithHeaders(t *testing.T) {
 }
 
 func TestRunHandlerHttps(t *testing.T) {
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	fakeHTTPDoer := fakeHTTP{}
 	fakePodStatusProvider := stubPodStatusProvider("127.0.0.1")
 	handlerRunner := NewHandlerRunner(&fakeHTTPDoer, &fakeContainerCommandRunner{}, fakePodStatusProvider, nil)
@@ -284,7 +288,8 @@ func TestRunHandlerHTTPPort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			_, tCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			fakeHTTPDoer := fakeHTTP{}
 			handlerRunner := NewHandlerRunner(&fakeHTTPDoer, &fakeContainerCommandRunner{}, fakePodStatusProvider, nil)
 
@@ -555,7 +560,8 @@ func TestRunHTTPHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			_, tCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			fakePodStatusProvider := stubPodStatusProvider(tt.PodIP)
 
 			container.Lifecycle.PostStart.HTTPGet = tt.HTTPGet
@@ -586,7 +592,8 @@ func TestRunHTTPHandler(t *testing.T) {
 }
 
 func TestRunHandlerNil(t *testing.T) {
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	handlerRunner := NewHandlerRunner(&fakeHTTP{}, &fakeContainerCommandRunner{}, nil, nil)
 	containerID := kubecontainer.ContainerID{Type: "test", ID: "abc1234"}
 	podName := "podFoo"
@@ -610,7 +617,8 @@ func TestRunHandlerNil(t *testing.T) {
 }
 
 func TestRunHandlerExecFailure(t *testing.T) {
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	expectedErr := fmt.Errorf("invalid command")
 	fakeCommandRunner := fakeContainerCommandRunner{Err: expectedErr, Msg: expectedErr.Error()}
 	handlerRunner := NewHandlerRunner(&fakeHTTP{}, &fakeCommandRunner, nil, nil)
@@ -645,7 +653,8 @@ func TestRunHandlerExecFailure(t *testing.T) {
 }
 
 func TestRunHandlerHttpFailure(t *testing.T) {
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	expectedErr := fmt.Errorf("fake http error")
 	expectedResp := http.Response{
 		Body: io.NopCloser(strings.NewReader(expectedErr.Error())),
@@ -688,7 +697,7 @@ func TestRunHandlerHttpFailure(t *testing.T) {
 }
 
 func TestRunHandlerHttpsFailureFallback(t *testing.T) {
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	// Since prometheus' gatherer is global, other tests may have updated metrics already, so
 	// we need to reset them prior running this test.
@@ -822,7 +831,8 @@ func TestRunSleepHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, tCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			pod.Spec.Containers[0].Lifecycle.PreStop.Sleep = &v1.SleepAction{Seconds: tt.sleepSeconds}
 			ctx, cancel := context.WithTimeout(tCtx, time.Duration(tt.terminationGracePeriodSeconds)*time.Second)
 			defer cancel()

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -225,8 +225,9 @@ func TestFormDNSSearchFitsLimits(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
-			dnsSearch := configurer.formDNSSearchFitsLimits(logger, tc.hostNames, pod)
+			tCtx := ktesting.Init(t)
+
+			dnsSearch := configurer.formDNSSearchFitsLimits(tCtx.Logger(), tc.hostNames, pod)
 			assert.EqualValues(t, tc.resultSearch, dnsSearch, "test [%d]", i)
 			for _, expectedEvent := range tc.events {
 				expected := fmt.Sprintf("%s %s %s", v1.EventTypeWarning, "DNSConfigForming", expectedEvent)
@@ -285,8 +286,9 @@ func TestFormDNSNameserversFitsLimits(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		logger, _ := ktesting.NewTestContext(t)
-		appliedNameservers := configurer.formDNSNameserversFitsLimits(logger, tc.nameservers, pod)
+		tCtx := ktesting.Init(t)
+
+		appliedNameservers := configurer.formDNSNameserversFitsLimits(tCtx.Logger(), tc.nameservers, pod)
 		assert.EqualValues(t, tc.expectedNameserver, appliedNameservers, tc.desc)
 		event := fetchEvent(recorder)
 		if tc.expectedEvent && len(event) == 0 {

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -563,7 +563,9 @@ func (m *manager) extractedReadinessHandling(logger klog.Logger) {
 }
 
 func TestUpdateReadiness(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	testPod := getTestPod()
 	setTestProbe(testPod, readiness, v1.Probe{})
 	m := newTestManager()
@@ -584,7 +586,7 @@ func TestUpdateReadiness(t *testing.T) {
 
 	m.statusManager.SetPodStatus(logger, testPod, getTestRunningStatus())
 
-	m.AddPod(ctx, testPod)
+	m.AddPod(tCtx, testPod)
 	probePaths := []probeKey{{testPodUID, testContainerName, readiness}}
 	if err := expectProbes(m, probePaths); err != nil {
 		t.Error(err)

--- a/pkg/kubelet/prober/scale_test.go
+++ b/pkg/kubelet/prober/scale_test.go
@@ -80,7 +80,8 @@ func TestTCPPortExhaustion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, tCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			podManager := kubepod.NewBasicPodManager()
 			podStartupLatencyTracker := kubeletutil.NewPodStartupLatencyTracker()
 			m := NewManager(
@@ -134,7 +135,7 @@ func TestTCPPortExhaustion(t *testing.T) {
 					})
 				}
 				podManager.AddPod(&pod)
-				m.statusManager.SetPodStatus(logger, &pod, pod.Status)
+				m.statusManager.SetPodStatus(tCtx.Logger(), &pod, pod.Status)
 				m.AddPod(tCtx, &pod)
 			}
 			t.Logf("Adding %d pods with %d containers each in %v", numTestPods, numContainers, time.Since(now))

--- a/pkg/kubelet/server/stats/volume_stat_calculator_test.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator_test.go
@@ -105,7 +105,8 @@ var (
 )
 
 func TestPVCRef(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	// Setup mock stats provider
 	mockStats := statstest.NewMockProvider(t)
 	volumes := map[string]volume.Volume{vol0: &fakeVolume{}, vol1: &fakeVolume{}, vol3: &fakeVolume{}}
@@ -120,7 +121,7 @@ func TestPVCRef(t *testing.T) {
 
 	// Calculate stats for pod
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	statsCalculator.calcAndStoreStats(logger)
+	statsCalculator.calcAndStoreStats(tCtx.Logger())
 	vs, _ := statsCalculator.GetLatest()
 
 	assert.Len(t, append(vs.EphemeralVolumes, vs.PersistentVolumes...), 4)
@@ -163,7 +164,8 @@ func TestPVCRef(t *testing.T) {
 }
 
 func TestNormalVolumeEvent(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	mockStats := statstest.NewMockProvider(t)
 
 	volumes := map[string]volume.Volume{vol0: &fakeVolume{}, vol1: &fakeVolume{}}
@@ -178,7 +180,7 @@ func TestNormalVolumeEvent(t *testing.T) {
 
 	// Calculate stats for pod
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	statsCalculator.calcAndStoreStats(logger)
+	statsCalculator.calcAndStoreStats(tCtx.Logger())
 
 	event, err := WatchEvent(eventStore)
 	assert.Error(t, err)
@@ -186,7 +188,8 @@ func TestNormalVolumeEvent(t *testing.T) {
 }
 
 func TestAbnormalVolumeEvent(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIVolumeHealth, true)
 
 	// Setup mock stats provider
@@ -207,7 +210,7 @@ func TestAbnormalVolumeEvent(t *testing.T) {
 		volumeCondition.Abnormal = true
 	}
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	statsCalculator.calcAndStoreStats(logger)
+	statsCalculator.calcAndStoreStats(tCtx.Logger())
 
 	event, err := WatchEvent(eventStore)
 	assert.NoError(t, err)

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -92,8 +92,10 @@ func TestFilterTerminatedContainerInfoAndAssembleByPodCgroupKey(t *testing.T) {
 		//ContainerInfo with no CPU/memory usage but has network usage for uncleaned cgroups, should not be filtered out
 		"/pod2-c222-zerocpumem-1": getContainerInfoWithZeroCpuMem(seedPastPod0Container0, pName2, namespace, cName222),
 	}
-	logger, _ := ktesting.NewTestContext(t)
-	filteredInfos, allInfos := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
+
+	tCtx := ktesting.Init(t)
+
+	filteredInfos, allInfos := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(tCtx.Logger(), infos)
 	assert.Len(t, filteredInfos, 5)
 	assert.Len(t, allInfos, 11)
 	for _, c := range []string{"/pod0-i", "/pod0-c0"} {

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -351,7 +351,8 @@ func TestCRIListPodStats(t *testing.T) {
 }
 
 func TestListPodStatsStrictlyFromCRI(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletPSI, true)
 	if runtime.GOOS == "windows" {
 		// TODO: remove skip once the failing test has been fixed.
@@ -483,7 +484,7 @@ func TestListPodStatsStrictlyFromCRI(t *testing.T) {
 		fakeContainerStatsProvider{},
 	)
 
-	cadvisorInfos, err := getCadvisorContainerInfo(logger, mockCadvisor)
+	cadvisorInfos, err := getCadvisorContainerInfo(tCtx.Logger(), mockCadvisor)
 	if err != nil {
 		t.Errorf("failed to get container info from cadvisor: %v", err)
 	}
@@ -1513,7 +1514,9 @@ func TestGetContainerUsageNanoCores(t *testing.T) {
 			expected: nil,
 		},
 	}
-	logger, _ := ktesting.NewTestContext(t)
+
+	tCtx := ktesting.Init(t)
+
 	for _, test := range tests {
 		provider := &criStatsProvider{cpuUsageCache: test.cpuUsageCache}
 		// Before the update, the cached value should be nil
@@ -1521,7 +1524,7 @@ func TestGetContainerUsageNanoCores(t *testing.T) {
 		assert.Nil(t, cached)
 
 		// Update the cache and get the latest value.
-		real := provider.getAndUpdateContainerUsageNanoCores(logger, test.stats)
+		real := provider.getAndUpdateContainerUsageNanoCores(tCtx.Logger(), test.stats)
 		assert.Equal(t, test.expected, real, test.desc)
 
 		// After the update, the cached value should be up-to-date

--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -424,7 +424,8 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 			skipped: true,
 		},
 	}
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// TODO: Remove skip once https://github.com/kubernetes/kubernetes/issues/116692 is fixed.
@@ -437,7 +438,7 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 				},
 				clock: fakeClock,
 			}
-			got, err := p.listContainerNetworkStats(logger)
+			got, err := p.listContainerNetworkStats(tCtx.Logger())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("listContainerNetworkStats() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -524,8 +525,9 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 		Uid:       "sb0-uid",
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
-	got, err := p.makeWinContainerStats(logger, inputStats, inputContainer, inputRootFsInfo, make(map[string]*cadvisorapiv2.FsInfo), inputPodSandboxMetadata)
+	tCtx := ktesting.Init(t)
+
+	got, err := p.makeWinContainerStats(tCtx.Logger(), inputStats, inputContainer, inputRootFsInfo, make(map[string]*cadvisorapiv2.FsInfo), inputPodSandboxMetadata)
 
 	expected := &statsapi.ContainerStats{
 		Name:      "c0",

--- a/pkg/kubelet/stats/helper_test.go
+++ b/pkg/kubelet/stats/helper_test.go
@@ -82,8 +82,9 @@ func TestCustomMetrics(t *testing.T) {
 			},
 		},
 	}
-	logger, _ := ktesting.NewTestContext(t)
-	assert.Contains(t, cadvisorInfoToUserDefinedMetrics(logger, &cInfo),
+	tCtx := ktesting.Init(t)
+
+	assert.Contains(t, cadvisorInfoToUserDefinedMetrics(tCtx.Logger(), &cInfo),
 		statsapi.UserDefinedMetric{
 			UserDefinedMetricDescriptor: statsapi.UserDefinedMetricDescriptor{
 				Name:  "qos",

--- a/pkg/kubelet/userns/userns_manager_disabled_test.go
+++ b/pkg/kubelet/userns/userns_manager_disabled_test.go
@@ -33,7 +33,9 @@ import (
 // Test all public methods behave ok when the feature gate is disabled.
 
 func TestMakeUserNsManagerDisabled(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
@@ -42,7 +44,9 @@ func TestMakeUserNsManagerDisabled(t *testing.T) {
 }
 
 func TestReleaseDisabled(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
@@ -97,7 +101,9 @@ func TestGetOrCreateUserNamespaceMappingsDisabled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
+
 			testUserNsPodsManager := &testUserNsPodsManager{}
 			m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 			require.NoError(t, err)
@@ -114,13 +120,13 @@ func TestGetOrCreateUserNamespaceMappingsDisabled(t *testing.T) {
 }
 
 func TestCleanupOrphanedPodUsernsAllocationsDisabled(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
-	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
+	m, err := MakeUserNsManager(tCtx.Logger(), testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
-	err = m.CleanupOrphanedPodUsernsAllocations(ctx, nil, nil)
+	err = m.CleanupOrphanedPodUsernsAllocations(tCtx, nil, nil)
 	assert.NoError(t, err)
 }

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -94,7 +94,9 @@ func (m *testUserNsPodsManager) GetMaxPods() int {
 }
 
 func TestUserNsManagerAllocate(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
 
 	customUserNsLength := uint32(1048576)
@@ -177,7 +179,9 @@ func TestUserNsManagerAllocate(t *testing.T) {
 }
 
 func TestMakeUserNsManager(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
 
 	cases := []struct {
@@ -232,7 +236,9 @@ func TestMakeUserNsManager(t *testing.T) {
 }
 
 func TestUserNsManagerParseUserNsFile(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
 
 	cases := []struct {
@@ -385,7 +391,9 @@ func TestGetOrCreateUserNamespaceMappings(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
+
 			// These tests will create the userns file, so use an existing podDir.
 			testUserNsPodsManager := &testUserNsPodsManager{
 				podDir: t.TempDir(),
@@ -407,7 +415,9 @@ func TestGetOrCreateUserNamespaceMappings(t *testing.T) {
 }
 
 func TestCleanupOrphanedPodUsernsAllocations(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
 
 	cases := []struct {
@@ -473,7 +483,7 @@ func TestCleanupOrphanedPodUsernsAllocations(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err = m.CleanupOrphanedPodUsernsAllocations(ctx, tc.pods, tc.runningPods)
+			err = m.CleanupOrphanedPodUsernsAllocations(tCtx, tc.pods, tc.runningPods)
 			require.NoError(t, err)
 
 			for _, pod := range tc.podSetAfterCleanup {
@@ -498,7 +508,9 @@ func (m *failingUserNsPodsManager) ListPodsFromDisk() ([]types.UID, error) {
 }
 
 func TestMakeUserNsManagerFailsListPod(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
 
 	testUserNsPodsManager := &failingUserNsPodsManager{}
@@ -508,7 +520,9 @@ func TestMakeUserNsManagerFailsListPod(t *testing.T) {
 }
 
 func TestRecordBounds(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
 
 	// Allow exactly for 1 pod

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -57,7 +57,6 @@ const (
 )
 
 func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name            string
 		pvMode, podMode v1.PersistentVolumeMode
@@ -118,7 +117,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 				tCtx.Done(),
 				manager)
 
-			err = manager.WaitForAttachAndMount(ctx, pod)
+			err = manager.WaitForAttachAndMount(tCtx, pod)
 			if err != nil && !test.expectError {
 				t.Errorf("Expected success: %v", err)
 			}
@@ -151,7 +150,8 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 }
 
 func TestWaitForAttachAndMountError(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
@@ -232,14 +232,13 @@ func TestWaitForAttachAndMountError(t *testing.T) {
 
 	manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, nil)
 
-	tCtx := ktesting.Init(t)
 	defer tCtx.Cancel("test has completed")
 	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 
 	podManager.SetPods([]*v1.Pod{pod})
 
-	err = manager.WaitForAttachAndMount(ctx, pod)
+	err = manager.WaitForAttachAndMount(tCtx, pod)
 	if err == nil {
 		t.Errorf("Expected error, got none")
 	}
@@ -389,7 +388,6 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 }
 
 func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
 	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
 	if err != nil {
 		t.Fatalf("can't make a temp dir: %v", err)
@@ -451,6 +449,7 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 
 		tCtx := ktesting.Init(t)
 		defer tCtx.Cancel("test has completed")
+
 		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 		go manager.Run(tCtx, sourcesReady)
 
@@ -462,7 +461,7 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 			tCtx.Done(),
 			manager)
 
-		err = manager.WaitForAttachAndMount(ctx, pod)
+		err = manager.WaitForAttachAndMount(tCtx, pod)
 		if err != nil {
 			t.Errorf("Expected success: %v", err)
 			continue

--- a/pkg/kubelet/watchdog/watchdog_linux_test.go
+++ b/pkg/kubelet/watchdog/watchdog_linux_test.go
@@ -81,12 +81,14 @@ func TestNewHealthChecker(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+
 			mockClient := &mockWatchdogClient{
 				enabledVal: tt.mockEnabled,
 				enabledErr: tt.mockErr,
 			}
-			logger, _ := ktesting.NewTestContext(t)
-			_, err := NewHealthChecker(logger, WithWatchdogClient(mockClient))
+
+			_, err := NewHealthChecker(tCtx.Logger(), WithWatchdogClient(mockClient))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewHealthChecker() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/proxy/conntrack/sysctls_test.go
+++ b/pkg/proxy/conntrack/sysctls_test.go
@@ -65,12 +65,14 @@ func TestGetConntrackMax(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
+		tCtx := ktesting.Init(t)
+
 		cfg := proxyconfigapi.KubeProxyConntrackConfiguration{
 			Min:        ptr.To(tc.min),
 			MaxPerCore: ptr.To(tc.maxPerCore),
 		}
-		_, ctx := ktesting.NewTestContext(t)
-		x, e := getConntrackMax(ctx, &cfg)
+
+		x, e := getConntrackMax(tCtx, &cfg)
 		if e != nil {
 			if tc.err == "" {
 				t.Errorf("[%d] unexpected error: %v", i, e)
@@ -115,7 +117,8 @@ func (fc *fakeConntracker) SetUDPStreamTimeout(ctx context.Context, seconds int)
 }
 
 func TestSetupConntrack(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	tests := []struct {
 		name         string
 		config       proxyconfigapi.KubeProxyConntrackConfiguration
@@ -226,7 +229,7 @@ func TestSetupConntrack(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fc := &fakeConntracker{err: test.conntrackErr}
-			err := setSysctls(ctx, fc, &test.config)
+			err := setSysctls(tCtx, fc, &test.config)
 			if test.wantErr && err == nil {
 				t.Errorf("Test %q: Expected error, got nil", test.name)
 			}

--- a/pkg/proxy/ipvs/cleanup_test.go
+++ b/pkg/proxy/ipvs/cleanup_test.go
@@ -38,7 +38,8 @@ import (
 )
 
 func TestCleanupLeftovers(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipts := map[v1.IPFamily]utiliptables.Interface{
 		v1.IPv4Protocol: ipt,
@@ -78,7 +79,7 @@ func TestCleanupLeftovers(t *testing.T) {
 		t.Fatalf("Unexpected error setting up iptables state: %v", err)
 	}
 
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcNodePort := 3001
@@ -117,7 +118,7 @@ func TestCleanupLeftovers(t *testing.T) {
 	_ = fp.syncProxyRules()
 
 	// test cleanup left over
-	encounteredError := cleanupLeftovers(ctx, ipvs, ipts, ipset)
+	encounteredError := cleanupLeftovers(tCtx, ipvs, ipts, ipset)
 	if encounteredError {
 		t.Errorf("Cleanup leftovers failed")
 	}

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -834,11 +834,12 @@ func TestNodePortIPv4(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			ipt := iptablestest.NewFake()
 			ipvs := ipvstest.NewFake()
 			ipset := ipsettest.NewFake(testIPSetVersion)
-			fp := NewFakeProxier(ctx, ipt, ipvs, ipset, test.nodeIPs, nil, v1.IPv4Protocol)
+			fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, test.nodeIPs, nil, v1.IPv4Protocol)
 			fp.nodePortAddresses = proxyutil.NewNodePortAddresses(v1.IPv4Protocol, test.nodePortAddresses)
 
 			makeServiceMap(fp, test.services...)
@@ -1177,11 +1178,12 @@ func TestNodePortIPv6(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			ipt := iptablestest.NewFake()
 			ipvs := ipvstest.NewFake()
 			ipset := ipsettest.NewFake(testIPSetVersion)
-			fp := NewFakeProxier(ctx, ipt, ipvs, ipset, test.nodeIPs, nil, v1.IPv6Protocol)
+			fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, test.nodeIPs, nil, v1.IPv6Protocol)
 			fp.nodePortAddresses = proxyutil.NewNodePortAddresses(v1.IPv6Protocol, test.nodePortAddresses)
 
 			makeServiceMap(fp, test.services...)
@@ -1207,11 +1209,12 @@ func TestNodePortIPv6(t *testing.T) {
 }
 
 func Test_syncEndpoint_updateWeightsOnRestart(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 	svc1 := makeTestService("ns1", "svc1", func(svc *v1.Service) {
 		svc.Spec.ClusterIP = "10.20.30.41"
@@ -1405,11 +1408,12 @@ func TestIPv4Proxier(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			ipt := iptablestest.NewFake()
 			ipvs := ipvstest.NewFake()
 			ipset := ipsettest.NewFake(testIPSetVersion)
-			fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+			fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 			makeServiceMap(fp, test.services...)
 			populateEndpointSlices(fp, test.endpoints...)
@@ -1543,11 +1547,12 @@ func TestIPv6Proxier(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			ipt := iptablestest.NewFake()
 			ipvs := ipvstest.NewFake()
 			ipset := ipsettest.NewFake(testIPSetVersion)
-			fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv6Protocol)
+			fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv6Protocol)
 
 			makeServiceMap(fp, test.services...)
 			populateEndpointSlices(fp, test.endpoints...)
@@ -1565,11 +1570,12 @@ func TestIPv6Proxier(t *testing.T) {
 
 func TestMasqueradeRule(t *testing.T) {
 	for _, testcase := range []bool{false, true} {
-		_, ctx := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+
 		ipt := iptablestest.NewFake().SetHasRandomFully(testcase)
 		ipvs := ipvstest.NewFake()
 		ipset := ipsettest.NewFake(testIPSetVersion)
-		fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+		fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 		makeServiceMap(fp)
 		fp.syncProxyRules()
 
@@ -1599,11 +1605,12 @@ func TestMasqueradeRule(t *testing.T) {
 }
 
 func TestExternalIPsNoEndpoint(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcExternalIPs := "50.60.70.81"
@@ -1652,11 +1659,12 @@ func TestExternalIPsNoEndpoint(t *testing.T) {
 }
 
 func TestExternalIPs(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcExternalIPs := sets.New[string]("50.60.70.81", "2012::51", "127.0.0.1")
@@ -1723,11 +1731,12 @@ func TestExternalIPs(t *testing.T) {
 }
 
 func TestOnlyLocalExternalIPs(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcExternalIPs := sets.New[string]("50.60.70.81", "2012::51", "127.0.0.1")
@@ -2351,11 +2360,12 @@ func addTestPort(array []v1.ServicePort, name string, protocol v1.Protocol, port
 }
 
 func TestBuildServiceMapAddRemove(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 	services := []*v1.Service{
 		makeTestService("somewhere-else", "cluster-ip", func(svc *v1.Service) {
@@ -2445,11 +2455,12 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 }
 
 func TestBuildServiceMapServiceHeadless(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 	makeServiceMap(fp,
 		makeTestService("somewhere-else", "headless", func(svc *v1.Service) {
@@ -2482,11 +2493,12 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 }
 
 func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 	makeServiceMap(fp,
 		makeTestService("somewhere-else", "external-name", func(svc *v1.Service) {
@@ -2510,11 +2522,12 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 }
 
 func TestBuildServiceMapServiceUpdate(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 	servicev1 := makeTestService("somewhere", "some-service", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
@@ -2587,12 +2600,13 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 }
 
 func TestSessionAffinity(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	nodeIP := "100.101.102.103"
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, []string{nodeIP}, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, []string{nodeIP}, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcNodePort := 3001
@@ -3337,11 +3351,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 
 	for tci, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			ipt := iptablestest.NewFake()
 			ipvs := ipvstest.NewFake()
 			ipset := ipsettest.NewFake(testIPSetVersion)
-			fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+			fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 			// First check that after adding all previous versions of endpoints,
 			// the fp.oldEndpoints is as we expect.
@@ -3586,11 +3601,12 @@ func Test_syncService(t *testing.T) {
 	}
 
 	for i := range testCases {
-		_, ctx := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+
 		ipt := iptablestest.NewFake()
 		ipvs := ipvstest.NewFake()
 		ipset := ipsettest.NewFake(testIPSetVersion)
-		proxier := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+		proxier := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 		proxier.netlinkHandle.EnsureDummyDevice(defaultDummyDevice)
 		if testCases[i].oldVirtualServer != nil {
@@ -3617,11 +3633,12 @@ func Test_syncService(t *testing.T) {
 }
 
 func buildFakeProxier(t *testing.T) (*iptablestest.FakeIPTables, *Proxier) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	return ipt, NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	return ipt, NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 }
 
 func getRules(ipt *iptablestest.FakeIPTables, chain utiliptables.Chain) []*iptablestest.Rule {
@@ -3710,12 +3727,13 @@ func checkIPVS(t *testing.T, fp *Proxier, vs *netlinktest.ExpectedVirtualServer)
 }
 
 func TestCleanLegacyService(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	excludeCIDRs, _ := netutils.ParseCIDRs([]string{"3.3.3.0/24", "4.4.4.0/24"})
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, excludeCIDRs, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, excludeCIDRs, v1.IPv4Protocol)
 
 	// All ipvs services that were processed in the latest sync loop.
 	activeServices := sets.New("ipvs0", "ipvs1")
@@ -3792,11 +3810,12 @@ func TestCleanLegacyService(t *testing.T) {
 }
 
 func TestCleanLegacyServiceWithRealServers(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 	// all deleted expect ipvs2
 	activeServices := sets.New("ipvs2")
@@ -3862,13 +3881,14 @@ func TestCleanLegacyServiceWithRealServers(t *testing.T) {
 }
 
 func TestCleanLegacyRealServersExcludeCIDRs(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	gtm := NewGracefulTerminationManager(ipvs)
 	excludeCIDRs, _ := netutils.ParseCIDRs([]string{"4.4.4.4/32"})
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, excludeCIDRs, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, excludeCIDRs, v1.IPv4Protocol)
 	fp.gracefuldeleteManager = gtm
 
 	vs := &utilipvs.VirtualServer{
@@ -3915,12 +3935,13 @@ func TestCleanLegacyRealServersExcludeCIDRs(t *testing.T) {
 }
 
 func TestCleanLegacyService6(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	excludeCIDRs, _ := netutils.ParseCIDRs([]string{"3000::/64", "4000::/64"})
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, excludeCIDRs, v1.IPv6Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, excludeCIDRs, v1.IPv6Protocol)
 	fp.nodeIP = netutils.ParseIPSloppy("::1")
 
 	// All ipvs services that were processed in the latest sync loop.
@@ -3998,11 +4019,12 @@ func TestCleanLegacyService6(t *testing.T) {
 }
 
 func TestMultiPortServiceBindAddr(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 
 	service1 := makeTestService("ns1", "svc1", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
@@ -4103,11 +4125,12 @@ raid10 57344 0 - Live 0xffffffffc0597000`,
 // the shared EndpointsChangeTracker and EndpointSliceCache. This test ensures that the
 // ipvs proxier supports translating EndpointSlices to ipvs output.
 func TestEndpointSliceE2E(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	fp.servicesSynced = true
 	fp.endpointSlicesSynced = true
 
@@ -4189,11 +4212,12 @@ func TestEndpointSliceE2E(t *testing.T) {
 }
 
 func TestHealthCheckNodePortE2E(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	fp.servicesSynced = true
 	fp.endpointSlicesSynced = true
 
@@ -4244,11 +4268,12 @@ func TestHealthCheckNodePortE2E(t *testing.T) {
 
 // Test_HealthCheckNodePortWhenTerminating tests that health check node ports are not enabled when all local endpoints are terminating
 func Test_HealthCheckNodePortWhenTerminating(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	fp.servicesSynced = true
 	// fp.endpointsSynced = true
 	fp.endpointSlicesSynced = true
@@ -4389,11 +4414,12 @@ func TestFilterCIDRs(t *testing.T) {
 }
 
 func TestCreateAndLinkKubeChain(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	fp.createAndLinkKubeChain()
 	expectedNATChains := `:KUBE-SERVICES - [0:0]
 :KUBE-POSTROUTING - [0:0]
@@ -4493,11 +4519,12 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		_, ctx := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+
 		ipt := iptablestest.NewFake()
 		ipvs := ipvstest.NewFake()
 		ipset := ipsettest.NewFake(testIPSetVersion)
-		fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+		fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 		fp.servicesSynced = true
 		// fp.endpointsSynced = true
 		fp.endpointSlicesSynced = true
@@ -4590,11 +4617,12 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 // Test_EndpointSliceReadyAndTerminatingCluster tests that when there are ready and ready + terminating
 // endpoints and the traffic policy is "Cluster", only the ready endpoints are used.
 func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	fp.servicesSynced = true
 	// fp.endpointsSynced = true
 	fp.endpointSlicesSynced = true
@@ -4763,11 +4791,12 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 // Test_EndpointSliceReadyAndTerminatingLocal tests that when there are local ready and ready + terminating
 // endpoints, only the ready endpoints are used.
 func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	fp.servicesSynced = true
 	// fp.endpointsSynced = true
 	fp.endpointSlicesSynced = true
@@ -4935,11 +4964,12 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 // Test_EndpointSliceOnlyReadyTerminatingCluster tests that when there are only ready terminating
 // endpoints and the traffic policy is "Cluster",  we fall back to terminating endpoints.
 func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	fp.servicesSynced = true
 	// fp.endpointsSynced = true
 	fp.endpointSlicesSynced = true
@@ -5107,11 +5137,12 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 // Test_EndpointSliceOnlyReadyTerminatingLocal tests that when there are only local ready terminating
 // endpoints, we fall back to those endpoints.
 func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
-	fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
+	fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	fp.servicesSynced = true
 	// fp.endpointsSynced = true
 	fp.endpointSlicesSynced = true
@@ -5450,11 +5481,12 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		_, ctx := ktesting.NewTestContext(t)
+		tCtx := ktesting.Init(t)
+
 		ipt := iptablestest.NewFake()
 		ipvs := ipvstest.NewFake()
 		ipset := ipsettest.NewFake(testIPSetVersion)
-		fp := NewFakeProxier(ctx, ipt, ipvs, ipset, []string{"10.0.0.1"}, nil, v1.IPv4Protocol)
+		fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, []string{"10.0.0.1"}, nil, v1.IPv4Protocol)
 		fp.servicesSynced = true
 		// fp.endpointsSynced = true
 		fp.endpointSlicesSynced = true
@@ -5546,14 +5578,15 @@ func TestDismissLocalhostRuleExist(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			ipt := iptablestest.NewFake()
 			if test.ipFamily == v1.IPv6Protocol {
 				ipt = iptablestest.NewIPv6Fake()
 			}
 			ipvs := ipvstest.NewFake()
 			ipset := ipsettest.NewFake(testIPSetVersion)
-			fp := NewFakeProxier(ctx, ipt, ipvs, ipset, nil, nil, test.ipFamily)
+			fp := NewFakeProxier(tCtx, ipt, ipvs, ipset, nil, nil, test.ipFamily)
 
 			fp.syncProxyRules()
 

--- a/pkg/proxy/ipvs/supported_test.go
+++ b/pkg/proxy/ipvs/supported_test.go
@@ -27,7 +27,8 @@ import (
 )
 
 func TestCanUseIPVSProxier(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	testCases := []struct {
 		name         string
 		scheduler    string
@@ -77,7 +78,7 @@ func TestCanUseIPVSProxier(t *testing.T) {
 	for _, tc := range testCases {
 		ipvs := &fakeIpvs{tc.ipvsErr, false}
 		versioner := &fakeIPSetVersioner{version: tc.ipsetVersion, err: tc.ipsetErr}
-		err := CanUseIPVSProxier(ctx, ipvs, versioner, tc.scheduler)
+		err := CanUseIPVSProxier(tCtx, ipvs, versioner, tc.scheduler)
 		if (err == nil) != tc.ok {
 			t.Errorf("Case [%s], expect %v, got err: %v", tc.name, tc.ok, err)
 		}

--- a/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources_test.go
@@ -262,8 +262,9 @@ func Test_createRequestsAndMappings_requests(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
-			gotDeviceRequests, _ := createRequestsAndMappings(tc.pod, tc.extendedResources, logger, tc.cache)
+			tCtx := ktesting.Init(t)
+
+			gotDeviceRequests, _ := createRequestsAndMappings(tc.pod, tc.extendedResources, tCtx.Logger(), tc.cache)
 			if len(tc.wantDeviceRequests) != len(gotDeviceRequests) {
 				t.Fatalf("different length, want %#v, len=%v, got %#v, len=%v", tc.wantDeviceRequests, len(tc.wantDeviceRequests), gotDeviceRequests, len(gotDeviceRequests))
 			}
@@ -535,8 +536,9 @@ func Test_createRequestsAndMappings_mappings(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
-			_, gotReqMappings := createRequestsAndMappings(tc.pod, tc.extnededResources, logger, tc.deviceClassMapping)
+			tCtx := ktesting.Init(t)
+
+			_, gotReqMappings := createRequestsAndMappings(tc.pod, tc.extnededResources, tCtx.Logger(), tc.deviceClassMapping)
 			if len(tc.wantReqMappings) != len(gotReqMappings) {
 				t.Fatalf("different length, want %#v, got %#v", tc.wantReqMappings, gotReqMappings)
 			}

--- a/pkg/scheduler/framework/plugins/nodename/node_name_test.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name_test.go
@@ -56,14 +56,16 @@ func TestNodeName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+
 			nodeInfo := framework.NewNodeInfo()
 			nodeInfo.SetNode(test.node)
-			_, ctx := ktesting.NewTestContext(t)
-			p, err := New(ctx, nil, nil, feature.Features{})
+
+			p, err := New(tCtx, nil, nil, feature.Features{})
 			if err != nil {
 				t.Fatalf("creating plugin: %v", err)
 			}
-			gotStatus := p.(fwk.FilterPlugin).Filter(ctx, nil, test.pod, nodeInfo)
+			gotStatus := p.(fwk.FilterPlugin).Filter(tCtx, nil, test.pod, nodeInfo)
 			if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
 				t.Errorf("status does not match (-want,+got):\n%s", diff)
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -471,9 +471,9 @@ func TestBalancedAllocationSignPod(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
 
-			p, err := NewBalancedAllocation(ctx, &config.NodeResourcesBalancedAllocationArgs{}, nil, feature.Features{
+			p, err := NewBalancedAllocation(tCtx, &config.NodeResourcesBalancedAllocationArgs{}, nil, feature.Features{
 				EnableDRAExtendedResource: test.enableDRAExtendedResource,
 			})
 			if err != nil {
@@ -481,7 +481,7 @@ func TestBalancedAllocationSignPod(t *testing.T) {
 			}
 
 			ba := p.(*BalancedAllocation)
-			fragments, status := ba.SignPod(ctx, test.pod)
+			fragments, status := ba.SignPod(tCtx, test.pod)
 
 			if status.Code() != test.expectedStatusCode {
 				t.Errorf("unexpected status code, want: %v, got: %v, message: %v", test.expectedStatusCode, status.Code(), status.Message())

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -76,14 +76,16 @@ func TestNodeUnschedulable(t *testing.T) {
 	}
 
 	for _, test := range testCases {
+		tCtx := ktesting.Init(t)
+
 		nodeInfo := framework.NewNodeInfo()
 		nodeInfo.SetNode(test.node)
-		_, ctx := ktesting.NewTestContext(t)
-		p, err := New(ctx, nil, nil, feature.Features{})
+
+		p, err := New(tCtx, nil, nil, feature.Features{})
 		if err != nil {
 			t.Fatalf("creating plugin: %v", err)
 		}
-		gotStatus := p.(fwk.FilterPlugin).Filter(ctx, nil, test.pod, nodeInfo)
+		gotStatus := p.(fwk.FilterPlugin).Filter(tCtx, nil, test.pod, nodeInfo)
 		if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
 			t.Errorf("status does not match (-want,+got):\n%s", diff)
 		}
@@ -198,9 +200,10 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			pl := &NodeUnschedulable{}
-			got, err := pl.isSchedulableAfterNodeChange(logger, testCase.pod, testCase.oldObj, testCase.newObj)
+			got, err := pl.isSchedulableAfterNodeChange(tCtx.Logger(), testCase.pod, testCase.oldObj, testCase.newObj)
 			if err != nil && !testCase.expectedErr {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -259,9 +262,10 @@ func TestIsSchedulableAfterPodTolerationChange(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			pl := &NodeUnschedulable{}
-			got, err := pl.isSchedulableAfterPodTolerationChange(logger, testCase.pod, testCase.oldObj, testCase.newObj)
+			got, err := pl.isSchedulableAfterPodTolerationChange(tCtx.Logger(), testCase.pod, testCase.oldObj, testCase.newObj)
 			if err != nil && !testCase.expectedErr {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
@@ -49,13 +49,14 @@ func TestPreEnqueue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			p, err := New(ctx, nil, nil, feature.Features{})
+			tCtx := ktesting.Init(t)
+
+			p, err := New(tCtx, nil, nil, feature.Features{})
 			if err != nil {
 				t.Fatalf("Creating plugin: %v", err)
 			}
 
-			got := p.(fwk.PreEnqueuePlugin).PreEnqueue(ctx, tt.pod)
+			got := p.(fwk.PreEnqueuePlugin).PreEnqueue(tCtx, tt.pod)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("unexpected status (-want, +got):\n%s", diff)
 			}
@@ -98,12 +99,13 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
-			p, err := New(ctx, nil, nil, feature.Features{})
+			tCtx := ktesting.Init(t)
+
+			p, err := New(tCtx, nil, nil, feature.Features{})
 			if err != nil {
 				t.Fatalf("Creating plugin: %v", err)
 			}
-			actualHint, err := p.(*SchedulingGates).isSchedulableAfterUpdatePodSchedulingGatesEliminated(logger, tc.pod, tc.oldObj, tc.newObj)
+			actualHint, err := p.(*SchedulingGates).isSchedulableAfterUpdatePodSchedulingGatesEliminated(tCtx.Logger(), tc.pod, tc.oldObj, tc.newObj)
 			if tc.expectedErr {
 				require.Error(t, err)
 				return

--- a/pkg/scheduler/framework/plugins/volumebinding/assume_cache_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/assume_cache_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 func TestPVAssumeCache(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
 	informer := &testInformer{
 		indexer: cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
 		t:       t,

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -1211,11 +1211,12 @@ func TestNodeInfoRemovePod(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			ni := fakeNodeInfo(pods...)
 
 			gen := ni.Generation
-			err := ni.RemovePod(logger, test.pod)
+			err := ni.RemovePod(tCtx.Logger(), test.pod)
 			if err != nil {
 				if test.errExpected {
 					expectedErrorMsg := fmt.Errorf("no corresponding pod %s in pods of node %s", test.pod.Name, ni.Node().Name)

--- a/test/e2e/framework/internal/unittests/cleanup/cleanup_test.go
+++ b/test/e2e/framework/internal/unittests/cleanup/cleanup_test.go
@@ -206,8 +206,9 @@ func TestCleanup(t *testing.T) {
 	//   skip its own helper functions. That's okay, normally
 	//   ktesting should not be installed as logging backend like this.
 	// - klog.Infof messages are printed with an extra newline.
-	logger, _ := ktesting.NewTestContext(t)
-	klog.SetLogger(logger)
+	tCtx := ktesting.Init(t)
+
+	klog.SetLogger(tCtx.Logger())
 
 	apiServer := testapiserver.StartAPITestServer(t)
 

--- a/test/integration/apimachinery/watch_restart_test.go
+++ b/test/integration/apimachinery/watch_restart_test.go
@@ -67,7 +67,7 @@ func TestWatchRestartsIfTimeoutNotReached(t *testing.T) {
 	// Has to be longer than 5 seconds
 	timeout := 30 * time.Second
 
-	logger, _ := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--min-request-timeout=7"}, framework.SharedEtcd())
 	defer server.TearDownFn()
@@ -202,7 +202,7 @@ func TestWatchRestartsIfTimeoutNotReached(t *testing.T) {
 				// since the watcher is driven by an informer it is crucial to start producing only after the informer has synced
 				// otherwise we might not get all expected events since the informer LIST (or watchelist) and only then WATCHES
 				// all events received during the initial LIST (or watchlist) will be seen as a single event (to most recent version of an obj)
-				_, informer, w, done := watchtools.NewIndexerInformerWatcherWithLogger(logger, lw, &corev1.Secret{})
+				_, informer, w, done := watchtools.NewIndexerInformerWatcherWithLogger(tCtx.Logger(), lw, &corev1.Secret{})
 				cache.WaitForCacheSync(context.TODO().Done(), informer.HasSynced)
 				return w, nil, func() { <-done }
 			},

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -1848,7 +1848,8 @@ func TestGetScaleSubresourceAsTableForAllBuiltins(t *testing.T) {
 			groupVersion, _ := schema.ParseGroupVersion(resourceList.GroupVersion)
 
 			t.Run(resourceName, func(t *testing.T) {
-				_, ctx := ktesting.NewTestContext(t)
+				tCtx := ktesting.Init(t)
+
 				scaleResourceObjName := fmt.Sprintf("%s.%s", resourceName, resourceList.GroupVersion)
 				obj, ok := scaleResources[scaleResourceObjName]
 				if !ok {
@@ -1871,7 +1872,7 @@ func TestGetScaleSubresourceAsTableForAllBuiltins(t *testing.T) {
 				err = client.Post().
 					NamespaceIfScoped(testNamespace, resource.Namespaced).Resource(resourceName).
 					VersionedParams(&metav1.CreateOptions{}, metav1.ParameterCodec).
-					Body(obj).Do(ctx).Error()
+					Body(obj).Do(tCtx).Error()
 				if err != nil {
 					t.Fatalf("failed to create object: %v", err)
 				}
@@ -1885,7 +1886,7 @@ func TestGetScaleSubresourceAsTableForAllBuiltins(t *testing.T) {
 					SetHeader("Accept", "application/json;as=Table;g=meta.k8s.io;v=v1").
 					Name(metaAccessor.GetName()).
 					SubResource("scale").
-					Do(ctx)
+					Do(tCtx)
 				resObj, err := res.Get()
 				if err != nil {
 					t.Fatalf("failed to retrieve object from response: %v", err)

--- a/test/integration/apiserver/cel/admission_policy_test.go
+++ b/test/integration/apiserver/cel/admission_policy_test.go
@@ -426,7 +426,8 @@ func TestPolicyAdmission(t *testing.T) {
 }
 
 func testPolicyAdmission(t *testing.T, supportV1Beta1 bool) {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+
 	supportedVersions := []string{}
 	if supportV1Beta1 {
 		supportedVersions = append(supportedVersions, "v1beta1")
@@ -466,7 +467,7 @@ func testPolicyAdmission(t *testing.T, supportV1Beta1 bool) {
 	// create CRDs
 	etcd.CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(server.ClientConfig), false, etcd.GetCustomResourceDefinitionData()...)
 
-	if _, err := client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}, metav1.CreateOptions{}); err != nil {
+	if _, err := client.CoreV1().Namespaces().Create(tCtx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -563,11 +564,11 @@ func testPolicyAdmission(t *testing.T, supportV1Beta1 bool) {
 	}
 
 	if supportV1Beta1 {
-		if err := createV1beta1ValidatingPolicyAndBinding(ctx, client, convertedV1beta1Rules); err != nil {
+		if err := createV1beta1ValidatingPolicyAndBinding(tCtx, client, convertedV1beta1Rules); err != nil {
 			t.Fatal(err)
 		}
 	} else {
-		if err := createV1ValidatingPolicyAndBinding(ctx, client, convertedV1Rules); err != nil {
+		if err := createV1ValidatingPolicyAndBinding(tCtx, client, convertedV1Rules); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -577,13 +578,13 @@ func testPolicyAdmission(t *testing.T, supportV1Beta1 bool) {
 			Name: "test-k8s",
 		},
 	}
-	_, err = client.CoreV1().ConfigMaps(testNamespace).Create(ctx, &testConfigmap, metav1.CreateOptions{})
+	_, err = client.CoreV1().ConfigMaps(testNamespace).Create(tCtx, &testConfigmap, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to patch the configmap and look for the warning message.
-	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*100, time.Second*5, false, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(tCtx, time.Millisecond*100, time.Second*5, false, func(ctx context.Context) (bool, error) {
 		holder.reset(t)
 		_, err = client.CoreV1().ConfigMaps(testNamespace).Patch(ctx, testConfigmap.Name, types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
 		if err != nil {
@@ -599,7 +600,7 @@ func testPolicyAdmission(t *testing.T, supportV1Beta1 bool) {
 		t.Errorf("timed out waiting policy and binding to establish: %v", err)
 	}
 
-	err = client.CoreV1().ConfigMaps(testNamespace).Delete(ctx, testConfigmap.Name, metav1.DeleteOptions{})
+	err = client.CoreV1().ConfigMaps(testNamespace).Delete(tCtx, testConfigmap.Name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Errorf("failed to delete ConfigMap with error: %+v", err)
 	}

--- a/test/integration/scheduler/batch/batch_test.go
+++ b/test/integration/scheduler/batch/batch_test.go
@@ -496,7 +496,7 @@ type batchGetter interface {
 }
 
 func runScenario(t *testing.T, tt *scenario, batch bool) ([]*v1.Pod, []bool) {
-	_, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 
 	cfg, err := newDefaultComponentConfig()
 	if err != nil {

--- a/test/integration/scheduler/bind/bind_test.go
+++ b/test/integration/scheduler/bind/bind_test.go
@@ -40,8 +40,9 @@ func TestDefaultBinder(t *testing.T) {
 			testCtx := testutil.InitTestSchedulerWithOptions(t, testutil.InitTestAPIServer(t, "", nil), 0)
 			testutil.SyncSchedulerInformerFactory(testCtx)
 			if testCtx.Scheduler.APIDispatcher != nil {
-				logger, _ := ktesting.NewTestContext(t)
-				testCtx.Scheduler.APIDispatcher.Run(logger)
+				tCtx := ktesting.Init(t)
+
+				testCtx.Scheduler.APIDispatcher.Run(tCtx.Logger())
 				defer testCtx.Scheduler.APIDispatcher.Close()
 			}
 

--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -543,7 +543,9 @@ func TestPreemptionAndNominatedNodeNameScenarios(t *testing.T) {
 						t.Fatalf("the preemption plugin should be initialized")
 					}
 
-					logger, _ := ktesting.NewTestContext(t)
+					tCtx := ktesting.Init(t)
+					logger := tCtx.Logger()
+
 					if testCtx.Scheduler.APIDispatcher != nil {
 						testCtx.Scheduler.APIDispatcher.Run(logger)
 						defer testCtx.Scheduler.APIDispatcher.Close()

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1335,7 +1335,9 @@ func TestAsyncPreemption(t *testing.T) {
 					t.Fatalf("the preemption plugin should be initialized")
 				}
 
-				logger, _ := ktesting.NewTestContext(t)
+				tCtx := ktesting.Init(t)
+				logger := tCtx.Logger()
+
 				if testCtx.Scheduler.APIDispatcher != nil {
 					testCtx.Scheduler.APIDispatcher.Run(logger)
 					defer testCtx.Scheduler.APIDispatcher.Close()

--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -2703,6 +2703,8 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 // TestCoreResourceEnqueue verify Pods failed by in-tree default plugins can be
 // moved properly upon their registered events.
 func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
+	tCtx := ktesting.Init(t)
+
 	t.Helper()
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 	if tt.EnableDRAExtendedResource {
@@ -2731,7 +2733,6 @@ func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
 			features.GangScheduling:  true,
 		})
 	}
-	logger, _ := ktesting.NewTestContext(t)
 
 	opts := []scheduler.Option{scheduler.WithPodInitialBackoffSeconds(0), scheduler.WithPodMaxBackoffSeconds(0)}
 	if tt.EnablePlugins != nil {
@@ -2771,7 +2772,7 @@ func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
 	)
 	testutils.SyncSchedulerInformerFactory(testCtx)
 
-	testCtx.Scheduler.SchedulingQueue.Run(logger)
+	testCtx.Scheduler.SchedulingQueue.Run(tCtx.Logger())
 	defer testCtx.Scheduler.SchedulingQueue.Close()
 
 	cs, ns, ctx := testCtx.ClientSet, testCtx.NS.Name, testCtx.Ctx

--- a/test/integration/scheduler/queueing/queue_test.go
+++ b/test/integration/scheduler/queueing/queue_test.go
@@ -114,8 +114,9 @@ func TestSchedulingGates(t *testing.T) {
 			testutils.SyncSchedulerInformerFactory(testCtx)
 
 			if testCtx.Scheduler.APIDispatcher != nil {
-				logger, _ := ktesting.NewTestContext(t)
-				testCtx.Scheduler.APIDispatcher.Run(logger)
+				tCtx := ktesting.Init(t)
+
+				testCtx.Scheduler.APIDispatcher.Run(tCtx.Logger())
 				defer testCtx.Scheduler.APIDispatcher.Close()
 			}
 

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -213,7 +213,8 @@ func TestRunOp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, tCtx := ktesting.NewTestContext(t)
+			tCtx := ktesting.Init(t)
+
 			client := fake.NewSimpleClientset()
 			tCtx = ktesting.WithClients(tCtx, nil, nil, client, nil, nil)
 

--- a/test/utils/ktesting/ktesting.go
+++ b/test/utils/ktesting/ktesting.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/klog/v2"
-
 	// Initialize command line parameters.
 	_ "k8s.io/component-base/logs/testinit"
 )
@@ -45,7 +43,7 @@ func SetDefaultVerbosity(v int) {
 
 // NewTestContext is a replacement for ktesting.NewTestContext
 // which returns a more versatile context.
-func NewTestContext(tb testing.TB) (klog.Logger, TContext) {
-	tCtx := Init(tb)
-	return tCtx.Logger(), tCtx
+// Prefer directly using ktesting.Init.
+func NewTestContext(tb testing.TB) TContext {
+	return Init(tb)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This is a follow up from previous review comment from another PR: https://github.com/kubernetes/kubernetes/pull/136341#discussion_r2708156865

1. Changed the signature of NewTestContext function to return only TContext.
2. Refactored the callers of NewTestContext to use ktensting.Init() directly.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
