### PR TITLE
ktesting: remove deprecated and unused functions

### DIFF
--- a/test/utils/ktesting/assert.go
+++ b/test/utils/ktesting/assert.go
@@ -164,12 +164,6 @@ func buildDescription(explain ...interface{}) string {
 	return fmt.Sprintf(explain[0].(string), explain[1:]...)
 }
 
-// Deprecated: use tCtx.Eventually instead.
-func Eventually[T any](tCtx TContext, cb func(TContext) T) gomega.AsyncAssertion {
-	tCtx.Helper()
-	return tCtx.Eventually(cb)
-}
-
 // Eventually wraps [gomega.Eventually]. Supported argument types are:
 //   - A function with a `tCtx ktesting.TContext` or `ctx context.Context`
 //     parameter plus additional parameters and arbitrary return values.
@@ -249,12 +243,6 @@ func (tc *TC) Eventually(arg any) gomega.AsyncAssertion {
 func (tc *TC) AssertEventually(arg any) gomega.AsyncAssertion {
 	tc.Helper()
 	return tc.newAsyncAssertion(gomega.NewWithT(assertTestingT{tc}).Eventually, arg)
-}
-
-// Deprecated: use tCtx.Consistently instead.
-func Consistently[T any](tCtx TContext, cb func(TContext) T) gomega.AsyncAssertion {
-	tCtx.Helper()
-	return tCtx.Consistently(cb)
 }
 
 // Consistently wraps [gomega.Consistently] the same way as [Eventually] wraps

--- a/test/utils/ktesting/clientcontext.go
+++ b/test/utils/ktesting/clientcontext.go
@@ -27,11 +27,6 @@ import (
 	"k8s.io/client-go/restmapper"
 )
 
-// Deprecated: use tCtx.WithRESTConfig instead
-func WithRESTConfig(tCtx TContext, cfg *rest.Config) TContext {
-	return tCtx.WithRESTConfig(cfg)
-}
-
 // WithRESTConfig initializes all client-go clients with new clients
 // created for the config. The current test name gets included in the UserAgent.
 func (tc *TC) WithRESTConfig(cfg *rest.Config) TContext {
@@ -46,11 +41,6 @@ func (tc *TC) WithRESTConfig(cfg *rest.Config) TContext {
 	cachedDiscovery := memory.NewMemCacheClient(tc.client.Discovery())
 	tc.restMapper = restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscovery)
 	return tc
-}
-
-// Deprecated: use tCtx.WithClients instead
-func WithClients(tCtx TContext, cfg *rest.Config, mapper *restmapper.DeferredDiscoveryRESTMapper, client clientset.Interface, dynamic dynamic.Interface, apiextensions apiextensions.Interface) TContext {
-	return tCtx.WithClients(cfg, mapper, client, dynamic, apiextensions)
 }
 
 // WithClients uses an existing config and clients.

--- a/test/utils/ktesting/errorcontext.go
+++ b/test/utils/ktesting/errorcontext.go
@@ -22,11 +22,6 @@ import (
 	"strings"
 )
 
-// Deprecated: use tCtx.WithError instead
-func WithError(tCtx TContext, err *error) (TContext, func()) {
-	return tCtx.WithError(err)
-}
-
 // WithError creates a context where test failures are collected and stored in
 // the provided error instance when the caller is done. Use it like this:
 //

--- a/test/utils/ktesting/stepcontext.go
+++ b/test/utils/ktesting/stepcontext.go
@@ -16,11 +16,6 @@ limitations under the License.
 
 package ktesting
 
-// Deprecated: use tCtx.WithStep instead
-func WithStep(tCtx TContext, step string) TContext {
-	return tCtx.WithStep(step)
-}
-
 // WithStep creates a context where a prefix is added to all errors and log
 // messages, similar to how errors are wrapped. This can be nested, leaving a
 // trail of "bread crumbs" that help figure out where in a test some problem
@@ -35,12 +30,6 @@ func (tc *TC) WithStep(step string) *TC {
 	tc = tc.clone()
 	tc.steps += step + ": "
 	return tc
-}
-
-// Deprecated: use tCtx.Step instead
-func Step(tCtx TContext, step string, cb func(tCtx TContext)) {
-	tCtx.Helper()
-	tCtx.Step(step, cb)
 }
 
 // Step is useful when the context with the step information is

--- a/test/utils/ktesting/tcontext.go
+++ b/test/utils/ktesting/tcontext.go
@@ -296,11 +296,6 @@ func run(tc *TC, name string, syncTest bool, cb func(tc *TC)) bool {
 	return false
 }
 
-// Deprecated: use tCtx.WithContext instead
-func WithContext(tCtx TContext, ctx context.Context) TContext {
-	return tCtx.WithContext(ctx)
-}
-
 // WithContext constructs a new TContext with a different Context instance.
 // This can be used in callbacks which receive a Context, for example
 // from Gomega:
@@ -320,11 +315,6 @@ func (tc *TC) WithContext(ctx context.Context) TContext {
 		tc = tc.WithLogger(logger)
 	}
 	return tc
-}
-
-// Deprecated: use tCtx.WithValue instead
-func WithValue(tCtx TContext, key, val any) TContext {
-	return tCtx.WithValue(key, val)
 }
 
 // WithValue wraps [context.WithValue] such that the result is again a TContext.
