### PR TITLE
[release-1.34] [go] Bump dependencies, images and versions used to Go 1.24.12 and distroless iptables

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.34.0-go1.24.11-bullseye.0
+v1.34.0-go1.24.12-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -97,8 +97,8 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.7.13
-readonly __default_go_runner_version=v2.4.0-go1.24.11-bookworm.0
+readonly __default_distroless_iptables_version=v0.7.14
+readonly __default_go_runner_version=v2.4.0-go1.24.12-bookworm.0
 readonly __default_setcap_version=bookworm-v1.0.6
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -127,7 +127,7 @@ dependencies:
   # should also be updated, but go-runner is much harder to exploit and has
   # far less relevancy to go updates for Kubernetes more generally.
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.34.0-go1.24.11-bullseye.0
+    version: v1.34.0-go1.24.12-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -175,7 +175,7 @@ dependencies:
       match: registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.7.13
+    version: v0.7.14
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=
@@ -183,7 +183,7 @@ dependencies:
       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
-    version: v2.4.0-go1.24.11-bookworm.0
+    version: v2.4.0-go1.24.12-bookworm.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -19,13 +19,13 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.34
       dirs:
@@ -60,7 +60,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -69,7 +69,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -184,7 +184,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -193,7 +193,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -242,7 +242,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -255,7 +255,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -309,7 +309,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -322,7 +322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -364,7 +364,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -373,7 +373,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -435,7 +435,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -452,7 +452,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -534,7 +534,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -555,7 +555,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -655,7 +655,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -681,7 +681,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -768,7 +768,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -788,7 +788,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -878,7 +878,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -901,7 +901,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -970,7 +970,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -985,7 +985,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1041,7 +1041,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1054,7 +1054,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1114,7 +1114,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1129,7 +1129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1190,7 +1190,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1205,7 +1205,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1240,13 +1240,13 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.34
       dirs:
@@ -1305,7 +1305,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1322,7 +1322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1404,7 +1404,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1425,7 +1425,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1493,7 +1493,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1508,7 +1508,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1582,7 +1582,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1601,7 +1601,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1691,7 +1691,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1714,7 +1714,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1814,7 +1814,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1839,7 +1839,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1899,7 +1899,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1910,7 +1910,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1956,7 +1956,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1967,7 +1967,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1998,13 +1998,13 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.34
       dirs:
@@ -2081,7 +2081,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2104,7 +2104,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2186,7 +2186,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2205,7 +2205,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2301,7 +2301,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -2326,7 +2326,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -2397,7 +2397,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2412,7 +2412,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2440,13 +2440,13 @@ rules:
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.34
       dirs:

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -226,7 +226,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-1"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.7.13"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.7.14"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.6.4-0"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Bump images and versions to go 1.24.12 and distroless iptables

/assign @liggitt @dims @saschagrunert @puerco 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/4237

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubernetes is now built using Go 1.24.12
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
