### PR TITLE
DRA: Introduce index-based naming in resourceslice controller and sort slices and pools lexicographically

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -732,6 +732,20 @@ func (d *Helper) Stop() {
 // called, then the kubelet plugin does not manage any ResourceSlice
 // objects.
 //
+// Note that the order of slices in the provided resources
+// is significant: ResourceSlices start with a name prefix based on
+// their index, and the allocator uses this order to prioritize allocation
+// (first-fit). Also, upgrading to this naming from an older
+// version using random names without the index at the beginning will
+// cause existing slices to be recreated.
+// The name prefix follows the scheme:
+// [index encoded as base16 string]-[driver name]-[owner name (if not nil)]-
+// See [resourceslice.Pool.Slices] for more details.
+//
+// Pools are sorted first so that pools with devices which have binding
+// conditions are tried last, then by name. So the name can also be used to
+// indicate preference when a driver publishes more than one pool.
+//
 // PublishResources does not block, so it might still take a while
 // after it returns before all information is actually written
 // to the API server.

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -66,6 +67,16 @@ const (
 	// causes redundant delete API calls) and not too long that a human mistake
 	// doesn't get fixed while that human is waiting for it.
 	DefaultSyncDelay = 30 * time.Second
+
+	// resourceSliceIndexMinLength is the minimum length of the encoded index in the
+	// ResourceSlice name.
+	//
+	// If the encoded highest index for a slice needs more characters, all slices will
+	// use a longer index prefix to ensure that lexicographic sorting still works.
+	resourceSliceIndexMinLength = 5
+
+	// nameSeparator is used to separate parts of the ResourceSlice name.
+	nameSeparator = "-"
 )
 
 // Controller synchronizes information about resources of one driver with
@@ -119,6 +130,12 @@ type Controller struct {
 // DriverResources is a complete description of all resources synchronized by the controller.
 type DriverResources struct {
 	// Each driver may manage different resource pools.
+	//
+	// The key in the map is the pool name. Pools are
+	// sorted first so that pools with devices which
+	// have binding conditions are tried last, then by name.
+	// So the name can also be used to indicate preference
+	// when a driver publishes more than one pool.
 	Pools map[string]Pool
 }
 
@@ -140,6 +157,22 @@ type Pool struct {
 	// that each resulting slice is valid. See the API
 	// definition for details, in particular the limit on
 	// the number of devices.
+	//
+	// ResourceSlices start with a name prefix based on their
+	// index in this list. This has two important consequences:
+	// 1. Priority: The allocator sorts ResourceSlices
+	//    lexicographically by name and uses a first-fit strategy.
+	//    Since the index is at the beginning of the name, the order
+	//    in this list determines the allocation priority. Driver
+	//    authors can influence priority by putting preferred slices
+	//    first. Likewise, within a slice the preferred devices should
+	//    be listed first.
+	// 2. Migration: When upgrading from a driver version that used
+	//    randomly generated names without index at the beginning,
+	//    existing ResourceSlices will be deleted and recreated with
+	//    names starting with the new prefix.
+	// The name prefix follows the scheme:
+	// [index encoded as base16 string]-[driver name]-[owner name (if not nil)]-
 	//
 	// If slices are not valid, then the controller will
 	// log errors produced by the apiserver.
@@ -639,9 +672,6 @@ func (c *Controller) syncPool(ctx context.Context, poolName string) error {
 		}
 	}
 
-	// Slices that don't match any driver slice need to be deleted.
-	obsoleteSlices := make([]*resourceapi.ResourceSlice, 0, len(slices))
-
 	// Determine highest generation.
 	var generation int64
 	for _, slice := range slices {
@@ -650,67 +680,34 @@ func (c *Controller) syncPool(ctx context.Context, poolName string) error {
 		}
 	}
 
-	// Everything older is obsolete.
-	currentSlices := make([]*resourceapi.ResourceSlice, 0, len(slices))
+	// Classify existing slices. If an existing slice has wrong generation
+	// or doesn't match a desired index, it's obsolete.
+	currentSliceForDesiredSlice := make(map[int]*resourceapi.ResourceSlice, len(pool.Slices))
+	obsoleteSlices := make([]*resourceapi.ResourceSlice, 0, len(slices))
+	expectedPrefixLength := getIndexLength(len(pool.Slices))
+
 	for _, slice := range slices {
+		// Wrong generation is always obsolete.
 		if slice.Spec.Pool.Generation < generation {
 			obsoleteSlices = append(obsoleteSlices, slice)
-		} else {
-			currentSlices = append(currentSlices, slice)
+			continue
 		}
-	}
-	logger.V(5).Info("Existing slices", "obsolete", klog.KObjSlice(obsoleteSlices), "current", klog.KObjSlice(currentSlices))
 
-	// Match each existing slice against the desired slices.
-	// Two slices "match" if they contain exactly the
-	// same device IDs, in an arbitrary order. As a
-	// special case, slices are also considered
-	// "matched" in the scenario where there's a single
-	// existing slice and a single desired slice. Such a
-	// matched slice gets updated with the desired
-	// content if there is a difference.
-	//
-	// In the case where there is more than one existing
-	// or desired slices, adding or removing devices is
-	// done by deleting the old slice and creating a new one.
-	//
-	// This is primarily a simplification of the code:
-	// to support adding or removing devices from
-	// existing slices, we would have to identify "most
-	// similar" slices (= minimal editing distance).
-	//
-	// In currentSliceForDesiredSlice we keep track of
-	// which desired slice has a matched slice.
-	//
-	// At the end of the loop, each current slice is either
-	// a match or obsolete.
-	currentSliceForDesiredSlice := make(map[int]*resourceapi.ResourceSlice, len(pool.Slices))
-	if len(currentSlices) == 1 && len(pool.Slices) == 1 {
-		// If there's just one existing slice and one desired slice, assume
-		// they "matched" such that if required, it is the existing slice
-		// which gets updated and we avoid an unnecessary deletion and
-		// recreation of the slice.
-		currentSliceForDesiredSlice[0] = currentSlices[0]
-	} else {
-		for _, currentSlice := range currentSlices {
-			matched := false
-			for i := range pool.Slices {
-				if _, ok := currentSliceForDesiredSlice[i]; ok {
-					// Already has a match.
-					continue
-				}
-				if sameSlice(currentSlice, &pool.Slices[i]) {
-					currentSliceForDesiredSlice[i] = currentSlice
-					logger.V(5).Info("Matched existing slice", "slice", klog.KObj(currentSlice), "matchIndex", i)
-					matched = true
-					break
-				}
-			}
-			if !matched {
-				obsoleteSlices = append(obsoleteSlices, currentSlice)
-				logger.V(5).Info("Unmatched existing slice", "slice", klog.KObj(currentSlice))
+		index, err := decodeIndex(slice.Name, expectedPrefixLength)
+		if err != nil {
+			logger.V(5).Info("Unmatched existing slice (invalid name)", "slice", klog.KObj(slice), "err", err)
+			obsoleteSlices = append(obsoleteSlices, slice)
+			continue
+		}
+		if index >= 0 && index < len(pool.Slices) {
+			if _, ok := currentSliceForDesiredSlice[index]; !ok {
+				currentSliceForDesiredSlice[index] = slice
+				logger.V(5).Info("Matched existing slice by index", "slice", klog.KObj(slice), "matchIndex", index)
+				continue
 			}
 		}
+		obsoleteSlices = append(obsoleteSlices, slice)
+		logger.V(5).Info("Unmatched existing slice (obsolete)", "slice", klog.KObj(slice))
 	}
 
 	// Desired metadata which must be set in each slice.
@@ -815,9 +812,13 @@ func (c *Controller) syncPool(ctx context.Context, poolName string) error {
 				},
 			)
 		}
-		generateName := c.driverName + "-"
+		// The GenerateName follows the scheme:
+		// [index encoded as base16 string]-[driver name]-[owner name (if not nil)]-
+		// This ensures that the index is at the beginning of the name,
+		// and the API server handles uniqueness by appending a random suffix.
+		generateName := encodeIndex(i, expectedPrefixLength) + nameSeparator + c.driverName + nameSeparator
 		if c.owner != nil {
-			generateName = c.owner.Name + "-" + generateName
+			generateName += c.owner.Name + nameSeparator
 		}
 		slice := &resourceapi.ResourceSlice{
 			ObjectMeta: metav1.ObjectMeta{
@@ -969,25 +970,6 @@ func copyServerDefaults(desiredSlice, actualSlice *resourceapi.ResourceSlice) bo
 	return copied
 }
 
-func sameSlice(existingSlice *resourceapi.ResourceSlice, desiredSlice *Slice) bool {
-	if len(existingSlice.Spec.Devices) != len(desiredSlice.Devices) {
-		return false
-	}
-
-	existingDevices := sets.New[string]()
-	for _, device := range existingSlice.Spec.Devices {
-		existingDevices.Insert(device.Name)
-	}
-	for _, device := range desiredSlice.Devices {
-		if !existingDevices.Has(device.Name) {
-			return false
-		}
-	}
-
-	// Same number of devices, names all present -> equal.
-	return true
-}
-
 // copyTaintTimeAdded copies existing TimeAdded values from one slice into
 // the other if the other one doesn't have it for a taint. Both input
 // slices are read-only.
@@ -1062,4 +1044,40 @@ func refIfNotZero[T comparable](t T) *T {
 		return nil
 	}
 	return &t
+}
+
+// getIndexLength calculates the minimum required prefix length to represent
+// the highest possible index (numSlices - 1) in base16. It ensures a minimum
+// length of resourceSliceIndexMinLength.
+func getIndexLength(numSlices int) int {
+	hexLen := len(strconv.FormatInt(int64(numSlices-1), 16))
+
+	return max(resourceSliceIndexMinLength, hexLen)
+}
+
+// decodeIndex parses a hex-encoded prefix of length expectedLength from name.
+// It returns the parsed integer, or -1 and an error if the format is invalid
+// or the value overflows.
+func decodeIndex(name string, expectedLength int) (int, error) {
+	idx := strings.Index(name, nameSeparator)
+	if idx != expectedLength {
+		return -1, fmt.Errorf("invalid index length or missing separator")
+	}
+	prefix := name[:idx]
+
+	// ParseInt handles invalid digits and overflow automatically by returning an error.
+	// Using '0' for bitSize makes it architecture-aware (32 or 64-bit).
+	// The result is always non-negative because name starting with "-" would result in invalid index length.
+	res, err := strconv.ParseInt(prefix, 16, 0)
+	if err != nil {
+		return -1, fmt.Errorf("failed to parse index: %w", err)
+	}
+
+	return int(res), nil
+}
+
+// encodeIndex encodes an integer into a deterministic base16 string,
+// padded to the expectedLength.
+func encodeIndex(index int, expectedLength int) string {
+	return fmt.Sprintf("%0*x", expectedLength, index)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -65,12 +66,13 @@ func TestControllerSyncPool(t *testing.T) {
 		deviceName2    = "device-2"
 		deviceName3    = "device-3"
 		deviceName4    = "device-4"
-		resourceSlice1 = "resource-slice-1"
-		resourceSlice2 = "resource-slice-2"
-		resourceSlice3 = "resource-slice-3"
-		generateName   = ownerName + "-" + driverName + "-"
-		generatedName1 = generateName + "0"
-		generatedName2 = generateName + "1"
+		generateName1  = encodeIndex(0, resourceSliceIndexMinLength) + "-" + driverName + "-" + ownerName + "-"
+		generateName2  = encodeIndex(1, resourceSliceIndexMinLength) + "-" + driverName + "-" + ownerName + "-"
+		generateName3  = encodeIndex(2, resourceSliceIndexMinLength) + "-" + driverName + "-" + ownerName + "-"
+		generateName4  = encodeIndex(3, resourceSliceIndexMinLength) + "-" + driverName + "-" + ownerName + "-"
+		resourceSlice1 = generateName1 + "0"
+		resourceSlice2 = generateName2 + "1"
+		resourceSlice3 = generateName3 + "2"
 		attrs          = map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 			"new-attribute": {StringValue: ptr.To("value")},
 		}
@@ -125,7 +127,7 @@ func TestControllerSyncPool(t *testing.T) {
 				NumCreates: 1,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -134,7 +136,7 @@ func TestControllerSyncPool(t *testing.T) {
 		"keep-slice-unchanged": {
 			nodeUID: nodeUID,
 			initialObjects: []runtime.Object{
-				MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -148,7 +150,7 @@ func TestControllerSyncPool(t *testing.T) {
 				},
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -157,7 +159,7 @@ func TestControllerSyncPool(t *testing.T) {
 		"keep-taint-unchanged": {
 			nodeUID: nodeUID,
 			initialObjects: []runtime.Object{
-				MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices([]resourceapi.Device{
@@ -188,7 +190,7 @@ func TestControllerSyncPool(t *testing.T) {
 				},
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices([]resourceapi.Device{
@@ -206,7 +208,7 @@ func TestControllerSyncPool(t *testing.T) {
 		"add-taints": {
 			nodeUID: nodeUID,
 			initialObjects: []runtime.Object{
-				MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices([]resourceapi.Device{
@@ -252,7 +254,7 @@ func TestControllerSyncPool(t *testing.T) {
 				NumUpdates: 1,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
@@ -284,7 +286,7 @@ func TestControllerSyncPool(t *testing.T) {
 			features: features{disableDeviceTaints: true},
 			nodeUID:  nodeUID,
 			initialObjects: []runtime.Object{
-				MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices([]resourceapi.Device{newDevice(deviceName)}).
@@ -310,7 +312,7 @@ func TestControllerSyncPool(t *testing.T) {
 				NumUpdates: 1,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
@@ -324,7 +326,7 @@ func TestControllerSyncPool(t *testing.T) {
 			features: features{disableConsumableCapacity: true},
 			nodeUID:  nodeUID,
 			initialObjects: []runtime.Object{
-				MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices([]resourceapi.Device{newDevice(deviceName)}).
@@ -348,7 +350,7 @@ func TestControllerSyncPool(t *testing.T) {
 				NumUpdates: 1,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
@@ -398,15 +400,15 @@ func TestControllerSyncPool(t *testing.T) {
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
 			},
 		},
-		"delete-and-add-slice-when-more-than-one-existing-or-desired-slice": {
+		"update-slice-when-more-than-one-existing-or-desired-slice": {
 			nodeUID: nodeUID,
 			initialObjects: []runtime.Object{
 				// No devices in first ResourceSlice.
-				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+				MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).UID(resourceSlice1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).Obj(),
-				MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+				MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).UID(resourceSlice2).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{{Name: deviceName2}}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).Obj(),
@@ -422,19 +424,17 @@ func TestControllerSyncPool(t *testing.T) {
 				},
 			},
 			expectedStats: Stats{
-				NumCreates: 1,
 				NumUpdates: 1,
-				NumDeletes: 1,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).UID(resourceSlice1).ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName1)}).
-					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 2}).Obj(),
-				*MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).ResourceVersion("1").
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).Obj(),
+				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).UID(resourceSlice2).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName2)}).
-					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 2}).Obj(),
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).Obj(),
 			},
 		},
 		"delete-redundant-slice": {
@@ -572,17 +572,17 @@ func TestControllerSyncPool(t *testing.T) {
 			nodeUID: nodeUID,
 			initialObjects: []runtime.Object{
 				// no devices
-				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
+				MakeResourceSlice().Name(generateName1+"random1").UID(generateName1+"random1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
 				// matching device
-				MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+				MakeResourceSlice().Name(generateName2+"random2").UID(generateName2+"random2").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 1}).Obj(),
 				// no devices
-				MakeResourceSlice().Name(resourceSlice3).UID(resourceSlice3).
+				MakeResourceSlice().Name(generateName3+"random3").UID(generateName3+"random3").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -601,13 +601,14 @@ func TestControllerSyncPool(t *testing.T) {
 				},
 			},
 			expectedStats: Stats{
-				NumDeletes: 2,
+				NumCreates: 1,
+				NumDeletes: 3,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
-					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 1}).Obj(),
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 3, ResourceSliceCount: 1}).Obj(),
 			},
 		},
 		"multiple-resourceslices-existing-one-changed": {
@@ -789,7 +790,7 @@ func TestControllerSyncPool(t *testing.T) {
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 4}).Obj(),
-				*MakeResourceSlice().GenerateName(generateName).Name(generatedName1).
+				*MakeResourceSlice().Name(generateName4+"0").GenerateName(generateName4).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName4)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 4}).Obj(),
@@ -809,7 +810,8 @@ func TestControllerSyncPool(t *testing.T) {
 				NumCreates: 1,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(driverName + "-0").GenerateName(driverName + "-").
+				*MakeResourceSlice().Name(encodeIndex(0, resourceSliceIndexMinLength) + "-" + driverName + "-0").
+					GenerateName(encodeIndex(0, resourceSliceIndexMinLength) + "-" + driverName + "-").
 					AllNodes(true).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -829,7 +831,7 @@ func TestControllerSyncPool(t *testing.T) {
 				NumCreates: 1,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(generateName1 + "0").GenerateName(generateName1).
 					AppOwnerReferences(ownerName).NodeSelector(nodeSelector).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -899,7 +901,7 @@ func TestControllerSyncPool(t *testing.T) {
 				NumCreates: 2,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					PerDeviceNodeSelection(true).
 					SharedCounters([]resourceapi.CounterSet{{
@@ -911,7 +913,7 @@ func TestControllerSyncPool(t *testing.T) {
 					Driver(driverName).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).
 					Obj(),
-				*MakeResourceSlice().Name(generatedName2).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					PerDeviceNodeSelection(true).
 					Driver(driverName).
@@ -971,12 +973,12 @@ func TestControllerSyncPool(t *testing.T) {
 				NumCreates: 2,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).
 					Obj(),
-				*MakeResourceSlice().Name(generatedName2).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices([]resourceapi.Device{newDevice(deviceName)}).
@@ -1010,7 +1012,7 @@ func TestControllerSyncPool(t *testing.T) {
 				NumCreates: 1,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices(func() []resourceapi.Device {
@@ -1047,7 +1049,7 @@ func TestControllerSyncPool(t *testing.T) {
 				NumCreates: 1,
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
-				*MakeResourceSlice().Name(generatedName1).GenerateName(generateName).
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices([]resourceapi.Device{newDevice(deviceName)}).
@@ -1188,6 +1190,99 @@ func TestControllerSyncPool(t *testing.T) {
 				NumCreates: 0,
 			},
 			expectedErrors: []string{`pool validation failed: counter "cpu" referenced by device "device" not found in counter set "counterset"`},
+		},
+		"migration-from-random-naming-to-index-based-naming": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				MakeResourceSlice().Name("random-name1").
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName1)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 3}).Obj(),
+				MakeResourceSlice().Name("random-name2").
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName2)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 3}).Obj(),
+				MakeResourceSlice().Name("random-name3").
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 3}).Obj(),
+			},
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Slices: []Slice{
+							{Devices: []resourceapi.Device{newDevice(deviceName1)}},
+							{Devices: []resourceapi.Device{newDevice(deviceName2)}},
+							{Devices: []resourceapi.Device{newDevice(deviceName3)}},
+						},
+					},
+				},
+			},
+			expectedStats: Stats{
+				NumCreates: 3,
+				NumDeletes: 3,
+			},
+			expectedResourceSlices: []resourceapi.ResourceSlice{
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName1)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
+				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName2)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
+				*MakeResourceSlice().Name(resourceSlice3).GenerateName(generateName3).
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
+			},
+		},
+		"migration-mixed-naming": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				MakeResourceSlice().Name("random-name1").
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName1)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 3}).Obj(),
+				MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).UID(resourceSlice2).
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName2)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 3}).Obj(),
+				MakeResourceSlice().Name("random-name3").
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 3}).Obj(),
+			},
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Slices: []Slice{
+							{Devices: []resourceapi.Device{newDevice(deviceName1)}},
+							{Devices: []resourceapi.Device{newDevice(deviceName2)}},
+							{Devices: []resourceapi.Device{newDevice(deviceName3)}},
+						},
+					},
+				},
+			},
+			expectedStats: Stats{
+				NumCreates: 2, // For index 0 and 2
+				NumDeletes: 2, // For random-name1 and random-name3
+				NumUpdates: 1, // resourceSlice2 is updated to Generation 2
+			},
+			expectedResourceSlices: []resourceapi.ResourceSlice{
+				*MakeResourceSlice().Name(generateName1+"0").GenerateName(generateName1).
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName1)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
+				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).UID(resourceSlice2).ResourceVersion("1").
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName2)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
+				*MakeResourceSlice().Name(generateName3+"1").GenerateName(generateName3).
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
+			},
 		},
 	}
 	for name, test := range testCases {
@@ -1592,4 +1687,116 @@ func newDevice(name string, fields ...any) resourceapi.Device {
 		}
 	}
 	return device
