### PR TITLE
Fix imageRef mismatch between PullImage and GetImageRef for containerd

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -386,7 +386,12 @@ func (m *imageManager) pullImage(ctx context.Context, logPrefix string, objRef *
 	imageRef = imagePullResult.imageRef
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletEnsureSecretPulledImages) {
 		if normalizedRef, getRefErr := m.imageService.GetImageRef(ctx, imgSpec); getRefErr == nil && normalizedRef != "" {
+			logger.V(4).Info("Normalized imageRef after pull", "original", imageRef, "normalized", normalizedRef)
 			imageRef = normalizedRef
+		} else if getRefErr != nil {
+			logger.V(4).Info("Failed to get normalized imageRef", "imageRef", imageRef, "error", getRefErr)
+		} else {
+			logger.V(4).Info("GetImageRef returned empty, using original imageRef", "imageRef", imageRef)
 		}
 	}
 

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -104,7 +104,7 @@ func noFGPullerTestCases() []pullerTestCase {
 			qps:            0.0,
 			burst:          0,
 			expected: []pullerExpects{
-				{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
@@ -146,17 +146,17 @@ func noFGPullerTestCases() []pullerTestCase {
 			qps:        0.0,
 			burst:      0,
 			expected: []pullerExpects{
-				{[]string{"PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
 					}, ""},
-				{[]string{"PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
 					}, ""},
-				{[]string{"PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
@@ -260,17 +260,17 @@ func noFGPullerTestCases() []pullerTestCase {
 			qps:        400.0,
 			burst:      600,
 			expected: []pullerExpects{
-				{[]string{"PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
 					}, ""},
-				{[]string{"PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
 					}, ""},
-				{[]string{"PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
@@ -411,17 +411,17 @@ func ensureSecretImagesTestCases() []pullerTestCase {
 			burst:          0,
 			enableFeatures: []featuregate.Feature{features.KubeletEnsureSecretPulledImages},
 			expected: []pullerExpects{
-				{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
 					}, ""},
-				{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
 					}, ""},
-				{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
@@ -446,17 +446,17 @@ func ensureSecretImagesTestCases() []pullerTestCase {
 			burst:          0,
 			enableFeatures: []featuregate.Feature{features.KubeletEnsureSecretPulledImages},
 			expected: []pullerExpects{
-				{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
 					}, ""},
-				{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
 					}, ""},
-				{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
@@ -649,7 +649,7 @@ func ensureSecretImagesTestCases() []pullerTestCase {
 			burst:          0,
 			enableFeatures: []featuregate.Feature{features.KubeletEnsureSecretPulledImages},
 			expected: []pullerExpects{
-				{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true,
+				{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true,
 					[]v1.Event{
 						{Reason: "Pulling"},
 						{Reason: "Pulled"},
@@ -1024,7 +1024,7 @@ func TestPullAndListImageWithPodAnnotations(t *testing.T) {
 		inspectErr:     nil,
 		pullerErr:      nil,
 		expected: []pullerExpects{
-			{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true, nil, ""},
+			{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true, nil, ""},
 		}}
 
 	useSerializedEnv := true
@@ -1087,7 +1087,7 @@ func TestPullAndListImageWithRuntimeHandlerInImageCriAPIFeatureGate(t *testing.T
 		inspectErr:     nil,
 		pullerErr:      nil,
 		expected: []pullerExpects{
-			{[]string{"GetImageRef", "PullImage", "GetImageSize"}, nil, true, true, nil, ""},
+			{[]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"}, nil, true, true, nil, ""},
 		}}
 
 	useSerializedEnv := true
@@ -1554,7 +1554,7 @@ func TestEnsureImageExistsWithServiceAccountCoordinates(t *testing.T) {
 			}
 
 			if tc.expectedImagePull {
-				fakeRuntime.AssertCalls([]string{"GetImageRef", "PullImage", "GetImageSize"})
+				fakeRuntime.AssertCalls([]string{"GetImageRef", "PullImage", "GetImageSize", "GetImageRef"})
 			} else {
 				fakeRuntime.AssertCalls([]string{"GetImageRef"})
 			}


### PR DESCRIPTION
Commit cb011623c84 ("test: Fix image credential pulls test for CRI-O digest handling") changed GetImageRef to return RepoDigests[0] instead of Image.Id.  (https://github.com/kubernetes/kubernetes/pull/135369)

Containerd's CRI returns different digest formats:
- PullImage returns config digest (sha256:...)
- ImageStatus.RepoDigests returns manifest digest (repo@sha256:...)

This caused KubeletEnsureSecretPulledImages credential verification to fail because the pull record was stored with the config digest but looked up with the manifest digest reference.

So after a successful image pull, normalize imageRef by calling GetImageRef to ensure pull record storage matches credential verification lookups. The fix normalizes the imageRef after a successful pull to use the same format that GetImageRef returns, ensuring consistent storage and lookup.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes https://github.com/kubernetes/kubernetes/issues/136549

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
