### PR TITLE
Remove redundant re-assignments in for-loops under tests

### DIFF
--- a/test/e2e/auth/projected_clustertrustbundle.go
+++ b/test/e2e/auth/projected_clustertrustbundle.go
@@ -503,7 +503,6 @@ func ctbForCA(ctbName, signerName, caPEM string, labels map[string]string) *cert
 func mustInitCTBs(ctx context.Context, f *framework.Framework, ctbs []*certificatesv1beta1.ClusterTrustBundle) func(context.Context) {
 	cleanups := []func(context.Context){}
 	for _, ctb := range ctbs {
-		ctb := ctb
 		cleanups = append(cleanups, mustCreateCTB(ctx, f, ctb.DeepCopy()))
 	}
 

--- a/test/e2e/chaosmonkey/chaosmonkey.go
+++ b/test/e2e/chaosmonkey/chaosmonkey.go
@@ -86,7 +86,6 @@ func (cm *Chaosmonkey) Do(ctx context.Context) {
 	stopCh := make(chan struct{})
 
 	for _, test := range cm.tests {
-		test := test
 		sem := newSemaphore(stopCh)
 		sems = append(sems, sem)
 		go func() {

--- a/test/e2e/cloud/gcp/kubelet_security.go
+++ b/test/e2e/cloud/gcp/kubelet_security.go
@@ -72,7 +72,6 @@ var _ = SIGDescribe("Ports Security Check", feature.KubeletSecurity, func() {
 	// make sure kubelet readonly (10255) and cadvisor (4194) ports are closed on the public IP address
 	disabledPorts := []int{ports.KubeletReadOnlyPort, 4194}
 	for _, port := range disabledPorts {
-		port := port
 		ginkgo.It(fmt.Sprintf("should not have port %d open on its all public IP addresses", port), func(ctx context.Context) {
 			portClosedTest(f, node, port)
 		})

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -3096,7 +3096,6 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			claim2b := b2.ExternalClaim()
 			pod := b1.PodExternal()
 			for i, claim := range []*resourceapi.ResourceClaim{claim1b, claim2, claim2b} {
-				claim := claim
 				pod.Spec.ResourceClaims = append(pod.Spec.ResourceClaims,
 					v1.PodResourceClaim{
 						Name:              fmt.Sprintf("claim%d", i+1),

--- a/test/e2e/framework/node/node_killer.go
+++ b/test/e2e/framework/node/node_killer.go
@@ -68,7 +68,6 @@ func (k *NodeKiller) kill(ctx context.Context, nodes []v1.Node) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(nodes))
 	for _, node := range nodes {
-		node := node
 		go func() {
 			defer ginkgo.GinkgoRecover()
 			defer wg.Done()

--- a/test/e2e/framework/pod/output/output.go
+++ b/test/e2e/framework/pod/output/output.go
@@ -273,7 +273,6 @@ func TestContainerOutputsMatcher(ctx context.Context, f *framework.Framework,
 
 	expectedNameOutputs := make(map[string][]string, len(expectedOutputs))
 	for containerIndex, expectedOutput := range expectedOutputs {
-		expectedOutput := expectedOutput
 		if containerIndex < 0 || containerIndex >= len(pod.Spec.Containers) {
 			framework.Failf("Invalid container index: %d", containerIndex)
 		}

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -414,7 +414,6 @@ var _ = SIGDescribe("kubelet", func() {
 
 			// execute It blocks from above table of tests
 			for _, t := range testTbl {
-				t := t
 				ginkgo.It(t.itDescr, func(ctx context.Context) {
 					pod = createPodUsingNfs(ctx, f, c, ns, nfsIP, t.podCmd)
 

--- a/test/e2e/storage/csimock/csi_fsgroup_mount.go
+++ b/test/e2e/storage/csimock/csi_fsgroup_mount.go
@@ -50,7 +50,6 @@ var _ = utils.SIGDescribe("CSI Mock fsgroup as mount option", func() {
 			},
 		}
 		for _, t := range tests {
-			t := t
 			ginkgo.It(t.name, func(ctx context.Context) {
 				var nodeStageFsGroup, nodePublishFsGroup string
 				if framework.NodeOSDistroIs("windows") {

--- a/test/e2e/storage/csimock/csi_selinux_mount.go
+++ b/test/e2e/storage/csimock/csi_selinux_mount.go
@@ -279,7 +279,6 @@ var _ = utils.SIGDescribe("CSI Mock selinux on mount", func() {
 			},
 		}
 		for _, t := range tests {
-			t := t
 			testFunc := func(ctx context.Context) {
 				if processLabel == "" {
 					e2eskipper.Skipf("SELinux tests are supported only on %+v", getSupportedSELinuxDistros())
@@ -799,7 +798,6 @@ var _ = utils.SIGDescribe("CSI Mock selinux on mount metrics and SELinuxWarningC
 			},
 		}
 		for _, t := range tests {
-			t := t
 			testFunc := func(ctx context.Context) {
 				if processLabel == "" {
 					e2eskipper.Skipf("SELinux tests are supported only on %+v", getSupportedSELinuxDistros())

--- a/test/e2e/storage/csimock/csi_service_account_token.go
+++ b/test/e2e/storage/csimock/csi_service_account_token.go
@@ -67,7 +67,6 @@ var _ = utils.SIGDescribe("CSI Mock volume service account token", func() {
 			},
 		}
 		for _, test := range tests {
-			test := test
 			csiServiceAccountTokenEnabled := test.tokenRequests != nil
 			ginkgo.It(test.desc, func(ctx context.Context) {
 				m.init(ctx, testParameters{

--- a/test/e2e/storage/csimock/csi_snapshot.go
+++ b/test/e2e/storage/csimock/csi_snapshot.go
@@ -64,7 +64,6 @@ var _ = utils.SIGDescribe("CSI Mock volume snapshot", func() {
 			},
 		}
 		for _, test := range tests {
-			test := test
 			ginkgo.It(test.name, func(ctx context.Context) {
 				var hooks *drivers.Hooks
 				if test.createSnapshotHook != nil {
@@ -208,7 +207,6 @@ var _ = utils.SIGDescribe("CSI Mock volume snapshot", func() {
 			},
 		}
 		for _, test := range tests {
-			test := test
 			ginkgo.It(test.name, func(ctx context.Context) {
 				hooks := createPreHook("CreateSnapshot", test.createSnapshotHook)
 				m.init(ctx, testParameters{
@@ -299,7 +297,6 @@ var _ = utils.SIGDescribe("CSI Mock volume snapshot", func() {
 			},
 		}
 		for _, test := range tests {
-			test := test
 			ginkgo.It(test.name, func(ctx context.Context) {
 				m.init(ctx, testParameters{
 					disableAttach:  true,

--- a/test/e2e/storage/ephemeral_volume.go
+++ b/test/e2e/storage/ephemeral_volume.go
@@ -54,7 +54,6 @@ var _ = utils.SIGDescribe("Ephemeralstorage", func() {
 
 	ginkgo.Describe("When pod refers to non-existent ephemeral storage", func() {
 		for _, testSource := range invalidEphemeralSource("pod-ephm-test") {
-			testSource := testSource
 			ginkgo.It(fmt.Sprintf("should allow deletion of pod with invalid volume : %s", testSource.volumeType), func(ctx context.Context) {
 				pod := testEphemeralVolumePod(f, testSource.volumeType, testSource.source)
 				pod, err := c.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})

--- a/test/e2e_node/standalone_test.go
+++ b/test/e2e_node/standalone_test.go
@@ -606,7 +606,6 @@ func getPodFromStandaloneKubelet(ctx context.Context, podNamespace string, podNa
 
 	for _, p := range pods.Items {
 		// Static pods has a node name suffix so comparing as substring
-		p := p
 		if strings.Contains(p.Name, podName) && strings.Contains(p.Namespace, podNamespace) {
 			return &p, nil
 		}

--- a/test/integration/apimachinery/watch_namespace_test.go
+++ b/test/integration/apimachinery/watch_namespace_test.go
@@ -100,7 +100,6 @@ func TestWatchNamespaceEvent(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range tt {
-			tc := tc // we need to copy it for parallel runs
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				startTest := time.Now()

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -2829,7 +2829,6 @@ type partialObjectMetadataCheck func(*metav1beta1.PartialObjectMetadata)
 func expectPartialObjectMetaEventsProtobuf(t *testing.T, r io.Reader, values ...string) {
 	checks := []partialObjectMetadataCheck{}
 	for i, value := range values {
-		i, value := i, value
 		checks = append(checks, func(meta *metav1beta1.PartialObjectMetadata) {
 			if meta.Annotations["test"] != value {
 				t.Fatalf("expected event %d to have value %q instead of %q", i+1, value, meta.Annotations["test"])

--- a/test/integration/apiserver/oidc/oidc_test.go
+++ b/test/integration/apiserver/oidc/oidc_test.go
@@ -411,7 +411,6 @@ jwt:
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, singleTestRunner(useAuthenticationConfig, rsaGenerateKey, tt))
 	}
 
@@ -554,7 +553,6 @@ func TestUpdatingRefreshTokenInCaseOfExpiredIDToken(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			expiredIDToken, stubRefreshToken := fetchExpiredToken(t, oidcServer, caCert, signingPrivateKey)
 			clientConfig := configureClientConfigForOIDC(t, apiServer.ClientConfig, defaultOIDCClientID, certPath, expiredIDToken, stubRefreshToken, oidcServer.URL())
@@ -1051,7 +1049,6 @@ jwt:
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			oidcServer, apiServer, signingPrivateKey, caCert, certPath := tt.configureInfrastructure(t, tt.authConfigFn, rsaGenerateKey)
@@ -1511,7 +1508,6 @@ jwt:
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			authenticationconfigmetrics.ResetMetricsForTest()
 			defer authenticationconfigmetrics.ResetMetricsForTest()
@@ -1675,7 +1671,6 @@ func TestStructuredAuthenticationDiscoveryURL(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			caCertContent, _, caFilePath, caKeyFilePath := generateCert(t)

--- a/test/integration/certificates/duration_test.go
+++ b/test/integration/certificates/duration_test.go
@@ -201,7 +201,6 @@ func TestCSRDuration(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -542,7 +542,6 @@ func execPluginClientTests(t *testing.T, unauthorizedCert, unauthorizedKey []byt
 func v1beta1TestsFromV1Tests(v1Tests []execPluginClientTestData) []execPluginClientTestData {
 	v1beta1Tests := make([]execPluginClientTestData, 0, len(v1Tests))
 	for _, v1Test := range v1Tests {
-		v1Test := v1Test
 
 		v1beta1Test := v1Test
 		v1beta1Test.name = fmt.Sprintf("%s v1beta1", v1Test.name)
@@ -573,7 +572,6 @@ func TestExecPluginViaClient(t *testing.T) {
 	tests := execPluginClientTests(t, unauthorizedCert, unauthorizedKey, clientAuthorizedToken, clientCertFileName, clientKeyFileName)
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			actualMetrics := captureMetrics(t)
 
@@ -1143,7 +1141,6 @@ func TestExecPluginGlobalCache(t *testing.T) {
 	getTestExecClientAddresses := func(t *testing.T, tests []execPluginClientTestData, suffix string) []string {
 		var addresses []string
 		for i, test := range tests {
-			test := test
 			t.Run(test.name+" "+suffix, func(t *testing.T) {
 				clientConfig := rest.AnonymousClientConfig(result.ClientConfig)
 				clientConfig.ExecProvider = &clientcmdapi.ExecConfig{

--- a/test/integration/controlplane/transformation/all_transformation_test.go
+++ b/test/integration/controlplane/transformation/all_transformation_test.go
@@ -117,7 +117,6 @@ resources:
 		{"apiregistration.k8s.io", "v1", "APIService", "apiservices", "as2.foo.com", ""},
 		{"", "v1", "Pod", "pods", "pod1", testNamespace},
 	} {
-		tt := tt
 		t.Run(tt.resource, func(t *testing.T) {
 			t.Parallel()
 

--- a/test/integration/dualstack/dualstack_test.go
+++ b/test/integration/dualstack/dualstack_test.go
@@ -240,7 +240,6 @@ func TestCreateServiceSingleStackIPv4(t *testing.T) {
 				}
 
 				for i, tc := range testcases {
-					tc := tc
 					t.Run(tc.name, func(t *testing.T) {
 
 						svc := &v1.Service{
@@ -483,7 +482,6 @@ func TestCreateServiceSingleStackIPv6(t *testing.T) {
 				}
 
 				for i, tc := range testcases {
-					tc := tc
 					t.Run(tc.name, func(t *testing.T) {
 
 						svc := &v1.Service{
@@ -763,7 +761,6 @@ func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 				}
 
 				for i, tc := range testcases {
-					tc := tc
 					t.Run(tc.name, func(t *testing.T) {
 
 						svc := &v1.Service{
@@ -1011,7 +1008,6 @@ func TestCreateServiceDualStackIPv6IPv4(t *testing.T) {
 				}
 
 				for i, tc := range testcases {
-					tc := tc
 					t.Run(tc.name, func(t *testing.T) {
 
 						svc := &v1.Service{

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -871,7 +871,6 @@ func waitForWardleAPIServiceReady(ctx context.Context, t *testing.T, kubeConfig 
 		}
 		resources := make([]string, 0, 2)
 		for _, resource := range apiResources.APIResources {
-			resource := resource
 			resources = append(resources, resource.Name)
 		}
 		sort.Strings(resources)

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -3209,7 +3209,6 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 	closeFn, restConfig, clientSet, ns := setup(t, "pod-replacement-policy")
 	t.Cleanup(closeFn)
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			if !tc.podReplacementPolicyEnabled {
 				// TODO: this will be removed in 1.37.
@@ -3436,7 +3435,6 @@ func TestElasticIndexedJob(t *testing.T) {
 	closeFn, restConfig, clientSet, ns := setup(t, "indexed")
 	t.Cleanup(closeFn)
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			ctx, cancel := startJobControllerAndWaitForCaches(t, restConfig)
 			t.Cleanup(cancel)
@@ -4563,7 +4561,6 @@ func TestDelayedJobUpdateEvent(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			ctx, cancel := startJobControllerAndWaitForCaches(t, restConfig, transformOpt)
 			t.Cleanup(cancel)
@@ -5003,7 +5000,6 @@ func updatePodStatuses(ctx context.Context, clientSet clientset.Interface, updat
 	var updated int32
 
 	for _, pod := range updates {
-		pod := pod
 		go func() {
 			_, err := clientSet.CoreV1().Pods(pod.Namespace).UpdateStatus(ctx, &pod, metav1.UpdateOptions{})
 			if err != nil {
@@ -5080,7 +5076,6 @@ func getJobPodsForIndex(ctx context.Context, clientSet clientset.Interface, jobO
 	}
 	var result []*v1.Pod
 	for _, pod := range pods.Items {
-		pod := pod
 		if !metav1.IsControlledBy(&pod, jobObj) {
 			continue
 		}

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -1521,7 +1521,6 @@ func startCollectingMetrics(tCtx ktesting.TContext, collectorWG *sync.WaitGroup,
 	collectors := getTestDataCollectors(podInformer, fmt.Sprintf("%s/%s", workloadName, name), namespaces, labelSelector, mcc, throughputErrorMargin)
 	for _, collector := range collectors {
 		// Need loop-local variable for function below.
-		collector := collector
 		err := collector.init()
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize data collector: %w", err)

--- a/test/integration/servicecidr/migration_test.go
+++ b/test/integration/servicecidr/migration_test.go
@@ -428,7 +428,6 @@ func TestServiceCIDRMigrationScenarios(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			etcdOptions := framework.SharedEtcd()

--- a/test/integration/storageversionmigrator/storageversionmigrator_test.go
+++ b/test/integration/storageversionmigrator/storageversionmigrator_test.go
@@ -328,7 +328,6 @@ func TestStorageVersionMigrationDuringChaos(t *testing.T) {
 	const migrations = 10 // more than the total workers of SVM
 	wg.Add(migrations)
 	for i := range migrations {
-		i := i
 		go func() {
 			defer wg.Done()
 

--- a/test/integration/storageversionmigrator/util.go
+++ b/test/integration/storageversionmigrator/util.go
@@ -1173,7 +1173,6 @@ func (svm *svmTest) createChaos(ctx context.Context, t *testing.T) {
 	const workers = 10
 	wg.Add(workers)
 	for i := range workers {
-		i := i
 		go func() {
 			defer wg.Done()
 

--- a/test/utils/ktesting/assert_test.go
+++ b/test/utils/ktesting/assert_test.go
@@ -429,7 +429,6 @@ func TestAssert(t *testing.T) {
 `,
 		},
 	} {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			tc.run(t)

--- a/test/utils/ktesting/contexthelper_test.go
+++ b/test/utils/ktesting/contexthelper_test.go
@@ -105,7 +105,6 @@ func TestCause(t *testing.T) {
 			expectDeadline: time.Minute,
 		},
 	} {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			ctx, cancel := withTimeout(tt.parentCtx, t, tt.timeout, timeoutCause.Error())
 			if tt.cancelCause != "" {

--- a/test/utils/ktesting/stepcontext_test.go
+++ b/test/utils/ktesting/stepcontext_test.go
@@ -89,7 +89,6 @@ func TestStepContext(t *testing.T) {
 			expectDuration: 5 * time.Second,
 		},
 	} {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			tc.run(t)
 		})


### PR DESCRIPTION
…,utils}

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The [modernize forvar](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_forvar) rule was applied. There are more details in this blog post: https://go.dev/blog/loopvar-preview

You can use this to run it:

```sh
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -forvar -fix -test ./...
```

I haven't added all touched files to the PR/commit, as this may stall progress to get it merged. 

#### Which issue(s) this PR is related to:

It's a follow-up to #136292 where `forvar` was suggested as one of the candidates to use in the modernize enabled rules in golangci-lint. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: