### PR TITLE
api: enable optionalorrequired linter for authentication API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2924,9 +2924,6 @@
           "description": "status is filled in by the server and indicates whether the token can be authenticated."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -2957,9 +2954,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "audiences"
-      ],
       "type": "object"
     },
     "io.k8s.api.authentication.v1.TokenRequestStatus": {
@@ -2974,10 +2968,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "token",
-        "expirationTimestamp"
-      ],
       "type": "object"
     },
     "io.k8s.api.authentication.v1.TokenReview": {
@@ -3032,6 +3022,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "token"
+      ],
       "type": "object"
     },
     "io.k8s.api.authentication.v1.TokenReviewStatus": {

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -62,9 +62,6 @@
             "description": "status is filled in by the server and indicates whether the token can be authenticated."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -100,9 +97,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "audiences"
-        ],
         "type": "object"
       },
       "io.k8s.api.authentication.v1.TokenRequestStatus": {
@@ -122,10 +116,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "token",
-          "expirationTimestamp"
-        ],
         "type": "object"
       },
       "io.k8s.api.autoscaling.v1.Scale": {

--- a/api/openapi-spec/v3/apis__authentication.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__authentication.k8s.io__v1_openapi.json
@@ -123,6 +123,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "token"
+        ],
         "type": "object"
       },
       "io.k8s.api.authentication.v1.TokenReviewStatus": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -215,7 +215,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -226,7 +226,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -91,7 +91,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -11996,7 +11996,6 @@ func schema_k8sio_api_authentication_v1_TokenRequest(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -12045,7 +12044,6 @@ func schema_k8sio_api_authentication_v1_TokenRequestSpec(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"audiences"},
 			},
 		},
 		Dependencies: []string{
@@ -12075,7 +12073,6 @@ func schema_k8sio_api_authentication_v1_TokenRequestStatus(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"token", "expirationTimestamp"},
 			},
 		},
 		Dependencies: []string{
@@ -12169,6 +12166,7 @@ func schema_k8sio_api_authentication_v1_TokenReviewSpec(ref common.ReferenceCall
 						},
 					},
 				},
+				Required: []string{"token"},
 			},
 		},
 	}
@@ -12516,6 +12514,7 @@ func schema_k8sio_api_authentication_v1beta1_TokenReviewSpec(ref common.Referenc
 						},
 					},
 				},
+				Required: []string{"token"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/authentication/v1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1/generated.proto
@@ -66,6 +66,7 @@ message SelfSubjectReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // status is filled in by the server with the user attributes.
+  // +optional
   optional SelfSubjectReviewStatus status = 2;
 }
 
