### PR TITLE
Fix kube-proxy nftables crash with newer nftables versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	k8s.io/system-validators v1.12.1
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
-	sigs.k8s.io/knftables v0.0.17
+	sigs.k8s.io/knftables v0.0.20
 	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2
 	sigs.k8s.io/yaml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -508,8 +508,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/knftables v0.0.17 h1:wGchTyRF/iGTIjd+vRaR1m676HM7jB8soFtyr/148ic=
-sigs.k8s.io/knftables v0.0.17/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
+sigs.k8s.io/knftables v0.0.20 h1:eU2NWpgcJ/wgb4Fy0cX3klK6nDjERvZRdYgkORLU0Tc=
+sigs.k8s.io/knftables v0.0.20/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
 sigs.k8s.io/kustomize/api v0.20.1 h1:iWP1Ydh3/lmldBnH/S5RXgT98vWYMaTUL1ADcr+Sv7I=
 sigs.k8s.io/kustomize/api v0.20.1/go.mod h1:t6hUFxO+Ph0VxIk1sKp1WS0dOjbPCtLJ4p8aADLwqjM=
 sigs.k8s.io/kustomize/cmd/config v0.20.1/go.mod h1:R7rQ8kxknVlXWVUIbxWtMgu8DCCNVtl8V0KrmeVd/KE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1207,7 +1207,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
 ## explicit; go 1.23
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
-# sigs.k8s.io/knftables v0.0.17
+# sigs.k8s.io/knftables v0.0.20
 ## explicit; go 1.20
 sigs.k8s.io/knftables
 # sigs.k8s.io/kustomize/api v0.20.1

--- a/vendor/sigs.k8s.io/knftables/CHANGELOG.md
+++ b/vendor/sigs.k8s.io/knftables/CHANGELOG.md
@@ -1,5 +1,60 @@
 # ChangeLog
 
