### PR TITLE
feat(wait): introduce waitOptions.RunWaitContext()

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -17,6 +17,7 @@ limitations under the License.
 package delete
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -466,7 +467,7 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		ConditionFn: cmdwait.IsDeleted,
 		IOStreams:   o.IOStreams,
 	}
-	err = waitOptions.RunWait()
+	err = waitOptions.RunWaitContext(context.Background())
 	if errors.IsForbidden(err) || errors.IsMethodNotSupported(err) {
 		// if we're forbidden from waiting, we shouldn't fail.
 		// if the resource doesn't support a verb we need, we shouldn't fail.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -543,7 +543,7 @@ func TestLog(t *testing.T) {
 			opts.Namespace = "test"
 			opts.Object = testPod()
 			opts.Options = &corev1.PodLogOptions{}
-			err := opts.RunLogs()
+			err := opts.RunLogsContext(t.Context())
 
 			if err == nil && len(test.expectedErr) > 0 {
 				t.Fatalf("expected error %q, got none", test.expectedErr)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -410,7 +410,6 @@ func (o PortForwardOptions) Validate() error {
 	return nil
 }
 
-// RunPortForward implements all the necessary functionality for port-forward cmd.
 // Deprecated: Use RunPortForwardContext instead, which allows canceling.
 func (o PortForwardOptions) RunPortForward() error {
 	return o.RunPortForwardContext(context.Background())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -410,8 +410,8 @@ func (o PortForwardOptions) Validate() error {
 	return nil
 }
 
-// Deprecated: Use RunPortForwardContext instead, which allows canceling.
 // RunPortForward implements all the necessary functionality for port-forward cmd.
+// Deprecated: Use RunPortForwardContext instead, which allows canceling.
 func (o PortForwardOptions) RunPortForward() error {
 	return o.RunPortForwardContext(context.Background())
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -599,7 +599,7 @@ func TestWaitForDeletion(t *testing.T) {
 				ConditionFn: IsDeleted,
 				IOStreams:   genericiooptions.NewTestIOStreamsDiscard(),
 			}
-			err := o.RunWait()
+			err := o.RunWaitContext(t.Context())
 			switch {
 			case err == nil && len(test.expectedErr) == 0:
 			case err != nil && len(test.expectedErr) == 0:
@@ -1009,7 +1009,7 @@ func TestWaitForCondition(t *testing.T) {
 				ConditionFn: ConditionalWait{conditionName: "the-condition", conditionStatus: "status-value", errOut: io.Discard}.IsConditionMet,
 				IOStreams:   genericiooptions.NewTestIOStreamsDiscard(),
 			}
-			err := o.RunWait()
+			err := o.RunWaitContext(t.Context())
 			switch {
 			case err == nil && len(test.expectedErr) == 0:
 			case err != nil && len(test.expectedErr) == 0:
@@ -1080,7 +1080,7 @@ func TestWaitForCreate(t *testing.T) {
 				ForCondition: "create",
 				IOStreams:    genericiooptions.NewTestIOStreamsDiscard(),
 			}
-			err := o.RunWait()
+			err := o.RunWaitContext(t.Context())
 			switch {
 			case err == nil && len(test.expectedErr) == 0:
 			case err != nil && len(test.expectedErr) == 0:
@@ -1112,7 +1112,7 @@ func TestWaitForDeletionIgnoreNotFound(t *testing.T) {
 		IOStreams:      genericiooptions.NewTestIOStreamsDiscard(),
 		ForCondition:   "delete",
 	}
-	err := o.RunWait()
+	err := o.RunWaitContext(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1367,7 +1367,7 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
 			}
 
-			err := o.RunWait()
+			err := o.RunWaitContext(t.Context())
 
 			switch {
 			case err == nil && len(test.expectedErr) == 0:
@@ -1630,7 +1630,7 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 				IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
 			}
 
-			err := o.RunWait()
+			err := o.RunWaitContext(t.Context())
 
 			switch {
 			case err == nil && len(test.expectedErr) == 0:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:

-->

#### What this PR does / why we need it: 

I have a tool that wraps opts.RunWait(). It would be nice if I could send in a context that will force the function to exit instead of relying solely to timeout. 

#### Which issue(s) this PR is related to:

Fixes: #136780

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
