### PR TITLE
DRA: support non-pod references in ReservedFor

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -841,7 +841,9 @@ func (ec *Controller) syncClaim(ctx context.Context, namespace, name string) err
 		return err
 	}
 
-	// Check if the ReservedFor entries are all still valid.
+	// Check if the ReservedFor entries are all still valid. Essentially we are
+	// validating and potentially removing pod references, but just leaving any
+	// non-pod references in the list.
 	valid := make([]resourceapi.ResourceClaimConsumerReference, 0, len(claim.Status.ReservedFor))
 	for _, reservedFor := range claim.Status.ReservedFor {
 		if reservedFor.APIGroup == "" &&

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -897,8 +897,11 @@ func (ec *Controller) syncClaim(ctx context.Context, namespace, name string) err
 			continue
 		}
 
+		// We don't know how to check this entry, so we just keep it to avoid
+		// accidentally removing a reservation for a non-pod consumer that we
+		// don't support yet.
 		// TODO: support generic object lookup
-		return fmt.Errorf("unsupported ReservedFor entry: %v", reservedFor)
+		valid = append(valid, reservedFor)
 	}
 
 	builtinControllerFinalizer := slices.Index(claim.Finalizers, resourceapi.Finalizer)

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -844,7 +844,7 @@ func (ec *Controller) syncClaim(ctx context.Context, namespace, name string) err
 	// Check if the ReservedFor entries are all still valid. Essentially we are
 	// validating and potentially removing pod references, but just leaving any
 	// non-pod references in the list.
-	valid := make([]resourceapi.ResourceClaimConsumerReference, 0, len(claim.Status.ReservedFor))
+	remaining := make([]resourceapi.ResourceClaimConsumerReference, 0, len(claim.Status.ReservedFor))
 	for _, reservedFor := range claim.Status.ReservedFor {
 		if reservedFor.APIGroup == "" &&
 			reservedFor.Resource == "pods" {
@@ -894,7 +894,7 @@ func (ec *Controller) syncClaim(ctx context.Context, namespace, name string) err
 			}
 
 			if keepEntry {
-				valid = append(valid, reservedFor)
+				remaining = append(remaining, reservedFor)
 			}
 			continue
 		}
@@ -902,17 +902,16 @@ func (ec *Controller) syncClaim(ctx context.Context, namespace, name string) err
 		// We don't know how to check this entry, so we just keep it to avoid
 		// accidentally removing a reservation for a non-pod consumer that we
 		// don't support yet.
-		// TODO: support generic object lookup
-		valid = append(valid, reservedFor)
+		remaining = append(remaining, reservedFor)
 	}
 
 	builtinControllerFinalizer := slices.Index(claim.Finalizers, resourceapi.Finalizer)
-	logger.V(5).Info("Claim reserved for counts", "currentCount", len(claim.Status.ReservedFor), "claim", klog.KRef(namespace, name), "updatedCount", len(valid), "builtinController", builtinControllerFinalizer >= 0)
-	if len(valid) < len(claim.Status.ReservedFor) {
+	logger.V(5).Info("Claim reserved for counts", "currentCount", len(claim.Status.ReservedFor), "claim", klog.KRef(namespace, name), "updatedCount", len(remaining), "builtinController", builtinControllerFinalizer >= 0)
+	if len(remaining) < len(claim.Status.ReservedFor) {
 		// This is not using a patch because we want the update to fail if anything
 		// changed in the meantime.
 		claim := claim.DeepCopy()
-		claim.Status.ReservedFor = valid
+		claim.Status.ReservedFor = remaining
 
 		// DRA always performs delayed allocations. Relatedly, it also
 		// deallocates a claim as soon as the last consumer stops using
@@ -930,7 +929,7 @@ func (ec *Controller) syncClaim(ctx context.Context, namespace, name string) err
 		// those, the resource claim controller will trigger deletion when the
 		// pod is done. However, it doesn't hurt to also trigger deallocation
 		// for such claims and not checking for them keeps this code simpler.
-		if len(valid) == 0 {
+		if len(remaining) == 0 {
 			// This is a sanity check. There shouldn't be any claims without this
 			// finalizer because there's no longer any other way of allocating claims.
 			// Classic DRA was the alternative earlier.
@@ -955,7 +954,7 @@ func (ec *Controller) syncClaim(ctx context.Context, namespace, name string) err
 				return err
 			}
 		}
-	} else if builtinControllerFinalizer >= 0 && claim.DeletionTimestamp != nil && len(valid) == 0 {
+	} else if builtinControllerFinalizer >= 0 && claim.DeletionTimestamp != nil && len(remaining) == 0 {
 		claim := claim.DeepCopy()
 		if claim.Status.Allocation != nil {
 			// This can happen when a claim with immediate allocation
@@ -976,7 +975,7 @@ func (ec *Controller) syncClaim(ctx context.Context, namespace, name string) err
 		}
 	}
 
-	if len(valid) == 0 {
+	if len(remaining) == 0 {
 		// Claim is not reserved. If it was generated for a pod and
 		// that pod is not going to run, the claim can be
 		// deleted. Normally the garbage collector does that, but the


### PR DESCRIPTION
Closing previous PR #136430 due to a local environment error that caused a massive accidental force-push. This new PR contains the clean, targeted fix and addresses the feedback from @troychiu.

Problem: TheResourceClaim controller would fail to process and clean up stale pod references if it encountered any non-pod references in the status.reservedFor field. This halted the controller's operation, preventing necessary cleanup.

Solution: Modified the syncClaim function to gracefully handle unknown (non-pod) ReservedFor entries. Instead of returning an error, it now logs a message and continues processing, ensuring that valid pod references can still be cleaned up.

Changes:

Updated pkg/controller/resourceclaim/controller.go to keep unknown references and continue processing.
Integrated a regression test case into the TestSyncHandler suite in pkg/controller/resourceclaim/controller_test.go
using realistic test data (testPodWithResource).
/kind feature

Added support for unknown (non-pod) references in ResourceClaim `status.reservedFor`. The controller now gracefully ignores these entries instead of returning an error, ensuring that stale pod references can still be cleaned up.

### Does this PR introduce a user-facing change?
```release-note
The ResourceClaim controller now correctly handles unknown (non-pod) references in the status.reservedFor field by skipping them instead of halting the sync process.
```