### PR TITLE
kubelet fix saving inconsistent cpu-manager state to checkpoint file

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -129,6 +129,10 @@ func (s *mockState) GetPodCPUAssignments() state.PodCPUAssignments {
 	return s.podAssignments.Clone()
 }
 
+func (s *mockState) HoldStore() {}
+
+func (s *mockState) Store() {}
+
 type mockPolicy struct {
 	err error
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -48,10 +48,24 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
+type mockStateStats struct {
+	SetCPUSet            int
+	SetDefaultCPUSet     int
+	SetCPUAssignments    int
+	SetPodCPUSet         int
+	SetPodCPUAssignments int
+	Delete               int
+	ClearState           int
+	HoldStore            int
+	Store                int
+}
+
 type mockState struct {
 	assignments    state.ContainerCPUAssignments
 	podAssignments state.PodCPUAssignments
 	defaultCPUSet  cpuset.CPUSet
+	hold           int
+	callStats      [2]mockStateStats
 }
 
 func (s *mockState) GetCPUSet(podUID string, containerName string) (cpuset.CPUSet, bool) {
@@ -76,6 +90,7 @@ func (s *mockState) GetPodCPUSet(podUID string) (cpuset.CPUSet, bool) {
 }
 
 func (s *mockState) SetCPUSet(podUID string, containerName string, cset cpuset.CPUSet) {
+	s.callStats[s.hold].SetCPUSet++
 	if _, exists := s.assignments[podUID]; !exists {
 		s.assignments[podUID] = make(map[string]cpuset.CPUSet)
 	}
@@ -83,6 +98,7 @@ func (s *mockState) SetCPUSet(podUID string, containerName string, cset cpuset.C
 }
 
 func (s *mockState) SetPodCPUSet(podUID string, cset cpuset.CPUSet) {
+	s.callStats[s.hold].SetPodCPUSet++
 	if s.podAssignments == nil {
 		s.podAssignments = make(state.PodCPUAssignments)
 	}
@@ -93,10 +109,12 @@ func (s *mockState) SetPodCPUSet(podUID string, cset cpuset.CPUSet) {
 }
 
 func (s *mockState) SetDefaultCPUSet(cset cpuset.CPUSet) {
+	s.callStats[s.hold].SetDefaultCPUSet++
 	s.defaultCPUSet = cset
 }
 
 func (s *mockState) Delete(podUID string, containerName string) {
+	s.callStats[s.hold].Delete++
 	delete(s.assignments[podUID], containerName)
 	if len(s.assignments[podUID]) == 0 {
 		delete(s.assignments, podUID)
@@ -104,6 +122,7 @@ func (s *mockState) Delete(podUID string, containerName string) {
 }
 
 func (s *mockState) ClearState() {
+	s.callStats[s.hold].ClearState++
 	s.defaultCPUSet = cpuset.New()
 	s.assignments = make(state.ContainerCPUAssignments)
 	s.podAssignments = make(state.PodCPUAssignments)
@@ -114,10 +133,12 @@ func (s *mockState) DeletePod(podUID string) {
 }
 
 func (s *mockState) SetCPUAssignments(a state.ContainerCPUAssignments) {
+	s.callStats[s.hold].SetCPUAssignments++
 	s.assignments = a.Clone()
 }
 
 func (s *mockState) SetPodCPUAssignments(a state.PodCPUAssignments) {
+	s.callStats[s.hold].SetPodCPUAssignments++
 	s.podAssignments = a.Clone()
 }
 
@@ -129,9 +150,15 @@ func (s *mockState) GetPodCPUAssignments() state.PodCPUAssignments {
 	return s.podAssignments.Clone()
 }
 
-func (s *mockState) HoldStore() {}
+func (s *mockState) HoldStore() {
+	s.callStats[s.hold].HoldStore++
+	s.hold = 1
+}
 
-func (s *mockState) Store() {}
+func (s *mockState) Store() {
+	s.callStats[s.hold].Store++
+	s.hold = 0
+}
 
 type mockPolicy struct {
 	err error

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -422,6 +422,8 @@ func (p *staticPolicy) AllocatePod(logger logr.Logger, s state.State, pod *v1.Po
 
 	// 4. Allocate the entire CPU "bubble" for the pod using the hint from the Topology Manager.
 	hint := p.affinity.GetAffinity(podUID, append(pod.Spec.InitContainers, pod.Spec.Containers...)[0].Name)
+	s.HoldStore()
+	defer s.Store()
 	podAllocation, err := p.allocateCPUs(logger, s, totalPodCPUs, hint.NUMANodeAffinity, cpuset.New())
 	if err != nil {
 		logger.Error(err, "Unable to allocate CPUs for pod", "totalPodCPUs", totalPodCPUs)
@@ -606,6 +608,8 @@ func (p *staticPolicy) Allocate(logger logr.Logger, s state.State, pod *v1.Pod, 
 	logger.Info("Topology Affinity", "affinity", hint)
 
 	// Allocate CPUs according to the NUMA affinity contained in the hint.
+	s.HoldStore()
+	defer s.Store()
 	cpuAllocation, err := p.allocateCPUs(logger, s, numCPUs, hint.NUMANodeAffinity, p.cpusToReuse[string(pod.UID)])
 	if err != nil {
 		logger.Error(err, "Unable to allocate CPUs", "numCPUs", numCPUs)
@@ -643,6 +647,8 @@ func (p *staticPolicy) RemoveContainer(logger logr.Logger, s state.State, podUID
 	if !ok {
 		return nil
 	}
+	s.HoldStore()
+	defer s.Store()
 	s.Delete(podUID, containerName)
 
 	// Check if this pod is managed with pod-level CPUs.

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -55,6 +55,30 @@ func newNUMAAffinity(bits ...int) bitmask.BitMask {
 	return affinity
 }
 
+type staticPolicyStateChange int
+
+const (
+	StateChangeNotCalled staticPolicyStateChange = iota
+	StateChangeNotChanged
+	StateChangeRemoval
+	StateChangeAllocation
+)
+
+func (sc staticPolicyStateChange) String() string {
+	switch sc {
+	case StateChangeNotCalled:
+		return "NotCalled"
+	case StateChangeNotChanged:
+		return "NotChanged"
+	case StateChangeRemoval:
+		return "Removal"
+	case StateChangeAllocation:
+		return "Allocation"
+	default:
+		return "Unknown"
+	}
+}
+
 type staticPolicyTest struct {
 	description     string
 	topo            *topology.CPUTopology
@@ -70,6 +94,7 @@ type staticPolicyTest struct {
 	expErr          error
 	expCPUAlloc     bool
 	expCSet         cpuset.CPUSet
+	stateChange     staticPolicyStateChange
 }
 
 // this is not a real Clone() - hence Pseudo- - because we don't clone some
@@ -88,6 +113,7 @@ func (spt staticPolicyTest) PseudoClone() staticPolicyTest {
 		expErr:          spt.expErr,
 		expCPUAlloc:     spt.expCPUAlloc,
 		expCSet:         spt.expCSet.Clone(),
+		stateChange:     spt.stateChange,
 	}
 }
 
@@ -264,6 +290,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(1, 5),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			description:     "GuPodMultipleCores, DualSocketHT, ExpectAllocOneSocket",
@@ -279,6 +306,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(1, 3, 5, 7, 9, 11),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			description:     "GuPodMultipleCores, DualSocketHT, ExpectAllocThreeCores",
@@ -294,6 +322,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(2, 3, 4, 8, 9, 10),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			description:     "GuPodMultipleCores, DualSocketNoHT, ExpectAllocOneSocket",
@@ -309,6 +338,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(4, 5, 6, 7),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			description:     "GuPodMultipleCores, DualSocketNoHT, ExpectAllocFourCores",
@@ -324,6 +354,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(1, 3, 6, 7),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			description:     "GuPodMultipleCores, DualSocketHT, ExpectAllocOneSocketOneCore",
@@ -339,6 +370,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(1, 3, 4, 5, 7, 9, 10, 11),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			description:     "NonGuPod, SingleSocketHT, NoAlloc",
@@ -350,6 +382,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     false,
 			expCSet:         cpuset.New(),
+			stateChange:     StateChangeNotCalled,
 		},
 		{
 			description:     "GuPodNonIntegerCore, SingleSocketHT, NoAlloc",
@@ -361,6 +394,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     false,
 			expCSet:         cpuset.New(),
+			stateChange:     StateChangeNotCalled,
 		},
 		{
 			// All the CPUs from Socket 0 are available. Some CPUs from each
@@ -378,6 +412,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         largeTopoSock0CPUSet,
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			// Only 2 full cores from three Sockets and some partial cores are available.
@@ -395,6 +430,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(1, 25, 13, 38, 11, 35, 23, 48, 53, 173, 113, 233),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			// All CPUs from Socket 1, 1 full core and some partial cores are available.
@@ -413,6 +449,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:      nil,
 			expCPUAlloc: true,
 			expCSet:     largeTopoSock1CPUSet.Union(cpuset.New(10, 34, 22, 47)),
+			stateChange: StateChangeAllocation,
 		},
 	}
 
@@ -428,6 +465,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(4), // expect sibling of partial core
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			// Only partial cores are available in the entire system.
@@ -444,6 +482,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(10, 11, 53, 67, 52),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			description:     "GuPodSingleCore, SingleSocketHT, ExpectError",
@@ -455,6 +494,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          fmt.Errorf("not enough cpus available to satisfy request: requested=8, available=7"),
 			expCPUAlloc:     false,
 			expCSet:         cpuset.New(),
+			stateChange:     StateChangeNotChanged,
 		},
 		{
 			description:     "GuPodMultipleCores, SingleSocketHT, ExpectSameAllocation",
@@ -470,6 +510,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(2, 3, 6, 7),
+			stateChange:     StateChangeNotCalled,
 		},
 		{
 			description:     "GuPodMultipleCores, DualSocketHT, NoAllocExpectError",
@@ -485,6 +526,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          fmt.Errorf("not enough cpus available to satisfy request: requested=10, available=8"),
 			expCPUAlloc:     false,
 			expCSet:         cpuset.New(),
+			stateChange:     StateChangeNotChanged,
 		},
 		{
 			description:     "GuPodMultipleCores, SingleSocketHT, NoAllocExpectError",
@@ -500,6 +542,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          fmt.Errorf("not enough cpus available to satisfy request: requested=2, available=1"),
 			expCPUAlloc:     false,
 			expCSet:         cpuset.New(),
+			stateChange:     StateChangeNotChanged,
 		},
 		{
 			// Only 7 CPUs are available.
@@ -517,6 +560,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          fmt.Errorf("not enough cpus available to satisfy request: requested=76, available=7"),
 			expCPUAlloc:     false,
 			expCSet:         cpuset.New(),
+			stateChange:     StateChangeNotChanged,
 		},
 	}
 
@@ -535,6 +579,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          SMTAlignmentError{RequestedCPUs: 1, CpusPerCore: 2},
 			expCPUAlloc:     false,
 			expCSet:         cpuset.New(), // reject allocation of sibling of partial core
+			stateChange:     StateChangeNotCalled,
 		},
 		{
 			// test SMT-level != 2 - which is the default on x86_64
@@ -550,6 +595,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          SMTAlignmentError{RequestedCPUs: 15, CpusPerCore: 4},
 			expCPUAlloc:     false,
 			expCSet:         cpuset.New(),
+			stateChange:     StateChangeNotCalled,
 		},
 		{
 			description: "GuPodManyCores, topoDualSocketHT, ExpectDoNotAllocPartialCPU",
@@ -565,6 +611,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          SMTAlignmentError{RequestedCPUs: 10, CpusPerCore: 2, AvailablePhysicalCPUs: 8, CausedByPhysicalCPUs: true},
 			expCPUAlloc:     false,
 			expCSet:         cpuset.New(),
+			stateChange:     StateChangeNotCalled,
 		},
 		{
 			description: "GuPodManyCores, topoDualSocketHT, AutoReserve, ExpectAllocAllCPUs",
@@ -579,6 +626,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			description: "GuPodManyCores, topoDualSocketHT, ExpectAllocAllCPUs",
@@ -594,6 +642,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+			stateChange:     StateChangeAllocation,
 		},
 	}
 	alignBySocketOptionTestCases := []staticPolicyTest{
@@ -611,6 +660,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(2, 11),
+			stateChange:     StateChangeAllocation,
 		},
 		{
 			description: "Align by socket: false, cpu's are taken strictly from NUMA nodes in hint",
@@ -626,6 +676,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expErr:          nil,
 			expCPUAlloc:     true,
 			expCSet:         cpuset.New(2, 21),
+			stateChange:     StateChangeAllocation,
 		},
 	}
 
@@ -706,11 +757,32 @@ func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 				testCase.description, container.Name, st.assignments)
 		}
 	}
+
+	testStateChangeStats(t, st, testCase)
 }
 
 func runStaticPolicyTestCaseWithFeatureGate(t *testing.T, testCase staticPolicyTest) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
 	runStaticPolicyTestCase(t, testCase)
+}
+
+var expectedStateCallStats = map[staticPolicyStateChange][2]mockStateStats{
+	StateChangeNotCalled:  {{}, {}},
+	StateChangeNotChanged: {{HoldStore: 1}, {Store: 1}},
+	StateChangeRemoval:    {{HoldStore: 1}, {SetDefaultCPUSet: 1, Delete: 1, Store: 1}},
+	StateChangeAllocation: {{HoldStore: 1}, {SetCPUSet: 1, SetDefaultCPUSet: 1, Store: 1}},
+}
+
+func testStateChangeStats(t *testing.T, st *mockState, testCase staticPolicyTest) {
+	if st.hold != 0 {
+		t.Errorf("StaticPolicy error (%v). Expected state hold to be disabled: hold %v",
+			testCase.description, st.hold)
+	}
+
+	if !reflect.DeepEqual(st.callStats, expectedStateCallStats[testCase.stateChange]) {
+		t.Errorf("StaticPolicy error (%v). Expected call stats: %+v for stateChange %v, collected call stats %+v",
+			testCase.description, expectedStateCallStats[testCase.stateChange], testCase.stateChange, st.callStats)
+	}
 }
 
 func TestStaticPolicyReuseCPUs(t *testing.T) {
@@ -836,6 +908,7 @@ func TestStaticPolicyRemove(t *testing.T) {
 			},
 			stDefaultCPUSet: cpuset.New(4, 5, 6, 7),
 			expCSet:         cpuset.New(1, 2, 3, 4, 5, 6, 7),
+			stateChange:     StateChangeRemoval,
 		},
 		{
 			description:   "SingleSocketHT, DeAllocOneContainer, BeginEmpty",
@@ -850,6 +923,7 @@ func TestStaticPolicyRemove(t *testing.T) {
 			},
 			stDefaultCPUSet: cpuset.New(),
 			expCSet:         cpuset.New(1, 2, 3),
+			stateChange:     StateChangeRemoval,
 		},
 		{
 			description:   "SingleSocketHT, DeAllocTwoContainer",
@@ -864,6 +938,7 @@ func TestStaticPolicyRemove(t *testing.T) {
 			},
 			stDefaultCPUSet: cpuset.New(6, 7),
 			expCSet:         cpuset.New(1, 3, 5, 6, 7),
+			stateChange:     StateChangeRemoval,
 		},
 		{
 			description:   "SingleSocketHT, NoDeAlloc",
@@ -877,6 +952,7 @@ func TestStaticPolicyRemove(t *testing.T) {
 			},
 			stDefaultCPUSet: cpuset.New(2, 4, 6, 7),
 			expCSet:         cpuset.New(2, 4, 6, 7),
+			stateChange:     StateChangeNotCalled,
 		},
 	}
 
