### PR TITLE
Enable modernize/slicessort rule

### DIFF
--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -597,14 +597,6 @@ linters:
         # A useful hint because it can make  code more obvious
         # and/or avoid helper functions.
         - slicescontains
-        # Replace sort.Slice with slices.Sort for basic types.
-        #
-        # A useful hint because the code becomes shorter.
-        - slicessort
-        # Use iterators instead of Len/At-style APIs.
-        #
-        # A useful hint because the code becomes shorter.
-        - stditerators
         # Replace HasPrefix/TrimPrefix with CutPrefix.
         #
         # A useful hint because the code becomes shorter.

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -333,14 +333,6 @@ linters:
         # A useful hint because it can make  code more obvious
         # and/or avoid helper functions.
         - slicescontains
-        # Replace sort.Slice with slices.Sort for basic types.
-        #
-        # A useful hint because the code becomes shorter.
-        - slicessort
-        # Use iterators instead of Len/At-style APIs.
-        #
-        # A useful hint because the code becomes shorter.
-        - stditerators
         # Replace HasPrefix/TrimPrefix with CutPrefix.
         #
         # A useful hint because the code becomes shorter.

--- a/pkg/controller/volume/selinuxwarning/cache/volumecache.go
+++ b/pkg/controller/volume/selinuxwarning/cache/volumecache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"slices"
 	"sort"
 	"sync"
 
@@ -195,9 +196,7 @@ func (c *volumeCache) dump(logger klog.Logger) {
 	for volumeID := range c.volumes {
 		volumeIDs = append(volumeIDs, volumeID)
 	}
-	sort.Slice(volumeIDs, func(i, j int) bool {
-		return volumeIDs[i] < volumeIDs[j]
-	})
+	slices.Sort(volumeIDs)
 	for _, volumeID := range volumeIDs {
 		volume := c.volumes[volumeID]
 		logger.Info("Cached volume", "volume", volumeID, "csiDriver", volume.csiDriver)

--- a/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
@@ -419,9 +419,7 @@ func createRequestsAndMappings(pod *v1.Pod, extendedResources map[v1.ResourceNam
 	for resource := range extendedResources {
 		resourceNames = append(resourceNames, resource)
 	}
-	sort.Slice(resourceNames, func(i, j int) bool {
-		return resourceNames[i] < resourceNames[j]
-	})
+	slices.Sort(resourceNames)
 
 	for _, resource := range resourceNames {
 		class := deviceClassMapping.GetDeviceClass(resource)

--- a/staging/src/k8s.io/apiserver/pkg/quota/v1/resources.go
+++ b/staging/src/k8s.io/apiserver/pkg/quota/v1/resources.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	"sort"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -198,7 +198,7 @@ func Intersection(a []corev1.ResourceName, b []corev1.ResourceName) []corev1.Res
 		}
 		result = append(result, item)
 	}
-	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	slices.Sort(result)
 	return result
 }
 
@@ -211,7 +211,7 @@ func Difference(a []corev1.ResourceName, b []corev1.ResourceName) []corev1.Resou
 		}
 		result = append(result, item)
 	}
-	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	slices.Sort(result)
 	return result
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
@@ -18,7 +18,7 @@ package validators
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/api/validate"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -226,9 +226,7 @@ func (ufv updateFieldValidator) generateValidation(context Context, constraints 
 	}
 
 	// Sort constraints to ensure deterministic order
-	sort.Slice(constraints, func(i, j int) bool {
-		return constraints[i] < constraints[j]
-	})
+	slices.Sort(constraints)
 
 	// Build the constraint arguments in deterministic order
 	var constraintArgs []any

--- a/staging/src/k8s.io/kube-scheduler/framework/signers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/signers.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"encoding/json"
+	"slices"
 	"sort"
 
 	v1 "k8s.io/api/core/v1"
@@ -59,9 +60,7 @@ func HostPortsSigner(pod *v1.Pod) any {
 		}
 	}
 	ports := portSet.UnsortedList()
-	sort.Slice(ports, func(i, j int) bool {
-		return ports[i] < ports[j]
-	})
+	slices.Sort(ports)
 	return ports
 }
 
@@ -69,18 +68,14 @@ func NodeSelectorRequirementsSigner(reqs []v1.NodeSelectorRequirement) ([]string
 	ret := make([]string, len(reqs))
 	for i, req := range reqs {
 		t := req.DeepCopy()
-		sort.Slice(t.Values, func(i, j int) bool {
-			return t.Values[i] < t.Values[j]
-		})
+		slices.Sort(t.Values)
 		v, err := json.Marshal(t)
 		if err != nil {
 			return nil, err
 		}
 		ret[i] = string(v)
 	}
-	sort.Slice(ret, func(i, j int) bool {
-		return ret[i] < ret[j]
-	})
+	slices.Sort(ret)
 	return ret, nil
 }
 
