### PR TITLE
kubelet: Fix race condition when pods are rejected

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2197,7 +2197,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		var volumeAttachLimitErr *volumemanager.VolumeAttachLimitExceededError
 		if errors.As(err, &volumeAttachLimitErr) {
 			kl.rejectPod(ctx, pod, volumemanager.VolumeAttachmentLimitExceededReason, volumeAttachLimitErr.Error())
-			recordAdmissionRejection(volumemanager.VolumeAttachmentLimitExceededReason)
+			observeAdmissionRejection(volumemanager.VolumeAttachmentLimitExceededReason)
 			return true, nil, nil
 		}
 		if !wait.Interrupted(err) {
@@ -2589,14 +2589,14 @@ func (kl *Kubelet) deletePod(ctx context.Context, pod *v1.Pod) error {
 func (kl *Kubelet) rejectPod(ctx context.Context, pod *v1.Pod, reason, message string) {
 	logger := klog.FromContext(ctx)
 	kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, reason, "%s", message)
-	kl.statusManager.SetPodStatus(logger, pod, v1.PodStatus{
+	kl.statusManager.SetPodRejected(logger, pod, v1.PodStatus{
 		QOSClass: v1qos.GetPodQOS(pod), // keep it as is
 		Phase:    v1.PodFailed,
 		Reason:   reason,
 		Message:  "Pod was rejected: " + message})
 }
 
-func recordAdmissionRejection(reason string) {
+func observeAdmissionRejection(reason string) {
 	// It is possible that the "reason" label can have high cardinality.
 	// To avoid this metric from exploding, we create an allowlist of known
 	// reasons, and only record reasons from this list. Use "Other" reason
@@ -2875,7 +2875,7 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 				// repeatedly during a resize, which would inflate the metric.
 				// Instead, we record the metric here in HandlePodAdditions for new pods
 				// and capture resize events separately.
-				recordAdmissionRejection(reason)
+				observeAdmissionRejection(reason)
 				continue
 			}
 
@@ -2889,6 +2889,15 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 				}
 			}
 		}
+
+		// Skip pods rejected during this kubelet session.
+		// After restart, previously rejected pods may enter pod_workers, but they
+		// will be immediately marked as terminated because their pod cache is empty
+		// (no containers were ever created), so they won't affect resource accounting.
+		if kl.statusManager.IsPodRejected(pod.UID) {
+			continue
+		}
+
 		kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{
 			Pod:        pod,
 			MirrorPod:  mirrorPod,
@@ -2959,6 +2968,18 @@ func (kl *Kubelet) HandlePodUpdates(ctx context.Context, pods []*v1.Pod) {
 					kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedNodeDeclaredFeaturesCheck, "Pod requires node features that are not available: %s", missingNodeDeclaredFeatures)
 				}
 			}
+		}
+
+		// Skip rejected pods during UPDATE operations.
+		// Pods always arrive as ADD before UPDATE (enforced by the config layer).
+		// If a pod failed admission in HandlePodAdditions, it was rejected and
+		// never sent to pod_workers. UPDATE operations for such pods should be
+		// ignored because:
+		// 1. No containers exist - nothing to sync or clean up
+		// 2. The pod is already in terminal Failed state
+		// 3. REMOVE operation will eventually clean up podManager
+		if kl.statusManager.IsPodRejected(pod.UID) {
+			continue
 		}
 
 		kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1880,7 +1880,12 @@ func TestSyncPodsSetStatusToFailedForPodsThatRunTooLong(t *testing.T) {
 	}
 
 	// Let the pod worker sets the status to fail after this sync.
-	kubelet.HandlePodUpdates(tCtx, pods)
+	// Use HandlePodSyncs to test active deadline behavior.
+	// This bypasses admission and sends pods directly to the pod worker.
+	// HandlePodUpdates requires the pod to already be known to the worker,
+	// and HandlePodAdditions would reject the pod due to test node capacity.
+	kubelet.podManager.SetPods(pods)
+	kubelet.HandlePodSyncs(tCtx, pods)
 	status, found := kubelet.statusManager.GetPodStatus(pods[0].UID)
 	assert.True(t, found, "expected to found status for pod %q", pods[0].UID)
 	assert.Equal(t, v1.PodFailed, status.Phase)
@@ -1930,8 +1935,11 @@ func TestSyncPodsDoesNotSetPodsThatDidNotRunTooLongToFailed(t *testing.T) {
 		}},
 	}
 
+	// Use HandlePodSyncs to test active deadline behavior.
+	// This bypasses admission and sends pods directly to the pod worker.
+	// HandlePodUpdates requires the pod to already be known to the worker.
 	kubelet.podManager.SetPods(pods)
