### PR TITLE
Log error when UpdatePod finds no existing PodGroup for the pod

### DIFF
--- a/pkg/scheduler/backend/workloadmanager/podgroupstate.go
+++ b/pkg/scheduler/backend/workloadmanager/podgroupstate.go
@@ -17,12 +17,14 @@ limitations under the License.
 package workloadmanager
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
 
@@ -38,6 +40,19 @@ type podGroupKey struct {
 	podGroupName string
 	replicaKey   string
 }
+
+func (pgk podGroupKey) GetName() string {
+	if pgk.replicaKey == "" {
+		return fmt.Sprintf("%s-%s", pgk.workloadName, pgk.podGroupName)
+	}
+	return fmt.Sprintf("%s-%s-%s", pgk.workloadName, pgk.podGroupName, pgk.replicaKey)
+}
+
+func (pgk podGroupKey) GetNamespace() string {
+	return pgk.namespace
+}
+
+var _ klog.KMetadata = &podGroupKey{}
 
 func newPodGroupKey(namespace string, workloadRef *v1.WorkloadReference) podGroupKey {
 	return podGroupKey{

--- a/pkg/scheduler/backend/workloadmanager/workloadmanager.go
+++ b/pkg/scheduler/backend/workloadmanager/workloadmanager.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 )
 
@@ -46,12 +47,15 @@ type workloadManager struct {
 
 	// podGroupStates stores the runtime state for each known pod group.
 	podGroupStates map[podGroupKey]*podGroupState
+
+	logger klog.Logger
 }
 
 // New initializes a new workload manager and returns it.
-func New() *workloadManager {
+func New(logger klog.Logger) *workloadManager {
 	return &workloadManager{
 		podGroupStates: make(map[podGroupKey]*podGroupState),
+		logger:         logger,
 	}
 }
 
@@ -89,6 +93,7 @@ func (wm *workloadManager) UpdatePod(oldPod, newPod *v1.Pod) {
 		state = newPodGroupState()
 		wm.podGroupStates[key] = state
 		state.addPod(newPod)
+		wm.logger.Error(nil, "UpdatePod found no existing PodGroup for pod. Created new PodGroup for the pod", "pod", klog.KObj(newPod), "podGroupKey", klog.KObj(key))
 		return
 	}
 	state.updatePod(oldPod, newPod)

--- a/pkg/scheduler/backend/workloadmanager/workloadmanager_test.go
+++ b/pkg/scheduler/backend/workloadmanager/workloadmanager_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2/ktesting"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
@@ -76,7 +77,9 @@ func TestWorkloadManager_AddPod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := New()
+			logger, _ := ktesting.NewTestContext(t)
+
+			manager := New(logger)
 			for _, p := range tt.initPods {
 				manager.AddPod(p)
 			}
@@ -178,7 +181,9 @@ func TestWorkloadManager_UpdatePod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := New()
+			logger, _ := ktesting.NewTestContext(t)
+
+			manager := New(logger)
 
 			manager.AddPod(tt.oldPod)
 			if tt.assumePod {
@@ -250,7 +255,9 @@ func TestWorkloadManager_DeletePod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := New()
+			logger, _ := ktesting.NewTestContext(t)
+
+			manager := New(logger)
 			for _, p := range tt.initPods {
 				manager.AddPod(p)
 			}

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gangscheduling
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -260,11 +259,8 @@ func TestGangSchedulingFlow(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-
-			manager := workloadmanager.New()
+			logger, ctx := ktesting.NewTestContext(t)
+			manager := workloadmanager.New(logger)
 
 			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
 			workloadInformer := informerFactory.Scheduling().V1alpha1().Workloads()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -350,7 +350,7 @@ func New(ctx context.Context,
 	}
 	var workloadManager internalworkloadmanager.WorkloadManager
 	if feature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
-		workloadManager = internalworkloadmanager.New()
+		workloadManager = internalworkloadmanager.New(logger)
 	}
 
 	profiles, err := profile.NewMap(ctx, options.profiles, registry, recorderFactory,


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Workload manager gracefully handles the case when UpdatePod is called for a pod within a workload, but no existing PodGroup is found for the specified Pod.
While this case should not crash the operation, it should be logged, since it may signal inconsistencies in kubescheduler.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
