### PR TITLE
Add Available condition to StatefulSet to support kubectl wait

### DIFF
--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -294,7 +294,12 @@ type StatefulSetStatus struct {
 // StatefulSetConditionType describes the condition types of StatefulSets.
 type StatefulSetConditionType string
 
-// TODO: Add valid condition types for Statefulsets.
+// TODO: Add more condition types like Progressing for StatefulSets.
+const (
+	// StatefulSetAvailable means at least the minimum available replicas required
+	// are up and running for at least minReadySeconds.
+	StatefulSetAvailable StatefulSetConditionType = "Available"
+)
 
 // StatefulSetCondition describes the state of a statefulset at a certain point.
 type StatefulSetCondition struct {

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -861,13 +861,14 @@ func (ssc *defaultStatefulSetControl) updateStatefulSetStatus(
 	// complete any in progress update if necessary
 	completeUpdate(set, status)
 
+	replicaCount := int(*set.Spec.Replicas)
+	maxUnavailable := 0
 	if utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) {
 		// Update metrics - this ensures metrics are always updated regardless of update strategy
 		podManagementPolicy := string(set.Spec.PodManagementPolicy)
-		replicaCount := int(*set.Spec.Replicas)
 
 		var err error
-		maxUnavailable := 1
+		maxUnavailable = 1
 		if set.Spec.UpdateStrategy.RollingUpdate != nil {
 			maxUnavailable, err = getStatefulSetMaxUnavailable(set.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable, replicaCount)
 			if err != nil {
@@ -875,6 +876,29 @@ func (ssc *defaultStatefulSetControl) updateStatefulSetStatus(
 			}
 		}
 		metrics.MaxUnavailable.WithLabelValues(set.Namespace, set.Name, podManagementPolicy).Set(float64(maxUnavailable))
+	}
+
+	// Set Available condition: available if we have at least (replicas - maxUnavailable) pods available.
+	minAvailable := int32(replicaCount - maxUnavailable)
+	if minAvailable < 0 {
+		minAvailable = 0
+	}
+	if status.AvailableReplicas >= minAvailable {
+		condition := NewStatefulSetCondition(
+			apps.StatefulSetAvailable,
+			v1.ConditionTrue,
+			MinimumReplicasAvailable,
+			"StatefulSet has minimum availability.",
+		)
+		SetStatefulSetCondition(status, *condition)
+	} else {
+		condition := NewStatefulSetCondition(
+			apps.StatefulSetAvailable,
+			v1.ConditionFalse,
+			MinimumReplicasUnavailable,
+			"StatefulSet does not have minimum availability.",
+		)
+		SetStatefulSetCondition(status, *condition)
 	}
 	// if the status is not inconsistent do not perform an update
 	if !inconsistentStatus(set, status) {

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -878,11 +878,8 @@ func (ssc *defaultStatefulSetControl) updateStatefulSetStatus(
 		metrics.MaxUnavailable.WithLabelValues(set.Namespace, set.Name, podManagementPolicy).Set(float64(maxUnavailable))
 	}
 
-	// Set Available condition: available if we have at least (replicas - maxUnavailable) pods available.
-	minAvailable := int32(replicaCount - maxUnavailable)
-	if minAvailable < 0 {
-		minAvailable = 0
-	}
+	// Set Available condition
+	minAvailable := max(int32(replicaCount-maxUnavailable), 0)
 	if status.AvailableReplicas >= minAvailable {
 		condition := NewStatefulSetCondition(
 			apps.StatefulSetAvailable,

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -878,8 +878,15 @@ func (ssc *defaultStatefulSetControl) updateStatefulSetStatus(
 		metrics.MaxUnavailable.WithLabelValues(set.Namespace, set.Name, podManagementPolicy).Set(float64(maxUnavailable))
 	}
 
-	// Set Available condition
-	minAvailable := max(int32(replicaCount-maxUnavailable), 0)
+	// Set Available condition: default maxUnavailable is 1 regardless of
+	// whether the MaxUnavailableStatefulSet feature gate is enabled.
+	availMaxUnavailable := 1
+	if utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) && set.Spec.UpdateStrategy.RollingUpdate != nil {
+		if mu, err := getStatefulSetMaxUnavailable(set.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable, replicaCount); err == nil {
+			availMaxUnavailable = mu
+		}
+	}
+	minAvailable := max(int32(replicaCount-availMaxUnavailable), 0)
 	if status.AvailableReplicas >= minAvailable {
 		condition := NewStatefulSetCondition(
 			apps.StatefulSetAvailable,

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -4418,8 +4418,12 @@ func TestStatefulSetAvailableCondition(t *testing.T) {
 				AvailableReplicas:  tc.availableReplicas,
 				ObservedGeneration: set.Generation,
 			}
-			ssc.UpdateStatefulSet(context.TODO(), set, []*v1.Pod{}, time.Now())
-			ssc.(*defaultStatefulSetControl).updateStatefulSetStatus(context.TODO(), set, &status)
+			if _, err := ssc.UpdateStatefulSet(context.TODO(), set, []*v1.Pod{}, time.Now()); err != nil {
+				t.Fatal(err)
+			}
+			if err := ssc.(*defaultStatefulSetControl).updateStatefulSetStatus(context.TODO(), set, &status); err != nil {
+				t.Fatal(err)
+			}
 
 			cond := GetStatefulSetCondition(status, apps.StatefulSetAvailable)
 			if cond == nil || cond.Status != tc.expectedStatus {

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -4393,3 +4393,38 @@ func TestStatefulSetMetrics(t *testing.T) {
 		})
 	}
 }
+
+func TestStatefulSetAvailableCondition(t *testing.T) {
+	testCases := []struct {
+		name              string
+		replicas          int32
+		availableReplicas int32
+		expectedStatus    v1.ConditionStatus
+	}{
+		{"available - all replicas", 3, 3, v1.ConditionTrue},
+		{"available - meets minimum (3-1=2)", 3, 2, v1.ConditionTrue},
+		{"unavailable - below minimum", 3, 1, v1.ConditionFalse},
+		{"zero replicas", 0, 0, v1.ConditionTrue},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			set := newStatefulSet(tc.replicas)
+			client := fake.NewClientset(set)
+			_, _, ssc := setupController(client)
+
+			status := apps.StatefulSetStatus{
+				Replicas:           tc.replicas,
+				AvailableReplicas:  tc.availableReplicas,
+				ObservedGeneration: set.Generation,
+			}
+			ssc.UpdateStatefulSet(context.TODO(), set, []*v1.Pod{}, time.Now())
+			ssc.(*defaultStatefulSetControl).updateStatefulSetStatus(context.TODO(), set, &status)
+
+			cond := GetStatefulSetCondition(status, apps.StatefulSetAvailable)
+			if cond == nil || cond.Status != tc.expectedStatus {
+				t.Errorf("Expected Available=%v, got %v", tc.expectedStatus, cond)
+			}
+		})
+	}
+}

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -619,7 +619,8 @@ func inconsistentStatus(set *apps.StatefulSet, status *apps.StatefulSetStatus) b
 		status.UpdatedReplicas != set.Status.UpdatedReplicas ||
 		status.CurrentRevision != set.Status.CurrentRevision ||
 		status.AvailableReplicas != set.Status.AvailableReplicas ||
-		status.UpdateRevision != set.Status.UpdateRevision
+		status.UpdateRevision != set.Status.UpdateRevision ||
+		!statefulSetConditionsEqual(set.Status.Conditions, status.Conditions)
 }
 
 // completeUpdate completes an update when all of set's replica Pods have been updated
@@ -632,6 +633,81 @@ func completeUpdate(set *apps.StatefulSet, status *apps.StatefulSetStatus) {
 		status.CurrentReplicas = status.UpdatedReplicas
 		status.CurrentRevision = status.UpdateRevision
 	}
+}
+
+// Reasons for statefulset conditions
+const (
+	MinimumReplicasAvailable   = "MinimumReplicasAvailable"
+	MinimumReplicasUnavailable = "MinimumReplicasUnavailable"
+)
+
+// NewStatefulSetCondition creates a new statefulset condition.
+func NewStatefulSetCondition(condType apps.StatefulSetConditionType, status v1.ConditionStatus, reason, message string) *apps.StatefulSetCondition {
+	return &apps.StatefulSetCondition{
+		Type:               condType,
+		Status:             status,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
+// GetStatefulSetCondition returns the condition with the provided type.
+func GetStatefulSetCondition(status apps.StatefulSetStatus, condType apps.StatefulSetConditionType) *apps.StatefulSetCondition {
+	for _, condition := range status.Conditions {
+		if condition.Type == condType {
+			return &condition
+		}
+	}
+	return nil
+}
+
+// SetStatefulSetCondition updates the statefulset to include the provided condition. If the condition that
+// we are about to add already exists and has the same status and reason then we are not going to update.
+func SetStatefulSetCondition(status *apps.StatefulSetStatus, condition apps.StatefulSetCondition) {
+	currentCond := GetStatefulSetCondition(*status, condition.Type)
+	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason {
+		return
+	}
+	if currentCond != nil && currentCond.Status == condition.Status {
+		condition.LastTransitionTime = currentCond.LastTransitionTime
+	}
+	newConditions := filterOutStatefulSetCondition(status.Conditions, condition.Type)
+	status.Conditions = append(newConditions, condition)
+}
+
+// filterOutStatefulSetCondition returns a new slice of statefulset conditions without conditions with the provided type.
+func filterOutStatefulSetCondition(conditions []apps.StatefulSetCondition, condType apps.StatefulSetConditionType) []apps.StatefulSetCondition {
+	var newConditions []apps.StatefulSetCondition
+	for _, condition := range conditions {
+		if condition.Type == condType {
+			continue
+		}
+		newConditions = append(newConditions, condition)
+	}
+	return newConditions
+}
+
+// statefulSetConditionsEqual compares two slices of StatefulSetCondition for equality.
+// It ignores LastTransitionTime if the status is the same.
+func statefulSetConditionsEqual(cond1, cond2 []apps.StatefulSetCondition) bool {
+	if len(cond1) != len(cond2) {
+		return false
+	}
+	cond1Map := make(map[apps.StatefulSetConditionType]apps.StatefulSetCondition)
+	for _, condition := range cond1 {
+		cond1Map[condition.Type] = condition
+	}
+	for _, c2 := range cond2 {
+		c1, exists := cond1Map[c2.Type]
+		if !exists {
+			return false
+		}
+		if c1.Status != c2.Status || c1.Reason != c2.Reason || c1.Message != c2.Message {
+			return false
+		}
+	}
+	return true
 }
 
 // ascendingOrdinal is a sort.Interface that Sorts a list of Pods based on the ordinals extracted

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -673,7 +673,8 @@ func SetStatefulSetCondition(status *apps.StatefulSetStatus, condition apps.Stat
 		condition.LastTransitionTime = currentCond.LastTransitionTime
 	}
 	newConditions := filterOutStatefulSetCondition(status.Conditions, condition.Type)
-	status.Conditions = append(newConditions, condition)
+	newConditions = append(newConditions, condition)
+	status.Conditions = newConditions
 }
 
 // filterOutStatefulSetCondition returns a new slice of statefulset conditions without conditions with the provided type.

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -1931,3 +1931,57 @@ func TestCompleteUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestStatefulSetConditionHelpers(t *testing.T) {
+	now := metav1.Now()
+
+	t.Run("SetStatefulSetCondition preserves LastTransitionTime when status unchanged", func(t *testing.T) {
+		status := apps.StatefulSetStatus{
+			Conditions: []apps.StatefulSetCondition{
+				{Type: apps.StatefulSetAvailable, Status: v1.ConditionTrue, Reason: "OldReason", LastTransitionTime: now},
+			},
+		}
+		SetStatefulSetCondition(&status, apps.StatefulSetCondition{
+			Type: apps.StatefulSetAvailable, Status: v1.ConditionTrue, Reason: MinimumReplicasAvailable,
+			LastTransitionTime: metav1.NewTime(now.Add(time.Second)),
+		})
+		cond := GetStatefulSetCondition(status, apps.StatefulSetAvailable)
+		if cond == nil || !cond.LastTransitionTime.Equal(&now) {
+			t.Error("Expected LastTransitionTime to be preserved when status unchanged")
+		}
+	})
+
+	t.Run("SetStatefulSetCondition updates LastTransitionTime when status changes", func(t *testing.T) {
+		status := apps.StatefulSetStatus{
+			Conditions: []apps.StatefulSetCondition{
+				{Type: apps.StatefulSetAvailable, Status: v1.ConditionFalse, Reason: MinimumReplicasUnavailable, LastTransitionTime: now},
+			},
+		}
+		newTime := metav1.NewTime(now.Add(time.Second))
+		SetStatefulSetCondition(&status, apps.StatefulSetCondition{
+			Type: apps.StatefulSetAvailable, Status: v1.ConditionTrue, Reason: MinimumReplicasAvailable,
+			LastTransitionTime: newTime,
+		})
+		cond := GetStatefulSetCondition(status, apps.StatefulSetAvailable)
+		if cond == nil || cond.Status != v1.ConditionTrue {
+			t.Error("Expected condition to be updated")
+		}
+	})
+
+	t.Run("statefulSetConditionsEqual ignores LastTransitionTime", func(t *testing.T) {
+		later := metav1.NewTime(now.Add(time.Second))
+		cond1 := []apps.StatefulSetCondition{{Type: apps.StatefulSetAvailable, Status: v1.ConditionTrue, LastTransitionTime: now}}
+		cond2 := []apps.StatefulSetCondition{{Type: apps.StatefulSetAvailable, Status: v1.ConditionTrue, LastTransitionTime: later}}
+		if !statefulSetConditionsEqual(cond1, cond2) {
+			t.Error("Expected conditions to be equal (ignoring LastTransitionTime)")
+		}
+	})
+
+	t.Run("statefulSetConditionsEqual detects status change", func(t *testing.T) {
+		cond1 := []apps.StatefulSetCondition{{Type: apps.StatefulSetAvailable, Status: v1.ConditionTrue}}
+		cond2 := []apps.StatefulSetCondition{{Type: apps.StatefulSetAvailable, Status: v1.ConditionFalse}}
+		if statefulSetConditionsEqual(cond1, cond2) {
+			t.Error("Expected conditions to be different")
+		}
+	})
+}

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -321,6 +321,12 @@ type StatefulSetStatus struct {
 
 type StatefulSetConditionType string
 
+const (
+	// StatefulSetAvailable means at least the minimum available replicas required
+	// are up and running for at least minReadySeconds.
+	StatefulSetAvailable StatefulSetConditionType = "Available"
+)
+
 // StatefulSetCondition describes the state of a statefulset at a certain point.
 type StatefulSetCondition struct {
 	// Type of statefulset condition.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds the `Available` condition to StatefulSet, enabling `kubectl wait --for condition=Available statefulset/my-sts` functionality.

#### Which issue(s) this PR is related to:

Fixes [#79606](https://github.com/kubernetes/kubernetes/issues/79606)

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:


Previous PR #133696 attempted to add a `Progressing` condition but stalled due to its complexity. This PR takes a minimal approach by focusing only on the `Available` condition, which is much more straightforward than the different scenarios `Progressing` would need to handle.

- Adds `StatefulSetAvailable` condition type constant to API types
- Sets `Available=True` when `availableReplicas >= replicas - maxUnavailable`, and sets `Available=False` otherwise

Code changes (~270 lines):
- Core logic: ~40 lines in `stateful_set_control.go`
- Helper functions: ~80 lines in `stateful_set_utils.go`  
- Tests: ~150 lines (unit + integration)

I also manually verified on Minikube: `kubectl wait --for=condition=Available statefulset/demo-sts` works correctly:

```
status:
  availableReplicas: 3
  collisionCount: 0
  conditions:
  - lastTransitionTime: "2026-02-05T09:19:43Z"
    message: StatefulSet has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
```




#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