@@ -903,6 +979,8 @@ func TestStaticPolicyRemove(t *testing.T) {
 			t.Errorf("StaticPolicy RemoveContainer() error (%v). expected (pod %v, container %v) not be in assignments %v",
 				testCase.description, testCase.podUID, testCase.containerName, st.assignments)
 		}
+
+		testStateChangeStats(t, st, testCase)
 	}
 }
 
@@ -2071,6 +2149,7 @@ type staticPolicyAllocatePodTest struct {
 	podLevelResourcesEnabled        bool
 	podLevelResourceManagersEnabled bool
 	requiredMetrics                 requiredMetrics
+	expChangeStateStats             [2]mockStateStats
 }
 
 type requiredMetrics struct {
@@ -2168,6 +2247,14 @@ func makePodWithContainersAndPodLevelResources(podName, podRequest, podLimit str
 	return pod
 }
 
+func defineStateChangeStats(containers int) [2]mockStateStats {
+	if containers == 0 {
+		return [2]mockStateStats{{}, {}}
+	} else {
+		return [2]mockStateStats{{HoldStore: 1}, {SetCPUSet: containers, SetDefaultCPUSet: 1, SetPodCPUSet: 1, Store: 1}}
+	}
+}
+
 func TestStaticPolicyAllocatePod(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 
@@ -2195,6 +2282,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 				expExclusiveAssignments:     1,
 				expPodSharedPoolAssignments: 0,
 			},
+			expChangeStateStats: defineStateChangeStats(1),
 		},
 		{
 			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and guaranteed container, PodLevelResourceManagers enabled",
@@ -2219,6 +2307,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 				expExclusiveAssignments:     1,
 				expPodSharedPoolAssignments: 0,
 			},