+}
+
+func TestGetIndexLength(t *testing.T) {
+	testCases := []struct {
+		numSlices int
+		expected  int
+	}{
+		{-1, 5},
+		{0, 5},
+		{1, 5},
+		{16, 5},
+		{0x10000, 5},
+		{0x100000, 5},
+		{0x100001, 6},
+		{0x1000000, 6},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", tc.numSlices), func(t *testing.T) {
+			assert.Equal(t, tc.expected, getIndexLength(tc.numSlices))
+		})
+	}
+}
+
+func TestEncodeIndex(t *testing.T) {
+	testCases := []struct {
+		index          int
+		expectedLength int
+		expected       string
+	}{
+		{0, 5, "00000"},
+		{1, 5, "00001"},
+		{9, 5, "00009"},
+		{10, 5, "0000a"},
+		{26, 5, "0001a"},
+		{27, 5, "0001b"},
+		{35, 5, "00023"},
+		{36, 5, "00024"},
+		{100000, 5, "186a0"},
+		{0, 6, "000000"},
+		{1048576, 6, "100000"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", tc.index), func(t *testing.T) {
+			assert.Equal(t, tc.expected, encodeIndex(tc.index, tc.expectedLength))
+		})
+	}
+}
+
+func TestDecodeIndex(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedLength int
+		expected       int
+		expectError    bool
+		expectedError  string
+	}{
+		{name: "00000-", expectedLength: 5, expected: 0},
+		{name: "00001-", expectedLength: 5, expected: 1},
+		{name: "00009-", expectedLength: 5, expected: 9},
+		{name: "0000a-", expectedLength: 5, expected: 10},
+		{name: "0001a-", expectedLength: 5, expected: 26},
+		{name: "0001b-", expectedLength: 5, expected: 27},
+		{name: "00023-", expectedLength: 5, expected: 35},
+		{name: "00024-", expectedLength: 5, expected: 36},
+		{name: "186a0-", expectedLength: 5, expected: 100000},
+		{name: "100000-", expectedLength: 6, expected: 1048576},
+		// Large value that fits in int64 but might exceed int32
+		{
+			name:           "80000000-",
+			expectedLength: 8,
+			expected:       getExpectedForLargeInt(int64(math.MaxInt32) + 1),
+			expectError:    getExpectedForLargeInt(int64(math.MaxInt32)+1) == -1,
+			expectedError:  "failed to parse index",
+		},
+		// Overflow Cases
+		{name: "8000000000000000-", expectedLength: 16, expectError: true, expectedError: "failed to parse index"}, // Absolute maximum possible string (overflows int64)
+		// With suffix (as created by GenerateName)
+		{name: "00000-driver-owner-suffix", expectedLength: 5, expected: 0},
+		{name: "00001-driver-owner-suffix", expectedLength: 5, expected: 1},
+		// Invalid
+		{name: "00000", expectedLength: 5, expectError: true, expectedError: "invalid index length or missing separator"},  // Missing separator
+		{name: "0000g-", expectedLength: 5, expectError: true, expectedError: "failed to parse index"},                     // 'g' is not base16
+		{name: "-0001-", expectedLength: 5, expectError: true, expectedError: "invalid index length or missing separator"}, // Negative hex (dash is separator, so strings.Index is 0)
+		// Wrong length
+		{name: "00000-", expectedLength: 6, expectError: true, expectedError: "invalid index length or missing separator"},
+		{name: "100000-", expectedLength: 5, expectError: true, expectedError: "invalid index length or missing separator"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := decodeIndex(tc.name, tc.expectedLength)
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.expectedError != "" {
+					assert.Contains(t, err.Error(), tc.expectedError)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}
+
+// Helper to handle platform-dependent test expectations
+func getExpectedForLargeInt(val int64) int {
+	if val > int64(math.MaxInt) {
+		return -1
+	}
+	return int(val)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -895,6 +895,33 @@ func deviceRequestAllocationResultWithBindingConditions(request, driver, pool, d
 	}
 }
 
+type AllocatorTestCase struct {
+	features                 Features
+	claimsToAllocate         []wrapResourceClaim
+	allocatedDevices         []DeviceID
+	allocatedSharedDeviceIDs sets.Set[SharedDeviceID]
+	allocatedCapacityDevices ConsumedCapacityCollection
+	classes                  []*resourceapi.DeviceClass
+	slices                   []*resourceapi.ResourceSlice
+	node                     *v1.Node
+
+	expectResults []any
+	expectError   types.GomegaMatcher // can be used to check for no error or match specific error
+
+	// Test case setting expectNumAllocateOneInvocations do not run against the "stable" variant of the allocator,
+	// which doesn't provide the stats and also falls over with excessive runtime for them.
+	expectNumAllocateOneInvocations int64
+
+	// expectNumAllocateOneInvocationsByChannel overrides expectNumAllocateOneInvocations with
+	// different values for specific implementations (e.g. "experimental").
+	//
+	// Ignored unless expectNumAllocateOneInvocations is also set.
+	// expectNumAllocateOneInvocations should contain the "best" result, so
+	// expectNumAllocateOneInvocationsByChannel is only needed as long as we have "worse"
+	// implementations.
+	expectNumAllocateOneInvocationsByChannel map[internal.AllocatorChannel]int64
+}
+
 // TestAllocator runs as many of the shared tests against a specific allocator implementation as possible.
 // Test cases which depend on features that are not supported by the implementation are silently skipped.
 func TestAllocator(t *testing.T,
@@ -947,33 +974,7 @@ func TestAllocator(t *testing.T,
 		Effect:   resourceapi.DeviceTaintEffectNoSchedule,
 	}
 
-	testcases := map[string]struct {
-		features                 Features
-		claimsToAllocate         []wrapResourceClaim
-		allocatedDevices         []DeviceID
-		allocatedSharedDeviceIDs sets.Set[SharedDeviceID]
-		allocatedCapacityDevices ConsumedCapacityCollection
-		classes                  []*resourceapi.DeviceClass
-		slices                   []*resourceapi.ResourceSlice
-		node                     *v1.Node
-
-		expectResults []any
-		expectError   types.GomegaMatcher // can be used to check for no error or match specific error
-
-		// Test case setting expectNumAllocateOneInvocations do not run against the "stable" variant of the allocator,
-		// which doesn't provide the stats and also falls over with excessive runtime for them.
-		expectNumAllocateOneInvocations int64
-
-		// expectNumAllocateOneInvocationsByChannel overrides expectNumAllocateOneInvocations with
-		// different values for specific implementations (e.g. "experimental").
-		//
-		// Ignored unless expectNumAllocateOneInvocations is also set.
-		// expectNumAllocateOneInvocations should contain the "best" result, so
-		// expectNumAllocateOneInvocationsByChannel is only needed as long as we have "worse"
-		// implementations.
-		expectNumAllocateOneInvocationsByChannel map[internal.AllocatorChannel]int64
-	}{
-
+	testcases := map[string]AllocatorTestCase{
 		"empty": {},
 		"simple": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
@@ -4253,7 +4254,7 @@ func TestAllocator(t *testing.T,
 			),
 			classes: objects(class(classA, driverA)),
 			slices: unwrapResourceSlices(
-				sliceWithDevices(slice1, node1, resourcePool(pool1, 4), driverA,
+				sliceWithDevices(slice4, node1, resourcePool(pool1, 4), driverA,
 					device(device1, fromCounters, nil).
 						withDeviceCounterConsumption(
 							deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
@@ -4262,12 +4263,12 @@ func TestAllocator(t *testing.T,
 						).
 						withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}),
 				),
-				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 4), driverA,
+				sliceWithCounterSets(slice3, node1, resourcePool(pool1, 4), driverA,
 					counterSet(counterSet1, map[string]resource.Quantity{
 						"memory": resource.MustParse("8Gi"),
 					}),
 				),
-				sliceWithDevices(slice3, node1, resourcePool(pool1, 4), driverA,
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 4), driverA,
 					device(device2, fromCounters, nil).
 						withDeviceCounterConsumption(
 							deviceCounterConsumption(counterSet2, map[string]resource.Quantity{
@@ -4275,7 +4276,7 @@ func TestAllocator(t *testing.T,
 							}),
 						),
 				),
-				sliceWithCounterSets(slice4, node1, resourcePool(pool1, 4), driverA,
+				sliceWithCounterSets(slice1, node1, resourcePool(pool1, 4), driverA,
 					counterSet(counterSet2, map[string]resource.Quantity{
 						"memory": resource.MustParse("8Gi"),
 					}),
@@ -6271,6 +6272,78 @@ func TestAllocator(t *testing.T,
 		},
 	}
 
+	RunTestAllocator(t, supportedFeatures, newAllocator, testcases)
+
+	t.Run("interrupt", func(t *testing.T) {
+		for _, name := range []string{"off", "timeout", "deadline", "cancel"} {
+			t.Run(name, func(t *testing.T) {
+				_, ctx := ktesting.NewTestContext(t)
+				g := gomega.NewWithT(t)
+
+				// This testcase is a smaller variant of the one in https://github.com/kubernetes/kubernetes/issues/131730#issuecomment-2873598287.
+				// That one took over 30 seconds, this one here only 0.07 seconds.
+				// But even that is too long when we interrupt in the near future or
+				// even before starting...
+				classLister := informerLister[resourceapi.DeviceClass]{
+					objs: []*resourceapi.DeviceClass{class(classA, driverA)},
+				}
+				claimsToAllocate := unwrap(claimWithRequests(claim0, nil,
+					request(req0, classA, 6),
+				))
+				slices := unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil),
+					device(device2, nil, nil),
+					device(device3, nil, nil),
+					device(device4, nil, nil),
+					device("device-5", nil, nil),
+				))
+				node := node(node1, region1)
+
+				switch name {
+				case "off":
+				case "timeout":
+					c, cancel := context.WithTimeout(ctx, time.Nanosecond)
+					defer cancel()
+					ctx = c
+				case "deadline":
+					c, cancel := context.WithDeadline(ctx, time.Now())
+					defer cancel()
+					ctx = c
+				case "cancel":
+					c, cancel := context.WithCancel(ctx)
+					cancel()
+					ctx = c
+				}
+
+				allocator, err := newAllocator(ctx, Features{}, AllocatedState{}, classLister, slices, cel.NewCache(1, cel.Features{}))
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+				_, err = allocator.Allocate(ctx, node, claimsToAllocate)
+				t.Logf("got error %v", err)
+				if ctx.Err() != nil {
+					if !errors.Is(err, ctx.Err()) {
+						t.Fatalf("expected %v, got error: %v", ctx.Err(), err)
+					}
+				} else {
+					if err != nil {
+						t.Fatalf("expected no error, got %v", err)
+					}
+				}
+			})
+		}
+	})
+}
+
+func RunTestAllocator(t *testing.T,
+	supportedFeatures Features,
+	newAllocator func(
+		ctx context.Context,
+		features Features,
+		allocateState AllocatedState,
+		classLister DeviceClassLister,
+		slices []*resourceapi.ResourceSlice,
+		celCache *cel.Cache,
+	) (Allocator, error),
+	testcases map[string]AllocatorTestCase) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
@@ -6344,64 +6417,6 @@ func TestAllocator(t *testing.T,
 			}
 		})
 	}
