### PR TITLE
Add common setup function to ResourceQuota tests

### DIFF
--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -103,7 +103,7 @@ func createHandler(kubeClient kubernetes.Interface, informerFactory informers.Sh
 	return createHandlerWithConfig(kubeClient, informerFactory, nil, stopCh)
 }
 
-func createHandlerWithConfig(kubeClient kubernetes.Interface, informerFactory informers.SharedInformerFactory, config *resourcequotaapi.Configuration, stopCh chan struct{}) (*resourcequota.QuotaAdmission, error) {
+func createHandlerWithConfig(kubeClient kubernetes.Interface, informerFactory informers.SharedInformerFactory, config *resourcequotaapi.Configuration, stopCh <-chan struct{}) (*resourcequota.QuotaAdmission, error) {
 	if config == nil {
 		config = &resourcequotaapi.Configuration{}
 	}
@@ -132,31 +132,16 @@ func createCommonHandler(t *testing.T, resourceQuotas ...runtime.Object) (*resou
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 
 	config := &resourcequotaapi.Configuration{}
-	quotaConfiguration, err := install.NewQuotaConfigurationForAdmission(informerFactory)
-	if err != nil {
-		t.Errorf("Error occurred while creating quota configuration: %v", err)
-	}
-
-	handler, err := resourcequota.NewResourceQuota(config, 5)
-	if err != nil {
-		t.Errorf("Error occurred while creating handler: %v", err)
-	}
 	stopCh := t.Context().Done()
 
-	initializers := admission.PluginInitializers{
-		genericadmissioninitializer.New(kubeClient, nil, informerFactory, nil, nil, nil, stopCh, nil),
-		controlplaneadmission.NewPluginInitializer(quotaConfiguration, nil),
+	handler, err := createHandlerWithConfig(kubeClient, informerFactory, config, stopCh)
+	if err != nil {
+		t.Errorf("Error occurred while creating admission plugin: %v", err)
 	}
-	initializers.Initialize(handler)
 
 	informerFactory.Start(stopCh)
 	informerFactory.WaitForCacheSync(stopCh)
 	kubeClient.ClearActions()
-
-	err = admission.ValidateInitialization(handler)
-	if err != nil {
-		t.Errorf("Error occurred while creating admission plugin: %v", err)
-	}
 
 	return handler, kubeClient
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This unlocks the following changes:
1. Migration from a deprecated `fake.NewSimpleClientSet` to `fake.NewClientSet`
2. Using actual informers instead of manually inserting objects into index/cache
3. Removal of duplicate code for test setup

This change makes https://github.com/kubernetes/kubernetes/pull/129998 much smaller and easier to review.

#### Which issue(s) this PR is related to:

N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This is smaller version of https://github.com/kubernetes/kubernetes/pull/134850 to make it easier to review.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