-	kubelet.HandlePodUpdates(tCtx, pods)
+	kubelet.HandlePodSyncs(tCtx, pods)
 	status, found := kubelet.statusManager.GetPodStatus(pods[0].UID)
 	assert.True(t, found, "expected to found status for pod %q", pods[0].UID)
 	assert.NotEqual(t, v1.PodFailed, status.Phase)
@@ -3699,7 +3707,7 @@ func TestSyncPodSpans(t *testing.T) {
 	}
 }
 
-func TestRecordAdmissionRejection(t *testing.T) {
+func TestObserveAdmissionRejection(t *testing.T) {
 	metrics.Register()
 
 	testCases := []struct {
@@ -3914,7 +3922,7 @@ func TestRecordAdmissionRejection(t *testing.T) {
 			metrics.AdmissionRejectionsTotal.Reset()
 
 			// Call the function.
-			recordAdmissionRejection(tc.reason)
+			observeAdmissionRejection(tc.reason)
 
 			if err := testutil.GatherAndCompare(metrics.GetGather(), strings.NewReader(tc.wants), "kubelet_admission_rejections_total"); err != nil {
 				t.Error(err)
@@ -5181,4 +5189,222 @@ func TestSyncPodRestartAllContainersRequeue(t *testing.T) {
 	// We expect SyncPod to be called once by us, and once recursively via UpdatePod -> fakePodWorkers.syncPodFn
 	// because the SyncResults contained a successful RemoveContainer action.
 	require.Equal(t, 1, callCount)
+}
+
+func TestIsPodRejected(t *testing.T) {
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kubelet := testKubelet.kubelet
+
+	// Helper to create a unique pod for each test case.
+	podCounter := 0
+	newUniquePod := func() *v1.Pod {
+		podCounter++
+		pod := newTestPods(1)[0]
+		pod.UID = types.UID(fmt.Sprintf("test-pod-uid-%d", podCounter))
+		pod.Name = fmt.Sprintf("test-pod-%d", podCounter)
+		return pod
+	}
+
+	testCases := []struct {
+		name             string
+		setupPod         func() *v1.Pod
+		setupLocalStatus func(*v1.Pod)
+		expectedRejected bool
+		description      string
+	}{
+		{
+			name: "no local status",
+			setupPod: func() *v1.Pod {
+				return newUniquePod()
+			},
+			setupLocalStatus: func(pod *v1.Pod) {},
+			expectedRejected: false,
+			description:      "pod with no local status should not be considered rejected",
+		},
+		{
+			name: "local status set via SetPodStatus",
+			setupPod: func() *v1.Pod {
+				return newUniquePod()
+			},
+			setupLocalStatus: func(pod *v1.Pod) {
+				kubelet.statusManager.SetPodStatus(klog.TODO(), pod, v1.PodStatus{
+					Phase:   v1.PodFailed,
+					Reason:  "ImagePullBackOff",
+					Message: "Failed to pull image",
+				})
+			},
+			expectedRejected: false,
+			description:      "pod with status set via SetPodStatus should not be considered rejected",
+		},
+		{
+			name: "rejected pod via SetPodRejected",
+			setupPod: func() *v1.Pod {
+				return newUniquePod()
+			},
+			setupLocalStatus: func(pod *v1.Pod) {
+				kubelet.statusManager.SetPodRejected(klog.TODO(), pod, v1.PodStatus{
+					Phase:   v1.PodFailed,
+					Reason:  "OutOfcpu",
+					Message: "Pod was rejected: insufficient CPU",
+				})
+			},
+			expectedRejected: true,
+			description:      "pod rejected via SetPodRejected should be considered rejected",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := tc.setupPod()
+			tc.setupLocalStatus(pod)
+
+			result := kubelet.statusManager.IsPodRejected(pod.UID)
+			assert.Equal(t, tc.expectedRejected, result, tc.description)
+		})
+	}
+}
+
+func TestRejectedPodNeverEntersPodWorkers(t *testing.T) {
+	ctx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kubelet := testKubelet.kubelet
+
+	// Set up node with limited CPU and memory so pods get rejected during admission
+	kubelet.nodeLister = testNodeLister{nodes: []*v1.Node{{
+		ObjectMeta: metav1.ObjectMeta{Name: string(kubelet.nodeName)},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+				v1.ResourceCPU:    resource.MustParse("100m"),  // Only 100 millicores available
+				v1.ResourceMemory: resource.MustParse("100Mi"), // Only 100Mi available
+			},
+		},
+	}}}
+
+	// Use real podWorkers for proper state tracking
+	kubelet.workQueue = queue.NewBasicWorkQueue(clock.RealClock{})
+	kubelet.podWorkers = newPodWorkers(
+		kubelet, kubelet.recorder, kubelet.workQueue,
+		kubelet.resyncInterval, backOffPeriod,
+		kubelet.podCache, kubelet.allocationManager,
+	)
+
+	// Initialize pod_workers by calling SyncKnownPods with empty list
+	// This sets podsSynced=true so CouldHaveRunningContainers works correctly
+	kubelet.podWorkers.SyncKnownPods(klog.TODO(), nil)
+
+	// Simulate force scheduling a pod into a node where it doesnt fit.
+	t.Run("rejected pod not added to podWorkers after ADD", func(t *testing.T) {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "rejected-add-pod",
+				Name:      "rejected-add-pod",
+				Namespace: "default",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{{
+					Name: "container",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("10Mi"),
+						},
+					},
+				}},
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodPending,
+			},
+		}
+
+		// Call HandlePodAdditions simulating a forced schedule followed by ADD operation.
+		kubelet.HandlePodAdditions(ctx, []*v1.Pod{pod})
+		assert.True(t, kubelet.statusManager.IsPodRejected(pod.UID),
+			"pod should be rejected")
+
+		// Verify pod is NOT in podWorkers by checking the known pods map
+		knownPods := kubelet.podWorkers.SyncKnownPods(klog.TODO(), nil)
+		_, isKnown := knownPods[pod.UID]
+		assert.False(t, isKnown,
+			"rejected pod should not be in pod_workers after ADD")
+	})
+
+	// Simulate a re-sync for a rejected pod that was force-scheduled.
+	t.Run("rejected pod not added to podWorkers after UPDATE sync", func(t *testing.T) {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "rejected-update-pod",
+				Name:      "rejected-update-pod",
+				Namespace: "default",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{{
+					Name: "container",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("10Mi"),
+						},
+					},
+				}},
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodPending,
+			},
+		}
+
+		kubelet.HandlePodAdditions(ctx, []*v1.Pod{pod})
+		assert.True(t, kubelet.statusManager.IsPodRejected(pod.UID),
+			"pod should be rejected")
+
+		// Now simulate an UPDATE from a re-sync for the rejected pod. Note
+		// the status in apiserver is still Pending as it was previously rejected
+		// but has not re-synced
+		kubelet.HandlePodUpdates(ctx, []*v1.Pod{pod})
+
+		// Verify pod is still NOT in pod_workers after UPDATE
+		knownPods := kubelet.podWorkers.SyncKnownPods(klog.TODO(), nil)
+		_, isKnown := knownPods[pod.UID]
+		assert.False(t, isKnown,
+			"rejected pod should not be in pod_workers after UPDATE")
+	})
+
+	// Simulate a pod that was rejected and synced to apiserver, then kubelet restarted
+	// and its getting the pod again, this time with Failed phase.
+	t.Run("pod with Failed status triggers termination in podWorkers", func(t *testing.T) {
+		// Create a pod with small resource requests that will be admitted
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "failed-pod",
+				Name:      "failed-pod",
+				Namespace: "default",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{{
+					Name: "container",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("10Mi"),
+						},
+					},
+				}},
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodFailed,
+			},
+		}
+
+		kubelet.HandlePodAdditions(ctx, []*v1.Pod{pod})
+		assert.False(t, kubelet.statusManager.IsPodRejected(pod.UID),
+			"pod can not be rejected because it was already terminal")
+
+		// HandlePodUpdates with Failed phase should trigger termination
+		kubelet.HandlePodUpdates(ctx, []*v1.Pod{pod})
+		// Verify pod has termination requested (terminatingAt is set)
+		assert.True(t, kubelet.podWorkers.IsPodTerminationRequested(pod.UID),
+			"pod with Failed status should have termination requested after UPDATE")
+	})
 }

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -61,6 +61,9 @@ type versionedPodStatus struct {
 	// True if the status is generated at the end of SyncTerminatedPod, or after it is completed.
 	podIsFinished bool
 
+	// True if the pod was rejected during admission.
+	podIsRejected bool
+
 	status v1.PodStatus
 }
 
