### PR TITLE
Revert GetImageRef to use Image.Id instead of RepoDigests

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -70,7 +70,7 @@ func (m *kubeGenericRuntimeManager) PullImage(ctx context.Context, image kubecon
 	return "", nil, utilerrors.NewAggregate(pullErrs)
 }
 
-// GetImageRef gets the reference (digest or ID) of the image which has already been in
+// GetImageRef gets the ID of the image which has already been in
 // the local storage. It returns ("", nil) if the image isn't in the local storage.
 func (m *kubeGenericRuntimeManager) GetImageRef(ctx context.Context, image kubecontainer.ImageSpec) (string, error) {
 	logger := klog.FromContext(ctx)
@@ -81,10 +81,6 @@ func (m *kubeGenericRuntimeManager) GetImageRef(ctx context.Context, image kubec
 	}
 	if resp.Image == nil {
 		return "", nil
-	}
-	// Prefer returning a digest reference over an image ID to ensure pull record lookups work correctly.
-	if len(resp.Image.RepoDigests) > 0 {
-		return resp.Image.RepoDigests[0], nil
 	}
 	return resp.Image.Id, nil
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Partially reverts cb011623c84 from #135369.

Using RepoDigests[0] as image identity causes credential verification issues because it makes identity location-dependent (registry.io/image@sha256:...) instead of content-based (sha256:...). This defeats deduplication and creates separate pull records for identical image content from different registries.

ImagePulledRecord already handles per-registry credentials via its two-level design: ImageRef identifies content, CredentialMapping tracks registry-specific credentials.


#### Which issue(s) this PR is related to:
Related: #136498, #136549


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
