### PR TITLE
linting: Enabling `modernize` rules as hints

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -520,40 +520,42 @@ linters:
       # By default, all analyzers are enabled but in
       # Kubernetes we want to be more selective and
       # disable those which are not useful for it.
+      #
+      # Analyzers which are kept enabled are not
+      # called out here, see https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#section-documentation
+      # for the full list.
       disable:
         # Replace interface{} with any.
+        #
+        # Disabled because developers may
+        # prefer to use `interface{}` for
+        # consistency with existing code
+        # and it's just syntactic sugar.
         - any
-        # Replace for-range over b.N with b.Loop.
-        - bloop
-        # Replace []byte(fmt.Sprintf) with fmt.Appendf.
-        - fmtappendf
-        # Remove redundant re-declaration of loop variables.
-        - forvar
-        # Replace explicit loops over maps with calls to maps package.
-        - mapsloop
-        # Replace if/else statements with calls to min or max.
-        - minmax
         # Suggest replacing omitempty with omitzero for struct fields.
+        #
+        # Disabled because might interfere
+        # with encoding of API structs.
         - omitzero
-        # Replace 3-clause for loops with for-range over integers.
-        - rangeint
-        # Replace reflect.TypeOf(x) with TypeFor[T]().
-        - reflecttypefor
-        # Replace loops with slices.Contains or slices.ContainsFunc.
-        - slicescontains
-        # Replace sort.Slice with slices.Sort for basic types.
-        - slicessort
-        # Use iterators instead of Len/At-style APIs.
-        - stditerators
-        # Replace HasPrefix/TrimPrefix with CutPrefix.
-        - stringscutprefix
-        # Replace ranging over Split/Fields with SplitSeq/FieldsSeq.
-        - stringsseq
         # Replace += with strings.Builder.
+        #
+        # Disabled because in code which
+        # isn't performance-sensitive +=
+        # can be a bit more readable.
         - stringsbuilder
         # Replace context.WithCancel with t.Context in tests.
+        #
+        # Disabled because in Kubernetes,
+        # test/utils/ktesting handles
+        # context cancellation and also
+        # addresses other pain points.
         - testingcontext
         # Replace wg.Add(1)/go/wg.Done() with wg.Go.
+        #
+        # A useful hint leading to shorter code.
+        # Makes wait.Group obsolete.
+        # Please enable when all supported Kubernetes versions
+        # are on GoLang 1.25+
         - waitgroup
 
     revive:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -541,40 +541,95 @@ linters:
       # By default, all analyzers are enabled but in
       # Kubernetes we want to be more selective and
       # disable those which are not useful for it.
+      #
+      # Analyzers which are kept enabled are not
+      # called out here, see https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#section-documentation
+      # for the full list.
       disable:
         # Replace interface{} with any.
+        #
+        # Disabled because developers may
+        # prefer to use `interface{}` for
+        # consistency with existing code
+        # and it's just syntactic sugar.
         - any
         # Replace for-range over b.N with b.Loop.
+        #
+        # Only a hint for new tests because there's
+        # too much existing code that isn't worth
+        # updating.
         - bloop
         # Replace []byte(fmt.Sprintf) with fmt.Appendf.
+        #
+        # A useful hint for new code, but
+        # should only be updated in old code
+        # where it really matters.
         - fmtappendf
         # Remove redundant re-declaration of loop variables.
+        #
+        # A useful hint that this is no longer necessary with
+        # the Go version that Kubernetes depends on.
         - forvar
         # Replace explicit loops over maps with calls to maps package.
+        #
+        # Completely disabled because the benefit
+        # isn't immediately obvious.
         - mapsloop
         # Replace if/else statements with calls to min or max.
+        #
+        # A useful hint for new code.
         - minmax
         # Suggest replacing omitempty with omitzero for struct fields.
+        #
+        # Disabled because might interfere
+        # with encoding of API structs.
         - omitzero
         # Replace 3-clause for loops with for-range over integers.
+        #
+        # A useful hint for new code (makes it shorter).
         - rangeint
         # Replace reflect.TypeOf(x) with TypeFor[T]().
+        #
+        # A useful hint for new code, it could be more efficient.
         - reflecttypefor
         # Replace loops with slices.Contains or slices.ContainsFunc.
+        #
+        # A useful hint because it can make  code more obvious
+        # and/or avoid helper functions.
         - slicescontains
         # Replace sort.Slice with slices.Sort for basic types.
+        #
+        # A useful hint because the code becomes shorter.
         - slicessort
         # Use iterators instead of Len/At-style APIs.
+        #
+        # A useful hint because the code becomes shorter.
         - stditerators
         # Replace HasPrefix/TrimPrefix with CutPrefix.
+        #
+        # A useful hint because the code becomes shorter.
         - stringscutprefix
         # Replace ranging over Split/Fields with SplitSeq/FieldsSeq.
