### PR TITLE
test: Fix KubeProxy CLOSE_WAIT test for IPv6 environments (and where /proc/net/nf_conntrack may be missing)

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -49,12 +49,11 @@ import (
 )
 
 // expandIPv6ForConntrack expands an IPv6 address to the format used in /proc/net/nf_conntrack.
-// The conntrack file uses fully expanded IPv6 addresses with leading zeros in each group.
 // e.g., "fc00:f853:ccd:e793::3" -> "fc00:f853:0ccd:e793:0000:0000:0000:0003"
 func expandIPv6ForConntrack(ipStr string) string {
 	ip := netutils.ParseIPSloppy(ipStr)
 	if !netutils.IsIPv6(ip) {
-		return ipStr // not IPv6 or invalid, return as-is
+		return ipStr
 	}
 	return fmt.Sprintf("%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
 		ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7],
@@ -220,52 +219,56 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPodSpec)
 
 		ginkgo.By("Checking conntrack entries for the timeout")
-		// These must be synchronized from the default values set in
-		// pkg/apis/../defaults.go ConntrackTCPCloseWaitTimeout. The
-		// current defaults are hidden in the initialization code.
 		const epsilonSeconds = 60
 		const expectedTimeoutSeconds = 60 * 60
-		// the conntrack file uses the IPv6 expanded format
+
+		// Detect conntrack method and build command
 		ip := serverNodeInfo.nodeIP
+		ipFamily := "ipv4"
 		if netutils.IsIPv6String(ip) {
-			ip = expandIPv6ForConntrack(ip)
+			ipFamily = "ipv6"
 		}
-		// Obtain the corresponding conntrack entry on the host by reading
-		// /proc/net/nf_conntrack directly from the pod e2e-net-exec.
-		// This avoids dependency on the conntrack binary.
-		// It retries in a loop if the entry is not found.
-		cmd := fmt.Sprintf("cat /proc/net/nf_conntrack "+
-			"| grep -m 1 -E 'CLOSE_WAIT.*dst=%v.*dport=%v'",
-			ip, testDaemonTCPPort)
+
+		var cmd, dumpCmd string
+		var timeoutIdx int
+		if _, err := e2epodoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", "test -f /proc/net/nf_conntrack"); err == nil {
+			procIP := ip
+			if ipFamily == "ipv6" {
+				procIP = expandIPv6ForConntrack(ip)
+			}
+			cmd = fmt.Sprintf("cat /proc/net/nf_conntrack | grep -m 1 -E 'CLOSE_WAIT.*dst=%s.*dport=%d'", procIP, testDaemonTCPPort)
+			dumpCmd = "cat /proc/net/nf_conntrack"
+			timeoutIdx = 4 // ipv4 2 tcp 6 <timeout> CLOSE_WAIT ...
+		} else if _, err := e2epodoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", "which conntrack"); err == nil {
+			cmd = fmt.Sprintf("conntrack -L -f %s -d %s 2>/dev/null | grep -m 1 'CLOSE_WAIT.*dport=%d'", ipFamily, ip, testDaemonTCPPort)
+			dumpCmd = "conntrack -L 2>/dev/null"
+			timeoutIdx = 2 // tcp 6 <timeout> CLOSE_WAIT ...
+		} else {
+			e2eskipper.Skipf("Neither /proc/net/nf_conntrack nor conntrack binary available")
+		}
+
 		if err := wait.PollImmediate(2*time.Second, epsilonSeconds*time.Second, func() (bool, error) {
 			result, err := e2epodoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", cmd)
-			// retry if we can't obtain the conntrack entry
 			if err != nil {
-				framework.Logf("failed to obtain conntrack entry: %v %v", result, err)
+				framework.Logf("failed to obtain conntrack entry: %v", err)
 				return false, nil
 			}
-			framework.Logf("conntrack entry for node %v and port %v:  %v", serverNodeInfo.nodeIP, testDaemonTCPPort, result)
-			// /proc/net/nf_conntrack format: ipv4 2 tcp 6 <timeout> <state> src=... dst=...
-			// Timeout in seconds is available as the fifth column (index 4)
-			line := strings.Fields(result)
-			if len(line) < 5 {
-				return false, fmt.Errorf("conntrack entry does not have a timeout field: %v", line)
+			fields := strings.Fields(result)
+			if len(fields) <= timeoutIdx {
+				return false, nil
 			}
-			timeoutSeconds, err := strconv.Atoi(line[4])
+			timeoutSeconds, err := strconv.Atoi(fields[timeoutIdx])
 			if err != nil {
-				return false, fmt.Errorf("failed to convert matched timeout %s to integer: %w", line[4], err)
+				return false, nil
 			}
+			framework.Logf("conntrack timeout for %v:%v = %v", serverNodeInfo.nodeIP, testDaemonTCPPort, timeoutSeconds)
 			if math.Abs(float64(timeoutSeconds-expectedTimeoutSeconds)) < epsilonSeconds {
 				return true, nil
 			}
 			return false, fmt.Errorf("wrong TCP CLOSE_WAIT timeout: %v expected: %v", timeoutSeconds, expectedTimeoutSeconds)
 		}); err != nil {
-			// Dump all conntrack entries for debugging
-			result, err2 := e2epodoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", "cat /proc/net/nf_conntrack")
-			if err2 != nil {
-				framework.Logf("failed to read /proc/net/nf_conntrack: %v %v", result, err2)
-			}
-			framework.Logf("conntrack entries for node %v:  %v", serverNodeInfo.nodeIP, result)
+			result, _ := e2epodoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", dumpCmd)
+			framework.Logf("conntrack entries: %v", result)
 			framework.Failf("no valid conntrack entry for port %d on node %s: %v", testDaemonTCPPort, serverNodeInfo.nodeIP, err)
 		}
 	})

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -48,6 +48,20 @@ import (
 	netutils "k8s.io/utils/net"
 )
 
