### PR TITLE
fix: normalize nil ports to empty slice in NewPortMapKey

### DIFF
--- a/staging/src/k8s.io/endpointslice/util/controller_utils.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils.go
@@ -159,6 +159,10 @@ type PortMapKey string
 
 // NewPortMapKey generates a PortMapKey from endpoint ports.
 func NewPortMapKey(endpointPorts []discovery.EndpointPort) PortMapKey {
+	// Normalize nil to empty slice so they hash the same.
+	if endpointPorts == nil {
+		endpointPorts = []discovery.EndpointPort{}
+	}
 	sort.Sort(portsInOrder(endpointPorts))
 	return PortMapKey(deepHashObjectToString(endpointPorts))
 }

--- a/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
@@ -948,3 +948,15 @@ func TestDeepObjectPointer(t *testing.T) {
 		}
 	}
 }
+
+func TestNewPortMapKey_NilVsEmptySlice(t *testing.T) {
+	var nilPorts []discovery.EndpointPort
+	emptyPorts := []discovery.EndpointPort{}
+
+	nilKey := NewPortMapKey(nilPorts)
+	emptyKey := NewPortMapKey(emptyPorts)
+
+	if nilKey != emptyKey {
+		t.Errorf("NewPortMapKey should return the same key for nil and empty slice, got nil=%q empty=%q", nilKey, emptyKey)
+	}
+}


### PR DESCRIPTION
Prevents EndpointSlice churn for headless services where getEndpointPorts [returns an empty slice](https://github.com/kubernetes/kubernetes/blob/b4947a5891ab3faa822e8bfe0c17725b2ba18766/staging/src/k8s.io/endpointslice/utils.go#L81) but existing slices from the API server have nil ports, causing different hash values. This leads to continuous churn of the endpoint slices as:
- no matches occur due to hash mismatch
- all new slices need to be created
- all old slices need to be deleted
- an [optimization](https://github.com/kubernetes/kubernetes/blob/b4947a5891ab3faa822e8bfe0c17725b2ba18766/staging/src/k8s.io/endpointslice/reconciler.go#L409) in the reconciler updates the old slices instead of deleting them and creating new ones making it appear as churn in the endpoint slices instead of deletions/creations of new endpoint slices

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes #133474

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that caused endpoint slice churn for headless services with no ports defined (#133474)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