+        #
+        # A useful hint because it's more efficient.
         - stringsseq
         # Replace += with strings.Builder.
+        #
+        # Disabled because in code which
+        # isn't performance-sensitive +=
+        # can be a bit more readable.
         - stringsbuilder
         # Replace context.WithCancel with t.Context in tests.
+        #
+        # Disabled because in Kubernetes,
+        # test/utils/ktesting handles
+        # context cancellation and also
+        # addresses other pain points.
         - testingcontext
         # Replace wg.Add(1)/go/wg.Done() with wg.Go.
+        #
+        # A useful hint leading to shorter code.
+        # Makes wait.Group obsolete.
         - waitgroup
 
     revive:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -274,40 +274,103 @@ linters:
       # By default, all analyzers are enabled but in
       # Kubernetes we want to be more selective and
       # disable those which are not useful for it.
+      #
+      # Analyzers which are kept enabled are not
+      # called out here, see https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#section-documentation
+      # for the full list.
       disable:
         # Replace interface{} with any.
+        #
+        # Disabled because developers may
+        # prefer to use `interface{}` for
+        # consistency with existing code
+        # and it's just syntactic sugar.
         - any
+        {{- if .Base }}
         # Replace for-range over b.N with b.Loop.
+        #
+        # Only a hint for new tests because there's
+        # too much existing code that isn't worth
+        # updating.
         - bloop
         # Replace []byte(fmt.Sprintf) with fmt.Appendf.
+        #
+        # A useful hint for new code, but
+        # should only be updated in old code
+        # where it really matters.
         - fmtappendf
         # Remove redundant re-declaration of loop variables.
+        #
+        # A useful hint that this is no longer necessary with
+        # the Go version that Kubernetes depends on.
         - forvar
         # Replace explicit loops over maps with calls to maps package.
+        #
+        # Completely disabled because the benefit
+        # isn't immediately obvious.
         - mapsloop
         # Replace if/else statements with calls to min or max.
+        #
+        # A useful hint for new code.
         - minmax
+        {{- end }}
         # Suggest replacing omitempty with omitzero for struct fields.
+        #
+        # Disabled because might interfere
+        # with encoding of API structs.
         - omitzero
+        {{- if .Base }}
         # Replace 3-clause for loops with for-range over integers.
+        #
+        # A useful hint for new code (makes it shorter).
         - rangeint
         # Replace reflect.TypeOf(x) with TypeFor[T]().
+        #
+        # A useful hint for new code, it could be more efficient.
         - reflecttypefor
         # Replace loops with slices.Contains or slices.ContainsFunc.
+        #
+        # A useful hint because it can make  code more obvious
+        # and/or avoid helper functions.
         - slicescontains
         # Replace sort.Slice with slices.Sort for basic types.
+        #
+        # A useful hint because the code becomes shorter.
         - slicessort
         # Use iterators instead of Len/At-style APIs.
+        #
+        # A useful hint because the code becomes shorter.
         - stditerators
         # Replace HasPrefix/TrimPrefix with CutPrefix.
+        #
+        # A useful hint because the code becomes shorter.
         - stringscutprefix
         # Replace ranging over Split/Fields with SplitSeq/FieldsSeq.
+        #
+        # A useful hint because it's more efficient.
         - stringsseq
+        {{- end }}
         # Replace += with strings.Builder.
+        #
+        # Disabled because in code which
+        # isn't performance-sensitive +=
+        # can be a bit more readable.
         - stringsbuilder
         # Replace context.WithCancel with t.Context in tests.
+        #
+        # Disabled because in Kubernetes,
+        # test/utils/ktesting handles
+        # context cancellation and also
+        # addresses other pain points.
         - testingcontext
         # Replace wg.Add(1)/go/wg.Done() with wg.Go.
+        #
+        # A useful hint leading to shorter code.
+        # Makes wait.Group obsolete.
+        {{- if .Hints }}
+        # Please enable when all supported Kubernetes versions
+        # are on GoLang 1.25+
+        {{- end }}
         - waitgroup
 
     revive:


### PR DESCRIPTION
#### What type of PR is this?

Follow-up to #136292
@pohly suggested a set of rules from [modernize](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize) that should be enabled as PR hints.

I've experimented with `slicescontains` which finds many matches across the entire code-base, and can be used to simplify code. There are some cases of internal functions that can be eliminated in favor a single `slices.Contains`:

* `func has(...`
* `func contains(...` (there are some variations of this).
* `func containsStr(...` 

/kind cleanup

#### What this PR does / why we need it:

It's good to use newer features in GoLang, especially when it serves to simplify the code. One highlight is that these rules should remain as hints, till they can be safely enabled.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

I don't know which is the correct way to write things in the hints golangci-lint file. `Hints` instead of `Base` didn't yield different files with `./hack/update-golangci-lint-config.sh`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: