### PR TITLE
ktesting: progress reporting fix

### DIFF
--- a/test/utils/ktesting/examples/with_ktesting/example_test.go
+++ b/test/utils/ktesting/examples/with_ktesting/example_test.go
@@ -40,6 +40,16 @@ func TestTimeout(t *testing.T) {
 	if deadline, ok := t.Deadline(); ok {
 		t.Logf("Will fail shortly before the test suite deadline at %s.", deadline)
 	}
+
+	// This is how Ginkgo and ktesting communicate to Gomega how to
+	// provide a progress report when stuck in e.g. gomega.Eventually.
+	// Here we use this to provide some additional output when
+	// this example is sent a SIGUSR1.
+	remove := tCtx.Value("GINKGO_SPEC_CONTEXT").(interface {
+		AttachProgressReporter(func() string) func()
+	}).AttachProgressReporter(func() string { return "waiting for timeout or interrupt" })
+	defer remove()
+
 	select {
 	case <-time.After(1000 * time.Hour):
 		// This should not be reached.

--- a/test/utils/ktesting/main_test.go
+++ b/test/utils/ktesting/main_test.go
@@ -29,10 +29,6 @@ func TestMain(m *testing.M) {
 	// Bail out early when -help was given as parameter.
 	flag.Parse()
 
-	// The unit tests assume that they run as a unit test, with progress reporting enabled.
-	// This leaks a goroutine, so we have to do it before IgnoreCurrent.
-	initSignals()
-
 	// Must be called *before* creating new goroutines.
 	goleakOpts := []goleak.Option{
 		goleak.IgnoreCurrent(),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The recent change to support importing ktesting into an E2E suite without progress reporting was flawed:

 - If a Go unit test had a deadline (the default when invoked
   by `go test`!), the early return skipped initializing progress
   reporting.

 - When it didn't, for example when invoking a test binary directly
   under stress, a test created goroutines which were kept running,
   which broke leak checking in e.g. an integration tests TestMain.
    
 The revised approach uses reference counting: as long as some unit test is running, the progress reporting with the required goroutines are active. When the last one ends, they get cleaned up, which keeps the goleak checker happy.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/136156/changes/7421eea877883bf2422ee7ef0470d178dc650d2d

#### Special notes for your reviewer:

When running the new test for progress reporting under `stress`, other time-sensitive unit tests started to fail and therefore get changed here to use synctest. `stress ./ktesting.test` is stable.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @nojnhuh 