### PR TITLE
Add Time Zone display for CronJob in describe output

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -2426,6 +2426,11 @@ func describeCronJob(cronJob *batchv1.CronJob, events *corev1.EventList) (string
 		printAnnotationsMultiline(w, "Annotations", cronJob.Annotations)
 		w.Write(LEVEL_0, "Schedule:\t%s\n", cronJob.Spec.Schedule)
 		w.Write(LEVEL_0, "Concurrency Policy:\t%s\n", cronJob.Spec.ConcurrencyPolicy)
+		if cronJob.Spec.TimeZone != nil && len(*cronJob.Spec.TimeZone) > 0 {
+            w.Write(LEVEL_0, "Time Zone:\t%s\n", *cronJob.Spec.TimeZone)
+        } else {
+            w.Write(LEVEL_0, "Time Zone:\t<none>\n")
+        }
 		w.Write(LEVEL_0, "Suspend:\t%s\n", printBoolPtr(cronJob.Spec.Suspend))
 		if cronJob.Spec.SuccessfulJobsHistoryLimit != nil {
 			w.Write(LEVEL_0, "Successful Job History Limit:\t%d\n", *cronJob.Spec.SuccessfulJobsHistoryLimit)


### PR DESCRIPTION
/kind feature

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds the `Time Zone` field to the `kubectl describe cronjob` output. This field has been GA since v1.27, and its omission makes it difficult for users to verify scheduling configurations without using YAML output.

#### Which issue(s) this PR is related to:
Fixes #136663

#### Special notes for your reviewer:
Field is placed between 'Schedule' and 'Concurrency Policy'. Updated unit tests to cover both populated and nil TimeZone specs.

#### Does this PR introduce a user-facing change?
```release-note
`kubectl describe cronjob` now displays the `Time Zone` field.