### PR TITLE
api: enable optionalorrequired linter for node API

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -214,7 +214,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|node|policy|rbac|resource|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|policy|rbac|resource|storage|storagemigration)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -225,7 +225,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|node|policy|rbac|resource|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|policy|rbac|resource|storage|storagemigration)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -90,7 +90,7 @@
 
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 - text: "must be marked as optional or required"
-  path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|node|policy|rbac|resource|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|policy|rbac|resource|storage|storagemigration)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/staging/src/k8s.io/api/node/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1alpha1/generated.proto
@@ -51,6 +51,7 @@ message RuntimeClass {
 
   // spec represents specification of the RuntimeClass
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+  // +required
   optional RuntimeClassSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/node/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/node/v1alpha1/types.go
@@ -41,6 +41,7 @@ type RuntimeClass struct {
 
 	// spec represents specification of the RuntimeClass
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +required
 	Spec RuntimeClassSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add missing `+required` marker to `RuntimeClass.Spec` in the node v1alpha1 API to satisfy the `optionalorrequired` linter rule and enable the linter for the node API group.

#### Which issue(s) this PR fixes:

Part of #134671

#### Special notes for your reviewer:

This adds `// +required` marker to:
- `RuntimeClass.Spec` in v1alpha1

#### Does this PR introduce a user-facing change?

```release-note
NONE
```