### PR TITLE
feat(ccm): introduce metric route_controller_route_sync_total

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package route
 
 import (

--- a/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
@@ -35,7 +35,7 @@ var (
 		Name:           "route_sync_total",
 		Subsystem:      subsystem,
 		Help:           "A metric counting the amount of times routes have been synced with the cloud provider.",
-		StabilityLevel: metrics.BETA,
+		StabilityLevel: metrics.ALPHA,
 	})
 )
 

--- a/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
@@ -1,0 +1,30 @@
+package route
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	// subsystem is the name of this subsystem used for prometheus metrics.
+	subsystem = "route_controller"
+)
+
+var registration sync.Once
+
+var (
+	routeSyncCount = metrics.NewCounter(&metrics.CounterOpts{
+		Name:           "route_sync_total",
+		Subsystem:      subsystem,
+		Help:           "A metric counting the amount of times routes have been synced with the cloud provider.",
+		StabilityLevel: metrics.BETA,
+	})
+)
+
+func registerMetrics() {
+	registration.Do(func() {
+		legacyregistry.MustRegister(routeSyncCount)
+	})
+}

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -87,6 +87,8 @@ func New(
 	clusterName string,
 	clusterCIDRs []*net.IPNet,
 ) (*RouteController, error) {
+	registerMetrics()
+
 	if len(clusterCIDRs) == 0 {
 		klog.Fatal("RouteController: Must specify clusterCIDR.")
 	}
@@ -247,6 +249,8 @@ func (rc *RouteController) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (rc *RouteController) reconcileNodeRoutes(ctx context.Context) error {
+	routeSyncCount.Inc()
+
 	routeList, err := rc.routes.ListRoutes(ctx, rc.clusterName)
 	if err != nil {
 		return fmt.Errorf("error listing routes: %v", err)

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -256,12 +256,6 @@
   labels:
   - deprecated_version
   - stability_level
-- name: route_sync_total
-  subsystem: route_controller
-  help: A metric counting the amount of times routes have been synced with the cloud
-    provider.
-  type: Counter
-  stabilityLevel: BETA
 - name: pod_scheduling_sli_duration_seconds
   subsystem: scheduler
   help: E2e latency for a pod being scheduled, from the time the pod enters the scheduling

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -256,6 +256,12 @@
   labels:
   - deprecated_version
   - stability_level
+- name: route_sync_total
+  subsystem: route_controller
+  help: A metric counting the amount of times routes have been synced with the cloud
+    provider.
+  type: Counter
+  stabilityLevel: BETA
 - name: pod_scheduling_sli_duration_seconds
   subsystem: scheduler
   help: E2e latency for a pod being scheduled, from the time the pod enters the scheduling


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a new metric to track the amount of times routes are synced with the cloud provider. This metric is mainly used for A/B tests on the feature gate `CloudControllerManagerWatchBasedRoutesReconciliation` introduced in Kubernetes v1.35.

#### Which issue(s) this PR is related to:

KEP update PR: https://github.com/kubernetes/enhancements/pull/5831
Feature gate implementation: https://github.com/kubernetes/kubernetes/pull/131220

#### Special notes for your reviewer:

This metric is introduced in alpha stage.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Cloud Controller Manager now exports the counter metric `route_controller_route_sync_total`, which increments each time routes are synced with the cloud provider. This metric is in alpha stage.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://kep.k8s.io/5237
```
