### PR TITLE
pkg: refactor to use atomic types

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1190,25 +1190,25 @@ func delayTerminalCondition() bool {
 // Returns number of successfully deleted ready pods and total number of successfully deleted pods.
 func (jm *Controller) deleteActivePods(ctx context.Context, job *batch.Job, pods []*v1.Pod) (int32, int32, error) {
 	errCh := make(chan error, len(pods))
-	successfulDeletes := int32(len(pods))
-	var deletedReady int32 = 0
-	wg := sync.WaitGroup{}
+	var successfulDeletes, deletedReady atomic.Int32
+	successfulDeletes.Store(int32(len(pods)))
+	var wg sync.WaitGroup
 	wg.Add(len(pods))
 	for i := range pods {
 		go func(pod *v1.Pod) {
 			defer wg.Done()
 			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job); err != nil && !apierrors.IsNotFound(err) {
-				atomic.AddInt32(&successfulDeletes, -1)
+				successfulDeletes.Add(-1)
 				errCh <- err
 				utilruntime.HandleError(err)
 			}
 			if podutil.IsPodReady(pod) {
-				atomic.AddInt32(&deletedReady, 1)
+				deletedReady.Add(1)
 			}
 		}(pods[i])
 	}
 	wg.Wait()
-	return deletedReady, successfulDeletes, errorFromChannel(errCh)
+	return deletedReady.Load(), successfulDeletes.Load(), errorFromChannel(errCh)
 }
 
 func nonIgnoredFailedPodsCount(jobCtx *syncJobCtx, failedPods []*v1.Pod) int {
@@ -1228,8 +1228,9 @@ func nonIgnoredFailedPodsCount(jobCtx *syncJobCtx, failedPods []*v1.Pod) int {
 // and any error.
 func (jm *Controller) deleteJobPods(ctx context.Context, job *batch.Job, jobKey string, pods []*v1.Pod) (int32, int32, error) {
 	errCh := make(chan error, len(pods))
-	successfulDeletes := int32(len(pods))
-	var deletedReady int32 = 0
+	var successfulDeletes, deletedReady atomic.Int32
+	successfulDeletes.Store(int32(len(pods)))
+
 	logger := klog.FromContext(ctx)
 
 	failDelete := func(pod *v1.Pod, err error) {
@@ -1237,7 +1238,7 @@ func (jm *Controller) deleteJobPods(ctx context.Context, job *batch.Job, jobKey 
 		jm.expectations.DeletionObserved(logger, jobKey)
 		if !apierrors.IsNotFound(err) {
 			logger.V(2).Info("Failed to delete Pod", "job", klog.KObj(job), "pod", klog.KObj(pod), "err", err)
-			atomic.AddInt32(&successfulDeletes, -1)
+			successfulDeletes.Add(-1)
 			errCh <- err
 			utilruntime.HandleError(err)
 		}
@@ -1258,12 +1259,12 @@ func (jm *Controller) deleteJobPods(ctx context.Context, job *batch.Job, jobKey 
 				failDelete(pod, err)
 			}
 			if podutil.IsPodReady(pod) {
-				atomic.AddInt32(&deletedReady, 1)
+				deletedReady.Add(1)
 			}
 		}(pods[i])
 	}
 	wg.Wait()
-	return deletedReady, successfulDeletes, errorFromChannel(errCh)
+	return deletedReady.Load(), successfulDeletes.Load(), errorFromChannel(errCh)
 }
 
 // trackJobStatusAndRemoveFinalizers does:
@@ -1721,7 +1722,8 @@ func jobSuspended(job *batch.Job) bool {
 // Does NOT modify <activePods>.
 func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syncJobCtx) (int32, string, error) {
 	logger := klog.FromContext(ctx)
-	active := int32(len(jobCtx.activePods))
+	var active atomic.Int32
+	active.Store(int32(len(jobCtx.activePods)))
 	parallelism := *job.Spec.Parallelism
 	jobKey, err := controller.KeyFunc(job)
 	if err != nil {
@@ -1730,16 +1732,16 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 	}
 
 	if jobSuspended(job) {
-		logger.V(4).Info("Deleting all active pods in suspended job", "job", klog.KObj(job), "active", active)
-		podsToDelete := activePodsForRemoval(job, jobCtx.activePods, int(active))
+		logger.V(4).Info("Deleting all active pods in suspended job", "job", klog.KObj(job), "active", active.Load())
+		podsToDelete := activePodsForRemoval(job, jobCtx.activePods, int(active.Load()))
 		jm.expectations.ExpectDeletions(logger, jobKey, len(podsToDelete))
 		removedReady, removed, err := jm.deleteJobPods(ctx, job, jobKey, podsToDelete)
-		active -= removed
+		active.Add(-removed)
 		if trackTerminatingPods(job) {
 			*jobCtx.terminating += removed
 		}
 		jobCtx.ready -= removedReady
-		return active, metrics.JobSyncActionPodsDeleted, err
+		return active.Load(), metrics.JobSyncActionPodsDeleted, err
 	}
 
 	wantActive := int32(0)
@@ -1748,7 +1750,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		// should be equal to parallelism, unless the job has seen at least
 		// once success, in which leave whatever is running, running.
 		if jobCtx.succeeded > 0 {
-			wantActive = active
+			wantActive = active.Load()
 		} else {
 			wantActive = parallelism
 		}
@@ -1764,10 +1766,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		}
 	}
 
-	rmAtLeast := active - wantActive
-	if rmAtLeast < 0 {
-		rmAtLeast = 0
-	}
+	rmAtLeast := max(active.Load()-wantActive, 0)
 	podsToDelete := activePodsForRemoval(job, jobCtx.activePods, int(rmAtLeast))
 	if len(podsToDelete) > MaxPodCreateDeletePerSync {
 		podsToDelete = podsToDelete[:MaxPodCreateDeletePerSync]
@@ -1776,7 +1775,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		jm.expectations.ExpectDeletions(logger, jobKey, len(podsToDelete))
 		logger.V(4).Info("Too many pods running for job", "job", klog.KObj(job), "deleted", len(podsToDelete), "target", wantActive)
 		removedReady, removed, err := jm.deleteJobPods(ctx, job, jobKey, podsToDelete)
-		active -= removed
+		active.Add(-removed)
 		if trackTerminatingPods(job) {
 			*jobCtx.terminating += removed
 		}
@@ -1785,7 +1784,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		// deletions at the same time (e.g. indexed Jobs with repeated indexes), we
 		// restrict ourselves to either just pod deletion or pod creation in any
 		// given sync cycle. Of these two, pod deletion takes precedence.
-		return active, metrics.JobSyncActionPodsDeleted, err
+		return active.Load(), metrics.JobSyncActionPodsDeleted, err
 	}
 
 	var terminating int32 = 0
@@ -1794,7 +1793,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		// and so we can use the value.
 		terminating = *jobCtx.terminating
 	}
