### PR TITLE
Fix route controller condition update 

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -497,12 +497,12 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 
 func (rc *RouteController) updateNetworkingCondition(node *v1.Node, routesCreated bool) error {
 	_, condition := nodeutil.GetNodeCondition(&(node.Status), v1.NodeNetworkUnavailable)
-	if routesCreated && condition != nil && condition.Status == v1.ConditionFalse {
+	if routesCreated && condition != nil && condition.Status == v1.ConditionFalse && condition.Reason == "RouteCreated" {
 		klog.V(2).Infof("set node %v with NodeNetworkUnavailable=false was canceled because it is already set", node.Name)
 		return nil
 	}
 
-	if !routesCreated && condition != nil && condition.Status == v1.ConditionTrue {
+	if !routesCreated && condition != nil && condition.Status == v1.ConditionTrue && condition.Reason == "NoRouteCreated" {
 		klog.V(2).Infof("set node %v with NodeNetworkUnavailable=true was canceled because it is already set", node.Name)
 		return nil
 	}

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
@@ -766,7 +766,7 @@ func TestUpdateNetworkingCondition(t *testing.T) {
 				node.Status.Conditions = []v1.NodeCondition{*tc.existingCondition}
 			}
 
-			client := fake.NewSimpleClientset(node)
+			client := fake.NewClientset(node)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
 			rc, err := New(nil, client, informerFactory.Core().V1().Nodes(), cluster, []*net.IPNet{clusterCIDR})
@@ -841,7 +841,7 @@ func TestUpdateNetworkingConditionWithCalicoScenario(t *testing.T) {
 		},
 	}
 
-	client := fake.NewSimpleClientset(node)
+	client := fake.NewClientset(node)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 
 	rc, err := New(nil, client, informerFactory.Core().V1().Nodes(), cluster, []*net.IPNet{clusterCIDR})


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Fix route controller condition update when external CNI sets NetworkUnavailable

The updateNetworkingCondition function was returning early if the
NetworkUnavailable condition Status matched, preventing RouteController
from updating the Reason field when external CNIs (e.g., Calico) had
already set the condition.

Now checks both Status and Reason before skipping the update, ensuring
RouteController can properly set its "RouteCreated" reason even when
the condition already exists with a different reason.

Added comprehensive tests covering various condition update scenarios
including the specific Calico interoperability case.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
