### PR TITLE
chore: Replacing deprecated type for set.String and sets.NewString

### DIFF
--- a/staging/src/k8s.io/endpointslice/util/controller_utils.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils.go
@@ -106,7 +106,7 @@ func GetPodUpdateProjectionKey(oldObj, newObj interface{}) *PodProjectionKey {
 	}
 }
 
-func GetServicesToUpdate(serviceLister v1listers.ServiceLister, key *PodProjectionKey) (sets.String, error) {
+func GetServicesToUpdate(serviceLister v1listers.ServiceLister, key *PodProjectionKey) (sets.Set[string], error) {
 	if key == nil {
 		return nil, nil
 	}
@@ -130,13 +130,13 @@ func GetServicesToUpdate(serviceLister v1listers.ServiceLister, key *PodProjecti
 }
 
 // getServicesForPod returns a set of services matching the given pod's namespace and labels (via service selector).
-func getServicesForPod(serviceLister v1listers.ServiceLister, namespace string, podLabels labels.Set) (sets.String, error) {
+func getServicesForPod(serviceLister v1listers.ServiceLister, namespace string, podLabels labels.Set) (sets.Set[string], error) {
 	services, err := serviceLister.Services(namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 
-	set := sets.String{}
+	set := sets.Set[string]{}
 	for _, service := range services {
 		if service.Spec.Selector == nil {
 			// If the service has a nil selector this means selectors match nothing, not everything.
@@ -269,7 +269,7 @@ func hostNameAndDomainAreEqual(pod1, pod2 *v1.Pod) bool {
 		pod1.Spec.Subdomain == pod2.Spec.Subdomain
 }
 
-func determineNeededServiceUpdates(oldServices, services sets.String, podChanged bool) sets.String {
+func determineNeededServiceUpdates(oldServices, services sets.Set[string], podChanged bool) sets.Set[string] {
 	if podChanged {
 		// if the labels and pod changed, all services need to be updated
 		services = services.Union(oldServices)

--- a/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
@@ -35,52 +35,52 @@ import (
 func TestDetermineNeededServiceUpdates(t *testing.T) {
 	testCases := []struct {
 		name  string
-		a     sets.String
-		b     sets.String
-		union sets.String
-		xor   sets.String
+		a     sets.Set[string]
+		b     sets.Set[string]
+		union sets.Set[string]
+		xor   sets.Set[string]
 	}{
 		{
 			name:  "no services changed",
-			a:     sets.NewString("a", "b", "c"),
-			b:     sets.NewString("a", "b", "c"),
-			xor:   sets.NewString(),
-			union: sets.NewString("a", "b", "c"),
+			a:     sets.New[string]("a", "b", "c"),
+			b:     sets.New[string]("a", "b", "c"),
+			xor:   sets.New[string](),
+			union: sets.New[string]("a", "b", "c"),
 		},
 		{
 			name:  "all old services removed, new services added",
-			a:     sets.NewString("a", "b", "c"),
-			b:     sets.NewString("d", "e", "f"),
-			xor:   sets.NewString("a", "b", "c", "d", "e", "f"),
-			union: sets.NewString("a", "b", "c", "d", "e", "f"),
+			a:     sets.New[string]("a", "b", "c"),
+			b:     sets.New[string]("d", "e", "f"),
+			xor:   sets.New[string]("a", "b", "c", "d", "e", "f"),
+			union: sets.New[string]("a", "b", "c", "d", "e", "f"),
 		},
 		{
 			name:  "all old services removed, no new services added",
-			a:     sets.NewString("a", "b", "c"),
-			b:     sets.NewString(),
-			xor:   sets.NewString("a", "b", "c"),
-			union: sets.NewString("a", "b", "c"),
+			a:     sets.New[string]("a", "b", "c"),
+			b:     sets.New[string](),
+			xor:   sets.New[string]("a", "b", "c"),
+			union: sets.New[string]("a", "b", "c"),
 		},
 		{
 			name:  "no old services, but new services added",
-			a:     sets.NewString(),
-			b:     sets.NewString("a", "b", "c"),
-			xor:   sets.NewString("a", "b", "c"),
-			union: sets.NewString("a", "b", "c"),
+			a:     sets.New[string](),
+			b:     sets.New[string]("a", "b", "c"),
+			xor:   sets.New[string]("a", "b", "c"),
+			union: sets.New[string]("a", "b", "c"),
 		},
 		{
 			name:  "one service removed, one service added, two unchanged",
-			a:     sets.NewString("a", "b", "c"),
-			b:     sets.NewString("b", "c", "d"),
-			xor:   sets.NewString("a", "d"),
-			union: sets.NewString("a", "b", "c", "d"),
+			a:     sets.New[string]("a", "b", "c"),
+			b:     sets.New[string]("b", "c", "d"),
+			xor:   sets.New[string]("a", "d"),
+			union: sets.New[string]("a", "b", "c", "d"),
 		},
 		{
 			name:  "no services",
-			a:     sets.NewString(),
-			b:     sets.NewString(),
-			xor:   sets.NewString(),
-			union: sets.NewString(),
+			a:     sets.New[string](),
+			b:     sets.New[string](),
+			xor:   sets.New[string](),
+			union: sets.New[string](),
 		},
 	}
 
@@ -88,12 +88,12 @@ func TestDetermineNeededServiceUpdates(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			retval := determineNeededServiceUpdates(testCase.a, testCase.b, false)
 			if !retval.Equal(testCase.xor) {
-				t.Errorf("%s (with podChanged=false): expected: %v  got: %v", testCase.name, testCase.xor.List(), retval.List())
+				t.Errorf("%s (with podChanged=false): expected: %v  got: %v", testCase.name, sets.List(testCase.xor), sets.List(retval))
 			}
 
 			retval = determineNeededServiceUpdates(testCase.a, testCase.b, true)
 			if !retval.Equal(testCase.union) {
-				t.Errorf("%s (with podChanged=true): expected: %v  got: %v", testCase.name, testCase.union.List(), retval.List())
+				t.Errorf("%s (with podChanged=true): expected: %v  got: %v", testCase.name, sets.List(testCase.union), sets.List(retval))
 			}
 		})
 	}
@@ -364,32 +364,32 @@ func TestGetPodServicesToUpdate(t *testing.T) {
 	tests := []struct {
 		name   string
 		pod    *v1.Pod
-		expect sets.String
+		expect sets.Set[string]
 	}{
 		{
 			name:   "get servicesMemberships for pod-0",
 			pod:    pods[0],
-			expect: sets.NewString("test/service-0"),
+			expect: sets.New[string]("test/service-0"),
 		},
 		{
 			name:   "get servicesMemberships for pod-1",
 			pod:    pods[1],
-			expect: sets.NewString("test/service-1"),
+			expect: sets.New[string]("test/service-1"),
 		},
 		{
 			name:   "get servicesMemberships for pod-2",
 			pod:    pods[2],
-			expect: sets.NewString("test/service-2"),
+			expect: sets.New[string]("test/service-2"),
 		},
 		{
 			name:   "get servicesMemberships for pod-3",
 			pod:    pods[3],
-			expect: sets.NewString(),
+			expect: sets.New[string](),
 		},
 		{
 			name:   "get servicesMemberships for pod-4",
 			pod:    pods[4],
-			expect: sets.NewString(),
+			expect: sets.New[string](),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated type for the set.String and set.NewString for the Endpointslice Utils package.

#### Which issue(s) this PR is related to:
Related to: #133935 

#### Special notes for your reviewer:
The List() Method is also deprecated:
https://pkg.go.dev/k8s.io/apimachinery/pkg/util/sets#String.List
```
t.Errorf("%s (with podChanged=true): expected: %v  got: %v", testCase.name, testCase.union.List(), retval.List())
```

Changing to the List function seems to be the most logical way for me:
https://pkg.go.dev/k8s.io/apimachinery/pkg/util/sets#List

```
t.Errorf("%s (with podChanged=true): expected: %v  got: %v", testCase.name, sets.List(testCase.union), sets.List(retval))
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