-	if diff := wantActive - terminating - active; diff > 0 {
+	if diff := wantActive - terminating - active.Load(); diff > 0 {
 		var remainingTime time.Duration
 		if !hasBackoffLimitPerIndex(job) {
 			// we compute the global remaining time for pod creation when backoffLimitPerIndex is not used
@@ -1827,7 +1826,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 
 		wait := sync.WaitGroup{}
 
-		active += diff
+		active.Add(diff)
 
 		podTemplate := job.Spec.Template.DeepCopy()
 		if isIndexedJob(job) {
@@ -1836,7 +1835,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		podTemplate.Finalizers = appendJobCompletionFinalizerIfNotFound(podTemplate.Finalizers)
 
 		// Counters for pod creation status (used by the job_pods_creation_total metric)
-		var creationsSucceeded, creationsFailed int32 = 0, 0
+		var creationsSucceeded, creationsFailed atomic.Int32
 
 		// Batch the pod creates. Batch sizes start at SlowStartInitialBatchSize
 		// and double with each successful iteration in a kind of "slow start".
@@ -1882,11 +1881,11 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 						// Decrement the expected number of creates because the informer won't observe this pod
 						logger.V(2).Info("Failed creation, decrementing expectations", "job", klog.KObj(job))
 						jm.expectations.CreationObserved(logger, jobKey)
-						atomic.AddInt32(&active, -1)
+						active.Add(-1)
 						errCh <- err
-						atomic.AddInt32(&creationsFailed, 1)
+						creationsFailed.Add(1)
 					}
-					atomic.AddInt32(&creationsSucceeded, 1)
+					creationsSucceeded.Add(1)
 				}()
 			}
 			wait.Wait()
@@ -1894,7 +1893,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 			skippedPods := diff - batchSize
 			if errorCount < len(errCh) && skippedPods > 0 {
 				logger.V(2).Info("Slow-start failure. Skipping creating pods, decrementing expectations", "skippedCount", skippedPods, "job", klog.KObj(job))
-				active -= skippedPods
+				active.Add(-skippedPods)
 				for i := int32(0); i < skippedPods; i++ {
 					// Decrement the expected number of creates because the informer won't observe this pod
 					jm.expectations.CreationObserved(logger, jobKey)
@@ -1905,11 +1904,11 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 			}
 			diff -= batchSize
 		}
-		recordJobPodsCreationTotal(job, jobCtx, creationsSucceeded, creationsFailed)
-		return active, metrics.JobSyncActionPodsCreated, errorFromChannel(errCh)
+		recordJobPodsCreationTotal(job, jobCtx, creationsSucceeded.Load(), creationsFailed.Load())
+		return active.Load(), metrics.JobSyncActionPodsCreated, errorFromChannel(errCh)
 	}
 
