### PR TITLE
vendor: refactor to use atomic types

### DIFF
--- a/vendor/github.com/emicklei/go-restful/v3/route_builder.go
+++ b/vendor/github.com/emicklei/go-restful/v3/route_builder.go
@@ -368,7 +368,7 @@ func concatPath(rootPath, routePath string) string {
 	}
 }
 
-var anonymousFuncCount int32
+var anonymousFuncCount atomic.Int32
 
 // nameOfFunction returns the short name of the function f for documentation.
 // It uses a runtime feature for debugging ; its value may change for later Go versions.
@@ -381,9 +381,9 @@ func nameOfFunction(f interface{}) string {
 	last = strings.TrimSuffix(last, "·fm")  // < Go 1.5
 	last = strings.TrimSuffix(last, "-fm")  // Go 1.5
 	if last == "func1" {                    // this could mean conflicts in API docs
-		val := atomic.AddInt32(&anonymousFuncCount, 1)
+		val := anonymousFuncCount.Add(1)
 		last = "func" + fmt.Sprintf("%d", val)
-		atomic.StoreInt32(&anonymousFuncCount, val)
+		anonymousFuncCount.Store(val)
 	}
 	return last
 }

--- a/vendor/github.com/google/cadvisor/manager/container.go
+++ b/vendor/github.com/google/cadvisor/manager/container.go
@@ -79,7 +79,7 @@ func (t *atomicTime) Time() time.Time {
 }
 
 type containerData struct {
-	oomEvents                uint64
+	oomEvents                atomic.Uint64
 	handler                  container.ContainerHandler
 	info                     containerInfo
 	memoryCache              *memory.InMemoryCache
@@ -699,7 +699,7 @@ func (cd *containerData) updateStats() error {
 		}
 	}
 
-	stats.OOMEvents = atomic.LoadUint64(&cd.oomEvents)
+	stats.OOMEvents = cd.oomEvents.Load()
 
 	var customStatsErr error
 	cm := cd.collectorManager.(*collector.GenericCollectorManager)

--- a/vendor/github.com/google/cadvisor/manager/manager.go
+++ b/vendor/github.com/google/cadvisor/manager/manager.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/cadvisor/cache/memory"
@@ -1261,7 +1260,7 @@ func (m *manager) watchForNewOoms() error {
 				continue
 			}
 			for _, cont := range conts {
-				atomic.AddUint64(&cont.oomEvents, 1)
+				cont.oomEvents.Add(1)
 			}
 		}
 	}()

--- a/vendor/github.com/ishidawataru/sctp/sctp.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp.go
@@ -277,10 +277,6 @@ func setInitOpts(fd int, options InitMsg) error {
 	return err
 }
 
