### PR TITLE
refactor image-util script that builds e2e test-images

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -259,7 +259,7 @@ dependencies:
 
   # GCB docker gcloud image
   - name: "gcb-docker-gcloud: dependents"
-    version: v20240523-a15ad90fc9@sha256:bb04162508c2c61637eae700a0d8e8c8be8f2d4c831d2b75e59db2d4dd6cf75d
+    version: v20260108-7f313c340e@sha256:4d778a001ae3f4247b2b61d8a870319e71d66c87556969a6399b90972e4d0491
     refPaths:
     - path: build/pause/cloudbuild.yaml
       match: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -20,7 +20,7 @@ IMAGE = $(REGISTRY)/pause
 TAG ?= 3.10.2
 REV = $(shell git describe --contains --always --match='v*')
 
-# Architectures supported: amd64, arm, arm64, ppc64le and s390x
+# Architectures supported: amd64, arm64, ppc64le and s390x
 ARCH ?= amd64
 # Operating systems supported: linux, windows
 OS ?= linux
@@ -38,7 +38,7 @@ BASE := ${BASE.${OS}}
 JQ_IMAGE := ghcr.io/jqlang/jq@sha256:a186dcd84a1e28bb48cdf3d7768b890d08621a87bb651fadb7db6815a6bf5ad5
 
 ALL_OS = linux windows
-ALL_ARCH.linux = amd64 arm arm64 ppc64le s390x
+ALL_ARCH.linux = amd64 arm64 ppc64le s390x
 ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 ALL_ARCH.windows = amd64
 # ALL_OSVERSIONS lists all os.versions in BASE.windows.
@@ -69,7 +69,6 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 
 TRIPLE.windows-amd64 := x86_64-w64-mingw32
 TRIPLE.linux-amd64 := x86_64-linux-gnu
-TRIPLE.linux-arm := arm-linux-gnueabihf
 TRIPLE.linux-arm64 := aarch64-linux-gnu
 TRIPLE.linux-ppc64le := powerpc64le-linux-gnu
 TRIPLE.linux-s390x := s390x-linux-gnu
@@ -124,7 +123,7 @@ bin/wincat-windows-${ARCH}: windows/wincat/wincat.go
 
 container: .container-${OS}-$(ARCH)
 .container-linux-$(ARCH): bin/$(BIN)-$(OS)-$(ARCH)
-	docker buildx build --provenance=false --sbom=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
+	docker buildx build --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
 		-t $(IMAGE):$(TAG)-${OS}-$(ARCH) --build-arg BASE=${BASE} --build-arg ARCH=$(ARCH) .
 	touch $@
 

--- a/build/pause/cloudbuild.yaml
+++ b/build/pause/cloudbuild.yaml
@@ -2,19 +2,13 @@
 timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240523-a15ad90fc9@sha256:bb04162508c2c61637eae700a0d8e8c8be8f2d4c831d2b75e59db2d4dd6cf75d'
-    entrypoint: 'bash'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260108-7f313c340e@sha256:4d778a001ae3f4247b2b61d8a870319e71d66c87556969a6399b90972e4d0491'
     dir: ./build/pause
     env:
-      - DOCKER_CLI_EXPERIMENTAL=enabled
       - REGISTRY=gcr.io/$PROJECT_ID
       - IMAGE=gcr.io/$PROJECT_ID/pause
-      - HOME=/root
     args:
-      - '-c'
-      - |
-        gcloud auth configure-docker \
-        && docker buildx create --name img-builder --use \
-        && make all-push
+      - make 
+      - all-push

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -15,7 +15,6 @@
 REPO_ROOT:=${CURDIR}/../..
 REGISTRY ?= registry.k8s.io/e2e-test-images
 DOCKER_CERT_BASE_PATH ?=
-QEMUVERSION=v5.1.0-2
 GOLANG_VERSION=$(shell cat $(REPO_ROOT)/.go-version)
 export
 

--- a/test/images/README.md
+++ b/test/images/README.md
@@ -12,12 +12,12 @@ new images, test the changes made, promote the newly built staging images.
 ## Prerequisites
 
 In order to build the docker test images, a Linux node is required. The node will require `make`,
-`docker (version 19.03.0 or newer)`, and ``docker buildx``, which will be used to build multiarch
+`docker`, and ``docker buildx``, which will be used to build multiarch
 images, as well as Windows images. In order to properly build multi-arch and Windows images, some
 initialization is required (in CI this is done in [cloudbuild.yaml](cloudbuild.yaml)):
 
 ```shell
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker run --privileged --rm tonistiigi/binfmt --install all
 docker buildx create --name img-builder --use
 docker buildx inspect --bootstrap
 ```
