### PR TITLE
validation: add FromImperative field to track source of validation errors

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -399,10 +399,12 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 		testCtx := rest.WithAllDeclarativeEnforcedForTest(ctx)
 		allDeclarativeErrs := runValidations(testCtx)
 
-		// The matcher here is more specific to ensure that errors from Alpha rules are included and matched correctly. This also ensure that errors are coming from the declarative validations only.
-		declarativeErrorMatcher := errOutputMatcher.ByErrorOrigination().ByValidationStabilityLevel()
+		// The matcher here is more specific to ensure that errors from Alpha rules
+		// are included and matched correctly.
+		// This also ensure that errors are coming from the declarative validations only.
+		dvErrorMatcher := errOutputMatcher.ByValidationStabilityLevel().BySource()
 		if len(expectedErrs) > 0 {
-			declarativeErrorMatcher.Test(t, expectedErrs, allDeclarativeErrs)
+			dvErrorMatcher.Test(t, expectedErrs, allDeclarativeErrs)
 		} else if len(allDeclarativeErrs) != 0 {
 			t.Errorf("expected no errors, but got: %v", allDeclarativeErrs)
 		}

--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -399,10 +399,10 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 		testCtx := rest.WithAllDeclarativeEnforcedForTest(ctx)
 		allDeclarativeErrs := runValidations(testCtx)
 
-		// The matcher here is more specific to ensure that errors from Alpha rules are included and matched correctly.
-		errOutputMatcherByStability := errOutputMatcher.ByValidationStabilityLevel()
+		// The matcher here is more specific to ensure that errors from Alpha rules are included and matched correctly. This also ensure that errors are coming from the declarative validations only.
+		declarativeErrorMatcher := errOutputMatcher.ByErrorOrigination().ByValidationStabilityLevel()
 		if len(expectedErrs) > 0 {
-			errOutputMatcherByStability.Test(t, expectedErrs, allDeclarativeErrs)
+			declarativeErrorMatcher.Test(t, expectedErrs, allDeclarativeErrs)
 		} else if len(allDeclarativeErrs) != 0 {
 			t.Errorf("expected no errors, but got: %v", allDeclarativeErrs)
 		}

--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -1019,6 +1019,7 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 				return // do not proceed
 			}
 			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1.DeviceRequestAllocationResult) *string { return &oldObj.Driver }), oldObj != nil)...)
 
@@ -1468,6 +1469,7 @@ func Validate_OpaqueDeviceConfiguration(ctx context.Context, op operation.Operat
 				return // do not proceed
 			}
 			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1.OpaqueDeviceConfiguration) *string { return &oldObj.Driver }), oldObj != nil)...)
 

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -1108,6 +1108,7 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 				return // do not proceed
 			}
 			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceRequestAllocationResult) *string { return &oldObj.Driver }), oldObj != nil)...)
 
@@ -1504,6 +1505,7 @@ func Validate_OpaqueDeviceConfiguration(ctx context.Context, op operation.Operat
 				return // do not proceed
 			}
 			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1beta1.OpaqueDeviceConfiguration) *string { return &oldObj.Driver }), oldObj != nil)...)
 

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -1039,6 +1039,7 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 				return // do not proceed
 			}
 			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceRequestAllocationResult) *string { return &oldObj.Driver }), oldObj != nil)...)
 
@@ -1498,6 +1499,7 @@ func Validate_OpaqueDeviceConfiguration(ctx context.Context, op operation.Operat
 				return // do not proceed
 			}
 			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1beta2.OpaqueDeviceConfiguration) *string { return &oldObj.Driver }), oldObj != nil)...)
 

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -409,7 +409,7 @@ func validateDeviceConfiguration(config resource.DeviceConfiguration, fldPath *f
 
 func validateOpaqueConfiguration(config resource.OpaqueDeviceConfiguration, fldPath *field.Path, stored bool) field.ErrorList {
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, validateDriverName(config.Driver, fldPath.Child("driver"), corevalidation.RequiredCovered, corevalidation.FormatCovered)...)
+	allErrs = append(allErrs, validateDriverName(config.Driver, fldPath.Child("driver"), corevalidation.RequiredCovered, corevalidation.FormatCovered, corevalidation.SizeCovered)...)
 	allErrs = append(allErrs, validateRawExtension(config.Parameters, fldPath.Child("parameters"), stored, resource.OpaqueParametersMaxLength)...)
 	return allErrs
 }
