### PR TITLE
Split from concurrent-node-syncs a separate flag for node status updates

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -146,6 +146,7 @@ API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudS
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,RouteReconciliationPeriod
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,UseServiceAccountCredentials
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,WebhookConfiguration,Webhooks
+API rule violation: names_match,k8s.io/cloud-provider/controllers/node/config/v1alpha1,NodeControllerConfiguration,ConcurrentNodeStatusUpdates
 API rule violation: names_match,k8s.io/cloud-provider/controllers/node/config/v1alpha1,NodeControllerConfiguration,ConcurrentNodeSyncs
 API rule violation: names_match,k8s.io/cloud-provider/controllers/service/config/v1alpha1,ServiceControllerConfiguration,ConcurrentServiceSyncs
 API rule violation: names_match,k8s.io/controller-manager/config/v1alpha1,GenericControllerManagerConfiguration,Address

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -64235,8 +64235,16 @@ func schema_controllers_node_config_v1alpha1_NodeControllerConfiguration(ref com
 							Format:      "int32",
 						},
 					},
+					"ConcurrentNodeStatusUpdates": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ConcurrentNodeStatusUpdates is the number of workers concurrently updating node statuses. If unspecified or 0, ConcurrentNodeSyncs is used instead",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
-				Required: []string{"ConcurrentNodeSyncs"},
+				Required: []string{"ConcurrentNodeSyncs", "ConcurrentNodeStatusUpdates"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/cloud-provider/app/core.go
+++ b/staging/src/k8s.io/cloud-provider/app/core.go
@@ -48,6 +48,7 @@ func startCloudNodeController(ctx context.Context, initContext ControllerInitCon
 		cloud,
 		completedConfig.ComponentConfig.NodeStatusUpdateFrequency.Duration,
 		completedConfig.ComponentConfig.NodeController.ConcurrentNodeSyncs,
+		completedConfig.ComponentConfig.NodeController.ConcurrentNodeStatusUpdates,
 	)
 	if err != nil {
 		klog.Warningf("failed to start cloud node controller: %s", err)

--- a/staging/src/k8s.io/cloud-provider/controllers/node/config/types.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/config/types.go
@@ -21,4 +21,8 @@ type NodeControllerConfiguration struct {
 	// ConcurrentNodeSyncs is the number of workers
 	// concurrently synchronizing nodes
 	ConcurrentNodeSyncs int32
+	// ConcurrentNodeStatusUpdates is the number of workers
+	// concurrently updating node statuses.
+	// If unspecified or 0, ConcurrentNodeSyncs is used instead
+	ConcurrentNodeStatusUpdates int32
 }

--- a/staging/src/k8s.io/cloud-provider/controllers/node/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/config/v1alpha1/types.go
@@ -21,4 +21,8 @@ type NodeControllerConfiguration struct {
 	// ConcurrentNodeSyncs is the number of workers
 	// concurrently synchronizing nodes
 	ConcurrentNodeSyncs int32
+	// ConcurrentNodeStatusUpdates is the number of workers
+	// concurrently updating node statuses.
+	// If unspecified or 0, ConcurrentNodeSyncs is used instead
+	ConcurrentNodeStatusUpdates int32
 }

--- a/staging/src/k8s.io/cloud-provider/controllers/node/config/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/config/v1alpha1/zz_generated.conversion.go
@@ -49,10 +49,12 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1alpha1_NodeControllerConfiguration_To_config_NodeControllerConfiguration(in *NodeControllerConfiguration, out *config.NodeControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentNodeSyncs = in.ConcurrentNodeSyncs
+	out.ConcurrentNodeStatusUpdates = in.ConcurrentNodeStatusUpdates
 	return nil
 }
 
 func autoConvert_config_NodeControllerConfiguration_To_v1alpha1_NodeControllerConfiguration(in *config.NodeControllerConfiguration, out *NodeControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentNodeSyncs = in.ConcurrentNodeSyncs
+	out.ConcurrentNodeStatusUpdates = in.ConcurrentNodeStatusUpdates
 	return nil
 }

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
@@ -2788,6 +2788,7 @@ func TestUpdateNodeStatus(t *testing.T) {
 				recorder:                  eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"}),
 				nodeStatusUpdateFrequency: 1 * time.Second,
 				workerCount:               test.workers,
+				statusUpdateWorkerCount:   test.workers,
 			}
 
 			for _, n := range generateNodes(test.nodes) {

--- a/staging/src/k8s.io/cloud-provider/options/nodecontroller_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/nodecontroller_test.go
@@ -35,7 +35,7 @@ func errSliceEq(a []error, b []error) bool {
 	return true
 }
 
-func TestNodeControllerConcurrentNodeSyncsValidation(t *testing.T) {
+func TestNodeControllerValidation(t *testing.T) {
 	testCases := []struct {
 		desc   string
 		input  *NodeControllerOptions
@@ -45,18 +45,27 @@ func TestNodeControllerConcurrentNodeSyncsValidation(t *testing.T) {
 			desc: "empty options",
 		},
 		{
-			desc:   "negative value",
+			desc:   "concurrent-node-syncs negative value",
 			input:  &NodeControllerOptions{NodeControllerConfiguration: &nodeconfig.NodeControllerConfiguration{ConcurrentNodeSyncs: -5}},
 			expect: []error{fmt.Errorf("concurrent-node-syncs must be a positive number")},
 		},
 		{
-			desc:   "zero value",
+			desc:   "concurrent-node-syncs zero value",
 			input:  &NodeControllerOptions{NodeControllerConfiguration: &nodeconfig.NodeControllerConfiguration{ConcurrentNodeSyncs: 0}},
 			expect: []error{fmt.Errorf("concurrent-node-syncs must be a positive number")},
 		},
 		{
-			desc:  "positive value",
+			desc:  "concurrent-node-syncs positive value, concurrent-node-status-updates default 0",
 			input: &NodeControllerOptions{NodeControllerConfiguration: &nodeconfig.NodeControllerConfiguration{ConcurrentNodeSyncs: 5}},
+		},
+		{
+			desc:  "concurrent-node-syncs positive value, concurrent-node-status-updates positive value",
+			input: &NodeControllerOptions{NodeControllerConfiguration: &nodeconfig.NodeControllerConfiguration{ConcurrentNodeSyncs: 5, ConcurrentNodeStatusUpdates: 5}},
+		},
+		{
+			desc:   "concurrent-node-syncs positive value, concurrent-node-status-updates negative value",
+			input:  &NodeControllerOptions{NodeControllerConfiguration: &nodeconfig.NodeControllerConfiguration{ConcurrentNodeSyncs: 5, ConcurrentNodeStatusUpdates: -1}},
+			expect: []error{fmt.Errorf("concurrent-node-status-updates cannot be a negative number")},
 		},
 	}
 	for _, tc := range testCases {

--- a/staging/src/k8s.io/cloud-provider/options/options.go
+++ b/staging/src/k8s.io/cloud-provider/options/options.go
@@ -242,7 +242,9 @@ func (o *CloudControllerManagerOptions) ApplyTo(c *config.Config, allControllers
 	// sync back to component config
 	// TODO: find more elegant way than syncing back the values.
 	c.ComponentConfig.NodeStatusUpdateFrequency = o.NodeStatusUpdateFrequency
-	c.ComponentConfig.NodeController.ConcurrentNodeSyncs = o.NodeController.ConcurrentNodeSyncs
+	if err = o.NodeController.ApplyTo(&c.ComponentConfig.NodeController); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -423,7 +423,11 @@ func TestCreateConfig(t *testing.T) {
 			ServiceController: serviceconfig.ServiceControllerConfiguration{
 				ConcurrentServiceSyncs: 1,
 			},
-			NodeController:            nodeconfig.NodeControllerConfiguration{ConcurrentNodeSyncs: 1},
+			NodeController: nodeconfig.NodeControllerConfiguration{
+				ConcurrentNodeSyncs: 1,
+				// ConcurrentNodeStatusUpdates should default to the value of ConcurrentNodeSyncs only at the stage of config creation
+				ConcurrentNodeStatusUpdates: 1,
+			},
 			NodeStatusUpdateFrequency: metav1.Duration{Duration: 10 * time.Minute},
 			Webhook: cpconfig.WebhookConfiguration{
 				Webhooks: []string{"foo", "bar", "-baz"},
@@ -491,6 +495,7 @@ func TestCreateConfigWithoutWebHooks(t *testing.T) {
 		"--controller-start-interval=2m",
 		"--controllers=foo,bar",
 		"--concurrent-node-syncs=1",
+		"--concurrent-node-status-updates=2",
 		"--http2-max-streams-per-connection=47",
 		"--kube-api-burst=101",
 		"--kube-api-content-type=application/vnd.kubernetes.protobuf",
@@ -564,7 +569,10 @@ func TestCreateConfigWithoutWebHooks(t *testing.T) {
 			ServiceController: serviceconfig.ServiceControllerConfiguration{
 				ConcurrentServiceSyncs: 1,
 			},
-			NodeController:            nodeconfig.NodeControllerConfiguration{ConcurrentNodeSyncs: 1},
+			NodeController: nodeconfig.NodeControllerConfiguration{
+				ConcurrentNodeSyncs:         1,
+				ConcurrentNodeStatusUpdates: 2,
+			},
 			NodeStatusUpdateFrequency: metav1.Duration{Duration: 10 * time.Minute},
 			Webhook:                   cpconfig.WebhookConfiguration{},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
/kind api-change

#### What this PR does / why we need it:

Currently the value of concurrent-node-syncs flag in cloud-controller-manager controls both the number of sync workers and the number of node status update workers.
This decoupling will allow to tune them separately.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

To maintain backwards compatibility the value will be derived from concurrent-node-syncs if the new flag is not specified

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a new concurrent-node-status-updates flag that is split from the concurrent-node-syncs flag
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