@@ -480,7 +470,7 @@ func (tc *TC) CleanupCtx(cb func(TContext)) {
 	if tb, ok := tc.TB().(ContextTB); ok {
 		// Use context from base TB (most likely Ginkgo).
 		tb.CleanupCtx(func(ctx context.Context) {
-			tCtx := WithContext(tc, ctx)
+			tCtx := tc.WithContext(ctx)
 			cb(tCtx)
 		})
 		return
@@ -491,7 +481,7 @@ func (tc *TC) CleanupCtx(cb func(TContext)) {
 		// context then has *no* deadline. In the code path above for
 		// Ginkgo, Ginkgo is more sophisticated and also applies
 		// timeouts to cleanup calls which accept a context.
-		childCtx := WithContext(tc, context.WithoutCancel(tc))
+		childCtx := tc.WithContext(context.WithoutCancel(tc))
 		cb(childCtx)
 	})
 }

--- a/test/utils/ktesting/withcontext.go
+++ b/test/utils/ktesting/withcontext.go
@@ -23,9 +23,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Deprecated: use tCtx.WithCancel instead
-func WithCancel(tCtx TContext) TContext { return tCtx.WithCancel() }
-
 // WithCancel sets up cancellation in a [TContext.Cleanup] callback and
 // constructs a new TContext where [TContext.Cancel] cancels only the new
 // context.
@@ -44,9 +41,6 @@ func (tc *TC) WithCancel() TContext {
 	return tc
 }
 
-// Deprecated: use tCtx.WithoutCancel instead
-func WithoutCancel(tCtx TContext) TContext { return tCtx.WithoutCancel() }
-
 // WithoutCancel causes the returned context to ignore cancellation of its parent.
 // Calling Cancel will not cancel the parent either.
 // This matches [context.WithoutCancel].
@@ -57,11 +51,6 @@ func (tc *TC) WithoutCancel() TContext {
 	tc.Context = ctx
 	tc.cancel = nil
 	return tc
-}
-
-// Deprecated: use tCtx.WithTimeout instead
-func WithTimeout(tCtx TContext, timeout time.Duration, timeoutCause string) TContext {
-	return tCtx.WithTimeout(timeout, timeoutCause)
 }
 
 // WithTimeout sets up new context with a timeout. Canceling the timeout gets
@@ -76,11 +65,6 @@ func (tc *TC) WithTimeout(timeout time.Duration, timeoutCause string) TContext {
 	tc.Context = ctx
 	tc.cancel = cancel
 	return tc
-}
-
-// Deprecated: used tCtx.WithLogger instead
-func WithLogger(tCtx TContext, logger klog.Logger) TContext {
-	return tCtx.WithLogger(logger)
 }
 
 // WithLogger constructs a new context with a different logger.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

They were replaced with methods and after their usage got updated can now also be removed.

#### Which issue(s) this PR is related to:

Follow-up to https://github.com/kubernetes/kubernetes/pull/136341

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @Karthik-K-N

Thanks for your support with this!