### PR TITLE
Prevent nil pointer exception in aggregated discovery

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
@@ -559,9 +559,13 @@ func writeDiscoveryResponse(
 		return
 	}
 	var targetGV schema.GroupVersion
-	if mediaType.Convert == nil ||
-		(mediaType.Convert.GroupVersion() != apidiscoveryv2.SchemeGroupVersion &&
-			mediaType.Convert.GroupVersion() != apidiscoveryv2beta1.SchemeGroupVersion) {
+	if mediaType.Convert == nil {
+		utilruntime.HandleError(fmt.Errorf("expected aggregated discovery group version, got unknown group and version"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if mediaType.Convert.GroupVersion() != apidiscoveryv2.SchemeGroupVersion &&
+		mediaType.Convert.GroupVersion() != apidiscoveryv2beta1.SchemeGroupVersion {
 		utilruntime.HandleError(fmt.Errorf("expected aggregated discovery group version, got group: %s, version %s", mediaType.Convert.Group, mediaType.Convert.Version))
 		w.WriteHeader(http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Note that the NPE is caught by the http server so this just reduces noise in the logs.

Extracted from #136355

/kind cleanup

```release-note
NONE
```