### PR TITLE
api: enable optionalorrequired linter for policy API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14882,12 +14882,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "disruptionsAllowed",
-        "currentHealthy",
-        "desiredHealthy",
-        "expectedPods"
-      ],
       "type": "object"
     },
     "io.k8s.api.rbac.v1.AggregationRule": {

--- a/api/openapi-spec/v3/apis__policy__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__policy__v1_openapi.json
@@ -187,12 +187,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "disruptionsAllowed",
-          "currentHealthy",
-          "desiredHealthy",
-          "expectedPods"
-        ],
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -214,7 +214,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|policy|rbac|resource|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -225,7 +225,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|policy|rbac|resource|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -90,7 +90,7 @@
 
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 - text: "must be marked as optional or required"
-  path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|policy|rbac|resource|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -43952,7 +43952,6 @@ func schema_k8sio_api_policy_v1_PodDisruptionBudgetStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"disruptionsAllowed", "currentHealthy", "desiredHealthy", "expectedPods"},
 			},
 		},
 		Dependencies: []string{
@@ -44229,7 +44228,6 @@ func schema_k8sio_api_policy_v1beta1_PodDisruptionBudgetStatus(ref common.Refere
 						},
 					},
 				},
-				Required: []string{"disruptionsAllowed", "currentHealthy", "desiredHealthy", "expectedPods"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/policy/v1/generated.proto
+++ b/staging/src/k8s.io/api/policy/v1/generated.proto
@@ -142,15 +142,19 @@ message PodDisruptionBudgetStatus {
   map<string, .k8s.io.apimachinery.pkg.apis.meta.v1.Time> disruptedPods = 2;
 
   // Number of pod disruptions that are currently allowed.
+  // +optional
   optional int32 disruptionsAllowed = 3;
 
   // current number of healthy pods
+  // +optional
   optional int32 currentHealthy = 4;
 
   // minimum desired number of healthy pods
+  // +optional
   optional int32 desiredHealthy = 5;
 
   // total number of pods counted by this disruption budget
+  // +optional
   optional int32 expectedPods = 6;
 
   // Conditions contain conditions for PDB. The disruption controller sets the

--- a/staging/src/k8s.io/api/policy/v1/types.go
+++ b/staging/src/k8s.io/api/policy/v1/types.go
@@ -117,15 +117,19 @@ type PodDisruptionBudgetStatus struct {
 	DisruptedPods map[string]metav1.Time `json:"disruptedPods,omitempty" protobuf:"bytes,2,rep,name=disruptedPods"`
 
 	// Number of pod disruptions that are currently allowed.
+	// +optional
 	DisruptionsAllowed int32 `json:"disruptionsAllowed" protobuf:"varint,3,opt,name=disruptionsAllowed"`
 
 	// current number of healthy pods
+	// +optional
 	CurrentHealthy int32 `json:"currentHealthy" protobuf:"varint,4,opt,name=currentHealthy"`
 
 	// minimum desired number of healthy pods
+	// +optional
 	DesiredHealthy int32 `json:"desiredHealthy" protobuf:"varint,5,opt,name=desiredHealthy"`
 
 	// total number of pods counted by this disruption budget
+	// +optional
 	ExpectedPods int32 `json:"expectedPods" protobuf:"varint,6,opt,name=expectedPods"`
 
 	// Conditions contain conditions for PDB. The disruption controller sets the

--- a/staging/src/k8s.io/api/policy/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/policy/v1beta1/generated.proto
@@ -142,15 +142,19 @@ message PodDisruptionBudgetStatus {
   map<string, .k8s.io.apimachinery.pkg.apis.meta.v1.Time> disruptedPods = 2;
 
   // Number of pod disruptions that are currently allowed.
+  // +optional
   optional int32 disruptionsAllowed = 3;
 
   // current number of healthy pods
+  // +optional
   optional int32 currentHealthy = 4;
 
   // minimum desired number of healthy pods
+  // +optional
   optional int32 desiredHealthy = 5;
 
   // total number of pods counted by this disruption budget
+  // +optional
   optional int32 expectedPods = 6;
 
   // Conditions contain conditions for PDB. The disruption controller sets the

--- a/staging/src/k8s.io/api/policy/v1beta1/types.go
+++ b/staging/src/k8s.io/api/policy/v1beta1/types.go
@@ -114,15 +114,19 @@ type PodDisruptionBudgetStatus struct {
 	DisruptedPods map[string]metav1.Time `json:"disruptedPods,omitempty" protobuf:"bytes,2,rep,name=disruptedPods"`
 
 	// Number of pod disruptions that are currently allowed.
+	// +optional
 	DisruptionsAllowed int32 `json:"disruptionsAllowed" protobuf:"varint,3,opt,name=disruptionsAllowed"`
 
 	// current number of healthy pods
+	// +optional
 	CurrentHealthy int32 `json:"currentHealthy" protobuf:"varint,4,opt,name=currentHealthy"`
 
 	// minimum desired number of healthy pods
+	// +optional
 	DesiredHealthy int32 `json:"desiredHealthy" protobuf:"varint,5,opt,name=desiredHealthy"`
 
 	// total number of pods counted by this disruption budget
+	// +optional
 	ExpectedPods int32 `json:"expectedPods" protobuf:"varint,6,opt,name=expectedPods"`
 
 	// Conditions contain conditions for PDB. The disruption controller sets the


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add missing `+optional` markers to PodDisruptionBudgetStatus fields in the policy API to satisfy the `optionalorrequired` linter rule and enable the linter for the policy API group.

#### Which issue(s) this PR fixes:

Part of #134671

#### Special notes for your reviewer:

This adds `// +optional` markers to:
- `PodDisruptionBudgetStatus.DisruptionsAllowed` in v1, v1beta1
- `PodDisruptionBudgetStatus.CurrentHealthy` in v1, v1beta1
- `PodDisruptionBudgetStatus.DesiredHealthy` in v1, v1beta1
- `PodDisruptionBudgetStatus.ExpectedPods` in v1, v1beta1

These are marked optional (not required) because:
1. Validation only checks non-negative values, allowing 0
2. Zero is a valid semantic value (e.g., DisruptionsAllowed=0 during failsafe)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```