### PR TITLE
Automated cherry pick of #136325: fix(expansion):Resolve the issue of UTF-8 characters being truncated

### DIFF
--- a/third_party/forked/golang/expansion/expand.go
+++ b/third_party/forked/golang/expansion/expand.go
@@ -2,6 +2,7 @@ package expansion
 
 import (
 	"bytes"
+	"unicode/utf8"
 )
 
 const (
@@ -79,10 +80,11 @@ func Expand(input string, mapping func(string) string) string {
 //
 // The input string is assumed not to contain the initial operator.
 func tryReadVariableName(input string) (string, bool, int) {
-	switch input[0] {
+	r, size := utf8.DecodeRuneInString(input)
+	switch r {
 	case operator:
 		// Escaped operator; return it.
-		return input[0:1], false, 1
+		return input[0:size], false, size
 	case referenceOpener:
 		// Scan to expression closer
 		for i := 1; i < len(input); i++ {
@@ -97,6 +99,7 @@ func tryReadVariableName(input string) (string, bool, int) {
 		// Not the beginning of an expression, ie, an operator
 		// that doesn't begin an expression.  Return the operator
 		// and the first rune in the string.
-		return (string(operator) + string(input[0])), false, 1
+
+		return string(operator) + string(r), false, size
 	}
 }

--- a/third_party/forked/golang/expansion/expand_test.go
+++ b/third_party/forked/golang/expansion/expand_test.go
@@ -274,6 +274,21 @@ func doExpansionTest(t *testing.T, mapping func(string) string) {
 			input:    "\n",
 			expected: "\n",
 		},
+		{
+			name:     "dollar sign followed by non-ASCII UTF-8 character",
+			input:    "$£FOO",
+			expected: "$£FOO",
+		},
+		{
+			name:     "dollar sign followed by multi-byte UTF-8 character in middle",
+			input:    "prefix-$€-suffix",
+			expected: "prefix-$€-suffix",
+		},
+		{
+			name:     "dollar sign followed by Chinese character",
+			input:    "$中文",
+			expected: "$中文",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Cherry pick of #136325 on release-1.34.

#136325: fix(expansion):Resolve the issue of UTF-8 characters being truncated

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.34 regression starting pods with environment variables with a value containing `$` followed by a multi-byte character
```