### PR TITLE
Add DRA GPU testing support for NVIDIA T4 GPUs

### DIFF
--- a/test/e2e/node/gpu_dra.go
+++ b/test/e2e/node/gpu_dra.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+const (
+	draDriverNamespace = "kube-system"
+	draDeviceClassName = "gpu.nvidia.com"
+	draDriverName      = "gpu.nvidia.com"
+
+	// DaemonSet name from helm chart (kubetest2-ec2 uses helm template)
+	draDaemonSetName = "nvidia-dra-driver-gpu-kubelet-plugin"
+)
+
+var _ = SIGDescribe(feature.DynamicResourceAllocation, "GPU", framework.WithSerial(), func() {
+
+	f := framework.NewDefaultFramework("dra-gpu")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		e2eskipper.SkipUnlessProviderIs("aws")
+		checkDRADriverReady(ctx, f)
+	})
+
+	f.It("should detect GPUs via DRA ResourceSlice", func(ctx context.Context) {
+		ginkgo.By("Listing ResourceSlices")
+		slices, err := f.ClientSet.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Checking for NVIDIA GPU devices in ResourceSlices")
+		var gpuCount int
+		for _, slice := range slices.Items {
+			if slice.Spec.Driver == draDriverName {
+				gpuCount += len(slice.Spec.Devices)
+				framework.Logf("Found ResourceSlice %s with %d devices from driver %s",
+					slice.Name, len(slice.Spec.Devices), slice.Spec.Driver)
+			}
+		}
+		gomega.Expect(gpuCount).To(gomega.BeNumerically(">", 0),
+			"Expected at least one GPU in ResourceSlices from driver %s", draDriverName)
+		framework.Logf("Total GPUs found via DRA: %d", gpuCount)
+	})
+
+	f.It("should allocate single GPU via ResourceClaim and run nvidia-smi", func(ctx context.Context) {
+		ginkgo.By("Creating a ResourceClaim for a single GPU")
+		claim := &resourceapi.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "single-gpu-" + string(uuid.NewUUID()),
+				Namespace: f.Namespace.Name,
+			},
+			Spec: resourceapi.ResourceClaimSpec{
+				Devices: resourceapi.DeviceClaim{
+					Requests: []resourceapi.DeviceRequest{{
+						Name: "gpu",
+						Exactly: &resourceapi.ExactDeviceRequest{
+							DeviceClassName: draDeviceClassName,
+						},
+					}},
+				},
+			},
+		}
+		claim, err := f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		framework.Logf("Created ResourceClaim: %s", claim.Name)
+
+		ginkgo.By("Creating a pod that uses the ResourceClaim")
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-dra-test-" + string(uuid.NewUUID()),
+				Namespace: f.Namespace.Name,
+			},
+			Spec: v1.PodSpec{
+				ResourceClaims: []v1.PodResourceClaim{{
+					Name:              "gpu",
+					ResourceClaimName: &claim.Name,
+				}},
+				Containers: []v1.Container{{
+					Name:    "nvidia-smi",
+					Image:   "nvidia/cuda:12.5.0-devel-ubuntu22.04",
+					Command: []string{"nvidia-smi"},
+					Resources: v1.ResourceRequirements{
+						Claims: []v1.ResourceClaim{{Name: "gpu"}},
+					},
+				}},
+				RestartPolicy: v1.RestartPolicyNever,
+			},
+		}
+
+		pod = e2epod.NewPodClient(f).Create(ctx, pod)
+
+		ginkgo.By("Waiting for pod to complete")
+		err = e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Checking pod logs for GPU detection")
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "nvidia-smi")
+		framework.ExpectNoError(err)
+		framework.Logf("nvidia-smi output:\n%s", logs)
+		gomega.Expect(logs).To(gomega.ContainSubstring("NVIDIA-SMI"))
+		gomega.Expect(logs).To(gomega.ContainSubstring("Driver Version:"))
+		gomega.Expect(logs).To(gomega.ContainSubstring("CUDA Version:"))
+	})
+
+	f.It("should run TensorFlow matrix multiplication via DRA", func(ctx context.Context) {
+		ginkgo.By("Creating a ResourceClaim for TensorFlow GPU test")
+		claim := &resourceapi.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tf-gpu-" + string(uuid.NewUUID()),
+				Namespace: f.Namespace.Name,
+			},
+			Spec: resourceapi.ResourceClaimSpec{
+				Devices: resourceapi.DeviceClaim{
+					Requests: []resourceapi.DeviceRequest{{
+						Name: "gpu",
+						Exactly: &resourceapi.ExactDeviceRequest{
+							DeviceClassName: draDeviceClassName,
+						},
+					}},
+				},
+			},
+		}
+		claim, err := f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Creating a TensorFlow pod that uses the ResourceClaim")
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tf-matmul-dra-" + string(uuid.NewUUID()),
+				Namespace: f.Namespace.Name,
+			},
+			Spec: v1.PodSpec{
+				ResourceClaims: []v1.PodResourceClaim{{
+					Name:              "gpu",
+					ResourceClaimName: &claim.Name,
+				}},
+				Containers: []v1.Container{{
+					Name:  "gpu-matmul",
+					Image: "tensorflow/tensorflow:latest-gpu",
+					Command: []string{
+						"python",
+						"-c",
+						`
+import tensorflow as tf
+import time
+
+print("TensorFlow version:", tf.__version__)
+print("Num GPUs Available: ", len(tf.config.experimental.list_physical_devices('GPU')))
+
+# Simple matrix multiplication test
+with tf.device('/GPU:0'):
+    a = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    b = tf.constant([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    c = tf.matmul(a, b)
+
+print("Matrix multiplication result:", c.numpy())
+
+# Performance test
+n = 5000
+start_time = time.time()
+with tf.device('/GPU:0'):
+    matrix1 = tf.random.normal((n, n))
+    matrix2 = tf.random.normal((n, n))
+    result = tf.matmul(matrix1, matrix2)
+end_time = time.time()
+
+print(f"Time taken for {n}x{n} matrix multiplication: {end_time - start_time:.2f} seconds")
+`,
+					},
+					Resources: v1.ResourceRequirements{
+						Claims: []v1.ResourceClaim{{Name: "gpu"}},
+					},
+				}},
+				RestartPolicy: v1.RestartPolicyNever,
+			},
+		}
+
+		pod = e2epod.NewPodClient(f).Create(ctx, pod)
+
+		ginkgo.By("Waiting for TensorFlow pod to complete")
+		err = e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Checking TensorFlow output")
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "gpu-matmul")
+		framework.ExpectNoError(err)
+		framework.Logf("TensorFlow output:\n%s", logs)
+		gomega.Expect(logs).To(gomega.ContainSubstring("TensorFlow version"))
+		gomega.Expect(logs).To(gomega.ContainSubstring("Matrix multiplication result:"))
+		gomega.Expect(logs).To(gomega.ContainSubstring("Time taken for 5000x5000 matrix multiplication"))
+	})
+
+	f.It("should share GPU between containers in same pod via DRA", func(ctx context.Context) {
+		ginkgo.By("Creating a ResourceClaim for shared GPU")
+		claim := &resourceapi.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-gpu-" + string(uuid.NewUUID()),
+				Namespace: f.Namespace.Name,
+			},
+			Spec: resourceapi.ResourceClaimSpec{
+				Devices: resourceapi.DeviceClaim{
+					Requests: []resourceapi.DeviceRequest{{
+						Name: "gpu",
+						Exactly: &resourceapi.ExactDeviceRequest{
+							DeviceClassName: draDeviceClassName,
+						},
+					}},
+				},
+			},
+		}
+		claim, err := f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Creating a pod with two containers sharing the same GPU")
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-gpu-pod-" + string(uuid.NewUUID()),
+				Namespace: f.Namespace.Name,
+			},
+			Spec: v1.PodSpec{
+				ResourceClaims: []v1.PodResourceClaim{{
+					Name:              "gpu",
+					ResourceClaimName: &claim.Name,
+				}},
+				Containers: []v1.Container{
+					{
+						Name:    "container-1",
+						Image:   "nvidia/cuda:12.5.0-devel-ubuntu22.04",
+						Command: []string{"nvidia-smi", "-L"},
+						Resources: v1.ResourceRequirements{
+							Claims: []v1.ResourceClaim{{Name: "gpu"}},
+						},
+					},
+					{
+						Name:    "container-2",
+						Image:   "nvidia/cuda:12.5.0-devel-ubuntu22.04",
+						Command: []string{"nvidia-smi", "-L"},
+						Resources: v1.ResourceRequirements{
+							Claims: []v1.ResourceClaim{{Name: "gpu"}},
+						},
+					},
+				},
+				RestartPolicy: v1.RestartPolicyNever,
+			},
+		}
+
+		pod = e2epod.NewPodClient(f).Create(ctx, pod)
+
+		ginkgo.By("Waiting for shared GPU pod to complete")
+		err = e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Verifying both containers see the GPU")
+		logs1, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "container-1")
+		framework.ExpectNoError(err)
+		logs2, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "container-2")
+		framework.ExpectNoError(err)
+
+		framework.Logf("Container 1 output:\n%s", logs1)
+		framework.Logf("Container 2 output:\n%s", logs2)
+
+		gomega.Expect(logs1).To(gomega.ContainSubstring("GPU"))
+		gomega.Expect(logs2).To(gomega.ContainSubstring("GPU"))
+	})
+})
+
+// checkDRADriverReady verifies the NVIDIA DRA driver is deployed and ready.
+// Fails the test if the driver is not available.
+func checkDRADriverReady(ctx context.Context, f *framework.Framework) {
+	ginkgo.By("Checking for NVIDIA DRA driver")
+
+	// Check DaemonSet exists and is ready
+	ds, err := f.ClientSet.AppsV1().DaemonSets(draDriverNamespace).Get(ctx, draDaemonSetName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "NVIDIA DRA driver DaemonSet %s/%s not deployed", draDriverNamespace, draDaemonSetName)
+	gomega.Expect(ds.Status.NumberReady).To(gomega.BeNumerically(">", 0),
+		"NVIDIA DRA driver not ready: 0 pods ready")
+
+	// Check DeviceClass exists
+	_, err = f.ClientSet.ResourceV1().DeviceClasses().Get(ctx, draDeviceClassName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "DeviceClass %s not found", draDeviceClassName)
+
+	// Check ResourceSlices have GPUs
+	slices, err := f.ClientSet.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	framework.ExpectNoError(err, "Failed to list ResourceSlices")
+	var gpuCount int
+	for _, slice := range slices.Items {
+		if slice.Spec.Driver == draDriverName {
+			gpuCount += len(slice.Spec.Devices)
+		}
+	}
+	gomega.Expect(gpuCount).To(gomega.BeNumerically(">", 0),
+		"No GPUs found in ResourceSlices from driver %s", draDriverName)
+
+	framework.Logf("DRA driver ready: %d pods, %d GPUs", ds.Status.NumberReady, gpuCount)
+}


### PR DESCRIPTION
Add Dynamic Resource Allocation (DRA) based GPU e2e tests. Tests expect the NVIDIA DRA driver to be pre-deployed via kubetest2-ec2 using the --dra-nvidia flag (which uses helm template). the tests are not AWS specific, will work on GCP as well.

Tests:
- ResourceSlice detection for NVIDIA GPUs
- Single GPU allocation via ResourceClaim with nvidia-smi
- TensorFlow matrix multiplication benchmark
- Shared GPU between containers in same pod

We have had device-plugin based GPU testing for a long time. Since DRA is the future, it makes sense to add some limited testing.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

Not a new feature, but a test for DRA :)

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
