### PR TITLE
feat(kubectl): warn when deletion is blocked by finalizers

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -517,7 +517,7 @@ func (o *DeleteOptions) PrintObj(info *resource.Info, response runtime.Object) {
 					finalizersList = append(finalizersList[:3], fmt.Sprintf("and %d more", len(finalizersList)-3))
 				}
 				finalizers := strings.Join(finalizersList, ", ")
-				msg := fmt.Sprintf("Warning: the resource %q has finalizers (%s) and will not be deleted until they are removed.\n", info.Name, finalizers)
+				msg := fmt.Sprintf("Warning: Resource %q has finalizers (%s) and will not be deleted until they are removed.\n", info.Name, finalizers)
 				o.WarningPrinter.Print(msg)
 			}
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -517,7 +517,7 @@ func (o *DeleteOptions) PrintObj(info *resource.Info, response runtime.Object) {
 					finalizersList = append(finalizersList[:3], fmt.Sprintf("and %d more", len(finalizersList)-3))
 				}
 				finalizers := strings.Join(finalizersList, ", ")
-				msg := fmt.Sprintf(" The resource %q has finalizers (%s) and will not be deleted until they are removed.\n", info.Name, finalizers)
+				msg := fmt.Sprintf("Warning: the resource %q has finalizers (%s) and will not be deleted until they are removed.\n", info.Name, finalizers)
 				o.WarningPrinter.Print(msg)
 			}
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -833,12 +833,21 @@ func TestDeleteObjectWithFinalizersWarning(t *testing.T) {
 
 	streams, _, _, errOut := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdDelete(tf, streams)
-	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
-	cmd.Flags().Set("cascade", "false")
-	cmd.Flags().Set("output", "name")
+	err := cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	err = cmd.Flags().Set("cascade", "false")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	err = cmd.Flags().Set("output", "name")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
 	cmd.Run(cmd, []string{})
 
-	expectedWarningPart := "The resource \"redis-master\" has finalizers (foregroundDeletion, another-finalizer, third-finalizer, and 1 more) and will not be deleted until they are removed."
+	expectedWarningPart := "Warning: the resource \"redis-master\" has finalizers (foregroundDeletion, another-finalizer, third-finalizer, and 1 more) and will not be deleted until they are removed."
 	if !strings.Contains(errOut.String(), expectedWarningPart) {
 		t.Errorf("expected warning to contain %q, got %q", expectedWarningPart, errOut.String())
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -833,21 +833,12 @@ func TestDeleteObjectWithFinalizersWarning(t *testing.T) {
 
 	streams, _, _, errOut := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdDelete(tf, streams)
-	err := cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-	err = cmd.Flags().Set("cascade", "false")
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-	err = cmd.Flags().Set("output", "name")
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
+	_ = cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
+	_ = cmd.Flags().Set("cascade", "false")
+	_ = cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	expectedWarningPart := "Warning: the resource \"redis-master\" has finalizers (foregroundDeletion, another-finalizer, third-finalizer, and 1 more) and will not be deleted until they are removed."
+	expectedWarningPart := "Warning: Resource \"redis-master\" has finalizers (foregroundDeletion, another-finalizer, third-finalizer, and 1 more) and will not be deleted until they are removed."
 	if !strings.Contains(errOut.String(), expectedWarningPart) {
 		t.Errorf("expected warning to contain %q, got %q", expectedWarningPart, errOut.String())
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR improves the user experience of `kubectl delete` when a resource cannot be deleted immediately due to pending finalizers (e.g., AWS ALB controller resources, ExternalSecrets).
Currently, `kubectl delete` reports `"<resource>" deleted` (to stdout) even if the deletion is blocked by a finalizer. This leads to user confusion ("Why is it still there?") and breaks GitOps sync loops that believe the resource is gone.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

I used the `WarningPrinter` to ensure the message goes to `stderr` and follows standard warning formatting. A unit test has been added to verify the warning logic.

#### Does this PR introduce a user-facing change?

```release-note
`kubectl delete` now displays a "Warning: " prefix when a resource deletion is blocked by finalizers.