### PR TITLE
Add missing tests for kubectl describe commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -7523,7 +7523,7 @@ func TestDescribeReplicaSet(t *testing.T) {
 			for _, pod := range testCase.pods {
 				objects = append(objects, &pod)
 			}
-			fake := fake.NewSimpleClientset(objects...)
+			fake := fake.NewClientset(objects...)
 			c := &describeClient{T: t, Namespace: "foo", Interface: fake}
 			d := ReplicaSetDescriber{c}
 			out, err := d.Describe(testCase.replicaSet.Namespace, testCase.replicaSet.Name, DescriberSettings{ShowEvents: true})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds basic test for several describers that were missing tests:
- ReplicaSet
- CronJob
- Role
- ClusterRole
- RoleBinding
- ClusterRoleBinding
- CertificateSigningRequest

#### Which issue(s) this PR is related to:

Fixes #136460 

#### Special notes for your reviewer:

Deprecated resources (Endpoints, ReplicationController) and resources already tested under different API groups are intentionally excluded.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
N/A
```