### PR TITLE
Fix potential double-locking of RWMutex in device manager

### DIFF
--- a/staging/src/k8s.io/client-go/util/retry/util_test.go
+++ b/staging/src/k8s.io/client-go/util/retry/util_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package retry
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -67,5 +69,232 @@ func TestRetryOnConflict(t *testing.T) {
 	})
 	if err != nil || i != 2 {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRetryOnConflictWithContext(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	conflictErr := errors.NewConflict(schema.GroupResource{Resource: "test"}, "other", nil)
+
+	// context cancelled before first attempt - returns context.Canceled immediately
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := RetryOnConflictWithContext(ctx, opts, func(context.Context) error {
+		return conflictErr
+	})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+
+	// context cancelled during retry - returns context.Canceled
+	ctx, cancel = context.WithCancel(context.Background())
+	i := 0
+	err = RetryOnConflictWithContext(ctx, wait.Backoff{Factor: 1.0, Steps: 100, Duration: 50 * time.Millisecond}, func(context.Context) error {
+		i++
+		if i == 2 {
+			cancel()
+		}
+		return conflictErr
+	})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+
+	// context timeout - returns context.DeadlineExceeded
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	i = 0
+	err = RetryOnConflictWithContext(ctx, wait.Backoff{Factor: 1.0, Steps: 100, Duration: time.Hour}, func(context.Context) error {
+		i++
+		return conflictErr
+	})
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
+	}
+	if i < 1 {
+		t.Errorf("expected at least one retry attempt, got: %d", i)
+	}
+
+	// max retries
+	i = 0
+	err = RetryOnConflictWithContext(context.Background(), opts, func(context.Context) error {
+		i++
+		return conflictErr
+	})
+	if err != conflictErr {
+		t.Errorf("expected conflictErr, got: %v", err)
+	}
+	if i != opts.Steps {
+		t.Errorf("expected %d attempts, got: %d", opts.Steps, i)
+	}
+
+	// returns immediately on success
+	i = 0
+	err = RetryOnConflictWithContext(context.Background(), opts, func(context.Context) error {
+		i++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 1 {
+		t.Errorf("expected 1 attempt, got: %d", i)
+	}
+
+	// returns immediately on non-retriable error
+	testErr := fmt.Errorf("some other error")
+	i = 0
+	err = RetryOnConflictWithContext(context.Background(), opts, func(context.Context) error {
+		i++
+		return testErr
+	})
+	if err != testErr {
+		t.Errorf("expected testErr, got: %v", err)
+	}
+	if i != 1 {
+		t.Errorf("expected 1 attempt, got: %d", i)
+	}
+
+	// retries until success
+	i = 0
+	err = RetryOnConflictWithContext(context.Background(), opts, func(context.Context) error {
+		if i < 2 {
+			i++
+			return conflictErr
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 2 {
+		t.Errorf("expected 2 attempts, got: %d", i)
+	}
+
+	// context is passed to callback
+	ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	var receivedCtx context.Context
+	_ = RetryOnConflictWithContext(ctx, opts, func(ctx context.Context) error {
+		receivedCtx = ctx
+		return nil
+	})
+	if receivedCtx != ctx {
+		t.Error("context was not passed to callback")
+	}
+}
+
+func TestOnErrorWithContext(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	testErr := fmt.Errorf("test error")
+	retriableErr := fmt.Errorf("retriable error")
+	retriable := func(err error) bool {
+		return err == retriableErr
+	}
+
+	// context cancelled before first attempt - returns context.Canceled immediately
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := OnErrorWithContext(ctx, opts, retriable, func(context.Context) error {
+		return testErr
+	})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+
+	// context cancelled during retry - returns context.Canceled
+	ctx, cancel = context.WithCancel(context.Background())
+	i := 0
+	err = OnErrorWithContext(ctx, wait.Backoff{Factor: 1.0, Steps: 100, Duration: 50 * time.Millisecond}, retriable, func(context.Context) error {
+		i++
+		if i == 2 {
+			cancel()
+		}
+		return retriableErr
+	})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+
+	// context timeout - returns context.DeadlineExceeded
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	i = 0
+	err = OnErrorWithContext(ctx, wait.Backoff{Factor: 1.0, Steps: 100, Duration: time.Hour}, retriable, func(context.Context) error {
+		i++
+		return retriableErr
+	})
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
+	}
+	if i < 1 {
+		t.Errorf("expected at least one retry attempt, got: %d", i)
+	}
+
+	// max retries
+	i = 0
+	err = OnErrorWithContext(context.Background(), opts, retriable, func(context.Context) error {
+		i++
+		return retriableErr
+	})
+	if err != retriableErr {
+		t.Errorf("expected retriableErr, got: %v", err)
+	}
+	if i != opts.Steps {
+		t.Errorf("expected %d attempts, got: %d", opts.Steps, i)
+	}
+
+	// returns immediately on success
+	i = 0
+	err = OnErrorWithContext(context.Background(), opts, retriable, func(context.Context) error {
+		i++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 1 {
+		t.Errorf("expected 1 attempt, got: %d", i)
+	}
+
+	// returns immediately on non-retriable error
+	i = 0
+	err = OnErrorWithContext(context.Background(), opts, retriable, func(context.Context) error {
+		i++
+		return testErr
+	})
+	if err != testErr {
+		t.Errorf("expected testErr, got: %v", err)
+	}
+	if i != 1 {
+		t.Errorf("expected 1 attempt, got: %d", i)
+	}
+
+	// retries until success
+	i = 0
+	err = OnErrorWithContext(context.Background(), opts, retriable, func(context.Context) error {
+		if i < 2 {
+			i++
+			return retriableErr
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 2 {
+		t.Errorf("expected 2 attempts, got: %d", i)
+	}
+
+	// context is passed to callback
+	ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	var receivedCtx context.Context
+	_ = OnErrorWithContext(ctx, opts, retriable, func(ctx context.Context) error {
+		receivedCtx = ctx
+		return nil
+	})
+	if receivedCtx != ctx {
+		t.Error("context was not passed to callback")
 	}
 }


### PR DESCRIPTION
The \`podDevices()\` function was calling \`containerDevices()\` while holding the read lock, but \`containerDevices()\` also attempts to acquire the same lock. This could cause a deadlock when a writer tries to acquire the lock between the two \`RLock()\` calls.

Introduce \`containerDevicesLocked()\` that expects the caller to already hold the lock, and use it from \`podDevices()\` to avoid nested locking.

This is a minimal fix based on PR #136235, with the style/format changes removed as requested by reviewer feedback.

Fixes #127826