### PR TITLE
Fix missing GetSharedDeviceIDs bug in GatherAllocatedState

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/allocateddevices.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/allocateddevices.go
@@ -120,6 +120,13 @@ func (a *allocatedDevices) Get() (sets.Set[structured.DeviceID], int64) {
 	return a.ids.Clone(), a.revision
 }
 
+func (a *allocatedDevices) GetSharedDeviceIDs() (sets.Set[structured.SharedDeviceID], int64) {
+	a.mutex.RLock()
+	defer a.mutex.RUnlock()
+
+	return a.shareIDs.Clone(), a.revision
+}
+
 func (a *allocatedDevices) Capacities() (structured.ConsumedCapacityCollection, int64) {
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/schedulerapi/types.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/schedulerapi/types.go
@@ -58,6 +58,10 @@ func (d SharedDeviceID) String() string {
 	return deviceIDStr
 }
 
+func (d SharedDeviceID) GetBaseDeviceID() DeviceID {
+	return MakeDeviceID(d.Driver.String(), d.Pool.String(), d.Device.String())
+}
+
 // MakeSharedDeviceID creates a new SharedDeviceID from a DeviceID and share ID.
 // This function is used in consumable capacity features and the scheduler.
 func MakeSharedDeviceID(deviceID DeviceID, shareID *types.UID) SharedDeviceID {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix bug found by unit test in "pkg/scheduler/framework/plugins/noderesources" when enable DRAConsumableCapacity by default for the following test cases: 
- DRA-backed-resource-with-shared-device-allocation
- DRA-backed-resource-multiple-devices-mixed-allocation

Root cause: `GatherAllocatedState` doesn't initialize sharedDeviceIDs from non-inflight allocation.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5075

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug where the DRA manager did not initialize sharedID from cache when DRAConsumableCapacity is enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/5075
```