@@ -84,6 +85,7 @@ message TokenRequest {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated
+  // +optional
   optional TokenRequestSpec spec = 2;
 
   // status is filled in by the server and indicates whether the token can be authenticated.
@@ -99,6 +101,7 @@ message TokenRequestSpec {
   // token issued for multiple audiences may be used to authenticate
   // against any of the audiences listed but implies a high degree of
   // trust between the target audiences.
+  // +optional
   // +listType=atomic
   repeated string audiences = 1;
 
@@ -120,9 +123,11 @@ message TokenRequestSpec {
 // TokenRequestStatus is the result of a token request.
 message TokenRequestStatus {
   // token is the opaque bearer token.
+  // +optional
   optional string token = 1;
 
   // expirationTimestamp is the time of expiration of the returned token.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time expirationTimestamp = 2;
 }
 
@@ -136,6 +141,7 @@ message TokenReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated
+  // +required
   optional TokenReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request can be authenticated.
@@ -146,7 +152,7 @@ message TokenReview {
 // TokenReviewSpec is a description of the token authentication request.
 message TokenReviewSpec {
   // token is the opaque bearer token.
-  // +optional
+  // +required
   optional string token = 1;
 
   // audiences is a list of the identifiers that the resource server presented

--- a/staging/src/k8s.io/api/authentication/v1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1/types.go
@@ -58,6 +58,7 @@ type TokenReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated
+	// +required
 	Spec TokenReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request can be authenticated.
@@ -68,7 +69,7 @@ type TokenReview struct {
 // TokenReviewSpec is a description of the token authentication request.
 type TokenReviewSpec struct {
 	// token is the opaque bearer token.
-	// +optional
+	// +required
 	Token string `json:"token,omitempty" protobuf:"bytes,1,opt,name=token"`
 	// audiences is a list of the identifiers that the resource server presented
 	// with the token identifies as. Audience-aware token authenticators will
@@ -146,6 +147,7 @@ type TokenRequest struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated
+	// +optional
 	Spec TokenRequestSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the token can be authenticated.
@@ -161,6 +163,7 @@ type TokenRequestSpec struct {
 	// token issued for multiple audiences may be used to authenticate
 	// against any of the audiences listed but implies a high degree of
 	// trust between the target audiences.
+	// +optional
 	// +listType=atomic
 	Audiences []string `json:"audiences" protobuf:"bytes,1,rep,name=audiences"`
 
@@ -182,8 +185,10 @@ type TokenRequestSpec struct {
 // TokenRequestStatus is the result of a token request.
 type TokenRequestStatus struct {
 	// token is the opaque bearer token.
+	// +optional
 	Token string `json:"token" protobuf:"bytes,1,opt,name=token"`
 	// expirationTimestamp is the time of expiration of the returned token.
+	// +optional
 	ExpirationTimestamp metav1.Time `json:"expirationTimestamp" protobuf:"bytes,2,opt,name=expirationTimestamp"`
 }
 
@@ -220,6 +225,7 @@ type SelfSubjectReview struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// status is filled in by the server with the user attributes.
+	// +optional
 	Status SelfSubjectReviewStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 }
 

--- a/staging/src/k8s.io/api/authentication/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1alpha1/generated.proto
@@ -39,6 +39,7 @@ message SelfSubjectReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // status is filled in by the server with the user attributes.
+  // +optional
   optional SelfSubjectReviewStatus status = 2;
 }
 

--- a/staging/src/k8s.io/api/authentication/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1alpha1/types.go
@@ -37,6 +37,7 @@ type SelfSubjectReview struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// status is filled in by the server with the user attributes.
+	// +optional
 	Status SelfSubjectReviewStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 }
 

--- a/staging/src/k8s.io/api/authentication/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1beta1/generated.proto
@@ -48,6 +48,7 @@ message SelfSubjectReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // status is filled in by the server with the user attributes.
+  // +optional
   optional SelfSubjectReviewStatus status = 2;
 }
 
@@ -68,6 +69,7 @@ message TokenReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated
+  // +required
   optional TokenReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the token can be authenticated.
@@ -78,7 +80,7 @@ message TokenReview {
 // TokenReviewSpec is a description of the token authentication request.
 message TokenReviewSpec {
   // token is the opaque bearer token.
-  // +optional
+  // +required
   optional string token = 1;
 
   // audiences is a list of the identifiers that the resource server presented

--- a/staging/src/k8s.io/api/authentication/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1beta1/types.go
@@ -42,6 +42,7 @@ type TokenReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated
+	// +required
 	Spec TokenReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the token can be authenticated.
@@ -52,7 +53,7 @@ type TokenReview struct {
 // TokenReviewSpec is a description of the token authentication request.
 type TokenReviewSpec struct {
 	// token is the opaque bearer token.
-	// +optional
+	// +required
 	Token string `json:"token,omitempty" protobuf:"bytes,1,opt,name=token"`
 	// audiences is a list of the identifiers that the resource server presented
 	// with the token identifies as. Audience-aware token authenticators will
@@ -134,6 +135,7 @@ type SelfSubjectReview struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// status is filled in by the server with the user attributes.
+	// +optional
 	Status SelfSubjectReviewStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add missing `+optional` and `+required` markers to authentication API types across v1, v1beta1, and v1alpha1 versions to satisfy the `optionalorrequired` linter rule and enable the linter for the authentication API group.

#### Which issue(s) this PR fixes:

Part of #134671

#### Special notes for your reviewer:

This adds `// +required` markers to:
- `TokenReview.Spec` in v1, v1beta1
- `TokenRequest.Spec` in v1
- `TokenRequestSpec.Audiences` in v1
- `TokenRequestStatus.Token` in v1
- `TokenRequestStatus.ExpirationTimestamp` in v1

This adds `// +optional` markers to:
- `SelfSubjectReview.Status` in v1, v1beta1, v1alpha1

These fields without `omitempty` in their JSON tags are marked as `+required`, while the status fields with `omitempty` are marked as `+optional` since they are populated by the server and may not be set initially.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```