### PR TITLE
Use Log instead of Logf for job integration tests

### DIFF
--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -5348,11 +5348,11 @@ func TestMutablePodResourcesWithPodReplacementPolicyFailed(t *testing.T) {
 	jobClient := cs.BatchV1().Jobs(ns.Name)
 
 	// Wait for pods to be active
-	t.Logf("Waiting for 2 pods to be active")
+	t.Log("Waiting for 2 pods to be active")
 	waitForPodsToBeActive(ctx, t, jobClient, 2, job)
 
 	// Suspend the job
-	t.Logf("Suspending the job")
+	t.Log("Suspending the job")
 	_, err = updateJob(ctx, jobClient, job.Name, func(j *batchv1.Job) {
 		j.Spec.Suspend = ptr.To(true)
 	})
@@ -5371,10 +5371,10 @@ func TestMutablePodResourcesWithPodReplacementPolicyFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to wait for job to be suspended: %v", err)
 	}
-	t.Logf("Job is suspended")
+	t.Log("Job is suspended")
 
 	// Delete the pods to make them go to Terminating state
-	t.Logf("Deleting pods to make them go to Terminating state")
+	t.Log("Deleting pods to make them go to Terminating state")
 	deletePods(ctx, t, cs, ns.Name)
 
 	// Verify pods are in Terminating state (because of the finalizer)
@@ -5383,10 +5383,10 @@ func TestMutablePodResourcesWithPodReplacementPolicyFailed(t *testing.T) {
 		Active:      0,
 		Ready:       ptr.To[int32](0),
 	})
-	t.Logf("Pods are in Terminating state")
+	t.Log("Pods are in Terminating state")
 
 	// Update the job's pod template with new resources
-	t.Logf("Updating job resources")
+	t.Log("Updating job resources")
 	_, err = updateJob(ctx, jobClient, job.Name, func(j *batchv1.Job) {
 		for i := range j.Spec.Template.Spec.Containers {
 			j.Spec.Template.Spec.Containers[i].Resources = v1.ResourceRequirements{
@@ -5404,7 +5404,7 @@ func TestMutablePodResourcesWithPodReplacementPolicyFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to update Job resources: %v", err)
 	}
-	t.Logf("Job resources updated")
+	t.Log("Job resources updated")
 
 	// Wait a bit to ensure the controller has time to process the update
 	// With PodReplacementPolicy=Failed, no new pods should be created while old pods are terminating
@@ -5416,10 +5416,10 @@ func TestMutablePodResourcesWithPodReplacementPolicyFailed(t *testing.T) {
 		Active:      0,
 		Ready:       ptr.To[int32](0),
 	})
-	t.Logf("Verified: No new pods created while old pods are terminating")
+	t.Log("Verified: No new pods created while old pods are terminating")
 
 	// Remove the finalizers to allow pods to finish terminating
-	t.Logf("Removing finalizers from terminating pods")
+	t.Log("Removing finalizers from terminating pods")
 	err = removePodsFinalizers(ctx, cs, ns.Name, []string{blockDeletionFinalizerForTest})
 	if err != nil {
 		t.Fatalf("Failed to remove finalizers: %v", err)
@@ -5436,10 +5436,10 @@ func TestMutablePodResourcesWithPodReplacementPolicyFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to wait for terminating pods to be removed: %v", err)
 	}
-	t.Logf("Terminating pods have been removed")
+	t.Log("Terminating pods have been removed")
 
 	// Unsuspend the job
-	t.Logf("Unsuspending the job")
+	t.Log("Unsuspending the job")
 	_, err = updateJob(ctx, jobClient, job.Name, func(j *batchv1.Job) {
 		j.Spec.Suspend = ptr.To(false)
 	})
@@ -5449,7 +5449,7 @@ func TestMutablePodResourcesWithPodReplacementPolicyFailed(t *testing.T) {
 
 	// Wait for new pods to be created
 	waitForPodsToBeActive(ctx, t, jobClient, 2, job)
-	t.Logf("New pods are active")
+	t.Log("New pods are active")
 
 	// Verify that the new pods have the updated resources
 	pods, err := getJobPods(ctx, t, cs, job, func(s v1.PodStatus) bool { return true })
@@ -5478,5 +5478,5 @@ func TestMutablePodResourcesWithPodReplacementPolicyFailed(t *testing.T) {
 			}
 		}
 	}
-	t.Logf("Verified: New pods have the updated resources")
+	t.Log("Verified: New pods have the updated resources")
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/pull/135381/files#r2718323619
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
t.Log works when we don't have any formatting needed.

I found the cases where we do this in our integration tests and propsed a fix for all these.

This addresses @tenzen-y comment on https://github.com/kubernetes/kubernetes/pull/135381/files#r2718323619.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
