### PR TITLE
apimachinery: Add null pointer validation in Accessor method to improve error handling

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
@@ -89,11 +89,18 @@ func ListAccessor(obj interface{}) (List, error) {
 // interfaces.
 var errNotObject = fmt.Errorf("object does not implement the Object interfaces")
 
+// errNilObject is returned when a nil object is passed to Accessor.
+var errNilObject = fmt.Errorf("nil object passed")
+
 // Accessor takes an arbitrary object pointer and returns meta.Interface.
 // obj must be a pointer to an API type. An error is returned if the minimum
 // required fields are missing. Fields that are not required return the default
 // value and are a no-op if set.
 func Accessor(obj interface{}) (metav1.Object, error) {
+	// nil pointer check
+	if obj == nil || (reflect.ValueOf(obj).Kind() == reflect.Ptr && reflect.ValueOf(obj).IsNil()) {
+		return nil, errNilObject
+	}
 	switch t := obj.(type) {
 	case metav1.Object:
 		return t, nil

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/meta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/meta_test.go
@@ -49,3 +49,16 @@ func TestAsPartialObjectMetadata(t *testing.T) {
 		}
 	}
 }
+
+func TestAccessor_NilPointer(t *testing.T) {
+	var object metav1.ObjectMeta
+	_, err := Accessor(object)
+	if err != errNotObject {
+		t.Fatalf("expected errNotObject, got: %v", err)
+	}
+	var nilPtr *metav1.ObjectMeta = nil
+	_, err = Accessor(nilPtr)
+	if err != errNilObject {
+		t.Fatalf("expected errNilObject, got: %v", err)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
I observed that CoreDN caused a panic when an unexpected null pointer was passed to this method. Similarly, the Kubernetes code does not check for null pointers when using this function.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