@@ -509,7 +509,7 @@ func validateDeviceAllocationResult(allocation resource.DeviceAllocationResult, 
 func validateDeviceRequestAllocationResult(result resource.DeviceRequestAllocationResult, fldPath *field.Path, requestNames requestNames) field.ErrorList {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, validateRequestNameRef(result.Request, fldPath.Child("request"), requestNames)...)
-	allErrs = append(allErrs, validateDriverName(result.Driver, fldPath.Child("driver"), corevalidation.RequiredCovered, corevalidation.FormatCovered)...)
+	allErrs = append(allErrs, validateDriverName(result.Driver, fldPath.Child("driver"), corevalidation.RequiredCovered, corevalidation.FormatCovered, corevalidation.SizeCovered)...)
 	allErrs = append(allErrs, validatePoolName(result.Pool, fldPath.Child("pool")).MarkCoveredByDeclarative()...)
 	allErrs = append(allErrs, validateDeviceName(result.Device, fldPath.Child("device"))...)
 	allErrs = append(allErrs, validateDeviceBindingParameters(result.BindingConditions, result.BindingFailureConditions, fldPath)...)

--- a/pkg/registry/core/replicationcontroller/declarative_validation_test.go
+++ b/pkg/registry/core/replicationcontroller/declarative_validation_test.go
@@ -49,7 +49,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				rc.Name = ""
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("metadata.name"), ""),
+				field.Required(field.NewPath("metadata.name"), "").MarkFromImperative(),
 			},
 		},
 		"name: label format": {
@@ -127,8 +127,8 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				rc.GenerateName = "name"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("metadata.name"), ""),
-				field.InternalError(field.NewPath("metadata.name"), fmt.Errorf("")),
+				field.Required(field.NewPath("metadata.name"), "").MarkFromImperative(),
+				field.InternalError(field.NewPath("metadata.name"), fmt.Errorf("")).MarkFromImperative(),
 			},
 		},
 
@@ -216,7 +216,7 @@ func TestValidateUpdateForDeclarative(t *testing.T) {
 				rc.Name += "x"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, ""),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").MarkFromImperative(),
 			},
 		},
 		// metadata.generateName

--- a/pkg/registry/resource/deviceclass/declarative_validation_test.go
+++ b/pkg/registry/resource/deviceclass/declarative_validation_test.go
@@ -55,7 +55,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"name: empty": {
 					input: mkDeviceClass(tweakName("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("metadata", "name"), ""),
+						field.Required(field.NewPath("metadata", "name"), "").MarkFromImperative(),
 					},
 				},
 				"name: valid": {
@@ -174,7 +174,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakName("test-classx")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("metadata", "name"), "test-classx", "field is immutable"),
+						field.Invalid(field.NewPath("metadata", "name"), "test-classx", "field is immutable").MarkFromImperative(),
 					},
 				},
 				"valid update: at limit selectors": {

--- a/pkg/registry/resource/resourceclaim/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaim/declarative_validation_test.go
@@ -190,10 +190,17 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.Required(opaqueDriverPath, ""),
 			},
 		},
-		"invalid opaque driver, too long": {
+		"invalid opaque driver, too long - 64 characters": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(opaqueDriverPath, "", 63),
+				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength"),
+			},
+		},
+		"invalid opaque driver, too long - 255 characters": {
+			input: mkValidResourceClaim(tweakDeviceConfigWithDriver(strings.Repeat("a", 255))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength"),
+				field.Invalid(opaqueDriverPath, "", "").WithOrigin("format=k8s-long-name-caseless"),
 			},
 		},
 		"invalid opaque driver, invalid character": {
@@ -849,11 +856,19 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				field.Required(driverPath, ""),
 			},
 		},
