### PR TITLE
Migrate CSR to declarative validation

### DIFF
--- a/pkg/apis/certificates/v1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1/zz_generated.validations.go
@@ -55,7 +55,20 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequest) (errs field.ErrorList) {
 	// field certificatesv1.CertificateSigningRequest.TypeMeta has no validation
 	// field certificatesv1.CertificateSigningRequest.ObjectMeta has no validation
-	// field certificatesv1.CertificateSigningRequest.Spec has no validation
+
+	// field certificatesv1.CertificateSigningRequest.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CertificateSigningRequestSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequest) *certificatesv1.CertificateSigningRequestSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
 
 	// field certificatesv1.CertificateSigningRequest.Status
 	errs = append(errs,
@@ -71,6 +84,77 @@ func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operat
 			return &oldObj.Status
 		}), oldObj != nil)...)
 
+	return errs
+}
+
+// Validate_CertificateSigningRequestSpec validates an instance of CertificateSigningRequestSpec according
+// to declarative validation rules in the API schema.
+func Validate_CertificateSigningRequestSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestSpec) (errs field.ErrorList) {
+	// field certificatesv1.CertificateSigningRequestSpec.Request
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []byte, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("request"), obj.Request, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestSpec) []byte { return oldObj.Request }), oldObj != nil)...)
+
+	// field certificatesv1.CertificateSigningRequestSpec.SignerName
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("signerName"), &obj.SignerName, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestSpec) *string { return &oldObj.SignerName }), oldObj != nil)...)
+
+	// field certificatesv1.CertificateSigningRequestSpec.ExpirationSeconds has no validation
+
+	// field certificatesv1.CertificateSigningRequestSpec.Usages
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1.KeyUsage, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("usages"), obj.Usages, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestSpec) []certificatesv1.KeyUsage {
+			return oldObj.Usages
+		}), oldObj != nil)...)
+
+	// field certificatesv1.CertificateSigningRequestSpec.Username has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.UID has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.Groups has no validation
+	// field certificatesv1.CertificateSigningRequestSpec.Extra has no validation
 	return errs
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -17483,7 +17483,7 @@ func schema_k8sio_api_certificates_v1_CertificateSigningRequestSpec(ref common.R
 						},
 					},
 				},
-				Required: []string{"request", "signerName"},
+				Required: []string{"request", "signerName", "usages"},
 			},
 		},
 	}

--- a/pkg/registry/certificates/certificatesigningrequest/declarative_validation_test.go
+++ b/pkg/registry/certificates/certificatesigningrequest/declarative_validation_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificatesigningrequest
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/certificates"
+)
+
+func TestDeclarativeValidate(t *testing.T) {
+	apiVersions := []string{"v1"}
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:          "certificates.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "certificatesigningrequests",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	testCases := map[string]struct {
+		input        certificates.CertificateSigningRequest
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidCSR(),
+		},
+		"invalid signerName (empty)": {
+			input: mkValidCSR(func(obj *certificates.CertificateSigningRequest) {
+				obj.Spec.SignerName = ""
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "signerName"), ""),
+			},
+		},
+		"invalid usages (empty)": {
+			input: mkValidCSR(func(obj *certificates.CertificateSigningRequest) {
+				obj.Spec.Usages = nil
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "usages"), ""),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+		})
+	}
+}
+
+func mkValidCSR(tweaks ...func(obj *certificates.CertificateSigningRequest)) certificates.CertificateSigningRequest {
+	obj := certificates.CertificateSigningRequest{
+		Spec: certificates.CertificateSigningRequestSpec{
+			Request:    []byte("some-csr-data"),
+			SignerName: "example.com/signer",
+			Usages:     []certificates.KeyUsage{certificates.UsageDigitalSignature},
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -111,6 +111,8 @@ message CertificateSigningRequestList {
 message CertificateSigningRequestSpec {
   // request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block.
   // When serialized as JSON or YAML, the data is additionally base64-encoded.
+  // +required
+  // +k8s:required
   optional bytes request = 1;
 
   // signerName indicates the requested signer, and is a qualified name.
@@ -134,6 +136,8 @@ message CertificateSigningRequestSpec {
   //  4. Required, permitted, or forbidden key usages / extended key usages.
   //  5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
   //  6. Whether or not requests for CA certificates are allowed.
+  // +required
+  // +k8s:required
   optional string signerName = 7;
 
   // expirationSeconds is the requested duration of validity of the issued
@@ -173,6 +177,8 @@ message CertificateSigningRequestSpec {
   //  "ipsec end system", "ipsec tunnel", "ipsec user",
   //  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
   // +listType=atomic
+  // +required
+  // +k8s:required
   repeated string usages = 5;
 
   // username contains the name of the user that created the CertificateSigningRequest.

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -61,6 +61,8 @@ type CertificateSigningRequest struct {
 type CertificateSigningRequestSpec struct {
 	// request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block.
 	// When serialized as JSON or YAML, the data is additionally base64-encoded.
+	// +required
+	// +k8s:required
 	Request []byte `json:"request" protobuf:"bytes,1,opt,name=request"`
 
 	// signerName indicates the requested signer, and is a qualified name.
@@ -84,6 +86,8 @@ type CertificateSigningRequestSpec struct {
 	//  4. Required, permitted, or forbidden key usages / extended key usages.
 	//  5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
 	//  6. Whether or not requests for CA certificates are allowed.
+	// +required
+	// +k8s:required
 	SignerName string `json:"signerName" protobuf:"bytes,7,opt,name=signerName"`
 
 	// expirationSeconds is the requested duration of validity of the issued
@@ -123,6 +127,8 @@ type CertificateSigningRequestSpec struct {
 	//  "ipsec end system", "ipsec tunnel", "ipsec user",
 	//  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
 	// +listType=atomic
+	// +required
+	// +k8s:required
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 
 	// username contains the name of the user that created the CertificateSigningRequest.


### PR DESCRIPTION
Migrates CertificateSigningRequest validation logic to use declarative markers and adds missing validation tests. Part of #135939.