### PR TITLE
Fix preStop sleep lifecycle hook to terminate when container exits

### DIFF
--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -94,7 +94,7 @@ func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.Cont
 		}
 		return msg, err
 	case handler.Sleep != nil:
-		err := hr.runSleepHandler(ctx, handler.Sleep.Seconds)
+		err := hr.runSleepHandler(ctx, containerID, pod, handler.Sleep.Seconds)
 		var msg string
 		if err != nil {
 			msg = fmt.Sprintf("Sleep lifecycle hook (%d) for Container %q in Pod %q failed - error: %v", handler.Sleep.Seconds, container.Name, format.Pod(pod), err)
@@ -109,18 +109,50 @@ func (hr *handlerRunner) Run(ctx context.Context, containerID kubecontainer.Cont
 	}
 }
 
-func (hr *handlerRunner) runSleepHandler(ctx context.Context, seconds int64) error {
+func (hr *handlerRunner) runSleepHandler(ctx context.Context, containerID kubecontainer.ContainerID, pod *v1.Pod, seconds int64) error {
+	logger := klog.FromContext(ctx)
 	if !utilfeature.DefaultFeatureGate.Enabled(features.PodLifecycleSleepAction) {
 		return nil
 	}
-	c := time.After(time.Duration(seconds) * time.Second)
-	select {
-	case <-ctx.Done():
-		// unexpected termination
-		metrics.LifecycleHandlerSleepTerminated.Inc()
-		return fmt.Errorf("container terminated before sleep hook finished")
-	case <-c:
-		return nil
+
+	// Create a ticker to poll container status periodically
+	// We check every 250ms to detect container exit quickly while minimizing overhead
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	deadline := time.After(time.Duration(seconds) * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Context canceled (e.g., grace period expired)
+			metrics.LifecycleHandlerSleepTerminated.Inc()
+			return fmt.Errorf("context canceled before sleep hook finished")
+		case <-deadline:
+			// Sleep completed successfully
+			return nil
+		case <-ticker.C:
+			// Check if container has exited
+			status, err := hr.containerManager.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
+			if err != nil {
+				logger.V(4).Info("Failed to get pod status during sleep hook, continuing", "pod", klog.KObj(pod), "error", err)
+				continue
+			}
+
+			// Find the container in the status
+			for _, containerStatus := range status.ContainerStatuses {
+				if containerStatus.ID == containerID {
+					// Check if container has exited (state is Exited or Unknown)
+					if containerStatus.State == kubecontainer.ContainerStateExited ||
+						containerStatus.State == kubecontainer.ContainerStateUnknown {
+						logger.V(2).Info("Container exited during sleep hook, terminating sleep early",
+							"pod", klog.KObj(pod), "containerID", containerID.String(), "containerState", containerStatus.State)
+						return nil
+					}
+					break
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:

This PR to continues the work started by @vietcgi in #134839. It addresses the PR feedback received there from @bart0sh and resolves the merge conflict. It seems the original author is busy elsewhere so I've done this in hopes of getting this fix across the line. I hope that's ok. All credit to @vietcgi.

From the original PR:

Fixes the preStop sleep lifecycle hook to terminate early when the container's main process exits, instead of continuing for the full sleep duration.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #134338
Closes #134839

#### Special notes for your reviewer:

```console
$ make test WHAT=./pkg/kubelet/lifecycle
+ KUBE_TIMEOUT=-timeout=180s
+ KUBE_COVER=n
+ KUBE_COVERMODE=atomic
+ KUBE_COVER_REPORT_DIR=
+ KUBE_RACE=-race
+ KUBE_GOVERALLS_BIN=
+ KUBE_JUNIT_REPORT_DIR=
+ [[ -z '' ]]
+ [[ -n '' ]]
+ KUBE_KEEP_VERBOSE_TEST_OUTPUT=n
+ KUBE_PRUNE_JUNIT_TESTS=true
+ set +x
+++ [0122 21:39:38] Normalizing Go targets
+++ [0122 21:39:38] Running tests without code coverage and with -race
+++ [0122 21:39:38] gotestsum --format=pkgname-and-test-fails --jsonfile= --junitfile= --raw-command -- go test -json -race -timeout=180s k8s.io/kubernetes/pkg/kubelet/lifecycle
✓  pkg/kubelet/lifecycle (4.63s)

DONE 90 tests in 7.114s
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug causing a pod's preStop sleep lifecycle hook to run for its full duration after a pod is terminated even if the pod exits on its own in the meantime.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig node
/area kubelet
/priority important-soon