### PR TITLE
Update publishing rules to reflect 1.25.6 and 1.24.12

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,25 +7,25 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.34
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     source:
       branch: release-1.35
       dirs:
@@ -42,7 +42,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -51,7 +51,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -60,7 +60,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -69,7 +69,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -95,7 +95,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -166,7 +166,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -175,7 +175,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -184,7 +184,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -193,7 +193,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -216,7 +216,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -229,7 +229,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -242,7 +242,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -255,7 +255,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -283,7 +283,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -296,7 +296,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -309,7 +309,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -322,7 +322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -346,7 +346,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -355,7 +355,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -364,7 +364,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -373,7 +373,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -401,7 +401,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -418,7 +418,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -435,7 +435,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -452,7 +452,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -492,7 +492,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -513,7 +513,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -534,7 +534,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -555,7 +555,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -603,7 +603,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -629,7 +629,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -655,7 +655,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -681,7 +681,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -728,7 +728,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -748,7 +748,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -768,7 +768,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -788,7 +788,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -832,7 +832,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -855,7 +855,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -878,7 +878,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -901,7 +901,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -940,7 +940,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -955,7 +955,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -970,7 +970,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -985,7 +985,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1015,7 +1015,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1028,7 +1028,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1041,7 +1041,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1054,7 +1054,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1084,7 +1084,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1099,7 +1099,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1114,7 +1114,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1129,7 +1129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1160,7 +1160,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -1175,7 +1175,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1190,7 +1190,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1205,7 +1205,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1228,25 +1228,25 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.34
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     source:
       branch: release-1.35
       dirs:
@@ -1271,7 +1271,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1288,7 +1288,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1305,7 +1305,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1322,7 +1322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1362,7 +1362,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -1383,7 +1383,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1404,7 +1404,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1425,7 +1425,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1467,7 +1467,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1486,7 +1486,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1505,7 +1505,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1524,7 +1524,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1568,7 +1568,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1591,7 +1591,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1614,7 +1614,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1637,7 +1637,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1687,7 +1687,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -1712,7 +1712,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1737,7 +1737,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1762,7 +1762,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1800,7 +1800,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -1811,7 +1811,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1822,7 +1822,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1833,7 +1833,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -1857,7 +1857,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1868,7 +1868,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1879,7 +1879,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1890,7 +1890,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -1909,25 +1909,25 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.34
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     source:
       branch: release-1.35
       dirs:
@@ -1958,7 +1958,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1981,7 +1981,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2004,7 +2004,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2027,7 +2027,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -2071,7 +2071,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.32
@@ -2090,7 +2090,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2109,7 +2109,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2128,7 +2128,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -2174,7 +2174,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -2199,7 +2199,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -2224,7 +2224,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -2249,7 +2249,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -2340,7 +2340,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -2355,7 +2355,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: apimachinery
       branch: release-1.35
@@ -2397,7 +2397,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.32
@@ -2412,7 +2412,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2427,7 +2427,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2442,7 +2442,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     dependencies:
     - repository: api
       branch: release-1.35
@@ -2464,25 +2464,25 @@ rules:
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.32
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.33
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.34
-    go: 1.24.11
+    go: 1.24.12
     source:
       branch: release-1.34
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.35
-    go: 1.25.5
+    go: 1.25.6
     source:
       branch: release-1.35
       dirs:


### PR DESCRIPTION
Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>

#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

- Update Go in publishing rules to 1.24.12 and 1.25.6 respectively

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/release/issues/4237

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