+			expChangeStateStats: defineStateChangeStats(1),
 		},
 		{
 			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and non-guaranteed container, PodLevelResourceManagers enabled",
@@ -2245,6 +2334,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 				expExclusiveAssignments:     0,
 				expPodSharedPoolAssignments: 1,
 			},
+			expChangeStateStats: defineStateChangeStats(1),
 		},
 		{
 			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and mix of guaranteed and non-guaranteed containers, PodLevelResourceManagers enabled",
@@ -2275,6 +2365,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 				expExclusiveAssignments:     2,
 				expPodSharedPoolAssignments: 1,
 			},
+			expChangeStateStats: defineStateChangeStats(3),
 		},
 		{
 			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and mix of guaranteed standard and init containers, PodLevelResourceManagers enabled",
@@ -2308,6 +2399,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 				expExclusiveAssignments:     4,
 				expPodSharedPoolAssignments: 0,
 			},
+			expChangeStateStats: defineStateChangeStats(4),
 		},
 		{
 			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and mix of guaranteed standard and guaranteed restartable and non-guaranteed standard init containers, PodLevelResourceManagers enabled",
@@ -2343,6 +2435,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 				expExclusiveAssignments:     2,
 				expPodSharedPoolAssignments: 3,
 			},
+			expChangeStateStats: defineStateChangeStats(5),
 		},
 		{
 			description:     "scope: pod, should allocate exclusive CPUs to a guaranteed pod with pod-level resources and mix of guaranteed standard and non-guaranteed restartable init containers, PodLevelResourceManagers enabled",
@@ -2378,6 +2471,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 				expExclusiveAssignments:     1,
 				expPodSharedPoolAssignments: 4,
 			},
