### PR TITLE
Show the critical pod UID to preemption event message

### DIFF
--- a/pkg/kubelet/preemption/preemption.go
+++ b/pkg/kubelet/preemption/preemption.go
@@ -100,7 +100,7 @@ func (c *CriticalPodAdmissionHandler) evictPodsToFreeRequests(ctx context.Contex
 	preemptionMsg := fmt.Sprintf("%s: %s", message, admitPod.UID)
 	for _, pod := range podsToPreempt {
 		// record that we are evicting the pod
-		c.recorder.Eventf(pod, v1.EventTypeWarning, events.PreemptContainer, preemptionMsg)
+		c.recorder.Eventf(pod, v1.EventTypeWarning, events.PreemptContainer, "%s", preemptionMsg)
 		// this is a blocking call and should only return when the pod and its containers are killed.
 		logger.V(2).Info("Preempting pod to free up resources", "pod", klog.KObj(pod), "podUID", pod.UID, "insufficientResources", insufficientResources.toString(), "requestingPod", klog.KObj(admitPod))
 		err := c.killPodFunc(pod, true, nil, func(status *v1.PodStatus) {

--- a/pkg/kubelet/preemption/preemption.go
+++ b/pkg/kubelet/preemption/preemption.go
@@ -97,7 +97,7 @@ func (c *CriticalPodAdmissionHandler) evictPodsToFreeRequests(ctx context.Contex
 	if err != nil {
 		return fmt.Errorf("preemption: error finding a set of pods to preempt: %v", err)
 	}
-	preemptionMsg := fmt.Sprintf("%s: %s", message, klog.KObj(admitPod))
+	preemptionMsg := fmt.Sprintf("%s: %s", message, admitPod.UID)
 	for _, pod := range podsToPreempt {
 		// record that we are evicting the pod
 		c.recorder.Eventf(pod, v1.EventTypeWarning, events.PreemptContainer, preemptionMsg)

--- a/pkg/kubelet/preemption/preemption_test.go
+++ b/pkg/kubelet/preemption/preemption_test.go
@@ -23,8 +23,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
 	kubeapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -221,7 +221,7 @@ func TestHandleAdmissionFailure(t *testing.T) {
 
 			// Verify status message
 			if !r.expectErr && len(outputPods) > 0 {
-				expectedCurrentMsg := fmt.Sprintf("%s: %s", message, klog.KObj(admitPodRef))
+				expectedCurrentMsg := fmt.Sprintf("%s: %s", message, admitPodRef.UID)
 				for _, p := range outputPods {
 					if status, ok := podKiller.podStatus[p.Name]; ok {
 						if status.Message != expectedCurrentMsg {
@@ -617,6 +617,7 @@ func getPodWithResources(name string, requests v1.ResourceRequirements) *v1.Pod 
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: name,
+			UID:          types.UID(name + "-uid"),
 			Annotations:  map[string]string{},
 		},
 		Spec: v1.PodSpec{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Previously, the event simply stated "Preempted in order to admit critical pod" without identifying which pod caused the preemption. This change appends the admitting pod's name to the message, making it easier to understand why a specific pod was evicted.

#### Which issue(s) this PR is related to:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Kubelet preemption events now include the name of the critical pod in the event message (e.g., "Preempted in order to admit critical pod: <pod-uid>").
```