### PR TITLE
Kubelet: reconstruct CSI globalmount volumes as uncertain

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -78,6 +78,12 @@ type ActualStateOfWorld interface {
 	// attached volumes, an error is returned.
 	SetDeviceMountState(volumeName v1.UniqueVolumeName, deviceMountState operationexecutor.DeviceMountState, devicePath, deviceMountPath, seLinuxMountContext string) error
 
+	// MarkDeviceAsUncertainViaReconstruction marks the device as uncertain and
+	// registers the volume in foundDuringReconstruction. This is used for
+	// CSI globalmount-only volumes found on disk during kubelet restart where
+	// no pod volume directory exists.
+	MarkDeviceAsUncertainViaReconstruction(volumeName v1.UniqueVolumeName, devicePath, deviceMountPath, seLinuxMountContext string) error
+
 	// DeletePodFromVolume removes the given pod from the given volume in the
 	// cache indicating the volume has been successfully unmounted from the pod.
 	// If a pod with the same unique name does not exist under the specified
@@ -555,6 +561,26 @@ func (asw *actualStateOfWorld) MarkDeviceAsMounted(
 func (asw *actualStateOfWorld) MarkDeviceAsUncertain(
 	volumeName v1.UniqueVolumeName, devicePath, deviceMountPath, seLinuxMountContext string) error {
 	return asw.SetDeviceMountState(volumeName, operationexecutor.DeviceMountUncertain, devicePath, deviceMountPath, seLinuxMountContext)
+}
+
+func (asw *actualStateOfWorld) MarkDeviceAsUncertainViaReconstruction(
+	volumeName v1.UniqueVolumeName, devicePath, deviceMountPath, seLinuxMountContext string) error {
+	if err := asw.SetDeviceMountState(
+		volumeName,
+		operationexecutor.DeviceMountUncertain,
+		devicePath,
+		deviceMountPath,
+		seLinuxMountContext,
+	); err != nil {
+		return err
+	}
+
+	asw.Lock()
+	defer asw.Unlock()
+	if _, ok := asw.foundDuringReconstruction[volumeName]; !ok {
+		asw.foundDuringReconstruction[volumeName] = map[volumetypes.UniquePodName]types.UID{}
+	}
+	return nil
 }
 
 func (asw *actualStateOfWorld) MarkVolumeMountAsUncertain(markVolumeOpts operationexecutor.MarkVolumeOpts) error {

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -1132,7 +1132,9 @@ func Test_GenerateMapVolumeFunc_Plugin_Not_Found(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			volumePluginMgr := &volume.VolumePluginMgr{}
-			volumePluginMgr.InitPlugins(tc.volumePlugins, nil, nil)
+			if err := volumePluginMgr.InitPlugins(tc.volumePlugins, nil, nil); err != nil {
+				t.Fatalf("failed to init plugins: %v", err)
+			}
 			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
 			oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
 				nil, /* kubeClient */
@@ -1182,7 +1184,9 @@ func Test_GenerateUnmapVolumeFunc_Plugin_Not_Found(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			volumePluginMgr := &volume.VolumePluginMgr{}
-			volumePluginMgr.InitPlugins(tc.volumePlugins, nil, nil)
+			if err := volumePluginMgr.InitPlugins(tc.volumePlugins, nil, nil); err != nil {
+				t.Fatalf("failed to init plugins: %v", err)
+			}
 			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
 			oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
 				nil, /* kubeClient */
@@ -1224,7 +1228,9 @@ func Test_GenerateUnmapDeviceFunc_Plugin_Not_Found(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			volumePluginMgr := &volume.VolumePluginMgr{}
-			volumePluginMgr.InitPlugins(tc.volumePlugins, nil, nil)
+			if err := volumePluginMgr.InitPlugins(tc.volumePlugins, nil, nil); err != nil {
+				t.Fatalf("failed to init plugins: %v", err)
+			}
 			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
 			oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
 				nil, /* kubeClient */

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -18,12 +18,14 @@ package reconciler
 
 import (
 	"context"
+	"path/filepath"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
+	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
 )
 
 // readyToUnmount returns true when reconciler can start unmounting volumes.
@@ -48,85 +50,131 @@ func (rc *reconciler) readyToUnmount() bool {
 // put the volumes to volumesFailedReconstruction to be cleaned up later when DesiredStateOfWorld
 // is populated.
 func (rc *reconciler) reconstructVolumes(logger klog.Logger) {
-	// Get volumes information by reading the pod's directory
+	// 1. Existing: scan pod volume dirs
 	podVolumes, err := getVolumesFromPodDir(logger, rc.kubeletPodsDir)
 	if err != nil {
-		logger.Error(err, "Cannot get volumes from disk, skip sync states for volume reconstruction")
-		return
+		logger.Info("Cannot get volumes from disk, continuing with CSI global reconstruction", "err", err)
+		podVolumes = []podVolume{}
 	}
+
 	reconstructedVolumes := make(map[v1.UniqueVolumeName]*globalVolumeInfo)
 	reconstructedVolumeNames := []v1.UniqueVolumeName{}
+
+	// 2. Existing flow: reconstruct pod volumes
 	for _, volume := range podVolumes {
 		if rc.actualStateOfWorld.VolumeExistsWithSpecName(volume.podName, volume.volumeSpecName) {
-			logger.V(4).Info("Volume exists in actual state, skip cleaning up mounts", "podName", volume.podName, "volumeSpecName", volume.volumeSpecName)
-			// There is nothing to reconstruct
+			logger.V(4).Info("Volume exists in actual state, skip cleaning up mounts",
+				"podName", volume.podName, "volumeSpecName", volume.volumeSpecName)
 			continue
 		}
-		reconstructedVolume, err := rc.reconstructVolume(volume)
+
+		reconVol, err := rc.reconstructVolume(volume)
 		if err != nil {
-			logger.Info("Could not construct volume information", "podName", volume.podName, "volumeSpecName", volume.volumeSpecName, "err", err)
-			// We can't reconstruct the volume. Remember to check DSW after it's fully populated and force unmount the volume when it's orphaned.
+			logger.Info("Could not construct volume information",
+				"podName", volume.podName, "volumeSpecName", volume.volumeSpecName, "err", err)
 			rc.volumesFailedReconstruction = append(rc.volumesFailedReconstruction, volume)
 			continue
 		}
-		logger.V(4).Info("Adding reconstructed volume to actual state and node status", "podName", volume.podName, "volumeSpecName", volume.volumeSpecName)
+
 		gvl := &globalVolumeInfo{
-			volumeName:        reconstructedVolume.volumeName,
-			volumeSpec:        reconstructedVolume.volumeSpec,
-			devicePath:        reconstructedVolume.devicePath,
-			deviceMounter:     reconstructedVolume.deviceMounter,
-			blockVolumeMapper: reconstructedVolume.blockVolumeMapper,
-			mounter:           reconstructedVolume.mounter,
+			volumeName:        reconVol.volumeName,
+			volumeSpec:        reconVol.volumeSpec,
+			devicePath:        reconVol.devicePath,
+			deviceMounter:     reconVol.deviceMounter,
+			blockVolumeMapper: reconVol.blockVolumeMapper,
+			mounter:           reconVol.mounter,
+			podVolumes:        make(map[volumetypes.UniquePodName]*reconstructedVolume),
 		}
-		if cachedInfo, ok := reconstructedVolumes[reconstructedVolume.volumeName]; ok {
+
+		if cachedInfo, ok := reconstructedVolumes[reconVol.volumeName]; ok {
 			gvl = cachedInfo
 		}
-		gvl.addPodVolume(reconstructedVolume)
 
-		reconstructedVolumeNames = append(reconstructedVolumeNames, reconstructedVolume.volumeName)
-		reconstructedVolumes[reconstructedVolume.volumeName] = gvl
+		gvl.addPodVolume(reconVol)
+
+		reconstructedVolumes[reconVol.volumeName] = gvl
+		reconstructedVolumeNames = append(reconstructedVolumeNames, reconVol.volumeName)
 	}
 
+	// 3. NEW: reconstruct CSI global mounts (NO pod dirs)
+	csiVolumes, err := rc.getVolumesFromCSIGlobalDir(logger, filepath.Dir(rc.kubeletPodsDir))
+	if err != nil {
+		logger.Error(err, "Failed to scan CSI global mounts")
+	} else {
+		for _, csiVol := range csiVolumes {
+
+			// Avoid duplicates
+			if _, exists := reconstructedVolumes[csiVol.volumeName]; exists {
+				continue
+			}
+
+			gvl := &globalVolumeInfo{
+				volumeName:        csiVol.volumeName,
+				volumeSpec:        csiVol.volumeSpec,
+				devicePath:        csiVol.devicePath,
+				deviceMounter:     csiVol.deviceMounter,
+				blockVolumeMapper: csiVol.blockVolumeMapper,
+				mounter:           csiVol.mounter,
+				podVolumes:        nil,
+			}
+
+			reconstructedVolumes[csiVol.volumeName] = gvl
+			reconstructedVolumeNames = append(reconstructedVolumeNames, csiVol.volumeName)
+
+			logger.V(4).Info("Reconstructed CSI global mount volume",
+				"volumeName", csiVol.volumeName)
+		}
+	}
+
+	// 4. Final state update
 	if len(reconstructedVolumes) > 0 {
-		// Add the volumes to ASW
 		rc.updateStates(logger, reconstructedVolumes)
 
-		// Remember to update devicePath from node.status.volumesAttached
+		// Ensure node status reconciliation happens
 		rc.volumesNeedUpdateFromNodeStatus = reconstructedVolumeNames
 	}
+
 	logger.V(2).Info("Volume reconstruction finished")
 }
 
 func (rc *reconciler) updateStates(logger klog.Logger, reconstructedVolumes map[v1.UniqueVolumeName]*globalVolumeInfo) {
 	for _, gvl := range reconstructedVolumes {
-		err := rc.actualStateOfWorld.AddAttachUncertainReconstructedVolume(
-			//TODO: the devicePath might not be correct for some volume plugins: see issue #54108
-			logger, gvl.volumeName, gvl.volumeSpec, rc.nodeName, gvl.devicePath)
+		var err error
+		var seLinuxMountContext string
+		err = rc.actualStateOfWorld.AddAttachUncertainReconstructedVolume(
+			logger,
+			gvl.volumeName,
+			gvl.volumeSpec,
+			rc.nodeName,
+			gvl.devicePath,
+		)
 		if err != nil {
-			logger.Error(err, "Could not add volume information to actual state of world", "volumeName", gvl.volumeName)
+			logger.Error(err, "Could not add volume to actual state of world", "volumeName", gvl.volumeName)
 			continue
 		}
-		var seLinuxMountContext string
-		for _, volume := range gvl.podVolumes {
-			markVolumeOpts := operationexecutor.MarkVolumeOpts{
-				PodName:             volume.podName,
-				PodUID:              types.UID(volume.podName),
-				VolumeName:          volume.volumeName,
-				Mounter:             volume.mounter,
-				BlockVolumeMapper:   volume.blockVolumeMapper,
-				VolumeGIDVolume:     volume.volumeGIDValue,
-				VolumeSpec:          volume.volumeSpec,
-				VolumeMountState:    operationexecutor.VolumeMountUncertain,
-				SELinuxMountContext: volume.seLinuxMountContext,
-			}
 
-			_, err = rc.actualStateOfWorld.CheckAndMarkVolumeAsUncertainViaReconstruction(markVolumeOpts)
-			if err != nil {
-				logger.Error(err, "Could not add pod to volume information to actual state of world", "pod", klog.KObj(volume.pod))
-				continue
+		if len(gvl.podVolumes) > 0 {
+			for _, volume := range gvl.podVolumes {
+				markVolumeOpts := operationexecutor.MarkVolumeOpts{
+					PodName:             volume.podName,
+					PodUID:              types.UID(volume.podName),
+					VolumeName:          volume.volumeName,
+					Mounter:             volume.mounter,
+					BlockVolumeMapper:   volume.blockVolumeMapper,
+					VolumeGIDVolume:     volume.volumeGIDValue,
+					VolumeSpec:          volume.volumeSpec,
+					VolumeMountState:    operationexecutor.VolumeMountUncertain,
+					SELinuxMountContext: volume.seLinuxMountContext,
+				}
+
+				_, err = rc.actualStateOfWorld.CheckAndMarkVolumeAsUncertainViaReconstruction(markVolumeOpts)
+				if err != nil {
+					logger.Error(err, "Could not add pod to volume information to actual state of world", "pod", klog.KObj(volume.pod))
+					continue
+				}
+				seLinuxMountContext = volume.seLinuxMountContext
+				logger.V(2).Info("Volume is marked as uncertain and added into the actual state", "pod", klog.KObj(volume.pod), "podName", volume.podName, "volumeName", volume.volumeName, "seLinuxMountContext", volume.seLinuxMountContext)
 			}
-			seLinuxMountContext = volume.seLinuxMountContext
-			logger.V(2).Info("Volume is marked as uncertain and added into the actual state", "pod", klog.KObj(volume.pod), "podName", volume.podName, "volumeName", volume.volumeName, "seLinuxMountContext", volume.seLinuxMountContext)
 		}
 		// If the volume has device to mount, we mark its device as uncertain.
 		if gvl.deviceMounter != nil || gvl.blockVolumeMapper != nil {
@@ -135,6 +183,21 @@ func (rc *reconciler) updateStates(logger klog.Logger, reconstructedVolumes map[
 				logger.Error(err, "Could not find device mount path for volume", "volumeName", gvl.volumeName)
 				continue
 			}
+			if len(gvl.podVolumes) == 0 {
+				err = rc.actualStateOfWorld.MarkDeviceAsUncertainViaReconstruction(
+					gvl.volumeName,
+					gvl.devicePath,
+					deviceMountPath,
+					seLinuxMountContext,
+				)
+				if err != nil {
+					logger.Error(err, "Could not mark device as uncertain via reconstruction", "volumeName", gvl.volumeName, "deviceMountPath", deviceMountPath)
+					continue
+				}
+				logger.V(2).Info("CSI globalmount-only volume marked as device uncertain via reconstruction", "volumeName", gvl.volumeName, "deviceMountPath", deviceMountPath)
+				continue
+			}
+
 			err = rc.actualStateOfWorld.MarkDeviceAsUncertain(gvl.volumeName, gvl.devicePath, deviceMountPath, seLinuxMountContext)
 			if err != nil {
 				logger.Error(err, "Could not mark device is uncertain to actual state of world", "volumeName", gvl.volumeName, "deviceMountPath", deviceMountPath)
@@ -204,4 +267,5 @@ func (rc *reconciler) updateReconstructedFromNodeStatus(ctx context.Context) {
 
 	logger.V(2).Info("DevicePaths of reconstructed volumes updated")
 	rc.volumesNeedUpdateFromNodeStatus = nil
+
 }

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -51,6 +52,19 @@ type podVolume struct {
 	pluginName     string
 	volumeMode     v1.PersistentVolumeMode
 }
+
+type csiVolumeData struct {
+	DriverName       string            `json:"driverName"`
+	VolumeHandle     string            `json:"volumeHandle"`
+	FSType           string            `json:"fsType,omitempty"`
+	ReadOnly         bool              `json:"readOnly,omitempty"`
+	VolumeAttributes map[string]string `json:"volumeAttributes,omitempty"`
+}
+
+const (
+	reconstructedCSIGlobalMountPodName = volumetypes.UniquePodName("csi-globalmount")
+	reconstructedCSIGlobalMountPodUID  = types.UID("csi-globalmount")
+)
 
 func (p podVolume) MarshalLog() interface{} {
 	return struct {
@@ -245,6 +259,116 @@ func getVolumesFromPodDir(logger klog.Logger, podDir string) ([]podVolume, error
 	for _, volume := range volumes {
 		logger.V(4).Info("Get volume from pod directory", "path", podDir, "volume", volume)
 	}
+	return volumes, nil
+}
+
+func buildCSIVolumeSpec(volData *csiVolumeData) *volumepkg.Spec {
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: volData.VolumeHandle,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:           volData.DriverName,
+					VolumeHandle:     volData.VolumeHandle,
+					FSType:           volData.FSType,
+					ReadOnly:         volData.ReadOnly,
+					VolumeAttributes: volData.VolumeAttributes,
+				},
+			},
+		},
+	}
+
+	return volumepkg.NewSpecFromPersistentVolume(pv, false)
+}
+
+func (rc *reconciler) getVolumesFromCSIGlobalDir(
+	logger klog.Logger,
+	kubeletRootDir string,
+) ([]*reconstructedVolume, error) {
+
+	var volumes []*reconstructedVolume
+
+	pluginDir := filepath.Join(
+		kubeletRootDir,
+		"plugins",
+		"kubernetes.io",
+		"csi",
+	)
+
+	drivers, err := os.ReadDir(pluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return volumes, nil
+		}
+		return nil, err
+	}
+
+	for _, driver := range drivers {
+		if !driver.IsDir() {
+			continue
+		}
+
+		driverDir := filepath.Join(pluginDir, driver.Name())
+		volumeDirs, err := os.ReadDir(driverDir)
+		if err != nil {
+			continue
+		}
+
+		for _, volDir := range volumeDirs {
+			if !volDir.IsDir() {
+				continue
+			}
+
+			volPath := filepath.Join(driverDir, volDir.Name())
+			volDataPath := filepath.Join(volPath, "vol_data.json")
+			data, err := os.ReadFile(volDataPath)
+			if err != nil {
+				continue
+			}
+
+			globalMountPath := filepath.Join(volPath, "globalmount")
+			if _, err := os.Stat(globalMountPath); err != nil {
+				continue
+			}
+
+			var volData csiVolumeData
+			if err := json.Unmarshal(data, &volData); err != nil {
+				logger.Error(err, "Failed to parse vol_data.json", "path", volDataPath)
+				continue
+			}
+
+			volumeSpec := buildCSIVolumeSpec(&volData)
+			plugin, err := rc.volumePluginMgr.FindPluginBySpec(volumeSpec)
+			if err != nil {
+				logger.Error(err, "Failed to find volume plugin for CSI globalmount volume", "path", volDataPath)
+				continue
+			}
+
+			pv := podVolume{
+				podName:        reconstructedCSIGlobalMountPodName,
+				volumeSpecName: volData.VolumeHandle,
+				volumePath:     volPath,
+				pluginName:     plugin.GetPluginName(),
+				volumeMode:     v1.PersistentVolumeFilesystem,
+			}
+
+			rv, err := rc.reconstructVolume(pv)
+			if err != nil {
+				logger.Error(err, "Failed to reconstruct CSI globalmount volume",
+					"volPath", volPath,
+				)
+				continue
+			}
+
+			logger.V(4).Info("Reconstructed CSI globalmount-only volume",
+				"volumeName", rv.volumeName,
+				"volPath", volPath)
+			volumes = append(volumes, rv)
+		}
+	}
+
 	return volumes, nil
 }
 

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -84,11 +85,17 @@ func TestReconstructVolumes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can't make a temp directory for kubeletPods: %v", err)
 			}
-			defer os.RemoveAll(tmpKubeletDir)
+			defer func() {
+				if err := os.RemoveAll(tmpKubeletDir); err != nil {
+					t.Errorf("failed to remove temp dir: %v", err)
+				}
+			}()
 
 			// create kubelet pod directory
 			tmpKubeletPodDir := filepath.Join(tmpKubeletDir, "pods")
-			os.MkdirAll(tmpKubeletPodDir, 0755)
+			if err := os.MkdirAll(tmpKubeletPodDir, 0755); err != nil {
+				t.Fatalf("failed to create pod dir: %v", err)
+			}
 
 			mountPaths := []string{}
 
@@ -96,7 +103,9 @@ func TestReconstructVolumes(t *testing.T) {
 			for _, volumePath := range tc.volumePaths {
 				vp := filepath.Join(tmpKubeletPodDir, volumePath)
 				mountPaths = append(mountPaths, vp)
-				os.MkdirAll(vp, 0755)
+				if err := os.MkdirAll(vp, 0755); err != nil {
+					t.Fatalf("failed to create volume path: %v", err)
+				}
 			}
 
 			rc, fakePlugin := getReconciler(tmpKubeletDir, t, mountPaths, nil /*custom kubeclient*/)
@@ -179,11 +188,17 @@ func TestCleanOrphanVolumes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can't make a temp directory for kubeletPods: %v", err)
 			}
-			defer os.RemoveAll(tmpKubeletDir)
+			defer func() {
+				if err := os.RemoveAll(tmpKubeletDir); err != nil {
+					t.Errorf("failed to remove temp dir: %v", err)
+				}
+			}()
 
 			// create kubelet pod directory
 			tmpKubeletPodDir := filepath.Join(tmpKubeletDir, "pods")
-			os.MkdirAll(tmpKubeletPodDir, 0755)
+			if err := os.MkdirAll(tmpKubeletPodDir, 0755); err != nil {
+				t.Fatalf("failed to create pod dir: %v", err)
+			}
 
 			mountPaths := []string{}
 
@@ -200,7 +215,11 @@ func TestCleanOrphanVolumes(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Error adding volume %s to dsow: %v", volumeSpec.Name(), err)
 				}
-				rcInstance.actualStateOfWorld.MarkVolumeAsAttached(logger, volumeName, volumeSpec, nodeName, "")
+				if err := rcInstance.actualStateOfWorld.MarkVolumeAsAttached(
+					logger, volumeName, volumeSpec, nodeName, "",
+				); err != nil {
+					t.Fatalf("failed to mark volume as attached: %v", err)
+				}
 			}
 
 			// Act
@@ -282,16 +301,24 @@ func TestReconstructVolumesMount(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can't make a temp directory for kubeletPods: %v", err)
 			}
-			defer os.RemoveAll(tmpKubeletDir)
+			defer func() {
+				if err := os.RemoveAll(tmpKubeletDir); err != nil {
+					t.Errorf("failed to remove temp dir: %v", err)
+				}
+			}()
 
 			// create kubelet pod directory
 			tmpKubeletPodDir := filepath.Join(tmpKubeletDir, "pods")
-			os.MkdirAll(tmpKubeletPodDir, 0755)
+			if err := os.MkdirAll(tmpKubeletPodDir, 0755); err != nil {
+				t.Fatalf("failed to create pod dir: %v", err)
+			}
 
 			// create pod and volume directories so as reconciler can find them.
 			vp := filepath.Join(tmpKubeletPodDir, tc.volumePath)
 			mountPaths := []string{vp}
-			os.MkdirAll(vp, 0755)
+			if err := os.MkdirAll(vp, 0755); err != nil {
+				t.Fatalf("failed to create volume path: %v", err)
+			}
 
 			// Arrange 2 - populate DSW
 			outerName := filepath.Base(tc.volumePath)
@@ -325,7 +352,11 @@ func TestReconstructVolumesMount(t *testing.T) {
 				t.Fatalf("Error adding volume %s to dsow: %v", volumeSpec.Name(), err)
 			}
 			logger, _ := ktesting.NewTestContext(t)
-			rcInstance.actualStateOfWorld.MarkVolumeAsAttached(logger, volumeName, volumeSpec, nodeName, "")
+			if err := rcInstance.actualStateOfWorld.MarkVolumeAsAttached(
+				logger, volumeName, volumeSpec, nodeName, "",
+			); err != nil {
+				t.Fatalf("failed to mark volume as attached: %v", err)
+			}
 
 			rcInstance.populatorHasAddedPods = func() bool {
 				// Mark DSW populated to allow unmounting of volumes.
@@ -390,8 +421,182 @@ func TestReconstructVolumesMount(t *testing.T) {
 			}
 
 			// Unmount was *not* attempted in any case
-			verifyTearDownCalls(fakePlugin, 0)
+			if err := verifyTearDownCalls(fakePlugin, 0); err != nil {
+				t.Fatalf("unexpected teardown calls: %v", err)
+			}
 		})
+	}
+}
+
+func TestReconstructCSIGlobalMountOnly(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	tmpKubeletDir, err := os.MkdirTemp("", "kubelet")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpKubeletDir); err != nil {
+			t.Errorf("failed to remove temp dir: %v", err)
+		}
+	}()
+
+	// Create CSI globalmount structure:
+	// plugins/kubernetes.io/csi/<driver>/<volume>/globalmount
+	driver := "fake.csi.driver"
+	volumeID := "test-volume-id"
+
+	globalMountPath := filepath.Join(
+		tmpKubeletDir,
+		"plugins",
+		"kubernetes.io",
+		"csi",
+		driver,
+		volumeID,
+		"globalmount",
+	)
+
+	volDataPath := filepath.Join(
+		tmpKubeletDir,
+		"plugins",
+		"kubernetes.io",
+		"csi",
+		driver,
+		volumeID,
+		"vol_data.json",
+	)
+
+	// Create directories
+	if err := os.MkdirAll(globalMountPath, 0755); err != nil {
+		t.Fatalf("failed to create globalmount dir: %v", err)
+	}
+
+	// Create vol_data.json
+	volData := map[string]interface{}{
+		"driverName":   driver,
+		"volumeHandle": volumeID,
+		"fsType":       "ext4",
+	}
+
+	data, _ := json.Marshal(volData)
+	if err := os.WriteFile(volDataPath, data, 0644); err != nil {
+		t.Fatalf("failed to write vol_data.json: %v", err)
+	}
+
+	// NOTE: No pod directory created → this is the core of the test
+
+	// Setup reconciler
+	rc, fakePlugin := getReconciler(tmpKubeletDir, t, nil, nil)
+	rcInstance, _ := rc.(*reconciler)
+
+	// Act
+	rcInstance.reconstructVolumes(logger)
+
+	// Assert
+
+	// 1. No volumes should be marked as fully mounted
+	mounted := rcInstance.actualStateOfWorld.GetMountedVolumes()
+	if len(mounted) != 0 {
+		t.Fatalf("expected 0 mounted volumes, got %d", len(mounted))
+	}
+
+	if len(rcInstance.volumesNeedUpdateFromNodeStatus) != 1 {
+		t.Fatalf("expected 1 volume needing node status update, got %d",
+			len(rcInstance.volumesNeedUpdateFromNodeStatus))
+	}
+
+	// 2. Volume should exist as UNCERTAIN
+	devices := rcInstance.actualStateOfWorld.GetUnmountedVolumes()
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 reconstructed (uncertain) device volume, got %d", len(devices))
+	}
+
+	// 3. Ensure it is marked as reconstructed (uncertain)
+	if !rcInstance.actualStateOfWorld.IsVolumeDeviceReconstructed(devices[0].VolumeName) {
+		t.Fatalf("expected volume %s to be marked as device-reconstructed", devices[0].VolumeName)
+	}
+
+	// 4. Ensure no teardown (unmount) was triggered
+	if err := verifyTearDownCalls(fakePlugin, 0); err != nil {
+		t.Fatalf("unexpected teardown calls: %v", err)
+	}
+}
+
+func TestReconstructCSIGlobalMountMissingVolData(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	tmpKubeletDir, _ := os.MkdirTemp("", "kubelet")
+	defer func() {
+		if err := os.RemoveAll(tmpKubeletDir); err != nil {
+			t.Errorf("failed to remove temp dir: %v", err)
+		}
+	}()
+
+	driver := "fake.csi.driver"
+	volumeID := "test-volume-id"
+
+	globalMountPath := filepath.Join(
+		tmpKubeletDir,
+		"plugins", "kubernetes.io", "csi",
+		driver, volumeID, "globalmount",
+	)
+
+	if err := os.MkdirAll(globalMountPath, 0755); err != nil {
+		t.Fatalf("failed to create globalMountPath: %v", err)
+	}
+
+	rc, _ := getReconciler(tmpKubeletDir, t, nil, nil)
+	rcInstance := rc.(*reconciler)
+
+	rcInstance.reconstructVolumes(logger)
+
+	all := rcInstance.actualStateOfWorld.GetAllMountedVolumes()
+	if len(all) != 0 {
+		t.Fatalf("expected no volumes reconstructed, got %d", len(all))
+	}
+}
+
+func TestReconstructCSIGlobalMountMissingGlobalMountDir(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	tmpKubeletDir, _ := os.MkdirTemp("", "kubelet")
+	defer func() {
+		if err := os.RemoveAll(tmpKubeletDir); err != nil {
+			t.Errorf("failed to remove temp dir: %v", err)
+		}
+	}()
+
+	driver := "fake.csi.driver"
+	volumeID := "test-volume-id"
+
+	basePath := filepath.Join(
+		tmpKubeletDir,
+		"plugins", "kubernetes.io", "csi",
+		driver, volumeID,
+	)
+
+	if err := os.MkdirAll(basePath, 0755); err != nil {
+		t.Fatalf("failed to create basePath: %v", err)
+	}
+
+	// Only vol_data.json, NO globalmount
+	volData := map[string]interface{}{
+		"driverName":   driver,
+		"volumeHandle": volumeID,
+	}
+	data, _ := json.Marshal(volData)
+	if err := os.WriteFile(filepath.Join(basePath, "vol_data.json"), data, 0644); err != nil {
+		t.Fatalf("failed to write vol_data.json: %v", err)
+	}
+
+	rc, _ := getReconciler(tmpKubeletDir, t, nil, nil)
+	rcInstance := rc.(*reconciler)
+
+	rcInstance.reconstructVolumes(logger)
+
+	all := rcInstance.actualStateOfWorld.GetAllMountedVolumes()
+	if len(all) != 0 {
+		t.Fatalf("expected no volumes reconstructed without globalmount dir, got %d", len(all))
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
On kubelet restart, CSI globalmount directories may exist on disk without corresponding in-memory state. Previously, such volumes could be reconstructed as fully attached or mounted, leading to incorrect attachment assumptions.

This PR ensures CSI globalmount volumes discovered during reconstruction are added to the Actual State of World in an Uncertain state. This allows the reconciler to re-verify attachment and mount status instead of assuming correctness based solely on filesystem presence.

A unit test is added to validate correct reconstruction behavior for CSI globalmount volumes.

#### Which issue(s) this PR is related to:

Fixes #121937

#### Special notes for your reviewer:

- This change only affects kubelet startup reconstruction logic
- No behavior change for steady-state volume operations
- Added targeted unit coverage for CSI globalmount reconstruction

#### Does this PR introduce a user-facing change?

```release-note 
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
