### PR TITLE
Add context-aware retry APIs to support cancellation and contextual logging

### DIFF
--- a/staging/src/k8s.io/client-go/util/retry/util.go
+++ b/staging/src/k8s.io/client-go/util/retry/util.go
@@ -18,6 +18,7 @@ package retry
 
 import (
 	"context"
+	stderrors "errors"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -65,7 +66,7 @@ func OnErrorWithContext(ctx context.Context, backoff wait.Backoff, retriable fun
 	})
 	// If the context was cancelled or the deadline was exceeded, return the context error.
 	// Otherwise, if we timed out (ran out of steps), return the last error we saw.
-	if err == context.Canceled || err == context.DeadlineExceeded {
+	if stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
 	if wait.Interrupted(err) {

--- a/staging/src/k8s.io/client-go/util/retry/util_test.go
+++ b/staging/src/k8s.io/client-go/util/retry/util_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package retry
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -67,5 +69,232 @@ func TestRetryOnConflict(t *testing.T) {
 	})
 	if err != nil || i != 2 {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRetryOnConflictWithContext(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	conflictErr := errors.NewConflict(schema.GroupResource{Resource: "test"}, "other", nil)
+
+	// context cancelled before first attempt - returns context.Canceled immediately
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := RetryOnConflictWithContext(ctx, opts, func(context.Context) error {
+		return conflictErr
+	})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+
+	// context cancelled during retry - returns context.Canceled
+	ctx, cancel = context.WithCancel(context.Background())
+	i := 0
+	err = RetryOnConflictWithContext(ctx, wait.Backoff{Factor: 1.0, Steps: 100, Duration: 50 * time.Millisecond}, func(context.Context) error {
+		i++
+		if i == 2 {
+			cancel()
+		}
+		return conflictErr
+	})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+
+	// context timeout - returns context.DeadlineExceeded
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	i = 0
+	err = RetryOnConflictWithContext(ctx, wait.Backoff{Factor: 1.0, Steps: 100, Duration: time.Hour}, func(context.Context) error {
+		i++
+		return conflictErr
+	})
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
+	}
+	if i < 1 {
+		t.Errorf("expected at least one retry attempt, got: %d", i)
+	}
+
+	// max retries
+	i = 0
+	err = RetryOnConflictWithContext(context.Background(), opts, func(context.Context) error {
+		i++
+		return conflictErr
+	})
+	if err != conflictErr {
+		t.Errorf("expected conflictErr, got: %v", err)
+	}
+	if i != opts.Steps {
+		t.Errorf("expected %d attempts, got: %d", opts.Steps, i)
+	}
+
+	// returns immediately on success
+	i = 0
+	err = RetryOnConflictWithContext(context.Background(), opts, func(context.Context) error {
+		i++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 1 {
+		t.Errorf("expected 1 attempt, got: %d", i)
+	}
+
+	// returns immediately on non-retriable error
+	testErr := fmt.Errorf("some other error")
+	i = 0
+	err = RetryOnConflictWithContext(context.Background(), opts, func(context.Context) error {
+		i++
+		return testErr
+	})
+	if err != testErr {
+		t.Errorf("expected testErr, got: %v", err)
+	}
+	if i != 1 {
+		t.Errorf("expected 1 attempt, got: %d", i)
+	}
+
+	// retries until success
+	i = 0
+	err = RetryOnConflictWithContext(context.Background(), opts, func(context.Context) error {
+		if i < 2 {
+			i++
+			return conflictErr
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 2 {
+		t.Errorf("expected 2 attempts, got: %d", i)
+	}
+
+	// context is passed to callback
+	ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	var receivedCtx context.Context
+	_ = RetryOnConflictWithContext(ctx, opts, func(ctx context.Context) error {
+		receivedCtx = ctx
+		return nil
+	})
+	if receivedCtx != ctx {
+		t.Error("context was not passed to callback")
+	}
+}
+
+func TestOnErrorWithContext(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	testErr := fmt.Errorf("test error")
+	retriableErr := fmt.Errorf("retriable error")
+	retriable := func(err error) bool {
+		return err == retriableErr
+	}
+
+	// context cancelled before first attempt - returns context.Canceled immediately
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := OnErrorWithContext(ctx, opts, retriable, func(context.Context) error {
+		return testErr
+	})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+
+	// context cancelled during retry - returns context.Canceled
+	ctx, cancel = context.WithCancel(context.Background())
+	i := 0
+	err = OnErrorWithContext(ctx, wait.Backoff{Factor: 1.0, Steps: 100, Duration: 50 * time.Millisecond}, retriable, func(context.Context) error {
+		i++
+		if i == 2 {
+			cancel()
+		}
+		return retriableErr
+	})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+
+	// context timeout - returns context.DeadlineExceeded
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	i = 0
+	err = OnErrorWithContext(ctx, wait.Backoff{Factor: 1.0, Steps: 100, Duration: time.Hour}, retriable, func(context.Context) error {
+		i++
+		return retriableErr
+	})
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
+	}
+	if i < 1 {
+		t.Errorf("expected at least one retry attempt, got: %d", i)
+	}
+
+	// max retries
+	i = 0
+	err = OnErrorWithContext(context.Background(), opts, retriable, func(context.Context) error {
+		i++
+		return retriableErr
+	})
+	if err != retriableErr {
+		t.Errorf("expected retriableErr, got: %v", err)
+	}
+	if i != opts.Steps {
+		t.Errorf("expected %d attempts, got: %d", opts.Steps, i)
+	}
+
+	// returns immediately on success
+	i = 0
+	err = OnErrorWithContext(context.Background(), opts, retriable, func(context.Context) error {
+		i++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 1 {
+		t.Errorf("expected 1 attempt, got: %d", i)
+	}
+
+	// returns immediately on non-retriable error
+	i = 0
+	err = OnErrorWithContext(context.Background(), opts, retriable, func(context.Context) error {
+		i++
+		return testErr
+	})
+	if err != testErr {
+		t.Errorf("expected testErr, got: %v", err)
+	}
+	if i != 1 {
+		t.Errorf("expected 1 attempt, got: %d", i)
+	}
+
+	// retries until success
+	i = 0
+	err = OnErrorWithContext(context.Background(), opts, retriable, func(context.Context) error {
+		if i < 2 {
+			i++
+			return retriableErr
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 2 {
+		t.Errorf("expected 2 attempts, got: %d", i)
+	}
+
+	// context is passed to callback
+	ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	var receivedCtx context.Context
+	_ = OnErrorWithContext(ctx, opts, retriable, func(ctx context.Context) error {
+		receivedCtx = ctx
+		return nil
+	})
+	if receivedCtx != ctx {
+		t.Error("context was not passed to callback")
 	}
 }

--- a/staging/src/k8s.io/client-go/util/retry/util_test.go
+++ b/staging/src/k8s.io/client-go/util/retry/util_test.go
@@ -18,6 +18,7 @@ package retry
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"testing"
 	"time"
@@ -82,7 +83,7 @@ func TestRetryOnConflictWithContext(t *testing.T) {
 	err := RetryOnConflictWithContext(ctx, opts, func(context.Context) error {
 		return conflictErr
 	})
-	if err != context.Canceled {
+	if !stderrors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got: %v", err)
 	}
 
@@ -96,7 +97,7 @@ func TestRetryOnConflictWithContext(t *testing.T) {
 		}
 		return conflictErr
 	})
-	if err != context.Canceled {
+	if !stderrors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got: %v", err)
 	}
 
@@ -108,7 +109,7 @@ func TestRetryOnConflictWithContext(t *testing.T) {
 		i++
 		return conflictErr
 	})
-	if err != context.DeadlineExceeded {
+	if !stderrors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
 	}
 	if i < 1 {
@@ -121,7 +122,7 @@ func TestRetryOnConflictWithContext(t *testing.T) {
 		i++
 		return conflictErr
 	})
-	if err != conflictErr {
+	if !stderrors.Is(err, conflictErr) {
 		t.Errorf("expected conflictErr, got: %v", err)
 	}
 	if i != opts.Steps {
@@ -189,7 +190,7 @@ func TestOnErrorWithContext(t *testing.T) {
 	testErr := fmt.Errorf("test error")
 	retriableErr := fmt.Errorf("retriable error")
 	retriable := func(err error) bool {
-		return err == retriableErr
+		return stderrors.Is(err, retriableErr)
 	}
 
 	// context cancelled before first attempt - returns context.Canceled immediately
@@ -198,7 +199,7 @@ func TestOnErrorWithContext(t *testing.T) {
 	err := OnErrorWithContext(ctx, opts, retriable, func(context.Context) error {
 		return testErr
 	})
-	if err != context.Canceled {
+	if !stderrors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got: %v", err)
 	}
 
@@ -212,7 +213,7 @@ func TestOnErrorWithContext(t *testing.T) {
 		}
 		return retriableErr
 	})
-	if err != context.Canceled {
+	if !stderrors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got: %v", err)
 	}
 
@@ -224,7 +225,7 @@ func TestOnErrorWithContext(t *testing.T) {
 		i++
 		return retriableErr
 	})
-	if err != context.DeadlineExceeded {
+	if !stderrors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
 	}
 	if i < 1 {
@@ -237,7 +238,7 @@ func TestOnErrorWithContext(t *testing.T) {
 		i++
 		return retriableErr
 	})
-	if err != retriableErr {
+	if !stderrors.Is(err, retriableErr) {
 		t.Errorf("expected retriableErr, got: %v", err)
 	}
 	if i != opts.Steps {

--- a/staging/src/k8s.io/client-go/util/retry/util_test.go
+++ b/staging/src/k8s.io/client-go/util/retry/util_test.go
@@ -149,7 +149,7 @@ func TestRetryOnConflictWithContext(t *testing.T) {
 		i++
 		return testErr
 	})
-	if err != testErr {
+	if !stderrors.Is(err, testErr) {
 		t.Errorf("expected testErr, got: %v", err)
 	}
 	if i != 1 {
@@ -264,7 +264,7 @@ func TestOnErrorWithContext(t *testing.T) {
 		i++
 		return testErr
 	})
-	if err != testErr {
+	if !stderrors.Is(err, testErr) {
 		t.Errorf("expected testErr, got: %v", err)
 	}
 	if i != 1 {


### PR DESCRIPTION
## Summary

- Add `OnErrorWithContext`: A context-aware version of `OnError` that allows callers to cancel retry operations and pass context to the retry callback for contextual logging
- Add `RetryOnConflictWithContext`: A context-aware version of `RetryOnConflict` that supports cancellation and context propagation for conflict retries
- Refactor existing `OnError` and `RetryOnConflict` to delegate to their context-aware counterparts, maintaining full backward compatibility

## Key Behaviors

- When context is cancelled or deadline exceeded, the function returns the context error (`context.Canceled` or `context.DeadlineExceeded`)
- When maximum retries are reached, returns the last error from retries
- Context is properly passed through to all callback functions

## Test Plan

- [x] Unit tests for `RetryOnConflictWithContext` covering 8 scenarios (context cancel, timeout, max retries, success, non-retriable error, retry until success, context propagation)
- [x] Unit tests for `OnErrorWithContext` covering the same 8 scenarios
- [x] All existing `retry` package tests pass
- [x] All `client-go/util` package tests pass

Part of #126379

```release-note
Add context-aware variants of retry functions: `RetryOnConflictWithContext` and `OnErrorWithContext` to support cancellation and contextual logging in client-go.
```