### PR TITLE
fix DeclarativeValidation fuzzing test panic and refactor subresource handlin

### DIFF
--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -77,7 +77,6 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 					if err != nil {
 						t.Fatalf("could not create a %v: %s", kind, err)
 					}
-					f.Fill(obj)
 
 					var opts []ValidationTestConfig
 					// TODO(API group level configuration): Consider configuring normalization rules at the
@@ -85,9 +84,11 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 					// This would allow each API group to register its own normalization rules independently.
 					allRules := append([]field.NormalizationRule{}, resourcevalidation.ResourceNormalizationRules...)
 					allRules = append(allRules, nodevalidation.NodeNormalizationRules...)
-					opts = append(opts, WithNormalizationRules(allRules...))
-					if gv.Group == "autoscaling" {
-						opts = append(opts, WithIgnoreObjectConversionErrors())
+					opts = append(opts, WithNormalizationRules(allRules...), WithFuzzer(f))
+
+					// Scale subresource needs to be specified explicitly.
+					if gv.Group == "autoscaling" && kind == "Scale" {
+						opts = append(opts, WithSubResources("scale"))
 					}
 
 					VerifyVersionedValidationEquivalence(t, obj, nil, opts...)
@@ -96,7 +97,7 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 					if err != nil {
 						t.Fatalf("could not create a %v: %s", kind, err)
 					}
-					f.Fill(old)
+
 					VerifyVersionedValidationEquivalence(t, obj, old, opts...)
 				}
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/kind failing-test

#### What this PR does / why we need it:
   - Ensures fuzzing is performed on internal objects by moving the fuzzing logic into the equivalence helper via a new WithFuzzer option. This is critical because custom fuzzing functions in the are typically registered for internal types rather than versioned ones.
   - Refactors the versioned validation fuzz test to use a declarative subresourceOnly map for GVKs that must be validated via a specific subresource path (like autoscaling/Scale),  providing a cleaner and more extensible structure.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
