### PR TITLE
dra: split slices to "shared" and "on node"

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -6307,7 +6307,9 @@ func TestAllocator(t *testing.T,
 			if _, ok := allocator.(internal.AllocatorExtended); tc.expectNumAllocateOneInvocations > 0 && !ok {
 				t.Skipf("%T does not support the AllocatorStats interface", allocator)
 			}
-
+			if tc.node == nil {
+				tc.node = node(node1, region1)
+			}
 			results, err := allocator.Allocate(ctx, tc.node, unwrap(claimsToAllocate...))
 			matchError := tc.expectError
 			if matchError == nil {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
@@ -55,11 +55,11 @@ func NodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 // Out-dated slices are silently ignored. Pools may be incomplete (not all
 // required slices available) or invalid (for example, device names not unique).
 // Both is recorded in the result.
-func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node *v1.Node, features Features) ([]*Pool, error) {
+func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice, node *v1.Node, features Features, allSlices []*resourceapi.ResourceSlice) ([]*Pool, error) {
 	pools := make(map[PoolID][]*draapi.ResourceSlice)
 	var slicesWithBindingConditions []*resourceapi.ResourceSlice
 
-	for _, slice := range slices {
+	for _, slice := range slicesForNode {
 		if !features.PartitionableDevices && (slice.Spec.PerDeviceNodeSelection != nil || len(slice.Spec.SharedCounters) > 0) {
 			continue
 		}
@@ -155,7 +155,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 		// which were filtered out above because their node selection made them look irrelevant
 		// for the current node. This is necessary for "allocate all" mode (it rejects incomplete
 		// pools).
-		isObsolete, allSlicesForPool := checkSlicesInPool(slices, poolID, slicesForPool[0].Spec.Pool.Generation)
+		isObsolete, allSlicesForPool := checkSlicesInPool(allSlices, poolID, slicesForPool[0].Spec.Pool.Generation)
 		if isObsolete {
 			// A more thorough check determined that the DRA driver is in the process
 			// of replacing the current generation. The newer one didn't have any slice

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
@@ -55,11 +55,11 @@ func NodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 // Out-dated slices are silently ignored. Pools may be incomplete (not all
 // required slices available) or invalid (for example, device names not unique).
 // Both is recorded in the result.
-func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node *v1.Node, features Features) ([]*Pool, error) {
+func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice, node *v1.Node, features Features, allSlices []*resourceapi.ResourceSlice) ([]*Pool, error) {
 	pools := make(map[PoolID][]*draapi.ResourceSlice)
 	var slicesWithBindingConditions []*resourceapi.ResourceSlice
 
-	for _, slice := range slices {
+	for _, slice := range slicesForNode {
 		if !features.PartitionableDevices && (slice.Spec.PerDeviceNodeSelection != nil || len(slice.Spec.SharedCounters) > 0) {
 			continue
 		}
@@ -155,7 +155,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 		// which were filtered out above because their node selection made them look irrelevant
 		// for the current node. This is necessary for "allocate all" mode (it rejects incomplete
 		// pools).
-		isObsolete, allSlicesForPool := checkSlicesInPool(slices, poolID, slicesForPool[0].Spec.Pool.Generation)
+		isObsolete, allSlicesForPool := checkSlicesInPool(allSlices, poolID, slicesForPool[0].Spec.Pool.Generation)
 		if isObsolete {
 			// A more thorough check determined that the DRA driver is in the process
 			// of replacing the current generation. The newer one didn't have any slice


### PR DESCRIPTION
The Filter stage of DRA scheduler plugin makes a big latency if the pod count is large, In our tests, we have 5000 pods, running on 5000 nodes, each nodes has a ResourceSlice of GPU resources. the schedule time is about 10 minutes.

We found that the most of the schedule time is in Filter stage, and we also found that GatherPools is frequently on the top of the goroutine stack, so we checked the codes in GatherPools, found that there is a loop of slices there.

```
	for _, slice := range slices {
		....
	}
```
We have 5000 slices so it has to loop 5000 times for every Filter, and we have 5000 pods to schedule on 5000 nodes, so we will have to execute millions times of Filter.

In this PR, we will split the slices into two kinds, Shared and OnNode, we can use a map to store those OnNode and we can directly get the the OnNode slices directly when we has to execute Filter of Pod on a Node.

Also I think we can assume that most of the ResourceSlices is OnNode, and the Shared ResourceSlices should be a small portion.


#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
This PR can reduce the DRA scheduling time for 5000 pods from 10min to 5min

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
