### PR TITLE
Add DEVELOPMENT.md for cel pkgs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/doc.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cel provides shared core functionality for both validating and mutating admission policies.
+// It bridges the generic admission control interfaces with the CEL runtime, handling compilation,
+// composition, and execution of CEL expressions against admission requests.
+//
+// # Core Components
+//
+// Compilation (compile.go)
+//
+// The Compiler interface and its implementations are the engine room of the plugin. They are responsible
+// for transforming raw CEL string expressions into executable programs that can be run against admission requests.
+//
+//   - Environment: The plugin builds upon the base CEL environment defined in k8s.io/apiserver/pkg/cel/environment.
+//     It extends this base with admission-specific variables like request (AdmissionRequest attributes), namespace
+//     (the namespace object), and authorizer.
+//
+// Composition (composition.go)
+//
+// Composition is a powerful feature that allows policy authors to define reusable logic and avoid repetition.
+//
+//   - CompositedCompiler: This is a sophisticated component that manages the complexity of having multiple types of
+//     expressions within a single policy. A single ValidatingAdmissionPolicy might contain match conditions, parameter
+//     definitions, variable definitions, validation rules, and audit annotations. The CompositedCompiler orchestrates
+//     the compilation of all these parts. It acts as a central factory, initializing the correct environment for each
+//     context (e.g., ensuring params are available only if paramKind is set) and managing the dependencies between them.
+//   - Variables & Lifting: ValidatingAdmissionPolicy and MutatingAdmissionPolicy support a variables list. These are
+//     named CEL expressions. The composition logic handles "lifting" these variables into the scope of subsequent
+//     expressions. For example, a variable isStable defined as object.spec.replicas < 5 becomes available as a typed
+//     boolean variable in all subsequent validation rules. This enables modular policy design.
+//   - Lazy Evaluation: To ensure efficiency, variable evaluation is lazy. The expression for a variable is not executed
+//     immediately upon policy evaluation. Instead, it is computed only the first time it is referenced by another rule.
+//     If a request is denied by a precondition and the complex variable is never used, its cost is never incurred.
+//
+// # Type Checking Mechanics
+//
+// The plugin architecture supports strict, schema-aware type checking to ensure policy validity before execution.
+//
+//   - Environment Construction: A specialized type-checking environment is constructed (via buildEnvSet) which differs
+//     from the runtime environment. It replaces dynamic types (DynType) with specific DeclType definitions derived from
+//     OpenAPI schemas.
+//   - Strongly Typed Variables: Key variables like object, oldObject, and params are strongly typed in this mode.
+//     This allows the compiler to catch field access errors (e.g., typos, invalid types) at compile time.
+//   - Type Overwrite: The TypeChecker (specifically in staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking.go)
+//     iterates through all GroupVersionKinds (GVKs) matched by a policy. For each GVK, it injects the specific schema types into the compiler context,
+//     effectively "overwriting" the generic types for that specific pass.
+//   - Limit: To ensure performance, a hard limit (e.g., 10) is often placed on the number of distinct GVKs checked per policy.
+//
+// # ValidatingAdmissionPolicy
+//
+// ValidatingAdmissionPolicy (VAP) allows administrators to define validation rules using CEL, offering a declarative
+// alternative to ValidatingAdmissionWebhooks.
+//
+//   - Implementation: The core logic resides in staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating.
+//   - Type Checking: The TypeChecker (in staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking.go) performs a multi-pass validation. It resolves all
+//     GroupVersionKinds (GVKs) that the policy matches (via matchConstraints). It then compiles the policy's expressions
+//     individually against each resolved GVK. For example, if a policy matches both apps/v1 Deployment and apps/v1 StatefulSet,
+//     the checker verifies that object.spec.replicas exists and has a compatible type in both schemas. If object.spec.template
+//     is referenced but only exists in one, type checking will report an error for the incompatible GVK.
+//   - Execution: The dispatcher evaluates the policy. It handles the retrieval of the param resource (if configured) and
+//     the namespace object, injecting them into the execution context alongside the admission request and the object under test.
+//   - Cost Management: A strict runtime cost budget is enforced. If the evaluation complexity exceeds the limit, the policy
+//     evaluation is aborted to protect the API server.
+//
+// # MutatingAdmissionPolicy
+//
+// MutatingAdmissionPolicy (MAP) enables modifying objects (setting defaults, injecting sidecars) using CEL.
+//
+//   - Implementation: Located in staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating.
+//   - Mutations: MAP supports two styles of mutation:
+//     1. JSONPatch: The expression returns a list of standard JSON Patch operations (add, remove, replace).
+//     2. ApplyConfiguration: The expression returns a structured object (an "Apply Configuration") that is merged onto the
+//     existing object, similar to a Server-Side Apply operation.
+//   - Reinvocation: This handles the complex interaction between multiple admission plugins. If reinvocationPolicy is set
+//     to IfNeeded, the policy allows itself to be re-run if a subsequent admission plugin (e.g., a mutating webhook or
+//     another policy) modifies the object. The dispatcher tracks the object state and re-triggers the policy to ensure its
+//     mutations (like adding a mandatory label) are still present after other plugins have run. A limit on the number of
+//     reinvocations prevents infinite loops.
+//   - Dispatcher: The dispatcher orchestrates this flow, applying the generated patches to the in-flight object version
+//     and managing the "dirty" state of the object attributes.
+//
+// # Shared Mechanics
+//
+//   - Filter/Matcher: Both policies use a common Matcher to determine applicability. This evaluates matchConstraints
+//     (resource, group, user), matchResources (namespace selectors, object selectors), and paramRef binding validity.
+//   - Match Conditions: These are high-performance CEL filters evaluated before the main policy logic or parameter retrieval.
+//     If a matchCondition evaluates to false or error, the policy is skipped immediately. This allows for very granular
+//     filtering (e.g., "only validate Pods with a specific annotation") without incurring the cost of loading parameters
+//     or running complex validation rules.
+//   - Configuration: Policies are configured via the API resources ValidatingAdmissionPolicy and MutatingAdmissionPolicy,
+//     and bound to specific resources via ...Binding resources.
+//   - Metrics: Standardized metrics are collected for policy evaluation counts, latency (broken down by check vs. execution),
+//     and error rates, enabling observability into the admission control pipeline.
+package cel