-
-	t.Run("interrupt", func(t *testing.T) {
-		for _, name := range []string{"off", "timeout", "deadline", "cancel"} {
-			t.Run(name, func(t *testing.T) {
-				_, ctx := ktesting.NewTestContext(t)
-				g := gomega.NewWithT(t)
-
-				// This testcase is a smaller variant of the one in https://github.com/kubernetes/kubernetes/issues/131730#issuecomment-2873598287.
-				// That one took over 30 seconds, this one here only 0.07 seconds.
-				// But even that is too long when we interrupt in the near future or
-				// even before starting...
-				classLister := informerLister[resourceapi.DeviceClass]{
-					objs: []*resourceapi.DeviceClass{class(classA, driverA)},
-				}
-				claimsToAllocate := unwrap(claimWithRequests(claim0, nil,
-					request(req0, classA, 6),
-				))
-				slices := unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
-					device(device1, nil, nil),
-					device(device2, nil, nil),
-					device(device3, nil, nil),
-					device(device4, nil, nil),
-					device("device-5", nil, nil),
-				))
-				node := node(node1, region1)
-
-				switch name {
-				case "off":
-				case "timeout":
-					c, cancel := context.WithTimeout(ctx, time.Nanosecond)
-					defer cancel()
-					ctx = c
-				case "deadline":
-					c, cancel := context.WithDeadline(ctx, time.Now())
-					defer cancel()
-					ctx = c
-				case "cancel":
-					c, cancel := context.WithCancel(ctx)
-					cancel()
-					ctx = c
-				}
-
-				allocator, err := newAllocator(ctx, Features{}, AllocatedState{}, classLister, slices, cel.NewCache(1, cel.Features{}))
-				g.Expect(err).ToNot(gomega.HaveOccurred())
-				_, err = allocator.Allocate(ctx, node, claimsToAllocate)
-				t.Logf("got error %v", err)
-				if ctx.Err() != nil {
-					if !errors.Is(err, ctx.Err()) {
-						t.Fatalf("expected %v, got error: %v", ctx.Err(), err)
-					}
-				} else {
-					if err != nil {
-						t.Fatalf("expected no error, got %v", err)
-					}
-				}
-			})
-		}
-	})
 }
 
 type informerLister[T any] struct {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/lexicographical_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/lexicographical_testing.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocatortesting
+
+import (
+	"context"
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/dynamic-resource-allocation/cel"
+)
+
+// TestLexicographicalAllocator runs tests which depend on lexicographical sorting.
+func TestLexicographicalAllocator(t *testing.T,
+	supportedFeatures Features,
+	newAllocator func(
+		ctx context.Context,
+		features Features,
+		allocateState AllocatedState,
+		classLister DeviceClassLister,
+		slices []*resourceapi.ResourceSlice,
+		celCache *cel.Cache,
+	) (Allocator, error)) {
+	testcases := map[string]AllocatorTestCase{
+		"lexicographical-sorting-pools": {
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 2))),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				// pool-3 before pool-2 before pool-1 in input.
+				sliceWithOneDevice(slice1, node1, resourcePool(pool3, 1), driverA),
+				sliceWithOneDevice(slice2, node1, resourcePool(pool2, 1), driverA),
+				sliceWithOneDevice(slice3, node1, resourcePool(pool1, 1), driverA),
+			),
+			node: node(node1, region1),
+
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req0, driverA, pool2, device1, false),
+			)},
+		},
+		"lexicographical-sorting-pools-with-binding-conditions": {
+			features: Features{
+				DeviceBindingAndStatus: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 2))),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				// pools with binding conditions will be considered after pools without binding conditions.
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 1), driverA,
+					device(device1, nil, nil).withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}),
+				),
+				sliceWithDevices(slice3, node1, resourcePool(pool3, 1), driverA, device(device3, nil, nil)),
+				sliceWithDevices(slice2, node1, resourcePool(pool2, 1), driverA, device(device2, nil, nil)),
+			),
+			node: node(node1, region1),
+
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool2, device2, false),
+				deviceAllocationResult(req0, driverA, pool3, device3, false),
+			)},
+		},
+		"lexicographical-sorting-slices": {
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 2))),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				// slice-3 before slice-2 before slice-1 in input.
+				sliceWithDevices(slice3, node1, resourcePool(pool1, 3), driverA, device(device3, nil, nil)),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 3), driverA, device(device2, nil, nil)),
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 3), driverA, device(device1, nil, nil)),
+			),
+			node: node(node1, region1),
+
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
+		"lexicographical-sorting-slices-with-binding-conditions": {
+			features: Features{
+				DeviceBindingAndStatus: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 2))),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 3), driverA,
+					device(device1, nil, nil).withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}),
+				),
+				sliceWithDevices(slice3, node1, resourcePool(pool1, 3), driverA, device(device3, nil, nil)),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 3), driverA, device(device2, nil, nil)),
+			),
+			node: node(node1, region1),
+
+			expectResults: []any{
+				resourceapi.AllocationResult{
+					Devices: resourceapi.DeviceAllocationResult{
+						Results: []resourceapi.DeviceRequestAllocationResult{
+							deviceRequestAllocationResultWithBindingConditions(req0, driverA, pool1, device1, []string{"IsPrepare"}, []string{"BindingFailed"}),
+							deviceAllocationResult(req0, driverA, pool1, device2, false),
+						},
+					},
+					NodeSelector: localNodeSelector(node1),
+				},
+			},
+		},
+	}
+
+	RunTestAllocator(t, supportedFeatures, newAllocator, testcases)
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_test.go
@@ -27,17 +27,22 @@ import (
 )
 
 func TestAllocator(t *testing.T) {
+	newAllocator := func(
+		ctx context.Context,
+		features Features,
+		allocatedState AllocatedState,
+		classLister DeviceClassLister,
+		slices []*resourceapi.ResourceSlice,
+		celCache *cel.Cache,
+	) (internal.Allocator, error) {
+		return NewAllocator(ctx, features, allocatedState, classLister, slices, celCache)
+	}
 	allocatortesting.TestAllocator(t,
 		SupportedFeatures,
-		func(
-			ctx context.Context,
-			features Features,
-			allocatedState AllocatedState,
-			classLister DeviceClassLister,
-			slices []*resourceapi.ResourceSlice,
-			celCache *cel.Cache,
-		) (internal.Allocator, error) {
-			return NewAllocator(ctx, features, allocatedState, classLister, slices, celCache)
-		},
+		newAllocator,
+	)
+	allocatortesting.TestLexicographicalAllocator(t,
+		SupportedFeatures,
+		newAllocator,
 	)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
@@ -17,8 +17,10 @@ limitations under the License.
 package experimental
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/go-logr/logr"
 
@@ -56,37 +58,25 @@ func NodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 // Both is recorded in the result.
 func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice, node *v1.Node, features Features, allSlices []*resourceapi.ResourceSlice) ([]*Pool, error) {
 	pools := make(map[PoolID][]*draapi.ResourceSlice)
-	var slicesWithBindingConditions []*resourceapi.ResourceSlice
 
 	for _, slice := range slicesForNode {
 		if !features.PartitionableDevices && (slice.Spec.PerDeviceNodeSelection != nil || len(slice.Spec.SharedCounters) > 0) {
 			continue
 		}
 
+		// Determine if the slice is relevant for the node.
+		relevant := false
+
 		// Always include slices with SharedCounters since they are needed to use a pool
 		// regardless of their node selector.
 		if len(slice.Spec.SharedCounters) > 0 {
-			if err := addSlice(pools, slice); err != nil {
-				return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
-			}
+			relevant = true
 		} else if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
 			match, err := NodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to perform node selection for slice %s: %w", slice.Name, err)
 			}
-			if match {
-				if hasBindingConditions(slice) {
-					// If there is a Device in the ResourceSlice that contains BindingConditions,
-					// the ResourceSlice should be sorted to be after the ResourceSlice without BindingConditions
-					// because then the allocation is going to prefer the simpler devices without
-					// binding conditions.
-					slicesWithBindingConditions = append(slicesWithBindingConditions, slice)
-					continue
-				}
-				if err := addSlice(pools, slice); err != nil {
-					return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
-				}
-			}
+			relevant = match
 		} else if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
 			for _, device := range slice.Spec.Devices {
 				match, err := NodeMatches(node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
@@ -95,15 +85,7 @@ func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice
 						device.String(), slice.Name, err)
 				}
 				if match {
-					if hasBindingConditions(slice) {
-						// If there is a Device in the ResourceSlice that contains BindingConditions,
-						// the ResourceSlice should be sorted to be after the ResourceSlice without BindingConditions.
-						slicesWithBindingConditions = append(slicesWithBindingConditions, slice)
-						break
-					}
-					if err := addSlice(pools, slice); err != nil {
-						return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
-					}
+					relevant = true
 					break
 				}
 			}