@@ -155,6 +158,7 @@ type Manager interface {
 	AddPodUpdateNotifier(notifier PodUpdateNotifier)
 
 	// SetPodStatus caches updates the cached status for the given pod, and triggers a status update.
+	// This function must be used only for admitted pods.
 	SetPodStatus(logger klog.Logger, pod *v1.Pod, status v1.PodStatus) (v1.PodStatus, bool)
 
 	// SetContainerReadiness updates the cached container status with the given readiness, and
@@ -204,6 +208,13 @@ type Manager interface {
 	// BackfillPodResizeConditions backfills the status manager's resize conditions by reading them from the
 	// provided pods' statuses.
 	BackfillPodResizeConditions(pods []*v1.Pod)
+
+	// SetPodRejected caches the status for a pod and also marks it as rejected.
+	// This function is exclusive for rejected pod status update.
+	SetPodRejected(logger klog.Logger, pod *v1.Pod, status v1.PodStatus) (v1.PodStatus, bool)
+
+	// IsPodRejected returns true if the pod was rejected during admission.
+	IsPodRejected(uid types.UID) bool
 }
 
 const syncPeriod = 10 * time.Second
@@ -471,7 +482,31 @@ func (m *manager) SetPodStatus(logger klog.Logger, pod *v1.Pod, status v1.PodSta
 
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
+	return m.setPodStatusLocked(logger, pod, status, false, &notification)
+}
 
+func (m *manager) SetPodRejected(logger klog.Logger, pod *v1.Pod, status v1.PodStatus) (v1.PodStatus, bool) {
+	var notification *podStatusNotification
+	defer func() {
+		if notification != nil {
+			m.sendNotification(notification)
+		}
+	}()
+
+	m.podStatusesLock.Lock()
+	defer m.podStatusesLock.Unlock()
+	return m.setPodStatusLocked(logger, pod, status, true, &notification)
+}
+
+func (m *manager) IsPodRejected(uid types.UID) bool {
+	m.podStatusesLock.RLock()
+	defer m.podStatusesLock.RUnlock()
+	status, ok := m.podStatuses[types.UID(m.podManager.TranslatePodUID(uid))]
+	return ok && status.podIsRejected
+}
+
+// setPodStatusLocked updates the pod status cache. The caller must hold podStatusesLock.
+func (m *manager) setPodStatusLocked(logger klog.Logger, pod *v1.Pod, status v1.PodStatus, podIsRejected bool, notification **podStatusNotification) (v1.PodStatus, bool) {
 	// Make sure we're caching a deep copy.
 	status = *status.DeepCopy()
 
@@ -481,8 +516,8 @@ func (m *manager) SetPodStatus(logger klog.Logger, pod *v1.Pod, status v1.PodSta
 	// Force a status update if deletion timestamp is set. This is necessary
 	// because if the pod is in the non-running state, the pod worker still
 	// needs to be able to trigger an update and/or deletion.
-	changed, notif := m.updateStatusInternal(logger, pod, status, pod.DeletionTimestamp != nil, false)
-	notification = notif
+	changed, notif := m.updateStatusInternal(logger, pod, status, pod.DeletionTimestamp != nil, false, podIsRejected)
+	*notification = notif
 
 	return m.podStatuses[pod.UID].status, changed
 }
@@ -554,7 +589,7 @@ func (m *manager) SetContainerReadiness(logger klog.Logger, podUID types.UID, co
 	allContainerStatuses := append(status.InitContainerStatuses, status.ContainerStatuses...)
 	updateConditionFunc(v1.PodReady, GeneratePodReadyCondition(pod, &oldStatus.status, status.Conditions, allContainerStatuses, status.Phase))
 	updateConditionFunc(v1.ContainersReady, GenerateContainersReadyCondition(pod, &oldStatus.status, allContainerStatuses, status.Phase))
-	_, notification = m.updateStatusInternal(logger, pod, status, false, false)
+	_, notification = m.updateStatusInternal(logger, pod, status, false, false, false)
 }
 
 func (m *manager) SetContainerStartup(logger klog.Logger, podUID types.UID, containerID kubecontainer.ContainerID, started bool) {
@@ -603,7 +638,7 @@ func (m *manager) SetContainerStartup(logger klog.Logger, podUID types.UID, cont
 	containerStatus, _, _ = findContainerStatus(&status, containerID.String())
 	containerStatus.Started = &started
 
-	_, notification = m.updateStatusInternal(logger, pod, status, false, false)
+	_, notification = m.updateStatusInternal(logger, pod, status, false, false, false)
 }
 
 func findContainerStatus(status *v1.PodStatus, containerID string) (containerStatus *v1.ContainerStatus, init bool, ok bool) {
@@ -704,7 +739,7 @@ func (m *manager) TerminatePod(logger klog.Logger, pod *v1.Pod) {
 	}
 
 	logger.V(5).Info("TerminatePod calling updateStatusInternal", "pod", klog.KObj(pod), "podUID", pod.UID)
-	_, notification = m.updateStatusInternal(logger, pod, status, true, true)
+	_, notification = m.updateStatusInternal(logger, pod, status, true, true, false)
 }
 
 // hasPodInitialized returns true if the pod has no evidence of ever starting a regular container, which
@@ -846,7 +881,7 @@ func checkContainerStateTransition(oldStatuses, newStatuses *v1.PodStatus, podSp
 // updateStatusInternal updates the internal status cache, and queues an update to the api server if
 // necessary.
 // This method IS NOT THREAD SAFE and must be called from a locked function.
-func (m *manager) updateStatusInternal(logger klog.Logger, pod *v1.Pod, status v1.PodStatus, forceUpdate, podIsFinished bool) (bool, *podStatusNotification) {
+func (m *manager) updateStatusInternal(logger klog.Logger, pod *v1.Pod, status v1.PodStatus, forceUpdate, podIsFinished, podIsRejected bool) (bool, *podStatusNotification) {
 	var oldStatus v1.PodStatus
 	cachedStatus, isCached := m.podStatuses[pod.UID]
 	if isCached {
@@ -856,6 +891,10 @@ func (m *manager) updateStatusInternal(logger klog.Logger, pod *v1.Pod, status v
 			if cachedStatus.podIsFinished && !podIsFinished {
 				logger.Info("Got unexpected podIsFinished=false, while podIsFinished=true in status cache, programmer error", "pod", klog.KObj(pod))
 				podIsFinished = true
+			}
+			if cachedStatus.podIsRejected && !podIsRejected {
+				logger.Info("Got unexpected podIsRejected=false, while podIsRejected=true in status cache, programmer error", "pod", klog.KObj(pod))
+				podIsRejected = true
 			}
 		}
 	} else if mirrorPod, ok := m.podManager.GetMirrorPodByPod(pod); ok {
@@ -979,6 +1018,7 @@ func (m *manager) updateStatusInternal(logger klog.Logger, pod *v1.Pod, status v
 		podName:       pod.Name,
 		podNamespace:  pod.Namespace,
 		podIsFinished: podIsFinished,
+		podIsRejected: podIsRejected,
 	}
 
 	// Multiple status updates can be generated before we update the API server,


### PR DESCRIPTION
Fix race condition in kubelet where rejected pods could be incorrectly counted as active during resource accounting, causing spurious rejections of subsequent pods.

When a pod fails admission (e.g., insufficient resources), the kubelet:
1. Sets pod status to Failed with a specific rejection message.
2. Skips adding the pod to pod_workers (no containers to manage). Also sets a specific status, including a message prefix about rejection.
3. Schedules sync of the pod's status to the API server.
4. A re-sync/UPDATE operation comes from the API server.
5. The pod is added to pod_workers as a first sync with Pending phase (as it is the API server status).
6. The pod's local status is updated to Failed and `terminatingAt` is set. This signals the pod as actively terminating, even though it has no containers.
7. A new pod comes in, while going through admission active pods are filtered using `filterOutInactivePods`.
8. A pod is considered active if it has containers running or is actively terminating. This is the case for the rejected pod, as it has `terminatingAt` set.
9. Race condition: The new pod may be rejected because resource accounting is considering a pod that has no containers.

This only happens if a new pod arrives before the whole status sync round-trip to API server is finished.

If rejected pods do not have any resources they do not require any surveillance/cleanup, therefore they should not be added to pod_workers. From Kubelet's POV:
When receiving an ADD:
- A pod being added to the kubelet undergoes the admission process. Rejected pods are not included in pod_workers.
- A pod being added after a kubelet restart (after a restart pod_workers is empty and needs rebuilding):
  - The pod was not yet rejected by previous ADD operation, therefore it does not have the status updated and goes through admission, which will reject it again.
  - The pod was rejected by previous ADD operation but API server did not have the re-sync ready, therefore it has no status and goes through regular admission process, getting a rejection.
  - The pod was rejected by previous ADD operation and API server was synced. The status on the pod signals it was rejected and the logic can skip it based on that.

When receiving an UPDATE:
- Any pod that comes through an UPDATE operation was already seen in an ADD operation. This is enforced by the Kubelet's config layer.
- If a pod is not present in the pod_workers already, it means it was previously rejected by the ADD operation, therefore it can be skipped.

#### What type of PR is this?
/kind bug
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes #135296

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug that caused rejected pods to be considered in resource accounting when scheduling (#135296)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
