### PR TITLE
Kubelet: DRA: improve contextual logging

### DIFF
--- a/pkg/kubelet/cm/dra/claiminfo_test.go
+++ b/pkg/kubelet/cm/dra/claiminfo_test.go
@@ -445,8 +445,7 @@ func TestNewClaimInfoCache(t *testing.T) {
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
-			tCtx := ktesting.Init(t)
-			result, err := newClaimInfoCache(tCtx.Logger(), test.stateDir, test.checkpointName)
+			result, err := newClaimInfoCache(test.stateDir, test.checkpointName)
 			if test.wantErr {
 				assert.Error(t, err)
 				return
@@ -505,10 +504,10 @@ func TestClaimInfoCacheWithLock(t *testing.T) {
 	} {
 		t.Run(test.description, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
-			cache, err := newClaimInfoCache(tCtx.Logger(), t.TempDir(), "test-checkpoint")
+			cache, err := newClaimInfoCache(t.TempDir(), "test-checkpoint")
 			require.NoError(t, err)
 			assert.NotNil(t, cache)
-			err = cache.withLock(test.funcGen(cache))
+			err = cache.withLock(tCtx.Logger(), test.funcGen(cache))
 			if test.wantErr {
 				assert.Error(t, err)
 				return
@@ -565,8 +564,7 @@ func TestClaimInfoCacheWithRLock(t *testing.T) {
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
-			tCtx := ktesting.Init(t)
-			cache, err := newClaimInfoCache(tCtx.Logger(), t.TempDir(), "test-checkpoint")
+			cache, err := newClaimInfoCache(t.TempDir(), "test-checkpoint")
 			require.NoError(t, err)
 			assert.NotNil(t, cache)
 			err = cache.withRLock(test.funcGen(cache))
@@ -619,7 +617,7 @@ dra_resource_claims_in_use{driver_name="<any>"} 1
 dra_resource_claims_in_use{driver_name="other-test-driver"} 1
 dra_resource_claims_in_use{driver_name="test-driver"} 1
 `,
-			expectLog: `INFO ResourceClaim usage changed claimsInUse=<
+			expectLog: `INFO dra-claiminfo: ResourceClaim usage changed claimsInUse=<
 	<any>: 1 (+1)
 	other-test-driver: 1 (+1)
 	test-driver: 1 (+1)
@@ -655,7 +653,7 @@ dra_resource_claims_in_use{driver_name="<any>"} 2
 dra_resource_claims_in_use{driver_name="other-test-driver"} 1
 dra_resource_claims_in_use{driver_name="test-driver"} 2
 `,
-			expectLog: `INFO ResourceClaim usage changed claimsInUse=<
+			expectLog: `INFO dra-claiminfo: ResourceClaim usage changed claimsInUse=<
 	<any>: 2 (+1)
 	other-test-driver: 1 (+1)
 	test-driver: 2 (+1)
@@ -665,13 +663,13 @@ dra_resource_claims_in_use{driver_name="test-driver"} 2
 	} {
 		t.Run(test.description, func(t *testing.T) {
 			tCtx := ktesting.Init(t, initoption.BufferLogs(true))
-			cache, err := newClaimInfoCache(tCtx.Logger(), t.TempDir(), "test-checkpoint")
+			cache, err := newClaimInfoCache(t.TempDir(), "test-checkpoint")
 			for _, claimInfo := range test.initialClaimInfo {
 				cache.add(claimInfo)
 			}
 			require.NoError(t, err)
 			assert.NotNil(t, cache)
-			_ = cache.withLock(func() error {
+			_ = cache.withLock(tCtx.Logger(), func() error {
 				cache.add(test.claimInfo)
 				return nil
 			})
@@ -809,7 +807,7 @@ dra_resource_claims_in_use{driver_name="<any>"} 1
 dra_resource_claims_in_use{driver_name="test-driver"} 1
 dra_resource_claims_in_use{driver_name="other-test-driver"} 1
 `,
-			expectLog: `INFO ResourceClaim usage changed claimsInUse=<
+			expectLog: `INFO dra-claiminfo: ResourceClaim usage changed claimsInUse=<
 	<any>: 1 (-1)
 	other-test-driver: 1 (+0)
 	test-driver: 1 (-1)
@@ -827,8 +825,7 @@ dra_resource_claims_in_use{driver_name="<any>"} 0
 	} {
 		t.Run(test.description, func(t *testing.T) {
 			tCtx := ktesting.Init(t, initoption.BufferLogs(true))
-			test.claimInfoCache.logger = tCtx.Logger()
-			_ = test.claimInfoCache.withLock(func() error {
+			_ = test.claimInfoCache.withLock(tCtx.Logger(), func() error {
 				test.claimInfoCache.delete(claimName, namespace)
 				return nil
 			})
@@ -886,8 +883,7 @@ func TestSyncToCheckpoint(t *testing.T) {
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
-			tCtx := ktesting.Init(t)
-			cache, err := newClaimInfoCache(tCtx.Logger(), test.stateDir, test.checkpointName)
+			cache, err := newClaimInfoCache(test.stateDir, test.checkpointName)
 			require.NoError(t, err)
 			err = cache.syncToCheckpoint()
 			if test.wantErr {

--- a/pkg/kubelet/cm/dra/healthinfo.go
+++ b/pkg/kubelet/cm/dra/healthinfo.go
@@ -42,6 +42,7 @@ type healthInfoCache struct {
 
 // newHealthInfoCache creates a new cache, loading from a checkpoint if present.
 func newHealthInfoCache(logger klog.Logger, stateFile string) (*healthInfoCache, error) {
+	logger = logger.WithName("dra-healthinfo")
 	cache := &healthInfoCache{
 		HealthInfo: &state.DevicesHealthMap{},
 		stateFile:  stateFile,
@@ -85,6 +86,7 @@ func (cache *healthInfoCache) withRLock(f func() error) error {
 // saveToCheckpointInternal does the actual saving without locking.
 // Assumes the caller holds the necessary lock.
 func (cache *healthInfoCache) saveToCheckpointInternal(logger klog.Logger) error {
+	logger = logger.WithName("dra-healthinfo")
 	if cache.stateFile == "" {
 		return nil
 	}
@@ -152,6 +154,7 @@ func (cache *healthInfoCache) getHealthInfo(driverName, poolName, deviceName str
 // from a plugin. It identifies which devices have changed state and handles devices
 // that are no longer being reported by the plugin.
 func (cache *healthInfoCache) updateHealthInfo(logger klog.Logger, driverName string, devices []state.DeviceHealth) ([]state.DeviceHealth, error) {
+	logger = logger.WithName("dra-healthinfo")
 	changedDevices := []state.DeviceHealth{}
 	err := cache.withLock(func() error {
 		now := time.Now()

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -123,7 +123,7 @@ func NewManager(logger klog.Logger, kubeClient clientset.Interface, stateFileDir
 		return nil, fmt.Errorf("create ResourceClaim cache: %w", err)
 	}
 
-	healthInfoCache, err := newHealthInfoCache(filepath.Join(stateFileDirectory, "dra_health_state"))
+	healthInfoCache, err := newHealthInfoCache(logger, filepath.Join(stateFileDirectory, "dra_health_state"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create healthInfo cache: %w", err)
 	}
@@ -898,7 +898,7 @@ func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream draheal
 	defer func() {
 		logger.V(4).Info("Clearing health cache for driver upon stream exit", "pluginName", pluginName)
 		// Use a separate context for clearDriver if needed, though background should be fine.
-		if err := m.healthInfoCache.clearDriver(pluginName); err != nil {
+		if err := m.healthInfoCache.clearDriver(logger, pluginName); err != nil {
 			logger.Error(err, "Failed to clear health info cache for driver", "pluginName", pluginName)
 		}
 	}()
@@ -959,7 +959,7 @@ func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream draheal
 			}
 		}
 
-		changedDevices, updateErr := m.healthInfoCache.updateHealthInfo(pluginName, devices)
+		changedDevices, updateErr := m.healthInfoCache.updateHealthInfo(logger, pluginName, devices)
 		if updateErr != nil {
 			logger.Error(updateErr, "Failed to update health info cache", "pluginName", pluginName)
 		}

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin.go
@@ -74,7 +74,7 @@ func (p *DRAPlugin) NodePrepareResources(
 	req *drapbv1.NodePrepareResourcesRequest,
 	opts ...grpc.CallOption,
 ) (*drapbv1.NodePrepareResourcesResponse, error) {
-	logger := klog.FromContext(ctx)
+	logger := klog.FromContext(ctx).WithName("dra-plugin")
 	logger = klog.LoggerWithValues(logger, "driverName", p.driverName, "endpoint", p.endpoint)
 	ctx = klog.NewContext(ctx, logger)
 	logger.V(4).Info("Calling NodePrepareResources rpc", "request", req)
@@ -105,10 +105,11 @@ func (p *DRAPlugin) NodeUnprepareResources(
 	req *drapbv1.NodeUnprepareResourcesRequest,
 	opts ...grpc.CallOption,
 ) (*drapbv1.NodeUnprepareResourcesResponse, error) {
-	logger := klog.FromContext(ctx)
-	logger.V(4).Info("Calling NodeUnprepareResource rpc", "request", req)
+	logger := klog.FromContext(ctx).WithName("dra-plugin")
 	logger = klog.LoggerWithValues(logger, "driverName", p.driverName, "endpoint", p.endpoint)
 	ctx = klog.NewContext(ctx, logger)
+
+	logger.V(4).Info("Calling NodeUnprepareResource rpc", "request", req)
 
 	ctx, cancel := context.WithTimeout(ctx, p.clientCallTimeout)
 	defer cancel()
@@ -157,9 +158,10 @@ func (p *DRAPlugin) HealthStreamCancel() context.CancelFunc {
 
 // NodeWatchResources establishes a stream to receive health updates from the DRA plugin.
 func (p *DRAPlugin) NodeWatchResources(ctx context.Context) (drahealthv1alpha1.DRAResourceHealth_NodeWatchResourcesClient, error) {
+	logger := klog.FromContext(ctx).WithName("dra-plugin")
+	logger = klog.LoggerWithValues(logger, "driverName", p.driverName, "endpoint", p.endpoint)
 	healthClient := drahealthv1alpha1.NewDRAResourceHealthClient(p.conn)
 
-	logger := klog.FromContext(ctx).WithValues("pluginName", p.driverName)
 	logger.V(4).Info("Starting WatchResources stream")
 	stream, err := healthClient.NodeWatchResources(ctx, &drahealthv1alpha1.NodeWatchResourcesRequest{})
 	if err != nil {

--- a/pkg/kubelet/cm/dra/plugin/registration_test.go
+++ b/pkg/kubelet/cm/dra/plugin/registration_test.go
@@ -203,12 +203,12 @@ func TestRegistrationHandler(t *testing.T) {
 			service := drapb.DRAPluginService
 			tmp := t.TempDir()
 			endpointA := path.Join(tmp, socketFileA)
-			teardownA, err := setupFakeGRPCServer(service, endpointA)
+			teardownA, err := setupFakeGRPCServer(tCtx, service, endpointA)
 			require.NoError(t, err)
 			tCtx.Cleanup(teardownA)
 
 			endpoint := path.Join(tmp, test.socketFile)
-			teardown, err := setupFakeGRPCServer(service, endpoint)
+			teardown, err := setupFakeGRPCServer(tCtx, service, endpoint)
 			require.NoError(t, err)
 			tCtx.Cleanup(teardown)
 
@@ -316,7 +316,7 @@ func TestConnectionHandling(t *testing.T) {
 
 			// Run GRPC service.
 			endpoint := path.Join(t.TempDir(), "dra.sock")
-			teardown, err := setupFakeGRPCServer(service, endpoint)
+			teardown, err := setupFakeGRPCServer(tCtx, service, endpoint)
 			require.NoError(t, err)
 			defer teardown()
 
@@ -345,7 +345,7 @@ func TestConnectionHandling(t *testing.T) {
 
 				// Start up gRPC server again.
 				tCtx.Log("Restarting plugin gRPC server")
-				teardown, err = setupFakeGRPCServer(service, endpoint)
+				teardown, err = setupFakeGRPCServer(tCtx, service, endpoint)
 				require.NoError(t, err)
 				defer teardown()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It improves contextual logging for the Kubelet DRA code: uses proper context and loggers and sets logging prefixes to make DRA logs easily identifiable. 

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/130069

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/cc @ffromani @swatisehgal @hoteye