### PR TITLE
egressselector: fix panic when using nil tlsConfig with HTTP scheme for TCP connectivity

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -326,13 +326,16 @@ func connectionToDialerCreator(c apiserver.Connection) (*dialerCreator, error) {
 				},
 			}, nil
 		} else if c.Transport.TCP != nil {
-			tlsConfig, err := getTLSConfig(c.Transport.TCP.TLSConfig)
-			if err != nil {
-				return nil, err
-			}
 			proxyAddress, err := getProxyAddress(c.Transport.TCP.URL)
 			if err != nil {
 				return nil, err
+			}
+			// tlsConfig may be nil if the transport URL scheme uses HTTP.
+			var tlsConfig *tls.Config
+			if c.Transport.TCP.TLSConfig != nil {
+				if tlsConfig, err = getTLSConfig(c.Transport.TCP.TLSConfig); err != nil {
+					return nil, err
+				}
 			}
 			return &dialerCreator{
 				connector: &tcpHTTPConnectConnector{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When configuring egress selectors using HTTPConnect with a proxy that does *not* use TLS/HTTPS, the apiserver panics on startup if TLSConfig is nil (and it errors on startup if it is non-nil/empty due to expecting it to not be specified via validation).

#### Which issue(s) this PR is related to:

None

#### Special notes for your reviewer:

I need to work out the best/proper way to test this change as clearly we don't have coverage for non-TLS egress proxies currently.

#### Does this PR introduce a user-facing change?

```release-note
Fix bug preventing use of HTTP CONNECT proxies that do not use TLS in EgressSelectorConfiguration
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None