### PR TITLE
kubectl: accept "yml" as alias for "yaml" output

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
@@ -54,6 +54,10 @@ func (f *JSONYamlPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePr
 	var printer printers.ResourcePrinter
 
 	outputFormat = strings.ToLower(outputFormat)
+	// Normalize "yml" to "yaml" as a universally accepted alias
+	if outputFormat == "yml" {
+		outputFormat = "yaml"
+	}
 
 	valid := f.AllowedFormats()
 	if !slices.Contains(valid, outputFormat) {

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags_test.go
@@ -48,6 +48,16 @@ func TestPrinterSupportsExpectedJSONYamlFormats(t *testing.T) {
 			expectedOutput: "name: foo",
 		},
 		{
+			name:           "yml output format matches a yaml printer (alias)",
+			outputFormat:   "yml",
+			expectedOutput: "name: foo",
+		},
+		{
+			name:           "YML output format (uppercase) matches a yaml printer (alias)",
+			outputFormat:   "YML",
+			expectedOutput: "name: foo",
+		},
+		{
 			name:          "output format for another printer does not match a json/yaml printer",
 			outputFormat:  "jsonpath",
 			expectNoMatch: true,
@@ -87,5 +97,39 @@ func TestPrinterSupportsExpectedJSONYamlFormats(t *testing.T) {
 				t.Errorf("unexpected output: expecting %q, got %q", tc.expectedOutput, out.String())
 			}
 		})
+	}
+}
+
+func TestYmlAliasProducesIdenticalOutputToYaml(t *testing.T) {
+	testObject := &v1.Pod{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+	}
+
+	printFlags := JSONYamlPrintFlags{}
+
+	yamlPrinter, err := printFlags.ToPrinter("yaml")
+	if err != nil {
+		t.Fatalf("unexpected error creating yaml printer: %v", err)
+	}
+
+	ymlPrinter, err := printFlags.ToPrinter("yml")
+	if err != nil {
+		t.Fatalf("unexpected error creating yml printer: %v", err)
+	}
+
+	yamlOut := bytes.NewBuffer([]byte{})
+	ymlOut := bytes.NewBuffer([]byte{})
+
+	if err := yamlPrinter.PrintObj(testObject, yamlOut); err != nil {
+		t.Fatalf("unexpected error printing yaml: %v", err)
+	}
+
+	if err := ymlPrinter.PrintObj(testObject, ymlOut); err != nil {
+		t.Fatalf("unexpected error printing yml: %v", err)
+	}
+
+	if yamlOut.String() != ymlOut.String() {
+		t.Errorf("yml and yaml output differ:\nyaml: %q\nyml:  %q", yamlOut.String(), ymlOut.String())
 	}
 }


### PR DESCRIPTION
# kubectl: accept "yml" as alias for "yaml" output

## What this PR does / why we need it

Adds support for `-o yml` as a strict alias for `-o yaml` in kubectl output formatting.

Currently, `kubectl get <resource> -o yml` fails with:
```
unable to match a printer suitable for the output format "yml"
```

The `.yml` file extension is universally accepted as equivalent to `.yaml`, and many users naturally expect `-o yml` to work. This is a common UX paper-cut.

## Which issue(s) this PR fixes

Fixes #<issue-number>

## Special notes for your reviewer

- Normalizes "yml" to "yaml" early in the parsing pipeline (in `JSONYamlPrintFlags.ToPrinter`)
- Silent alias (not advertised in `AllowedFormats()` to keep help text clean)
- Comprehensive unit tests verify output equivalence between `-o yml` and `-o yaml`
- Backward compatible - no behavior changes for existing formats
- Minimal scope - single normalization point, no refactoring

## Implementation Details

The change normalizes "yml" to "yaml" immediately after lowercasing the output format string, before validation. This ensures:
- The alias works regardless of case ("yml", "YML", "Yml")
- Validation and printer selection use the normalized "yaml" value
- No changes needed to error messages or help text
- Existing `-o yaml` behavior is completely unchanged

## Testing

- [x] Unit tests added and passing
- [x] Verified `-o yml` produces identical output to `-o yaml`
- [x] Verified `-o yaml` still works (regression test)
- [x] Verified other formats (json, etc.) unaffected
- [x] Tested case insensitivity (yml, YML, Yml all work)

### Test Coverage

Added test cases in `json_yaml_flags_test.go`:
1. `TestPrinterSupportsExpectedJSONYamlFormats` - Extended with "yml" and "YML" test cases
2. `TestYmlAliasProducesIdenticalOutputToYaml` - New test function verifying byte-for-byte identical output

## Release Note

```release-note
kubectl now accepts `-o yml` as an alias for `-o yaml` output format
```
