### PR TITLE
Fix nil pointer dereference in calculateLinuxResources

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -285,7 +285,11 @@ func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit
 	} else {
 		// if cpuRequest.Amount is nil, then MilliCPUToShares will return the minimal number
 		// of CPU shares.
-		cpuShares = int64(cm.MilliCPUToShares(cpuRequest.MilliValue()))
+		var milliCPU int64
+		if cpuRequest != nil {
+			milliCPU = cpuRequest.MilliValue()
+		}
+		cpuShares = int64(cm.MilliCPUToShares(milliCPU))
 	}
 	resources.CpuShares = cpuShares
 	if memLimit != 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Fixes a potential nil pointer dereference in `kubeGenericRuntimeManager.calculateLinuxResources`.

Previously, when a Pod had no CPU requests or limits specified, both `cpuRequest` and `cpuLimit` parameters could be `nil`. The code path in the `else` block would then call `cpuRequest.MilliValue()` on a nil receiver, leading to a runtime panic.

This PR adds an explicit nil check before calling `MilliValue()`, ensuring safe access and preserving the intended behavior where `cm.MilliCPUToShares(0)` returns the minimal CPU shares.

#### Which issue(s) this PR is related to:
Relates to #135889

#### Special notes for your reviewer:
This PR addresses the specific nil pointer dereference risk in `calculateLinuxResources` that was discussed in the linked issue.

The fix is minimal and non-breaking: it explicitly handles the `nil` case by defaulting `milliCPU` to 0, which `cm.MilliCPUToShares(0)` already correctly converts to the minimal share count (`MinShares`). This aligns the implementation with the existing code comment.

#### Does this PR introduce a user-facing change?

```release-note
NONE
