### PR TITLE
Fix kubectl plugin list overshadow detection on Windows

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -217,8 +217,7 @@ func (v *CommandOverrideVerifier) Verify(path string) []error {
 	}
 
 	// extract the plugin binary name
-	segs := strings.Split(path, "/")
-	binName := segs[len(segs)-1]
+	binName := filepath.Base(path)
 
 	cmdPath := strings.Split(binName, "-")
 	if len(cmdPath) > 1 {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes plugin binary name extraction in `kubectl plugin list` to work correctly on Windows.

The previous implementation used `strings.Split(path, "/")` which does not recognize `\` as a path separator on Windows, causing overshadowed plugin detection to fail.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1821

#### Special notes for your reviewer:

For now, no tests are added as cross-platform path handling is difficult to test in unit tests.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where `kubectl plugin list` failed to detect overshadowed plugins on Windows.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```