### PR TITLE
Export `validateAffinity()` as `ValidateAffinity()` for external validation consistency

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4257,6 +4257,11 @@ func validateImagePullSecrets(imagePullSecrets []core.LocalObjectReference, fldP
 	return allErrors
 }
 
+// ValidateAffinity checks if given affinities are valid.
+func ValidateAffinity(affinity *core.Affinity, opts PodValidationOptions, fldPath *field.Path) field.ErrorList {
+	return validateAffinity(affinity, opts, fldPath)
+}
+
 // validateAffinity checks if given affinities are valid
 func validateAffinity(affinity *core.Affinity, opts PodValidationOptions, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it

The `validateAffinity()` function in the `k8s.io/kubernetes/pkg/apis/core/validation` package was previously unexported (private). This forced external projects needing to validate Affinity configurations to duplicate approximately 200 lines of validation logic, including helper functions like `validateNodeAffinity`, `validatePodAffinity`, and `validatePodAntiAffinity`.

This PR exports `validateAffinity()` as `ValidateAffinity()`, following the established pattern in the same package where validation methods are already exported for NodeSelector (`ValidateNodeSelector`) and Tolerations (`ValidateTolerations`).

**Benefits:**

- **Reduces Maintenance Burden:** External projects no longer need to keep duplicated logic in sync with upstream changes.
- **Ensures Validation Consistency:** Guarantees that client-side and server-side validation logic remains identical.
- **Follows Project Patterns:** Mirrors the implementation of other exported validation helpers.

#### Which issue(s) this PR is related to

Fixes #136422

#### Special notes for your reviewer

This is a non-breaking wrapper implementing the suggested approach:

```go
func ValidateAffinity(affinity *core.Affinity, opts PodValidationOptions, fldPath *field.Path) field.ErrorList {
    return validateAffinity(affinity, opts, fldPath)
}
```

Existing internal code paths remain unaffected.

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc

N/A
