### PR TITLE
e2e: Better error message, when no InternalIP was found.

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -1267,6 +1267,9 @@ func getNodeHostIP(ctx context.Context, f *framework.Framework, nodeName string)
 	node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	ips := e2enode.GetAddressesByTypeAndFamily(node, v1.NodeInternalIP, family)
-	gomega.Expect(ips).ToNot(gomega.BeEmpty())
+	if len(ips) == 0 {
+		framework.Failf("No address by type (%s) and family (%s) on node (%s) found.",
+			v1.NodeInternalIP, family, nodeName)
+	}
 	return ips[0]
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Our nodes just have public IPs. It took some time for us to understand why some sonobuoy tests were failing.

This is a tiny change, to get a better error message, when no InternalIP was found in an e2e test.

#### Which issue(s) this PR is related to:

We thought it was related to Cilium, but it was not: https://github.com/cilium/cilium/issues/44054

#### Does this PR introduce a user-facing change?
```
NONE
```