+// expandIPv6ForConntrack expands an IPv6 address to the format used in /proc/net/nf_conntrack.
+// The conntrack file uses fully expanded IPv6 addresses with leading zeros in each group.
+// e.g., "fc00:f853:ccd:e793::3" -> "fc00:f853:0ccd:e793:0000:0000:0000:0003"
+func expandIPv6ForConntrack(ipStr string) string {
+	ip := netutils.ParseIPSloppy(ipStr)
+	if ip == nil || ip.To4() != nil {
+		return ipStr // not IPv6 or invalid, return as-is
+	}
+	ip = ip.To16()
+	return fmt.Sprintf("%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
+		ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7],
+		ip[8], ip[9], ip[10], ip[11], ip[12], ip[13], ip[14], ip[15])
+}
+
 var kubeProxyE2eImage = imageutils.GetE2EImage(imageutils.Agnhost)
 
 var _ = common.SIGDescribe("KubeProxy", func() {
@@ -217,6 +231,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		ipFamily := "ipv4"
 		if netutils.IsIPv6String(ip) {
 			ipFamily = "ipv6"
+			ip = expandIPv6ForConntrack(ip)
 		}
 		// Obtain the corresponding conntrack entry on the host by reading
 		// /proc/net/nf_conntrack directly from the pod e2e-net-exec.

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -53,10 +53,9 @@ import (
 // e.g., "fc00:f853:ccd:e793::3" -> "fc00:f853:0ccd:e793:0000:0000:0000:0003"
 func expandIPv6ForConntrack(ipStr string) string {
 	ip := netutils.ParseIPSloppy(ipStr)
-	if ip == nil || ip.To4() != nil {
+	if !netutils.IsIPv6(ip) {
 		return ipStr // not IPv6 or invalid, return as-is
 	}
-	ip = ip.To16()
 	return fmt.Sprintf("%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
 		ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7],
 		ip[8], ip[9], ip[10], ip[11], ip[12], ip[13], ip[14], ip[15])
@@ -228,9 +227,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		const expectedTimeoutSeconds = 60 * 60
 		// the conntrack file uses the IPv6 expanded format
 		ip := serverNodeInfo.nodeIP
-		ipFamily := "ipv4"
 		if netutils.IsIPv6String(ip) {
-			ipFamily = "ipv6"
 			ip = expandIPv6ForConntrack(ip)
 		}
 		// Obtain the corresponding conntrack entry on the host by reading
@@ -238,8 +235,8 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		// This avoids dependency on the conntrack binary.
 		// It retries in a loop if the entry is not found.
 		cmd := fmt.Sprintf("cat /proc/net/nf_conntrack "+
-			"| grep -m 1 -E '%s.*CLOSE_WAIT.*dst=%v.*dport=%v'",
-			ipFamily, ip, testDaemonTCPPort)
+			"| grep -m 1 -E 'CLOSE_WAIT.*dst=%v.*dport=%v'",
+			ip, testDaemonTCPPort)
 		if err := wait.PollImmediate(2*time.Second, epsilonSeconds*time.Second, func() (bool, error) {
 			result, err := e2epodoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", cmd)
 			// retry if we can't obtain the conntrack entry


### PR DESCRIPTION
The /proc/net/nf_conntrack file uses fully expanded IPv6 addresses with leading zeros in each 16-bit group. For example:
  fc00:f853:ccd:e793::3 -> fc00:f853:0ccd:e793:0000:0000:0000:0003

Add expandIPv6ForConntrack() helper function to expand IPv6 addresses to the format used by /proc/net/nf_conntrack before using them in the grep pattern.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

Fix for https://github.com/kubernetes/kubernetes/issues/136553

/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
