### PR TITLE
Dv shadow strategy

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
@@ -45,6 +45,7 @@ type ErrorMatcher struct {
 	matchDetail              func(want, got string) bool
 	requireOriginWhenInvalid bool
 	matchDeclarativeNative   bool
+	matchShadow              bool
 	// normalizationRules holds the pre-compiled regex patterns for path normalization.
 	normalizationRules []NormalizationRule
 }
@@ -88,6 +89,9 @@ func (m ErrorMatcher) Matches(want, got *Error) bool {
 		return false
 	}
 	if m.matchDeclarativeNative && want.DeclarativeNative != got.DeclarativeNative {
+		return false
+	}
+	if m.matchShadow && want.Shadow != got.Shadow {
 		return false
 	}
 
@@ -156,6 +160,10 @@ func (m ErrorMatcher) Render(e *Error) string {
 	if m.matchDeclarativeNative {
 		comma()
 		buf.WriteString(fmt.Sprintf("DeclarativeNative=%t", e.DeclarativeNative))
+	}
+	if m.matchShadow {
+		comma()
+		buf.WriteString(fmt.Sprintf("Shadow=%t", e.Shadow))
 	}
 	return "{" + buf.String() + "}"
 }
@@ -237,6 +245,13 @@ func (m ErrorMatcher) RequireOriginWhenInvalid() ErrorMatcher {
 // value of field errors.
 func (m ErrorMatcher) ByDeclarativeNative() ErrorMatcher {
 	m.matchDeclarativeNative = true
+	return m
+}
+
+// ByShadow returns a derived ErrorMatcher which also matches by the Shadow
+// value of field errors.
+func (m ErrorMatcher) ByShadow() ErrorMatcher {
+	m.matchShadow = true
 	return m
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
@@ -438,6 +438,17 @@ func TestErrorMatcher_Test(t *testing.T) {
 		got:            ErrorList{{DeclarativeNative: false}},
 		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
 	}, {
+		name:    "declarative shadow: match",
+		matcher: ErrorMatcher{}.ByShadow(),
+		want:    ErrorList{{Shadow: true}},
+		got:     ErrorList{{Shadow: true}},
+	}, {
+		name:           "declarative shadow: no match",
+		matcher:        ErrorMatcher{}.ByShadow(),
+		want:           ErrorList{{Shadow: true}},
+		got:            ErrorList{{Shadow: false}},
+		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
+	}, {
 		name:    "with origin: single match",
 		matcher: ErrorMatcher{}.ByField().ByOrigin(),
 		want:    ErrorList{Invalid(NewPath("f"), nil, "").WithOrigin("o")},

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -59,6 +59,9 @@ type Error struct {
 	// DeclarativeNative is true when this error originates from a declarative-native validation.
 	// This field is used to distinguish errors that are exclusively declarative and lack an imperative counterpart.
 	DeclarativeNative bool
+
+	// Shadow is true when this error is coming from a mirrored declarative validation.
+	Shadow bool
 }
 
 var _ error = &Error{}
@@ -460,6 +463,20 @@ func (e *Error) MarkDeclarativeNative() *Error {
 func (list ErrorList) MarkDeclarativeNative() ErrorList {
 	for _, err := range list {
 		err.DeclarativeNative = true
+	}
+	return list
+}
+
+// MarkShadow marks the error as a shadow of the handwritten validation code error.
+func (e *Error) MarkShadow() *Error {
+	e.Shadow = true
+	return e
+}
+
+// MarkShadow marks the errors as a shadow of the handwritten validation code errors.
+func (list ErrorList) MarkShadow() ErrorList {
+	for _, err := range list {
+		err.Shadow = true
 	}
 	return list
 }


### PR DESCRIPTION
### PR Description

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This change updates the `field.Error` structure to include a `Shadow` boolean, which is used to identify errors originating from "shadowed" declarative validation (validations that mirror existing imperative checks). 

It also performs a significant refactor of the `registry/rest` package to align with the new terminology:
- **Renaming "Native" to "Non-Shadowed":** Fields and functions previously using "Native" (like `containsDeclarativeNative`) now use "Non-Shadowed" to refer to validations that are exclusively declarative.
- **Renaming "Mirrored" to "Shadowed":** Terminology has shifted from "mirrored" to "shadowed" to represent declarative validations that overlap with imperative ones.
- **Error Matcher Updates:** The `ErrorMatcher` utility now includes a `ByShadow()` method and `matchShadow` logic to allow for precise testing of shadowed errors.

#### Which issue(s) this PR is related to:
KEP: `https://github.com/kubernetes/enhancements/issues/5073`

#### Special notes for your reviewer:
The refactor includes renaming `WithDeclarativeNative` to `WithDeclarativeEnforcement` in the `ValidationConfig` options.

#### Does this PR introduce a user-facing change?
```
NONE
```

#### Additional documentation:
- [KEP]: https://github.com/kubernetes/enhancements/issues/5073