-func setNumOstreams(fd, num int) error {
-	return setInitOpts(fd, InitMsg{NumOstreams: uint16(num)})
-}
-
 type SCTPAddr struct {
 	IPAddrs []net.IPAddr
 	Port    int
@@ -422,19 +418,19 @@ func SCTPBind(fd int, addr *SCTPAddr, flags int) error {
 }
 
 type SCTPConn struct {
-	_fd                 int32
+	_fd                 atomic.Int32
 	notificationHandler NotificationHandler
 }
 
 func (c *SCTPConn) fd() int {
-	return int(atomic.LoadInt32(&c._fd))
+	return int(c._fd.Load())
 }
 
 func NewSCTPConn(fd int, handler NotificationHandler) *SCTPConn {
 	conn := &SCTPConn{
-		_fd:                 int32(fd),
 		notificationHandler: handler,
 	}
+	conn._fd.Store(int32(fd))
 	return conn
 }
 
@@ -697,7 +693,7 @@ func (c *SCTPConn) RemoteAddr() net.Addr {
 func (c *SCTPConn) PeelOff(id int) (*SCTPConn, error) {
 	type peeloffArg struct {
 		assocId int32
-		sd      int
+		sd      int32
 	}
 	param := peeloffArg{
 		assocId: int32(id),
@@ -707,7 +703,9 @@ func (c *SCTPConn) PeelOff(id int) (*SCTPConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SCTPConn{_fd: int32(param.sd)}, nil
+	var conn SCTPConn
+	conn._fd.Store(int32(param.sd))
+	return &conn, nil
 }
 
 func (c *SCTPConn) SetDeadline(t time.Time) error {

--- a/vendor/github.com/ishidawataru/sctp/sctp_linux.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp_linux.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net"
 	"runtime"
-	"sync/atomic"
 	"syscall"
 	"unsafe"
 )
@@ -138,7 +137,7 @@ func (c *SCTPConn) SCTPRead(b []byte) (int, *SndRcvInfo, error) {
 
 func (c *SCTPConn) Close() error {
 	if c != nil {
-		fd := atomic.SwapInt32(&c._fd, -1)
+		fd := c._fd.Swap(-1)
 		if fd > 0 {
 			info := &SndRcvInfo{
 				Flags: SCTP_EOF,

--- a/vendor/github.com/moby/ipvs/ipvs_linux.go
+++ b/vendor/github.com/moby/ipvs/ipvs_linux.go
@@ -3,6 +3,7 @@ package ipvs
 import (
 	"fmt"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/vishvananda/netlink/nl"
@@ -75,7 +76,7 @@ type Config struct {
 // Handle provides a namespace specific ipvs handle to program ipvs
 // rules.
 type Handle struct {
-	seq  uint32
+	seq  atomic.Uint32
 	sock *nl.NetlinkSocket
 }
 

--- a/vendor/github.com/moby/ipvs/netlink_linux.go
+++ b/vendor/github.com/moby/ipvs/netlink_linux.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -119,7 +118,7 @@ func fillDestination(d *Destination) nl.NetlinkRequestData {
 
 func (i *Handle) doCmdwithResponse(s *Service, d *Destination, cmd uint8) ([][]byte, error) {
 	req := newIPVSRequest(cmd)
-	req.Seq = atomic.AddUint32(&i.seq, 1)
+	req.Seq = i.seq.Add(1)
 
 	if s == nil {
 		req.Flags |= syscall.NLM_F_DUMP                    // Flag to dump all messages
@@ -410,7 +409,7 @@ func (i *Handle) doGetServicesCmd(svc *Service) ([]*Service, error) {
 // doCmdWithoutAttr a simple wrapper of netlink socket execute command
 func (i *Handle) doCmdWithoutAttr(cmd uint8) ([][]byte, error) {
 	req := newIPVSRequest(cmd)
-	req.Seq = atomic.AddUint32(&i.seq, 1)
+	req.Seq = i.seq.Add(1)
 	return execute(i.sock, req, 0)
 }
 
@@ -601,7 +600,7 @@ func (i *Handle) doGetConfigCmd() (*Config, error) {
 // doSetConfigCmd a wrapper function to be used by SetConfig
 func (i *Handle) doSetConfigCmd(c *Config) error {
 	req := newIPVSRequest(ipvsCmdSetConfig)
-	req.Seq = atomic.AddUint32(&i.seq, 1)
+	req.Seq = i.seq.Add(1)
 
 	req.AddData(nl.NewRtAttr(ipvsCmdAttrTimeoutTCP, nl.Uint32Attr(uint32(c.TimeoutTCP.Seconds()))))
 	req.AddData(nl.NewRtAttr(ipvsCmdAttrTimeoutTCPFin, nl.Uint32Attr(uint32(c.TimeoutTCPFin.Seconds()))))

--- a/vendor/go.etcd.io/etcd/server/v3/etcdserver/server.go
+++ b/vendor/go.etcd.io/etcd/server/v3/etcdserver/server.go
@@ -210,11 +210,11 @@ type Server interface {
 // EtcdServer is the production implementation of the Server interface
 type EtcdServer struct {
 	// inflightSnapshots holds count the number of snapshots currently inflight.
-	inflightSnapshots int64  // must use atomic operations to access; keep 64-bit aligned.
-	appliedIndex      uint64 // must use atomic operations to access; keep 64-bit aligned.
-	committedIndex    uint64 // must use atomic operations to access; keep 64-bit aligned.
-	term              uint64 // must use atomic operations to access; keep 64-bit aligned.
-	lead              uint64 // must use atomic operations to access; keep 64-bit aligned.
+	inflightSnapshots atomic.Int64  // must use atomic operations to access; keep 64-bit aligned.
+	appliedIndex      atomic.Uint64 // must use atomic operations to access; keep 64-bit aligned.
+	committedIndex    atomic.Uint64 // must use atomic operations to access; keep 64-bit aligned.
+	term              atomic.Uint64 // must use atomic operations to access; keep 64-bit aligned.
+	lead              atomic.Uint64 // must use atomic operations to access; keep 64-bit aligned.
 
 	consistIndex cindex.ConsistentIndexer // consistIndex is used to get/set/save consistentIndex
 	r            raftNode                 // uses 64-bit atomics; keep 64-bit aligned.
@@ -1671,35 +1671,35 @@ func (s *EtcdServer) UpdateMember(ctx context.Context, memb membership.Member) (
 }
 
 func (s *EtcdServer) setCommittedIndex(v uint64) {
-	atomic.StoreUint64(&s.committedIndex, v)
+	s.committedIndex.Store(v)
 }
 
 func (s *EtcdServer) getCommittedIndex() uint64 {
-	return atomic.LoadUint64(&s.committedIndex)
+	return s.committedIndex.Load()
 }
 
 func (s *EtcdServer) setAppliedIndex(v uint64) {
-	atomic.StoreUint64(&s.appliedIndex, v)
+	s.appliedIndex.Store(v)
 }
 
 func (s *EtcdServer) getAppliedIndex() uint64 {
-	return atomic.LoadUint64(&s.appliedIndex)
+	return s.appliedIndex.Load()
 }
 
 func (s *EtcdServer) setTerm(v uint64) {
-	atomic.StoreUint64(&s.term, v)
+	s.term.Store(v)
 }
 
 func (s *EtcdServer) getTerm() uint64 {
-	return atomic.LoadUint64(&s.term)
+	return s.term.Load()
 }
 
 func (s *EtcdServer) setLead(v uint64) {
-	atomic.StoreUint64(&s.lead, v)
+	s.lead.Store(v)
 }
 
 func (s *EtcdServer) getLead() uint64 {
-	return atomic.LoadUint64(&s.lead)
+	return s.lead.Load()
 }
 
 func (s *EtcdServer) LeaderChangedNotify() <-chan struct{} {
@@ -1839,7 +1839,7 @@ func (s *EtcdServer) publishV3(timeout time.Duration) {
 }
 
 func (s *EtcdServer) sendMergedSnap(merged snap.Message) {
-	atomic.AddInt64(&s.inflightSnapshots, 1)
+	s.inflightSnapshots.Add(1)
 
 	lg := s.Logger()
 	fields := []zap.Field{
@@ -1867,7 +1867,7 @@ func (s *EtcdServer) sendMergedSnap(merged snap.Message) {
 				}
 			}
 
-			atomic.AddInt64(&s.inflightSnapshots, -1)
+			s.inflightSnapshots.Add(-1)
 
 			lg.Info("sent merged snapshot", append(fields, zap.Duration("took", time.Since(now)))...)
 
@@ -2258,7 +2258,7 @@ func (s *EtcdServer) compactRaftLog(snapi uint64) {
 	// the snapshot sent to catch up. If we do not pause compaction, the log entries right after
 	// the snapshot sent might already be compacted. It happens when the snapshot takes long time
 	// to send and save. Pausing compaction avoids triggering a snapshot sending cycle.
-	if atomic.LoadInt64(&s.inflightSnapshots) != 0 {
+	if s.inflightSnapshots.Load() != 0 {
 		lg.Info("skip compaction since there is an inflight snapshot")
 		return
 	}

--- a/vendor/go.etcd.io/etcd/server/v3/storage/backend/batch_tx.go
+++ b/vendor/go.etcd.io/etcd/server/v3/storage/backend/batch_tx.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"math"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -275,7 +274,7 @@ func (t *batchTx) commit(stop bool) {
 		spillSec.Observe(t.tx.Stats().SpillTime.Seconds())
 		writeSec.Observe(t.tx.Stats().WriteTime.Seconds())
 		commitSec.Observe(time.Since(start).Seconds())
-		atomic.AddInt64(&t.backend.commits, 1)
+		t.backend.commits.Add(1)
 
 		t.pending = 0
 		if err != nil {

--- a/vendor/go.opentelemetry.io/otel/attribute/encoder.go
+++ b/vendor/go.opentelemetry.io/otel/attribute/encoder.go
@@ -53,7 +53,7 @@ var (
 	_ Encoder = &defaultAttrEncoder{}
 
 	// encoderIDCounter is for generating IDs for other attribute encoders.
-	encoderIDCounter uint64
+	encoderIDCounter atomic.Uint64
 
 	defaultEncoderOnce     sync.Once
 	defaultEncoderID       = NewEncoderID()
@@ -64,7 +64,7 @@ var (
 // once per each type of attribute encoder. Preferably in init() or in var
 // definition.
 func NewEncoderID() EncoderID {
-	return EncoderID{value: atomic.AddUint64(&encoderIDCounter, 1)}
+	return EncoderID{value: encoderIDCounter.Add(1)}
 }
 
 // DefaultEncoder returns an attribute encoder that encodes attributes in such

--- a/vendor/golang.org/x/crypto/ssh/mux.go
+++ b/vendor/golang.org/x/crypto/ssh/mux.go
@@ -101,7 +101,7 @@ type mux struct {
 
 // When debugging, each new chanList instantiation has a different
 // offset.
-var globalOff uint32
+var globalOff atomic.Uint32
 
 func (m *mux) Wait() error {
 	m.errCond.L.Lock()
@@ -122,7 +122,7 @@ func newMux(p packetConn) *mux {
 		errCond:          newCond(),
 	}
 	if debugMux {
-		m.chanList.offset = atomic.AddUint32(&globalOff, 1)
+		m.chanList.offset = globalOff.Add(1)
 	}
 
 	go m.loop()

--- a/vendor/google.golang.org/grpc/internal/channelz/channel.go
+++ b/vendor/google.golang.org/grpc/internal/channelz/channel.go
@@ -41,7 +41,7 @@ type Channel struct {
 	trace       *ChannelTrace
 	// traceRefCount is the number of trace events that reference this channel.
 	// Non-zero traceRefCount means the trace of this channel cannot be deleted.
-	traceRefCount int32
+	traceRefCount atomic.Int32
 
 	// ChannelMetrics holds connectivity state, target and call metrics for the
 	// channel within channelz.
@@ -253,15 +253,15 @@ func (c *Channel) getChannelTrace() *ChannelTrace {
 }
 
 func (c *Channel) incrTraceRefCount() {
-	atomic.AddInt32(&c.traceRefCount, 1)
+	c.traceRefCount.Add(1)
 }
 
 func (c *Channel) decrTraceRefCount() {
-	atomic.AddInt32(&c.traceRefCount, -1)
+	c.traceRefCount.Add(-1)
 }
 
 func (c *Channel) getTraceRefCount() int {
-	i := atomic.LoadInt32(&c.traceRefCount)
+	i := c.traceRefCount.Load()
 	return int(i)
 }
 

--- a/vendor/google.golang.org/grpc/internal/channelz/funcs.go
+++ b/vendor/google.golang.org/grpc/internal/channelz/funcs.go
@@ -36,23 +36,23 @@ var (
 	db = newChannelMap()
 	// EntriesPerPage defines the number of channelz entries to be shown on a web page.
 	EntriesPerPage = 50
-	curState       int32
+	curState       atomic.Int32
 )
 
 // TurnOn turns on channelz data collection.
 func TurnOn() {
-	atomic.StoreInt32(&curState, 1)
+	curState.Store(1)
 }
 
 func init() {
 	internal.ChannelzTurnOffForTesting = func() {
-		atomic.StoreInt32(&curState, 0)
+		curState.Store(0)
 	}
 }
 
 // IsOn returns whether channelz data collection is on.
 func IsOn() bool {
-	return atomic.LoadInt32(&curState) == 1
+	return curState.Load() == 1
 }
 
 // GetTopChannels returns a slice of top channel's ChannelMetric, along with a
@@ -208,17 +208,17 @@ func RemoveEntry(id int64) {
 
 // IDGenerator is an incrementing atomic that tracks IDs for channelz entities.
 type IDGenerator struct {
-	id int64
+	id atomic.Int64
 }
 
 // Reset resets the generated ID back to zero.  Should only be used at
 // initialization or by tests sensitive to the ID number.
 func (i *IDGenerator) Reset() {
-	atomic.StoreInt64(&i.id, 0)
+	i.id.Store(0)
 }
 
 func (i *IDGenerator) genID() int64 {
-	return atomic.AddInt64(&i.id, 1)
+	return i.id.Add(1)
 }
 
 // Identifier is an opaque channelz identifier used to expose channelz symbols

--- a/vendor/google.golang.org/grpc/internal/channelz/subchannel.go
+++ b/vendor/google.golang.org/grpc/internal/channelz/subchannel.go
@@ -34,7 +34,7 @@ type SubChannel struct {
 	sockets       map[int64]string
 	parent        *Channel
 	trace         *ChannelTrace
-	traceRefCount int32
+	traceRefCount atomic.Int32
 
 	ChannelMetrics ChannelMetrics
 }
@@ -136,15 +136,15 @@ func (sc *SubChannel) getChannelTrace() *ChannelTrace {
 }
 
 func (sc *SubChannel) incrTraceRefCount() {
-	atomic.AddInt32(&sc.traceRefCount, 1)
+	sc.traceRefCount.Add(1)
 }
 
 func (sc *SubChannel) decrTraceRefCount() {
-	atomic.AddInt32(&sc.traceRefCount, -1)
+	sc.traceRefCount.Add(-1)
 }
 
 func (sc *SubChannel) getTraceRefCount() int {
-	i := atomic.LoadInt32(&sc.traceRefCount)
+	i := sc.traceRefCount.Load()
 	return int(i)
 }
 

--- a/vendor/google.golang.org/grpc/internal/transport/client_stream.go
+++ b/vendor/google.golang.org/grpc/internal/transport/client_stream.go
@@ -47,7 +47,7 @@ type ClientStream struct {
 	// reading its value).
 	headerValid      bool
 	noHeaders        bool        // set if the client never received headers (set only after the stream is done).
-	headerChanClosed uint32      // set when headerChan is closed. Used to avoid closing headerChan multiple times.
+	headerChanClosed atomic.Uint32      // set when headerChan is closed. Used to avoid closing headerChan multiple times.
 	bytesReceived    atomic.Bool // indicates whether any bytes have been received on this stream
 	unprocessed      atomic.Bool // set if the server sends a refused stream or GOAWAY including this stream
 }

--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
@@ -55,8 +55,8 @@ type (
 		fileRaw
 		L1 FileL1
 
-		once uint32     // atomically set if L2 is valid
-		mu   sync.Mutex // protects L2
+		once atomic.Uint32 // atomically set if L2 is valid
+		mu   sync.Mutex    // protects L2
 		L2   *FileL2
 	}
 	FileL1 struct {
@@ -160,7 +160,7 @@ func (fd *File) OptionImports() protoreflect.FileImports {
 }
 
 func (fd *File) lazyInit() *FileL2 {
-	if atomic.LoadUint32(&fd.once) == 0 {
+	if fd.once.Load() == 0 {
 		fd.lazyInitOnce()
 	}
 	return fd.L2
@@ -171,7 +171,7 @@ func (fd *File) lazyInitOnce() {
 	if fd.L2 == nil {
 		fd.lazyRawInit() // recursively initializes all L2 structures
 	}
-	atomic.StoreUint32(&fd.once, 1)
+	fd.once.Store(1)
 	fd.mu.Unlock()
 }
 

--- a/vendor/google.golang.org/protobuf/internal/impl/message_opaque.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/message_opaque.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"reflect"
 	"strings"
-	"sync/atomic"
 
 	"google.golang.org/protobuf/internal/filedesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -46,7 +45,7 @@ func opaqueInitHook(mi *MessageInfo) bool {
 		return false
 	}
 
-	defer atomic.StoreUint32(&mi.initDone, 1)
+	defer mi.initDone.Store(1)
 
 	mi.fields = map[protoreflect.FieldNumber]*fieldInfo{}
 	fds := mi.Desc.Fields()

--- a/vendor/sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/conn.go
+++ b/vendor/sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/conn.go
@@ -51,7 +51,7 @@ type conn struct {
 	// closing is an atomic bool represented as a 0 or 1, and set to true when the connection is being closed.
 	// closing should only be accessed through atomic methods.
 	// TODO: switch this to an atomic.Bool once the client is exclusively buit with go1.19+
-	closing uint32
+	closing atomic.Uint32
 }
 
 var _ net.Conn = &conn{}
@@ -126,7 +126,7 @@ func (c *conn) SetWriteDeadline(t time.Time) error {
 // Close closes the connection, sends best-effort close signal to proxy
 // service, and frees resources.
 func (c *conn) Close() error {
-	old := atomic.SwapUint32(&c.closing, 1)
+	old := c.closing.Swap(1)
 	if old != 0 {
 		// prevent duplicate messages
 		return nil

--- a/vendor/sigs.k8s.io/kustomize/kyaml/runfn/runfn.go
+++ b/vendor/sigs.k8s.io/kustomize/kyaml/runfn/runfn.go
@@ -76,7 +76,7 @@ type RunFns struct {
 	LogWriter io.Writer
 
 	// resultsCount is used to generate the results filename for each container
-	resultsCount uint32
+	resultsCount atomic.Uint32
 
 	// functionFilterProvider provides a filter to perform the function.
 	// this is a variable so it can be mocked in tests
@@ -481,8 +481,8 @@ func (r *RunFns) ffp(spec runtimeutil.FunctionSpec, api *yaml.RNode, currentUser
 	var resultsFile string
 	if r.ResultsDir != "" {
 		resultsFile = filepath.Join(r.ResultsDir, fmt.Sprintf(
-			"results-%v.yaml", r.resultsCount))
-		atomic.AddUint32(&r.resultsCount, 1)
+			"results-%v.yaml", r.resultsCount.Load()))
+		r.resultsCount.Add(1)
 	}
 	if !r.DisableContainers && spec.Container.Image != "" {
 		// TODO: Add a test for this behavior


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
cleanup

#### What this PR does / why we need it:

This PR updates our atomic operations to use `Go 1.19's` newer typed atomic approach instead of the old function-based method. We're changing fields like `uint64` to `atomic.Uint64` so we can write cleaner code like `counter.Add(1)` instead of `atomic.AddUint64(&counter, 1)`. This removes the need for pointer handling and gives us better compile-time safety when multiple threads access the same variables in validator operations.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
- This is a mechanical refactor focused on correctness and maintainability.
- No behavioral or performance changes are intended.
- The change relies on Go 1.19+ typed atomics, which are already required by the project.
- All atomic operations are semantically equivalent to the previous implementation.

#### Does this PR introduce a user-facing change?
N/A


Refrence: https://github.com/kubernetes/kubernetes/pull/136665