### PR TITLE
Fix container_restart_test AfterEach failing when CRI Proxy is undefined

### DIFF
--- a/test/e2e_node/container_restart_test.go
+++ b/test/e2e_node/container_restart_test.go
@@ -100,11 +100,9 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
-		})
-
-		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector(e2eCriProxy)
-			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
 		})
 
 		ginkgo.It("Reduced default restart backs off.", func(ctx context.Context) {
@@ -128,11 +126,9 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
 				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
 			}
-		})
-
-		ginkgo.AfterEach(func() {
-			err := resetCRIProxyInjector(e2eCriProxy)
-			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() error {
+				return resetCRIProxyInjector(e2eCriProxy)
+			})
 		})
 
 		ginkgo.It("Reduced default restart backs off.", func(ctx context.Context) {


### PR DESCRIPTION
Two test contexts were failing because their AfterEach blocks run even when BeforeEach skips the test (standard Ginkgo behavior). This caused resetCRIProxyInjector to fail with "CRI Proxy is undefined".

Switched to using DeferCleanup inside BeforeEach instead, which only runs if BeforeEach succeeds. This is the same pattern the other test contexts in this file already use.

Example log from https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-node-kubelet-serial-containerd/2014731738818809856/artifacts/e2-standard-2-ubuntu-gke-2404-1-34-amd64-v20260120-2233b8ac/e2-standard-2-ubuntu-gke-2404-1-34-amd64-v20260120-2233b8ac-ginkgo.log
```
  I0123 16:45:14.060787    1852 container_restart_test.go:107] Unexpected error: 
      <*errors.errorString | 0xc000c27f40>: 
      failed to reset injector because the CRI Proxy is undefined
      {
          s: "failed to reset injector because the CRI Proxy is undefined",
      }
  [FAILED] in [AfterEach] - k8s.io/kubernetes/test/e2e_node/container_restart_test.go:107 @ 01/23/26 16:45:14.061
  I0123 16:45:14.061369    1852 helper.go:125] Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "container-restart-5335" for this suite. @ 01/23/26 16:45:14.064
S [SKIPPED] [10.311 seconds]
[sig-node] Container Restart [Feature:CriProxy] [Serial] Reduced default container restart backs off as expected [BeforeEach] Reduced default restart backs off. [sig-node, Feature:CriProxy, Serial]
  [BeforeEach] k8s.io/kubernetes/test/e2e_node/container_restart_test.go:99
  [It] k8s.io/kubernetes/test/e2e_node/container_restart_test.go:110
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
