### PR TITLE
Validate node name in Binding API

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6557,6 +6557,13 @@ func ValidatePodBinding(binding *core.Binding) field.ErrorList {
 	if len(binding.Target.Name) == 0 {
 		// TODO: When validation becomes versioned, this gets more complicated.
 		allErrs = append(allErrs, field.Required(field.NewPath("target", "name"), ""))
+	} else {
+		// Validate node name format when binding to a Node (or when Kind is empty, which defaults to Node)
+		if len(binding.Target.Kind) == 0 || binding.Target.Kind == "Node" {
+			for _, msg := range ValidateNodeName(binding.Target.Name, false) {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("target", "name"), binding.Target.Name, msg))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6557,12 +6557,10 @@ func ValidatePodBinding(binding *core.Binding) field.ErrorList {
 	if len(binding.Target.Name) == 0 {
 		// TODO: When validation becomes versioned, this gets more complicated.
 		allErrs = append(allErrs, field.Required(field.NewPath("target", "name"), ""))
-	} else {
+	} else if len(binding.Target.Kind) == 0 || binding.Target.Kind == "Node" {
 		// Validate node name format when binding to a Node (or when Kind is empty, which defaults to Node)
-		if len(binding.Target.Kind) == 0 || binding.Target.Kind == "Node" {
-			for _, msg := range ValidateNodeName(binding.Target.Name, false) {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("target", "name"), binding.Target.Name, msg))
-			}
+		for _, msg := range ValidateNodeName(binding.Target.Name, false) {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("target", "name"), binding.Target.Name, msg))
 		}
 	}
 

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -30477,7 +30477,6 @@ func TestValidateWorkloadReference(t *testing.T) {
 	}
 }
 
-
 func TestValidatePodBinding(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -30614,4 +30613,3 @@ func TestValidatePodBinding(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Binding API doesn't validate node names, so you can bind a pod to a node with an invalid name (like uppercase characters). If the pod has a finalizer, it gets stuck in deletion because the node doesn't exist and never will.

This adds validation to `ValidatePodBinding` to reject invalid node names upfront using the existing `ValidateNodeName` function.

#### Which issue(s) this PR fixes:

Fixes #136723

#### Does this PR introduce a user-facing change?

```release-note
The `pods/binding` endpoint now validates the specified node name consistently.
```