### PR TITLE
E2E gce: extend cluster initialization timeout

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -139,7 +139,11 @@ PREEXISTING_NETWORK_MODE=""
 
 KUBE_PROMPT_FOR_UPDATE=${KUBE_PROMPT_FOR_UPDATE:-"n"}
 # How long (in seconds) to wait for cluster initialization.
-KUBE_CLUSTER_INITIALIZATION_TIMEOUT=${KUBE_CLUSTER_INITIALIZATION_TIMEOUT:-300}
+#
+# This includes the time to download packages from a remote
+# repo like http://us-central1.gce.archive.ubuntu.com/ubuntu,
+# so this can vary quite a bit.
+KUBE_CLUSTER_INITIALIZATION_TIMEOUT=${KUBE_CLUSTER_INITIALIZATION_TIMEOUT:-600}
 
 function join_csv() {
   local IFS=','; echo "$*";
@@ -3582,6 +3586,7 @@ function check-cluster() {
       local elapsed
       elapsed=$(($(date +%s) - start_time))
       if [[ ${elapsed} -gt ${KUBE_CLUSTER_INITIALIZATION_TIMEOUT} ]]; then
+          echo
           echo -e "${color_red}Cluster failed to initialize within ${KUBE_CLUSTER_INITIALIZATION_TIMEOUT} seconds.${color_norm}" >&2
           echo "Last output from querying API server follows:" >&2
           echo "-----------------------------------------------------" >&2


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

This includes the time to download packages from a remote repo like http://us-central1.gce.archive.ubuntu.com/ubuntu, so this can vary quite a bit.

In practice, "normal" setup time for the master is under two minutes, but also has been observed to be still downloading packages after almost three minutes - see https://github.com/kubernetes/kubernetes/issues/136708#issuecomment-3840882524.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/136708

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
