### PR TITLE
kubelet: add test for GetImageRef content-based deduplication

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -136,6 +136,37 @@ func TestGetImageRef(t *testing.T) {
 	assert.Equal(t, image, imageRef)
 }
 
+// TestGetImageRefReturnsImageIdNotRepoDigest verifies that GetImageRef returns
+// Image.Id instead of RepoDigests to ensure content-based deduplication.
+// This prevents the same image pulled from different registries from being
+// treated as different images in pull record lookups.
+func TestGetImageRefReturnsImageIdNotRepoDigest(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+
+	// Simulate an image with both Id and RepoDigests set
+	// In a real scenario, the same image content pulled from different registries
+	// would have the same Id but different RepoDigests
+	imageID := "sha256:abcd1234"
+	repoDigest1 := "registry1.io/myimage@sha256:abcd1234"
+	repoDigest2 := "registry2.io/myimage@sha256:abcd1234"
+
+	fakeImageService.Lock()
+	fakeImageService.Images["myimage"] = &runtimeapi.Image{
+		Id:          imageID,
+		RepoDigests: []string{repoDigest1, repoDigest2},
+		RepoTags:    []string{"myimage:latest"},
+		Size:        1000,
+	}
+	fakeImageService.Unlock()
+
+	// GetImageRef should return the content-based Image.Id, not the location-based RepoDigest
+	imageRef, err := fakeManager.GetImageRef(tCtx, kubecontainer.ImageSpec{Image: "myimage"})
+	require.NoError(t, err)
+	assert.Equal(t, imageID, imageRef, "GetImageRef should return Image.Id for content-based deduplication")
+}
+
 func TestImageSize(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Adds TestGetImageRefReturnsImageIdNotRepoDigest to verify that GetImageRef returns Image.Id instead of RepoDigests. This ensures content-based deduplication where the same image pulled from different registries is treated as identical content rather than separate images.

The test prevents regression of the issue fixed in the revert of cb011623c84 where using RepoDigests[0] caused location-dependent identity (registry.io/image@sha256:...) instead of content-based identity (sha256:...), breaking deduplication and creating separate pull records for identical image content.
#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:
Follow-up on https://github.com/kubernetes/kubernetes/pull/136558
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