+			expChangeStateStats: defineStateChangeStats(5),
 		},
 		{
 			description:     "scope: pod, should reject a pod that would result in an empty pod shared pool",
@@ -2400,6 +2494,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 			requiredMetrics: requiredMetrics{
 				expTotalErrors: 1,
 			},
+			expChangeStateStats: defineStateChangeStats(0),
 		},
 		{
 			description:     "scope: pod, should not allocate exclusive CPUs to a non-guaranteed pod with pod-level resources and guaranteed containers, PodLevelResourceManagers enabled",
@@ -2420,6 +2515,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 			requiredMetrics: requiredMetrics{
 				expTotalErrors: 0,
 			},
+			expChangeStateStats: defineStateChangeStats(0),
 		},
 	}
 
@@ -2444,6 +2540,16 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 			}
 
 			err = policy.AllocatePod(logger, st, testCase.pod)
+
+			if st.hold != 0 {
+				t.Errorf("StaticPolicy AllocatePod() error (%v). Expected state hold to be disabled: hold %v",
+					testCase.description, st.hold)
+			}
+			if !reflect.DeepEqual(st.callStats, testCase.expChangeStateStats) {
+				t.Errorf("StaticPolicy AllocatePod() error (%v). Expected call stats: %+v, collected call stats %+v",
+					testCase.description, testCase.expChangeStateStats, st.callStats)
+			}
+
 			if testCase.expErr != nil {
 				require.Error(t, err)
 

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -105,6 +105,10 @@ type writer interface {
 	SetPodCPUAssignments(PodCPUAssignments)
 	// DeletePod deletes pod-level CPU assignments for specified pod
 	DeletePod(podUID string)
+	// Temporarily disables saving cache to checkpoint for all state modifying operations
+	HoldStore()
+	// Re-enables saving to checkpoint for all state modifying operations
+	Store()
 }
 
 // State interface provides methods for tracking and setting cpu/pod assignment

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -43,7 +43,16 @@ type stateCheckpoint struct {
 	checkpointManager checkpointmanager.CheckpointManager
 	checkpointName    string
 	initialContainers containermap.ContainerMap
+	storingHeld       storingHoldState
 }
+
+type storingHoldState int
+
+const (
+	storingEnabled storingHoldState = iota
+	storingHeldNoChanges
+	storingHeldUnsavedChanges
+)
 
 // NewCheckpointState creates new State for keeping track of CPU/pod assignment with checkpoint backend
 func NewCheckpointState(logger logr.Logger, stateDir, checkpointName, policyName string, initialContainers containermap.ContainerMap) (State, error) {
@@ -61,6 +70,7 @@ func NewCheckpointState(logger logr.Logger, stateDir, checkpointName, policyName
 		checkpointManager: checkpointManager,
 		checkpointName:    checkpointName,
 		initialContainers: initialContainers,
+		storingHeld:       storingEnabled,
 	}
 
 	if err := stateCheckpoint.restoreState(); err != nil {
@@ -291,6 +301,9 @@ func (sc *stateCheckpoint) loadCheckpointV1() (*CPUManagerCheckpointV1, error) {
 
 // saves state to a checkpoint, caller is responsible for locking
 func (sc *stateCheckpoint) storeState() error {
+	if sc.storingHeld != storingEnabled {
+		return nil
+	}
 	checkpoint := newCPUManagerCheckpoint()
 	checkpoint.CheckpointData.PolicyName = sc.policyName
 	checkpoint.CheckpointData.DefaultCPUSet = sc.cache.GetDefaultCPUSet().String()
@@ -362,6 +375,7 @@ func (sc *stateCheckpoint) SetPodCPUAssignments(assignments PodCPUAssignments) {
 	defer sc.mux.Unlock()
 
 	sc.cache.SetPodCPUAssignments(assignments)
+	sc.stateChanged()
 	err := sc.storeState()
 	if err != nil {
 		sc.logger.Error(err, "Failed to store state to checkpoint")
@@ -380,6 +394,7 @@ func (sc *stateCheckpoint) SetCPUSet(podUID string, containerName string, cset c
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.SetCPUSet(podUID, containerName, cset)
+	sc.stateChanged()
 	err := sc.storeState()
 	if err != nil {
 		sc.logger.Error(err, "Failed to store state to checkpoint", "podUID", podUID, "containerName", containerName)
@@ -391,6 +406,7 @@ func (sc *stateCheckpoint) SetDefaultCPUSet(cset cpuset.CPUSet) {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.SetDefaultCPUSet(cset)
+	sc.stateChanged()
 	err := sc.storeState()
 	if err != nil {
 		sc.logger.Error(err, "Failed to store state to checkpoint")
@@ -402,6 +418,7 @@ func (sc *stateCheckpoint) SetCPUAssignments(a ContainerCPUAssignments) {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.SetCPUAssignments(a)
+	sc.stateChanged()
 	err := sc.storeState()
 	if err != nil {
 		sc.logger.Error(err, "Failed to store state to checkpoint")
@@ -413,6 +430,7 @@ func (sc *stateCheckpoint) SetPodCPUSet(podUID string, cset cpuset.CPUSet) {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.SetPodCPUSet(podUID, cset)
+	sc.stateChanged()
 	err := sc.storeState()
 	if err != nil {
 		sc.logger.Error(err, "Failed to store state to checkpoint", "podUID", podUID)
@@ -424,6 +442,7 @@ func (sc *stateCheckpoint) Delete(podUID string, containerName string) {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.Delete(podUID, containerName)
+	sc.stateChanged()
 	err := sc.storeState()
 	if err != nil {
 		sc.logger.Error(err, "Failed to store state to checkpoint", "podUID", podUID, "containerName", containerName)
@@ -436,6 +455,7 @@ func (sc *stateCheckpoint) DeletePod(podUID string) {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.DeletePod(podUID)
+	sc.stateChanged()
 	err := sc.storeState()
 	if err != nil {
 		sc.logger.Error(err, "Failed to store state to checkpoint", "podUID", podUID)
@@ -447,8 +467,42 @@ func (sc *stateCheckpoint) ClearState() {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	sc.cache.ClearState()
+	sc.stateChanged()
 	err := sc.storeState()
 	if err != nil {
 		sc.logger.Error(err, "Failed to store state to checkpoint")
+	}
+}
+
+// stateChanged stateChanged remembers that state was changed if storing is held, caller is responsible for locking
+func (sc *stateCheckpoint) stateChanged() {
+	if sc.storingHeld == storingHeldNoChanges {
+		sc.storingHeld = storingHeldUnsavedChanges
+	}
+}
+
+// HoldStore disables storing state to checkpoint file until Store is called
+func (sc *stateCheckpoint) HoldStore() {
+	sc.mux.Lock()
+	defer sc.mux.Unlock()
+	if sc.storingHeld == storingEnabled {
+		sc.storingHeld = storingHeldNoChanges
+	}
+}
+
+// Store enables storing state if HoldStore was called earlier and calls storeState if state has unsaved changes
+func (sc *stateCheckpoint) Store() {
+	sc.mux.Lock()
+	defer sc.mux.Unlock()
+
+	switch sc.storingHeld {
+	case storingHeldNoChanges:
+		sc.storingHeld = storingEnabled
+	case storingHeldUnsavedChanges:
+		sc.storingHeld = storingEnabled
+		err := sc.storeState()
+		if err != nil {
+			sc.logger.Error(err, "Failed to store state to checkpoint")
+		}
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -741,6 +741,610 @@ func TestCheckpointStateClear(t *testing.T) {
 	}
 }
 
+func TestCheckpointStateHoldStore(t *testing.T) {
+	podUID := "pod"
+	initialState := &stateMemory{
+		defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+		assignments: map[string]map[string]cpuset.CPUSet{
+			podUID: {
+				"c1": cpuset.New(0, 1),
+				"c2": cpuset.New(2, 3, 4, 5),
+				"c3": cpuset.New(),
+			},
+		},
+	}
+	testCases := []struct {
+		description         string
+		fgRequirements      FeatureGateCombination
+		scenario            func(State)
+		expectedCachedState *stateMemory
+		expectedStoredState *stateMemory
+	}{
+		{
+			"Hold store and assign CPUs to container",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				s.SetCPUSet(podUID, "c1", cpuset.New(6, 7))
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(6, 7),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+			initialState,
+		},
+		{
+			"Hold store and set default CPU set",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				s.SetDefaultCPUSet(cpuset.New(0, 1, 2, 3, 4, 5, 6, 9, 10))
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 9, 10),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+			initialState,
+		},
+		{
+			"Hold store and set CPU assignments",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				s.SetCPUAssignments(map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(),
+						"c2": cpuset.New(2, 3),
+						"c4": cpuset.New(0, 1),
+					},
+				})
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(),
+						"c2": cpuset.New(2, 3),
+						"c4": cpuset.New(0, 1),
+					},
+				},
+			},
+			initialState,
+		},
+		{
+			"Hold store and delete CPU assignment to container",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				s.Delete(podUID, "c2")
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+			initialState,
+		},
+		{
+			"Hold store and cleare the state",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				s.ClearState()
+			},
+			&stateMemory{},
+			initialState,
+		},
+		{
+			"Hold store and set pod-level CPU set",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			func(s State) {
+				s.HoldStore()
+				s.SetPodCPUSet(podUID, cpuset.New(0, 1, 2, 3, 4, 5, 6, 7))
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+				podAssignments: PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)},
+				},
+			},
+			initialState,
+		},
+		{
+			"Hold store and set pod-level CPU assignments",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			func(s State) {
+				s.HoldStore()
+				s.SetPodCPUAssignments(PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6)},
+				})
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+				podAssignments: PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6)},
+				},
+			},
+			initialState,
+		},
+		{
+			"Hold store and delete pod-level CPU for pod",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			func(s State) {
+				s.SetPodCPUAssignments(PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6)},
+				})
+
+				s.HoldStore()
+				s.DeletePod(podUID)
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+				podAssignments: PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6)},
+				},
+			},
+		},
+		{
+			"Store container CPU set after hold is disabled",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				defer s.Store()
+				s.SetCPUSet(podUID, "c1", cpuset.New(6, 7))
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(6, 7),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(6, 7),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+		},
+		{
+			"Store default CPU set after hold is disabled",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				defer s.Store()
+				s.SetDefaultCPUSet(cpuset.New(0, 1, 2, 3, 4, 5, 6, 9, 10))
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 9, 10),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 9, 10),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+		},
+		{
+			"Store CPU assignments after hold is disabled",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				defer s.Store()
+				s.SetCPUAssignments(map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(),
+						"c2": cpuset.New(2, 3),
+						"c4": cpuset.New(0, 1),
+					},
+				})
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(),
+						"c2": cpuset.New(2, 3),
+						"c4": cpuset.New(0, 1),
+					},
+				},
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(),
+						"c2": cpuset.New(2, 3),
+						"c4": cpuset.New(0, 1),
+					},
+				},
+			},
+		},
+		{
+			"Store deletion of CPU assignments after hold is disabled",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				defer s.Store()
+				s.Delete(podUID, "c2")
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+		},
+		{
+			"Store clearing the state after hold is disabled",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				defer s.Store()
+				s.ClearState()
+			},
+			&stateMemory{},
+			&stateMemory{},
+		},
+		{
+			"Store pod-level CPU setting after hold is disabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			func(s State) {
+				s.HoldStore()
+				defer s.Store()
+				s.SetPodCPUSet(podUID, cpuset.New(0, 1, 2, 3, 4, 5, 6, 7))
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+				podAssignments: PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)},
+				},
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+				podAssignments: PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)},
+				},
+			},
+		},
+		{
+			"Store pod-level CPU assignments after hold is disabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			func(s State) {
+				s.HoldStore()
+				defer s.Store()
+				s.SetPodCPUAssignments(PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6)},
+				})
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+				podAssignments: PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6)},
+				},
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+				podAssignments: PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6)},
+				},
+			},
+		},
+		{
+			"Store pod-level CPU assignments without deleted after hold is disabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			func(s State) {
+				s.SetPodCPUAssignments(PodCPUAssignments{
+					podUID: PodEntry{cpuset.New(0, 1, 2, 3, 4, 5, 6)},
+				})
+
+				s.HoldStore()
+				defer s.Store()
+				s.DeletePod(podUID)
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(0, 1),
+						"c2": cpuset.New(2, 3, 4, 5),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+		},
+		{
+			"Continue regular storing after hold is disabled",
+			nil,
+			func(s State) {
+				s.HoldStore()
+				s.SetCPUSet(podUID, "c1", cpuset.New(6, 7))
+				s.Store()
+
+				s.SetCPUSet(podUID, "c2", cpuset.New(8))
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(6, 7),
+						"c2": cpuset.New(8),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+			&stateMemory{
+				defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+				assignments: map[string]map[string]cpuset.CPUSet{
+					podUID: {
+						"c1": cpuset.New(6, 7),
+						"c2": cpuset.New(8),
+						"c3": cpuset.New(),
+					},
+				},
+			},
+		},
+	}
+
+	// create temp dir
+	testingDir, err := os.MkdirTemp("", "cpumanager_state_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testingDir)
+
+	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
+	if err != nil {
+		t.Fatalf("could not create testing checkpoint manager: %v", err)
+	}
+
+	// list of all features verified in this test
+	featureGateList := []featuregate.Feature{
+		features.PodLevelResourceManagers,
+	}
+	// iterate over all possible enabled/disabled feature combinations
+	for _, fgComb := range allFeatureGateCombinations(featureGateList) {
+		// run all testcases for current feature combination
+		t.Run(describe(fgComb), func(t *testing.T) {
+			for _, key := range slices.Sorted(maps.Keys(fgComb)) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, key, fgComb[key])
+			}
+
+			for _, tc := range testCases {
+				// verify feature gate requirements for testcase
+				skip := false
+				for fg, requiredState := range tc.fgRequirements {
+					state, exist := fgComb[fg]
+					if !exist || requiredState != state {
+						skip = true
+					}
+				}
+				if skip {
+					continue
+				}
+				t.Run(tc.description, func(t *testing.T) {
+					// ensure there is no previous checkpoint
+					cpm.RemoveCheckpoint(testingCheckpoint)
+
+					logger, _ := ktesting.NewTestContext(t)
+					cs1, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
+					if err != nil {
+						t.Fatalf("could not create testing checkpointState instance: %v", err)
+					}
+
+					// set initial values
+					cs1.SetDefaultCPUSet(initialState.defaultCPUSet)
+					cs1.SetCPUAssignments(initialState.assignments)
+
+					// execute test case scenario
+					tc.scenario(cs1)
+
+					// verify cached state
+					AssertStateEqual(t, cs1, tc.expectedCachedState)
+
+					// restore checkpoint with previously stored values
+					cs2, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
+					if err != nil {
+						t.Fatalf("could not create testing checkpointState instance: %v", err)
+					}
+
+					AssertStateEqual(t, cs2, tc.expectedStoredState)
+				})
+			}
+		})
+	}
+}
+
+func TestCheckpointStateHoldStoreWithNoChanges(t *testing.T) {
+	podUID := "pod"
+	initialState := &stateMemory{
+		defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+		assignments: map[string]map[string]cpuset.CPUSet{
+			podUID: {
+				"c1": cpuset.New(0, 1),
+				"c2": cpuset.New(2, 3, 4, 5),
+				"c3": cpuset.New(),
+			},
+		},
+	}
+	modifiedState := &stateMemory{
+		defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6),
+		assignments: map[string]map[string]cpuset.CPUSet{
+			"pod": {
+				"c1": cpuset.New(0, 6),
+				"c2": cpuset.New(),
+				"c3": cpuset.New(3, 5),
+			},
+		},
+	}
+
+	// create temp dir
+	testingDir, err := os.MkdirTemp("", "cpumanager_state_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testingDir)
+
+	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
+	if err != nil {
+		t.Fatalf("could not create testing checkpoint manager: %v", err)
+	}
+
+	// ensure there is no previous checkpoint
+	cpm.RemoveCheckpoint(testingCheckpoint)
+
+	logger, _ := ktesting.NewTestContext(t)
+	cs1, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
+	if err != nil {
+		t.Fatalf("could not create testing checkpointState instance: %v", err)
+	}
+
+	// set initial values
+	cs1.SetDefaultCPUSet(initialState.defaultCPUSet)
+	cs1.SetCPUAssignments(initialState.assignments)
+
+	// create secondary checkpoint poining to same location
+	cs2, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
+	if err != nil {
+		t.Fatalf("could not create testing checkpointState instance: %v", err)
+	}
+
+	// initiate hold in primary checkpoint
+	cs1.HoldStore()
+
+	// overwrite checkpoint file
+	cs2.SetDefaultCPUSet(modifiedState.defaultCPUSet)
+	cs2.SetCPUAssignments(modifiedState.assignments)
+
+	// release hold on primary checkpoint
+	cs1.Store()
+
+	// verify the primary checkpoint cache is unchanged and contains initial values
+	AssertStateEqual(t, cs1, initialState)
+
+	// verify the stored values with tertiary checkpoint
+	cs3, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
+	if err != nil {
+		t.Fatalf("could not create testing checkpointState instance: %v", err)
+	}
+	AssertStateEqual(t, cs3, modifiedState)
+}
+
 func AssertStateEqual(t *testing.T, sf State, sm State) {
 	cpusetSf := sf.GetDefaultCPUSet()
 	cpusetSm := sm.GetDefaultCPUSet()
@@ -757,7 +1361,7 @@ func AssertStateEqual(t *testing.T, sf State, sm State) {
 	podcpuassignmentSf := sf.GetPodCPUAssignments()
 	podcpuassignmentSm := sm.GetPodCPUAssignments()
 	if !reflect.DeepEqual(podcpuassignmentSf, podcpuassignmentSm) {
-		t.Errorf("State CPU assignments mismatch. Have %s, want %s", podcpuassignmentSf, podcpuassignmentSm)
+		t.Errorf("State Pod CPU assignments mismatch. Have %s, want %s", podcpuassignmentSf, podcpuassignmentSm)
 	}
 }
 

--- a/pkg/kubelet/cm/cpumanager/state/state_mem.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_mem.go
@@ -182,3 +182,9 @@ func (s *stateMemory) ClearState() {
 	}
 	s.logger.V(2).Info("Cleared state")
 }
+
+// HoldStore does nothing as stateMemory don't store data
+func (s *stateMemory) HoldStore() {}
+
+// Store does nothing as stateMemory don't store data
+func (s *stateMemory) Store() {}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes saving inconsistent CPU sets state to cpu-manager's checkpoint file.
It has 2 commits:
* first introduces optional "transaction" feature to cpu-manager's State interface and implementation in stateCheckpoint
* second applies the mechanism to Allocate() and RemoveContainer() function where the issue occurs.

For details please read commit messages, where patches are described in details.
Changes in both patches are covered by unit tests.

#### Which issue(s) this PR is related to:

Fixes #136604

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