@@ -118,11 +100,10 @@ func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice
 			continue
 		}
 
-	}
-
-	for _, slice := range slicesWithBindingConditions {
-		if err := addSlice(pools, slice); err != nil {
-			return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
+		if relevant {
+			if err := addSlice(pools, slice); err != nil {
+				return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
+			}
 		}
 	}
 
@@ -191,11 +172,33 @@ func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice
 		}
 		result = append(result, pool)
 	}
+
+	// Sort pools by ID to ensure a deterministic allocation order.
+	// Because the allocator uses a first-fit search, this allows driver authors
+	// to influence prioritization through their naming conventions.
+	sortPoolsByID(result)
+	sortPoolsByID(resultWithBindingConditions)
+
 	if len(resultWithBindingConditions) != 0 {
 		result = append(result, resultWithBindingConditions...)
 	}
 
 	return result, nil
+}
+
+func sortSlicesByName(slicesToSort []*draapi.ResourceSlice) {
+	slices.SortFunc(slicesToSort, func(a, b *draapi.ResourceSlice) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+}
+
+func sortPoolsByID(pools []*Pool) {
+	slices.SortFunc(pools, func(a, b *Pool) int {
+		if cmp := cmp.Compare(a.PoolID.Driver.String(), b.PoolID.Driver.String()); cmp != 0 {
+			return cmp
+		}
+		return cmp.Compare(a.PoolID.Pool.String(), b.PoolID.Pool.String())
+	})
 }
 
 func addSlice(pools map[PoolID][]*draapi.ResourceSlice, s *resourceapi.ResourceSlice) error {
@@ -230,6 +233,11 @@ func addSlice(pools map[PoolID][]*draapi.ResourceSlice, s *resourceapi.ResourceS
 }
 
 func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, allSlicesForPool []*resourceapi.ResourceSlice) (*Pool, error) {
+	// Sort slices by name to ensure a deterministic allocation order.
+	// Because the allocator uses a first-fit search, this allows driver authors
+	// to influence prioritization through their naming conventions.
+	sortSlicesByName(slices)
+
 	var deviceSlices []*draapi.ResourceSlice
 	var counterSetSlices []*draapi.ResourceSlice
 	if features.PartitionableDevices {
@@ -375,15 +383,6 @@ func validateDeviceCounterConsumption(counterSets map[draapi.UniqueString]*draap
 		}
 	}
 	return nil
-}
-
-func hasBindingConditions(slice *resourceapi.ResourceSlice) bool {
-	for _, device := range slice.Spec.Devices {
-		if device.BindingConditions != nil {
-			return true
-		}
-	}
-	return false
 }
 
 func poolHasBindingConditions(pool Pool) bool {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_test.go
@@ -27,17 +27,22 @@ import (
 )
 
 func TestAllocator(t *testing.T) {
+	newAllocator := func(
+		ctx context.Context,
+		features Features,
+		allocatedState AllocatedState,
+		classLister DeviceClassLister,
+		slices []*resourceapi.ResourceSlice,
+		celCache *cel.Cache,
+	) (internal.Allocator, error) {
+		return NewAllocator(ctx, features, allocatedState, classLister, slices, celCache)
+	}
 	allocatortesting.TestAllocator(t,
 		SupportedFeatures,
-		func(
-			ctx context.Context,
-			features Features,
-			allocatedState AllocatedState,
-			classLister DeviceClassLister,
-			slices []*resourceapi.ResourceSlice,
-			celCache *cel.Cache,
-		) (internal.Allocator, error) {
-			return NewAllocator(ctx, features, allocatedState, classLister, slices, celCache)
-		},
+		newAllocator,
+	)
+	allocatortesting.TestLexicographicalAllocator(t,
+		SupportedFeatures,
+		newAllocator,
 	)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
@@ -17,8 +17,10 @@ limitations under the License.
 package incubating
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/go-logr/logr"
 
@@ -56,37 +58,25 @@ func NodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 // Both is recorded in the result.
 func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice, node *v1.Node, features Features, allSlices []*resourceapi.ResourceSlice) ([]*Pool, error) {
 	pools := make(map[PoolID][]*draapi.ResourceSlice)
-	var slicesWithBindingConditions []*resourceapi.ResourceSlice
 
 	for _, slice := range slicesForNode {
 		if !features.PartitionableDevices && (slice.Spec.PerDeviceNodeSelection != nil || len(slice.Spec.SharedCounters) > 0) {
 			continue
 		}
 
+		// Determine if the slice is relevant for the node.
+		relevant := false
+
 		// Always include slices with SharedCounters since they are needed to use a pool
 		// regardless of their node selector.
 		if len(slice.Spec.SharedCounters) > 0 {
-			if err := addSlice(pools, slice); err != nil {
-				return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
-			}
+			relevant = true
 		} else if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
 			match, err := NodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to perform node selection for slice %s: %w", slice.Name, err)
 			}
-			if match {
-				if hasBindingConditions(slice) {
-					// If there is a Device in the ResourceSlice that contains BindingConditions,
-					// the ResourceSlice should be sorted to be after the ResourceSlice without BindingConditions
-					// because then the allocation is going to prefer the simpler devices without
-					// binding conditions.
-					slicesWithBindingConditions = append(slicesWithBindingConditions, slice)
-					continue
-				}
-				if err := addSlice(pools, slice); err != nil {
-					return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
-				}
-			}
+			relevant = match
 		} else if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
 			for _, device := range slice.Spec.Devices {
 				match, err := NodeMatches(node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
@@ -95,15 +85,7 @@ func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice
 						device.String(), slice.Name, err)
 				}
 				if match {
-					if hasBindingConditions(slice) {
-						// If there is a Device in the ResourceSlice that contains BindingConditions,
-						// the ResourceSlice should be sorted to be after the ResourceSlice without BindingConditions.
-						slicesWithBindingConditions = append(slicesWithBindingConditions, slice)
-						break
-					}
-					if err := addSlice(pools, slice); err != nil {
-						return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
-					}
+					relevant = true
 					break
 				}
 			}
@@ -118,11 +100,10 @@ func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice
 			continue
 		}
 
