### PR TITLE
fix(kube-proxy): skip topology hints logging when no ready endpoints exist

### DIFF
--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -168,6 +168,7 @@ func topologyModeFromHints(svcInfo ServicePort, endpoints []Endpoint, nodeName, 
 		return ""
 	}
 
+	hasReadyEndpoints := false
 	hasEndpointForNode := false
 	allEndpointsHaveNodeHints := true
 	hasEndpointForZone := false
@@ -176,6 +177,7 @@ func topologyModeFromHints(svcInfo ServicePort, endpoints []Endpoint, nodeName, 
 		if !endpoint.IsReady() {
 			continue
 		}
+		hasReadyEndpoints = true
 
 		if endpoint.NodeHints().Len() == 0 {
 			allEndpointsHaveNodeHints = false
@@ -188,6 +190,11 @@ func topologyModeFromHints(svcInfo ServicePort, endpoints []Endpoint, nodeName, 
 		} else if endpoint.ZoneHints().Has(zone) {
 			hasEndpointForZone = true
 		}
+	}
+
+	// If no ready endpoints exist, there are no hints to consider
+	if !hasReadyEndpoints {
+		return ""
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.PreferSameTrafficDistribution) {

--- a/pkg/proxy/topology_test.go
+++ b/pkg/proxy/topology_test.go
@@ -398,6 +398,15 @@ func TestCategorizeEndpoints(t *testing.T) {
 		clusterEndpoints: nil,
 		localEndpoints:   nil,
 		allEndpoints:     nil,
+	}, {
+		name:       "single endpoint not ready, not serving, not terminating",
+		nodeLabels: map[string]string{v1.LabelTopologyZone: "zone-a"},
+		serviceInfo: &BaseServicePortInfo{},
+		endpoints: []Endpoint{
+			&BaseEndpointInfo{endpoint: "10.0.0.0:80", ready: false, serving: false, terminating: false},
+		},
+		clusterEndpoints: sets.New[string](),
+		localEndpoints:   nil,
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When all endpoints are non-ready (ready=false, serving=false, terminating=false), the topologyModeFromHints function was incorrectly logging "Ignoring same-zone topology hints for service since no hints were provided for zone" because the boolean flags remained at their initial values after the loop skipped all non-ready endpoints.

This fix adds tracking for whether any ready endpoints were processed and returns early if none exist, avoiding misleading log messages.

Also adds a test case covering this scenario.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/136740