### PR TITLE
Mark flynn/go-shlex and kr/pty as unwanted dependencies

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -21,6 +21,7 @@
       "github.com/containerd/cgroups": "standardize on single cgroups library from runc, refer #128157",
       "github.com/davecgh/go-spew": "refer to #103942",
       "github.com/evanphx/json-patch/v5": "refer to https://github.com/kubernetes/kubernetes/pull/91622#issuecomment-637087847",
+      "github.com/flynn/go-shlex": "unmaintained, archive mode",
       "github.com/form3tech-oss/jwt-go": "unmaintained, archive mode",
       "github.com/getsentry/raven-go": "unmaintained, archive mode",
       "github.com/go-bindata/go-bindata": "refer to #99829",
@@ -63,6 +64,7 @@
       "github.com/influxdata/influxdb1-client": "db/datastore clients should not be required",
       "github.com/json-iterator/go": "refer to #105030",
       "github.com/klauspost/compress": "unreviewable assembly code, `prometheus/client_golang` should use stdlib instead",
+      "github.com/kr/pty": "unmaintained, archive mode",
       "github.com/mailru/easyjson": "unmaintained",
       "github.com/miekg/dns": "no dns client/server should be required",
       "github.com/mindprince/gonvml": "depends on nvml.h that does not appear to permit modification, redistribution",
@@ -136,6 +138,9 @@
         "sigs.k8s.io/kustomize/api",
         "sigs.k8s.io/kustomize/kustomize/v5",
         "sigs.k8s.io/kustomize/kyaml"
+      ],
+      "github.com/flynn/go-shlex": [
+        "github.com/coredns/caddy"
       ],
       "github.com/gogo/protobuf": [
         "github.com/containerd/containerd/api",


### PR DESCRIPTION
Both repositories are archived on GitHub and were detected by the new check-dependency-archived-periodical CI job.

- https://testgrid.k8s.io/sig-arch-code-organization#verify-archived-dependencies&width=20
- https://storage.googleapis.com/kubernetes-ci-logs/logs/check-dependency-archived-periodical/2019653174050164736/build-log.txt

```
go: downloading github.com/kubernetes-sigs/depstat v0.8.4
go: downloading github.com/spf13/cobra v1.8.1
go: downloading github.com/spf13/pflag v1.0.5
  162 direct GitHub repos
  105 vanity/non-GitHub modules to resolve...
  Resolved 81 vanity URLs to GitHub repos
  Could not resolve 2 modules (non-GitHub or unavailable)
    - bitbucket.org/bertimus9/systemstat
    - buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go

Checking 242 unique GitHub repos for archived status...
  Checked 50/242 repos...
  Checked 100/242 repos...
  Checked 150/242 repos...
  Checked 200/242 repos...
  Checked 242/242 repos...
FAIL: github.com/flynn/go-shlex (v0.0.0-20150515145356-3f9db97f8568) archived at https://github.com/flynn/go-shlex — not in unwanted-dependencies.json
OK:   github.com/google/btree (unmaintained, archive mode)
OK:   github.com/google/gofuzz (unmaintained, use sigs.k8s.io/randfill)
OK:   github.com/json-iterator/go (refer to #105030)
FAIL: github.com/kr/pty (v1.1.1) archived at https://github.com/kr/pty — not in unwanted-dependencies.json
OK:   github.com/pkg/errors (unmaintained, archive mode)
OK:   gopkg.in/yaml.v3 (prefer sigs.k8s.io/yaml/goyaml.v3)
FAILED: 2 archived dep(s) not tracked in unwanted-dependencies.json
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