@@ -37,7 +37,7 @@ last known stable version.
 
 Most tests used in E2E testing suite use the `agnhost` image. It contains several subcommands with
 different [functionalities](agnhost/README.md) used to validate different Kubernetes behaviors. If
-a new functionality needs testing, consider adding an `agnhost` subcommand for it first, before
+a new functionality needs testing, add it as an `agnhost` subcommand first, before
 creating an entirely separate test image.
 
 The general process of making updates to the images is as follows:

--- a/test/images/agnhost/Dockerfile
+++ b/test/images/agnhost/Dockerfile
@@ -29,8 +29,7 @@ RUN chmod +x /prepare_registry.sh
 RUN /prepare_registry.sh
 
 FROM $BASEIMAGE AS main
-
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
+ARG TARGETARCH
 
 # from dnsutils image
 # install necessary packages:
@@ -47,7 +46,7 @@ RUN apk --update add bind-tools curl netcat-openbsd iproute2 iperf bash util-lin
     && ln -s /usr/bin/iperf /usr/local/bin/iperf \
     && ls -altrh /usr/local/bin/iperf
 
-ADD https://github.com/coredns/coredns/releases/download/v1.6.2/coredns_1.6.2_linux_BASEARCH.tgz /coredns.tgz
+ADD https://github.com/coredns/coredns/releases/download/v1.6.2/coredns_1.6.2_linux_${TARGETARCH}.tgz /coredns.tgz
 RUN tar -xzvf /coredns.tgz && rm -f /coredns.tgz
 
 # PORT 80 needed by: test-webserver

--- a/test/images/apparmor-loader/BASEIMAGE
+++ b/test/images/apparmor-loader/BASEIMAGE
@@ -1,4 +1,0 @@
-linux/amd64=alpine:3.22
-linux/arm64=arm64v8/alpine:3.22
-linux/ppc64le=ppc64le/alpine:3.22
-linux/s390x=s390x/alpine:3.22

--- a/test/images/apparmor-loader/Dockerfile
+++ b/test/images/apparmor-loader/Dockerfile
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE
+ARG BASEIMAGE=alpine:3.22
 FROM $BASEIMAGE
-
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 
 RUN apk add apparmor libapparmor --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted
 

--- a/test/images/cloudbuild.yaml
+++ b/test/images/cloudbuild.yaml
@@ -7,32 +7,17 @@ timeout: 5400s
 # or any new substitutions added in the future.
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240523-a15ad90fc9@sha256:bb04162508c2c61637eae700a0d8e8c8be8f2d4c831d2b75e59db2d4dd6cf75d'
-    entrypoint: 'bash'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260108-7f313c340e@sha256:4d778a001ae3f4247b2b61d8a870319e71d66c87556969a6399b90972e4d0491'
     dir: ./test/images/
     env:
-    - DOCKER_CLI_EXPERIMENTAL=enabled
     - BASE_REF=$_PULL_BASE_REF
     - GIT_COMMIT_ID=$_PULL_BASE_SHA
     - WHAT=$_WHAT
     - REGISTRY=$_REGISTRY
-    # The default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
-    # We need to set the HOME to /root explicitly since we're using docker buildx
-    - HOME=/root
-    # NOTE(claudiub): we need to call register.sh before creating and bootstraping a docker buildx instance.
     args:
-    - '-c'
-    - |
-      gcloud auth configure-docker \
-      && ../../third_party/multiarch/qemu-user-static/register/register.sh --reset -p yes \
-      && export DOCKER_CLI_EXPERIMENTAL=enabled \
-      && docker version \
-      && docker buildx version \
-      && docker buildx create --name img-builder --use \
-      && docker buildx inspect --bootstrap \
-      && make all-build-and-push
+    - make
+    - all-build-and-push
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
@@ -46,3 +31,5 @@ substitutions:
   _REGISTRY: 'gcr.io/k8s-staging-e2e-test-images'
   # _WHAT will contain the image name to be built and published to the staging registry.
   _WHAT: 'all-conformance'
+tags:
+  - $_WHAT

--- a/test/images/glibc-dns-testing/Dockerfile
+++ b/test/images/glibc-dns-testing/Dockerfile
@@ -27,8 +27,6 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
 RUN apt-get update && \
     apt-get install -y dnsutils && \
     apt-get clean && \

--- a/test/images/ipc-utils/Dockerfile
+++ b/test/images/ipc-utils/Dockerfile
@@ -15,6 +15,4 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
 RUN apk add --no-cache util-linux

