### PR TITLE
Netpol: reduce e2e pod churn with agnhost porter

### DIFF
--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -43,10 +43,9 @@ const defaultPollTimeoutSeconds = 10
 // there will be a corresponding TestPod. TestPod includes some runtime info
 // (namespace name, service IP) which is not available in the model.
 type TestPod struct {
-	Namespace     string
-	Name          string
-	ContainerName string
-	ServiceIP     string
+	Namespace string
+	Name      string
+	ServiceIP string
 }
 
 func (pod TestPod) PodString() PodString {
@@ -107,10 +106,9 @@ func (k *kubeManager) initializeClusterFromModel(ctx context.Context, model *Mod
 			}
 
 			k.allPods = append(k.allPods, TestPod{
-				Namespace:     kubePod.Namespace,
-				Name:          kubePod.Name,
-				ContainerName: pod.Containers[0].Name(),
-				ServiceIP:     svc.Spec.ClusterIP,
+				Namespace: kubePod.Namespace,
+				Name:      kubePod.Name,
+				ServiceIP: svc.Spec.ClusterIP,
 			})
 			k.allPodStrings = append(k.allPodStrings, NewPodString(kubePod.Namespace, kubePod.Name))
 		}
@@ -176,7 +174,7 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 		framework.Failf("protocol %s not supported", args.protocol)
 	}
 
-	commandDebugString := fmt.Sprintf("kubectl exec %s -c %s -n %s -- %s", args.podFrom, args.containerFrom, args.nsFrom, strings.Join(cmd, " "))
+	commandDebugString := fmt.Sprintf("kubectl exec %s -n %s -- %s", args.podFrom, args.nsFrom, strings.Join(cmd, " "))
 
 	attempt := 0
 
