### PR TITLE
Fix kubectl create configmap example

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -64,11 +64,8 @@ var (
 		  # Create a new config map named my-config with key1=config1 and key2=config2
 		  kubectl create configmap my-config --from-literal=key1=config1 --from-literal=key2=config2
 
-		  # Create a new config map named my-config from the key=value pairs in the file
-		  kubectl create configmap my-config --from-file=path/to/bar
-
-		  # Create a new config map named my-config from an env file
-		  kubectl create configmap my-config --from-env-file=path/to/foo.env --from-env-file=path/to/bar.env`))
+		  # Create a new config map named my-config with key=value pairs from an env file
+		  kubectl create configmap my-config --from-env-file=path/to/bar.env`))
 )
 
 // ConfigMapOptions holds properties for create configmap sub-command


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

example 4 and example 1 are the same but example 4 comment is about key=value from file which needs --from-env-file not --from-file

#### Which issue(s) this PR is related to:

Fixes kubernetes/website#54270

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```