### PR TITLE
[release-1.35] [go] Bump images and versions to go 1.25.6 and distroless iptables

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.35.0-go1.25.5-bullseye.0
+v1.35.0-go1.25.6-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -80,8 +80,8 @@ readonly REMOTE_OUTPUT_BINPATH="${REMOTE_OUTPUT_SUBPATH}/bin"
 readonly REMOTE_OUTPUT_GOPATH="${REMOTE_OUTPUT_SUBPATH}/go"
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.8.6
-readonly __default_go_runner_version=v2.4.0-go1.25.5-bookworm.0
+readonly __default_distroless_iptables_version=v0.8.7
+readonly __default_go_runner_version=v2.4.0-go1.25.6-bookworm.0
 readonly __default_setcap_version=bookworm-v1.0.6
 
 # The default image for all binaries which are dynamically linked.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -131,7 +131,7 @@ dependencies:
   # should also be updated, but go-runner is much harder to exploit and has
   # far less relevancy to go updates for Kubernetes more generally.
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.35.0-go1.25.5-bullseye.0
+    version: v1.35.0-go1.25.6-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -179,7 +179,7 @@ dependencies:
       match: registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.8.6
+    version: v0.8.7
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=
@@ -187,7 +187,7 @@ dependencies:
       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
-    version: v2.4.0-go1.25.5-bookworm.0
+    version: v2.4.0-go1.25.6-bookworm.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -25,7 +25,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     source:
       branch: release-1.35
       dirs:
@@ -69,7 +69,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -193,7 +193,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -255,7 +255,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -322,7 +322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -373,7 +373,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -452,7 +452,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -555,7 +555,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -681,7 +681,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -788,7 +788,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -901,7 +901,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -985,7 +985,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1054,7 +1054,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1129,7 +1129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1205,7 +1205,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1246,7 +1246,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     source:
       branch: release-1.35
       dirs:
@@ -1322,7 +1322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1425,7 +1425,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1524,7 +1524,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1637,7 +1637,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1762,7 +1762,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1833,7 +1833,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1890,7 +1890,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1927,7 +1927,7 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     source:
       branch: release-1.35
       dirs:
@@ -2027,7 +2027,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -2128,7 +2128,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -2249,7 +2249,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -2355,7 +2355,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -2442,7 +2442,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -2482,7 +2482,7 @@ rules:
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     source:
       branch: release-1.35
       dirs:

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -214,7 +214,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-1"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.8.6"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.8.7"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.6.6-0"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{list.PromoterE2eRegistry, "ipc-utils", "1.3"}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Bump images and versions to go 1.25.6 and distroless iptables

/assign @liggitt @dims @saschagrunert @puerco 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/4237

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubernetes is now built using Go 1.25.6
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
