### PR TITLE
DRA: add scheduler_perf benchmark for implicit resources

### DIFF
--- a/test/integration/scheduler_perf/dra/extendedresource/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/extendedresource/performance-config.yaml
@@ -149,3 +149,48 @@
       initPods: 2500
       measurePods: 2500
       maxClaimsPerNode: 10
+
+- name: ImplicitExtendedResource_25Classes
+  featureGates:
+    DynamicResourceAllocation: true
+    DRAExtendedResource: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $nodesWithoutDRA
+  - opcode: createNodes
+    nodeTemplatePath: ../templates/node-with-dra-test-driver.yaml
+    countParam: $nodesWithDRA
+  - opcode: createResourceDriver
+    driverName: test-driver.cdi.k8s.io
+    nodes: scheduler-perf-dra-*
+    maxClaimsPerNodeParam: $maxClaimsPerNode
+  - opcode: createAny
+    templatePath: ../templates/deviceclass-implicit-extended-resource.yaml
+    countParam: $classes
+  - opcode: createPods
+    namespace: init
+    countParam: $initPods
+    podTemplatePath: ../templates/pod-with-implicit-extended-resource-mod25.yaml
+  - opcode: createPods
+    namespace: test
+    countParam: $measurePods
+    podTemplatePath: ../templates/pod-with-implicit-extended-resource-mod25.yaml
+    collectMetrics: true
+  workloads:
+  - name: 2000pods_200nodes
+    params:
+      classes: 25
+      nodesWithDRA: 200
+      nodesWithoutDRA: 0
+      initPods: 1000
+      measurePods: 1000
+      maxClaimsPerNode: 10
+  - name: 5000pods_500nodes
+    labels: [performance]
+    params:
+      classes: 25
+      nodesWithDRA: 500
+      nodesWithoutDRA: 0
+      initPods: 2500
+      measurePods: 2500
+      maxClaimsPerNode: 10

--- a/test/integration/scheduler_perf/dra/templates/deviceclass-implicit-extended-resource.yaml
+++ b/test/integration/scheduler_perf/dra/templates/deviceclass-implicit-extended-resource.yaml
@@ -1,0 +1,8 @@
+apiVersion: resource.k8s.io/v1beta2
+kind: DeviceClass
+metadata:
+  name: test-class-{{.Index}}
+spec:
+  selectors:
+  - cel:
+      expression: device.driver == "test-driver.cdi.k8s.io"

--- a/test/integration/scheduler_perf/dra/templates/pod-with-implicit-extended-resource-mod25.yaml
+++ b/test/integration/scheduler_perf/dra/templates/pod-with-implicit-extended-resource-mod25.yaml
@@ -1,0 +1,16 @@
+# Pod template for implicit extended resource tests.
+# Pods cycle through 25 device classes:
+# from deviceclass.resource.kubernetes.io/test-class-0 to deviceclass.resource.kubernetes.io/test-class-24
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-dra-{{.Index}}
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.9
+    name: pause
+    resources:
+      requests:
+         deviceclass.resource.kubernetes.io/test-class-{{mod .Index 25}}: 1
+      limits:
+         deviceclass.resource.kubernetes.io/test-class-{{mod .Index 25}}: 1


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add performance configuration that measures scheduling performance of the implicit extended resources.

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/136473

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