@@ -190,7 +188,7 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 	// the job when the observed value don't match the expected value, so we don't rely on return value of PollImmediate, we
 	// simply discard it and use probeError, defined outside scope of conditionFunc, for returning the result of probeConnectivity.
 	conditionFunc := func() (bool, error) {
-		_, stderr, probeError = k.executeRemoteCommand(args.nsFrom, args.podFrom, args.containerFrom, cmd)
+		_, stderr, probeError = k.executeRemoteCommand(args.nsFrom, args.podFrom, cmd)
 		// retry should only occur if expected and observed value don't match.
 		if args.expectConnectivity {
 			if probeError != nil {
@@ -237,12 +235,11 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 }
 
 // executeRemoteCommand executes a remote shell command on the given pod.
-func (k *kubeManager) executeRemoteCommand(namespace string, pod string, containerName string, command []string) (string, string, error) {
+func (k *kubeManager) executeRemoteCommand(namespace string, pod string, command []string) (string, string, error) {
 	return e2epod.ExecWithOptions(k.framework, e2epod.ExecOptions{
 		Command:            command,
 		Namespace:          namespace,
 		PodName:            pod,
-		ContainerName:      containerName,
 		Stdin:              nil,
 		CaptureStdout:      true,
 		CaptureStderr:      true,

--- a/test/e2e/network/netpol/model.go
+++ b/test/e2e/network/netpol/model.go
@@ -55,18 +55,10 @@ func NewModel(namespaceNames []string, podNames []string, ports []int32, protoco
 	for _, ns := range namespaceNames {
 		var pods []*Pod
 		for _, podName := range podNames {
-			var containers []*Container
-			for _, port := range ports {
-				for _, protocol := range protocols {
-					containers = append(containers, &Container{
-						Port:     port,
-						Protocol: protocol,
-					})
-				}
-			}
 			pods = append(pods, &Pod{
-				Name:       podName,
-				Containers: containers,
+				Name:      podName,
+				Ports:     ports,
+				Protocols: protocols,
 			})
 		}
 		model.Namespaces = append(model.Namespaces, &Namespace{
@@ -87,17 +79,9 @@ type Namespace struct {
 // Pod is the abstract representation of what matters to network policy tests for
 // a pod; i.e. it ignores kube implementation details
 type Pod struct {
-	Name       string
-	Containers []*Container
-}
-
-// ContainerSpecs builds kubernetes container specs for the pod
-func (p *Pod) ContainerSpecs() []v1.Container {
-	var containers []v1.Container
-	for _, cont := range p.Containers {
-		containers = append(containers, cont.Spec())
-	}
-	return containers
+	Name      string
+	Ports     []int32
+	Protocols []v1.Protocol
 }
 
 func podNameLabelKey() string {
@@ -157,70 +141,44 @@ func (p *Pod) Service(namespace string) *v1.Service {
 			Selector: p.Labels(),
 		},
 	}
-	for _, container := range p.Containers {
-		service.Spec.Ports = append(service.Spec.Ports, v1.ServicePort{
-			Name:     fmt.Sprintf("service-port-%s-%d", strings.ToLower(string(container.Protocol)), container.Port),
-			Protocol: container.Protocol,
-			Port:     container.Port,
-		})
+	for _, protocol := range p.Protocols {
+		for _, port := range p.Ports {
+			service.Spec.Ports = append(service.Spec.Ports, v1.ServicePort{
+				Name:     fmt.Sprintf("service-port-%s-%d", strings.ToLower(string(protocol)), port),
+				Protocol: protocol,
+				Port:     port,
+			})
+		}
 	}
 	return service
 }
 
-// Container is the abstract representation of what matters to network policy tests for
-// a container; i.e. it ignores kube implementation details
-type Container struct {
-	Port     int32
-	Protocol v1.Protocol
-}
+// ContainerSpecs builds kubernetes container specs for the pod
+func (p *Pod) ContainerSpecs() []v1.Container {
+	env := make([]v1.EnvVar, 0, len(p.Ports)*len(p.Protocols))
+	ports := make([]v1.ContainerPort, 0, len(p.Ports)*len(p.Protocols))
 
-// Name returns the container name
-func (c *Container) Name() string {
-	return fmt.Sprintf("cont-%d-%s", c.Port, strings.ToLower(string(c.Protocol)))
-}
-
-// PortName returns the container port name
-func (c *Container) PortName() string {
-	return fmt.Sprintf("serve-%d-%s", c.Port, strings.ToLower(string(c.Protocol)))
-}
-
-// Spec returns the kube container spec
-func (c *Container) Spec() v1.Container {
-	var (
-		// agnHostImage is the image URI of AgnHost
-		agnHostImage = imageutils.GetE2EImage(imageutils.Agnhost)
-		env          = []v1.EnvVar{}
-		cmd          []string
-	)
-
-	switch c.Protocol {
-	case v1.ProtocolTCP:
-		cmd = []string{"/agnhost", "serve-hostname", "--tcp", "--http=false", "--port", fmt.Sprintf("%d", c.Port)}
-	case v1.ProtocolUDP:
-		cmd = []string{"/agnhost", "serve-hostname", "--udp", "--http=false", "--port", fmt.Sprintf("%d", c.Port)}
-	case v1.ProtocolSCTP:
-		env = append(env, v1.EnvVar{
-			Name:  fmt.Sprintf("SERVE_SCTP_PORT_%d", c.Port),
-			Value: "foo",
-		})
-		cmd = []string{"/agnhost", "porter"}
-	default:
-		framework.Failf("invalid protocol %v", c.Protocol)
+	for _, protocol := range p.Protocols {
+		for _, port := range p.Ports {
+			env = append(env, v1.EnvVar{
+				Name:  fmt.Sprintf("SERVE_%s_PORT_%d", protocol, port),
+				Value: "foo",
+			})
+			ports = append(ports, v1.ContainerPort{
+				Name:          fmt.Sprintf("serve-%d-%s", port, strings.ToLower(string(protocol))),
+				Protocol:      protocol,
+				ContainerPort: port,
+			})
+		}
 	}
 
-	return v1.Container{
-		Name:            c.Name(),
+	return []v1.Container{{
+		Name:            "agnhost",
 		ImagePullPolicy: v1.PullIfNotPresent,
-		Image:           agnHostImage,
-		Command:         cmd,
-		Env:             env,
+		Image:           imageutils.GetE2EImage(imageutils.Agnhost),
+		Command:         []string{"/agnhost", "porter"},
 		SecurityContext: &v1.SecurityContext{},
-		Ports: []v1.ContainerPort{
-			{
-				ContainerPort: c.Port,
-				Name:          c.PortName(),
-				Protocol:      c.Protocol,
-			},
-		},
-	}
+		Env:             env,
+		Ports:           ports,
+	}}
 }

--- a/test/e2e/network/netpol/probe.go
+++ b/test/e2e/network/netpol/probe.go
@@ -29,7 +29,6 @@ import (
 type probeConnectivityArgs struct {
 	nsFrom              string
 	podFrom             string
-	containerFrom       string
 	addrTo              string
 	protocol            v1.Protocol
 	toPort              int
@@ -132,7 +131,6 @@ func probeWorker(prober Prober, jobs <-chan *ProbeJob, results chan<- *ProbeJobR
 		connected, command, err := prober.probeConnectivity(&probeConnectivityArgs{
 			nsFrom:              podFrom.Namespace,
 			podFrom:             podFrom.Name,
-			containerFrom:       podFrom.ContainerName,
 			addrTo:              job.PodTo.ServiceIP,
 			protocol:            job.Protocol,
 			toPort:              job.ToPort,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig network

#### What this PR does / why we need it:
The Netpol e2e suite is resource-intensive. This change reduces per-test resource usage by consolidating Netpol test pods to a single container per pod using `agnhost porter` to serve multiple ports/protocols.
#### Which issue(s) this PR is related to:
- Part of #135721
- Revives #135706

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