--- a/test/images/node-perf/npb-ep/Dockerfile
+++ b/test/images/node-perf/npb-ep/Dockerfile
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 ARG BASEIMAGE
-FROM $BASEIMAGE as build_node_perf_npb_ep
-
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
+FROM $BASEIMAGE AS build_node_perf_npb_ep
 
 RUN apt-get update && apt-get install -y libc6-dev g++ bzip2 dpkg-dev build-essential gfortran
 
@@ -31,9 +29,9 @@ RUN sed -i '1i#!/bin/sh' sys/print_header sys/print_instructions
 
 RUN if [ $(arch) != "x86_64" ]; then \
     sed s/-mcmodel=medium//g config/NAS.samples/make.def_gcc > config/make.def; \
-else \
+    else \
     cp config/NAS.samples/make.def_gcc config/make.def; \
-fi
+    fi
 RUN make EP CLASS=D
 
 # Copying the required libraries (shared object files) to a convenient location so that it can be copied into the

--- a/test/images/node-perf/npb-is/Dockerfile
+++ b/test/images/node-perf/npb-is/Dockerfile
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 ARG BASEIMAGE
-FROM $BASEIMAGE as build_node_perf_npb_is
-
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
+FROM $BASEIMAGE AS build_node_perf_npb_is
 
 RUN apt-get update && apt-get install -y build-essential gfortran
 
@@ -36,9 +34,9 @@ RUN sed -i '1i#!/bin/sh' sys/print_header sys/print_instructions
 #   -mno-outline-atomics: inline atomics to avoid linker issues
 RUN if [ $(arch) = "aarch64" ]; then \
     sed 's/-mcmodel=medium/-mcmodel=large -fno-PIE -mno-outline-atomics/g' config/NAS.samples/make.def.gcc_x86 > config/make.def; \
-else \
+    else \
     cp config/NAS.samples/make.def.gcc_x86 config/make.def; \
-fi
+    fi
 RUN make IS CLASS=D
 
 # Copying the required libraries (shared object files) to a convenient location so that it can be copied into the

--- a/test/images/node-perf/pytorch-wide-deep/Dockerfile
+++ b/test/images/node-perf/pytorch-wide-deep/Dockerfile
@@ -15,8 +15,6 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
 # Install time, curl, and g++ (g++ required for torch.compile() inductor backend)
 RUN apt-get update && apt-get install -y --no-install-recommends time curl g++ && \
     rm -rf /var/lib/apt/lists/*

--- a/test/images/nonewprivs/Dockerfile
+++ b/test/images/nonewprivs/Dockerfile
@@ -15,8 +15,6 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
 COPY nnp /usr/local/bin/nnp
 RUN chmod +s /usr/local/bin/nnp
 

--- a/test/images/pets/peer-finder/Dockerfile
+++ b/test/images/pets/peer-finder/Dockerfile
@@ -15,8 +15,6 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
 RUN clean-install wget bash dnsutils
 
 COPY peer-finder /

--- a/test/images/pets/zookeeper-installer/Dockerfile
+++ b/test/images/pets/zookeeper-installer/Dockerfile
@@ -17,8 +17,6 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
 RUN clean-install wget bash netcat-openbsd
 
 ADD on-start.sh /

--- a/test/images/regression-issue-74839/Dockerfile
+++ b/test/images/regression-issue-74839/Dockerfile
@@ -15,8 +15,6 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
 ADD regression-issue-74839 /regression-issue-74839
 
 ENTRYPOINT ["/regression-issue-74839"]

--- a/test/images/resource-consumer/Dockerfile
+++ b/test/images/resource-consumer/Dockerfile
@@ -15,8 +15,6 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
 RUN clean-install stress
 
 ADD consumer /consumer

--- a/test/images/volume/iscsi/Dockerfile
+++ b/test/images/volume/iscsi/Dockerfile
@@ -15,8 +15,6 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
 RUN yum install -y targetcli && yum clean all
 ADD run_iscsi_target.sh /usr/local/bin/
 ADD block.tar.gz /

--- a/test/images/volume/nfs/Dockerfile
+++ b/test/images/volume/nfs/Dockerfile
@@ -15,7 +15,6 @@
 ARG BASEIMAGE
 FROM $BASEIMAGE
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 RUN dnf -y install procps-ng nfs-utils && dnf clean all
 RUN mkdir -p /exports
 ADD run_nfs.sh /usr/local/bin/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Refactor the image build script to use newer version of Docker and remove various legacy kruft.

I'll comment inline for all the important changes.

I ran a test build for agnhost, and it was successful. https://console.cloud.google.com/cloud-build/builds;region=us-central1/adf418f1-2849-4285-a28a-d908dc34e1a9?project=k8s-infra-e2e-node-e2e-project

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
