### PR TITLE
Refactor to use atomic types

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1123,7 +1123,7 @@ func (jm *Controller) deleteActivePods(ctx context.Context, job *batch.Job, pods
 	errCh := make(chan error, len(pods))
 	var successfulDeletes, deletedReady atomic.Int32
 	successfulDeletes.Store(int32(len(pods)))
-	wg := sync.WaitGroup{}
+	var wg sync.WaitGroup
 	wg.Add(len(pods))
 	for i := range pods {
 		go func(pod *v1.Pod) {
@@ -1697,10 +1697,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		}
 	}
 
-	rmAtLeast := active.Load() - wantActive
-	if rmAtLeast < 0 {
-		rmAtLeast = 0
-	}
+	rmAtLeast := max(active.Load() - wantActive, 0)
 	podsToDelete := activePodsForRemoval(job, jobCtx.activePods, int(rmAtLeast))
 	if len(podsToDelete) > MaxPodCreateDeletePerSync {
 		podsToDelete = podsToDelete[:MaxPodCreateDeletePerSync]

--- a/pkg/controller/tainteviction/timed_workers_test.go
+++ b/pkg/controller/tainteviction/timed_workers_test.go
@@ -29,11 +29,11 @@ import (
 
 func TestExecute(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	testVal := int32(0)
+	var testVal atomic.Int32
 	wg := sync.WaitGroup{}
 	wg.Add(5)
 	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
-		atomic.AddInt32(&testVal, 1)
+		testVal.Add(1)
 		wg.Done()
 		return nil
 	})
@@ -44,7 +44,7 @@ func TestExecute(t *testing.T) {
 	queue.AddWork(ctx, NewWorkArgs("4", "4"), now, now)
 	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, now)
 	wg.Wait()
-	lastVal := atomic.LoadInt32(&testVal)
+	lastVal := testVal.Load()
 	if lastVal != 5 {
 		t.Errorf("Expected testVal = 5, got %v", lastVal)
 	}
@@ -52,11 +52,11 @@ func TestExecute(t *testing.T) {
 
 func TestExecuteDelayed(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	testVal := int32(0)
+	var testVal atomic.Int32
 	wg := sync.WaitGroup{}
 	wg.Add(5)
 	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
-		atomic.AddInt32(&testVal, 1)
+		testVal.Add(1)
 		wg.Done()
 		return nil
 	})
@@ -76,7 +76,7 @@ func TestExecuteDelayed(t *testing.T) {
 	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, then)
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
-	lastVal := atomic.LoadInt32(&testVal)
+	lastVal := testVal.Load()
 	if lastVal != 5 {
 		t.Errorf("Expected testVal = 5, got %v", lastVal)
 	}
@@ -84,11 +84,11 @@ func TestExecuteDelayed(t *testing.T) {
 
 func TestCancel(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
-	testVal := int32(0)
+	var testVal atomic.Int32
 	wg := sync.WaitGroup{}
 	wg.Add(3)
 	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
-		atomic.AddInt32(&testVal, 1)
+		testVal.Add(1)
 		wg.Done()
 		return nil
 	})
@@ -110,7 +110,7 @@ func TestCancel(t *testing.T) {
 	queue.CancelWork(logger, NewWorkArgs("4", "4").KeyFromWorkArgs())
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
-	lastVal := atomic.LoadInt32(&testVal)
+	lastVal := testVal.Load()
 	if lastVal != 3 {
 		t.Errorf("Expected testVal = 3, got %v", lastVal)
 	}
@@ -118,11 +118,11 @@ func TestCancel(t *testing.T) {
 
 func TestCancelAndRead(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
-	testVal := int32(0)
+	var testVal atomic.Int32
 	wg := sync.WaitGroup{}
 	wg.Add(4)
 	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
-		atomic.AddInt32(&testVal, 1)
+		testVal.Add(1)
 		wg.Done()
 		return nil
 	})
@@ -145,7 +145,7 @@ func TestCancelAndRead(t *testing.T) {
 	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, then)
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
-	lastVal := atomic.LoadInt32(&testVal)
+	lastVal := testVal.Load()
 	if lastVal != 4 {
 		t.Errorf("Expected testVal = 4, got %v", lastVal)
 	}

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -717,16 +717,16 @@ func wrapTestWithInjectedOperation(ctx context.Context, toWrap testCall, injectB
 		// Run the tested function (typically syncClaim/syncVolume) in a
 		// separate goroutine.
 		var testError error
-		var testFinished int32
+		var testFinished atomic.Int32
 
 		go func() {
 			testError = toWrap(ctrl, reactor, test)
 			// Let the "main" test function know that syncVolume has finished.
-			atomic.StoreInt32(&testFinished, 1)
+			testFinished.Store(1)
 		}()
 
 		// Wait for the controller to finish the test function.
-		for atomic.LoadInt32(&testFinished) == 0 {
+		for testFinished.Load() == 0 {
 			time.Sleep(time.Millisecond * 10)
 		}
 

--- a/pkg/kubelet/prober/scale_test.go
+++ b/pkg/kubelet/prober/scale_test.go
@@ -220,7 +220,7 @@ func newFakePod(httpServer bool) (*fakePod, error) {
 					// exit when the listener is closed
 					return
 				}
-					f.numConnection.Add(1)
+				f.numConnection.Add(1)
 				// handle request but not block
 				go func(c net.Conn) {
 					defer c.Close()

--- a/pkg/kubelet/prober/scale_test.go
+++ b/pkg/kubelet/prober/scale_test.go
@@ -208,7 +208,7 @@ func newFakePod(httpServer bool) (*fakePod, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			if _, ok := visitors[r.RemoteAddr]; !ok {
-				atomic.AddInt64(&f.numConnection, 1)
+				f.numConnection.Add(1)
 				visitors[r.RemoteAddr] = struct{}{}
 			}
 		}))
@@ -220,7 +220,7 @@ func newFakePod(httpServer bool) (*fakePod, error) {
 					// exit when the listener is closed
 					return
 				}
-				atomic.AddInt64(&f.numConnection, 1)
+					f.numConnection.Add(1)
 				// handle request but not block
 				go func(c net.Conn) {
 					defer c.Close()
@@ -240,7 +240,7 @@ func newFakePod(httpServer bool) (*fakePod, error) {
 
 type fakePod struct {
 	ln            net.Listener
-	numConnection int64
+	numConnection atomic.Int64
 	http          bool
 }
 
@@ -270,5 +270,5 @@ func (f *fakePod) stop() {
 }
 
 func (f *fakePod) connections() int {
-	return int(atomic.LoadInt64(&f.numConnection))
+	return int(f.numConnection.Load())
 }

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -152,7 +152,7 @@ type Proxier struct {
 	servicesSynced       bool
 	lastFullSync         time.Time
 	needFullSync         bool
-	initialized          int32
+	initialized          atomic.Int32
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	lastIPTablesCleanup  time.Time
@@ -449,11 +449,11 @@ func (proxier *Proxier) setInitialized(value bool) {
 	if value {
 		initialized = 1
 	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(initialized)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load() > 0
 }
 
 // OnServiceAdd is called whenever creation of new service object

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -184,7 +184,7 @@ type Proxier struct {
 	// ipvs rules with some partial data after kube-proxy restart.
 	endpointSlicesSynced bool
 	servicesSynced       bool
-	initialized          int32
+	initialized          atomic.Int32
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 
 	// These are effectively const and do not need the mutex to be held.
@@ -586,11 +586,11 @@ func (proxier *Proxier) setInitialized(value bool) {
 	if value {
 		initialized = 1
 	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(initialized)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load() > 0
 }
 
 // OnServiceAdd is called whenever creation of new service object is observed.

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -157,7 +157,7 @@ type Proxier struct {
 	syncedOnce           bool
 	lastFullSync         time.Time
 	needFullSync         bool
-	initialized          int32
+	initialized          atomic.Int32
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	flushed              bool
@@ -677,11 +677,11 @@ func (proxier *Proxier) setInitialized(value bool) {
 	if value {
 		initialized = 1
 	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(initialized)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load() > 0
 }
 
 // OnServiceAdd is called whenever creation of new service object

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -583,7 +583,7 @@ type Proxier struct {
 	// with some partial data after kube-proxy restart.
 	endpointSlicesSynced bool
 	servicesSynced       bool
-	initialized          int32
+	initialized          atomic.Int32
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	// These are effectively const and do not need the mutex to be held.
 	nodeName string
@@ -943,11 +943,11 @@ func (proxier *Proxier) setInitialized(value bool) {
 	if value {
 		initialized = 1
 	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(initialized)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load() > 0
 }
 
 // OnServiceAdd is called whenever creation of new service object

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -1242,8 +1242,9 @@ func TestDryRunPreemption(t *testing.T) {
 				for i := range got {
 					candidates = append(candidates, candidate{victims: got[i].Victims(), name: got[i].Name()})
 				}
-				if fakePlugin.NumFilterCalled.Add(-prevNumFilterCalled) != tt.expectedNumFilterCalled[cycle] {
-					t.Errorf("cycle %d: got NumFilterCalled=%d, want %d", cycle, fakePlugin.NumFilterCalled.Add(-prevNumFilterCalled), tt.expectedNumFilterCalled[cycle])
+				delta := fakePlugin.NumFilterCalled.Load() - prevNumFilterCalled
+				if delta != tt.expectedNumFilterCalled[cycle] {
+					t.Errorf("cycle %d: got NumFilterCalled=%d, want %d", cycle, delta, tt.expectedNumFilterCalled[cycle])
 				}
 				prevNumFilterCalled = fakePlugin.NumFilterCalled.Load()
 				if diff := cmp.Diff(tt.expected[cycle], candidates, cmp.AllowUnexported(candidate{})); diff != "" {

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -52,12 +52,12 @@ import (
 	apipod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	configv1 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1"
-	"k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
-	"k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
+	apicache "k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
+	apidispatcher "k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
+	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -1242,10 +1242,10 @@ func TestDryRunPreemption(t *testing.T) {
 				for i := range got {
 					candidates = append(candidates, candidate{victims: got[i].Victims(), name: got[i].Name()})
 				}
-				if fakePlugin.NumFilterCalled-prevNumFilterCalled != tt.expectedNumFilterCalled[cycle] {
-					t.Errorf("cycle %d: got NumFilterCalled=%d, want %d", cycle, fakePlugin.NumFilterCalled-prevNumFilterCalled, tt.expectedNumFilterCalled[cycle])
+				if fakePlugin.NumFilterCalled.Add(-prevNumFilterCalled) != tt.expectedNumFilterCalled[cycle] {
+					t.Errorf("cycle %d: got NumFilterCalled=%d, want %d", cycle, fakePlugin.NumFilterCalled.Add(-prevNumFilterCalled), tt.expectedNumFilterCalled[cycle])
 				}
-				prevNumFilterCalled = fakePlugin.NumFilterCalled
+				prevNumFilterCalled = fakePlugin.NumFilterCalled.Load()
 				if diff := cmp.Diff(tt.expected[cycle], candidates, cmp.AllowUnexported(candidate{})); diff != "" {
 					t.Errorf("cycle %d: unexpected candidates (-want, +got): %s", cycle, diff)
 				}

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -221,7 +221,8 @@ func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, p
 
 	result := make(topologyToMatchedTermCount)
 	// Traditional for loop is slightly faster in this case than its "for range" equivalent.
-	for i := 0; i <= int(index.Load()); i++ {
+	end := index.Load()
+	for i := int32(0); i <= end; i++ {
 		result.mergeWithList(antiAffinityCountsList[i])
 	}
 
@@ -264,7 +265,8 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 	}
 	pl.parallelizer.Until(ctx, len(allNodes), processNode, pl.Name())
 
-	for i := 0; i <= int(index.Load()); i++ {
+	end := index.Load()
+	for i := int32(0); i <= end; i++ {
 		affinityCounts.mergeWithList(affinityCountsList[i])
 		antiAffinityCounts.mergeWithList(antiAffinityCountsList[i])
 	}

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -213,7 +213,8 @@ func (pl *InterPodAffinity) PreScore(
 		return fwk.NewStatus(fwk.Skip)
 	}
 
-	for i := 0; i <= int(index.Load()); i++ {
+	end := int(index.Load())
+	for i := 0; i <= end; i++ {
 		state.topologyScore.append(topoScores[i])
 	}
 

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -40,7 +40,7 @@ import (
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
 
-var generation int64
+var generation atomic.Int64
 
 var (
 	// basicActionTypes is a list of basic ActionTypes.
@@ -494,7 +494,7 @@ func (n *NodeInfo) RemoveNode() {
 // Collision of the generation numbers would be particularly problematic if a node was deleted and
 // added back with the same name. See issue#63262.
 func nextGeneration() int64 {
-	return atomic.AddInt64(&generation, 1)
+	return generation.Add(1)
 }
 
 // QueuedPodInfo is a Pod wrapper with additional information related to

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -351,7 +351,7 @@ func TestNewNodeInfo(t *testing.T) {
 
 	gen := generation
 	ni := NewNodeInfo(pods...)
-	if ni.Generation <= gen {
+	if ni.Generation <= gen.Load() {
 		t.Errorf("Generation is not incremented. previous: %v, current: %v", gen, ni.Generation)
 	}
 	expected.Generation = ni.Generation

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -349,9 +349,9 @@ func TestNewNodeInfo(t *testing.T) {
 		},
 	}
 
-	gen := generation
+	gen := generation.Load()
 	ni := NewNodeInfo(pods...)
-	if ni.Generation <= gen.Load() {
+	if ni.Generation <= gen {
 		t.Errorf("Generation is not incremented. previous: %v, current: %v", gen, ni.Generation)
 	}
 	expected.Generation = ni.Generation

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -57,14 +57,16 @@ func TestInc(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter.Load() != int64(loops) {
-		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter.Load())
+	got := fakeRecorder.counter.Load()
+	if got != int64(loops) {
+		t.Errorf("Expected %v, got %v", loops, got)
 	}
+
 }
 
 func TestDec(t *testing.T) {
 	var fakeRecorder fakePodsRecorder
-	fakeRecorder.counter.Add(100)
+	fakeRecorder.counter.Store(100)
 	var wg sync.WaitGroup
 	loops := 100
 	wg.Add(loops)
@@ -75,8 +77,9 @@ func TestDec(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter.Load() != int64(0) {
-		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter.Load())
+	got := fakeRecorder.counter.Load()
+	if got != int64(0) {
+		t.Errorf("Expected %v, got %v", loops, got)
 	}
 }
 
@@ -98,13 +101,15 @@ func TestClear(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter.Load() != int64(incLoops-decLoops) {
-		t.Errorf("Expected %v, got %v", incLoops-decLoops, fakeRecorder.counter.Load())
+	got := fakeRecorder.counter.Load()
+	if got  != int64(incLoops-decLoops) {
+		t.Errorf("Expected %v, got %v", incLoops-decLoops, got)
 	}
 	// verify Clear() works
 	fakeRecorder.Clear()
-	if fakeRecorder.counter.Load() != int64(0) {
-		t.Errorf("Expected %v, got %v", 0, fakeRecorder.counter.Load())
+	got = fakeRecorder.counter.Load()
+	if got != int64(0) {
+		t.Errorf("Expected %v, got %v", 0, got)
 	}
 }
 

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -30,19 +30,19 @@ import (
 var _ MetricRecorder = &fakePodsRecorder{}
 
 type fakePodsRecorder struct {
-	counter int64
+	counter atomic.Int64
 }
 
 func (r *fakePodsRecorder) Inc() {
-	atomic.AddInt64(&r.counter, 1)
+	r.counter.Add(1)
 }
 
 func (r *fakePodsRecorder) Dec() {
-	atomic.AddInt64(&r.counter, -1)
+	r.counter.Add(-1)
 }
 
 func (r *fakePodsRecorder) Clear() {
-	atomic.StoreInt64(&r.counter, 0)
+	r.counter.Store(0)
 }
 
 func TestInc(t *testing.T) {
@@ -50,32 +50,33 @@ func TestInc(t *testing.T) {
 	var wg sync.WaitGroup
 	loops := 100
 	wg.Add(loops)
-	for i := 0; i < loops; i++ {
+	for range loops {
 		go func() {
 			fakeRecorder.Inc()
 			wg.Done()
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter != int64(loops) {
-		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter)
+	if fakeRecorder.counter.Load() != int64(loops) {
+		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter.Load())
 	}
 }
 
 func TestDec(t *testing.T) {
-	fakeRecorder := fakePodsRecorder{counter: 100}
+	var fakeRecorder fakePodsRecorder
+	fakeRecorder.counter.Add(100)
 	var wg sync.WaitGroup
 	loops := 100
 	wg.Add(loops)
-	for i := 0; i < loops; i++ {
+	for range loops {
 		go func() {
 			fakeRecorder.Dec()
 			wg.Done()
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter != int64(0) {
-		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter)
+	if fakeRecorder.counter.Load() != int64(0) {
+		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter.Load())
 	}
 }
 
@@ -84,26 +85,26 @@ func TestClear(t *testing.T) {
 	var wg sync.WaitGroup
 	incLoops, decLoops := 100, 80
 	wg.Add(incLoops + decLoops)
-	for i := 0; i < incLoops; i++ {
+	for range incLoops {
 		go func() {
 			fakeRecorder.Inc()
 			wg.Done()
 		}()
 	}
-	for i := 0; i < decLoops; i++ {
+	for range decLoops {
 		go func() {
 			fakeRecorder.Dec()
 			wg.Done()
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter != int64(incLoops-decLoops) {
-		t.Errorf("Expected %v, got %v", incLoops-decLoops, fakeRecorder.counter)
+	if fakeRecorder.counter.Load() != int64(incLoops-decLoops) {
+		t.Errorf("Expected %v, got %v", incLoops-decLoops, fakeRecorder.counter.Load())
 	}
 	// verify Clear() works
 	fakeRecorder.Clear()
-	if fakeRecorder.counter != int64(0) {
-		t.Errorf("Expected %v, got %v", 0, fakeRecorder.counter)
+	if fakeRecorder.counter.Load() != int64(0) {
+		t.Errorf("Expected %v, got %v", 0, fakeRecorder.counter.Load())
 	}
 }
 

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -697,7 +697,8 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	// Stops searching for more nodes once the configured number of feasible nodes
 	// are found.
 	schedFramework.Parallelizer().Until(ctx, numAllNodes, checkNode, metrics.Filter)
-	feasibleNodes = feasibleNodes[:feasibleNodesLen.Load()]
+	len := feasibleNodesLen.Load()
+	feasibleNodes = feasibleNodes[:len]
 	for _, item := range result {
 		if item == nil {
 			continue

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -3740,8 +3740,9 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if test.expectedCount != plugin.NumFilterCalled.Load() {
-				t.Errorf("predicate was called %d times, expected is %d", plugin.NumFilterCalled, test.expectedCount)
+			got := plugin.NumFilterCalled.Load()
+			if test.expectedCount != got {
+				t.Errorf("predicate was called %d times, expected is %d", got, test.expectedCount)
 			}
 		})
 	}
@@ -4347,8 +4348,9 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if test.expectedCount != plugin.NumFilterCalled.Load() {
-				t.Errorf("predicate was called %d times, expected is %d", plugin.NumFilterCalled, test.expectedCount)
+			got := plugin.NumFilterCalled.Load()
+			if test.expectedCount != got {
+				t.Errorf("predicate was called %d times, expected is %d", got, test.expectedCount)
 			}
 		})
 	}

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -3740,7 +3740,7 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if test.expectedCount != plugin.NumFilterCalled {
+			if test.expectedCount != plugin.NumFilterCalled.Load() {
 				t.Errorf("predicate was called %d times, expected is %d", plugin.NumFilterCalled, test.expectedCount)
 			}
 		})
@@ -4347,7 +4347,7 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if test.expectedCount != plugin.NumFilterCalled {
+			if test.expectedCount != plugin.NumFilterCalled.Load() {
 				t.Errorf("predicate was called %d times, expected is %d", plugin.NumFilterCalled, test.expectedCount)
 			}
 		})

--- a/pkg/scheduler/testing/framework/fake_plugins.go
+++ b/pkg/scheduler/testing/framework/fake_plugins.go
@@ -80,7 +80,7 @@ func (pl FakePreFilterAndFilterPlugin) Name() string {
 // FakeFilterPlugin is a test filter plugin to record how many times its Filter() function have
 // been called, and it returns different 'Code' depending on its internal 'failedNodeReturnCodeMap'.
 type FakeFilterPlugin struct {
-	NumFilterCalled         int32
+	NumFilterCalled         atomic.Int32
 	FailedNodeReturnCodeMap map[string]fwk.Code
 }
 
@@ -91,7 +91,7 @@ func (pl *FakeFilterPlugin) Name() string {
 
 // Filter invoked at the filter extension point.
 func (pl *FakeFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
-	atomic.AddInt32(&pl.NumFilterCalled, 1)
+	pl.NumFilterCalled.Add(1)
 
 	if returnCode, ok := pl.FailedNodeReturnCodeMap[nodeInfo.Node().Name]; ok {
 		return fwk.NewStatus(returnCode, fmt.Sprintf("injecting failure for pod %v", pod.Name))

--- a/pkg/volume/metrics_cached.go
+++ b/pkg/volume/metrics_cached.go
@@ -53,22 +53,22 @@ func (md *cachedMetrics) GetMetrics() (*Metrics, error) {
 // error
 type cacheOnce struct {
 	m    sync.Mutex
-	done uint32
+	done atomic.Uint32
 }
 
 // Copied from sync.Once but we don't want to cache the results if there is an
 // error
 func (o *cacheOnce) cache(f func() error) {
-	if atomic.LoadUint32(&o.done) == 1 {
+	if o.done.Load() == 1 {
 		return
 	}
 	// Slow-path.
 	o.m.Lock()
 	defer o.m.Unlock()
-	if o.done == 0 {
+	if o.done.Load() == 0 {
 		err := f()
 		if err == nil {
-			atomic.StoreUint32(&o.done, 1)
+			o.done.Store(1)
 		}
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection_test.go
@@ -210,7 +210,7 @@ func TestConnectionPings(t *testing.T) {
 			return
 		}
 
-		var pingsSent int64
+		var pingsSent atomic.Int64
 		srvSPDYConn := newConnection(
 			spdyConn,
 			func(stream httpstream.Stream, replySent <-chan struct{}) error {
@@ -220,7 +220,7 @@ func TestConnectionPings(t *testing.T) {
 			},
 			pingPeriod,
 			func() (time.Duration, error) {
-				atomic.AddInt64(&pingsSent, 1)
+				pingsSent.Add(1)
 				return 0, nil
 			})
 		defer srvSPDYConn.Close()
@@ -235,7 +235,7 @@ func TestConnectionPings(t *testing.T) {
 		}
 
 		// Count pings sent by the server.
-		gotPings := atomic.LoadInt64(&pingsSent)
+		gotPings := pingsSent.Load()
 		if gotPings < 1 {
 			t.Errorf("server: failed to send any pings (check logs)")
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/upgrade.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/upgrade.go
@@ -45,12 +45,12 @@ type responseUpgrader struct {
 // read.
 type connWrapper struct {
 	net.Conn
-	closed    int32
+	closed    atomic.Int32
 	bufReader *bufio.Reader
 }
 
 func (w *connWrapper) Read(b []byte) (n int, err error) {
-	if atomic.LoadInt32(&w.closed) == 1 {
+	if w.closed.Load() == 1 {
 		return 0, io.EOF
 	}
 	return w.bufReader.Read(b)
@@ -58,7 +58,7 @@ func (w *connWrapper) Read(b []byte) (n int, err error) {
 
 func (w *connWrapper) Close() error {
 	err := w.Conn.Close()
-	atomic.StoreInt32(&w.closed, 1)
+	w.closed.Store(1)
 	return err
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,8 +80,8 @@ func BenchmarkAdmit(b *testing.B) {
 			ns := "webhook-test"
 			client, informer := webhooktesting.NewFakeMutatingDataSource(ns, tt.Webhooks, stopCh)
 
-			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
-			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
+				wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(atomic.Int32))))
+				wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
 			wh.SetExternalKubeClientSet(client)
 			wh.SetExternalKubeInformerFactory(informer)
 
@@ -138,7 +139,7 @@ func TestAdmit(t *testing.T) {
 			ns := "webhook-test"
 			client, informer := webhooktesting.NewFakeMutatingDataSource(ns, tt.Webhooks, stopCh)
 
-			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(atomic.Int32))))
 			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
 			wh.SetExternalKubeClientSet(client)
 			wh.SetExternalKubeInformerFactory(informer)
@@ -240,7 +241,7 @@ func TestAdmitCachedClient(t *testing.T) {
 		client, informer := webhooktesting.NewFakeMutatingDataSource(ns, webhooktesting.ConvertToMutatingWebhooks(tt.Webhooks), stopCh)
 
 		// override the webhook source. The client cache will stay the same.
-		cacheMisses := new(int32)
+		cacheMisses := new(atomic.Int32)
 		wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(cacheMisses)))
 		wh.SetExternalKubeClientSet(client)
 		wh.SetExternalKubeInformerFactory(informer)
@@ -258,12 +259,12 @@ func TestAdmitCachedClient(t *testing.T) {
 			t.Errorf("%s: expected allowed=%v, but got err=%v", tt.Name, tt.ExpectAllow, err)
 		}
 
-		if tt.ExpectCacheMiss && *cacheMisses == 0 {
+		if tt.ExpectCacheMiss && cacheMisses.Load() == 0 {
 			t.Errorf("%s: expected cache miss, but got no AuthenticationInfoResolver call", tt.Name)
 		}
 
-		if !tt.ExpectCacheMiss && *cacheMisses > 0 {
-			t.Errorf("%s: expected client to be cached, but got %d AuthenticationInfoResolver calls", tt.Name, *cacheMisses)
+		if !tt.ExpectCacheMiss && cacheMisses.Load() > 0 {
+			t.Errorf("%s: expected client to be cached, but got %d AuthenticationInfoResolver calls", tt.Name, cacheMisses.Load())
 		}
 	}
 }
@@ -299,7 +300,7 @@ func TestWebhookDuration(ts *testing.T) {
 			ns := "webhook-test"
 			client, informer := webhooktesting.NewFakeMutatingDataSource(ns, webhooktesting.ConvertToMutatingWebhooks(test.Webhooks), stopCh)
 
-			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(atomic.Int32))))
 			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
 			wh.SetExternalKubeClientSet(client)
 			wh.SetExternalKubeInformerFactory(informer)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/authentication_info_resolver.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/authentication_info_resolver.go
@@ -34,7 +34,7 @@ func Wrapper(r webhook.AuthenticationInfoResolver) func(webhook.AuthenticationIn
 
 // NewAuthenticationInfoResolver creates a fake AuthenticationInfoResolver that counts cache misses on
 // every call to its methods.
-func NewAuthenticationInfoResolver(cacheMisses *int32) webhook.AuthenticationInfoResolver {
+func NewAuthenticationInfoResolver(cacheMisses *atomic.Int32) webhook.AuthenticationInfoResolver {
 	a := &authenticationInfoResolver{
 		restConfig: &rest.Config{
 			TLSClientConfig: rest.TLSClientConfig{
@@ -44,7 +44,7 @@ func NewAuthenticationInfoResolver(cacheMisses *int32) webhook.AuthenticationInf
 			},
 		},
 	}
-	a.cacheMisses.Store(*cacheMisses)
+	a.cacheMisses.Store(cacheMisses.Load())
 	return a
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2130,11 +2130,11 @@ func TestStoreDeletionPropagation(t *testing.T) {
 type storageWithCounter struct {
 	storage.Interface
 
-	listCounter int64
+	listCounter atomic.Int64
 }
 
 func (s *storageWithCounter) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
-	atomic.AddInt64(&s.listCounter, 1)
+	s.listCounter.Add(1)
 	return s.Interface.GetList(ctx, key, opts, listObj)
 }
 
@@ -2171,7 +2171,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 		t.Errorf("Unexpected number of pods deleted: %d, expected: %d", len(deletedPods.Items), numPods)
 	}
 	expectedCalls := (int64(numPods) + deleteCollectionPageSize - 1) / deleteCollectionPageSize
-	if listCalls := atomic.LoadInt64(&storeWithCounter.listCounter); listCalls != expectedCalls {
+	if listCalls := storeWithCounter.listCounter.Load(); listCalls != expectedCalls {
 		t.Errorf("Unexpected number of list calls: %d, expected: %d", listCalls, expectedCalls)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
@@ -79,7 +79,7 @@ func TestCachingObject(t *testing.T) {
 	}
 	for _, encoder := range encoders {
 		if encoder.callsNumber.Load() != 1 {
-			t.Errorf("%s: unexpected number of encode() calls: %d", encoder.identifier, encoder.callsNumber)
+			t.Errorf("%s: unexpected number of encode() calls: %d", encoder.identifier, encoder.callsNumber.Load())
 		}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
@@ -35,7 +35,7 @@ type mockEncoder struct {
 	expectedResult string
 	expectedError  error
 
-	callsNumber int32
+	callsNumber atomic.Int32
 }
 
 func newMockEncoder(id, result string, err error) *mockEncoder {
@@ -47,7 +47,7 @@ func newMockEncoder(id, result string, err error) *mockEncoder {
 }
 
 func (e *mockEncoder) encode(_ runtime.Object, w io.Writer) error {
-	atomic.AddInt32(&e.callsNumber, 1)
+	e.callsNumber.Add(1)
 	if e.expectedError != nil {
 		return e.expectedError
 	}
@@ -78,7 +78,7 @@ func TestCachingObject(t *testing.T) {
 		}
 	}
 	for _, encoder := range encoders {
-		if encoder.callsNumber != 1 {
+		if encoder.callsNumber.Load() != 1 {
 			t.Errorf("%s: unexpected number of encode() calls: %d", encoder.identifier, encoder.callsNumber)
 		}
 	}
@@ -147,7 +147,7 @@ func TestCachingObjectRaces(t *testing.T) {
 				if err := object.CacheEncode(encoder.identifier, encoder.encode, buffer); err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				if callsNumber := atomic.LoadInt32(&encoder.callsNumber); callsNumber != 1 {
+				if callsNumber := encoder.callsNumber.Load(); callsNumber != 1 {
 					t.Errorf("unexpected number of serializations: %d", callsNumber)
 				}
 			}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
@@ -28,7 +28,7 @@ import (
 type KVRecorder struct {
 	clientv3.KV
 
-	reads uint64
+	reads atomic.Uint64
 }
 
 func NewKVRecorder(kv clientv3.KV) *KVRecorder {
@@ -36,12 +36,12 @@ func NewKVRecorder(kv clientv3.KV) *KVRecorder {
 }
 
 func (r *KVRecorder) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
-	atomic.AddUint64(&r.reads, 1)
+	r.reads.Add(1)
 	return r.KV.Get(ctx, key, opts...)
 }
 
 func (r *KVRecorder) GetReadsAndReset() uint64 {
-	return atomic.SwapUint64(&r.reads, 0)
+	return r.reads.Swap(0)
 }
 
 type KubernetesRecorder struct {

--- a/staging/src/k8s.io/apiserver/pkg/storage/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/util.go
@@ -69,16 +69,18 @@ func NoNamespaceKeyFunc(prefix string, obj runtime.Object) (string, error) {
 
 // HighWaterMark is a thread-safe object for tracking the maximum value seen
 // for some quantity.
-type HighWaterMark int64
+type HighWaterMark struct {
+	V atomic.Int64
+}
 
 // Update returns true if and only if 'current' is the highest value ever seen.
 func (hwm *HighWaterMark) Update(current int64) bool {
 	for {
-		old := atomic.LoadInt64((*int64)(hwm))
+		old := hwm.V.Load()
 		if current <= old {
 			return false
 		}
-		if atomic.CompareAndSwapInt64((*int64)(hwm), old, current) {
+		if hwm.V.CompareAndSwap(old, current) {
 			return true
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/util_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/util_test.go
@@ -1,3 +1,4 @@
+
 /*
 Copyright 2015 The Kubernetes Authors.
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/util_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/util_test.go
@@ -56,7 +56,7 @@ func TestHighWaterMark(t *testing.T) {
 
 	m := int64(0)
 	wg := sync.WaitGroup{}
-	for i := 0; i < 300; i++ {
+	for range 300 {
 		wg.Add(1)
 		v := rand.Int63()
 		go func(v int64) {
@@ -68,8 +68,8 @@ func TestHighWaterMark(t *testing.T) {
 		}
 	}
 	wg.Wait()
-	if m != int64(h) {
-		t.Errorf("unexpected value, wanted %v, got %v", m, int64(h))
+	if m != int64(h.V.Load()) {
+		t.Errorf("unexpected value, wanted %v, got %v", m, int64(h.V.Load()))
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
@@ -68,11 +68,11 @@ type testEnvelopeService struct {
 	disabled     bool
 	keyVersion   string
 	ciphertext   []byte
-	decryptCalls int32
+	decryptCalls atomic.Int32
 }
 
 func (t *testEnvelopeService) Decrypt(ctx context.Context, uid string, req *kmsservice.DecryptRequest) ([]byte, error) {
-	atomic.AddInt32(&t.decryptCalls, 1)
+	t.decryptCalls.Add(1)
 	if t.disabled {
 		return nil, fmt.Errorf("Envelope service was disabled")
 	}
@@ -232,7 +232,7 @@ func TestEnvelopeCaching(t *testing.T) {
 					}
 				}
 			}
-			if int(envelopeService.decryptCalls) != tt.expectedDecryptCalls {
+			if int(envelopeService.decryptCalls.Load()) != tt.expectedDecryptCalls {
 				t.Fatalf("expected %d decrypt calls, got %d", tt.expectedDecryptCalls, envelopeService.decryptCalls)
 			}
 		})

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/dropped_requests_tracker.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/dropped_requests_tracker.go
@@ -65,7 +65,7 @@ type droppedRequestsStats struct {
 	retryAfterUpdateUnix int64
 }
 
-func newDroppedRequestsStats(nowUnix int64) *droppedRequestsStats {
+func newDroppedRequestsStats(_ int64) *droppedRequestsStats {
 	result := &droppedRequestsStats{
 		// We assume that we can bump at any time after first dropped request.
 		retryAfterUpdateUnix: 0,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/real_event_clock_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/real_event_clock_test.go
@@ -25,14 +25,14 @@ import (
 
 func TestRealEventClock(t *testing.T) {
 	ec := Real{}
-	var numDone int32
+	var numDone atomic.Int32
 	now := ec.Now()
 	const batchSize = 100
 	times := make(chan time.Time, batchSize+1)
 	try := func(abs bool, d time.Duration) {
 		f := func(u time.Time) {
 			realD := ec.Since(now)
-			atomic.AddInt32(&numDone, 1)
+			numDone.Add(1)
 			times <- u
 			if realD < d {
 				t.Errorf("Asked for %v, got %v", d, realD)
@@ -50,8 +50,8 @@ func TestRealEventClock(t *testing.T) {
 		try(i%2 == 0, d)
 	}
 	time.Sleep(time.Second * 4)
-	if atomic.LoadInt32(&numDone) != batchSize+1 {
-		t.Errorf("Got only %v events", numDone)
+	if numDone.Load() != batchSize+1 {
+		t.Errorf("Got only %v events", numDone.Load())
 	}
 	lastTime := now
 	for i := 0; i <= batchSize; i++ {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock/fake_event_clock_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock/fake_event_clock_test.go
@@ -77,7 +77,7 @@ func exerciseTestableEventClock(t *testing.T, ec TestableEventClock, fuzz time.D
 	now = endTime
 	var shouldRun int32
 	strictable = false
-	for i := 0; i < batchSize; i++ {
+	for i := range batchSize {
 		d := time.Duration(rand.Intn(30)-3) * time.Second
 		try(i%2 == 0, d >= 0, d)
 		if d <= 12*time.Second {
@@ -85,9 +85,11 @@ func exerciseTestableEventClock(t *testing.T, ec TestableEventClock, fuzz time.D
 		}
 	}
 	ec.SetTime(now.Add(13*time.Second - 1))
-	if numDone.Load() != batchSize+1+shouldRun {
-		t.Errorf("Expected %v, but %v ran", shouldRun, numDone.Load()-batchSize-1)
+	got := numDone.Load()
+	if got != batchSize+1+shouldRun {
+		t.Errorf("Expected %v, but %v ran", shouldRun, got-batchSize-1)
 	}
+
 	lastTime = now.Add(-3 * time.Second)
 	for i := int32(0); i < shouldRun; i++ {
 		nextTime := <-times

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
@@ -34,7 +34,7 @@ import (
 // to the given version first.
 // If PrintObj() is called multiple times, objects are separated with a '---' separator.
 type YAMLPrinter struct {
-	printCount int64
+	printCount atomic.Int64
 }
 
 // PrintObj prints the data as YAML.
@@ -46,7 +46,7 @@ func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		return errors.New(InternalObjectPrinterErr)
 	}
 
-	count := atomic.AddInt64(&p.printCount, 1)
+	count := p.printCount.Add(1)
 	if count > 1 {
 		if _, err := w.Write([]byte("---\n")); err != nil {
 			return err

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -4081,10 +4081,10 @@ func TestRetryableConditions(t *testing.T) {
 }
 
 func TestRequestConcurrencyWithRetry(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 	client := clientForFunc(func(req *http.Request) (*http.Response, error) {
 		defer func() {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 		}()
 
 		// always send a retry-after response
@@ -4122,8 +4122,8 @@ func TestRequestConcurrencyWithRetry(t *testing.T) {
 
 	// we expect (concurrency*req.maxRetries+1) attempts to be recorded
 	expected := concurrency * (req.maxRetries + 1)
-	if atomic.LoadInt32(&attempts) != int32(expected) {
-		t.Errorf("Expected attempts: %d, but got: %d", expected, attempts)
+	if attempts.Load() != int32(expected) {
+		t.Errorf("Expected attempts: %d, but got: %d", expected, attempts.Load())
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_bench_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_bench_test.go
@@ -126,10 +126,8 @@ func benchmarkSharedIndexInformer(b *testing.B, readers int, watcher *watch.Fake
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
 	var reads atomic.Int64
-	for i := 0; i < readers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range readers {
+		wg.Go(func() {
 			for {
 				select {
 				case <-stop:
@@ -143,7 +141,7 @@ func benchmarkSharedIndexInformer(b *testing.B, readers int, watcher *watch.Fake
 				}
 				reads.Add(1)
 			}
-		}()
+		})
 	}
 
 	writes.Store(0)

--- a/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack.go
+++ b/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack.go
@@ -82,7 +82,7 @@ type SingleFileTracker struct {
 	// aligned, otherwise atomic operations will panic. Having it at the top of
 	// the struct will guarantee that, even on 32-bit arches.
 	// See https://pkg.go.dev/sync/atomic#pkg-note-BUG for more information.
-	count int64
+	count atomic.Int64
 
 	UpstreamHasSynced func() bool
 }
@@ -90,7 +90,7 @@ type SingleFileTracker struct {
 // Start should be called prior to processing each key which is part of the
 // initial list.
 func (t *SingleFileTracker) Start() {
-	atomic.AddInt64(&t.count, 1)
+	t.count.Add(1)
 }
 
 // Finished should be called when finished processing a key which was part of
@@ -99,7 +99,7 @@ func (t *SingleFileTracker) Start() {
 // return a wrong value. To help you notice this should it happen, Finished()
 // will panic if the internal counter goes negative.
 func (t *SingleFileTracker) Finished() {
-	result := atomic.AddInt64(&t.count, -1)
+	result := t.count.Add(-1)
 	if result < 0 {
 		panic("synctrack: negative counter; this logic error means HasSynced may return incorrect value")
 	}
@@ -116,5 +116,5 @@ func (t *SingleFileTracker) HasSynced() bool {
 	if !t.UpstreamHasSynced() {
 		return false
 	}
-	return atomic.LoadInt64(&t.count) <= 0
+	return t.count.Load() <= 0
 }

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -88,7 +88,7 @@ func newRetryWatcher(ctx context.Context, initialResourceVersion string, watcher
 		lastResourceVersion: initialResourceVersion,
 		watcherClient:       watcherClient,
 		doneChan:            make(chan struct{}),
-		resultChan:          make(chan watch.Event, 0),
+		resultChan:          make(chan watch.Event),
 		minRestartDelay:     minRestartDelay,
 	}
 

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -56,15 +56,14 @@ func (o testObject) DeepCopyObject() runtime.Object   { return o }
 func (o testObject) GetResourceVersion() string       { return o.resourceVersion }
 
 func withCounter(w cache.Watcher) (*atomic.Uint32, cache.WatcherWithContext) {
-    var counter atomic.Uint32
-    return &counter, &cache.ListWatch{
-        WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-            counter.Add(1)
-            return w.Watch(options)
-        },
-    }
+	var counter atomic.Uint32
+	return &counter, &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			counter.Add(1)
+			return w.Watch(options)
+		},
+	}
 }
-
 
 func makeTestEvent(rv int) watch.Event {
 	return watch.Event{
@@ -124,11 +123,11 @@ func fromRV(resourceVersion string, array []watch.Event) []watch.Event {
 }
 
 func closeAfterN(n int, source chan watch.Event) chan watch.Event {
-	result := make(chan watch.Event, 0)
+	result := make(chan watch.Event)
 	go func() {
 		defer close(result)
 		defer close(source)
-		for i := 0; i < n; i++ {
+		for range n {
 			result <- <-source
 		}
 	}()
@@ -162,8 +161,8 @@ func TestNewRetryWatcher(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := NewRetryWatcher(tc.initialRV, nil)
-			if !reflect.DeepEqual(err, tc.err) {
-				t.Errorf("Expected error: %v, got: %v", tc.err, err)
+			if !errors.Is(err, tc.err) {
+				t.Errorf("Expected error %v, got %v", tc.err, err)
 			}
 		})
 	}

--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -298,8 +298,8 @@ func TestUntilWithSync(t *testing.T) {
 
 			event, err := UntilWithSync(ctx, tc.lw, &corev1.Secret{}, tc.preconditionFunc, tc.conditionFunc)
 
-			if !reflect.DeepEqual(err, tc.expectedErr) {
-				t.Errorf("expected error %#v, got %#v", tc.expectedErr, err)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("expected error %v, got %v", tc.expectedErr, err)
 			}
 
 			if !reflect.DeepEqual(event, tc.expectedEvent) {

--- a/staging/src/k8s.io/client-go/util/workqueue/parallelizer_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/parallelizer_test.go
@@ -61,10 +61,10 @@ var cases = []testCase{
 func TestParallelizeUntil(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.String(), func(t *testing.T) {
-			seen := make([]int32, tc.pieces)
+			seen := make([]atomic.Int32, tc.pieces)
 			ctx := context.Background()
 			ParallelizeUntil(ctx, tc.workers, tc.pieces, func(p int) {
-				atomic.AddInt32(&seen[p], 1)
+				seen[p].Add(1)
 			}, WithChunkSize(tc.chunkSize))
 
 			wantSeen := make([]int32, tc.pieces)

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -447,15 +447,15 @@ func TestGarbageCollection(t *testing.T) {
 // The input must be a pointer to an object.
 func mustGarbageCollect(t *testing.T, i interface{}) {
 	t.Helper()
-	var collected int32 = 0
+	var collected atomic.Int32
 	runtime.SetFinalizer(i, func(x interface{}) {
-		atomic.StoreInt32(&collected, 1)
+		collected.Store(1)
 	})
 	t.Cleanup(func() {
 		if err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (done bool, err error) {
 			// Trigger GC explicitly, otherwise we may need to wait a long time for it to run
 			runtime.GC()
-			return atomic.LoadInt32(&collected) == 1, nil
+			return collected.Load() == 1, nil
 		}); err != nil {
 			t.Errorf("object was not garbage collected")
 		}

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/nonblockinggrpcserver.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/nonblockinggrpcserver.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var requestID int64
+var requestID atomic.Int64
 
 type grpcServer struct {
 	grpcVerbosity int
@@ -143,7 +143,7 @@ func (m mergeCtx) Value(i interface{}) interface{} {
 // sequentially increasing request ID and adds that logger to the context. It
 // also logs request and response.
 func (s *grpcServer) interceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-	requestID := atomic.AddInt64(&requestID, 1)
+	requestID := requestID.Add(1)
 	logger := klog.FromContext(ctx)
 	logger = klog.LoggerWithValues(logger, "requestID", requestID, "method", info.FullMethod)
 	ctx = klog.NewContext(ctx, logger)
@@ -163,8 +163,10 @@ func (s *grpcServer) interceptor(ctx context.Context, req interface{}, info *grp
 	return
 }
 
+
+
 func (s *grpcServer) streamInterceptor(server interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	requestID := atomic.AddInt64(&requestID, 1)
+	requestID := requestID.Add(1)
 	ctx := stream.Context()
 	logger := klog.FromContext(ctx)
 	logger = klog.LoggerWithValues(logger, "requestID", requestID, "method", info.FullMethod)

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -107,7 +107,7 @@ func getOrphanOptions() metav1.DeleteOptions {
 
 var (
 	zero       = int64(0)
-	lablecount = int64(0)
+	lablecount atomic.Int64
 )
 
 const (
@@ -312,7 +312,7 @@ func newCronJob(name, schedule string) *batchv1.CronJob {
 
 // getUniqLabel returns a UniqLabel based on labeLkey and labelvalue.
 func getUniqLabel(labelkey, labelvalue string) map[string]string {
-	count := atomic.AddInt64(&lablecount, 1)
+	count := lablecount.Add(1)
 	uniqlabelkey := fmt.Sprintf("%s-%05d", labelkey, count)
 	uniqlabelvalue := fmt.Sprintf("%s-%05d", labelvalue, count)
 	return map[string]string{uniqlabelkey: uniqlabelvalue}

--- a/test/e2e/chaosmonkey/chaosmonkey_test.go
+++ b/test/e2e/chaosmonkey/chaosmonkey_test.go
@@ -23,23 +23,23 @@ import (
 )
 
 func TestDoWithPanic(t *testing.T) {
-	var counter int64
+	var counter atomic.Int64
 	cm := New(func(ctx context.Context) {})
 	tests := []Test{
 		// No panic
 		func(ctx context.Context, sem *Semaphore) {
-			defer atomic.AddInt64(&counter, 1)
+			defer counter.Add(1)
 			sem.Ready()
 		},
 		// Panic after sem.Ready()
 		func(ctx context.Context, sem *Semaphore) {
-			defer atomic.AddInt64(&counter, 1)
+			defer counter.Add(1)
 			sem.Ready()
 			panic("Panic after calling sem.Ready()")
 		},
 		// Panic before sem.Ready()
 		func(ctx context.Context, sem *Semaphore) {
-			defer atomic.AddInt64(&counter, 1)
+			defer counter.Add(1)
 			panic("Panic before calling sem.Ready()")
 		},
 	}
@@ -48,7 +48,7 @@ func TestDoWithPanic(t *testing.T) {
 	}
 	cm.Do(context.Background())
 	// Check that all funcs in tests were called.
-	if int(counter) != len(tests) {
+	if int(counter.Load()) != len(tests) {
 		t.Errorf("Expected counter to be %v, but it was %v", len(tests), counter)
 	}
 }

--- a/test/e2e/storage/csimock/base.go
+++ b/test/e2e/storage/csimock/base.go
@@ -1086,13 +1086,13 @@ func createFSGroupRequestPreHook(nodeStageFsGroup, nodePublishFsGroup *string) *
 
 // createPreHook counts invocations of a certain method (identified by a substring in the full gRPC method name).
 func createPreHook(method string, callback func(counter int64) error) *drivers.Hooks {
-	var counter int64
+	var counter atomic.Int64
 
 	return &drivers.Hooks{
 		Pre: func() func(ctx context.Context, fullMethod string, request interface{}) (reply interface{}, err error) {
 			return func(ctx context.Context, fullMethod string, request interface{}) (reply interface{}, err error) {
 				if strings.Contains(fullMethod, method) {
-					counter := atomic.AddInt64(&counter, 1)
+					counter := counter.Add(1)
 					return nil, callback(counter)
 				}
 				return nil, nil

--- a/test/e2e/storage/csimock/mutable_csinode_allocatable.go
+++ b/test/e2e/storage/csimock/mutable_csinode_allocatable.go
@@ -63,12 +63,12 @@ var _ = utils.SIGDescribe("MutableCSINodeAllocatableCount", framework.WithFeatur
 		)
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			var calls int32
+			var calls atomic.Int32
 			hook := drivers.Hooks{
 				Post: func(_ context.Context, method string, _ interface{}, reply interface{}, err error) (interface{}, error) {
 					if strings.Contains(method, "NodeGetInfo") {
 						if r, ok := reply.(*csipbv1.NodeGetInfoResponse); ok && err == nil {
-							if atomic.AddInt32(&calls, 1) == 1 {
+							if calls.Add(1) == 1 {
 								r.MaxVolumesPerNode = initialMaxVolumesPerNode
 							} else {
 								r.MaxVolumesPerNode = updatedMaxVolumesPerNode

--- a/test/e2e/storage/drivers/csi-test/mock/service/service.go
+++ b/test/e2e/storage/drivers/csi-test/mock/service/service.go
@@ -120,9 +120,9 @@ type service struct {
 	nodeID       string
 	vols         []csi.Volume
 	volsRWL      sync.RWMutex
-	volsNID      uint64
+	volsNID      atomic.Uint64
 	snapshots    cache.SnapshotCache
-	snapshotsNID uint64
+	snapshotsNID atomic.Uint64
 	config       Config
 }
 
@@ -173,7 +173,7 @@ const (
 
 func (s *service) newVolume(name string, capcity int64) csi.Volume {
 	vol := csi.Volume{
-		VolumeId:      fmt.Sprintf("%d", atomic.AddUint64(&s.volsNID, 1)),
+		VolumeId:      fmt.Sprintf("%d", s.volsNID.Add(1)),
 		VolumeContext: map[string]string{"name": name},
 		CapacityBytes: capcity,
 	}
@@ -263,7 +263,7 @@ func (s *service) newSnapshot(name, sourceVolumeId string, parameters map[string
 		Name:       name,
 		Parameters: parameters,
 		SnapshotCSI: csi.Snapshot{
-			SnapshotId:     fmt.Sprintf("%d", atomic.AddUint64(&s.snapshotsNID, 1)),
+			SnapshotId:     fmt.Sprintf("%d", s.snapshotsNID.Add(1)),
 			CreationTime:   ptime,
 			SourceVolumeId: sourceVolumeId,
 			ReadyToUse:     true,

--- a/test/images/agnhost/netexec/netexec.go
+++ b/test/images/agnhost/netexec/netexec.go
@@ -48,7 +48,7 @@ var (
 	udpPort            = 8081
 	sctpPort           = -1
 	shellPath          = "/bin/sh"
-	serverReady        = &atomicBool{0}
+	serverReady        = &atomicBool{v: atomic.Int32{}}
 	certFile           = ""
 	privKeyFile        = ""
 	httpOverride       = ""
@@ -148,21 +148,21 @@ func init() {
 
 // atomicBool uses load/store operations on an int32 to simulate an atomic boolean.
 type atomicBool struct {
-	v int32
+	v atomic.Int32
 }
 
 // set sets the int32 to the given boolean.
 func (a *atomicBool) set(value bool) {
 	if value {
-		atomic.StoreInt32(&a.v, 1)
+		a.v.Store(1)
 		return
 	}
-	atomic.StoreInt32(&a.v, 0)
+	a.v.Store(0)
 }
 
 // get returns true if the int32 == 1
 func (a *atomicBool) get() bool {
-	return atomic.LoadInt32(&a.v) == 1
+	return a.v.Load() == 1
 }
 
 func main(cmd *cobra.Command, args []string) {

--- a/test/integration/apiserver/admissionwebhook/load_balance_test.go
+++ b/test/integration/apiserver/admissionwebhook/load_balance_test.go
@@ -349,7 +349,7 @@ func (c *connectionTrackingListener) Reset() {
 func (c *connectionTrackingListener) Accept() (net.Conn, error) {
 	conn, err := c.delegate.Accept()
 	if err == nil {
-		c.connections.Store(1)
+		c.connections.Add(1)
 	}
 	return conn, err
 }

--- a/test/integration/apiserver/admissionwebhook/load_balance_test.go
+++ b/test/integration/apiserver/admissionwebhook/load_balance_test.go
@@ -221,7 +221,7 @@ func TestWebhookLoadBalance(t *testing.T) {
 			}
 			wg.Wait()
 
-			actual := atomic.LoadInt64(&trackingListener.connections)
+			actual := trackingListener.connections.Load()
 			if tc.http2 && actual != tc.expected {
 				t.Errorf("expected %d connections, got %d", tc.expected, actual)
 			}
@@ -244,7 +244,7 @@ func TestWebhookLoadBalance(t *testing.T) {
 			}
 			wg.Wait()
 
-			if actual := atomic.LoadInt64(&trackingListener.connections); actual > 0 {
+			if actual := trackingListener.connections.Load(); actual > 0 {
 				t.Errorf("expected no additional connections (reusing kept-alive connections), got %d", actual)
 			}
 		})
@@ -338,18 +338,18 @@ var loadBalanceMarkerFixture = &corev1.Pod{
 }
 
 type connectionTrackingListener struct {
-	connections int64
+	connections atomic.Int64
 	delegate    net.Listener
 }
 
 func (c *connectionTrackingListener) Reset() {
-	atomic.StoreInt64(&c.connections, 0)
+	c.connections.Store(0)
 }
 
 func (c *connectionTrackingListener) Accept() (net.Conn, error) {
 	conn, err := c.delegate.Accept()
 	if err == nil {
-		atomic.AddInt64(&c.connections, 1)
+		c.connections.Store(1)
 	}
 	return conn, err
 }

--- a/test/integration/apiserver/patch_test.go
+++ b/test/integration/apiserver/patch_test.go
@@ -71,7 +71,7 @@ func TestPatchConflicts(t *testing.T) {
 	}
 	client := clientSet.CoreV1().RESTClient()
 
-	successes := int32(0)
+	var successes atomic.Int32
 
 	// Run a lot of simultaneous patch operations to exercise internal API server retry of application of patches that do not specify resourceVersion.
 	// They should all succeed.
@@ -116,12 +116,12 @@ func TestPatchConflicts(t *testing.T) {
 				t.Errorf("patch of %s with $patch directive was ineffective, didn't delete the entry in the ownerReference slice: %#v", "secrets", UIDs[i])
 			}
 
-			atomic.AddInt32(&successes, 1)
+			successes.Add(1)
 		}(i)
 	}
 	wg.Wait()
 
-	if successes < int32(numOfConcurrentPatches) {
+	if successes.Load() < int32(numOfConcurrentPatches) {
 		t.Errorf("Expected at least %d successful patches for %s, got %d", numOfConcurrentPatches, "secrets", successes)
 	} else {
 		t.Logf("Got %d successful patches for %s", successes, "secrets")

--- a/test/integration/evictions/evictions_test.go
+++ b/test/integration/evictions/evictions_test.go
@@ -106,7 +106,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 
 	waitPDBStable(t, clientSet, ns.Name, pdb.Name, numOfEvictions)
 
-	var numberPodsEvicted uint32
+	var numberPodsEvicted atomic.Uint32
 	errCh := make(chan error, 3*numOfEvictions)
 	var wg sync.WaitGroup
 	// spawn numOfEvictions goroutines to concurrently evict the pods
@@ -139,7 +139,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 			_, err = clientSet.CoreV1().Pods(ns.Name).Get(context.TODO(), podName, metav1.GetOptions{})
 			switch {
 			case apierrors.IsNotFound(err):
-				atomic.AddUint32(&numberPodsEvicted, 1)
+				numberPodsEvicted.Add(1)
 				// pod was evicted and deleted so return from goroutine immediately
 				return
 			case err == nil:
@@ -172,8 +172,8 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 		t.Fatal(utilerrors.NewAggregate(errList))
 	}
 
-	if atomic.LoadUint32(&numberPodsEvicted) != numOfEvictions {
-		t.Fatalf("fewer number of successful evictions than expected : %d", numberPodsEvicted)
+	if numberPodsEvicted.Load() != numOfEvictions {
+		t.Fatalf("fewer number of successful evictions than expected : %d", numberPodsEvicted.Load())
 	}
 }
 

--- a/test/integration/examples/webhook_test.go
+++ b/test/integration/examples/webhook_test.go
@@ -39,7 +39,7 @@ import (
 func TestWebhookLoopback(t *testing.T) {
 	webhookPath := "/webhook-test"
 
-	called := int32(0)
+	var called atomic.Int32
 
 	tCtx := ktesting.Init(t)
 	client, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
@@ -56,7 +56,7 @@ func TestWebhookLoopback(t *testing.T) {
 					if attrs.GetUser().GetName() != "system:apiserver" {
 						t.Errorf("expected user %q, got %q", "system:apiserver", attrs.GetUser().GetName())
 					}
-					atomic.AddInt32(&called, 1)
+					called.Add(1)
 				}
 				return audit.RequestAuditConfig{
 					Level: auditinternal.LevelNone,
@@ -96,7 +96,7 @@ func TestWebhookLoopback(t *testing.T) {
 		if err == nil {
 			t.Fatal("Unexpected success")
 		}
-		if called > 0 {
+		if called.Load() > 0 {
 			return true, nil
 		}
 		t.Logf("%v", err)

--- a/vendor/github.com/emicklei/go-restful/v3/route_builder.go
+++ b/vendor/github.com/emicklei/go-restful/v3/route_builder.go
@@ -368,7 +368,7 @@ func concatPath(rootPath, routePath string) string {
 	}
 }
 
-var anonymousFuncCount int32
+var anonymousFuncCount atomic.Int32
 
 // nameOfFunction returns the short name of the function f for documentation.
 // It uses a runtime feature for debugging ; its value may change for later Go versions.
@@ -381,9 +381,9 @@ func nameOfFunction(f interface{}) string {
 	last = strings.TrimSuffix(last, "·fm")  // < Go 1.5
 	last = strings.TrimSuffix(last, "-fm")  // Go 1.5
 	if last == "func1" {                    // this could mean conflicts in API docs
-		val := atomic.AddInt32(&anonymousFuncCount, 1)
+		val := anonymousFuncCount.Add(1)
 		last = "func" + fmt.Sprintf("%d", val)
-		atomic.StoreInt32(&anonymousFuncCount, val)
+		anonymousFuncCount.Store(val)
 	}
 	return last
 }

--- a/vendor/github.com/google/cadvisor/manager/container.go
+++ b/vendor/github.com/google/cadvisor/manager/container.go
@@ -79,7 +79,7 @@ func (t *atomicTime) Time() time.Time {
 }
 
 type containerData struct {
-	oomEvents                uint64
+	oomEvents                atomic.Uint64
 	handler                  container.ContainerHandler
 	info                     containerInfo
 	memoryCache              *memory.InMemoryCache
@@ -699,7 +699,7 @@ func (cd *containerData) updateStats() error {
 		}
 	}
 
-	stats.OOMEvents = atomic.LoadUint64(&cd.oomEvents)
+	stats.OOMEvents = cd.oomEvents.Load()
 
 	var customStatsErr error
 	cm := cd.collectorManager.(*collector.GenericCollectorManager)

--- a/vendor/github.com/google/cadvisor/manager/manager.go
+++ b/vendor/github.com/google/cadvisor/manager/manager.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/cadvisor/cache/memory"
@@ -1261,7 +1260,7 @@ func (m *manager) watchForNewOoms() error {
 				continue
 			}
 			for _, cont := range conts {
-				atomic.AddUint64(&cont.oomEvents, 1)
+				cont.oomEvents.Add(1)
 			}
 		}
 	}()

--- a/vendor/github.com/ishidawataru/sctp/sctp_linux.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp_linux.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net"
 	"runtime"
-	"sync/atomic"
 	"syscall"
 	"unsafe"
 )
@@ -138,7 +137,7 @@ func (c *SCTPConn) SCTPRead(b []byte) (int, *SndRcvInfo, error) {
 
 func (c *SCTPConn) Close() error {
 	if c != nil {
-		fd := atomic.SwapInt32(&c._fd, -1)
+		fd := c._fd.Swap(-1)
 		if fd > 0 {
 			info := &SndRcvInfo{
 				Flags: SCTP_EOF,

--- a/vendor/github.com/moby/ipvs/ipvs_linux.go
+++ b/vendor/github.com/moby/ipvs/ipvs_linux.go
@@ -3,6 +3,7 @@ package ipvs
 import (
 	"fmt"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/vishvananda/netlink/nl"
@@ -75,7 +76,7 @@ type Config struct {
 // Handle provides a namespace specific ipvs handle to program ipvs
 // rules.
 type Handle struct {
-	seq  uint32
+	seq  atomic.Uint32
 	sock *nl.NetlinkSocket
 }
 

--- a/vendor/github.com/moby/ipvs/netlink_linux.go
+++ b/vendor/github.com/moby/ipvs/netlink_linux.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -119,7 +118,7 @@ func fillDestination(d *Destination) nl.NetlinkRequestData {
 
 func (i *Handle) doCmdwithResponse(s *Service, d *Destination, cmd uint8) ([][]byte, error) {
 	req := newIPVSRequest(cmd)
-	req.Seq = atomic.AddUint32(&i.seq, 1)
+	req.Seq = i.seq.Add(1)
 
 	if s == nil {
 		req.Flags |= syscall.NLM_F_DUMP                    // Flag to dump all messages
@@ -410,7 +409,7 @@ func (i *Handle) doGetServicesCmd(svc *Service) ([]*Service, error) {
 // doCmdWithoutAttr a simple wrapper of netlink socket execute command
 func (i *Handle) doCmdWithoutAttr(cmd uint8) ([][]byte, error) {
 	req := newIPVSRequest(cmd)
-	req.Seq = atomic.AddUint32(&i.seq, 1)
+	req.Seq = i.seq.Add(1)
 	return execute(i.sock, req, 0)
 }
 
@@ -601,7 +600,7 @@ func (i *Handle) doGetConfigCmd() (*Config, error) {
 // doSetConfigCmd a wrapper function to be used by SetConfig
 func (i *Handle) doSetConfigCmd(c *Config) error {
 	req := newIPVSRequest(ipvsCmdSetConfig)
-	req.Seq = atomic.AddUint32(&i.seq, 1)
+	req.Seq = i.seq.Add(1)
 
 	req.AddData(nl.NewRtAttr(ipvsCmdAttrTimeoutTCP, nl.Uint32Attr(uint32(c.TimeoutTCP.Seconds()))))
 	req.AddData(nl.NewRtAttr(ipvsCmdAttrTimeoutTCPFin, nl.Uint32Attr(uint32(c.TimeoutTCPFin.Seconds()))))

--- a/vendor/go.etcd.io/etcd/server/v3/etcdserver/server.go
+++ b/vendor/go.etcd.io/etcd/server/v3/etcdserver/server.go
@@ -210,11 +210,11 @@ type Server interface {
 // EtcdServer is the production implementation of the Server interface
 type EtcdServer struct {
 	// inflightSnapshots holds count the number of snapshots currently inflight.
-	inflightSnapshots int64  // must use atomic operations to access; keep 64-bit aligned.
-	appliedIndex      uint64 // must use atomic operations to access; keep 64-bit aligned.
-	committedIndex    uint64 // must use atomic operations to access; keep 64-bit aligned.
-	term              uint64 // must use atomic operations to access; keep 64-bit aligned.
-	lead              uint64 // must use atomic operations to access; keep 64-bit aligned.
+	inflightSnapshots atomic.Int64  // must use atomic operations to access; keep 64-bit aligned.
+	appliedIndex      atomic.Uint64 // must use atomic operations to access; keep 64-bit aligned.
+	committedIndex    atomic.Uint64 // must use atomic operations to access; keep 64-bit aligned.
+	term              atomic.Uint64 // must use atomic operations to access; keep 64-bit aligned.
+	lead              atomic.Uint64 // must use atomic operations to access; keep 64-bit aligned.
 
 	consistIndex cindex.ConsistentIndexer // consistIndex is used to get/set/save consistentIndex
 	r            raftNode                 // uses 64-bit atomics; keep 64-bit aligned.
@@ -1671,35 +1671,35 @@ func (s *EtcdServer) UpdateMember(ctx context.Context, memb membership.Member) (
 }
 
 func (s *EtcdServer) setCommittedIndex(v uint64) {
-	atomic.StoreUint64(&s.committedIndex, v)
+	s.committedIndex.Store(v)
 }
 
 func (s *EtcdServer) getCommittedIndex() uint64 {
-	return atomic.LoadUint64(&s.committedIndex)
+	return s.committedIndex.Load()
 }
 
 func (s *EtcdServer) setAppliedIndex(v uint64) {
-	atomic.StoreUint64(&s.appliedIndex, v)
+	s.appliedIndex.Store(v)
 }
 
 func (s *EtcdServer) getAppliedIndex() uint64 {
-	return atomic.LoadUint64(&s.appliedIndex)
+	return s.appliedIndex.Load()
 }
 
 func (s *EtcdServer) setTerm(v uint64) {
-	atomic.StoreUint64(&s.term, v)
+	s.term.Store(v)
 }
 
 func (s *EtcdServer) getTerm() uint64 {
-	return atomic.LoadUint64(&s.term)
+	return s.term.Load()
 }
 
 func (s *EtcdServer) setLead(v uint64) {
-	atomic.StoreUint64(&s.lead, v)
+	s.lead.Store(v)
 }
 
 func (s *EtcdServer) getLead() uint64 {
-	return atomic.LoadUint64(&s.lead)
+	return s.lead.Load()
 }
 
 func (s *EtcdServer) LeaderChangedNotify() <-chan struct{} {
@@ -1839,7 +1839,7 @@ func (s *EtcdServer) publishV3(timeout time.Duration) {
 }
 
 func (s *EtcdServer) sendMergedSnap(merged snap.Message) {
-	atomic.AddInt64(&s.inflightSnapshots, 1)
+	s.inflightSnapshots.Add(1)
 
 	lg := s.Logger()
 	fields := []zap.Field{
@@ -1867,7 +1867,7 @@ func (s *EtcdServer) sendMergedSnap(merged snap.Message) {
 				}
 			}
 
-			atomic.AddInt64(&s.inflightSnapshots, -1)
+			s.inflightSnapshots.Add(-1)
 
 			lg.Info("sent merged snapshot", append(fields, zap.Duration("took", time.Since(now)))...)
 
@@ -2258,7 +2258,7 @@ func (s *EtcdServer) compactRaftLog(snapi uint64) {
 	// the snapshot sent to catch up. If we do not pause compaction, the log entries right after
 	// the snapshot sent might already be compacted. It happens when the snapshot takes long time
 	// to send and save. Pausing compaction avoids triggering a snapshot sending cycle.
-	if atomic.LoadInt64(&s.inflightSnapshots) != 0 {
+	if s.inflightSnapshots.Load() != 0 {
 		lg.Info("skip compaction since there is an inflight snapshot")
 		return
 	}

--- a/vendor/go.etcd.io/etcd/server/v3/storage/backend/batch_tx.go
+++ b/vendor/go.etcd.io/etcd/server/v3/storage/backend/batch_tx.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"math"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -275,7 +274,7 @@ func (t *batchTx) commit(stop bool) {
 		spillSec.Observe(t.tx.Stats().SpillTime.Seconds())
 		writeSec.Observe(t.tx.Stats().WriteTime.Seconds())
 		commitSec.Observe(time.Since(start).Seconds())
-		atomic.AddInt64(&t.backend.commits, 1)
+		t.backend.commits.Add(1)
 
 		t.pending = 0
 		if err != nil {

--- a/vendor/go.opentelemetry.io/otel/attribute/encoder.go
+++ b/vendor/go.opentelemetry.io/otel/attribute/encoder.go
@@ -53,7 +53,7 @@ var (
 	_ Encoder = &defaultAttrEncoder{}
 
 	// encoderIDCounter is for generating IDs for other attribute encoders.
-	encoderIDCounter uint64
+	encoderIDCounter atomic.Uint64
 
 	defaultEncoderOnce     sync.Once
 	defaultEncoderID       = NewEncoderID()
@@ -64,7 +64,7 @@ var (
 // once per each type of attribute encoder. Preferably in init() or in var
 // definition.
 func NewEncoderID() EncoderID {
-	return EncoderID{value: atomic.AddUint64(&encoderIDCounter, 1)}
+	return EncoderID{value: encoderIDCounter.Add(1)}
 }
 
 // DefaultEncoder returns an attribute encoder that encodes attributes in such

--- a/vendor/golang.org/x/crypto/ssh/mux.go
+++ b/vendor/golang.org/x/crypto/ssh/mux.go
@@ -101,7 +101,7 @@ type mux struct {
 
 // When debugging, each new chanList instantiation has a different
 // offset.
-var globalOff uint32
+var globalOff atomic.Uint32
 
 func (m *mux) Wait() error {
 	m.errCond.L.Lock()
@@ -122,7 +122,7 @@ func newMux(p packetConn) *mux {
 		errCond:          newCond(),
 	}
 	if debugMux {
-		m.chanList.offset = atomic.AddUint32(&globalOff, 1)
+		m.chanList.offset = globalOff.Add(1)
 	}
 
 	go m.loop()

--- a/vendor/google.golang.org/grpc/internal/channelz/channel.go
+++ b/vendor/google.golang.org/grpc/internal/channelz/channel.go
@@ -41,7 +41,7 @@ type Channel struct {
 	trace       *ChannelTrace
 	// traceRefCount is the number of trace events that reference this channel.
 	// Non-zero traceRefCount means the trace of this channel cannot be deleted.
-	traceRefCount int32
+	traceRefCount atomic.Int32
 
 	// ChannelMetrics holds connectivity state, target and call metrics for the
 	// channel within channelz.
@@ -253,15 +253,15 @@ func (c *Channel) getChannelTrace() *ChannelTrace {
 }
 
 func (c *Channel) incrTraceRefCount() {
-	atomic.AddInt32(&c.traceRefCount, 1)
+	c.traceRefCount.Add(1)
 }
 
 func (c *Channel) decrTraceRefCount() {
-	atomic.AddInt32(&c.traceRefCount, -1)
+	c.traceRefCount.Add(-1)
 }
 
 func (c *Channel) getTraceRefCount() int {
-	i := atomic.LoadInt32(&c.traceRefCount)
+	i := c.traceRefCount.Load()
 	return int(i)
 }
 

--- a/vendor/google.golang.org/grpc/internal/channelz/funcs.go
+++ b/vendor/google.golang.org/grpc/internal/channelz/funcs.go
@@ -36,23 +36,23 @@ var (
 	db = newChannelMap()
 	// EntriesPerPage defines the number of channelz entries to be shown on a web page.
 	EntriesPerPage = 50
-	curState       int32
+	curState       atomic.Int32
 )
 
 // TurnOn turns on channelz data collection.
 func TurnOn() {
-	atomic.StoreInt32(&curState, 1)
+	curState.Store(1)
 }
 
 func init() {
 	internal.ChannelzTurnOffForTesting = func() {
-		atomic.StoreInt32(&curState, 0)
+		curState.Store(0)
 	}
 }
 
 // IsOn returns whether channelz data collection is on.
 func IsOn() bool {
-	return atomic.LoadInt32(&curState) == 1
+	return curState.Load() == 1
 }
 
 // GetTopChannels returns a slice of top channel's ChannelMetric, along with a
@@ -208,17 +208,17 @@ func RemoveEntry(id int64) {
 
 // IDGenerator is an incrementing atomic that tracks IDs for channelz entities.
 type IDGenerator struct {
-	id int64
+	id atomic.Int64
 }
 
 // Reset resets the generated ID back to zero.  Should only be used at
 // initialization or by tests sensitive to the ID number.
 func (i *IDGenerator) Reset() {
-	atomic.StoreInt64(&i.id, 0)
+	i.id.Store(0)
 }
 
 func (i *IDGenerator) genID() int64 {
-	return atomic.AddInt64(&i.id, 1)
+	return i.id.Add(1)
 }
 
 // Identifier is an opaque channelz identifier used to expose channelz symbols

--- a/vendor/google.golang.org/grpc/internal/channelz/subchannel.go
+++ b/vendor/google.golang.org/grpc/internal/channelz/subchannel.go
@@ -34,7 +34,7 @@ type SubChannel struct {
 	sockets       map[int64]string
 	parent        *Channel
 	trace         *ChannelTrace
-	traceRefCount int32
+	traceRefCount atomic.Int32
 
 	ChannelMetrics ChannelMetrics
 }
@@ -136,15 +136,15 @@ func (sc *SubChannel) getChannelTrace() *ChannelTrace {
 }
 
 func (sc *SubChannel) incrTraceRefCount() {
-	atomic.AddInt32(&sc.traceRefCount, 1)
+	sc.traceRefCount.Add(1)
 }
 
 func (sc *SubChannel) decrTraceRefCount() {
-	atomic.AddInt32(&sc.traceRefCount, -1)
+	sc.traceRefCount.Add(-1)
 }
 
 func (sc *SubChannel) getTraceRefCount() int {
-	i := atomic.LoadInt32(&sc.traceRefCount)
+	i := sc.traceRefCount.Load()
 	return int(i)
 }
 

--- a/vendor/google.golang.org/grpc/internal/transport/client_stream.go
+++ b/vendor/google.golang.org/grpc/internal/transport/client_stream.go
@@ -47,7 +47,7 @@ type ClientStream struct {
 	// reading its value).
 	headerValid      bool
 	noHeaders        bool        // set if the client never received headers (set only after the stream is done).
-	headerChanClosed uint32      // set when headerChan is closed. Used to avoid closing headerChan multiple times.
+	headerChanClosed atomic.Uint32      // set when headerChan is closed. Used to avoid closing headerChan multiple times.
 	bytesReceived    atomic.Bool // indicates whether any bytes have been received on this stream
 	unprocessed      atomic.Bool // set if the server sends a refused stream or GOAWAY including this stream
 }

--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
@@ -55,8 +55,8 @@ type (
 		fileRaw
 		L1 FileL1
 
-		once uint32     // atomically set if L2 is valid
-		mu   sync.Mutex // protects L2
+		once atomic.Uint32 // atomically set if L2 is valid
+		mu   sync.Mutex    // protects L2
 		L2   *FileL2
 	}
 	FileL1 struct {
@@ -160,7 +160,7 @@ func (fd *File) OptionImports() protoreflect.FileImports {
 }
 
 func (fd *File) lazyInit() *FileL2 {
-	if atomic.LoadUint32(&fd.once) == 0 {
+	if fd.once.Load() == 0 {
 		fd.lazyInitOnce()
 	}
 	return fd.L2
@@ -171,7 +171,7 @@ func (fd *File) lazyInitOnce() {
 	if fd.L2 == nil {
 		fd.lazyRawInit() // recursively initializes all L2 structures
 	}
-	atomic.StoreUint32(&fd.once, 1)
+	fd.once.Store(1)
 	fd.mu.Unlock()
 }
 

--- a/vendor/google.golang.org/protobuf/internal/impl/message_opaque.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/message_opaque.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"reflect"
 	"strings"
-	"sync/atomic"
 
 	"google.golang.org/protobuf/internal/filedesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -46,7 +45,7 @@ func opaqueInitHook(mi *MessageInfo) bool {
 		return false
 	}
 
-	defer atomic.StoreUint32(&mi.initDone, 1)
+	defer mi.initDone.Store(1)
 
 	mi.fields = map[protoreflect.FieldNumber]*fieldInfo{}
 	fds := mi.Desc.Fields()

--- a/vendor/sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/conn.go
+++ b/vendor/sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/conn.go
@@ -51,7 +51,7 @@ type conn struct {
 	// closing is an atomic bool represented as a 0 or 1, and set to true when the connection is being closed.
 	// closing should only be accessed through atomic methods.
 	// TODO: switch this to an atomic.Bool once the client is exclusively buit with go1.19+
-	closing uint32
+	closing atomic.Uint32
 }
 
 var _ net.Conn = &conn{}
@@ -126,7 +126,7 @@ func (c *conn) SetWriteDeadline(t time.Time) error {
 // Close closes the connection, sends best-effort close signal to proxy
 // service, and frees resources.
 func (c *conn) Close() error {
-	old := atomic.SwapUint32(&c.closing, 1)
+	old := c.closing.Swap(1)
 	if old != 0 {
 		// prevent duplicate messages
 		return nil

--- a/vendor/sigs.k8s.io/kustomize/kyaml/runfn/runfn.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/runfn/runfn.go
@@ -76,7 +76,7 @@ type RunFns struct {
 	LogWriter io.Writer
 
 	// resultsCount is used to generate the results filename for each container
-	resultsCount uint32
+	resultsCount atomic.Uint32
 
 	// functionFilterProvider provides a filter to perform the function.
 	// this is a variable so it can be mocked in tests
@@ -481,8 +481,8 @@ func (r *RunFns) ffp(spec runtimeutil.FunctionSpec, api *yaml.RNode, currentUser
 	var resultsFile string
 	if r.ResultsDir != "" {
 		resultsFile = filepath.Join(r.ResultsDir, fmt.Sprintf(
-			"results-%v.yaml", r.resultsCount))
-		atomic.AddUint32(&r.resultsCount, 1)
+			"results-%v.yaml", r.resultsCount.Load()))
+		r.resultsCount.Add(1)
 	}
 	if !r.DisableContainers && spec.Container.Image != "" {
 		// TODO: Add a test for this behavior


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
```text
cleanup
```
#### What this PR does / why we need it:

This PR updates our atomic operations to use `Go 1.19's` newer typed atomic approach instead of the old function-based method. We're changing fields like `uint64` to `atomic.Uint64` so we can write cleaner code like `counter.Add(1)` instead of `atomic.AddUint64(&counter, 1)`. This removes the need for pointer handling and gives us better compile-time safety when multiple threads access the same variables in validator operations.

#### Which issue(s) this PR is related to:
```text
N/A
```

#### Special notes for your reviewer:
- This is a mechanical refactor focused on correctness and maintainability.
- No behavioral or performance changes are intended.
- The change relies on Go 1.19+ typed atomics, which are already required by the project.
- All atomic operations are semantically equivalent to the previous implementation.

#### Does this PR introduce a user-facing change?
```text
N/A
```