### PR TITLE
fix: Set effectively unlimited MaxSize for audit logs when 0 is specified

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
@@ -38,10 +38,10 @@ func TestAuditValidOptions(t *testing.T) {
 	auditPath := filepath.Join(tmpDir, "audit")
 
 	webhookConfig := makeTmpWebhookConfig(t)
-	defer os.Remove(webhookConfig)
+	defer func() { _ = os.Remove(webhookConfig) }()
 
 	policy := makeTmpPolicy(t)
-	defer os.Remove(policy)
+	defer func() { _ = os.Remove(policy) }()
 
 	testCases := []struct {
 		name     string
@@ -177,12 +177,44 @@ func TestAuditValidOptions(t *testing.T) {
 			if options.LogOptions.Path == "-" {
 				assert.Equal(t, os.Stdout, w)
 				assert.NoFileExists(t, options.LogOptions.Path)
-			} else {
-				assert.IsType(t, (*lumberjack.Logger)(nil), w)
+			} else if options.LogOptions.MaxSize == 0 {
+				// When MaxSize is 0, we return a raw file writer (os.File) for unlimited size
+				file, ok := w.(*os.File)
+				assert.True(t, ok, "Writer should be of type *os.File when MaxSize is 0")
 				assert.FileExists(t, options.LogOptions.Path)
+				assert.NoError(t, file.Close())
+			} else {
+				logger, ok := w.(*lumberjack.Logger)
+				assert.True(t, ok, "Writer should be of type *lumberjack.Logger")
+				assert.FileExists(t, options.LogOptions.Path)
+				assert.Equal(t, options.LogOptions.MaxSize, logger.MaxSize)
 			}
 		})
 	}
+}
+
+func TestAuditLogMaxSizeZero(t *testing.T) {
+	tmpDir := t.TempDir()
+	auditPath := filepath.Join(tmpDir, "audit")
+	policy := makeTmpPolicy(t)
+	defer func() { _ = os.Remove(policy) }()
+
+	o := NewAuditOptions()
+	o.LogOptions.Path = auditPath
+	o.PolicyFile = policy
+	o.LogOptions.MaxSize = 0
+
+	w, err := o.LogOptions.getWriter()
+	require.NoError(t, err)
+	require.NotNil(t, w)
+
+	// When MaxSize is 0, we return a raw file writer (os.File) for unlimited size
+	file, ok := w.(*os.File)
+	require.True(t, ok, "Should be an os.File when MaxSize is 0")
+
+	// Verify that the file was opened correctly
+	require.NotNil(t, file)
+	require.NoError(t, file.Close())
 }
 
 func TestAuditInvalidOptions(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix audit log rotation when MaxSize is 0.
This PR fixes a bug where setting --audit-log-maxsize=0 would result in default 100MB rotation instead of unlimited size. It sets MaxSize to MaxInt32 when 0 is provided.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #N/A

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: setting `--audit-log-maxsize=0` now disables audit log rotation (the default remains `100` MB). In order to avoid outages due to filling disks with ever-growing audit logs, `--audit-log-maxage` now defaults to 366 (1 year) and `--audit-log-maxbackup` now defaults to 100. If retention of all rotated logs is desired, age and count-based pruning can be disabled by explicitly specifying `--audit-log-maxage=0` and `--audit-log-maxbackup=0`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
- [Other doc]: <link>
-->
```docs

```
