### PR TITLE
Handle the kubelet stop posting gracefully when node is shutting down

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -964,7 +964,7 @@ func (nc *Controller) tryUpdateNodeHealth(ctx context.Context, node *v1.Node) (t
 			} else {
 				logger.V(2).Info("Node hasn't been updated",
 					"node", klog.KObj(node), "duration", nc.now().Time.Sub(nodeHealth.probeTimestamp.Time), "nodeConditionType", nodeConditionType, "currentCondition", currentCondition)
-				if currentCondition.Status != v1.ConditionUnknown {
+				if currentCondition.Status != v1.ConditionUnknown && currentCondition.Message != "node is shutting down" {
 					currentCondition.Status = v1.ConditionUnknown
 					currentCondition.Reason = "NodeStatusUnknown"
 					currentCondition.Message = "Kubelet stopped posting node status."


### PR DESCRIPTION
#### What type of PR is this?
/kind flake


#### What this PR does / why we need it:
* During node shutdown process, I observe node will update to `node is shutting down` condition and then changed to `Kubelet stopped posting node status`. This wasn't an issue for us when using non-graceful shutdown because the gap between kubelet stop and node drain is minimal. But when I enable graceful shutdown, the gap in between is relative large ~40s, and trigger the node healthy tracking alarm on fire.
* I think when node is shutting down, we should keep it in shutting down status instead of changing to kubelet stop posting to handle it more gracefully.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
handle shutting down case more gracefully

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