--- a/staging/src/k8s.io/apiserver/pkg/cel/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/doc.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cel provides a comprehensive overview of the Common Expression Language (CEL) integration within Kubernetes,
+// specifically focusing on the k8s.io/apiserver/pkg/cel package.
+//
+// # Context & History
+//
+// CEL was selected for Kubernetes to handle CRD validation and admission control after a thorough evaluation of alternatives.
+//
+//   - Alternatives Considered:
+//
+//   - WebAssembly (Wasm): While powerful, Wasm was deemed too complex for the target use cases. It introduces significant
+//     operational overhead for managing binaries, potential "cold start" latency issues, and a more complex developer
+//     workflow compared to in-line expressions.
+//
+//   - Rego (OPA): Rego is a robust policy language but operates as a separate engine. Integrating it would require
+//     external webhooks or a heavier embedding, whereas CEL offers a lightweight, expression-based syntax that fits
+//     naturally within Kubernetes YAML manifests.
+//
+//   - Why CEL?
+//
+//   - Low Overhead: CEL is designed for microseconds-level execution, making it suitable for high-throughput admission
+//     control where every millisecond counts.
+//
+//   - Type Safety: CEL provides compile-time type checking. This allows the API server to reject invalid policies
+//     before they are accepted, preventing runtime errors during admission.
+//
+//   - Simplicity: It allows logic to be embedded directly in CRD definitions (validation rules) or Policy objects,
+//     removing the need to build, deploy, and manage separate webhook infrastructure.
+//
+// # Core Architecture
+//
+// # Use Cases
+//
+// CEL is currently utilized in several key areas of Kubernetes, becoming the standard for in-process extensibility:
+//  1. CRD Validation: The initial use case, allowing CRD authors to define complex validation rules (e.g., "minReplicas < maxReplicas")
+//     that OpenAPI schema validation cannot express.
+//  2. Admission Control: ValidatingAdmissionPolicy and MutatingAdmissionPolicy allow cluster administrators to enforce policy
+//     and modify objects on built-in types (like Pods, PVCs) without writing Go code or deploying webhooks.
+//  3. Webhook Match Conditions: Allows filtering requests before they are sent to a remote webhook, reducing unnecessary traffic and latency.
+//  4. AuthN/AuthZ: Used in SubjectAccessReview and other authorization paths to manage dynamic access controls.
+//  5. Dynamic Resource Allocation (DRA): Used to configure complex resource parameters and perform matching logic within the scheduler.
+//
+// # Type System Integration
+//
+// The integration uses CelGo to bridge Kubernetes native Go types with CEL's runtime values.
+//
+//   - ref.Val Interface: Kubernetes internal types (both structured Go structs and unstructured map[string]interface{}) are
+//     adapted to implement CEL's ref.Val interface via staging/src/k8s.io/apiserver/pkg/cel/types.go and value.go.
+//   - Lazy Evaluation: This is a critical performance optimization. Instead of converting a whole Kubernetes object (which can be very large)
+//     into a CEL-native map before evaluation, the integration uses reflection-based wrappers. Fields are accessed and converted
+//     only when the CEL expression actually reads them. This "pay-for-what-you-use" model significantly reduces memory allocation
+//     and CPU usage. Implementation details can be found in staging/src/k8s.io/apiserver/pkg/cel/lazy.
+//   - Compile-Time Safety: The system uses the OpenAPI schema information (decl.Type) to inform the CEL compiler about the structure
+//     of the input variables. This allows the compiler to catch errors like accessing non-existent fields or comparing incompatible
+//     types (e.g., string vs int) at configuration time.
+//
+// Compilation & Optimization
+//
+//   - Lifecycle: CEL expressions are not interpreted raw at runtime. They are compiled into an executable program representation
+//     when the API object (CRD, ValidatingAdmissionPolicy) is written to the API server. This compilation step performs syntax
+//     parsing and type checking.
+//   - Caching: The compiled programs are stored in an in-memory cache within the API server. This means the heavy lifting of
+//     parsing and checking is done once (amortized), and runtime evaluation involves executing the efficient, pre-compiled program.
+//     These cached programs are thread-safe and shared across concurrent requests.
+//   - Two-Step Process for CRDs:
+//     1. Validator Construction: When a CRD is loaded, a validator is constructed based on its OpenAPIV3 schema.
+//     2. Compilation: Any CEL validation rules within the schema are found and compiled. These rules are then stored alongside the schema validator.
+//   - Admission Policies: For ValidatingAdmissionPolicy, an informer-based controller monitors the policy resources. When a policy
+//     is added or updated, the controller asynchronously compiles the expressions and updates the ready status of the policy.
+//   - Ahead-of-Time (AOT): Currently, there is no AOT compilation to native machine code (Go/Assembly). Serialization of compiled
+//     results to proto is supported by the library but is not currently used for execution persistence in Kubernetes.
+//
+// # Available CEL Libraries
+//
+// Kubernetes provides a rich set of CEL libraries, managed via EnvSet in pkg/cel/environment. Libraries are versioned to ensure backward compatibility.
+//
+// Standard Libraries (Core)
+//
+//   - URLs: URL parsing and manipulation (Always available).
+//     Methods: url, isURL, getScheme, getHost, getHostname, getPort, getEscapedPath, getQuery.
+//     Cost: Parsing functions (url, isURL) cost is proportional to string length. Accessors cost 1 (nominal).
+//   - Regex: Regular expression matching (Always available).
+//     Methods: find, findAll.
+//     Cost: Proportional to string length * regex length.
+//   - Lists: List manipulation utilities (Always available).
+//     Methods: isSorted, sum, min, max, indexOf, lastIndexOf.
+//     Cost: Proportional to list size (O(n) traversal).
+//
+// Kubernetes-Specific Libraries
+//
+//   - Authz: Authorization checks (Introduced v1.27).
+//     Methods: path, group, serviceAccount, resource, subresource, namespace, name, check, allowed, reason, errored, error.
+//     Cost: check() has a fixed cost of 350,000. Builders and accessors have a nominal cost of 1.
+//   - AuthzSelectors: Authorization with field/label selectors (Introduced v1.31).
+//     Methods: fieldSelector, labelSelector.
+//     Cost: Proportional to the length of the selector string.
+//   - Quantity: Support for Kubernetes resource quantities (Introduced v1.28).
+//     Methods: quantity, isQuantity, sign, add, sub, isGreaterThan, isLessThan, compareTo, asInteger, asApproximateFloat, isInteger.
+//     Cost: Parsing (quantity) is proportional to string length. Arithmetic and comparisons have a nominal cost of 1.
+//   - IP / CIDR: IP address and CIDR block handling (Introduced v1.30).
+//     Methods: ip, isIP, ip.isCanonical, family, isUnspecified, isLoopback, isLinkLocalMulticast, isLinkLocalUnicast,
+//     isGlobalUnicast, cidr, isCIDR, containsIP, containsCIDR, prefixLength, masked.
+//     Cost: Parsing is proportional to string length. Accessors cost 1. Containment checks (containsIP, containsCIDR)
+//     are proportional to input size.
+//   - Format: Standardized string formatting (Introduced v1.31).
+//     Methods: validate, format.named.
+//     Cost: validate cost is proportional to string length * estimated regex length. format.named costs 1.
+//   - Semver: Semantic versioning support (Introduced v1.33).
+//     Methods: semver, isSemver, major, minor, patch, compareTo, isGreaterThan, isLessThan.
+//     Cost: Parsing is proportional to string length. Comparisons and accessors have a nominal cost of 1.
+//   - JSONPatch: Creation of JSON Patch operations (Used in MutatingAdmissionPolicy).
+//     Methods: jsonpatch.escapeKey.
+//     Cost: Proportional to string length (traversal).
+//
+// Extension Libraries
+//
+//   - Strings: String manipulation (Version 2 active since v1.29).
+//     Methods: includes split, join, replace, lowerAscii, upperAscii, substring, trim.
+//     Cost: Generally proportional to string traversal + result construction cost.
+//   - Sets: Set operations (Introduced v1.29).
+//   - TwoVarComprehensions: Support for two-variable comprehensions (Introduced v1.32).
+//   - Lists Extension: Extended list features (Version 3 active since v1.34).
+//
+// Core Features
+//
+//   - CrossTypeNumericComparisons: Enabled since v1.28.
+//   - OptionalTypes: Enabled since v1.28.
+//   - DefaultUTCTimeZone: Enabled by default.
+//
+// # The Cost System
+//
+// A critical component for running user-defined logic in the API server is resource protection. Since CEL executes in the
+// same process as the API server, a runaway expression could degrade the performance of the entire control plane. The Cost
+// System mitigates this risk by assigning a cost to every operation and enforcing strict budgets.
+//
+//   - Purpose: The primary goal is to prevent Denial of Service (DoS) attacks or accidental performance degradation caused
+//     by computationally expensive expressions. Unlike webhooks, which run externally and mainly affect the request latency
+//     via I/O blocking, CEL runs locally and consumes shared CPU and memory resources.
+//   - Cost Unit: Costs are abstract units, but they are roughly calibrated such that 1 cost unit corresponds to approximately
+//     50 nanoseconds of execution time on a reference CPU. This provides a deterministic metric independent of momentary system load.
+//   - Estimation (Static): Before a policy is accepted, the system performs a static cost estimation. It calculates the worst-case
+//     running time by analyzing the AST. It uses the MaxItems and MaxLength constraints from the CRD schema to bound the cost of
+//     list traversals and string operations. If the estimated cost exceeds the limit, the policy is rejected at configuration time.
+//   - Enforcement (Runtime): During execution, the interpreter tracks the actual accumulated cost. If the cost exceeds the
+//     RuntimeCELCostBudget (defined in staging/src/k8s.io/apiserver/pkg/apis/cel/config.go), execution is halted immediately,
+//     and the validation fails (or defaults to the failure policy).
+//
+// High-Cost Operations
+//
+//   - Traversal: Iterating over lists or maps (e.g., list.all(...), list.map(...)) has a cost proportional to the size of the data structure (O(N)).
+//   - String Operations: Operations like replace, split, or parsing large strings have costs proportional to the string length.
+//   - Regex: Functions like find or findAll have costs proportional to string_length * regex_complexity. While the RE2 library
+//     prevents catastrophic backtracking, complex regexes on large inputs are still expensive.
+//   - Allocations: Creating new lists or strings (e.g., list1 + list2) incurs costs for memory allocation and copying.
+//
+// # Best Practices for Cost Reduction
+//
+// To ensure policies are accepted by the API server and do not impact cluster performance, authors should follow these guidelines
+// to minimize both estimated (static) and actual (runtime) costs.
+//
+//   - Define Schema Constraints (Crucial):
+//     Why: The static cost estimator calculates the worst-case execution time. If a list does not have a maxItems limit, the
+//     estimator must assume it could be infinitely large (up to system limits), resulting in a massive estimated cost that
+//     likely exceeds the budget.
+//     Action: Always define maxItems for arrays and maxLength for strings in your CRD or API schema. This allows the estimator
+//     to mathematically bound the cost of traversals (list.all(...)) and string operations, keeping the estimated cost within the limit.
+//
+//   - Leverage Short-Circuiting:
+//     Why: CEL evaluates logical && (AND) and || (OR) operators using short-circuit logic. If the left-hand side determines
+//     the result, the right-hand side is never executed/billed.
+//     Action: Place cheap, simple checks before expensive ones.
+//     Bad: object.spec.items.all(i, i.matches('^complex-regex$')) && has(object.spec.items)
+//     Good: has(object.spec.items) && object.spec.items.size() < 100 && object.spec.items.all(i, i.matches('^complex-regex$'))
+//
+//   - Use Efficient Libraries:
+//     Why: Native library functions are optimized in Go. Manual implementations in CEL are often slower and costlier.
+//     Action:
+//     Use the Sets library (sets.contains) for membership checks instead of iterating lists.
+//     Use startsWith / endsWith for simple string matching instead of full Regex matches.
+//     Use ip and cidr libraries for network checks instead of string parsing.
+//
+//   - Avoid Redundancy with Variables:
+//     Why: Repeatedly calculating an expensive value (e.g., parsing a complex annotation) multiplies the cost.
+//     Action: In ValidatingAdmissionPolicy, define the expensive calculation once in the variables section. The variable is
+//     lazily evaluated once, and subsequent references cost almost nothing.
+//
+// # Development Patterns
+//
+// # Backward Compatibility
+//
+// Kubernetes maintains strict backward compatibility for CEL, managed in staging/src/k8s.io/apiserver/pkg/cel/environment:
+//   - Base Environments: Capabilities are mapped to Kubernetes versions via EnvSet.
+//   - Rollback Support: New expressions can only utilize features available in $N-1$ versions.
+//   - Forward Compatibility: Stored environments must be forward-compatible.
+//
+// # Mutation
+//
+// Mutating Admission Policies (Beta) allow CEL to define JSON patches or server-side apply operations.
+//   - Logic: Implemented in staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go.
+//   - Cascading Changes: A retry mechanism re-runs policies if changes occur (randomized order) to handle dependencies between policies.
+//
+// # Limitations
+//
+//   - No Cross-Resource Lookups: Restricted for security and performance (except for limited namespace metadata access via namespaceObject).
+//   - List Filtering: CEL is generally not used for filtering large lists of objects due to the high cost of compilation and type-checking relative to evaluation.
+//   - String Length: Soft limits are encouraged to keep expressions readable and manageable.
+package cel


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This PR introduces two new developer guides (`DEVELOPMENT.md`) to improve the maintainability and understandability of the Common Expression Language (CEL) implementation within the Kubernetes API server.

