### PR TITLE
KEP-4680: Add tests to validate ShareID does not interfere with DRA Resource Health Status

### DIFF
--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -56,6 +56,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/dra/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/resourceupdates"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -536,7 +537,7 @@ func genTestClaimWithExtendedResource(name, driver, device, podUID string) *reso
 }
 
 // genTestClaimInfo generates claim info object
-func genTestClaimInfo(claimUID types.UID, podUIDs []string, prepared bool) *ClaimInfo {
+func genTestClaimInfo(claimUID types.UID, podUIDs []string, prepared bool, shareID *types.UID) *ClaimInfo {
 	return &ClaimInfo{
 		ClaimInfoState: state.ClaimInfoState{
 			ClaimUID:  claimUID,
@@ -548,6 +549,7 @@ func genTestClaimInfo(claimUID types.UID, podUIDs []string, prepared bool) *Clai
 					Devices: []state.Device{{
 						PoolName:     poolName,
 						DeviceName:   deviceName,
+						ShareID:      shareID,
 						RequestNames: []string{requestName},
 						CDIDeviceIDs: []string{cdiID},
 					}},
@@ -655,7 +657,7 @@ func TestGetResources(t *testing.T) {
 				},
 			},
 			pod:       genTestPod(),
-			claimInfo: genTestClaimInfo(claimUID, nil, false),
+			claimInfo: genTestClaimInfo(claimUID, nil, false, nil),
 		},
 		{
 			description: "nil claiminfo",
@@ -851,7 +853,7 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="PrepareRe
 			driverName:             driverName,
 			pod:                    genTestPod(),
 			claim:                  genTestClaim(claimName, driverName, deviceName, podUID),
-			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true),
+			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true, nil),
 			expectedClaimInfoState: genClaimInfoState(cdiID),
 			resp:                   genPrepareResourcesResponse(claimUID),
 			expectedMetric: `# HELP dra_operations_duration_seconds [ALPHA] Latency histogram in seconds for the duration of handling all ResourceClaims referenced by a pod when the pod starts or stops. Identified by the name of the operation (PrepareResources or UnprepareResources) and separated by the success of the operation. The number of failed operations is provided through the histogram's overall count.
@@ -937,7 +939,7 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="PrepareRe
 			driverName:     driverName,
 			pod:            genTestPod(),
 			claim:          genTestClaim(claimName, driverName, deviceName, podUID),
-			claimInfo:      genTestClaimInfo(anotherClaimUID, []string{podUID}, false),
+			claimInfo:      genTestClaimInfo(anotherClaimUID, []string{podUID}, false, nil),
 			expectedErrMsg: fmt.Sprintf("old ResourceClaim with same name %s and different UID %s still exists", claimName, anotherClaimUID),
 			expectedMetric: `# HELP dra_operations_duration_seconds [ALPHA] Latency histogram in seconds for the duration of handling all ResourceClaims referenced by a pod when the pod starts or stops. Identified by the name of the operation (PrepareResources or UnprepareResources) and separated by the success of the operation. The number of failed operations is provided through the histogram's overall count.
 # TYPE dra_operations_duration_seconds histogram
@@ -1197,7 +1199,7 @@ dra_operations_duration_seconds_count{is_error="true",operation_name="UnprepareR
 			description:         "resource claim referenced by other pod(s)",
 			driverName:          driverName,
 			pod:                 genTestPod(),
-			claimInfo:           genTestClaimInfo(claimUID, []string{podUID, "another-pod-uid"}, true),
+			claimInfo:           genTestClaimInfo(claimUID, []string{podUID, "another-pod-uid"}, true, nil),
 			wantResourceSkipped: true,
 			expectedMetric: `# HELP dra_operations_duration_seconds [ALPHA] Latency histogram in seconds for the duration of handling all ResourceClaims referenced by a pod when the pod starts or stops. Identified by the name of the operation (PrepareResources or UnprepareResources) and separated by the success of the operation. The number of failed operations is provided through the histogram's overall count.
 # TYPE dra_operations_duration_seconds histogram
@@ -1210,7 +1212,7 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="Unprepare
 			description:            "should timeout",
 			driverName:             driverName,
 			pod:                    genTestPod(),
-			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true),
+			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true, nil),
 			wantTimeout:            true,
 			expectedUnprepareCalls: 1,
 			expectedErrMsg:         "NodeUnprepareResources: rpc error: code = DeadlineExceeded",
@@ -1230,7 +1232,7 @@ dra_operations_duration_seconds_count{is_error="true",operation_name="UnprepareR
 			description:            "should fail when driver returns empty response",
 			driverName:             driverName,
 			pod:                    genTestPod(),
-			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true),
+			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true, nil),
 			resp:                   &drapb.NodeUnprepareResourcesResponse{Claims: map[string]*drapb.NodeUnprepareResourceResponse{}},
 			expectedUnprepareCalls: 1,
 			expectedErrMsg:         "NodeUnprepareResources skipped 1 ResourceClaims",
@@ -1270,7 +1272,7 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="Unprepare
 			driverName:             driverName,
 			pod:                    genTestPod(),
 			claim:                  genTestClaim(claimName, driverName, deviceName, podUID),
-			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true),
+			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true, nil),
 			expectedUnprepareCalls: 1,
 			expectedMetric: `# HELP dra_grpc_operations_duration_seconds [ALPHA] Duration in seconds of the DRA gRPC operations
 # TYPE dra_grpc_operations_duration_seconds histogram
@@ -1288,7 +1290,7 @@ dra_operations_duration_seconds_count{is_error="false",operation_name="Unprepare
 			description:            "should unprepare resource when driver returns nil value",
 			driverName:             driverName,
 			pod:                    genTestPod(),
-			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true),
+			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, true, nil),
 			resp:                   &drapb.NodeUnprepareResourcesResponse{Claims: map[string]*drapb.NodeUnprepareResourceResponse{string(claimUID): nil}},
 			expectedUnprepareCalls: 1,
 			expectedMetric: `# HELP dra_grpc_operations_duration_seconds [ALPHA] Duration in seconds of the DRA gRPC operations
@@ -1415,7 +1417,7 @@ func TestGetContainerClaimInfos(t *testing.T) {
 			description:       "should get claim info",
 			expectedClaimName: claimName,
 			pod:               genTestPod(),
-			claimInfo:         genTestClaimInfo(claimUID, []string{podUID}, false),
+			claimInfo:         genTestClaimInfo(claimUID, []string{podUID}, false, nil),
 		},
 		{
 			description:       "should get extended resource claim info",
@@ -1457,7 +1459,7 @@ func TestGetContainerClaimInfos(t *testing.T) {
 					},
 				},
 			},
-			claimInfo:      genTestClaimInfo(claimUID, []string{podUID}, false),
+			claimInfo:      genTestClaimInfo(claimUID, []string{podUID}, false, nil),
 			expectedErrMsg: "none of the supported fields are set",
 		},
 		{
@@ -1664,7 +1666,7 @@ func TestHandleWatchResourcesStream(t *testing.T) {
 		defer stCancel()
 
 		// Setup: Create a manager with a relevant claim already in its cache.
-		initialClaim := genTestClaimInfo(claimUID, []string{string(podUID)}, true)
+		initialClaim := genTestClaimInfo(claimUID, []string{string(podUID)}, true, nil)
 		manager, runStreamTest := setupNewManagerAndRunStreamTest(t, stCtx, initialClaim)
 
 		t.Log("HealthChangeForAllocatedDevice: Test Case Started")
@@ -1781,7 +1783,7 @@ func TestHandleWatchResourcesStream(t *testing.T) {
 		defer stCancel()
 
 		// Setup: Manager with a claim and the device already marked Unhealthy in health cache
-		initialClaim := genTestClaimInfo(claimUID, []string{string(podUID)}, true)
+		initialClaim := genTestClaimInfo(claimUID, []string{string(podUID)}, true, nil)
 		manager, runStreamTest := setupNewManagerAndRunStreamTest(t, stCtx, initialClaim)
 
 		// Pre-populate health cache
@@ -1896,6 +1898,192 @@ func TestHandleWatchResourcesStream(t *testing.T) {
 		}
 		require.Error(t, finalErr)
 		assert.True(t, errors.Is(finalErr, context.Canceled) || errors.Is(finalErr, context.DeadlineExceeded))
+	})
+
+	// Test Case 6: Health change for a device allocated with ShareID
+	// This test validates that ShareID does not interfere with health status reporting.
+	t.Run("HealthChangeForDeviceWithShareID", func(t *testing.T) {
+		stCtx, stCancel := context.WithCancel(overallTestCtx)
+		defer stCancel()
+
+		// Setup: Create a manager with a claim that has ShareID set on the device
+		testShareUID := types.UID("test-share-uid-for-health")
+		initialClaim := genTestClaimInfo(claimUID, []string{string(podUID)}, true, &testShareUID)
+		manager, runStreamTest := setupNewManagerAndRunStreamTest(t, stCtx, initialClaim)
+
+		t.Log("HealthChangeForDeviceWithShareID: Test Case Started")
+
+		responses := make(chan struct {
+			Resp *drahealthv1alpha1.NodeWatchResourcesResponse
+			Err  error
+		}, 1)
+		updateChan, done, streamErrChan := runStreamTest(stCtx, responses)
+
+		// Send health update for the device (same device that has ShareID in the claim)
+		unhealthyDeviceMsg := &drahealthv1alpha1.DeviceHealth{
+			Device: &drahealthv1alpha1.DeviceIdentifier{
+				PoolName:   poolName,
+				DeviceName: deviceName,
+			},
+			Health:          drahealthv1alpha1.HealthStatus_UNHEALTHY,
+			LastUpdatedTime: time.Now().Unix(),
+		}
+		t.Logf("HealthChangeForDeviceWithShareID: Sending health update: %+v", unhealthyDeviceMsg)
+		responses <- struct {
+			Resp *drahealthv1alpha1.NodeWatchResourcesResponse
+			Err  error
+		}{
+			Resp: &drahealthv1alpha1.NodeWatchResourcesResponse{Devices: []*drahealthv1alpha1.DeviceHealth{unhealthyDeviceMsg}},
+		}
+
+		t.Log("HealthChangeForDeviceWithShareID: Waiting for update on manager channel")
+		select {
+		case upd := <-updateChan:
+			t.Logf("HealthChangeForDeviceWithShareID: Received update: %+v", upd)
+			assert.ElementsMatch(t, []string{string(podUID)}, upd.PodUIDs, "Expected pod UID in update for device with ShareID")
+		case <-time.After(2 * time.Second):
+			t.Fatal("HealthChangeForDeviceWithShareID: Timeout waiting for pod update - ShareID may be interfering with health reporting")
+		}
+
+		// Verify health cache is updated correctly
+		cachedHealth := manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName)
+		assert.Equal(t, state.DeviceHealthStatus("Unhealthy"), cachedHealth, "Health cache should be updated for device with ShareID")
+
+		// Verify the claim still has the ShareID set (it shouldn't be lost during health updates)
+		claimFromCache, exists := manager.cache.get(claimName, namespace)
+		require.True(t, exists, "Claim should still exist in cache")
+		devices := claimFromCache.DriverState[driverName].Devices
+		require.Len(t, devices, 1, "Claim should have one device")
+		assert.NotNil(t, devices[0].ShareID, "ShareID should still be set on the device")
+		assert.Equal(t, testShareUID, *devices[0].ShareID, "ShareID value should be preserved")
+
+		t.Log("HealthChangeForDeviceWithShareID: Closing responses channel to signal EOF")
+		close(responses)
+
+		t.Log("HealthChangeForDeviceWithShareID: Waiting on done channel")
+		var finalErr error
+		select {
+		case <-done:
+			finalErr = <-streamErrChan
+			t.Log("HealthChangeForDeviceWithShareID: done channel closed, stream goroutine finished.")
+		case <-time.After(1 * time.Second):
+			t.Fatal("HealthChangeForDeviceWithShareID: Timed out waiting for HandleWatchResourcesStream to finish")
+		}
+		assert.True(t, finalErr == nil || errors.Is(finalErr, io.EOF), "Expected nil or io.EOF, got %v", finalErr)
+	})
+
+	// Test Case 7: Health change affects multiple pods sharing the same device via ShareID
+	// When two pods share the same physical device (identified by pool/device, but with different ShareIDs),
+	// a health change should notify both pods since they're using the same underlying hardware.
+	t.Run("HealthChangeForMultiplePodsWithSharedDevice", func(t *testing.T) {
+		stCtx, stCancel := context.WithCancel(overallTestCtx)
+		defer stCancel()
+
+		// Setup: Two claims from different pods, both using the same device with different ShareIDs
+		pod1UID := types.UID("pod-1-sharing-device")
+		pod2UID := types.UID("pod-2-sharing-device")
+		claim1UID := types.UID("claim-1-shared")
+		claim2UID := types.UID("claim-2-shared")
+		shareUID1 := types.UID("share-uid-1")
+		shareUID2 := types.UID("share-uid-2")
+
+		// Both claims reference the same physical device (same pool/device) but with different ShareIDs
+		claim1 := &ClaimInfo{
+			ClaimInfoState: state.ClaimInfoState{
+				ClaimUID:  claim1UID,
+				ClaimName: "shared-claim-1",
+				Namespace: namespace,
+				PodUIDs:   sets.New[string](string(pod1UID)),
+				DriverState: map[string]state.DriverState{
+					driverName: {
+						Devices: []state.Device{{
+							PoolName:     poolName,
+							DeviceName:   deviceName, // Same device as claim2
+							ShareID:      &shareUID1,
+							RequestNames: []string{requestName},
+							CDIDeviceIDs: []string{cdiID},
+						}},
+					},
+				},
+			},
+			prepared: true,
+		}
+		claim2 := &ClaimInfo{
+			ClaimInfoState: state.ClaimInfoState{
+				ClaimUID:  claim2UID,
+				ClaimName: "shared-claim-2",
+				Namespace: namespace,
+				PodUIDs:   sets.New[string](string(pod2UID)),
+				DriverState: map[string]state.DriverState{
+					driverName: {
+						Devices: []state.Device{{
+							PoolName:     poolName,
+							DeviceName:   deviceName, // Same device as claim1
+							ShareID:      &shareUID2,
+							RequestNames: []string{requestName},
+							CDIDeviceIDs: []string{cdiID},
+						}},
+					},
+				},
+			},
+			prepared: true,
+		}
+
+		manager, runStreamTest := setupNewManagerAndRunStreamTest(t, stCtx, claim1, claim2)
+
+		t.Log("HealthChangeForMultiplePodsWithSharedDevice: Test Case Started")
+
+		responses := make(chan struct {
+			Resp *drahealthv1alpha1.NodeWatchResourcesResponse
+			Err  error
+		}, 1)
+		updateChan, done, streamErrChan := runStreamTest(stCtx, responses)
+
+		// Send health update for the shared device
+		unhealthyDeviceMsg := &drahealthv1alpha1.DeviceHealth{
+			Device: &drahealthv1alpha1.DeviceIdentifier{
+				PoolName:   poolName,
+				DeviceName: deviceName,
+			},
+			Health:          drahealthv1alpha1.HealthStatus_UNHEALTHY,
+			LastUpdatedTime: time.Now().Unix(),
+		}
+		t.Logf("HealthChangeForMultiplePodsWithSharedDevice: Sending health update: %+v", unhealthyDeviceMsg)
+		responses <- struct {
+			Resp *drahealthv1alpha1.NodeWatchResourcesResponse
+			Err  error
+		}{
+			Resp: &drahealthv1alpha1.NodeWatchResourcesResponse{Devices: []*drahealthv1alpha1.DeviceHealth{unhealthyDeviceMsg}},
+		}
+
+		t.Log("HealthChangeForMultiplePodsWithSharedDevice: Waiting for update on manager channel")
+		select {
+		case upd := <-updateChan:
+			t.Logf("HealthChangeForMultiplePodsWithSharedDevice: Received update: %+v", upd)
+			// Both pods should be notified since they share the same device
+			assert.Len(t, upd.PodUIDs, 2, "Both pods sharing the device should be notified")
+			assert.Contains(t, upd.PodUIDs, string(pod1UID), "Pod 1 should be notified")
+			assert.Contains(t, upd.PodUIDs, string(pod2UID), "Pod 2 should be notified")
+		case <-time.After(2 * time.Second):
+			t.Fatal("HealthChangeForMultiplePodsWithSharedDevice: Timeout waiting for pod update")
+		}
+
+		// Verify health cache is updated
+		cachedHealth := manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName)
+		assert.Equal(t, state.DeviceHealthStatus("Unhealthy"), cachedHealth, "Health cache should show Unhealthy for shared device")
+
+		t.Log("HealthChangeForMultiplePodsWithSharedDevice: Closing responses channel to signal EOF")
+		close(responses)
+
+		var finalErr error
+		select {
+		case <-done:
+			finalErr = <-streamErrChan
+			t.Log("HealthChangeForMultiplePodsWithSharedDevice: done channel closed")
+		case <-time.After(1 * time.Second):
+			t.Fatal("HealthChangeForMultiplePodsWithSharedDevice: Timed out waiting for stream to finish")
+		}
+		assert.True(t, finalErr == nil || errors.Is(finalErr, io.EOF), "Expected nil or io.EOF, got %v", finalErr)
 	})
 }
 
@@ -2025,6 +2213,51 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 					Name: "claim:templated-claim",
 					Resources: []v1.ResourceHealth{
 						{ResourceID: "test-driver/pool/dev-c", Health: v1.ResourceHealthStatusHealthy},
+					},
+				},
+			},
+		},
+		// Test case for ShareID: Verifies that health status is correctly reported for devices with ShareID set.
+		// This validates that KEP-4860 (ShareID) does not interfere with KEP-4680 (Resource Health Status).
+		{
+			name: "Claim with ShareID",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-shareid", UID: "pod-shareid-uid"},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "container1", Resources: v1.ResourceRequirements{Claims: []v1.ResourceClaim{{Name: "shareid-claim"}}}},
+					},
+					ResourceClaims: []v1.PodResourceClaim{
+						{Name: "shareid-claim", ResourceClaimName: ptr.To("shareid-claim-object")},
+					},
+				},
+				Status: v1.PodStatus{
+					ResourceClaimStatuses: []v1.PodResourceClaimStatus{
+						{Name: "shareid-claim", ResourceClaimName: ptr.To("shareid-claim-object")},
+					},
+				},
+			},
+			claimInfos: []*ClaimInfo{
+				{
+					ClaimInfoState: state.ClaimInfoState{
+						ClaimName: "shareid-claim-object",
+						PodUIDs:   sets.New("pod-shareid-uid"),
+						DriverState: map[string]state.DriverState{
+							"test-driver": {Devices: []state.Device{{
+								PoolName:   "pool",
+								DeviceName: "dev-shared",
+								ShareID:    ptr.To(types.UID("test-share-id")), // Device has ShareID
+							}}},
+						},
+					},
+				},
+			},
+			initialStatus: &v1.PodStatus{ContainerStatuses: []v1.ContainerStatus{{Name: "container1"}}},
+			expectedAllocatedResourcesStatus: []v1.ResourceStatus{
+				{
+					Name: "claim:shareid-claim",
+					Resources: []v1.ResourceHealth{
+						{ResourceID: "test-driver/pool/dev-shared", Health: v1.ResourceHealthStatusHealthy},
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
--

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
Adds unit and e2e_node tests to validate that ShareID (DRAConsumableCapacity)  does not interfere with Resource Health Status (KEP-4680).
                                                                                                                                                                                                                                                                                    These tests address a gap identified during the review of #134520, where @SergeyKanzhelev noted the need for tests to ensure both features work correctly together.
                                                                                            
The new tests verify:
  - Health updates propagate correctly to pods using devices with ShareID
  - Multiple pods sharing the same device (via different ShareIDs) all receive health notifications
  - Pod status correctly reflects health for devices allocated with ShareID
  - Health status transitions (Healthy → Unhealthy → Healthy) work with ShareID allocations

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes : https://github.com/kubernetes/kubernetes/issues/135190 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/issues/4680
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4680

```
