### PR TITLE
hack: switch local-up-cluster to ptp CNI for reliable DIND networking

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -424,6 +424,13 @@ function detect_binary {
 cleanup()
 {
   echo "Cleaning up..."
+
+  # Capture CoreDNS logs before shutting down (useful for debugging DNS issues)
+  if [[ "${ENABLE_CLUSTER_DNS}" == true ]]; then
+    echo "Capturing CoreDNS logs..."
+    ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" logs -n kube-system -l k8s-app=kube-dns --all-containers > "${LOG_DIR}/coredns.log" 2>&1 || true
+  fi
+
   # delete running images
   # if [[ "${ENABLE_CLUSTER_DNS}" == true ]]; then
   # Still need to figure why this commands throw an error: Error from server: client: etcd cluster is unavailable or misconfigured
@@ -839,27 +846,6 @@ function wait_node_ready(){
 function wait_coredns_available(){
   if [[ -n "${DRY_RUN}" ]]; then
     return
-  fi
-
-  local interval_time=2
-  local coredns_wait_time=300
-
-  # kick the coredns pods to be recreated
-  ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" -n kube-system delete pods -l k8s-app=kube-dns
-  sleep 30
-
-  local coredns_pods_ready="${KUBECTL} --kubeconfig '${CERT_DIR}/admin.kubeconfig' wait --for=condition=Ready --timeout=60s pods -l k8s-app=kube-dns -n kube-system"
-  kube::util::wait_for_success "$coredns_wait_time" "$interval_time" "$coredns_pods_ready"
-  if [ $? == "1" ]; then
-    echo "time out on waiting for coredns pods"
-    exit 1
-  fi
-
-  local coredns_available="${KUBECTL} --kubeconfig '${CERT_DIR}/admin.kubeconfig' wait --for=condition=Available --timeout=60s deployments coredns -n kube-system"
-  kube::util::wait_for_success "$coredns_wait_time" "$interval_time" "$coredns_available"
-  if [ $? == "1" ]; then
-    echo "time out on waiting for coredns deployment"
-    exit 1
   fi
 
   if [[ "${ENABLE_DAEMON}" = false ]]; then
@@ -1312,14 +1298,19 @@ function install_cni {
     rm -rf "${cni_plugin_tarball}" &&
     sudo find /opt/cni/bin -type f -not \( \
         -iname host-local \
-        -o -iname bridge \
+        -o -iname ptp \
         -o -iname portmap \
         -o -iname loopback \
         \) \
         -delete
 
-  # containerd in kubekins supports CNI version 0.4.0
-  echo "Configuring cni"
+  # Configure CNI using ptp (point-to-point) plugin instead of bridge.
+  # ptp creates direct veth pairs between pods and host namespace, which
+  # avoids the need for br_netfilter and bridge-nf-call-iptables settings
+  # that are unreliable in docker-in-docker environments.
+  # This approach is proven to work reliably by KIND (Kubernetes IN Docker):
+  # https://github.com/kubernetes-sigs/kind/blob/main/images/kindnetd/cmd/kindnetd/cni.go#L83-L121
+  echo "Configuring cni (ptp mode)"
   sudo mkdir -p "$CNI_CONFIG_DIR"
   cat << EOF | sudo tee "$CNI_CONFIG_DIR"/10-containerd-net.conflist
 {
@@ -1327,11 +1318,8 @@ function install_cni {
  "name": "containerd-net",
  "plugins": [
    {
-     "type": "bridge",
-     "bridge": "cni0",
-     "isGateway": true,
+     "type": "ptp",
      "ipMasq": true,
-     "promiscMode": true,
      "ipam": {
        "type": "host-local",
        "ranges": [
@@ -1386,6 +1374,26 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
 
   # configure shared mounts to prevent failure in DIND scenarios
   mount --make-rshared /
+
+  # Configure kernel network parameters for container networking.
+  # These settings are required for ptp CNI and iptables-based kube-proxy
+  # to work correctly in docker-in-docker environments.
+  # See KIND's network configuration for reference.
+  echo "Configuring kernel network parameters for DIND..."
+
+  # Enable route_localnet - allows routing to localhost addresses after NAT.
+  # Required for proper DNS resolution in containers.
+  echo 1 > /proc/sys/net/ipv4/conf/all/route_localnet
+
+  # Set arp_ignore=0 - required for ptp CNI which uses /32 addresses.
+  # Ensures ARP replies are sent for all local addresses.
+  echo 0 > /proc/sys/net/ipv4/conf/all/arp_ignore
+
+  # Ensure IP forwarding is enabled for pod-to-pod traffic
+  echo 1 > /proc/sys/net/ipv4/ip_forward
+  echo 1 > /proc/sys/net/ipv6/conf/all/forwarding 2>/dev/null || true
+
+  echo "Kernel network parameters configured"
 
   # to use containerd as kubelet container runtime we need to install cni
   install_cni 


### PR DESCRIPTION
The ci-kubernetes-local-e2e job has been flaky (~40-45% success rate) with intermittent DNS/service connectivity failures. The root cause is that bridge CNI requires br_netfilter and bridge-nf-call-iptables kernel settings, which don't work reliably in docker-in-docker.

This switches to ptp (point-to-point) CNI, which creates direct veth pairs between pods and host namespace. No bridge means no br_netfilter dependency. This is the same approach KIND uses and it works reliably.

Changes:
- Replace bridge CNI with ptp CNI plugin
- Configure kernel network parameters for DIND (route_localnet,
  arp_ignore, ip_forward) required for ptp and iptables-based kube-proxy
- Remove CoreDNS pod delete/restart workaround from https://github.com/kubernetes/kubernetes/commit/1168b1187507d17d60e93520f46ad532711e7c88 that was
  masking the underlying networking issues (no longer needed)
- Add CoreDNS log capture during cleanup for debugging DNS issues

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig testing