The documentation is split into two main areas:
1.  **Core CEL Integration (`staging/src/k8s.io/apiserver/pkg/cel/DEVELOPMENT.md`):**
    *   **Context & History:** Explains the design choice of CEL over alternatives like Wasm or Rego.
    *   **Architecture:** Details on type system integration (including reflection-based lazy evaluation), compilation, and caching strategies.
    *   **Libraries:** A comprehensive list of available CEL libraries (Authz, Quantity, IP/CIDR, Semver, etc.) and their associated costs.
    *   **Cost System:** In-depth explanation of static vs. runtime cost estimation, resource protection, and best practices for policy authors.

2.  **CEL Admission Plugin Implementation (`staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/DEVELOPMENT.md`):**
    *   **Core Components:** Documentation on the `CompositedCompiler`, expression composition (lifting variables), and lazy evaluation.
    *   **Type Checking:** Details the mechanics of schema-aware type checking across multiple GroupVersionKinds (GVKs).
    *   **Policy Specifics:** Implementation details for both `ValidatingAdmissionPolicy` and `MutatingAdmissionPolicy`, including mutation styles (JSONPatch/ApplyConfiguration) and reinvocation logic.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
The documentation includes Mermaid diagrams to visualize the type-checking loop and the compilation lifecycle Constraints[MatchConstraints] -->.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```