### PR TITLE
Fix validatingadmissionpolicy nil panic

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking.go
@@ -244,7 +244,11 @@ func (c *TypeChecker) declType(gvk schema.GroupVersionKind) (*apiservercel.DeclT
 	if err != nil {
 		return nil, err
 	}
-	return common.SchemaDeclType(&openapi.Schema{Schema: s}, true).MaybeAssignTypeName(generateUniqueTypeName(gvk.Kind)), nil
+	declType := common.SchemaDeclType(&openapi.Schema{Schema: s}, true)
+	if declType == nil {
+		return nil, nil
+	}
+	return declType.MaybeAssignTypeName(generateUniqueTypeName(gvk.Kind)), nil
 }
 
 func (c *TypeChecker) paramsGVK(policy *v1.ValidatingAdmissionPolicy) schema.GroupVersionKind {
@@ -404,7 +408,9 @@ func buildEnvSet(hasParams bool, hasAuthorizer bool, types typeOverwrite) (*envi
 	varOpts = append(varOpts, createVariableOpts(requestType, plugincel.RequestVarName)...)
 
 	// object and oldObject, same type, type(s) resolved from constraints
-	declTypes = append(declTypes, types.object)
+	if types.object != nil {
+		declTypes = append(declTypes, types.object)
+	}
 	varOpts = append(varOpts, createVariableOpts(types.object, plugincel.ObjectVarName, plugincel.OldObjectVarName)...)
 
 	// params, defined by ParamKind

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking.go
@@ -177,7 +177,7 @@ func (c *TypeChecker) CreateContext(policy *v1.ValidatingAdmissionPolicy) *TypeC
 
 func (c *TypeChecker) compiler(ctx *TypeCheckingContext, typeOverwrite typeOverwrite) (*plugincel.CompositedCompiler, error) {
 	envSet, err := buildEnvSet(
-		/* hasParams */ ctx.paramDeclType != nil,
+		/* hasParams */ !ctx.paramGVK.Empty(),
 		/* hasAuthorizer */ true,
 		typeOverwrite)
 	if err != nil {
@@ -205,7 +205,7 @@ func (c *TypeChecker) CheckExpression(ctx *TypeCheckingContext, expression strin
 			continue
 		}
 		options := plugincel.OptionalVariableDeclarations{
-			HasParams:     ctx.paramDeclType != nil,
+			HasParams:     !ctx.paramGVK.Empty(),
 			HasAuthorizer: true,
 		}
 		compiler.CompileAndStoreVariables(convertv1beta1Variables(ctx.variables), options, environment.StoredExpressions)
@@ -414,8 +414,10 @@ func buildEnvSet(hasParams bool, hasAuthorizer bool, types typeOverwrite) (*envi
 	varOpts = append(varOpts, createVariableOpts(types.object, plugincel.ObjectVarName, plugincel.OldObjectVarName)...)
 
 	// params, defined by ParamKind
-	if hasParams && types.params != nil {
-		declTypes = append(declTypes, types.params)
+	if hasParams {
+		if types.params != nil {
+			declTypes = append(declTypes, types.params)
+		}
 		varOpts = append(varOpts, createVariableOpts(types.params, plugincel.ParamsVarName)...)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking_test.go
@@ -214,6 +214,24 @@ func TestTypeCheck(t *testing.T) {
 			},
 		}},
 	}}
+	noTypeSchemaPolicy := &v1.ValidatingAdmissionPolicy{Spec: v1.ValidatingAdmissionPolicySpec{
+		Validations: []v1.Validation{
+			{
+				Expression: "true",
+			},
+		},
+		MatchConstraints: &v1.MatchResources{ResourceRules: []v1.NamedRuleWithOperations{
+			{
+				RuleWithOperations: v1.RuleWithOperations{
+					Rule: v1.Rule{
+						APIGroups:   []string{"apps"},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"deployments"},
+					},
+				},
+			},
+		}},
+	}}
 
 	deploymentPolicyWithBadMessageExpression := deploymentPolicy.DeepCopy()
 	deploymentPolicyWithBadMessageExpression.Spec.Validations[0].MessageExpression = "object.foo + 114514" // confusion
@@ -489,6 +507,12 @@ func TestTypeCheck(t *testing.T) {
 				},
 			},
 			assertions: []assertionFunc{toBeEmpty},
+		},
+		{
+			name:           "schema without type",
+			policy:         noTypeSchemaPolicy,
+			schemaToReturn: &spec.Schema{},
+			assertions:     []assertionFunc{toBeEmpty},
 		},
 		{
 			name: "variables valid",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking_test.go
@@ -414,6 +414,23 @@ func TestTypeCheck(t *testing.T) {
 			},
 		},
 		{
+			name: "params with untyped schema",
+			policy: &v1.ValidatingAdmissionPolicy{Spec: v1.ValidatingAdmissionPolicySpec{
+				ParamKind: &v1.ParamKind{
+					APIVersion: "v1",
+					Kind:       "Config",
+				},
+				Validations: []v1.Validation{
+					{
+						Expression: "params != null",
+					},
+				},
+				MatchConstraints: deploymentPolicy.Spec.MatchConstraints,
+			}},
+			schemaToReturn: &spec.Schema{},
+			assertions:     []assertionFunc{toBeEmpty},
+		},
+		{
 			name:   "multiple expressions",
 			policy: multiExpressionPolicy,
 			schemaToReturn: &spec.Schema{


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
This PR fixes a nil-handling issue in the ValidatingAdmissionPolicy type checker when a schema does not define a type.

Specifically:
- Avoids returning or appending nil DeclTypes when a schema or resolved object type is absent
- Prevents potential nil dereference during variable and environment construction
- Adds test coverage to ensure policies with schemas lacking a type are handled safely

This improves robustness of type checking for edge cases where schemas are present but incomplete.

#### Which issue(s) this PR is related to:
Fixes #136472

#### Special notes for your reviewer:
- The change is intentionally minimal and defensive
- New test case (schema without type) covers the previously unhandled scenario
- Existing behavior remains unchanged for valid schemas

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
