### PR TITLE
e2e tests netpol: Set getProbeTimeoutSeconds to 3

### DIFF
--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -321,13 +321,15 @@ func (k *kubeManager) getNamespace(ctx context.Context, ns string) (*v1.Namespac
 	return selectedNameSpace, nil
 }
 
-// getProbeTimeoutSeconds returns a timeout for how long the probe should work before failing a check, and takes windows heuristics into account, where requests can take longer sometimes.
+// getProbeTimeoutSeconds returns a timeout for how long the probe should work before failing a
+// check. The 3-second timeout not only ensures probe reliability across different platforms,
+// but also serves as an assertion on the non-functional requirement that the dataplane must
+// program network policies within an acceptable latency. This is especially critical for
+// network policy features where slow dataplane programming could impact connectivity and security.
+// The 3-second threshold was determined through empirical evidence as the maximum acceptable
+// latency for network policy enforcement.
 func getProbeTimeoutSeconds() int {
-	timeoutSeconds := 1
-	if framework.NodeOSDistroIs("windows") {
-		timeoutSeconds = 3
-	}
-	return timeoutSeconds
+	return 3
 }
 
 // getWorkers returns the number of workers suggested to run when testing.


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

e2e tests netpol: Set getProbeTimeoutSeconds to 3

Before tests sometimes failed randomly. For example:

> [It] [sig-network] Netpol NetworkPolicy between server and client should allow ingress access from updated namespace [Feature:NetworkPolicy]


#### Special notes for your reviewer:

Related: https://kubernetes.slack.com/archives/C09QYUH5W/p1770111316158039

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