-	return active, metrics.JobSyncActionTracking, nil
+	return active.Load(), metrics.JobSyncActionTracking, nil
 }
 
 // getPodCreationInfoForIndependentIndexes returns a sub-list of all indexes

--- a/pkg/controller/tainteviction/timed_workers_test.go
+++ b/pkg/controller/tainteviction/timed_workers_test.go
@@ -29,11 +29,11 @@ import (
 
 func TestExecute(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	testVal := int32(0)
+	var testVal atomic.Int32
 	wg := sync.WaitGroup{}
 	wg.Add(5)
 	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
-		atomic.AddInt32(&testVal, 1)
+		testVal.Add(1)
 		wg.Done()
 		return nil
 	})
@@ -44,7 +44,7 @@ func TestExecute(t *testing.T) {
 	queue.AddWork(ctx, NewWorkArgs("4", "4"), now, now)
 	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, now)
 	wg.Wait()
-	lastVal := atomic.LoadInt32(&testVal)
+	lastVal := testVal.Load()
 	if lastVal != 5 {
 		t.Errorf("Expected testVal = 5, got %v", lastVal)
 	}
@@ -52,11 +52,11 @@ func TestExecute(t *testing.T) {
 
 func TestExecuteDelayed(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	testVal := int32(0)
+	var testVal atomic.Int32
 	wg := sync.WaitGroup{}
 	wg.Add(5)
 	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
-		atomic.AddInt32(&testVal, 1)
+		testVal.Add(1)
 		wg.Done()
 		return nil
 	})
