### PR TITLE
Fix typo in `TestContainerMapCloneUnshared`

### DIFF
--- a/pkg/kubelet/cm/containermap/container_map_test.go
+++ b/pkg/kubelet/cm/containermap/container_map_test.go
@@ -52,7 +52,7 @@ func TestContainerMapCloneUnshared(t *testing.T) {
 	// check the original copy didn't change
 	// early sanity check, random ID, no special meaning
 	podUIDRedo, containerNameRedo, err2 := cm.GetContainerRef("fakeContainerID-C")
-	if err != nil {
+	if err2 != nil {
 		t.Fatalf("unexpected error: %v", err2)
 	}
 	if podUIDRedo != "fakePodUID-2" || containerNameRedo != "fakeContainerName-c2" {


### PR DESCRIPTION
#### What type of PR is this?

[nilness](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/nilness#cond) gives a bunch of matches. This one is pretty obvious that `err` should be `err2`.
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
#### Special notes for your reviewer:

```sh
go install golang.org/x/tools/go/analysis/passes/nilness@latest
go vet -vettool $(which nilness) ./...
```

So far, I just put `cleanup` as a label, but maybe `flaky-test` would also be a candidate.

This will find a list of matches from `nilness`. Most of them are not immediately obvious, so I decided to leave them.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```