### PR TITLE
kubelet: prevent the removal of nested mounted points contents when tearing down emptyDir volumes

### DIFF
--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/util/swap"
@@ -539,6 +541,13 @@ func (ed *emptyDir) TearDownAt(dir string) error {
 	if err != nil {
 		return err
 	}
+
+	// Unmount mounts propagated into the emptyDir during pod lifetime.
+	// The directory teardown must not recurse into mounted filesystems.
+	if err := unmountNestedMounts(ed.mounter, dir); err != nil {
+		return err
+	}
+
 	if isMnt {
 		if medium == v1.StorageMediumMemory {
 			ed.medium = v1.StorageMediumMemory
@@ -550,6 +559,41 @@ func (ed *emptyDir) TearDownAt(dir string) error {
 	}
 	// assume StorageMediumDefault
 	return ed.teardownDefault(dir)
+}
+
+// unmountNestedMounts unmounts any mounts that exist inside the given directory.
+func unmountNestedMounts(mounter mount.Interface, dir string) error {
+	mps, err := mounter.List()
+	if err != nil {
+		return fmt.Errorf("failed to list mounts: %w", err)
+	}
+
+	var nested []string
+	for _, mp := range mps {
+		if mp.Path != dir && mount.PathWithinBase(mp.Path, dir) {
+			nested = append(nested, mp.Path)
+		}
+	}
+
+	if len(nested) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(nested, func(a, b string) int {
+		if cmp := len(b) - len(a); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a, b)
+	})
+
+	for _, p := range nested {
+		klog.V(4).Infof("Unmounting nested mount %s inside emptyDir %s", p, dir)
+		if err := mounter.Unmount(p); err != nil {
+			return fmt.Errorf("failed to unmount nested mount %q inside emptyDir %q: %w", p, dir, err)
+		}
+	}
+
+	return nil
 }
 
 func (ed *emptyDir) teardownDefault(dir string) error {

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1479,5 +1480,150 @@ func TestEmptyDirVolumeModeFeatureGateDisabled(t *testing.T) {
 
 	if fileinfo.Mode().Perm() != perm.Perm() {
 		t.Errorf("expected default permissions %v when feature gate is disabled, got %v", perm.Perm(), fileinfo.Mode().Perm())
+	}
+}
+
+// TestUnmountNestedMounts verifies that unmountNestedMounts unmounts exactly
+// the nested mounts, deepest first, leaving the directory itself and unrelated
+// mounts untouched.
+func TestUnmountNestedMounts(t *testing.T) {
+	testCases := map[string]struct {
+		path             string
+		mountPoints      []string
+		unmountFailsAt   string
+		expectedUnmounts []string
+	}{
+		"no mounts": {
+			path: "/mnt/dir",
+		},
+		"no nested mounts": {
+			path:        "/mnt/dir",
+			mountPoints: []string{"/mnt", "/mnt/dir-unrelated-a", "/mnt/dir-unrelated-b"},
+		},
+		"path itself is a mount point": {
+			path:        "/mnt/dir",
+			mountPoints: []string{"/mnt/dir"},
+		},
+		"nested mount": {
+			path:             "/mnt/dir",
+			mountPoints:      []string{"/mnt/dir/a"},
+			expectedUnmounts: []string{"/mnt/dir/a"},
+		},
+		"all nested mounts are unmounted deepest first, then alphabetically": {
+			path:             "/mnt/dir",
+			mountPoints:      []string{"/mnt/dir/d", "/mnt/dir/a/b", "/mnt/dir/a/b/c", "/mnt/dir/a", "/mnt/unrelated"},
+			expectedUnmounts: []string{"/mnt/dir/a/b/c", "/mnt/dir/a/b", "/mnt/dir/a", "/mnt/dir/d"},
+		},
+		"first failure propagates the error and aborts the unmount sequence": {
+			path:             "/mnt/dir",
+			mountPoints:      []string{"/mnt/dir/a", "/mnt/dir/a/b", "/mnt/dir/a/b/c"},
+			unmountFailsAt:   "/mnt/dir/a/b",
+			expectedUnmounts: []string{"/mnt/dir/a/b/c"},
+		},
+	}
+
+	for testCaseName, testCase := range testCases {
+		t.Run(testCaseName, func(t *testing.T) {
+			physicalMounter := &mount.FakeMounter{}
+			for _, p := range testCase.mountPoints {
+				physicalMounter.MountPoints = append(physicalMounter.MountPoints, mount.MountPoint{Path: p})
+			}
+			physicalMounter.UnmountFunc = func(path string) error {
+				if path == testCase.unmountFailsAt {
+					return fmt.Errorf("device busy")
+				}
+				return nil
+			}
+
+			err := unmountNestedMounts(physicalMounter, testCase.path)
+			wantErr := testCase.unmountFailsAt != ""
+			if (err != nil) != wantErr {
+				t.Errorf("expected error: %v, got: %v", wantErr, err)
+			}
+
+			var unmounts []string
+			for _, action := range physicalMounter.GetLog() {
+				if action.Action == mount.FakeActionUnmount {
+					unmounts = append(unmounts, action.Target)
+				}
+			}
+			if !slices.Equal(unmounts, testCase.expectedUnmounts) {
+				t.Errorf("expected unmount sequence: %v, got: %v", testCase.expectedUnmounts, unmounts)
+			}
+		})
+	}
+}
+
+// TestTeardownUnmountsNestedMounts verifies that TearDown unmounts the
+// nested mounts before removing the directory recursively.
+func TestTeardownUnmountsNestedMounts(t *testing.T) {
+	testCases := map[string]struct {
+		nestedMounts      []string
+		unmountShouldFail bool
+	}{
+		"no nested mounts": {},
+		"with nested mounts": {
+			nestedMounts: []string{"nested/a", "nested/b"},
+		},
+		"unmount fails": {
+			nestedMounts:      []string{"nested/a"},
+			unmountShouldFail: true,
+		},
+	}
+
+	for testCaseName, testCase := range testCases {
+		t.Run(testCaseName, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			plug := makePluginUnderTest(t, "kubernetes.io/empty-dir", tmpDir)
+
+			physicalMounter := &mount.FakeMounter{}
+			if testCase.unmountShouldFail {
+				physicalMounter.UnmountFunc = func(path string) error {
+					return fmt.Errorf("device busy")
+				}
+			}
+
+			unmounter, err := plug.(*emptyDirPlugin).newUnmounterInternal(
+				"test-volume",
+				types.UID("poduid"),
+				physicalMounter,
+				&fakeMountDetector{},
+			)
+			if err != nil {
+				t.Fatalf("failed to make a new Unmounter: %v", err)
+			}
+
+			volPath := unmounter.GetPath()
+			if err := os.MkdirAll(volPath, perm); err != nil {
+				t.Fatalf("failed to create volume dir: %v", err)
+			}
+			for _, m := range testCase.nestedMounts {
+				physicalMounter.MountPoints = append(
+					physicalMounter.MountPoints,
+					mount.MountPoint{Path: filepath.Join(volPath, m)},
+				)
+			}
+
+			err = unmounter.TearDown()
+			if (err != nil) != testCase.unmountShouldFail {
+				t.Errorf("expected error: %v, got: %v", testCase.unmountShouldFail, err)
+			}
+
+			_, err = os.Stat(volPath)
+			if testCase.unmountShouldFail {
+				// A failed unmount aborts teardown, so the directory must still exist
+				if err != nil {
+					t.Errorf("expected volume path to still exist after failed teardown")
+				}
+			} else {
+				if mps, _ := physicalMounter.List(); len(mps) != 0 {
+					t.Errorf("expected all nested mounts to be unmounted, still mounted: %v", mps)
+				}
+				if !os.IsNotExist(err) {
+					t.Errorf("expected volume path to be removed after teardown")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Follow-up to #122114

When tearing down an emptyDir volume, all of its contents are recursively deleted using `os.RemoveAll`. In certain scenarios, there might be a nested mount inside the emptyDir that was bidirectionally propagated (rshared) from the container. Running a `rm -rf` in this directory would then remove all contents from the nested mount point.

For example, if we mount a NFS PV inside a bidirectionally propagated emptyDir, tearing down the emptyDir would result in wiping out all NFS contents (note that the NFS mount path is a subpath of emptyDir path):

```yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  name: pv-nfs
spec:
  accessModes:
  - ReadWriteMany
  capacity:
    storage: 1Gi
  nfs:
    server: 192.168.10.40
    path: /mnt/pool0/shared
  mountOptions:
  - vers=3
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pvc-nfs
spec:
  volumeName: pv-nfs
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 1Gi
---
apiVersion: v1
kind: Pod
metadata:
  name: pod
spec:
  containers:
  - name: sleep
    image: ubuntu:22.04
    command:
    - "bash"
    - "-c"
    - "trap : EXIT; sleep infinity & wait"
    securityContext:
      privileged: true
    volumeMounts:
    - name: rshared
      mountPath: /mnt/rshared
      mountPropagation: Bidirectional
    - name: nfs
      mountPath: /mnt/rshared/nfs
  volumes:
  - name: rshared
    emptyDir: {}
  - name: nfs
    persistentVolumeClaim:
      claimName: pvc-nfs
```

To simplify the example, I used a PV. However, this behavior occurs with any mounts; for instance, those mounted inside the container using the mount command.

---

The previously rejected fix (#122114) changed emptyDir teardown logic by replacing `os.RemoveAll` with `RemoveAllOneFilesystem`, which prevents crossing mount boundaries. However, that change broke some tests for volumes that delegates their teardown to emptyDir unmount logic, such as downwardapi, secret and configmap (`UnmountViaEmptyDir`).

In those tests, `FakeMounter` registers the volumes as mount points inside the emptyDir, so `RemoveAllOneFilesystem` correctly refused to delete them. While this is acceptable in this bug scenario (we should not delete nested mounts), the tests expect the volumes to be removed as part of teardown.

The new approach moves the logic into the emptyDir teardown process:

- During teardown, before "rmrf"ing the volume directory, we list all mount points that are nested inside the emptyDir path.
- These mounts are sorted by path length (deepest first) and unmounted in that order.
- If unmounting any nested mount fails, teardown returns an error, just as it would if the original `os.RemoveAll` failed for any other reason.
- After all nested mounts are unmounted, `os.RemoveAll` is called to delete the emptyDir directory, now free of nested mount points.

This ensures we never delete data from nested mounts, like those created via bidirectional mount propagation, while keeping the behavior local to emptyDir teardown.

Now all existing tests pass unchanged!

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR updates the emptyDir teardown logic to safely handle nested mounts.

#### Which issue(s) this PR is related to:

#122114

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