-	}
-
-	for _, slice := range slicesWithBindingConditions {
-		if err := addSlice(pools, slice); err != nil {
-			return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
+		if relevant {
+			if err := addSlice(pools, slice); err != nil {
+				return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
+			}
 		}
 	}
 
@@ -191,11 +172,33 @@ func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice
 		}
 		result = append(result, pool)
 	}
+
+	// Sort pools by ID to ensure a deterministic allocation order.
+	// Because the allocator uses a first-fit search, this allows driver authors
+	// to influence prioritization through their naming conventions.
+	sortPoolsByID(result)
+	sortPoolsByID(resultWithBindingConditions)
+
 	if len(resultWithBindingConditions) != 0 {
 		result = append(result, resultWithBindingConditions...)
 	}
 
 	return result, nil
+}
+
+func sortSlicesByName(slicesToSort []*draapi.ResourceSlice) {
+	slices.SortFunc(slicesToSort, func(a, b *draapi.ResourceSlice) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+}
+
+func sortPoolsByID(pools []*Pool) {
+	slices.SortFunc(pools, func(a, b *Pool) int {
+		if cmp := cmp.Compare(a.PoolID.Driver.String(), b.PoolID.Driver.String()); cmp != 0 {
+			return cmp
+		}
+		return cmp.Compare(a.PoolID.Pool.String(), b.PoolID.Pool.String())
+	})
 }
 
 func addSlice(pools map[PoolID][]*draapi.ResourceSlice, s *resourceapi.ResourceSlice) error {
@@ -230,6 +233,11 @@ func addSlice(pools map[PoolID][]*draapi.ResourceSlice, s *resourceapi.ResourceS
 }
 
 func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, allSlicesForPool []*resourceapi.ResourceSlice) (*Pool, error) {
+	// Sort slices by name to ensure a deterministic allocation order.
+	// Because the allocator uses a first-fit search, this allows driver authors
+	// to influence prioritization through their naming conventions.
+	sortSlicesByName(slices)
+
 	var deviceSlices []*draapi.ResourceSlice
 	var counterSetSlices []*draapi.ResourceSlice
 	if features.PartitionableDevices {
@@ -375,15 +383,6 @@ func validateDeviceCounterConsumption(counterSets map[draapi.UniqueString]*draap
 		}
 	}
 	return nil
-}
-
-func hasBindingConditions(slice *resourceapi.ResourceSlice) bool {
-	for _, device := range slice.Spec.Devices {
-		if device.BindingConditions != nil {
-			return true
-		}
-	}
-	return false
 }
 
 func poolHasBindingConditions(pool Pool) bool {

--- a/test/integration/dra/resourceslicecontroller.go
+++ b/test/integration/dra/resourceslicecontroller.go
@@ -118,10 +118,10 @@ func TestCreateResourceSlices(tCtx ktesting.TContext, numSlices int) {
 	resources.Pools[poolName] = resourceslice.Pool{Slices: []resourceslice.Slice{{}}}
 	controller.Update(resources)
 
-	// One empty slice should remain, after removing the full ones and adding the empty one.
+	// A slice should be updated to be empty, and the rest should be deleted.
 	emptySlice := gomega.HaveField("Spec.Devices", gomega.BeEmpty())
 	tCtx.Eventually(listSlices).WithTimeout(2 * time.Minute).Should(gomega.HaveField("Items", gomega.HaveExactElements(emptySlice)))
-	expectStats = resourceslice.Stats{NumCreates: int64(numSlices) + 1, NumDeletes: int64(numSlices)}
+	expectStats = resourceslice.Stats{NumCreates: int64(numSlices), NumUpdates: 1, NumDeletes: int64(numSlices) - 1}
 
 	// There is a window of time where the ResourceSlice exists and is
 	// returned in a list but before that ResourceSlice is accounted for


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
https://github.com/kubernetes/enhancements/pull/5794 discussed setting priority for `ResourceSlices` and `Pools`. We eventually agreed to sort slices and pools in lexicographical order to avoid API changes. Below is a summary of the changes and relevant notes.

**Allocator**
When gathering pools, we now sort slices and pools by name. Since the allocator uses a first-fit search, this allows driver authors to influence prioritization through their naming conventions. Notably, we no longer treat slices with binding conditions specially, as driver authors now have the flexibility to control the order themselves. Since different pools may be published by different drivers, we'll still consider pools without binding conditions first as we do currently.

**Resource Slice Controller**
Prior to this PR, slices were named randomly and matched with existing slices based on their content. This PR introduces index-based naming, where slices are named in the order provided by the driver. Consequently, the allocation process considers slices in the driver-specified order. Also, slices are now matched by names in synchronization.

While inserting a new slice requires updating all subsequent slices, this does not result in a performance degradation. Previously, adding a new slice required bumping the generation, which also necessitated updating all slices.

When users upgrade from an older version to this one, existing slices will be recreated with index-based names. This behavior is covered in the included unit tests.

**Test**
Since the new allocation feature is currently exclusive to the experimental allocator and not behind a feature gate, I have placed the related tests in a separate section named after the feature. I anticipate these may be referenced by multiple channels in the future; for example, if the feature moves from experimental to incubating, these lexicographical tests can be shared across both channels.

#### Which issue(s) this PR is related to:
Fixes #136628

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Introduce index-based naming in ResourceSlice controller and ensure ResourceSlices and pools are sorted lexicographically before allocation, allowing users to control allocation priority.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
