### PR TITLE
test: refactor to use atomic types

### DIFF
--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -107,7 +107,7 @@ func getOrphanOptions() metav1.DeleteOptions {
 
 var (
 	zero       = int64(0)
-	lablecount = int64(0)
+	lablecount atomic.Int64
 )
 
 const (
@@ -312,7 +312,7 @@ func newCronJob(name, schedule string) *batchv1.CronJob {
 
 // getUniqLabel returns a UniqLabel based on labeLkey and labelvalue.
 func getUniqLabel(labelkey, labelvalue string) map[string]string {
-	count := atomic.AddInt64(&lablecount, 1)
+	count := lablecount.Add(1)
 	uniqlabelkey := fmt.Sprintf("%s-%05d", labelkey, count)
 	uniqlabelvalue := fmt.Sprintf("%s-%05d", labelvalue, count)
 	return map[string]string{uniqlabelkey: uniqlabelvalue}

--- a/test/e2e/chaosmonkey/chaosmonkey_test.go
+++ b/test/e2e/chaosmonkey/chaosmonkey_test.go
@@ -23,23 +23,23 @@ import (
 )
 
 func TestDoWithPanic(t *testing.T) {
-	var counter int64
+	var counter atomic.Int64
 	cm := New(func(ctx context.Context) {})
 	tests := []Test{
 		// No panic
 		func(ctx context.Context, sem *Semaphore) {
-			defer atomic.AddInt64(&counter, 1)
+			defer counter.Add(1)
 			sem.Ready()
 		},
 		// Panic after sem.Ready()
 		func(ctx context.Context, sem *Semaphore) {
-			defer atomic.AddInt64(&counter, 1)
+			defer counter.Add(1)
 			sem.Ready()
 			panic("Panic after calling sem.Ready()")
 		},
 		// Panic before sem.Ready()
 		func(ctx context.Context, sem *Semaphore) {
-			defer atomic.AddInt64(&counter, 1)
+			defer counter.Add(1)
 			panic("Panic before calling sem.Ready()")
 		},
 	}
@@ -48,7 +48,7 @@ func TestDoWithPanic(t *testing.T) {
 	}
 	cm.Do(context.Background())
 	// Check that all funcs in tests were called.
-	if int(counter) != len(tests) {
-		t.Errorf("Expected counter to be %v, but it was %v", len(tests), counter)
+	if int(counter.Load()) != len(tests) {
+		t.Errorf("Expected counter to be %v, but it was %v", len(tests), counter.Load())
 	}
 }

--- a/test/e2e/storage/csimock/base.go
+++ b/test/e2e/storage/csimock/base.go
@@ -1086,13 +1086,13 @@ func createFSGroupRequestPreHook(nodeStageFsGroup, nodePublishFsGroup *string) *
 
 // createPreHook counts invocations of a certain method (identified by a substring in the full gRPC method name).
 func createPreHook(method string, callback func(counter int64) error) *drivers.Hooks {
-	var counter int64
+	var counter atomic.Int64
 
 	return &drivers.Hooks{
 		Pre: func() func(ctx context.Context, fullMethod string, request interface{}) (reply interface{}, err error) {
 			return func(ctx context.Context, fullMethod string, request interface{}) (reply interface{}, err error) {
 				if strings.Contains(fullMethod, method) {
-					counter := atomic.AddInt64(&counter, 1)
+					counter := counter.Add(1)
 					return nil, callback(counter)
 				}
 				return nil, nil

--- a/test/e2e/storage/csimock/mutable_csinode_allocatable.go
+++ b/test/e2e/storage/csimock/mutable_csinode_allocatable.go
@@ -63,12 +63,12 @@ var _ = utils.SIGDescribe("MutableCSINodeAllocatableCount", framework.WithFeatur
 		)
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			var calls int32
+			var calls atomic.Int32
 			hook := drivers.Hooks{
 				Post: func(_ context.Context, method string, _ interface{}, reply interface{}, err error) (interface{}, error) {
 					if strings.Contains(method, "NodeGetInfo") {
 						if r, ok := reply.(*csipbv1.NodeGetInfoResponse); ok && err == nil {
-							if atomic.AddInt32(&calls, 1) == 1 {
+							if calls.Add(1) == 1 {
 								r.MaxVolumesPerNode = initialMaxVolumesPerNode
 							} else {
 								r.MaxVolumesPerNode = updatedMaxVolumesPerNode

--- a/test/e2e/storage/drivers/csi-test/mock/service/service.go
+++ b/test/e2e/storage/drivers/csi-test/mock/service/service.go
@@ -120,9 +120,9 @@ type service struct {
 	nodeID       string
 	vols         []csi.Volume
 	volsRWL      sync.RWMutex
-	volsNID      uint64
+	volsNID      atomic.Uint64
 	snapshots    cache.SnapshotCache
-	snapshotsNID uint64
+	snapshotsNID atomic.Uint64
 	config       Config
 }
 
@@ -173,7 +173,7 @@ const (
 
 func (s *service) newVolume(name string, capcity int64) csi.Volume {
 	vol := csi.Volume{
-		VolumeId:      fmt.Sprintf("%d", atomic.AddUint64(&s.volsNID, 1)),
+		VolumeId:      fmt.Sprintf("%d", s.volsNID.Add(1)),
 		VolumeContext: map[string]string{"name": name},
 		CapacityBytes: capcity,
 	}
@@ -263,7 +263,7 @@ func (s *service) newSnapshot(name, sourceVolumeId string, parameters map[string
 		Name:       name,
 		Parameters: parameters,
 		SnapshotCSI: csi.Snapshot{
-			SnapshotId:     fmt.Sprintf("%d", atomic.AddUint64(&s.snapshotsNID, 1)),
+			SnapshotId:     fmt.Sprintf("%d", s.snapshotsNID.Add(1)),
 			CreationTime:   ptime,
 			SourceVolumeId: sourceVolumeId,
 			ReadyToUse:     true,

--- a/test/integration/apiserver/admissionwebhook/load_balance_test.go
+++ b/test/integration/apiserver/admissionwebhook/load_balance_test.go
@@ -221,7 +221,7 @@ func TestWebhookLoadBalance(t *testing.T) {
 			}
 			wg.Wait()
 
-			actual := atomic.LoadInt64(&trackingListener.connections)
+			actual := trackingListener.connections.Load()
 			if tc.http2 && actual != tc.expected {
 				t.Errorf("expected %d connections, got %d", tc.expected, actual)
 			}
@@ -244,7 +244,7 @@ func TestWebhookLoadBalance(t *testing.T) {
 			}
 			wg.Wait()
 
-			if actual := atomic.LoadInt64(&trackingListener.connections); actual > 0 {
+			if actual := trackingListener.connections.Load(); actual > 0 {
 				t.Errorf("expected no additional connections (reusing kept-alive connections), got %d", actual)
 			}
 		})
@@ -338,18 +338,18 @@ var loadBalanceMarkerFixture = &corev1.Pod{
 }
 
 type connectionTrackingListener struct {
-	connections int64
+	connections atomic.Int64
 	delegate    net.Listener
 }
 
 func (c *connectionTrackingListener) Reset() {
-	atomic.StoreInt64(&c.connections, 0)
+	c.connections.Store(0)
 }
 
 func (c *connectionTrackingListener) Accept() (net.Conn, error) {
 	conn, err := c.delegate.Accept()
 	if err == nil {
-		atomic.AddInt64(&c.connections, 1)
+		c.connections.Add(1)
 	}
 	return conn, err
 }

--- a/test/integration/apiserver/max_json_patch_operations_test.go
+++ b/test/integration/apiserver/max_json_patch_operations_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiserver
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestMaxJSONPatchOperations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = c.Patch(types.JSONPatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+	err = c.Patch(types.JSONPatchType).AbsPath("/api/v1/namespaces/default/secrets/test").
 		Body(hugePatch).Do(tCtx).Error()
 	if err == nil {
 		t.Fatalf("unexpected no error")

--- a/test/integration/apiserver/patch_test.go
+++ b/test/integration/apiserver/patch_test.go
@@ -71,7 +71,7 @@ func TestPatchConflicts(t *testing.T) {
 	}
 	client := clientSet.CoreV1().RESTClient()
 
-	successes := int32(0)
+	var successes atomic.Int32
 
 	// Run a lot of simultaneous patch operations to exercise internal API server retry of application of patches that do not specify resourceVersion.
 	// They should all succeed.
@@ -116,15 +116,15 @@ func TestPatchConflicts(t *testing.T) {
 				t.Errorf("patch of %s with $patch directive was ineffective, didn't delete the entry in the ownerReference slice: %#v", "secrets", UIDs[i])
 			}
 
-			atomic.AddInt32(&successes, 1)
+			successes.Add(1)
 		}(i)
 	}
 	wg.Wait()
 
-	if successes < int32(numOfConcurrentPatches) {
-		t.Errorf("Expected at least %d successful patches for %s, got %d", numOfConcurrentPatches, "secrets", successes)
+	if successes.Load() < int32(numOfConcurrentPatches) {
+		t.Errorf("Expected at least %d successful patches for %s, got %d", numOfConcurrentPatches, "secrets", successes.Load())
 	} else {
-		t.Logf("Got %d successful patches for %s", successes, "secrets")
+		t.Logf("Got %d successful patches for %s", successes.Load(), "secrets")
 	}
 
 }

--- a/test/integration/evictions/evictions_test.go
+++ b/test/integration/evictions/evictions_test.go
@@ -106,7 +106,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 
 	waitPDBStable(t, clientSet, ns.Name, pdb.Name, numOfEvictions)
 
-	var numberPodsEvicted uint32
+	var numberPodsEvicted atomic.Uint32
 	errCh := make(chan error, 3*numOfEvictions)
 	var wg sync.WaitGroup
 	// spawn numOfEvictions goroutines to concurrently evict the pods
@@ -139,7 +139,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 			_, err = clientSet.CoreV1().Pods(ns.Name).Get(context.TODO(), podName, metav1.GetOptions{})
 			switch {
 			case apierrors.IsNotFound(err):
-				atomic.AddUint32(&numberPodsEvicted, 1)
+				numberPodsEvicted.Add(1)
 				// pod was evicted and deleted so return from goroutine immediately
 				return
 			case err == nil:
@@ -172,8 +172,8 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 		t.Fatal(utilerrors.NewAggregate(errList))
 	}
 
-	if atomic.LoadUint32(&numberPodsEvicted) != numOfEvictions {
-		t.Fatalf("fewer number of successful evictions than expected : %d", numberPodsEvicted)
+	if numberPodsEvicted.Load() != numOfEvictions {
+		t.Fatalf("fewer number of successful evictions than expected : %d", numberPodsEvicted.Load())
 	}
 }
 

--- a/test/integration/examples/webhook_test.go
+++ b/test/integration/examples/webhook_test.go
@@ -39,7 +39,7 @@ import (
 func TestWebhookLoopback(t *testing.T) {
 	webhookPath := "/webhook-test"
 
-	called := int32(0)
+	var called atomic.Int32
 
 	tCtx := ktesting.Init(t)
 	client, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
@@ -56,7 +56,7 @@ func TestWebhookLoopback(t *testing.T) {
 					if attrs.GetUser().GetName() != "system:apiserver" {
 						t.Errorf("expected user %q, got %q", "system:apiserver", attrs.GetUser().GetName())
 					}
-					atomic.AddInt32(&called, 1)
+					called.Add(1)
 				}
 				return audit.RequestAuditConfig{
 					Level: auditinternal.LevelNone,
@@ -96,7 +96,7 @@ func TestWebhookLoopback(t *testing.T) {
 		if err == nil {
 			t.Fatal("Unexpected success")
 		}
-		if called > 0 {
+		if called.Load() > 0 {
 			return true, nil
 		}
 		t.Logf("%v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
cleanup

#### What this PR does / why we need it:

This PR updates our atomic operations to use `Go 1.19's` newer typed atomic approach instead of the old function-based method. We're changing fields like `uint64` to `atomic.Uint64` so we can write cleaner code like `counter.Add(1)` instead of `atomic.AddUint64(&counter, 1)`. This removes the need for pointer handling and gives us better compile-time safety when multiple threads access the same variables in validator operations.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
- This is a mechanical refactor focused on correctness and maintainability.
- No behavioral or performance changes are intended.
- The change relies on Go 1.19+ typed atomics, which are already required by the project.
- All atomic operations are semantically equivalent to the previous implementation.

#### Does this PR introduce a user-facing change?
N/A


Refrence: https://github.com/kubernetes/kubernetes/pull/136665