### PR TITLE
Extend NodeResourcesFit plugin to score placements in the PodGroup scheduling cycle

### DIFF
--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -159,6 +159,11 @@ var ExpandedPluginsV1 = &config.Plugins{
 			{Name: names.DefaultBinder},
 		},
 	},
+	PlacementScore: config.PluginSet{
+		Enabled: []config.Plugin{
+			{Name: names.NodeResourcesFit, Weight: 1},
+		},
+	},
 }
 
 // PluginConfigsV1 default plugin configurations.

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -47,6 +47,7 @@ var _ fwk.EnqueueExtensions = &Fit{}
 var _ fwk.PreScorePlugin = &Fit{}
 var _ fwk.ScorePlugin = &Fit{}
 var _ fwk.SignPlugin = &Fit{}
+var _ fwk.PlacementScorePlugin = &Fit{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -62,27 +63,27 @@ const (
 
 // nodeResourceStrategyTypeMap maps strategy to scorer implementation
 var nodeResourceStrategyTypeMap = map[config.ScoringStrategyType]scorer{
-	config.LeastAllocated: func(args *config.NodeResourcesFitArgs) *resourceAllocationScorer {
-		resources := args.ScoringStrategy.Resources
+	config.LeastAllocated: func(strategy *config.ScoringStrategy) *resourceAllocationScorer {
+		resources := strategy.Resources
 		return &resourceAllocationScorer{
 			Name:      string(config.LeastAllocated),
 			scorer:    leastResourceScorer(resources),
 			resources: resources,
 		}
 	},
-	config.MostAllocated: func(args *config.NodeResourcesFitArgs) *resourceAllocationScorer {
-		resources := args.ScoringStrategy.Resources
+	config.MostAllocated: func(strategy *config.ScoringStrategy) *resourceAllocationScorer {
+		resources := strategy.Resources
 		return &resourceAllocationScorer{
 			Name:      string(config.MostAllocated),
 			scorer:    mostResourceScorer(resources),
 			resources: resources,
 		}
 	},
-	config.RequestedToCapacityRatio: func(args *config.NodeResourcesFitArgs) *resourceAllocationScorer {
-		resources := args.ScoringStrategy.Resources
+	config.RequestedToCapacityRatio: func(strategy *config.ScoringStrategy) *resourceAllocationScorer {
+		resources := strategy.Resources
 		return &resourceAllocationScorer{
 			Name:      string(config.RequestedToCapacityRatio),
-			scorer:    requestedToCapacityRatioScorer(resources, args.ScoringStrategy.RequestedToCapacityRatio.Shape),
+			scorer:    requestedToCapacityRatioScorer(resources, strategy.RequestedToCapacityRatio.Shape),
 			resources: resources,
 		}
 	},
@@ -100,6 +101,7 @@ type Fit struct {
 	enableInPlacePodLevelResourcesVerticalScaling bool
 	handle                                        fwk.Handle
 	*resourceAllocationScorer
+	placementScorer *resourceAllocationScorer
 }
 
 // ScoreExtensions of the Score plugin.
@@ -194,6 +196,17 @@ func (pl *Fit) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *f
 	}, nil
 }
 
+func getScorer(strategy *config.ScoringStrategy) (*resourceAllocationScorer, error) {
+	if strategy == nil {
+		return nil, fmt.Errorf("scoring strategy not specified")
+	}
+	scorerFactory, exists := nodeResourceStrategyTypeMap[strategy.Type]
+	if !exists {
+		return nil, fmt.Errorf("scoring strategy %s is not supported", strategy.Type)
+	}
+	return scorerFactory(strategy), nil
+}
+
 // NewFit initializes a new plugin and returns it.
 func NewFit(_ context.Context, plArgs runtime.Object, h fwk.Handle, fts feature.Features) (fwk.Plugin, error) {
 	args, ok := plArgs.(*config.NodeResourcesFitArgs)
@@ -204,17 +217,10 @@ func NewFit(_ context.Context, plArgs runtime.Object, h fwk.Handle, fts feature.
 		return nil, err
 	}
 
-	if args.ScoringStrategy == nil {
-		return nil, fmt.Errorf("scoring strategy not specified")
+	scorer, err := getScorer(args.ScoringStrategy)
+	if err != nil {
+		return nil, err
 	}
-
-	strategy := args.ScoringStrategy.Type
-	scorePlugin, exists := nodeResourceStrategyTypeMap[strategy]
-	if !exists {
-		return nil, fmt.Errorf("scoring strategy %s is not supported", strategy)
-	}
-
-	scorer := scorePlugin(args)
 	if fts.EnableDRAExtendedResource {
 		scorer.enableDRAExtendedResource = true
 		scorer.draManager = h.SharedDRAManager()
@@ -224,7 +230,7 @@ func NewFit(_ context.Context, plArgs runtime.Object, h fwk.Handle, fts feature.
 		scorer.DRACaches.celCache = cel.NewCache(10, cel.Features{EnableConsumableCapacity: fts.EnableDRAConsumableCapacity})
 	}
 
-	return &Fit{
+	pl := &Fit{
 		ignoredResources:                              sets.New(args.IgnoredResources...),
 		ignoredResourceGroups:                         sets.New(args.IgnoredResourceGroups...),
 		enableInPlacePodVerticalScaling:               fts.EnableInPlacePodVerticalScaling,
@@ -235,7 +241,20 @@ func NewFit(_ context.Context, plArgs runtime.Object, h fwk.Handle, fts feature.
 		enableDRAExtendedResource:                     fts.EnableDRAExtendedResource,
 		enableInPlacePodLevelResourcesVerticalScaling: fts.EnableInPlacePodLevelResourcesVerticalScaling,
 		resourceAllocationScorer:                      scorer,
-	}, nil
+	}
+
+	if fts.EnableTopologyAwareWorkloadScheduling {
+		placementScorer, err := getScorer(&config.ScoringStrategy{
+			Type:      config.MostAllocated,
+			Resources: args.ScoringStrategy.Resources,
+		})
+		if err != nil {
+			return nil, err
+		}
+		pl.placementScorer = placementScorer
+	}
+
+	return pl, nil
 }
 
 // ResourceRequestsOptions contains feature gate flags for resource request computation.
@@ -759,4 +778,14 @@ func (f *Fit) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, node
 	}
 
 	return f.score(ctx, pod, nodeInfo, s.podRequests, s.draPreScoreState)
+}
+
+// PlacementScoreExtensions is not used by this plugin.
+func (f *Fit) PlacementScoreExtensions() fwk.PlacementScoreExtensions {
+	return nil
+}
+
+// ScorePlacement scores capacity ratio on all nodes in the placement including all assigned pod group pods' resource requests.
+func (f *Fit) ScorePlacement(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, placement *fwk.PodGroupAssignments) (int64, *fwk.Status) {
+	return f.placementScorer.scorePlacement(ctx, podGroup, placement)
 }

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -2288,6 +2289,269 @@ func testFitSignPod(tCtx ktesting.TContext) {
 				if diff := cmp.Diff(test.expectedFragments, fragments); diff != "" {
 					tCtx.Errorf("unexpected fragments, diff (-want,+got):\n%s", diff)
 				}
+			}
+		})
+	}
+}
+
+type podAssignment struct {
+	pod      *v1.Pod
+	nodeName string
+}
+
+func (pa *podAssignment) GetPod() *v1.Pod {
+	return pa.pod
+}
+
+func (pa *podAssignment) GetNodeName() string {
+	return pa.nodeName
+}
+
+func TestScorePlacement_Resources(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload:                 true,
+		features.TopologyAwareWorkloadScheduling: true,
+	})
+
+	testCases := []struct {
+		name                string
+		nodes               []*v1.Node
+		placementNodeNames  []string
+		podGroupPods        []*v1.Pod
+		podGroupAssignments map[types.UID]string
+		preExistingPods     []*v1.Pod
+		resourceSpec        []config.ResourceSpec
+		expectedScore       int64
+	}{
+		{
+			name: "Computes score based on total requests",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+				st.MakeNode().Name("node2").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+			},
+			placementNodeNames: []string{"node1", "node2"},
+			podGroupPods: []*v1.Pod{
+				st.MakePod().UID("foo").Req(cpuAndMemory("1000m", "0")).Obj(),
+				st.MakePod().UID("bar").Req(cpuAndMemory("2000m", "2000")).Obj(),
+			},
+			podGroupAssignments: map[types.UID]string{
+				"foo": "node1",
+				"bar": "node2",
+			},
+			resourceSpec: []config.ResourceSpec{
+				{Name: "cpu", Weight: 1},
+				{Name: "memory", Weight: 1},
+			},
+			// CPU: (1000m + 2000m) / (5000m + 5000m) = 0.3
+			// Memory: (0 + 2000) / (5000 + 5000) = 0.2
+			// Score: MaxScore * (0.3 + 0.2) / 2 = 25
+			expectedScore: 25,
+		},
+		{
+			name: "Computes score using weights",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+				st.MakeNode().Name("node2").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+			},
+			placementNodeNames: []string{"node1", "node2"},
+			podGroupPods: []*v1.Pod{
+				st.MakePod().UID("foo").Req(cpuAndMemory("1000m", "0")).Obj(),
+				st.MakePod().UID("bar").Req(cpuAndMemory("2000m", "2000")).Obj(),
+			},
+			podGroupAssignments: map[types.UID]string{
+				"foo": "node1",
+				"bar": "node2",
+			},
+			resourceSpec: []config.ResourceSpec{
+				{Name: "cpu", Weight: 4},
+				{Name: "memory", Weight: 1},
+			},
+			// CPU: (1000m + 2000m) / (5000m + 5000m) = 0.3
+			// Memory: (0 + 2000) / (5000 + 5000) = 0.2
+			// Score: MaxScore * (4 * 0.3 + 0.2) / 5 = 28
+			expectedScore: 28,
+		},
+		{
+			name: "Handles multiple pods per node",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+				st.MakeNode().Name("node2").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+			},
+			placementNodeNames: []string{"node1", "node2"},
+			podGroupPods: []*v1.Pod{
+				st.MakePod().UID("foo").Req(cpuAndMemory("1000m", "0")).Obj(),
+				st.MakePod().UID("bar").Req(cpuAndMemory("2000m", "2000")).Obj(),
+			},
+			podGroupAssignments: map[types.UID]string{
+				"foo": "node1",
+				"bar": "node1",
+			},
+			resourceSpec: []config.ResourceSpec{
+				{Name: "cpu", Weight: 4},
+				{Name: "memory", Weight: 1},
+			},
+			// CPU: (1000m + 2000m) / (5000m + 5000m) = 0.3
+			// Memory: (0 + 2000) / (5000 + 5000) = 0.2
+			// Score: MaxScore * (4 * 0.3 + 0.2) / 5 = 28
+			expectedScore: 28,
+		},
+		{
+			name: "Does not include nodes from outside of placement",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+				st.MakeNode().Name("node2").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+				st.MakeNode().Name("node3").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+			},
+			placementNodeNames: []string{"node1", "node2"},
+			podGroupPods: []*v1.Pod{
+				st.MakePod().UID("foo").Req(cpuAndMemory("1000m", "0")).Obj(),
+				st.MakePod().UID("bar").Req(cpuAndMemory("2000m", "2000")).Obj(),
+			},
+			podGroupAssignments: map[types.UID]string{
+				"foo": "node1",
+				"bar": "node2",
+			},
+			resourceSpec: []config.ResourceSpec{
+				{Name: "cpu", Weight: 1},
+				{Name: "memory", Weight: 1},
+			},
+			expectedScore: 25,
+		},
+		{
+			name: "Includes pre-existing pods from outside of pod group",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+				st.MakeNode().Name("node2").Capacity(cpuAndMemory("5000m", "5000")).Obj(),
+			},
+			placementNodeNames: []string{"node1", "node2"},
+			podGroupPods: []*v1.Pod{
+				st.MakePod().UID("foo").Req(cpuAndMemory("1000m", "0")).Obj(),
+				st.MakePod().UID("bar").Req(cpuAndMemory("2000m", "2000")).Obj(),
+			},
+			podGroupAssignments: map[types.UID]string{
+				"foo": "node1",
+				"bar": "node2",
+			},
+			preExistingPods: []*v1.Pod{
+				st.MakePod().Node("node1").UID("baz").Req(cpuAndMemory("1000m", "0")).Obj(),
+			},
+			resourceSpec: []config.ResourceSpec{
+				{Name: "cpu", Weight: 1},
+				{Name: "memory", Weight: 1},
+			},
+			// CPU: (1000m + 2000m + 1000m) / (5000m + 5000m) = 0.4
+			// Memory: (0 + 2000 + 0) / (5000 + 5000) = 0.2
+			// Score: MaxScore * (0.3 + 0.2) / 2 = 30
+			expectedScore: 30,
+		},
+		{
+			name: "Includes scalar resources if any pod in pod group has nonzero requests",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(cpuAndMemoryAndGpu("5000m", "5000", "5")).Obj(),
+				st.MakeNode().Name("node2").Capacity(cpuAndMemoryAndGpu("5000m", "5000", "5")).Obj(),
+			},
+			placementNodeNames: []string{"node1", "node2"},
+			podGroupPods: []*v1.Pod{
+				st.MakePod().UID("foo").Req(cpuAndMemoryAndGpu("1000m", "0", "0")).Obj(),
+				st.MakePod().UID("bar").Req(cpuAndMemoryAndGpu("1000m", "2000", "1")).Obj(),
+			},
+			podGroupAssignments: map[types.UID]string{
+				"foo": "node1",
+				"bar": "node2",
+			},
+			preExistingPods: []*v1.Pod{
+				st.MakePod().Node("node1").UID("baz").Req(cpuAndMemoryAndGpu("1000m", "0", "0")).Obj(),
+			},
+			resourceSpec: []config.ResourceSpec{
+				{Name: "cpu", Weight: 1},
+				{Name: "memory", Weight: 1},
+				{Name: "nvidia.com/gpu", Weight: 1},
+			},
+			// CPU: (1000m + 1000m + 1000m) / (5000m + 5000m) = 0.3
+			// Memory: (0 + 2000 + 0) / (5000 + 5000) = 0.2
+			// GPU: (0 + 1 + 0) / (5 + 5) = 0.1
+			// Score: MaxScore * (0.3 + 0.2 + 0.1) / 3 = 20
+			expectedScore: 20,
+		},
+		{
+			name: "Does not include scalar resources if all pods in pod group have zero requests",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(cpuAndMemoryAndGpu("5000m", "5000", "5")).Obj(),
+				st.MakeNode().Name("node2").Capacity(cpuAndMemoryAndGpu("5000m", "5000", "5")).Obj(),
+			},
+			placementNodeNames: []string{"node1", "node2"},
+			podGroupPods: []*v1.Pod{
+				st.MakePod().UID("foo").Req(cpuAndMemoryAndGpu("1000m", "0", "0")).Obj(),
+				st.MakePod().UID("bar").Req(cpuAndMemoryAndGpu("1000m", "2000", "0")).Obj(),
+			},
+			podGroupAssignments: map[types.UID]string{
+				"foo": "node1",
+				"bar": "node2",
+			},
+			preExistingPods: []*v1.Pod{
+				st.MakePod().Node("node1").UID("baz").Req(cpuAndMemoryAndGpu("1000m", "0", "1")).Obj(),
+			},
+			resourceSpec: []config.ResourceSpec{
+				{Name: "cpu", Weight: 1},
+				{Name: "memory", Weight: 1},
+				{Name: "nvidia.com/gpu", Weight: 1},
+			},
+			// CPU: (1000m + 1000m + 1000m) / (5000m + 5000m) = 0.3
+			// Memory: (0 + 2000 + 0) / (5000 + 5000) = 0.2
+			// GPU: not included as it isn't requested by the pods
+			// Score: MaxScore * (0.3 + 0.2) / 2 = 25
+			expectedScore: 25,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			snapshot := cache.NewSnapshot(tc.preExistingPods, tc.nodes)
+			fh, _ := runtime.NewFramework(tCtx, nil, nil, runtime.WithSnapshotSharedLister(snapshot))
+			scoringStrategy := defaultScoringStrategy.DeepCopy()
+			scoringStrategy.Resources = tc.resourceSpec
+			plugin, err := NewFit(tCtx, &config.NodeResourcesFitArgs{
+				ScoringStrategy: scoringStrategy,
+			}, fh, plfeature.Features{EnableTopologyAwareWorkloadScheduling: true})
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			placementNodes := make([]fwk.NodeInfo, 0, len(tc.placementNodeNames))
+			for _, name := range tc.placementNodeNames {
+				nodeInfo, err := snapshot.NodeInfos().Get(name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				placementNodes = append(placementNodes, nodeInfo)
+			}
+			proposedAssignments := make([]fwk.ProposedAssignment, 0, len(tc.podGroupPods))
+			for _, pod := range tc.podGroupPods {
+				if nodeName, ok := tc.podGroupAssignments[pod.UID]; ok {
+					proposedAssignments = append(proposedAssignments, &podAssignment{
+						pod:      pod,
+						nodeName: nodeName,
+					})
+				}
+			}
+			podGroupInfo := &framework.PodGroupInfo{
+				UnscheduledPods: tc.podGroupPods,
+			}
+			podGroupAssignments := &fwk.PodGroupAssignments{
+				Placement: &fwk.Placement{
+					Nodes: placementNodes,
+				},
+				ProposedAssignments: proposedAssignments,
+			}
+
+			score, status := plugin.(*Fit).ScorePlacement(tCtx, framework.NewCycleState(), podGroupInfo, podGroupAssignments)
+
+			if !status.IsSuccess() {
+				t.Fatalf("ScorePlacement failed: %v", status.AsError())
+			}
+			if score != tc.expectedScore {
+				t.Fatalf("Unexpected score, want %v got %v", tc.expectedScore, score)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -36,7 +36,7 @@ import (
 )
 
 // scorer is decorator for resourceAllocationScorer
-type scorer func(args *config.NodeResourcesFitArgs) *resourceAllocationScorer
+type scorer func(strategy *config.ScoringStrategy) *resourceAllocationScorer
 
 // DRACaches holds various caches used for DRA-related computations
 type DRACaches struct {
@@ -150,9 +150,29 @@ func (r *resourceAllocationScorer) score(
 		return 0, fwk.NewStatus(fwk.Error, "resources not found")
 	}
 
-	allocated := make([]int64, len(r.resources))
-	requested := make([]int64, len(r.resources))
-	allocatable := make([]int64, len(r.resources))
+	requested, allocated, allocatable := r.calculateNodeAllocatableRequest(ctx, nodeInfo, podRequests, draPreScoreState)
+
+	score := r.scorer(requested, allocated, allocatable)
+
+	if loggerV := logger.V(10); loggerV.Enabled() { // Serializing these maps is costly.
+		loggerV.Info("Listed internal info for allocatable resources, requested resources and score", "pod",
+			klog.KObj(pod), "node", klog.KObj(node), "resourceAllocationScorer", r.Name,
+			"allocatableResource", allocatable, "requestedResource", requested, "resourceScore", score,
+		)
+	}
+
+	return score, nil
+}
+
+func (r *resourceAllocationScorer) calculateNodeAllocatableRequest(
+	ctx context.Context,
+	nodeInfo fwk.NodeInfo,
+	podRequests []int64,
+	draPreScoreState *draPreScoreState,
+) (requested []int64, allocated []int64, allocatable []int64) {
+	requested = make([]int64, len(r.resources))
+	allocated = make([]int64, len(r.resources))
+	allocatable = make([]int64, len(r.resources))
 	for i := range r.resources {
 		resource := v1.ResourceName(r.resources[i].Name)
 		// If it's an extended resource, and the pod doesn't request it.
@@ -169,17 +189,7 @@ func (r *resourceAllocationScorer) score(
 		allocated[i] = nodeAllocated
 		requested[i] = allocated[i] + podRequests[i]
 	}
-
-	score := r.scorer(requested, allocated, allocatable)
-
-	if loggerV := logger.V(10); loggerV.Enabled() { // Serializing these maps is costly.
-		loggerV.Info("Listed internal info for allocatable resources, requested resources and score", "pod",
-			klog.KObj(pod), "node", klog.KObj(node), "resourceAllocationScorer", r.Name,
-			"allocatableResource", allocatable, "requestedResource", requested, "resourceScore", score,
-		)
-	}
-
-	return score, nil
+	return requested, allocated, allocatable
 }
 
 // calculateResourceAllocatableRequest returns 2 parameters:
@@ -190,7 +200,7 @@ func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(
 	nodeInfo fwk.NodeInfo,
 	resource v1.ResourceName,
 	draPreScoreState *draPreScoreState,
-) (int64, int64) {
+) (allocatable int64, allocated int64) {
 	requested := nodeInfo.GetNonZeroRequested()
 	if r.useRequested {
 		requested = nodeInfo.GetRequested()
@@ -490,4 +500,45 @@ func (r *resourceAllocationScorer) deviceMatchesClass(ctx context.Context, devic
 	}
 
 	return true, nil
+}
+
+func (r *resourceAllocationScorer) scorePlacement(
+	ctx context.Context,
+	podGroupInfo fwk.PodGroupInfo,
+	podGroupAssignments *fwk.PodGroupAssignments,
+) (int64, *fwk.Status) {
+	requested := make([]int64, len(r.resources))
+	// Calculate requests for the pod group pods scheduled for this placement
+	for _, assignment := range podGroupAssignments.ProposedAssignments {
+		pod := assignment.GetPod()
+		podRequests := r.calculatePodResourceRequestList(pod, r.resources)
+		for i := range len(r.resources) {
+			requested[i] += podRequests[i]
+		}
+	}
+	allocatable := make([]int64, len(r.resources))
+	allocated := make([]int64, len(r.resources))
+	// Calculate resources on all nodes in this placement
+	for _, node := range podGroupAssignments.Nodes {
+		_, nodeAllocated, nodeAllocatable := r.calculateNodeAllocatableRequest(ctx, node, requested, nil)
+		for i := range r.resources {
+			allocatable[i] += nodeAllocatable[i]
+			allocated[i] += nodeAllocated[i]
+			// requested includes both the already existing pods
+			// and the pod group pods that are being scheduled for this placement
+			requested[i] += nodeAllocated[i]
+		}
+	}
+
+	score := r.scorer(requested, allocated, allocatable)
+
+	logger := klog.FromContext(ctx)
+	if loggerV := logger.V(10); loggerV.Enabled() { // Serializing these maps is costly.
+		loggerV.Info("Listed internal info for placement's allocatable resources, requested resources and placement score", "podGroup",
+			klog.KRef(podGroupInfo.GetNamespace(), podGroupInfo.GetName()), "placement", podGroupAssignments.Name, "resourceAllocationScorer", r.Name,
+			"allocatableResource", allocatable, "requestedResource", requested, "resourceScore", score,
+		)
+	}
+
+	return score, nil
 }

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -667,6 +667,10 @@ func (pgi *PodGroupInfo) GetNamespace() string {
 	return pgi.Namespace
 }
 
+func (pgi *PodGroupInfo) GetUnscheduledPods() []*v1.Pod {
+	return pgi.UnscheduledPods
+}
+
 // PodInfo is a wrapper to a Pod with additional pre-computed information to
 // accelerate processing. This information is typically immutable (e.g., pre-processed
 // inter-pod affinity selectors).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR builds on top of https://github.com/kubernetes/kubernetes/pull/137201

In the workload scheduling cycle, for each placement we try to assign pods to nodes. There may be more than one placement where we can schedule the pods, so we need a way to choose the best one.

PlacementBinPacking plugin scores the placement based on the request / capacity ratio and the selected strategy, following the same logic as the NodeResourcesFit plugin (https://kubernetes.io/docs/concepts/scheduling-eviction/resource-bin-packing/) but using all of the nodes of the placement instead of using a single node and all of the pods of the pod group instead of a single pod.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/5732

#### Special notes for your reviewer:

This PR builds on top of [other changes](https://github.com/kubernetes/kubernetes/pull/137201), and won't be merged until those are merged first. The core implementation is related to the PlacementBinPacking type:

* plugin configuration args
* plugin implementation

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Extended NodeResourcesFit to implement the PlacementScore extension point. The usage of the PlacementScore extension point is guarded by the TopologyAwareWorkloadScheduling feature gate.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/fc11808b9162c04039dbd6f58646d6dee2dd3d40/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md?plain=1#L540
```
