### PR TITLE
kubelet: force 'create' verb for exec/attach/run/portForward endpoints

### DIFF
--- a/pkg/kubelet/server/auth.go
+++ b/pkg/kubelet/server/auth.go
@@ -95,6 +95,15 @@ func (n nodeAuthorizerAttributesGetter) GetRequestAttributes(ctx context.Context
 
 	requestPath := r.URL.Path
 
+	// Force "create" verb for endpoints that execute operations,
+	// regardless of HTTP method (e.g. WebSocket upgrades via GET).
+	if isSubpath(requestPath, "/exec") ||
+		isSubpath(requestPath, "/attach") ||
+		isSubpath(requestPath, "/run") ||
+		isSubpath(requestPath, "/portForward") {
+		apiVerb = "create"
+	}
+
 	var subresources []string
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletFineGrainedAuthz) {
 		switch {


### PR DESCRIPTION
## What this PR does

WebSocket connections start as HTTP GET requests, which the Kubelet's authorization logic maps to the RBAC `get` verb. This allows callers with only `nodes/proxy GET` permission to execute commands in any container via the Kubelet's `/exec`, `/attach`, `/run`, and `/portForward` endpoints — bypassing the `create` permission that should be required.

This is the same class of bug fixed on the API Server side for `pods/exec` by the `AuthorizePodWebsocketUpgradeCreatePermission` feature gate (KEP-4006, beta in v1.35), but was never applied to the Kubelet's direct API (port 10250).

## How it works

Force the API verb to `create` for these four endpoint paths regardless of HTTP method, in `GetRequestAttributes` (`pkg/kubelet/server/auth.go`). This ensures WebSocket upgrade requests are correctly authorized.

## Impact

- Monitoring tools (Prometheus, Datadog, etc.) that use `nodes/proxy GET` are unaffected — they hit `/metrics`, `/stats`, `/pods`, not `/exec`.
- `kubectl exec` is unaffected — it goes through the API Server, which authenticates to the Kubelet with privileged credentials that have `create` permissions.
- POST requests already map to `create`, so this is a no-op for SPDY-based connections.

## References

- Blog post: https://grahamhelton.com/blog/nodes-proxy-rce
- Related API Server fix: https://github.com/kubernetes/kubernetes/issues/133515
- KEP-4006: WebSocket upgrade authorization