### PR TITLE
cleanup: remove stale kube-proxy TODO in GCE config

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -522,7 +522,6 @@ PROMETHEUS_TO_SD_ENDPOINT=${PROMETHEUS_TO_SD_ENDPOINT:-https://monitoring.google
 PROMETHEUS_TO_SD_PREFIX=${PROMETHEUS_TO_SD_PREFIX:-custom.googleapis.com}
 ENABLE_PROMETHEUS_TO_SD=${ENABLE_PROMETHEUS_TO_SD:-true}
 
-# TODO(#51292): Make kube-proxy Daemonset default and remove the configuration here.
 # Optional: [Experiment Only] Run kube-proxy as a DaemonSet if set to true, run as static pods otherwise.
 KUBE_PROXY_DAEMONSET=${KUBE_PROXY_DAEMONSET:-false} # true, false
 


### PR DESCRIPTION
#### What type of PR is this? 
/kind cleanup

#### What this PR does / why we need it: 
While reviewing GCE cluster scripts, I found a stale TODO from 2017 regarding defaulting kube-proxy to a DaemonSet. Per maintainer feedback in #136563, these scripts are for testing only and no further development is anticipated. This PR removes the stale TODO to keep the configuration clean without changing existing test behavior.

#### Which issue(s) this PR is related to: 
Fixes #136563

#### Special notes for your reviewer: 
This is my second contribution. Following the guidance from @liggitt, I have opted to only remove the comment rather than flipping the technical default.

#### Does this PR introduce a user-facing change? 
None