### PR TITLE
cluster gce: remove installation of additional packages

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -570,10 +570,6 @@ function install-containerd-ubuntu {
   local -r custom_containerd="${UBUNTU_INSTALL_CONTAINERD_VERSION:-}"
   local -r custom_runc="${UBUNTU_INSTALL_RUNC_VERSION:-}"
 
-  apt-get update
-  apt-get install -y --no-install-recommends apt-transport-https ca-certificates \
-    socat curl gnupg2 nfs-common software-properties-common lsb-release
-
   # Both versions specified: skip apt, install binaries directly
   if [[ -n "${custom_containerd}" && -n "${custom_runc}" ]]; then
     echo "Installing containerd ${custom_containerd} and runc ${custom_runc} (skipping apt)"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

Downloading repository metadata and installing these packages can take too long, causing timeouts in e2e-gce and similar jobs because the 300s timeout for "Kubernetes is up and running" gets exceeded.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/136708#issuecomment-3851443488

#### Special notes for your reviewer:

It's unclear whether all of these packages are still needed. They apparently were in 2020 (acd286d), but maybe not anymore?

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
