### PR TITLE
staging: refactor to use atomic types

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -349,11 +349,11 @@ DRAIN:
 
 type fakePoller struct {
 	max  int
-	used int32 // accessed with atomics
+	used atomic.Int32
 	wg   sync.WaitGroup
 }
 
-func fakeTicker(max int, used *int32, doneFunc func()) waitFunc {
+func fakeTicker(max int, used *atomic.Int32, doneFunc func()) waitFunc {
 	return func(done <-chan struct{}) <-chan struct{} {
 		ch := make(chan struct{})
 		go func() {
@@ -366,7 +366,7 @@ func fakeTicker(max int, used *int32, doneFunc func()) waitFunc {
 					return
 				}
 				if used != nil {
-					atomic.AddInt32(used, 1)
+					used.Add(1)
 				}
 			}
 		}()
@@ -396,7 +396,7 @@ func TestPoll(t *testing.T) {
 	if invocations != 1 {
 		t.Errorf("Expected exactly one invocation, got %d", invocations)
 	}
-	used := atomic.LoadInt32(&fp.used)
+	used := fp.used.Load()
 	if used != 1 {
 		t.Errorf("Expected exactly one tick, got %d", used)
 	}
@@ -415,7 +415,7 @@ func TestPollError(t *testing.T) {
 		t.Fatalf("Expected error %v, got none %v", expectedError, err)
 	}
 	fp.wg.Wait()
-	used := atomic.LoadInt32(&fp.used)
+	used := fp.used.Load()
 	if used != 1 {
 		t.Errorf("Expected exactly one tick, got %d", used)
 	}
@@ -438,7 +438,7 @@ func TestPollImmediate(t *testing.T) {
 	if invocations != 1 {
 		t.Errorf("Expected exactly one invocation, got %d", invocations)
 	}
-	used := atomic.LoadInt32(&fp.used)
+	used := fp.used.Load()
 	if used != 0 {
 		t.Errorf("Expected exactly zero ticks, got %d", used)
 	}
@@ -457,7 +457,7 @@ func TestPollImmediateError(t *testing.T) {
 		t.Fatalf("Expected error %v, got none %v", expectedError, err)
 	}
 	// We don't need to wait for fp.wg, as pollImmediate shouldn't call waitFunc at all.
-	used := atomic.LoadInt32(&fp.used)
+	used := fp.used.Load()
 	if used != 0 {
 		t.Errorf("Expected exactly zero ticks, got %d", used)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,7 +80,7 @@ func BenchmarkAdmit(b *testing.B) {
 			ns := "webhook-test"
 			client, informer := webhooktesting.NewFakeMutatingDataSource(ns, tt.Webhooks, stopCh)
 
-			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(&atomic.Int32{})))
 			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
 			wh.SetExternalKubeClientSet(client)
 			wh.SetExternalKubeInformerFactory(informer)
@@ -138,7 +139,7 @@ func TestAdmit(t *testing.T) {
 			ns := "webhook-test"
 			client, informer := webhooktesting.NewFakeMutatingDataSource(ns, tt.Webhooks, stopCh)
 
-			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(&atomic.Int32{})))
 			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
 			wh.SetExternalKubeClientSet(client)
 			wh.SetExternalKubeInformerFactory(informer)
@@ -240,7 +241,7 @@ func TestAdmitCachedClient(t *testing.T) {
 		client, informer := webhooktesting.NewFakeMutatingDataSource(ns, webhooktesting.ConvertToMutatingWebhooks(tt.Webhooks), stopCh)
 
 		// override the webhook source. The client cache will stay the same.
-		cacheMisses := new(int32)
+		cacheMisses := &atomic.Int32{}
 		wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(cacheMisses)))
 		wh.SetExternalKubeClientSet(client)
 		wh.SetExternalKubeInformerFactory(informer)
@@ -258,12 +259,12 @@ func TestAdmitCachedClient(t *testing.T) {
 			t.Errorf("%s: expected allowed=%v, but got err=%v", tt.Name, tt.ExpectAllow, err)
 		}
 
-		if tt.ExpectCacheMiss && *cacheMisses == 0 {
+		if tt.ExpectCacheMiss && cacheMisses.Load() == 0 {
 			t.Errorf("%s: expected cache miss, but got no AuthenticationInfoResolver call", tt.Name)
 		}
 
-		if !tt.ExpectCacheMiss && *cacheMisses > 0 {
-			t.Errorf("%s: expected client to be cached, but got %d AuthenticationInfoResolver calls", tt.Name, *cacheMisses)
+		if !tt.ExpectCacheMiss && cacheMisses.Load() > 0 {
+			t.Errorf("%s: expected client to be cached, but got %d AuthenticationInfoResolver calls", tt.Name, cacheMisses.Load())
 		}
 	}
 }
@@ -299,7 +300,7 @@ func TestWebhookDuration(ts *testing.T) {
 			ns := "webhook-test"
 			client, informer := webhooktesting.NewFakeMutatingDataSource(ns, webhooktesting.ConvertToMutatingWebhooks(test.Webhooks), stopCh)
 
-			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(&atomic.Int32{})))
 			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
 			wh.SetExternalKubeClientSet(client)
 			wh.SetExternalKubeInformerFactory(informer)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/authentication_info_resolver.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/authentication_info_resolver.go
@@ -34,7 +34,7 @@ func Wrapper(r webhook.AuthenticationInfoResolver) func(webhook.AuthenticationIn
 
 // NewAuthenticationInfoResolver creates a fake AuthenticationInfoResolver that counts cache misses on
 // every call to its methods.
-func NewAuthenticationInfoResolver(cacheMisses *int32) webhook.AuthenticationInfoResolver {
+func NewAuthenticationInfoResolver(cacheMisses *atomic.Int32) webhook.AuthenticationInfoResolver {
 	return &authenticationInfoResolver{
 		restConfig: &rest.Config{
 			TLSClientConfig: rest.TLSClientConfig{
@@ -49,16 +49,16 @@ func NewAuthenticationInfoResolver(cacheMisses *int32) webhook.AuthenticationInf
 
 type authenticationInfoResolver struct {
 	restConfig  *rest.Config
-	cacheMisses *int32
+	cacheMisses *atomic.Int32
 }
 
 func (a *authenticationInfoResolver) ClientConfigFor(hostPort string) (*rest.Config, error) {
-	atomic.AddInt32(a.cacheMisses, 1)
+	a.cacheMisses.Add(1)
 	return a.restConfig, nil
 }
 
 func (a *authenticationInfoResolver) ClientConfigForService(serviceName, serviceNamespace string, servicePort int) (*rest.Config, error) {
-	atomic.AddInt32(a.cacheMisses, 1)
+	a.cacheMisses.Add(1)
 	return a.restConfig, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,7 +74,7 @@ func BenchmarkValidate(b *testing.B) {
 			ns := "webhook-test"
 			client, informer := webhooktesting.NewFakeValidatingDataSource(ns, tt.Webhooks, stopCh)
 
-			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(&atomic.Int32{})))
 			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
 			wh.SetExternalKubeClientSet(client)
 			wh.SetExternalKubeInformerFactory(informer)
@@ -124,7 +125,7 @@ func TestValidate(t *testing.T) {
 		ns := "webhook-test"
 		client, informer := webhooktesting.NewFakeValidatingDataSource(ns, tt.Webhooks, stopCh)
 
-		wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+		wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(&atomic.Int32{})))
 		wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
 		wh.SetExternalKubeClientSet(client)
 		wh.SetExternalKubeInformerFactory(informer)
@@ -203,7 +204,7 @@ func TestValidateCachedClient(t *testing.T) {
 		client, informer := webhooktesting.NewFakeValidatingDataSource(ns, tt.Webhooks, stopCh)
 
 		// override the webhook source. The client cache will stay the same.
-		cacheMisses := new(int32)
+		cacheMisses := &atomic.Int32{}
 		wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(cacheMisses)))
 		wh.SetExternalKubeClientSet(client)
 		wh.SetExternalKubeInformerFactory(informer)
@@ -221,12 +222,12 @@ func TestValidateCachedClient(t *testing.T) {
 			t.Errorf("%s: expected allowed=%v, but got err=%v", tt.Name, tt.ExpectAllow, err)
 		}
 
-		if tt.ExpectCacheMiss && *cacheMisses == 0 {
+		if tt.ExpectCacheMiss && cacheMisses.Load() == 0 {
 			t.Errorf("%s: expected cache miss, but got no AuthenticationInfoResolver call", tt.Name)
 		}
 
-		if !tt.ExpectCacheMiss && *cacheMisses > 0 {
-			t.Errorf("%s: expected client to be cached, but got %d AuthenticationInfoResolver calls", tt.Name, *cacheMisses)
+		if !tt.ExpectCacheMiss && cacheMisses.Load() > 0 {
+			t.Errorf("%s: expected client to be cached, but got %d AuthenticationInfoResolver calls", tt.Name, cacheMisses.Load())
 		}
 	}
 }
@@ -262,7 +263,7 @@ func TestValidateWebhookDuration(ts *testing.T) {
 			ns := "webhook-test"
 			client, informer := webhooktesting.NewFakeValidatingDataSource(ns, test.Webhooks, stopCh)
 
-			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(&atomic.Int32{})))
 			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
 			wh.SetExternalKubeClientSet(client)
 			wh.SetExternalKubeInformerFactory(informer)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
@@ -183,11 +183,11 @@ func TestSharedLookup(t *testing.T) {
 	var chewie = &authenticator.Response{User: &user.DefaultInfo{Name: "chewbacca"}}
 
 	t.Run("actually shared", func(t *testing.T) {
-		var lookups uint32
+		var lookups atomic.Uint32
 		c := make(chan struct{})
 		a := New(authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 			<-c
-			atomic.AddUint32(&lookups, 1)
+			lookups.Add(1)
 			return chewie, true, nil
 		}), true, time.Minute, 0)
 
@@ -205,8 +205,8 @@ func TestSharedLookup(t *testing.T) {
 		close(c)
 		wg.Wait()
 
-		if lookups > 3 {
-			t.Fatalf("unexpected number of lookups: got=%d, wanted less than 3", lookups)
+		if lookups.Load() > 3 {
+			t.Fatalf("unexpected number of lookups: got=%d, wanted less than 3", lookups.Load())
 		}
 	})
 
@@ -283,11 +283,11 @@ func TestCachedAuditAnnotations(t *testing.T) {
 	snorlax := &authenticator.Response{User: &user.DefaultInfo{Name: "snorlax"}}
 
 	t.Run("annotations from cache", func(t *testing.T) {
-		var lookups uint32
+		var lookups atomic.Uint32
 		c := make(chan struct{})
 		a := New(authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 			<-c
-			atomic.AddUint32(&lookups, 1)
+			lookups.Add(1)
 			audit.AddAuditAnnotation(ctx, "snorlax", "rocks")
 			audit.AddAuditAnnotation(ctx, "pandas", "are amazing")
 			return snorlax, true, nil
@@ -326,8 +326,8 @@ func TestCachedAuditAnnotations(t *testing.T) {
 			t.Errorf("expected all annoations to be processed: %d", queued)
 		}
 
-		if lookups > 3 {
-			t.Errorf("unexpected number of lookups: got=%d, wanted less than 3", lookups)
+		if lookups.Load() > 3 {
+			t.Errorf("unexpected number of lookups: got=%d, wanted less than 3", lookups.Load())
 		}
 	})
 
@@ -506,11 +506,11 @@ func (s *singleBenchmark) bench(b *testing.B) {
 	const maxInFlight = 40
 	chokepoint := make(chan struct{}, maxInFlight)
 	// lookup count
-	var lookups uint64
+	var lookups atomic.Uint64
 
 	a := newWithClock(
 		authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
-			atomic.AddUint64(&lookups, 1)
+			lookups.Add(1)
 
 			chokepoint <- struct{}{}
 			defer func() { <-chokepoint }()
@@ -538,7 +538,7 @@ func (s *singleBenchmark) bench(b *testing.B) {
 	})
 	b.StopTimer()
 
-	b.ReportMetric(float64(lookups)/float64(b.N), "lookups/op")
+	b.ReportMetric(float64(lookups.Load())/float64(b.N), "lookups/op")
 }
 
 // Add a test version of the audit context with a pre-populated event for easy annotation

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -354,14 +354,14 @@ func TestDeleteCollectionDeleteOptions(t *testing.T) {
 
 func TestDeleteCollectionWithNoContextDeadlineEnforced(t *testing.T) {
 	ctx := t.Context()
-	var invokedGot, hasDeadlineGot int32
+	var invokedGot, hasDeadlineGot atomic.Int32
 	fakeDeleterFn := func(ctx context.Context, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions, _ *metainternalversion.ListOptions) (runtime.Object, error) {
 		// we expect CollectionDeleter to be executed once
-		atomic.AddInt32(&invokedGot, 1)
+		invokedGot.Add(1)
 
 		// we don't expect any context deadline to be set
 		if _, hasDeadline := ctx.Deadline(); hasDeadline {
-			atomic.AddInt32(&hasDeadlineGot, 1)
+			hasDeadlineGot.Add(1)
 		}
 		return nil, nil
 	}
@@ -386,10 +386,10 @@ func TestDeleteCollectionWithNoContextDeadlineEnforced(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, request)
-	if atomic.LoadInt32(&invokedGot) != 1 {
+	if invokedGot.Load() != 1 {
 		t.Errorf("expected collection deleter to be invoked")
 	}
-	if atomic.LoadInt32(&hasDeadlineGot) > 0 {
+	if hasDeadlineGot.Load() > 0 {
 		t.Errorf("expected context to not have any deadline")
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2130,11 +2130,11 @@ func TestStoreDeletionPropagation(t *testing.T) {
 type storageWithCounter struct {
 	storage.Interface
 
-	listCounter int64
+	listCounter atomic.Int64
 }
 
 func (s *storageWithCounter) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
-	atomic.AddInt64(&s.listCounter, 1)
+	s.listCounter.Add(1)
 	return s.Interface.GetList(ctx, key, opts, listObj)
 }
 
@@ -2171,7 +2171,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 		t.Errorf("Unexpected number of pods deleted: %d, expected: %d", len(deletedPods.Items), numPods)
 	}
 	expectedCalls := (int64(numPods) + deleteCollectionPageSize - 1) / deleteCollectionPageSize
-	if listCalls := atomic.LoadInt64(&storeWithCounter.listCounter); listCalls != expectedCalls {
+	if listCalls := storeWithCounter.listCounter.Load(); listCalls != expectedCalls {
 		t.Errorf("Unexpected number of list calls: %d, expected: %d", listCalls, expectedCalls)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -261,8 +261,6 @@ type indexedTriggerFunc struct {
 // delegated to the underlying storage).
 type Cacher struct {
 	// HighWaterMarks for performance debugging.
-	// Important: Since HighWaterMark is using sync/atomic, it has to be at the top of the struct due to a bug on 32-bit platforms
-	// See: https://golang.org/pkg/sync/atomic/ for more information
 	incomingHWM storage.HighWaterMark
 	// Incoming events that should be dispatched to watchers.
 	incoming chan watchCacheEvent

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -196,9 +196,9 @@ type storeWithPrefixTransformer struct {
 
 func (s *storeWithPrefixTransformer) UpdatePrefixTransformer(modifier storagetesting.PrefixTransformerModifier) func() {
 	originalTransformer := s.transformer.(*storagetesting.PrefixTransformer)
-	transformer := *originalTransformer
-	s.transformer = modifier(&transformer)
-	s.watcher.transformer = modifier(&transformer)
+	transformer := originalTransformer.Clone()
+	s.transformer = modifier(transformer)
+	s.watcher.transformer = modifier(transformer)
 	return func() {
 		s.transformer = originalTransformer
 		s.watcher.transformer = originalTransformer

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
@@ -277,12 +277,12 @@ func TestRateLimitHealthcheck(t *testing.T) {
 
 			ready := make(chan struct{})
 
-			var counter uint64
+			var counter atomic.Uint64
 			newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
 				defer close(ready)
 				dummyKV := mockKV{
 					get: func(ctx context.Context) (*clientv3.GetResponse, error) {
-						atomic.AddUint64(&counter, 1)
+						counter.Add(1)
 						select {
 						case <-ctx.Done():
 							return nil, ctx.Err()
@@ -325,8 +325,8 @@ func TestRateLimitHealthcheck(t *testing.T) {
 
 			// check the counter once the requests have finished
 			wg.Wait()
-			if counter != 1 {
-				t.Errorf("healthcheck() called etcd %d times, expected only one call", counter)
+			if counter.Load() != 1 {
+				t.Errorf("healthcheck() called etcd %d times, expected only one call", counter.Load())
 			}
 
 			// wait until the rate limit allows new connections
@@ -347,8 +347,8 @@ func TestRateLimitHealthcheck(t *testing.T) {
 			}
 			wg.Wait()
 
-			if counter != 2 {
-				t.Errorf("healthcheck() called etcd %d times, expected only two calls", counter)
+			if counter.Load() != 2 {
+				t.Errorf("healthcheck() called etcd %d times, expected only two calls", counter.Load())
 			}
 		})
 	}
@@ -373,13 +373,13 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	ready := make(chan struct{})
 	signal := make(chan struct{})
 
-	var counter uint64
+	var counter atomic.Uint64
 	newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
 		defer close(ready)
 		dummyKV := mockKV{
 			get: func(ctx context.Context) (*clientv3.GetResponse, error) {
-				atomic.AddUint64(&counter, 1)
-				val := atomic.LoadUint64(&counter)
+				counter.Add(1)
+				val := counter.Load()
 				// the first request wait for a custom timeout to trigger an error.
 				// We don't use the context timeout because we want to check that
 				// the cached answer is not overridden, and since the rate limit is
@@ -433,7 +433,7 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	c := atomic.LoadUint64(&counter)
+	c := counter.Load()
 	if c != 2 {
 		t.Errorf("healthcheck() called etcd %d times, expected only two calls", c)
 	}
@@ -444,7 +444,7 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	c = atomic.LoadUint64(&counter)
+	c = counter.Load()
 	if c != 2 {
 		t.Errorf("healthcheck() called etcd %d times, expected only two calls", c)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
@@ -28,7 +28,7 @@ import (
 type KVRecorder struct {
 	clientv3.KV
 
-	reads uint64
+	reads atomic.Uint64
 }
 
 func NewKVRecorder(kv clientv3.KV) *KVRecorder {
@@ -36,12 +36,12 @@ func NewKVRecorder(kv clientv3.KV) *KVRecorder {
 }
 
 func (r *KVRecorder) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
-	atomic.AddUint64(&r.reads, 1)
+	r.reads.Add(1)
 	return r.KV.Get(ctx, key, opts...)
 }
 
 func (r *KVRecorder) GetReadsAndReset() uint64 {
-	return atomic.SwapUint64(&r.reads, 0)
+	return r.reads.Swap(0)
 }
 
 type KubernetesRecorder struct {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
@@ -302,7 +302,7 @@ type PrefixTransformer struct {
 	prefix []byte
 	stale  bool
 	err    error
-	reads  uint64
+	reads  atomic.Uint64
 }
 
 func NewPrefixTransformer(prefix []byte, stale bool) *PrefixTransformer {
@@ -313,7 +313,7 @@ func NewPrefixTransformer(prefix []byte, stale bool) *PrefixTransformer {
 }
 
 func (p *PrefixTransformer) TransformFromStorage(ctx context.Context, data []byte, dataCtx value.Context) ([]byte, bool, error) {
-	atomic.AddUint64(&p.reads, 1)
+	p.reads.Add(1)
 	if dataCtx == nil {
 		panic("no context provided")
 	}
@@ -333,7 +333,17 @@ func (p *PrefixTransformer) TransformToStorage(ctx context.Context, data []byte,
 }
 
 func (p *PrefixTransformer) GetReadsAndReset() uint64 {
-	return atomic.SwapUint64(&p.reads, 0)
+	return p.reads.Swap(0)
+}
+
+// Clone returns a new PrefixTransformer with identical configuration (prefix, stale, err)
+// but a zeroed reads counter. This avoids copying the atomic.Uint64 which contains noCopy.
+func (p *PrefixTransformer) Clone() *PrefixTransformer {
+	return &PrefixTransformer{
+		prefix: p.prefix,
+		stale:  p.stale,
+		err:    p.err,
+	}
 }
 
 // reproducingTransformer is a custom test-only transformer used purely
@@ -345,7 +355,7 @@ type reproducingTransformer struct {
 	wrapped value.Transformer
 	store   storage.Interface
 
-	index      uint32
+	index      atomic.Uint32
 	nextObject func(uint32) (string, *example.Pod)
 }
 
@@ -361,7 +371,7 @@ func (rt *reproducingTransformer) TransformToStorage(ctx context.Context, data [
 }
 
 func (rt *reproducingTransformer) createObject(ctx context.Context) error {
-	key, obj := rt.nextObject(atomic.AddUint32(&rt.index, 1))
+	key, obj := rt.nextObject(rt.index.Add(1))
 	out := &example.Pod{}
 	return rt.store.Create(ctx, key, obj, out, 0)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/util.go
@@ -69,19 +69,26 @@ func NoNamespaceKeyFunc(prefix string, obj runtime.Object) (string, error) {
 
 // HighWaterMark is a thread-safe object for tracking the maximum value seen
 // for some quantity.
-type HighWaterMark int64
+type HighWaterMark struct {
+	val atomic.Int64
+}
 
 // Update returns true if and only if 'current' is the highest value ever seen.
 func (hwm *HighWaterMark) Update(current int64) bool {
 	for {
-		old := atomic.LoadInt64((*int64)(hwm))
+		old := hwm.val.Load()
 		if current <= old {
 			return false
 		}
-		if atomic.CompareAndSwapInt64((*int64)(hwm), old, current) {
+		if hwm.val.CompareAndSwap(old, current) {
 			return true
 		}
 	}
+}
+
+// Load returns the current high water mark value.
+func (hwm *HighWaterMark) Load() int64 {
+	return hwm.val.Load()
 }
 
 // AnnotateInitialEventsEndBookmark adds a special annotation to the given object

--- a/staging/src/k8s.io/apiserver/pkg/storage/util_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/util_test.go
@@ -68,8 +68,8 @@ func TestHighWaterMark(t *testing.T) {
 		}
 	}
 	wg.Wait()
-	if m != int64(h) {
-		t.Errorf("unexpected value, wanted %v, got %v", m, int64(h))
+	if m != h.Load() {
+		t.Errorf("unexpected value, wanted %v, got %v", m, h.Load())
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
@@ -68,11 +68,11 @@ type testEnvelopeService struct {
 	disabled     bool
 	keyVersion   string
 	ciphertext   []byte
-	decryptCalls int32
+	decryptCalls atomic.Int32
 }
 
 func (t *testEnvelopeService) Decrypt(ctx context.Context, uid string, req *kmsservice.DecryptRequest) ([]byte, error) {
-	atomic.AddInt32(&t.decryptCalls, 1)
+	t.decryptCalls.Add(1)
 	if t.disabled {
 		return nil, fmt.Errorf("Envelope service was disabled")
 	}
@@ -232,8 +232,8 @@ func TestEnvelopeCaching(t *testing.T) {
 					}
 				}
 			}
-			if int(envelopeService.decryptCalls) != tt.expectedDecryptCalls {
-				t.Fatalf("expected %d decrypt calls, got %d", tt.expectedDecryptCalls, envelopeService.decryptCalls)
+			if int(envelopeService.decryptCalls.Load()) != tt.expectedDecryptCalls {
+				t.Fatalf("expected %d decrypt calls, got %d", tt.expectedDecryptCalls, envelopeService.decryptCalls.Load())
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/real_event_clock_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/eventclock/real_event_clock_test.go
@@ -25,14 +25,14 @@ import (
 
 func TestRealEventClock(t *testing.T) {
 	ec := Real{}
-	var numDone int32
+	var numDone atomic.Int32
 	now := ec.Now()
 	const batchSize = 100
 	times := make(chan time.Time, batchSize+1)
 	try := func(abs bool, d time.Duration) {
 		f := func(u time.Time) {
 			realD := ec.Since(now)
-			atomic.AddInt32(&numDone, 1)
+			numDone.Add(1)
 			times <- u
 			if realD < d {
 				t.Errorf("Asked for %v, got %v", d, realD)
@@ -50,8 +50,8 @@ func TestRealEventClock(t *testing.T) {
 		try(i%2 == 0, d)
 	}
 	time.Sleep(time.Second * 4)
-	if atomic.LoadInt32(&numDone) != batchSize+1 {
-		t.Errorf("Got only %v events", numDone)
+	if numDone.Load() != batchSize+1 {
+		t.Errorf("Got only %v events", numDone.Load())
 	}
 	lastTime := now
 	for i := 0; i <= batchSize; i++ {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -197,8 +197,8 @@ func (us uniformScenario) exercise(t *testing.T) {
 		startTime:                 us.clk.Now(),
 		execSeatsIntegrators:      make([]fq.Integrator, len(us.clients)),
 		seatDemandIntegratorCheck: fq.NewNamedIntegrator(us.clk, us.name+"-seatDemandCheck"),
-		executions:                make([]int32, len(us.clients)),
-		rejects:                   make([]int32, len(us.clients)),
+		executions:                make([]atomic.Int32, len(us.clients)),
+		rejects:                   make([]atomic.Int32, len(us.clients)),
 	}
 	for _, uc := range us.clients {
 		uss.doSplit = uss.doSplit || uc.split
@@ -213,9 +213,9 @@ type uniformScenarioState struct {
 	doSplit                                                                                bool
 	execSeatsIntegrators                                                                   []fq.Integrator
 	seatDemandIntegratorCheck                                                              fq.Integrator
-	failedCount                                                                            uint64
+	failedCount                                                                            atomic.Uint64
 	expectedInqueueReqs, expectedInqueueSeats, expectedExecuting, expectedConcurrencyInUse string
-	executions, rejects                                                                    []int32
+	executions, rejects                                                                    []atomic.Int32
 }
 
 func (uss *uniformScenarioState) exercise() {
@@ -287,8 +287,8 @@ func (ust *uniformScenarioThread) callK(k int) {
 	req, idle := ust.uss.qs.StartRequest(ctx, &fcrequest.WorkEstimate{InitialSeats: ust.uc.initialSeats, FinalSeats: ust.uc.finalSeats, AdditionalLatency: ust.uc.padDuration}, ust.uc.hash, "", ust.fsName, ust.uss.name, []int{ust.i, ust.j, k}, nil)
 	ust.uss.t.Logf("%s: %d, %d, %d got req=%p, idle=%v", ust.uss.clk.Now().Format(nsTimeFmt), ust.i, ust.j, k, req, idle)
 	if req == nil {
-		atomic.AddUint64(&ust.uss.failedCount, 1)
-		atomic.AddInt32(&ust.uss.rejects[ust.i], 1)
+		ust.uss.failedCount.Add(1)
+		ust.uss.rejects[ust.i].Add(1)
 		returnSeatDemand(ust.uss.clk.Now())
 		return
 	}
@@ -303,7 +303,7 @@ func (ust *uniformScenarioThread) callK(k int) {
 	idle2 := req.Finish(func() {
 		executed = true
 		execStart := ust.uss.clk.Now()
-		atomic.AddInt32(&ust.uss.executions[ust.i], 1)
+		ust.uss.executions[ust.i].Add(1)
 		ust.execSeatsIntegrator.Add(float64(ust.uc.initialSeats))
 		ust.uss.t.Logf("%s: %d, %d, %d executing; width1=%d", execStart.Format(nsTimeFmt), ust.i, ust.j, k, ust.uc.initialSeats)
 		ust.uss.clk.EventAfterDuration(ust.genCallK(k+1), ust.uc.execDuration+ust.uc.thinkDuration)
@@ -315,8 +315,8 @@ func (ust *uniformScenarioThread) callK(k int) {
 	now := ust.uss.clk.Now()
 	ust.uss.t.Logf("%s: %d, %d, %d got executed=%v, idle2=%v", now.Format(nsTimeFmt), ust.i, ust.j, k, executed, idle2)
 	if !executed {
-		atomic.AddUint64(&ust.uss.failedCount, 1)
-		atomic.AddInt32(&ust.uss.rejects[ust.i], 1)
+		ust.uss.failedCount.Add(1)
+		ust.uss.rejects[ust.i].Add(1)
 		returnSeatDemand(ust.uss.clk.Now())
 	} else if now != returnTime {
 		ust.uss.t.Errorf("%s: %d, %d, %d returnTime=%s", now.Format(nsTimeFmt), ust.i, ust.j, k, returnTime.Format(nsTimeFmt))
@@ -404,9 +404,9 @@ func (uss *uniformScenarioState) evalTo(lim time.Time, last, expectFair bool, ma
 }
 
 func (uss *uniformScenarioState) finalReview() {
-	if uss.expectAllRequests && uss.failedCount > 0 {
-		uss.t.Errorf("Expected all requests to be successful but got %v failed requests", uss.failedCount)
-	} else if !uss.expectAllRequests && uss.failedCount == 0 {
+	if uss.expectAllRequests && uss.failedCount.Load() > 0 {
+		uss.t.Errorf("Expected all requests to be successful but got %v failed requests", uss.failedCount.Load())
+	} else if !uss.expectAllRequests && uss.failedCount.Load() == 0 {
 		uss.t.Errorf("Expected failed requests but all requests succeeded")
 	}
 	if uss.evalInqueueMetrics {
@@ -435,12 +435,12 @@ func (uss *uniformScenarioState) finalReview() {
 	expectedRejects := ""
 	for i := range uss.clients {
 		fsName := fmt.Sprintf("client%d", i)
-		if atomic.LoadInt32(&uss.executions[i]) > 0 {
+		if uss.executions[i].Load() > 0 {
 			uss.expectedExecuting = uss.expectedExecuting + fmt.Sprintf(`				apiserver_flowcontrol_current_executing_requests{flow_schema=%q,priority_level=%q} 0%s`, fsName, uss.name, "\n")
 			uss.expectedConcurrencyInUse = uss.expectedConcurrencyInUse + fmt.Sprintf(`				apiserver_flowcontrol_request_concurrency_in_use{flow_schema=%q,priority_level=%q} 0%s`, fsName, uss.name, "\n")
 		}
-		if atomic.LoadInt32(&uss.rejects[i]) > 0 {
-			expectedRejects = expectedRejects + fmt.Sprintf(`				apiserver_flowcontrol_rejected_requests_total{flow_schema=%q,priority_level=%q,reason=%q} %d%s`, fsName, uss.name, uss.rejectReason, uss.rejects[i], "\n")
+		if uss.rejects[i].Load() > 0 {
+			expectedRejects += fmt.Sprintf(`				apiserver_flowcontrol_rejected_requests_total{flow_schema=%q,priority_level=%q,reason=%q} %d%s`, fsName, uss.name, uss.rejectReason, uss.rejects[i].Load(), "\n")
 		}
 	}
 	if uss.evalExecutingMetrics && len(uss.expectedExecuting) > 0 {
@@ -1091,19 +1091,19 @@ func TestContextCancel(t *testing.T) {
 	qs := qsComplete(qsc, 1)
 	counter.Add(1) // account for main activity of the goroutine running this test
 	ctx1 := context.Background()
-	pZero := func() *int32 { var zero int32; return &zero }
+	pZero := func() *atomic.Int32 { return &atomic.Int32{} }
 	// counts of calls to the QueueNoteFns
-	queueNoteCounts := map[int]map[bool]*int32{
+	queueNoteCounts := map[int]map[bool]*atomic.Int32{
 		1: {false: pZero(), true: pZero()},
 		2: {false: pZero(), true: pZero()},
 	}
 	queueNoteFn := func(fn int) func(inQueue bool) {
-		return func(inQueue bool) { atomic.AddInt32(queueNoteCounts[fn][inQueue], 1) }
+		return func(inQueue bool) { queueNoteCounts[fn][inQueue].Add(1) }
 	}
 	fatalErrs := []string{}
 	var errsLock sync.Mutex
 	expectQNCount := func(fn int, inQueue bool, expect int32) {
-		if a := atomic.LoadInt32(queueNoteCounts[fn][inQueue]); a != expect {
+		if a := queueNoteCounts[fn][inQueue].Load(); a != expect {
 			errsLock.Lock()
 			defer errsLock.Unlock()
 			fatalErrs = append(fatalErrs, fmt.Sprintf("Got %d calls to queueNoteFn%d(%v), expected %d", a, fn, inQueue, expect))

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/gen_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/gen_test.go
@@ -406,12 +406,16 @@ func shuffleAndTakeDigests(t *testing.T, rng *rand.Rand, rule *flowcontrol.Polic
 	return ans
 }
 
-var uCounter uint32 = 1
+var uCounter atomic.Uint32
+
+func init() {
+	uCounter.Store(1)
+}
 
 func uniqify(in RequestDigest) RequestDigest {
 	u1 := in.User.(*user.DefaultInfo)
 	u2 := *u1
-	u2.Extra = map[string][]string{"u": {fmt.Sprintf("z%d", atomic.AddUint32(&uCounter, 1))}}
+	u2.Extra = map[string][]string{"u": {fmt.Sprintf("z%d", uCounter.Add(1))}}
 	return RequestDigest{User: &u2, RequestInfo: in.RequestInfo}
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/yaml.go
@@ -34,7 +34,7 @@ import (
 // to the given version first.
 // If PrintObj() is called multiple times, objects are separated with a '---' separator.
 type YAMLPrinter struct {
-	printCount int64
+	printCount atomic.Int64
 }
 
 // PrintObj prints the data as YAML.
@@ -46,7 +46,7 @@ func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		return errors.New(InternalObjectPrinterErr)
 	}
 
-	count := atomic.AddInt64(&p.printCount, 1)
+	count := p.printCount.Add(1)
 	if count > 1 {
 		if _, err := w.Write([]byte("---\n")); err != nil {
 			return err

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -4081,10 +4081,10 @@ func TestRetryableConditions(t *testing.T) {
 }
 
 func TestRequestConcurrencyWithRetry(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 	client := clientForFunc(func(req *http.Request) (*http.Response, error) {
 		defer func() {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 		}()
 
 		// always send a retry-after response
@@ -4122,8 +4122,8 @@ func TestRequestConcurrencyWithRetry(t *testing.T) {
 
 	// we expect (concurrency*req.maxRetries+1) attempts to be recorded
 	expected := concurrency * (req.maxRetries + 1)
-	if atomic.LoadInt32(&attempts) != int32(expected) {
-		t.Errorf("Expected attempts: %d, but got: %d", expected, attempts)
+	if attempts.Load() != int32(expected) {
+		t.Errorf("Expected attempts: %d, but got: %d", expected, attempts.Load())
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/synctrack/lazy_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/synctrack/lazy_test.go
@@ -27,11 +27,11 @@ import (
 )
 
 func TestLazy(t *testing.T) {
-	var reality int64
+	var reality atomic.Int64
 	var z synctrack.Lazy[int64]
 
 	z.Evaluate = func() (int64, error) {
-		return atomic.LoadInt64(&reality), nil
+		return reality.Load(), nil
 	}
 
 	var wg sync.WaitGroup
@@ -42,7 +42,7 @@ func TestLazy(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < 100; i++ {
 				t.Helper()
-				set := atomic.AddInt64(&reality, 1)
+				set := reality.Add(1)
 				z.Notify()
 				got, err := z.Get()
 				if err != nil {
@@ -60,11 +60,11 @@ func TestLazy(t *testing.T) {
 }
 
 func TestLazyThroughput(t *testing.T) {
-	var reality int64
+	var reality atomic.Int64
 	var z synctrack.Lazy[int64]
-	var totalWait int64
+	var totalWait atomic.Int64
 	z.Evaluate = func() (int64, error) {
-		got := atomic.LoadInt64(&reality)
+		got := reality.Load()
 		time.Sleep(11 * time.Millisecond)
 		return got, nil
 	}
@@ -78,7 +78,7 @@ func TestLazyThroughput(t *testing.T) {
 		tt := time.NewTicker(10 * time.Millisecond)
 		for {
 			<-tt.C
-			atomic.AddInt64(&reality, 1)
+			reality.Add(1)
 			z.Notify()
 			notifies++
 			if notifies >= 100 {
@@ -92,14 +92,14 @@ func TestLazyThroughput(t *testing.T) {
 				start := time.Now()
 				z.Get()
 				d := time.Since(start)
-				atomic.AddInt64(&totalWait, int64(d))
+				totalWait.Add(int64(d))
 			}()
 		}
 	}()
 
 	wg.Wait()
 
-	twd := time.Duration(totalWait)
+	twd := time.Duration(totalWait.Load())
 
 	if twd > 3*time.Second {
 		t.Errorf("total wait was: %v; par would be ~1s", twd)
@@ -155,11 +155,11 @@ func TestLazySlowEval(t *testing.T) {
 
 	seq := newSequence(10)
 
-	var getCount int64
+	var getCount atomic.Int64
 	var z synctrack.Lazy[int64]
 
 	z.Evaluate = func() (int64, error) {
-		count := atomic.AddInt64(&getCount, 1)
+		count := getCount.Add(1)
 		if count == 1 {
 			seq.Step(1)
 			seq.Step(6)
@@ -200,11 +200,11 @@ func TestLazySlowEval2(t *testing.T) {
 
 	seq := newSequence(11)
 
-	var getCount int64
+	var getCount atomic.Int64
 	var z synctrack.Lazy[int64]
 
 	z.Evaluate = func() (int64, error) {
-		count := atomic.AddInt64(&getCount, 1)
+		count := getCount.Add(1)
 		if count == 1 {
 			seq.Step(1)
 			seq.Step(5)
@@ -244,11 +244,11 @@ func TestLazyOnlyOnce(t *testing.T) {
 
 	seq := newSequence(8)
 
-	var getCount int64
+	var getCount atomic.Int64
 	var z synctrack.Lazy[int64]
 
 	z.Evaluate = func() (int64, error) {
-		count := atomic.AddInt64(&getCount, 1)
+		count := getCount.Add(1)
 		if count == 1 {
 			seq.Step(1)
 			seq.Step(4)

--- a/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack.go
+++ b/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack.go
@@ -130,11 +130,7 @@ type SingleFileTracker struct {
 	// name describes the instance.
 	name string
 
-	// Important: count is used with atomic operations so it must be 64-bit
-	// aligned, otherwise atomic operations will panic. Having it at the top of
-	// the struct will guarantee that, even on 32-bit arches.
-	// See https://pkg.go.dev/sync/atomic#pkg-note-BUG for more information.
-	count int64
+	count atomic.Int64
 
 	// upstreamHasSynced is changed from false (initial value) to true
 	// when UpstreamHasSynced is called.
@@ -158,7 +154,7 @@ func NewSingleFileTracker(name string) *SingleFileTracker {
 // Start should be called prior to processing each key which is part of the
 // initial list.
 func (t *SingleFileTracker) Start() {
-	atomic.AddInt64(&t.count, 1)
+	t.count.Add(1)
 }
 
 // Finished should be called when finished processing a key which was part of
@@ -167,7 +163,7 @@ func (t *SingleFileTracker) Start() {
 // return a wrong value. To help you notice this should it happen, Finished()
 // will panic if the internal counter goes negative.
 func (t *SingleFileTracker) Finished() {
-	result := atomic.AddInt64(&t.count, -1)
+	result := t.count.Add(-1)
 	if result < 0 {
 		panic("synctrack: negative counter; this logic error means HasSynced may return incorrect value")
 	}
@@ -187,7 +183,7 @@ func (t *SingleFileTracker) Finished() {
 func (t *SingleFileTracker) UpstreamHasSynced() {
 	// Upstream is done, but we might not be yet.
 	t.upstreamHasSynced.Store(true)
-	if atomic.LoadInt64(&t.count) == 0 {
+	if t.count.Load() == 0 {
 		// Mark as synced.
 		t.cancel()
 	}

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -55,11 +55,11 @@ func (o testObject) GetObjectKind() schema.ObjectKind { return schema.EmptyObjec
 func (o testObject) DeepCopyObject() runtime.Object   { return o }
 func (o testObject) GetResourceVersion() string       { return o.resourceVersion }
 
-func withCounter(w cache.Watcher) (*uint32, cache.WatcherWithContext) {
-	var counter uint32
+func withCounter(w cache.Watcher) (*atomic.Uint32, cache.WatcherWithContext) {
+	var counter atomic.Uint32
 	return &counter, &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			atomic.AddUint32(&counter, 1)
+			counter.Add(1)
 			return w.Watch(options)
 		},
 	}
@@ -591,7 +591,7 @@ func TestRetryWatcher(t *testing.T) {
 			// We always count with the last watch reestablishing which is imminent but still a race.
 			// We will wait for the last watch to reestablish to avoid it.
 			err = wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-				counter = atomic.LoadUint32(atomicCounter)
+				counter = atomicCounter.Load()
 				return counter == tc.watchCount, nil
 			})
 			if wait.Interrupted(err) {

--- a/staging/src/k8s.io/client-go/util/workqueue/parallelizer_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/parallelizer_test.go
@@ -61,17 +61,21 @@ var cases = []testCase{
 func TestParallelizeUntil(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.String(), func(t *testing.T) {
-			seen := make([]int32, tc.pieces)
+			seen := make([]atomic.Int32, tc.pieces)
 			ctx := context.Background()
 			ParallelizeUntil(ctx, tc.workers, tc.pieces, func(p int) {
-				atomic.AddInt32(&seen[p], 1)
+				seen[p].Add(1)
 			}, WithChunkSize(tc.chunkSize))
 
+			gotSeen := make([]int32, tc.pieces)
+			for i := range seen {
+				gotSeen[i] = seen[i].Load()
+			}
 			wantSeen := make([]int32, tc.pieces)
 			for i := 0; i < tc.pieces; i++ {
 				wantSeen[i] = 1
 			}
-			if diff := cmp.Diff(wantSeen, seen); diff != "" {
+			if diff := cmp.Diff(wantSeen, gotSeen); diff != "" {
 				t.Errorf("bad number of visits (-want,+got):\n%s", diff)
 			}
 		})

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -447,15 +447,15 @@ func TestGarbageCollection(t *testing.T) {
 // The input must be a pointer to an object.
 func mustGarbageCollect(t *testing.T, i interface{}) {
 	t.Helper()
-	var collected int32 = 0
+	var collected atomic.Int32
 	runtime.SetFinalizer(i, func(x interface{}) {
-		atomic.StoreInt32(&collected, 1)
+		collected.Store(1)
 	})
 	t.Cleanup(func() {
 		if err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (done bool, err error) {
 			// Trigger GC explicitly, otherwise we may need to wait a long time for it to run
 			runtime.GC()
-			return atomic.LoadInt32(&collected) == 1, nil
+			return collected.Load() == 1, nil
 		}); err != nil {
 			t.Errorf("object was not garbage collected")
 		}

--- a/staging/src/k8s.io/component-base/logs/json/json.go
+++ b/staging/src/k8s.io/component-base/logs/json/json.go
@@ -36,12 +36,12 @@ var (
 )
 
 type runtime struct {
-	v uint32
+	v atomic.Uint32
 }
 
 func (r *runtime) ZapV() zapcore.Level {
 	// zap levels are inverted: everything with a verbosity >= threshold gets logged.
-	return -zapcore.Level(atomic.LoadUint32(&r.v))
+	return -zapcore.Level(r.v.Load())
 }
 
 // Enabled implements the zapcore.LevelEnabler interface.
@@ -50,7 +50,7 @@ func (r *runtime) Enabled(level zapcore.Level) bool {
 }
 
 func (r *runtime) SetVerbosityLevel(v uint32) error {
-	atomic.StoreUint32(&r.v, v)
+	r.v.Store(v)
 	return nil
 }
 
@@ -60,7 +60,8 @@ var _ zapcore.LevelEnabler = &runtime{}
 // control interface. The separate error stream is optional and may be nil.
 // The encoder config is also optional.
 func NewJSONLogger(v logsapi.VerbosityLevel, infoStream, errorStream zapcore.WriteSyncer, encoderConfig *zapcore.EncoderConfig) (logr.Logger, logsapi.RuntimeControl) {
-	r := &runtime{v: uint32(v)}
+	r := &runtime{}
+	r.v.Store(uint32(v))
 
 	if encoderConfig == nil {
 		encoderConfig = &zapcore.EncoderConfig{

--- a/staging/src/k8s.io/controller-manager/pkg/healthz/handler_test.go
+++ b/staging/src/k8s.io/controller-manager/pkg/healthz/handler_test.go
@@ -140,9 +140,9 @@ func TestConcurrentChecks(t *testing.T) {
 	stopChan := make(chan interface{})
 	defer close(stopChan) // always close no matter passing or not
 	concurrentChan := make(chan interface{}, N)
-	var concurrentCount int32
+	var concurrentCount atomic.Int32
 	pausingCheck := healthz.NamedCheck("pausing", func(r *http.Request) error {
-		atomic.AddInt32(&concurrentCount, 1)
+		concurrentCount.Add(1)
 		concurrentChan <- nil
 		<-stopChan
 		return nil
@@ -168,7 +168,7 @@ func TestConcurrentChecks(t *testing.T) {
 		}
 	}
 
-	if concurrentCount != N {
-		t.Errorf("expected %v concurrency, got %v", N, concurrentCount)
+	if concurrentCount.Load() != N {
+		t.Errorf("expected %v concurrency, got %v", N, concurrentCount.Load())
 	}
 }

--- a/staging/src/k8s.io/streaming/pkg/httpstream/spdy/connection_test.go
+++ b/staging/src/k8s.io/streaming/pkg/httpstream/spdy/connection_test.go
@@ -210,7 +210,7 @@ func TestConnectionPings(t *testing.T) {
 			return
 		}
 
-		var pingsSent int64
+		var pingsSent atomic.Int64
 		srvSPDYConn := newConnection(
 			spdyConn,
 			func(stream httpstream.Stream, replySent <-chan struct{}) error {
@@ -220,7 +220,7 @@ func TestConnectionPings(t *testing.T) {
 			},
 			pingPeriod,
 			func() (time.Duration, error) {
-				atomic.AddInt64(&pingsSent, 1)
+				pingsSent.Add(1)
 				return 0, nil
 			})
 		defer srvSPDYConn.Close()
@@ -235,7 +235,7 @@ func TestConnectionPings(t *testing.T) {
 		}
 
 		// Count pings sent by the server.
-		gotPings := atomic.LoadInt64(&pingsSent)
+		gotPings := pingsSent.Load()
 		if gotPings < 1 {
 			t.Errorf("server: failed to send any pings (check logs)")
 		}

--- a/staging/src/k8s.io/streaming/pkg/httpstream/spdy/upgrade.go
+++ b/staging/src/k8s.io/streaming/pkg/httpstream/spdy/upgrade.go
@@ -45,12 +45,12 @@ type responseUpgrader struct {
 // read.
 type connWrapper struct {
 	net.Conn
-	closed    int32
+	closed    atomic.Int32
 	bufReader *bufio.Reader
 }
 
 func (w *connWrapper) Read(b []byte) (n int, err error) {
-	if atomic.LoadInt32(&w.closed) == 1 {
+	if w.closed.Load() == 1 {
 		return 0, io.EOF
 	}
 	return w.bufReader.Read(b)
@@ -58,7 +58,7 @@ func (w *connWrapper) Read(b []byte) (n int, err error) {
 
 func (w *connWrapper) Close() error {
 	err := w.Conn.Close()
-	atomic.StoreInt32(&w.closed, 1)
+	w.closed.Store(1)
 	return err
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR updates atomic operations to use Go 1.19’s typed atomic types instead of the older function-based atomic API.
Fields such as uint64 are replaced with atomic.Uint64, allowing usage like:
```
counter.Add(1)
```
instead of
```
atomic.AddUint64(&counter, 1)
```
This removes pointer-based atomic calls, improves readability, and provides stronger compile-time safety when working with shared state in concurrent validator operations. The change is purely mechanical and does not modify logic.



#### Which issue(s) this PR is related to:
Refrence: https://github.com/kubernetes/kubernetes/pull/136665

#### Special notes for your reviewer:
- This is a mechanical refactor focused on correctness and maintainability.
- No behavioral or performance changes are intended.
- The change relies on Go 1.19+ typed atomics, which are already required by the project.
- All atomic operations are semantically equivalent to the previous implementation.

#### Does this PR introduce a user-facing change?
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```

```

/sig release