### PR TITLE
issue: setcap build image shouldn't require a shell

### DIFF
--- a/build/server-image/kube-apiserver/Dockerfile
+++ b/build/server-image/kube-apiserver/Dockerfile
@@ -23,7 +23,7 @@ ARG BINARY
 COPY --chmod=755 ${BINARY} /binary_to_set
 # We apply cap_net_bind_service so that kube-apiserver can be run as
 # non-root and still listen on port less than 1024
-RUN ["/usr/sbin/setcap", "cap_net_bind_service=+ep", "/binary_to_set"]
+RUN ["setcap", "cap_net_bind_service=+ep", "/binary_to_set"]
 
 FROM --platform=linux/$TARGETARCH ${BASEIMAGE}
 ARG BINARY

--- a/build/server-image/kube-apiserver/Dockerfile
+++ b/build/server-image/kube-apiserver/Dockerfile
@@ -20,15 +20,15 @@ ARG SETCAP_IMAGE
 # to setup qemu for the builder.
 FROM --platform=linux/$BUILDARCH ${SETCAP_IMAGE}
 ARG BINARY
-COPY --chmod=755 ${BINARY} /set_cap_binary
+COPY --chmod=755 ${BINARY} /binary_to_set
 # We apply cap_net_bind_service so that kube-apiserver can be run as
 # non-root and still listen on port less than 1024
-RUN ["setcap", "cap_net_bind_service=+ep", "/set_cap_binary"]
+RUN ["/usr/sbin/setcap", "cap_net_bind_service=+ep", "/binary_to_set"]
 
 FROM --platform=linux/$TARGETARCH ${BASEIMAGE}
 ARG BINARY
 
-COPY --from=0 /set_cap_binary /usr/local/bin/${BINARY}
+COPY --from=0 /binary_to_set /usr/local/bin/${BINARY}
 # NOTE: /go-runner is used here for compatibility
 COPY --chmod=755 kube-log-runner /go-runner
 ENTRYPOINT ["/go-runner"]

--- a/build/server-image/kube-apiserver/Dockerfile
+++ b/build/server-image/kube-apiserver/Dockerfile
@@ -20,14 +20,15 @@ ARG SETCAP_IMAGE
 # to setup qemu for the builder.
 FROM --platform=linux/$BUILDARCH ${SETCAP_IMAGE}
 ARG BINARY
-COPY --chmod=755 ${BINARY} /${BINARY}
+COPY --chmod=755 ${BINARY} /set_cap_binary
 # We apply cap_net_bind_service so that kube-apiserver can be run as
 # non-root and still listen on port less than 1024
-RUN setcap cap_net_bind_service=+ep /${BINARY}
+RUN ["setcap", "cap_net_bind_service=+ep", "/set_cap_binary"]
 
 FROM --platform=linux/$TARGETARCH ${BASEIMAGE}
 ARG BINARY
-COPY --from=0 /${BINARY} /usr/local/bin/${BINARY}
+
+COPY --from=0 /set_cap_binary /usr/local/bin/${BINARY}
 # NOTE: /go-runner is used here for compatibility
 COPY --chmod=755 kube-log-runner /go-runner
 ENTRYPOINT ["/go-runner"]


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Removes the dependency on a shell being in the `setcap` build image for the kube-apiserver


#### Which issue(s) this PR is related to:
Fixes  #136631

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None

```release-note
reduces the needs of the setcap build image for kube-apiserver by no longer requiring that image to contain a shell (`sh` or `dash` or `bash`).
```

