### PR TITLE
Use quantity.Sign() instead of quantity.Cmp(zeroQuantity)

### DIFF
--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -18,7 +18,6 @@ package qos
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/apis/core"
@@ -43,10 +42,6 @@ func GetPodQOS(pod *v1.Pod) v1.PodQOSClass {
 	return ComputePodQOS(pod)
 }
 
-// zeroQuantity represents a resource.Quantity with value "0", used as a baseline
-// for resource comparisons.
-var zeroQuantity = resource.MustParse("0")
-
 // processResourceList adds non-zero quantities for supported QoS compute resources
 // quantities from newList to list.
 func processResourceList(list, newList v1.ResourceList) {
@@ -54,7 +49,7 @@ func processResourceList(list, newList v1.ResourceList) {
 		if !isSupportedQoSComputeResource(name) {
 			continue
 		}
-		if quantity.Cmp(zeroQuantity) == 1 {
+		if quantity.Sign() == 1 {
 			delta := quantity.DeepCopy()
 			if _, exists := list[name]; !exists {
 				list[name] = delta
@@ -75,7 +70,7 @@ func getQOSResources(list v1.ResourceList) sets.Set[string] {
 		if !isSupportedQoSComputeResource(name) {
 			continue
 		}
-		if quantity.Cmp(zeroQuantity) == 1 {
+		if quantity.Sign() == 1 {
 			qosResources.Insert(string(name))
 		}
 	}
@@ -120,7 +115,7 @@ func ComputePodQOS(pod *v1.Pod) v1.PodQOSClass {
 				if !isSupportedQoSComputeResource(name) {
 					continue
 				}
-				if quantity.Cmp(zeroQuantity) == 1 {
+				if quantity.Sign() == 1 {
 					delta := quantity.DeepCopy()
 					if _, exists := requests[name]; !exists {
 						requests[name] = delta
@@ -136,7 +131,7 @@ func ComputePodQOS(pod *v1.Pod) v1.PodQOSClass {
 				if !isSupportedQoSComputeResource(name) {
 					continue
 				}
-				if quantity.Cmp(zeroQuantity) == 1 {
+				if quantity.Sign() == 1 {
 					qosLimitsFound.Insert(string(name))
 					delta := quantity.DeepCopy()
 					if _, exists := limits[name]; !exists {

--- a/staging/src/k8s.io/kubectl/pkg/util/qos/qos.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/qos/qos.go
@@ -18,7 +18,6 @@ package qos
 
 import (
 	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -37,10 +36,6 @@ func GetPodQOS(pod *core.Pod) core.PodQOSClass {
 	return ComputePodQOS(pod)
 }
 
-// zeroQuantity represents a resource.Quantity with value "0", used as a baseline
-// for resource comparisons.
-var zeroQuantity = resource.MustParse("0")
-
 // processResourceList adds non-zero quantities for supported QoS compute resources
 // quantities from newList to list.
 func processResourceList(list, newList core.ResourceList) {
@@ -48,7 +43,7 @@ func processResourceList(list, newList core.ResourceList) {
 		if !isSupportedQoSComputeResource(name) {
 			continue
 		}
-		if quantity.Cmp(zeroQuantity) == 1 {
+		if quantity.Sign() == 1 {
 			delta := quantity.DeepCopy()
 			if _, exists := list[name]; !exists {
 				list[name] = delta
@@ -69,7 +64,7 @@ func getQOSResources(list core.ResourceList) sets.Set[string] {
 		if !isSupportedQoSComputeResource(name) {
 			continue
 		}
-		if quantity.Cmp(zeroQuantity) == 1 {
+		if quantity.Sign() == 1 {
 			qosResources.Insert(string(name))
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Minor cleanup/optimization: use `quantity.Sign()` rather than comparing to a cached zero-value with `quantity.Cmp(zeroQuantity)`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```