@@ -125,9 +120,7 @@ func PreferredSchedulingTermSigner(terms []v1.PreferredSchedulingTerm) ([]string
 		}
 		newTerms[i] = string(termStr)
 	}
-	sort.Slice(newTerms, func(i, j int) bool {
-		return newTerms[i] < newTerms[j]
-	})
+	slices.Sort(newTerms)
 	return newTerms, nil
 }
 
@@ -144,10 +137,7 @@ func NodeSelectorTermsSigner(terms []v1.NodeSelectorTerm) ([]string, error) {
 		}
 		req[i] = string(tStr)
 	}
-
-	sort.Slice(req, func(i, j int) bool {
-		return req[i] < req[j]
-	})
+	slices.Sort(req)
 
 	return req, nil
 }
@@ -210,8 +200,6 @@ func VolumesSigner(pod *v1.Pod) any {
 			ret = append(ret, string(volStr))
 		}
 	}
-	sort.Slice(ret, func(i, j int) bool {
-		return ret[i] < ret[j]
-	})
+	slices.Sort(ret)
 	return ret
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -18,7 +18,7 @@ package rollout
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -191,7 +191,7 @@ func (o *RolloutHistoryOptions) Run() error {
 				for k := range historyInfo {
 					sortedKeys = append(sortedKeys, k)
 				}
-				sort.Slice(sortedKeys, func(i, j int) bool { return sortedKeys[i] < sortedKeys[j] })
+				slices.Sort(sortedKeys)
 				for _, k := range sortedKeys {
 					printer.PrintObj(historyInfo[k], o.Out)
 				}

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"text/tabwriter"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -38,7 +39,6 @@ import (
 	"k8s.io/kubectl/pkg/apps"
 	"k8s.io/kubectl/pkg/describe"
 	deploymentutil "k8s.io/kubectl/pkg/util/deployment"
-	sliceutil "k8s.io/kubectl/pkg/util/slice"
 )
 
 const (
@@ -142,7 +142,7 @@ func (h *DeploymentHistoryViewer) ViewHistory(namespace, name string, revision i
 	for r := range historyInfo {
 		revisions = append(revisions, r)
 	}
-	sliceutil.SortInts64(revisions)
+	slices.Sort(revisions)
 
 	return tabbedString(func(out io.Writer) error {
 		fmt.Fprintf(out, "REVISION\tCHANGE-CAUSE\n")
@@ -255,7 +255,7 @@ func printHistory(history []*appsv1.ControllerRevision, revision int64, getPodTe
 	for r := range historyInfo {
 		revisions = append(revisions, r)
 	}
-	sliceutil.SortInts64(revisions)
+	slices.Sort(revisions)
 
 	return tabbedString(func(out io.Writer) error {
 		fmt.Fprintf(out, "REVISION\tCHANGE-CAUSE\n")

--- a/staging/src/k8s.io/kubectl/pkg/util/slice/slice.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/slice/slice.go
@@ -16,12 +16,10 @@ limitations under the License.
 
 package slice
 
-import (
-	"sort"
-)
+import "slices"
 
 // SortInts64 sorts []int64 in increasing order
-func SortInts64(a []int64) { sort.Slice(a, func(i, j int) bool { return a[i] < a[j] }) }
+func SortInts64(a []int64) { slices.Sort(a) }
 
 // Contains checks if a given slice of type T contains the provided item.
 // If a modifier func is provided, it is called with the slice item before the comparation.

--- a/staging/src/k8s.io/pod-security-admission/policy/registry.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/registry.go
@@ -18,7 +18,7 @@ package policy
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -163,8 +163,8 @@ func populate(r *checkRegistry, validChecks []Check) {
 	}
 
 	// Sort the IDs to maintain consistent error messages.
-	sort.Slice(restrictedIDs, func(i, j int) bool { return restrictedIDs[i] < restrictedIDs[j] })
-	sort.Slice(baselineIDs, func(i, j int) bool { return baselineIDs[i] < baselineIDs[j] })
+	slices.Sort(restrictedIDs)
+	slices.Sort(baselineIDs)
 	orderedIDs := append(baselineIDs, restrictedIDs...) // Baseline checks first, then restricted.
 
 	for v := api.MajorMinorVersion(1, 0); v.Older(nextMinor(r.maxVersion)); v = nextMinor(v) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

There were only two instances of this in the entire code-base. Hence, I have enabled the modernize rule/linter in golangci-lint.

Fixed using
```sh
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -slicessort -fix -test ./...
```

There are no matches for `stditerators` so I suggest this will also be enabled.

Related to #136500

#### Which issue(s) this PR is related to:

Follow-up to #136500

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```