-		"invalid driver name, too long": {
+		"invalid driver name, too long - 64 characters": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(driverPath, "", 63),
+				field.TooLong(driverPath, "", 63).WithOrigin("maxLength"),
+			},
+		},
+		"invalid driver name, too long - 255 characters": {
+			old:    mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver(strings.Repeat("a", 255))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(driverPath, "", 63).WithOrigin("maxLength"),
+				field.Invalid(driverPath, "", "").WithOrigin("format=k8s-long-name-caseless"),
 			},
 		},
 		"invalid driver name, invalid character": {

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -171,7 +171,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			updateObj: mkValidStorageClass(TweakVolumeBindingModeNil()),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable"),
-				field.Required(field.NewPath("volumeBindingMode"), ""),
+				field.Required(field.NewPath("volumeBindingMode"), "").MarkFromImperative(),
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -880,6 +880,7 @@ message DeviceRequestAllocationResult {
   // +required
   // +k8s:format=k8s-long-name-caseless
   // +k8s:required
+  // +k8s:maxLength=63
   optional string driver = 2;
 
   // This name together with the driver name and the device name field
@@ -1347,6 +1348,7 @@ message OpaqueDeviceConfiguration {
   // +required
   // +k8s:required
   // +k8s:format=k8s-long-name-caseless
+  // +k8s:maxLength=63
   optional string driver = 1;
 
   // Parameters can contain arbitrary data. It is the responsibility of

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -1359,6 +1359,7 @@ type OpaqueDeviceConfiguration struct {
 	// +required
 	// +k8s:required
 	// +k8s:format=k8s-long-name-caseless
+	// +k8s:maxLength=63
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
 
 	// Parameters can contain arbitrary data. It is the responsibility of
@@ -1603,6 +1604,7 @@ type DeviceRequestAllocationResult struct {
 	// +required
 	// +k8s:format=k8s-long-name-caseless
 	// +k8s:required
+	// +k8s:maxLength=63
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
 
 	// This name together with the driver name and the device name field

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -1007,6 +1007,7 @@ message DeviceRequestAllocationResult {
   // +required
   // +k8s:format=k8s-long-name-caseless
   // +k8s:required
+  // +k8s:maxLength=63
   optional string driver = 2;
 
   // This name together with the driver name and the device name field
@@ -1364,6 +1365,7 @@ message OpaqueDeviceConfiguration {
   //
   // +required
   // +k8s:required
+  // +k8s:maxLength=63
   // +k8s:format=k8s-long-name-caseless
   optional string driver = 1;
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1375,6 +1375,7 @@ type OpaqueDeviceConfiguration struct {
 	//
 	// +required
 	// +k8s:required
+	// +k8s:maxLength=63
 	// +k8s:format=k8s-long-name-caseless
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
 
@@ -1620,6 +1621,7 @@ type DeviceRequestAllocationResult struct {
 	// +required
 	// +k8s:format=k8s-long-name-caseless
 	// +k8s:required
+	// +k8s:maxLength=63
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
 
 	// This name together with the driver name and the device name field

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -882,6 +882,7 @@ message DeviceRequestAllocationResult {
   //
   // +required
   // +k8s:format=k8s-long-name-caseless
+  // +k8s:maxLength=63
   // +k8s:required
   optional string driver = 2;
 
@@ -1349,6 +1350,7 @@ message OpaqueDeviceConfiguration {
   //
   // +required
   // +k8s:required
+  // +k8s:maxLength=63
   // +k8s:format=k8s-long-name-caseless
   optional string driver = 1;
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -1364,6 +1364,7 @@ type OpaqueDeviceConfiguration struct {
 	//
 	// +required
 	// +k8s:required
+	// +k8s:maxLength=63
 	// +k8s:format=k8s-long-name-caseless
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
 
@@ -1608,6 +1609,7 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +required
 	// +k8s:format=k8s-long-name-caseless
+	// +k8s:maxLength=63
 	// +k8s:required
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
@@ -45,7 +45,7 @@ type ErrorMatcher struct {
 	matchDetail                   func(want, got string) bool
 	requireOriginWhenInvalid      bool
 	matchValidationStabilityLevel bool
-	matchErrorOrigination         bool
+	matchSource                   bool
 	// normalizationRules holds the pre-compiled regex patterns for path normalization.
 	normalizationRules []NormalizationRule
 }
@@ -92,7 +92,7 @@ func (m ErrorMatcher) Matches(want, got *Error) bool {
 		return false
 	}
 
-	if m.matchErrorOrigination && want.OriginatingFromImperative != got.OriginatingFromImperative {
+	if m.matchSource && want.FromImperative != got.FromImperative {
 		return false
 	}
 
@@ -162,9 +162,9 @@ func (m ErrorMatcher) Render(e *Error) string {
 		comma()
 		buf.WriteString(fmt.Sprintf("ValidationStabilityLevel=%s", e.ValidationStabilityLevel))
 	}
-	if m.matchErrorOrigination {
+	if m.matchSource {
 		comma()
-		buf.WriteString(fmt.Sprintf("OriginatingFromImperative=%t", e.OriginatingFromImperative))
+		buf.WriteString(fmt.Sprintf("FromImperative=%t", e.FromImperative))
 	}
 	return "{" + buf.String() + "}"
 }
@@ -242,10 +242,10 @@ func (m ErrorMatcher) RequireOriginWhenInvalid() ErrorMatcher {
 	return m
 }
 
-// ByErrorOrigination returns a derived ErrorMatcher which also matches by the error origination
+// BySource returns a derived ErrorMatcher which also matches by the error origination
 // value of field errors.
-func (m ErrorMatcher) ByErrorOrigination() ErrorMatcher {
-	m.matchErrorOrigination = true
+func (m ErrorMatcher) BySource() ErrorMatcher {
+	m.matchSource = true
 	return m
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
@@ -45,6 +45,7 @@ type ErrorMatcher struct {
 	matchDetail                   func(want, got string) bool
 	requireOriginWhenInvalid      bool
 	matchValidationStabilityLevel bool
+	matchErrorOrigination         bool
 	// normalizationRules holds the pre-compiled regex patterns for path normalization.
 	normalizationRules []NormalizationRule
 }
@@ -88,6 +89,10 @@ func (m ErrorMatcher) Matches(want, got *Error) bool {
 		return false
 	}
 	if m.matchValidationStabilityLevel && want.ValidationStabilityLevel != got.ValidationStabilityLevel {
+		return false
+	}
+
+	if m.matchErrorOrigination && want.OriginatingFromImperative != got.OriginatingFromImperative {
 		return false
 	}
 
@@ -156,6 +161,10 @@ func (m ErrorMatcher) Render(e *Error) string {
 	if m.matchValidationStabilityLevel {
 		comma()
 		buf.WriteString(fmt.Sprintf("ValidationStabilityLevel=%s", e.ValidationStabilityLevel))
+	}
+	if m.matchErrorOrigination {
+		comma()
+		buf.WriteString(fmt.Sprintf("OriginatingFromImperative=%t", e.OriginatingFromImperative))
 	}
 	return "{" + buf.String() + "}"
 }
@@ -230,6 +239,13 @@ func (m ErrorMatcher) ByOrigin() ErrorMatcher {
 // matching by Origin.
 func (m ErrorMatcher) RequireOriginWhenInvalid() ErrorMatcher {
 	m.requireOriginWhenInvalid = true
+	return m
+}
+
+// ByErrorOrigination returns a derived ErrorMatcher which also matches by the error origination
+// value of field errors.
+func (m ErrorMatcher) ByErrorOrigination() ErrorMatcher {
+	m.matchErrorOrigination = true
 	return m
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
@@ -315,6 +315,26 @@ func TestErrorMatcher_Matches(t *testing.T) {
 		wantedErr: baseErr,
 		actualErr: &Error{Type: ErrorTypeInvalid},
 		matches:   false,
+	}, {
+		name:    "BySource: match",
+		matcher: ErrorMatcher{}.BySource(),
+		wantedErr: func() *Error {
+			e := baseErr()
+			e.FromImperative = true
+			return e
+		},
+		actualErr: &Error{FromImperative: true},
+		matches:   true,
+	}, {
+		name:    "BySource: no match",
+		matcher: ErrorMatcher{}.BySource(),
+		wantedErr: func() *Error {
+			e := baseErr()
+			e.FromImperative = true
+			return e
+		},
+		actualErr: &Error{FromImperative: false},
+		matches:   false,
 	}}
 
 	for _, tc := range testCases {
@@ -416,6 +436,17 @@ func TestErrorMatcher_Test(t *testing.T) {
 		matcher:        ErrorMatcher{}.ByValidationStabilityLevel(),
 		want:           ErrorList{{}}.MarkAlpha(),
 		got:            ErrorList{{}}.MarkBeta(),
+		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
+	}, {
+		name:    "by source: match",
+		matcher: ErrorMatcher{}.BySource(),
+		want:    ErrorList{{FromImperative: true}},
+		got:     ErrorList{{FromImperative: true}},
+	}, {
+		name:           "by source: no match",
+		matcher:        ErrorMatcher{}.BySource(),
+		want:           ErrorList{{FromImperative: true}},
+		got:            ErrorList{{FromImperative: false}},
 		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
 	}, {
 		name:    "with origin: single match",
@@ -554,6 +585,26 @@ func TestErrorMatcher_Render(t *testing.T) {
 			matcher:  ErrorMatcher{}.ByType().ByValue(),
 			err:      Required(NewPath("field"), "detail"),
 			expected: `{Type="Required value", Value=""}`,
+		},
+		{
+			name:    "with from imperative",
+			matcher: ErrorMatcher{}.BySource(),
+			err: func() *Error {
+				e := Invalid(NewPath("field"), "value", "detail")
+				e.FromImperative = true
+				return e
+			}(),
+			expected: `{FromImperative=true}`,
+		},
+		{
+			name:    "all fields with from imperative",
+			matcher: ErrorMatcher{}.ByType().ByField().ByValue().ByOrigin().ByDetailExact().BySource(),
+			err: func() *Error {
+				e := Invalid(NewPath("field"), "value", "detail").WithOrigin("origin")
+				e.FromImperative = true
+				return e
+			}(),
+			expected: `{Type="Invalid value", Field="field", Value="value", Origin="origin", Detail="detail", FromImperative=true}`,
 		},
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -56,6 +56,9 @@ type Error struct {
 	// that should also be caught by declarative validation.
 	CoveredByDeclarative bool
 
+	// OriginatingFromImperative denotes these errors are originating from  the hand written validations.
+	OriginatingFromImperative bool
+
 	// ValidationStabilityLevel denotes the validation stability level of the declarative validation from this error is returned. This should be used in the declarative validations only.
 	ValidationStabilityLevel ValidationStabilityLevel
 }
@@ -504,6 +507,18 @@ func (e *Error) MarkBeta() *Error {
 func (list ErrorList) MarkBeta() ErrorList {
 	for _, err := range list {
 		err.ValidationStabilityLevel = stabilityLevelBeta
+	}
+	return list
+}
+
+func (e *Error) MarkOriginatingFromImperative() *Error {
+	e.OriginatingFromImperative = true
+	return e
+}
+
+func (list ErrorList) MarkOriginatingFromImperative() ErrorList {
+	for _, err := range list {
+		err.OriginatingFromImperative = true
 	}
 	return list
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -56,8 +56,8 @@ type Error struct {
 	// that should also be caught by declarative validation.
 	CoveredByDeclarative bool
 
-	// OriginatingFromImperative denotes these errors are originating from  the hand written validations.
-	OriginatingFromImperative bool
+	// FromImperative denotes these errors are originating from  the hand written validations.
+	FromImperative bool
 
 	// ValidationStabilityLevel denotes the validation stability level of the declarative validation from this error is returned. This should be used in the declarative validations only.
 	ValidationStabilityLevel ValidationStabilityLevel
@@ -511,14 +511,14 @@ func (list ErrorList) MarkBeta() ErrorList {
 	return list
 }
 
-func (e *Error) MarkOriginatingFromImperative() *Error {
-	e.OriginatingFromImperative = true
+func (e *Error) MarkFromImperative() *Error {
+	e.FromImperative = true
 	return e
 }
 
-func (list ErrorList) MarkOriginatingFromImperative() ErrorList {
+func (list ErrorList) MarkFromImperative() ErrorList {
 	for _, err := range list {
-		err.OriginatingFromImperative = true
+		err.FromImperative = true
 	}
 	return list
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
@@ -200,6 +200,45 @@ func TestErrorListMarkDeclarative(t *testing.T) {
 	}
 }
 
+func TestErrorMarkFromImperative(t *testing.T) {
+	// Test for single Error
+	err := Invalid(NewPath("field"), "value", "detail")
+	if err.FromImperative {
+		t.Errorf("New error should not be from imperative by default")
+	}
+
+	// Mark as FromImperative
+	err.MarkFromImperative() //nolint:errcheck // The "error" here is not an unexpected error from the function.
+	if !err.FromImperative {
+		t.Errorf("Error should be from imperative after marking")
+	}
+}
+
+func TestErrorListMarkFromImperative(t *testing.T) {
+	// Test for ErrorList
+	list := ErrorList{
+		Invalid(NewPath("field1"), "value1", "detail1"),
+		Invalid(NewPath("field2"), "value2", "detail2"),
+	}
+
+	// Verify none are from imperative by default
+	for i, err := range list {
+		if err.FromImperative {
+			t.Errorf("Error %d should not be from imperative by default", i)
+		}
+	}
+
+	// Mark list as from imperative
+	list.MarkFromImperative()
+
+	// Verify all errors in the list are now from imperative
+	for i, err := range list {
+		if !err.FromImperative {
+			t.Errorf("Error %d should be from imperative after marking the list", i)
+		}
+	}
+}
+
 func TestErrorListExtractCoveredByDeclarative(t *testing.T) {
 	testCases := []struct {
 		list         ErrorList

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -392,7 +392,8 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 	betaEnabled := utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidationBeta)
 	// allDeclarativeEnforced indicates that we should check all declarative errors for testing purposes.
 	allDeclarativeEnforced := ctx.Value(allDeclarativeEnforcedKey) == true
-
+	// These errors must be errors returned by the handwritten validation.
+	errs = errs.MarkOriginatingFromImperative()
 	validationIdentifier, err := metricIdentifier(ctx, scheme, obj, opType)
 	if err != nil {
 		// Log the error, but continue with the best-effort identifier.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -393,7 +393,7 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 	// allDeclarativeEnforced indicates that we should check all declarative errors for testing purposes.
 	allDeclarativeEnforced := ctx.Value(allDeclarativeEnforcedKey) == true
 	// These errors must be errors returned by the handwritten validation.
-	errs = errs.MarkOriginatingFromImperative()
+	errs = errs.MarkFromImperative()
 	validationIdentifier, err := metricIdentifier(ctx, scheme, obj, opType)
 	if err != nil {
 		// Log the error, but continue with the best-effort identifier.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR enhances the validation framework to distinguish between handwritten (imperative) and declarative validation (DV) errors. Previously, there was no reliable way to differentiate whether an error originated from a declarative rule or the legacy handwritten code.

Currently, when we migrate validations from legacy handwritten (imperative) code to the Declarative Validation (DV) framework, our tests verify that the resulting error lists match. However, without source tracking, these tests often provide a "fake illusion" of success. Because both validation paths run handwritten  validation code during a transition period, an equivalence test might pass simply because the legacy handwritten validation caught an error and DV didn't. 

Key changes include:
*   **Error Origin Tracking**: Adds an `OriginatingFromImperative` boolean field to `field.Error` to specifically identify errors stemming from legacy handwritten validations.
*   **Marking Utilities**: Introduces `MarkOriginatingFromImperative()` for both `field.Error` and `field.ErrorList` to facilitate tagging errors during the validation flow.
*   **Enhanced Error Matching**: Adds a `ByErrorOrigination()` method to the `ErrorMatcher` utility. This allows testing utilities to verify that validation errors are coming from the expected source (Imperative vs. Declarative).
*   **API Constraint Alignment**: Adds `+k8s:maxLength=63` marker to the `Driver` field in `OpaqueDeviceConfiguration` and `DeviceRequestAllocationResult` types across `v1`, `v1beta1`, and `v1beta2`. This ensures the 63-character limit is enforced by the declarative validation engine.
*   **Integration in Registry Utilities**: Updates `ValidateDeclarativelyWithMigrationChecks` to automatically mark incoming errors as originating from imperative validation before performing migration checks.

These changes are a prerequisite for safely deleting legacy handwritten validation code, as they ensure the equivalence tests can accurately confirm that declarative validation has fully taken over.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
The `verifyDeclarativeValidations` helper function now uses the refined `ErrorMatcher` to ensure that errors in `declarative_validation_test.go` are explicitly verified as originating from DV.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation:
N/A