### PR TITLE
client-go/testing: avoid mutating TypeMeta in NewClientset Create

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
@@ -132,3 +132,18 @@ func TestManagedFieldClientset(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"k99": "v99"}, cm.Data)
 }
+
+func TestNewClientsetCreateDoesNotMutateInputTypeMeta(t *testing.T) {
+	client := NewClientset()
+
+	// TypeMeta should not be stamped onto the input object as a side effect of Create.
+	in := &v1.ConfigMap{
+		ObjectMeta: meta_v1.ObjectMeta{Name: "cm-1", Namespace: "default"},
+		Data:       map[string]string{"k0": "v0"},
+	}
+
+	_, err := client.CoreV1().ConfigMaps("default").Create(context.Background(), in, meta_v1.CreateOptions{FieldManager: "test-manager"})
+	require.NoError(t, err)
+	require.Empty(t, in.APIVersion)
+	require.Empty(t, in.Kind)
+}

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -771,15 +771,6 @@ func (t *managedFieldObjectTracker) Create(gvr schema.GroupVersionResource, obj 
 		return err
 	}
 
-	objType, err := meta.TypeAccessor(obj)
-	if err != nil {
-		return err
-	}
-	// Stamp GVK
-	apiVersion, kind := gvk.ToAPIVersionAndKind()
-	objType.SetAPIVersion(apiVersion)
-	objType.SetKind(kind)
-
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Avoid mutating the input object\x27s TypeMeta (APIVersion/Kind) as a side effect of Create when using the field-managed fake clientset (NewClientset). This prevents unexpected reflect.DeepEqual failures for callers that compare the original object they passed in.

Adds a regression test to ensure Create does not stamp TypeMeta onto the input object.

#### Which issue(s) this PR is related to:
Fixes #136427

#### Special notes for your reviewer:
Stored/returned objects are unchanged; only the caller-provided input object is no longer mutated.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```