@@ -76,7 +76,7 @@ func TestExecuteDelayed(t *testing.T) {
 	queue.AddWork(ctx, NewWorkArgs("5", "5"), now, then)
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
-	lastVal := atomic.LoadInt32(&testVal)
+	lastVal := testVal.Load()
 	if lastVal != 5 {
 		t.Errorf("Expected testVal = 5, got %v", lastVal)
 	}
@@ -84,11 +84,11 @@ func TestExecuteDelayed(t *testing.T) {
 
 func TestCancel(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
-	testVal := int32(0)
+	var testVal atomic.Int32
 	wg := sync.WaitGroup{}
 	wg.Add(3)
 	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
-		atomic.AddInt32(&testVal, 1)
+		testVal.Add(1)
 		wg.Done()
 		return nil
 	})
@@ -110,7 +110,7 @@ func TestCancel(t *testing.T) {
 	queue.CancelWork(logger, NewWorkArgs("4", "4").KeyFromWorkArgs())
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
-	lastVal := atomic.LoadInt32(&testVal)
+	lastVal := testVal.Load()
 	if lastVal != 3 {
 		t.Errorf("Expected testVal = 3, got %v", lastVal)
 	}
@@ -118,11 +118,11 @@ func TestCancel(t *testing.T) {
 
 func TestCancelAndRead(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
-	testVal := int32(0)
+	var testVal atomic.Int32
 	wg := sync.WaitGroup{}
 	wg.Add(4)
 	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
-		atomic.AddInt32(&testVal, 1)
+		testVal.Add(1)
 		wg.Done()
 		return nil
 	})
@@ -145,7 +145,7 @@ func TestCancelAndRead(t *testing.T) {
 	queue.AddWork(ctx, NewWorkArgs("2", "2"), now, then)
 	fakeClock.Step(11 * time.Second)
 	wg.Wait()
-	lastVal := atomic.LoadInt32(&testVal)
+	lastVal := testVal.Load()
 	if lastVal != 4 {
 		t.Errorf("Expected testVal = 4, got %v", lastVal)
 	}

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -717,16 +717,16 @@ func wrapTestWithInjectedOperation(ctx context.Context, toWrap testCall, injectB
 		// Run the tested function (typically syncClaim/syncVolume) in a
 		// separate goroutine.
 		var testError error
-		var testFinished int32
+		var testFinished atomic.Int32
 
 		go func() {
 			testError = toWrap(ctrl, reactor, test)
 			// Let the "main" test function know that syncVolume has finished.
-			atomic.StoreInt32(&testFinished, 1)
+			testFinished.Store(1)
 		}()
 
 		// Wait for the controller to finish the test function.
-		for atomic.LoadInt32(&testFinished) == 0 {
+		for testFinished.Load() == 0 {
 			time.Sleep(time.Millisecond * 10)
 		}
 

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -543,8 +543,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	attempts := int64(0)
-	failureCallbacks := int64(0)
+	var attempts, failureCallbacks atomic.Int64
 
 	// set up a listener that hangs connections
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -559,7 +558,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 				return
 			}
 			t.Log("accepted connection")
-			atomic.AddInt64(&attempts, 1)
+			attempts.Add(1)
 		}
 	}()
 
@@ -577,7 +576,7 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 	kubelet.heartbeatClient, err = clientset.NewForConfig(config)
 	require.NoError(t, err)
 	kubelet.onRepeatedHeartbeatFailure = func() {
-		atomic.AddInt64(&failureCallbacks, 1)
+		failureCallbacks.Add(1)
 	}
 	kubelet.containerManager = &localCM{
 		ContainerManager: cm.NewStubContainerManager(),
@@ -595,11 +594,11 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 	require.Error(t, kubelet.updateNodeStatus(tCtx))
 
 	// should have attempted multiple times
-	if actualAttempts := atomic.LoadInt64(&attempts); actualAttempts < nodeStatusUpdateRetry {
+	if actualAttempts := attempts.Load(); actualAttempts < nodeStatusUpdateRetry {
 		t.Errorf("Expected at least %d attempts, got %d", nodeStatusUpdateRetry, actualAttempts)
 	}
 	// should have gotten multiple failure callbacks
-	if actualFailureCallbacks := atomic.LoadInt64(&failureCallbacks); actualFailureCallbacks < (nodeStatusUpdateRetry - 1) {
+	if actualFailureCallbacks := failureCallbacks.Load(); actualFailureCallbacks < (nodeStatusUpdateRetry - 1) {
 		t.Errorf("Expected %d failure callbacks, got %d", (nodeStatusUpdateRetry - 1), actualFailureCallbacks)
 	}
 }

--- a/pkg/kubelet/prober/scale_test.go
+++ b/pkg/kubelet/prober/scale_test.go
@@ -208,7 +208,7 @@ func newFakePod(httpServer bool) (*fakePod, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			if _, ok := visitors[r.RemoteAddr]; !ok {
-				atomic.AddInt64(&f.numConnection, 1)
+				f.numConnection.Add(1)
 				visitors[r.RemoteAddr] = struct{}{}
 			}
 		}))
@@ -220,7 +220,7 @@ func newFakePod(httpServer bool) (*fakePod, error) {
 					// exit when the listener is closed
 					return
 				}
-				atomic.AddInt64(&f.numConnection, 1)
+				f.numConnection.Add(1)
 				// handle request but not block
 				go func(c net.Conn) {
 					defer c.Close()
@@ -240,7 +240,7 @@ func newFakePod(httpServer bool) (*fakePod, error) {
 
 type fakePod struct {
 	ln            net.Listener
-	numConnection int64
+	numConnection atomic.Int64
 	http          bool
 }
 
@@ -270,5 +270,5 @@ func (f *fakePod) stop() {
 }
 
 func (f *fakePod) connections() int {
-	return int(atomic.LoadInt64(&f.numConnection))
+	return int(f.numConnection.Load())
 }

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -152,7 +152,7 @@ type Proxier struct {
 	servicesSynced       bool
 	lastFullSync         time.Time
 	needFullSync         bool
-	initialized          int32
+	initialized          atomic.Int32
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	lastIPTablesCleanup  time.Time
@@ -449,11 +449,11 @@ func (proxier *Proxier) setInitialized(value bool) {
 	if value {
 		initialized = 1
 	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(initialized)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load() > 0
 }
 
 // OnServiceAdd is called whenever creation of new service object

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -184,7 +184,7 @@ type Proxier struct {
 	// ipvs rules with some partial data after kube-proxy restart.
 	endpointSlicesSynced bool
 	servicesSynced       bool
-	initialized          int32
+	initialized          atomic.Int32
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 
 	// These are effectively const and do not need the mutex to be held.
@@ -586,11 +586,11 @@ func (proxier *Proxier) setInitialized(value bool) {
 	if value {
 		initialized = 1
 	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(initialized)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load() > 0
 }
 
 // OnServiceAdd is called whenever creation of new service object is observed.

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -157,7 +157,7 @@ type Proxier struct {
 	servicesSynced       bool
 	lastFullSync         time.Time
 	needFullSync         bool
-	initialized          int32
+	initialized          atomic.Int32
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	flushed              bool
@@ -722,11 +722,11 @@ func (proxier *Proxier) setInitialized(value bool) {
 	if value {
 		initialized = 1
 	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(initialized)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load() > 0
 }
 
 // OnServiceAdd is called whenever creation of new service object

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -583,7 +583,7 @@ type Proxier struct {
 	// with some partial data after kube-proxy restart.
 	endpointSlicesSynced bool
 	servicesSynced       bool
-	initialized          int32
+	initialized          atomic.Int32
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	// These are effectively const and do not need the mutex to be held.
 	nodeName string
@@ -943,11 +943,11 @@ func (proxier *Proxier) setInitialized(value bool) {
 	if value {
 		initialized = 1
 	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(initialized)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load() > 0
 }
 
 // OnServiceAdd is called whenever creation of new service object

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -52,12 +52,12 @@ import (
 	apipod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	configv1 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1"
-	"k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
-	"k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
+	apicache "k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
+	apidispatcher "k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
+	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -1243,10 +1243,11 @@ func TestDryRunPreemption(t *testing.T) {
 				for i := range got {
 					candidates = append(candidates, candidate{victims: got[i].Victims(), name: got[i].Name()})
 				}
-				if fakePlugin.NumFilterCalled-prevNumFilterCalled != tt.expectedNumFilterCalled[cycle] {
-					t.Errorf("cycle %d: got NumFilterCalled=%d, want %d", cycle, fakePlugin.NumFilterCalled-prevNumFilterCalled, tt.expectedNumFilterCalled[cycle])
+				delta := fakePlugin.NumFilterCalled.Load() - prevNumFilterCalled
+				if delta != tt.expectedNumFilterCalled[cycle] {
+					t.Errorf("cycle %d: got NumFilterCalled=%d, want %d", cycle, delta, tt.expectedNumFilterCalled[cycle])
 				}
-				prevNumFilterCalled = fakePlugin.NumFilterCalled
+				prevNumFilterCalled = fakePlugin.NumFilterCalled.Load()
 				if diff := cmp.Diff(tt.expected[cycle], candidates, cmp.AllowUnexported(candidate{})); diff != "" {
 					t.Errorf("cycle %d: unexpected candidates (-want, +got): %s", cycle, diff)
 				}

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -203,7 +203,8 @@ func podMatchesAllAffinityTerms(terms []fwk.AffinityTerm, pod *v1.Pod) bool {
 //  2. Whether any AntiAffinityTerm matches the incoming pod
 func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, pod *v1.Pod, nsLabels labels.Set, nodes []fwk.NodeInfo) topologyToMatchedTermCount {
 	antiAffinityCountsList := make([]topologyToMatchedTermCountList, len(nodes))
-	index := int32(-1)
+	var index atomic.Int32
+	index.Store(-1)
 	processNode := func(i int) {
 		nodeInfo := nodes[i]
 		node := nodeInfo.Node()
@@ -213,14 +214,15 @@ func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, p
 			antiAffinityCounts.appendWithAntiAffinityTerms(existingPod.GetRequiredAntiAffinityTerms(), pod, nsLabels, node, 1)
 		}
 		if len(antiAffinityCounts) != 0 {
-			antiAffinityCountsList[atomic.AddInt32(&index, 1)] = antiAffinityCounts
+			antiAffinityCountsList[index.Add(1)] = antiAffinityCounts
 		}
 	}
 	pl.parallelizer.Until(ctx, len(nodes), processNode, pl.Name())
 
 	result := make(topologyToMatchedTermCount)
 	// Traditional for loop is slightly faster in this case than its "for range" equivalent.
-	for i := 0; i <= int(index); i++ {
+	end := index.Load()
+	for i := int32(0); i <= end; i++ {
 		result.mergeWithList(antiAffinityCountsList[i])
 	}
 
@@ -240,7 +242,8 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 
 	affinityCountsList := make([]topologyToMatchedTermCountList, len(allNodes))
 	antiAffinityCountsList := make([]topologyToMatchedTermCountList, len(allNodes))
-	index := int32(-1)
+	var index atomic.Int32
+	index.Store(-1)
 	processNode := func(i int) {
 		nodeInfo := allNodes[i]
 		node := nodeInfo.Node()
@@ -255,14 +258,15 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 		}
 
 		if len(affinity) > 0 || len(antiAffinity) > 0 {
-			k := atomic.AddInt32(&index, 1)
+			k := index.Add(1)
 			affinityCountsList[k] = affinity
 			antiAffinityCountsList[k] = antiAffinity
 		}
 	}
 	pl.parallelizer.Until(ctx, len(allNodes), processNode, pl.Name())
 
-	for i := 0; i <= int(index); i++ {
+	end := index.Load()
+	for i := int32(0); i <= end; i++ {
 		affinityCounts.mergeWithList(affinityCountsList[i])
 		antiAffinityCounts.mergeWithList(antiAffinityCountsList[i])
 	}

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -186,7 +186,8 @@ func (pl *InterPodAffinity) PreScore(
 	state.namespaceLabels = GetNamespaceLabelsSnapshot(logger, pod.Namespace, pl.nsLister)
 
 	topoScores := make([]scoreMap, len(allNodes))
-	index := int32(-1)
+	var index atomic.Int32
+	index.Store(-1)
 	processNode := func(i int) {
 		nodeInfo := allNodes[i]
 
@@ -203,16 +204,17 @@ func (pl *InterPodAffinity) PreScore(
 			pl.processExistingPod(state, existingPod, nodeInfo, pod, topoScore)
 		}
 		if len(topoScore) > 0 {
-			topoScores[atomic.AddInt32(&index, 1)] = topoScore
+			topoScores[index.Add(1)] = topoScore
 		}
 	}
 	pl.parallelizer.Until(pCtx, len(allNodes), processNode, pl.Name())
 
-	if index == -1 {
+	if index.Load() == -1 {
 		return fwk.NewStatus(fwk.Skip)
 	}
 
-	for i := 0; i <= int(index); i++ {
+	end := int(index.Load())
+	for i := 0; i <= end; i++ {
 		state.topologyScore.append(topoScores[i])
 	}
 

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -40,7 +40,7 @@ import (
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
 
-var generation int64
+var generation atomic.Int64
 
 var (
 	// basicActionTypes is a list of basic ActionTypes.
@@ -497,7 +497,7 @@ func (n *NodeInfo) RemoveNode() {
 // Collision of the generation numbers would be particularly problematic if a node was deleted and
 // added back with the same name. See issue#63262.
 func nextGeneration() int64 {
-	return atomic.AddInt64(&generation, 1)
+	return generation.Add(1)
 }
 
 // QueuedPodInfo is a Pod wrapper with additional information related to

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -350,7 +350,7 @@ func TestNewNodeInfo(t *testing.T) {
 		},
 	}
 
-	gen := generation
+	gen := generation.Load()
 	ni := NewNodeInfo(pods...)
 	if ni.Generation <= gen {
 		t.Errorf("Generation is not incremented. previous: %v, current: %v", gen, ni.Generation)

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -30,19 +30,19 @@ import (
 var _ MetricRecorder = &fakePodsRecorder{}
 
 type fakePodsRecorder struct {
-	counter int64
+	counter atomic.Int64
 }
 
 func (r *fakePodsRecorder) Inc() {
-	atomic.AddInt64(&r.counter, 1)
+	r.counter.Add(1)
 }
 
 func (r *fakePodsRecorder) Dec() {
-	atomic.AddInt64(&r.counter, -1)
+	r.counter.Add(-1)
 }
 
 func (r *fakePodsRecorder) Clear() {
-	atomic.StoreInt64(&r.counter, 0)
+	r.counter.Store(0)
 }
 
 func TestInc(t *testing.T) {
@@ -50,32 +50,36 @@ func TestInc(t *testing.T) {
 	var wg sync.WaitGroup
 	loops := 100
 	wg.Add(loops)
-	for i := 0; i < loops; i++ {
+	for range loops {
 		go func() {
 			fakeRecorder.Inc()
 			wg.Done()
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter != int64(loops) {
-		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter)
+	got := fakeRecorder.counter.Load()
+	if got != int64(loops) {
+		t.Errorf("Expected %v, got %v", loops, got)
 	}
+
 }
 
 func TestDec(t *testing.T) {
-	fakeRecorder := fakePodsRecorder{counter: 100}
+	var fakeRecorder fakePodsRecorder
+	fakeRecorder.counter.Store(100)
 	var wg sync.WaitGroup
 	loops := 100
 	wg.Add(loops)
-	for i := 0; i < loops; i++ {
+	for range loops {
 		go func() {
 			fakeRecorder.Dec()
 			wg.Done()
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter != int64(0) {
-		t.Errorf("Expected %v, got %v", loops, fakeRecorder.counter)
+	got := fakeRecorder.counter.Load()
+	if got != int64(0) {
+		t.Errorf("Expected %v, got %v", loops, got)
 	}
 }
 
@@ -84,26 +88,28 @@ func TestClear(t *testing.T) {
 	var wg sync.WaitGroup
 	incLoops, decLoops := 100, 80
 	wg.Add(incLoops + decLoops)
-	for i := 0; i < incLoops; i++ {
+	for range incLoops {
 		go func() {
 			fakeRecorder.Inc()
 			wg.Done()
 		}()
 	}
-	for i := 0; i < decLoops; i++ {
+	for range decLoops {
 		go func() {
 			fakeRecorder.Dec()
 			wg.Done()
 		}()
 	}
 	wg.Wait()
-	if fakeRecorder.counter != int64(incLoops-decLoops) {
-		t.Errorf("Expected %v, got %v", incLoops-decLoops, fakeRecorder.counter)
+	got := fakeRecorder.counter.Load()
+	if got != int64(incLoops-decLoops) {
+		t.Errorf("Expected %v, got %v", incLoops-decLoops, got)
 	}
 	// verify Clear() works
 	fakeRecorder.Clear()
-	if fakeRecorder.counter != int64(0) {
-		t.Errorf("Expected %v, got %v", 0, fakeRecorder.counter)
+	got = fakeRecorder.counter.Load()
+	if got != int64(0) {
+		t.Errorf("Expected %v, got %v", 0, got)
 	}
 }
 

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -797,7 +797,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	}
 
 	errCh := parallelize.NewResultChannel[error]()
-	var feasibleNodesLen int32
+	var feasibleNodesLen atomic.Int32
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(errors.New("findNodesThatPassFilters has completed"))
 
@@ -818,10 +818,10 @@ func (sched *Scheduler) findNodesThatPassFilters(
 			return
 		}
 		if status.IsSuccess() {
-			length := atomic.AddInt32(&feasibleNodesLen, 1)
+			length := feasibleNodesLen.Add(1)
 			if length > numNodesToFind {
 				cancel(errors.New("findNodesThatPassFilters has found enough nodes"))
-				atomic.AddInt32(&feasibleNodesLen, -1)
+				feasibleNodesLen.Add(-1)
 			} else {
 				feasibleNodes[length-1] = nodeInfo
 			}
@@ -842,7 +842,8 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	// Stops searching for more nodes once the configured number of feasible nodes
 	// are found.
 	schedFramework.Parallelizer().Until(ctx, numAllNodes, checkNode, metrics.Filter)
-	feasibleNodes = feasibleNodes[:feasibleNodesLen]
+	len := feasibleNodesLen.Load()
+	feasibleNodes = feasibleNodes[:len]
 	for _, item := range result {
 		if item == nil {
 			continue

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -3874,8 +3874,9 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if test.expectedCount != plugin.NumFilterCalled {
-				t.Errorf("predicate was called %d times, expected is %d", plugin.NumFilterCalled, test.expectedCount)
+			got := plugin.NumFilterCalled.Load()
+			if test.expectedCount != got {
+				t.Errorf("predicate was called %d times, expected is %d", got, test.expectedCount)
 			}
 		})
 	}
@@ -4483,8 +4484,9 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if test.expectedCount != plugin.NumFilterCalled {
-				t.Errorf("predicate was called %d times, expected is %d", plugin.NumFilterCalled, test.expectedCount)
+			got := plugin.NumFilterCalled.Load()
+			if test.expectedCount != got {
+				t.Errorf("predicate was called %d times, expected is %d", got, test.expectedCount)
 			}
 		})
 	}

--- a/pkg/scheduler/testing/framework/fake_plugins.go
+++ b/pkg/scheduler/testing/framework/fake_plugins.go
@@ -80,7 +80,7 @@ func (pl FakePreFilterAndFilterPlugin) Name() string {
 // FakeFilterPlugin is a test filter plugin to record how many times its Filter() function have
 // been called, and it returns different 'Code' depending on its internal 'failedNodeReturnCodeMap'.
 type FakeFilterPlugin struct {
-	NumFilterCalled         int32
+	NumFilterCalled         atomic.Int32
 	FailedNodeReturnCodeMap map[string]fwk.Code
 }
 
@@ -91,7 +91,7 @@ func (pl *FakeFilterPlugin) Name() string {
 
 // Filter invoked at the filter extension point.
 func (pl *FakeFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
-	atomic.AddInt32(&pl.NumFilterCalled, 1)
+	pl.NumFilterCalled.Add(1)
 
 	if returnCode, ok := pl.FailedNodeReturnCodeMap[nodeInfo.Node().Name]; ok {
 		return fwk.NewStatus(returnCode, fmt.Sprintf("injecting failure for pod %v", pod.Name))

--- a/pkg/volume/metrics_cached.go
+++ b/pkg/volume/metrics_cached.go
@@ -53,22 +53,22 @@ func (md *cachedMetrics) GetMetrics() (*Metrics, error) {
 // error
 type cacheOnce struct {
 	m    sync.Mutex
-	done uint32
+	done atomic.Uint32
 }
 
 // Copied from sync.Once but we don't want to cache the results if there is an
 // error
 func (o *cacheOnce) cache(f func() error) {
-	if atomic.LoadUint32(&o.done) == 1 {
+	if o.done.Load() == 1 {
 		return
 	}
 	// Slow-path.
 	o.m.Lock()
 	defer o.m.Unlock()
-	if o.done == 0 {
+	if o.done.Load() == 0 {
 		err := f()
 		if err == nil {
-			atomic.StoreUint32(&o.done, 1)
+			o.done.Store(1)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR updates atomic operations to use Go 1.19’s typed atomic types instead of the older function-based atomic API.
Fields such as uint64 are replaced with atomic.Uint64, allowing usage like:
```
counter.Add(1)
```
instead of
```
atomic.AddUint64(&counter, 1)
```
This removes pointer-based atomic calls, improves readability, and provides stronger compile-time safety when working with shared state in concurrent validator operations. The change is purely mechanical and does not modify logic.



#### Which issue(s) this PR is related to:
Refrence: https://github.com/kubernetes/kubernetes/pull/136665

#### Special notes for your reviewer:
- This is a mechanical refactor focused on correctness and maintainability.
- No behavioral or performance changes are intended.
- The change relies on Go 1.19+ typed atomics, which are already required by the project.
- All atomic operations are semantically equivalent to the previous implementation.

#### Does this PR introduce a user-facing change?
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```

```

/sig release