### PR TITLE
Improve error message for immutable job.status.startTime

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -741,7 +741,7 @@ func ValidateJobStatusUpdate(job, oldJob *batch.Job, opts JobStatusValidationOpt
 		// Note that we check `oldJob.Status.StartTime != nil` to allow transitioning from
 		// startTime = nil to startTime != nil for unsuspended jobs, which is a desired transition.
 		if oldJob.Status.StartTime != nil && !ptr.Equal(oldJob.Status.StartTime, job.Status.StartTime) && !ptr.Deref(job.Spec.Suspend, false) {
-			allErrs = append(allErrs, field.Required(statusFld.Child("startTime"), "startTime cannot be removed for unsuspended job"))
+			allErrs = append(allErrs, field.Invalid(statusFld.Child("startTime"), job.Status.StartTime, "field is immutable for unsuspended job once set"))
 		}
 	}
 	if isJobSuccessCriteriaMet(oldJob) && !isJobSuccessCriteriaMet(job) {

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 	_ "time/tzdata"
 
 	"github.com/google/go-cmp/cmp"
@@ -2583,12 +2584,16 @@ func TestValidateJobUpdate(t *testing.T) {
 }
 
 func TestValidateJobUpdateStatus(t *testing.T) {
+	now := time.Now()
+
 	cases := map[string]struct {
 		opts JobStatusValidationOptions
 
 		old      batch.Job
 		update   batch.Job
 		wantErrs field.ErrorList
+
+		cmpopts cmp.Options
 	}{
 		"valid": {
 			old: batch.Job{
@@ -2680,6 +2685,7 @@ func TestValidateJobUpdateStatus(t *testing.T) {
 				{Type: field.ErrorTypeInvalid, Field: "status.ready"},
 				{Type: field.ErrorTypeInvalid, Field: "status.terminating"},
 			},
+			cmpopts: cmp.Options{ignoreErrValueDetail},
 		},
 		"empty and duplicated uncounted pods": {
 			old: batch.Job{
@@ -2709,12 +2715,105 @@ func TestValidateJobUpdateStatus(t *testing.T) {
 				{Type: field.ErrorTypeDuplicate, Field: "status.uncountedTerminatedPods.failed[3]"},
 				{Type: field.ErrorTypeInvalid, Field: "status.uncountedTerminatedPods.failed[4]"},
 			},
+			cmpopts: cmp.Options{ignoreErrValueDetail},
+		},
+		"immutable startTime for unsuspended job: with non-nil startTime": {
+			opts: JobStatusValidationOptions{
+				RejectStartTimeUpdateForUnsuspendedJob: true,
+			},
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "abc",
+					Namespace:       metav1.NamespaceDefault,
+					ResourceVersion: "1",
+				},
+				Spec: batch.JobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: batch.JobStatus{
+					StartTime: &metav1.Time{
+						Time: now,
+					},
+					Active: 1,
+				},
+			},
+			update: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "abc",
+					Namespace:       metav1.NamespaceDefault,
+					ResourceVersion: "1",
+				},
+				Spec: batch.JobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: batch.JobStatus{
+					StartTime: &metav1.Time{
+						Time: now.Add(time.Second), // Attempt to change startTime
+					},
+					Active: 1,
+				},
+			},
+			wantErrs: field.ErrorList{
+				{
+					Type:  field.ErrorTypeInvalid,
+					Field: "status.startTime",
+					BadValue: &metav1.Time{
+						Time: now.Add(time.Second),
+					},
+					Detail: "field is immutable for unsuspended job once set",
+				},
+			},
+			cmpopts: cmp.Options{cmpopts.IgnoreFields(field.Error{}, "Origin")},
+		},
+		"immutable startTime for unsuspended job: with nil startTime": {
+			opts: JobStatusValidationOptions{
+				RejectStartTimeUpdateForUnsuspendedJob: true,
+			},
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "abc",
+					Namespace:       metav1.NamespaceDefault,
+					ResourceVersion: "1",
+				},
+				Spec: batch.JobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: batch.JobStatus{
+					StartTime: &metav1.Time{
+						Time: now,
+					},
+					Active: 1,
+				},
+			},
+			update: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "abc",
+					Namespace:       metav1.NamespaceDefault,
+					ResourceVersion: "1",
+				},
+				Spec: batch.JobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: batch.JobStatus{
+					StartTime: nil,
+					Active:    1,
+				},
+			},
+			wantErrs: field.ErrorList{
+				{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "status.startTime",
+					BadValue: (*metav1.Time)(nil),
+					Detail:   "field is immutable for unsuspended job once set",
+				},
+			},
+			cmpopts: cmp.Options{cmpopts.IgnoreFields(field.Error{}, "Origin")},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			errs := ValidateJobUpdateStatus(&tc.update, &tc.old, tc.opts)
-			if diff := cmp.Diff(tc.wantErrs, errs, ignoreErrValueDetail); diff != "" {
+			if diff := cmp.Diff(tc.wantErrs, errs, tc.cmpopts); diff != "" {
 				t.Errorf("Unexpected errors (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/registry/batch/job/strategy_test.go
+++ b/pkg/registry/batch/job/strategy_test.go
@@ -2844,7 +2844,7 @@ func TestStatusStrategy_ValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErrs: field.ErrorList{
-				{Type: field.ErrorTypeRequired, Field: "status.startTime"},
+				{Type: field.ErrorTypeInvalid, Field: "status.startTime"},
 			},
 		},
 		"verify startTime cannot be updated for unsuspended job": {
@@ -2862,7 +2862,7 @@ func TestStatusStrategy_ValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErrs: field.ErrorList{
-				{Type: field.ErrorTypeRequired, Field: "status.startTime"},
+				{Type: field.ErrorTypeInvalid, Field: "status.startTime"},
 			},
 		},
 		"verify startTime can be updated when resuming job (JobSuspended: True -> False)": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR improves a misleading error message that occurs when updating a `batch.Job` with an already set `status.startTime`.

Previously, attempting to change the `startTime` for an unsuspended `batch.Job` would result in the error: `startTime cannot be removed for unsuspended job`. This message was confusing because the user's action was a modification, not a removal.

This has been corrected to provide a clearer error: `field is immutable for unsuspended job once set`. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #136527

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improved a misleading error message when updating `batch.Job`'s `status.startTime`. The error for unsuspended jobs now correctly indicates the field is immutable once set, instead of incorrectly referring to the action as a "removal".
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