+## v0.0.20
+
+- `List()` has been changed to use `nft list table` rather than, e.g.,
+  `nft list sets`, to ensure that it doesn't try to parse objects in
+  other tables (which may have been created by newer versions of `nft`
+  and might trigger crashes in older versions of `nft`; see
+  https://issues.k8s.io/136786). (`@danwinship` based on a previous PR
+  from `@kairosci`).
+
+- A new `ListAll()` method has been added to help work around the fact
+  that `List()` is now much less efficient with large tables.
+  (`@danwinship`).
+
+- `ListElements()` now correctly handles maps/sets with concatenated
+  keys/values including CIDR values. (`@danwinship`)
+
+## v0.0.19
+
+- Added the ability to use a single `knftables.Interface` (and a
+  single `knftables.Transaction`) with multiple tables/families. To do
+  this, pass `""` for the family and table name to `knftables.New`,
+  and then manually fill in the `Table` and `Family` fields in all
+  `Object`s you create. (`@danwinship`)
+
+- Added `tx.Destroy()`, corresponding to `nft destroy`. Since `nft
+  destroy` requires a new-ish kernel (6.3) and CLI (1.0.8), there are
+  also two new `knftables.New()` options: `RequireDestroy` if you want
+  construction to fail on older systems, or `EmulateDestroy` if you
+  want knftables to try to emulate "destroy" on older systems, with
+  some limitations. See [README.md](./README.md#destroy-operations)
+  for more details. (`@danwinship`)
+
+- Added `Counter` objects and the `tx.Reset()` verb, to support
+  nftables counters. (`@aroradaman`)
+
+- Added `Table.Flags` and `Chain.Policy`. (Note that at this time the
+  "owner" and "persist" table flags can't usefully be used with
+  knftables, since knftables opens a new connection to the kernel for
+  each transaction and so the table would become un-owned immediately
+  after it was created.) (`@danwinship`)
+
+- Fixed `Fake.ParseDump()` to correctly parse rules with raw payload
+  expressions (`@danwinship`) and `flow add` rules (`hongliangl`).
+
+## v0.0.18
+
+- Added locking to `Fake` to allow it to be safely used concurrently.
+  (`@npinaeva`)
+
+- Added a `Flowtable` object, and `Fake` support for correctly parsing
+  flowtable references. (`@aojea`)
+
+- Fixed a bug in `Fake.ParseDump`, which accidentally required the
+  table to have a comment. (`@danwinship`)
+
 ## v0.0.17
 
 - `ListRules()` now accepts `""` for the chain name, meaning to list

--- a/vendor/sigs.k8s.io/knftables/CONTRIBUTING.md
+++ b/vendor/sigs.k8s.io/knftables/CONTRIBUTING.md
@@ -25,4 +25,4 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 knftables is maintained by [Kubernetes SIG Network](https://github.com/kubernetes/community/tree/master/sig-network).
 
 - [sig-network slack channel](https://kubernetes.slack.com/messages/sig-network)
-- [kubernetes-sig-network mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-network)
+- [kubernetes-sig-network mailing list](https://groups.google.com/a/kubernetes.io/g/sig-network)

--- a/vendor/sigs.k8s.io/knftables/objects.go
+++ b/vendor/sigs.k8s.io/knftables/objects.go
@@ -46,18 +46,43 @@ func getComment(commentGroup string) *string {
 	return &noQuotes
 }
 
+func getTable(ctx *nftContext, family Family, table string) (Family, string, error) {
+	switch {
+	case ctx.family == "" && family == "":
+		return "", "", fmt.Errorf("must specify family and table for each object when the Interface has no default")
+	case ctx.family != "" && family != "" && family != ctx.family:
+		return "", "", fmt.Errorf("cannot override family or table when the Interface has a default")
+	case ctx.family != "" && family == "":
+		family = ctx.family
+	}
+
+	switch {
+	case ctx.table == "" && table == "":
+		return "", "", fmt.Errorf("must specify family and table for each object when the Interface has no default")
+	case ctx.table != "" && table != "" && table != ctx.table:
+		return "", "", fmt.Errorf("cannot override family or table when the Interface has a default")
+	case ctx.table != "" && table == "":
+		table = ctx.table
+	}
+
+	return family, table, nil
+}
+
 var commentGroup = `(".*")`
 var noSpaceGroup = `([^ ]*)`
 var numberGroup = `([0-9]*)`
 
 // Object implementation for Table
-func (table *Table) validate(verb verb) error {
+func (table *Table) validate(verb verb, ctx *nftContext) error {
+	if _, _, err := getTable(ctx, table.Family, table.Name); err != nil {
+		return err
+	}
 	switch verb {
 	case addVerb, createVerb, flushVerb:
 		if table.Handle != nil {
 			return fmt.Errorf("cannot specify Handle in %s operation", verb)
 		}
-	case deleteVerb:
+	case deleteVerb, destroyVerb:
 		// Handle can be nil or non-nil
 	default:
 		return fmt.Errorf("%s is not implemented for tables", verb)
@@ -67,39 +92,75 @@ func (table *Table) validate(verb verb) error {
 }
 
 func (table *Table) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
+	family, tableName, _ := getTable(ctx, table.Family, table.Name)
+
 	// Special case for delete-by-handle
-	if verb == deleteVerb && table.Handle != nil {
-		fmt.Fprintf(writer, "delete table %s handle %d", ctx.family, *table.Handle)
+	if (verb == deleteVerb || verb == destroyVerb) && table.Handle != nil {
+		fmt.Fprintf(writer, "%s table %s handle %d", verb, family, *table.Handle)
 		return
 	}
 
 	// All other cases refer to the table by name
-	fmt.Fprintf(writer, "%s table %s %s", verb, ctx.family, ctx.table)
+	fmt.Fprintf(writer, "%s table %s %s", verb, family, tableName)
 	if verb == addVerb || verb == createVerb {
-		if table.Comment != nil && !ctx.noObjectComments {
-			fmt.Fprintf(writer, " { comment %q ; }", *table.Comment)
+		hasComment := table.Comment != nil && !ctx.noObjectComments
+		if hasComment || len(table.Flags) != 0 {
+			fmt.Fprintf(writer, " {")
+			if hasComment {
+				fmt.Fprintf(writer, " comment %q ;", *table.Comment)
+			}
+			if len(table.Flags) != 0 {
+				fmt.Fprintf(writer, " flags ")
+				for i := range table.Flags {
+					if i > 0 {
+						fmt.Fprintf(writer, ",")
+					}
+					fmt.Fprintf(writer, "%s", table.Flags[i])
+				}
+				fmt.Fprintf(writer, " ;")
+			}
+			fmt.Fprintf(writer, " }")
 		}
 	}
 	fmt.Fprintf(writer, "\n")
 }
 
 var tableRegexp = regexp.MustCompile(fmt.Sprintf(
-	`(?:{ comment %s ; })?`, commentGroup))
+	`(?:{ (?:comment %s ; )?(?:flags %s ; )?})?`, commentGroup, noSpaceGroup))
 
-func (table *Table) parse(line string) error {
+func parseTableFlags(s string) []TableFlag {
+	var res []TableFlag
+	for _, flag := range strings.Split(s, ",") {
+		res = append(res, TableFlag(flag))
+	}
+	return res
+}
+
+func (table *Table) parse(family Family, tableName, line string) error {
 	match := tableRegexp.FindStringSubmatch(line)
 	if match == nil {
 		return fmt.Errorf("failed parsing table add command")
 	}
+	table.Family = family
+	table.Name = tableName
 	table.Comment = getComment(match[1])
+	if match[2] != "" {
+		table.Flags = parseTableFlags(match[2])
+	}
 	return nil
 }
 
 // Object implementation for Chain
-func (chain *Chain) validate(verb verb) error {
+func (chain *Chain) validate(verb verb, ctx *nftContext) error {
+	if _, _, err := getTable(ctx, chain.Family, chain.Table); err != nil {
+		return err
+	}
 	if chain.Hook == nil {
 		if chain.Type != nil || chain.Priority != nil {
 			return fmt.Errorf("regular chain %q must not specify Type or Priority", chain.Name)
+		}
+		if chain.Policy != nil {
+			return fmt.Errorf("regular chain %q must not specify Policy", chain.Name)
 		}
 		if chain.Device != nil {
 			return fmt.Errorf("regular chain %q must not specify Device", chain.Name)
@@ -118,7 +179,7 @@ func (chain *Chain) validate(verb verb) error {
 		if chain.Handle != nil {
 			return fmt.Errorf("cannot specify Handle in %s operation", verb)
 		}
-	case deleteVerb:
+	case deleteVerb, destroyVerb:
 		if chain.Name == "" && chain.Handle == nil {
 			return fmt.Errorf("must specify either name or handle")
 		}
@@ -130,13 +191,15 @@ func (chain *Chain) validate(verb verb) error {
 }
 
 func (chain *Chain) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
+	family, table, _ := getTable(ctx, chain.Family, chain.Table)
+
 	// Special case for delete-by-handle
-	if verb == deleteVerb && chain.Handle != nil {
-		fmt.Fprintf(writer, "delete chain %s %s handle %d", ctx.family, ctx.table, *chain.Handle)
+	if (verb == deleteVerb || verb == destroyVerb) && chain.Handle != nil {
+		fmt.Fprintf(writer, "%s chain %s %s handle %d", verb, family, table, *chain.Handle)
 		return
 	}
 
-	fmt.Fprintf(writer, "%s chain %s %s %s", verb, ctx.family, ctx.table, chain.Name)
+	fmt.Fprintf(writer, "%s chain %s %s %s", verb, family, table, chain.Name)
 	if verb == addVerb || verb == createVerb {
 		if chain.Type != nil || (chain.Comment != nil && !ctx.noObjectComments) {
 			fmt.Fprintf(writer, " {")
@@ -151,10 +214,13 @@ func (chain *Chain) writeOperation(verb verb, ctx *nftContext, writer io.Writer)
 				// versions of nft don't accept certain named priorities
 				// in all contexts (eg, "dstnat" priority in the "output"
 				// hook).
-				if priority, err := ParsePriority(ctx.family, string(*chain.Priority)); err == nil {
+				if priority, err := ParsePriority(family, string(*chain.Priority)); err == nil {
 					fmt.Fprintf(writer, " priority %d ;", priority)
 				} else {
 					fmt.Fprintf(writer, " priority %s ;", *chain.Priority)
+				}
+				if chain.Policy != nil {
+					fmt.Fprintf(writer, " policy %s ;", *chain.Policy)
 				}
 			}
 			if chain.Comment != nil && !ctx.noObjectComments {
@@ -168,18 +234,20 @@ func (chain *Chain) writeOperation(verb verb, ctx *nftContext, writer io.Writer)
 	fmt.Fprintf(writer, "\n")
 }
 
-// groups in []: [1]%s(?: {(?: type [2]%s hook [3]%s(?: device "[4]%s")(?: priority [5]%s ;))(?: comment [6]%s ;) })
+// groups in []: [1]%s(?: {(?: type [2]%s hook [3]%s(?: device "[4]%s")(?: priority [5]%s ;)(?: policy [6]%s ;)?)(?: comment [7]%s ;) })
 var chainRegexp = regexp.MustCompile(fmt.Sprintf(
-	`%s(?: {(?: type %s hook %s(?: device "%s")?(?: priority %s ;))?(?: comment %s ;)? })?`,
-	noSpaceGroup, noSpaceGroup, noSpaceGroup, noSpaceGroup, noSpaceGroup, commentGroup))
+	`%s(?: {(?: type %s hook %s(?: device "%s")?(?: priority %s ;)(?: policy %s ;)?)?(?: comment %s ;)? })?`,
+	noSpaceGroup, noSpaceGroup, noSpaceGroup, noSpaceGroup, noSpaceGroup, noSpaceGroup, commentGroup))
 
-func (chain *Chain) parse(line string) error {
+func (chain *Chain) parse(family Family, table, line string) error {
 	match := chainRegexp.FindStringSubmatch(line)
 	if match == nil {
 		return fmt.Errorf("failed parsing chain add command")
 	}
+	chain.Family = family
+	chain.Table = table
 	chain.Name = match[1]
-	chain.Comment = getComment(match[6])
+	chain.Comment = getComment(match[7])
 	if match[2] != "" {
 		chain.Type = (*BaseChainType)(&match[2])
 	}
@@ -192,11 +260,17 @@ func (chain *Chain) parse(line string) error {
 	if match[5] != "" {
 		chain.Priority = (*BaseChainPriority)(&match[5])
 	}
+	if match[6] != "" {
+		chain.Policy = (*BaseChainPolicy)(&match[6])
+	}
 	return nil
 }
 
 // Object implementation for Rule
-func (rule *Rule) validate(verb verb) error {
+func (rule *Rule) validate(verb verb, ctx *nftContext) error {
+	if _, _, err := getTable(ctx, rule.Family, rule.Table); err != nil {
+		return err
+	}
 	if rule.Chain == "" {
 		return fmt.Errorf("no chain name specified for rule")
 	}
@@ -217,7 +291,7 @@ func (rule *Rule) validate(verb verb) error {
 		if rule.Handle == nil {
 			return fmt.Errorf("must specify Handle with %s", verb)
 		}
-	case deleteVerb:
+	case deleteVerb, destroyVerb:
 		if rule.Handle == nil {
 			return fmt.Errorf("must specify Handle with %s", verb)
 		}
@@ -229,7 +303,9 @@ func (rule *Rule) validate(verb verb) error {
 }
 
 func (rule *Rule) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
-	fmt.Fprintf(writer, "%s rule %s %s %s", verb, ctx.family, ctx.table, rule.Chain)
+	family, table, _ := getTable(ctx, rule.Family, rule.Table)
+
+	fmt.Fprintf(writer, "%s rule %s %s %s", verb, family, table, rule.Chain)
 	if rule.Index != nil {
 		fmt.Fprintf(writer, " index %d", *rule.Index)
 	} else if rule.Handle != nil {
@@ -253,11 +329,13 @@ var ruleRegexp = regexp.MustCompile(fmt.Sprintf(
 	`%s(?: index %s)?(?: handle %s)? ([^"]*)(?: comment %s)?$`,
 	noSpaceGroup, numberGroup, numberGroup, commentGroup))
 
-func (rule *Rule) parse(line string) error {
+func (rule *Rule) parse(family Family, table, line string) error {
 	match := ruleRegexp.FindStringSubmatch(line)
 	if match == nil {
 		return fmt.Errorf("failed parsing rule add command")
 	}
+	rule.Family = family
+	rule.Table = table
 	rule.Chain = match[1]
 	rule.Rule = match[4]
 	rule.Comment = getComment(match[5])
@@ -271,21 +349,26 @@ func (rule *Rule) parse(line string) error {
 }
 
 // Object implementation for Set
-func (set *Set) validate(verb verb) error {
+func (set *Set) validate(verb verb, ctx *nftContext) error {
+	if _, _, err := getTable(ctx, set.Family, set.Table); err != nil {
+		return err
+	}
 	switch verb {
 	case addVerb, createVerb:
+		if set.Name == "" {
+			return fmt.Errorf("no name specified for set")
+		}
 		if (set.Type == "" && set.TypeOf == "") || (set.Type != "" && set.TypeOf != "") {
 			return fmt.Errorf("set must specify either Type or TypeOf")
 		}
 		if set.Handle != nil {
 			return fmt.Errorf("cannot specify Handle in %s operation", verb)
 		}
-		fallthrough
 	case flushVerb:
 		if set.Name == "" {
 			return fmt.Errorf("no name specified for set")
 		}
-	case deleteVerb:
+	case deleteVerb, destroyVerb:
 		if set.Name == "" && set.Handle == nil {
 			return fmt.Errorf("must specify either name or handle")
 		}
@@ -297,13 +380,15 @@ func (set *Set) validate(verb verb) error {
 }
 
 func (set *Set) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
+	family, table, _ := getTable(ctx, set.Family, set.Table)
+
 	// Special case for delete-by-handle
-	if verb == deleteVerb && set.Handle != nil {
-		fmt.Fprintf(writer, "delete set %s %s handle %d", ctx.family, ctx.table, *set.Handle)
+	if (verb == deleteVerb || verb == destroyVerb) && set.Handle != nil {
+		fmt.Fprintf(writer, "%v set %s %s handle %d", verb, family, table, *set.Handle)
 		return
 	}
 
-	fmt.Fprintf(writer, "%s set %s %s %s", verb, ctx.family, ctx.table, set.Name)
+	fmt.Fprintf(writer, "%s set %s %s %s", verb, family, table, set.Name)
 	if verb == addVerb || verb == createVerb {
 		fmt.Fprintf(writer, " {")
 
@@ -350,32 +435,39 @@ func (set *Set) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
 	fmt.Fprintf(writer, "\n")
 }
 
-func (set *Set) parse(line string) error {
+func (set *Set) parse(family Family, table, line string) error {
 	match := setRegexp.FindStringSubmatch(line)
 	if match == nil {
 		return fmt.Errorf("failed parsing set add command")
 	}
+	set.Family = family
+	set.Table = table
 	set.Name, set.Type, set.TypeOf, set.Flags, set.Timeout, set.GCInterval,
 		set.Size, set.Policy, set.Comment, set.AutoMerge = parseMapAndSetProps(match)
 	return nil
 }
 
 // Object implementation for Map
-func (mapObj *Map) validate(verb verb) error {
+func (mapObj *Map) validate(verb verb, ctx *nftContext) error {
+	if _, _, err := getTable(ctx, mapObj.Family, mapObj.Table); err != nil {
+		return err
+	}
 	switch verb {
 	case addVerb, createVerb:
+		if mapObj.Name == "" {
+			return fmt.Errorf("no name specified for map")
+		}
 		if (mapObj.Type == "" && mapObj.TypeOf == "") || (mapObj.Type != "" && mapObj.TypeOf != "") {
 			return fmt.Errorf("map must specify either Type or TypeOf")
 		}
 		if mapObj.Handle != nil {
 			return fmt.Errorf("cannot specify Handle in %s operation", verb)
 		}
-		fallthrough
 	case flushVerb:
 		if mapObj.Name == "" {
 			return fmt.Errorf("no name specified for map")
 		}
-	case deleteVerb:
+	case deleteVerb, destroyVerb:
 		if mapObj.Name == "" && mapObj.Handle == nil {
 			return fmt.Errorf("must specify either name or handle")
 		}
@@ -387,13 +479,15 @@ func (mapObj *Map) validate(verb verb) error {
 }
 
 func (mapObj *Map) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
+	family, table, _ := getTable(ctx, mapObj.Family, mapObj.Table)
+
 	// Special case for delete-by-handle
-	if verb == deleteVerb && mapObj.Handle != nil {
-		fmt.Fprintf(writer, "delete map %s %s handle %d", ctx.family, ctx.table, *mapObj.Handle)
+	if (verb == deleteVerb || verb == destroyVerb) && mapObj.Handle != nil {
+		fmt.Fprintf(writer, "%v map %s %s handle %d", verb, family, table, *mapObj.Handle)
 		return
 	}
 
-	fmt.Fprintf(writer, "%s map %s %s %s", verb, ctx.family, ctx.table, mapObj.Name)
+	fmt.Fprintf(writer, "%s map %s %s %s", verb, family, table, mapObj.Name)
 	if verb == addVerb || verb == createVerb {
 		fmt.Fprintf(writer, " {")
 
@@ -437,11 +531,13 @@ func (mapObj *Map) writeOperation(verb verb, ctx *nftContext, writer io.Writer) 
 	fmt.Fprintf(writer, "\n")
 }
 
-func (mapObj *Map) parse(line string) error {
+func (mapObj *Map) parse(family Family, table, line string) error {
 	match := mapRegexp.FindStringSubmatch(line)
 	if match == nil {
 		return fmt.Errorf("failed parsing map add command")
 	}
+	mapObj.Family = family
+	mapObj.Table = table
 	mapObj.Name, mapObj.Type, mapObj.TypeOf, mapObj.Flags, mapObj.Timeout, mapObj.GCInterval,
 		mapObj.Size, mapObj.Policy, mapObj.Comment, _ = parseMapAndSetProps(match)
 	return nil
@@ -500,7 +596,10 @@ func parseSetFlags(s string) []SetFlag {
 }
 
 // Object implementation for Element
-func (element *Element) validate(verb verb) error {
+func (element *Element) validate(verb verb, ctx *nftContext) error {
+	if _, _, err := getTable(ctx, element.Family, element.Table); err != nil {
+		return err
+	}
 	if element.Map == "" && element.Set == "" {
 		return fmt.Errorf("no set/map name specified for element")
 	} else if element.Set != "" && element.Map != "" {
@@ -519,7 +618,7 @@ func (element *Element) validate(verb verb) error {
 		if element.Map != "" && len(element.Value) == 0 {
 			return fmt.Errorf("no map value specified for map element")
 		}
-	case deleteVerb:
+	case deleteVerb, destroyVerb:
 	default:
 		return fmt.Errorf("%s is not implemented for elements", verb)
 	}
@@ -528,12 +627,14 @@ func (element *Element) validate(verb verb) error {
 }
 
 func (element *Element) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
+	family, table, _ := getTable(ctx, element.Family, element.Table)
+
 	name := element.Set
 	if name == "" {
 		name = element.Map
 	}
 
-	fmt.Fprintf(writer, "%s element %s %s %s { %s", verb, ctx.family, ctx.table, name,
+	fmt.Fprintf(writer, "%s element %s %s %s { %s", verb, family, table, name,
 		strings.Join(element.Key, " . "))
 
 	if verb == addVerb || verb == createVerb {
@@ -557,7 +658,7 @@ var mapElementRegexp = regexp.MustCompile(fmt.Sprintf(
 var setElementRegexp = regexp.MustCompile(fmt.Sprintf(
 	`%s { ([^"]*)(?: comment %s)? }`, noSpaceGroup, commentGroup))
 
-func (element *Element) parse(line string) error {
+func (element *Element) parse(family Family, table, line string) error {
 	// try to match map element first, since it has more groups, and if it matches, then we can be sure
 	// this is map element.
 	match := mapElementRegexp.FindStringSubmatch(line)
@@ -567,6 +668,8 @@ func (element *Element) parse(line string) error {
 			return fmt.Errorf("failed parsing element add command")
 		}
 	}
+	element.Family = family
+	element.Table = table
 	element.Comment = getComment(match[3])
 	mapOrSetName := match[1]
 	element.Key = append(element.Key, strings.Split(match[2], " . ")...)
@@ -578,4 +681,176 @@ func (element *Element) parse(line string) error {
 		element.Set = mapOrSetName
 	}
 	return nil
+}
+
+// Object implementation for Flowtable
+func (flowtable *Flowtable) validate(verb verb, ctx *nftContext) error {
+	if _, _, err := getTable(ctx, flowtable.Family, flowtable.Table); err != nil {
+		return err
+	}
+	switch verb {
+	case addVerb, createVerb:
+		if flowtable.Name == "" {
+			return fmt.Errorf("no name specified for flowtable")
+		}
+		if flowtable.Handle != nil {
+			return fmt.Errorf("cannot specify Handle in %s operation", verb)
+		}
+	case deleteVerb, destroyVerb:
+		if flowtable.Name == "" && flowtable.Handle == nil {
+			return fmt.Errorf("must specify either name or handle")
+		}
+	default:
+		return fmt.Errorf("%s is not implemented for flowtables", verb)
+	}
+
+	return nil
+}
+
+func (flowtable *Flowtable) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
+	family, table, _ := getTable(ctx, flowtable.Family, flowtable.Table)
+
+	// Special case for delete-by-handle
+	if (verb == deleteVerb || verb == destroyVerb) && flowtable.Handle != nil {
+		fmt.Fprintf(writer, "delete flowtable %s %s handle %d", family, table, *flowtable.Handle)
+		return
+	}
+
+	fmt.Fprintf(writer, "%s flowtable %s %s %s", verb, family, table, flowtable.Name)
+	if verb == addVerb || verb == createVerb {
+		fmt.Fprintf(writer, " {")
+
+		if flowtable.Priority != nil {
+			// since there is only one priority value allowed "filter" just use the value
+			// provided and not try to parse it.
+			fmt.Fprintf(writer, " hook ingress priority %s ;", *flowtable.Priority)
+		}
+
+		if len(flowtable.Devices) > 0 {
+			fmt.Fprintf(writer, " devices = { %s } ;", strings.Join(flowtable.Devices, ", "))
+		}
+
+		fmt.Fprintf(writer, " }")
+	}
+
+	fmt.Fprintf(writer, "\n")
+}
+
+// nft add flowtable inet example_table example_flowtable { hook ingress priority filter ; devices = { eth0 };  }
+var flowtableRegexp = regexp.MustCompile(fmt.Sprintf(
+	`%s(?: {(?: hook ingress priority %s ;)(?: devices = {(.*)} ;) })?`,
+	noSpaceGroup, noSpaceGroup))
+
+func (flowtable *Flowtable) parse(family Family, table, line string) error {
+	match := flowtableRegexp.FindStringSubmatch(line)
+	if match == nil {
+		return fmt.Errorf("failed parsing flowtableRegexp add command")
+	}
+	flowtable.Family = family
+	flowtable.Table = table
+	flowtable.Name = match[1]
+	if match[2] != "" {
+		flowtable.Priority = (*FlowtableIngressPriority)(&match[2])
+	}
+	// to avoid complex regular expressions the regex match everything between the brackets
+	// to match a single interface or a comma separated list of interfaces, and it is postprocessed
+	// here to remove the whitespaces.
+	if match[3] != "" {
+		devices := strings.Split(strings.TrimSpace(match[3]), ",")
+		for i := range devices {
+			devices[i] = strings.TrimSpace(devices[i])
+		}
+		if len(devices) > 0 {
+			flowtable.Devices = devices
+		}
+	}
+	return nil
+}
+
+// nft add counter [family] table name [{ [ packets packets bytes bytes ; ] [ comment comment ; }]
+// ([^ ]*)(?: {(?: packets ([0-9]*) bytes ([0-9]*) ;)?(?: comment (".*") ;)? })?
+var counterRegexp = regexp.MustCompile(fmt.Sprintf(
+	`%s(?: {(?: packets %s bytes %s ;)?(?: comment %s ;)? })?`,
+	noSpaceGroup, numberGroup, numberGroup, commentGroup))
+
+func (counter *Counter) parse(family Family, table, line string) error {
+	match := counterRegexp.FindStringSubmatch(line)
+	if match == nil {
+		return fmt.Errorf("failed parsing table add command")
+	}
+	counter.Family = family
+	counter.Table = table
+	counter.Name = match[1]
+	if match[2] != "" {
+		counter.Packets = PtrTo(uint64(*parseInt(match[2])))
+	}
+	if match[3] != "" {
+		counter.Bytes = PtrTo(uint64(*parseInt(match[3])))
+	}
+	if match[4] != "" {
+		counter.Comment = getComment(match[4])
+	}
+	return nil
+}
+
+// Object implementation for Counter
+func (counter *Counter) validate(verb verb, ctx *nftContext) error {
+	if _, _, err := getTable(ctx, counter.Family, counter.Table); err != nil {
+		return err
+	}
+	switch verb {
+	case addVerb, createVerb:
+		if counter.Name == "" {
+			return fmt.Errorf("no counter name specified")
+		}
+		if counter.Handle != nil {
+			return fmt.Errorf("cannot specify Handle in %s operation", verb)
+		}
+		if counter.Packets != nil && counter.Bytes == nil {
+			return fmt.Errorf("cannot specify Packets without Bytes in %s operation", verb)
+		}
+		if counter.Packets == nil && counter.Bytes != nil {
+			return fmt.Errorf("cannot specify Bytes without Packets in %s operation", verb)
+		}
+	case deleteVerb, destroyVerb:
+		if counter.Name == "" && counter.Handle == nil {
+			return fmt.Errorf("neither counter name nor handle specified")
+		}
+	case resetVerb:
+		if counter.Name == "" {
+			return fmt.Errorf("no counter name specified")
+		}
+	default:
+		return fmt.Errorf("%s is not implemented for counters", verb)
+	}
+	return nil
+}
+
+func (counter *Counter) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
+	family, table, _ := getTable(ctx, counter.Family, counter.Table)
+
+	// Special case for delete-by-handle
+	if (verb == deleteVerb || verb == destroyVerb) && counter.Handle != nil {
+		fmt.Fprintf(writer, "%s counter %s %s handle %d", verb, family, table, *counter.Handle)
+		return
+	}
+
+	fmt.Fprintf(writer, "%s counter %s %s ", verb, family, table)
+	switch verb {
+	case addVerb, createVerb:
+		fmt.Fprint(writer, counter.Name)
+		if counter.Comment != nil || counter.Packets != nil || counter.Bytes != nil {
+			fmt.Fprintf(writer, " {")
+			if counter.Packets != nil && counter.Bytes != nil {
+				fmt.Fprintf(writer, " packets %d bytes %d ;", *counter.Packets, *counter.Bytes)
+			}
+			if counter.Comment != nil && (verb == addVerb || verb == createVerb) {
+				fmt.Fprintf(writer, " comment %q ;", *counter.Comment)
+			}
+			fmt.Fprintf(writer, " }")
+		}
+	default:
+		fmt.Fprint(writer, counter.Name)
+	}
+	fmt.Fprintf(writer, "\n")
 }


### PR DESCRIPTION
## What this PR does / why we need it

Fixes kube-proxy crashes on systems with nftables 1.1.3+ due to segmentation faults when listing nftables sets with udata support.

## Which issue this PR fixes (if applicable)

Fixes #136786

## Special notes for reviewers

This fix addresses the crash without requiring patches to nftables itself, making kube-proxy robust across different nftables versions.

## Checklist
- [x] All tests pass
- [x] No workarounds - proper solution using upstream updates
- [x] Backward compatible with older nftables versions

#### Does this PR introduce a user-facing change?
```release-note
Fixes kube-proxy's nftables mode to work on systems with nft 1.1.3.
```
