### PR TITLE
Fix data race in PopulateRefs by copying Items and AdditionalProperties

### DIFF
--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.3
+	github.com/go-openapi/jsonreference v0.20.2
 	github.com/google/cel-go v0.26.0
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0
@@ -76,7 +77,6 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
-	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go
@@ -86,7 +86,9 @@ func populateRefs(schemaOf func(ref string) (*spec.Schema, bool), visited sets.S
 		}
 		if populated != result.AdditionalProperties.Schema {
 			changed = true
-			result.AdditionalProperties.Schema = populated
+			newProps := *result.AdditionalProperties
+			newProps.Schema = populated
+			result.AdditionalProperties = &newProps
 		}
 	}
 	// schema is a list, populate its items
@@ -97,7 +99,9 @@ func populateRefs(schemaOf func(ref string) (*spec.Schema, bool), visited sets.S
 		}
 		if populated != result.Items.Schema {
 			changed = true
-			result.Items.Schema = populated
+			newItems := *result.Items
+			newItems.Schema = populated
+			result.Items = &newItems
 		}
 	}
 	if changed {

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/jsonreference"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+func schemaRef(ref string) *spec.Schema {
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Ref: spec.MustCreateRef(ref),
+		},
+	}
+}
+
+func newSchema(ref string) *spec.Schema {
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			ID: ref,
+		},
+	}
+}
+
+// rootSchema returns a schema with references in all places where TestPopulateRefs
+// resolves references.
+func rootSchema() *spec.Schema {
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Properties: map[string]spec.Schema{
+				"a": *schemaRef("prop"),
+			},
+			AdditionalProperties: &spec.SchemaOrBool{
+				Schema: schemaRef("additional"),
+			},
+			Items: &spec.SchemaOrArray{
+				Schema: schemaRef("item"),
+			},
+		},
+	}
+}
+
+func resolvedRootSchema() *spec.Schema {
+	return &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Properties: map[string]spec.Schema{
+				"a": *newSchema("prop"),
+			},
+			AdditionalProperties: &spec.SchemaOrBool{
+				Schema: newSchema("additional"),
+			},
+			Items: &spec.SchemaOrArray{
+				Schema: newSchema("item"),
+			},
+		},
+	}
+}
+
+func TestPopulateRefs(t *testing.T) {
+	schemas := map[string]*spec.Schema{
+		"root": rootSchema(),
+	}
+
+	// Add one schema for each of the references above, with an ID that allows
+	// verifying that the right schema got resolved.
+	for _, ref := range []string{"prop", "additional", "item"} {
+		schemas[ref] = newSchema(ref)
+	}
+
+	schemaOf := func(ref string) (*spec.Schema, bool) {
+		schema, ok := schemas[ref]
+		return schema, ok
+	}
+
+	// Comparing the root schema below detects mutations where the data is semantically different,
+	// but it cannot detect undesired writes where the thing being written is the same (unlikely,
+	// but it could happen). Therefore we run two PopulateRefs calls and let the data race
+	// detector warn about concurrent, uncoordinated writes.
+	var wg sync.WaitGroup
+	var actualResolved *spec.Schema
+	wg.Go(func() {
+		schema, err := PopulateRefs(schemaOf, "root")
+		if err != nil {
+			t.Errorf("first PopulateRefs failed: %v", err)
+		}
+		actualResolved = schema
+	})
+	wg.Go(func() {
+		_, err := PopulateRefs(schemaOf, "root")
+		if err != nil {
+			t.Errorf("second PopulateRefs failed: %v", err)
+		}
+	})
+	wg.Wait()
+
+	if diff := cmp.Diff(resolvedRootSchema(), actualResolved, cmpopts.IgnoreUnexported(jsonreference.Ref{})); diff != "" {
+		t.Errorf("unexpected resolved schema (- want, + got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(rootSchema(), schemas["root"], cmpopts.IgnoreUnexported(jsonreference.Ref{})); diff != "" {
+		t.Errorf("read-only input schema got modified (- original, + modification):\n%s", diff)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a data race in `PopulateRefs` function in `staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go`.

The `populateRefs` function was modifying `result.Items.Schema` and `result.AdditionalProperties.Schema` directly. Since result is a shallow copy of the input schema (`result := *schema`), these pointer fields still reference the original shared structures, causing a data race when multiple goroutines call PopulateRefs concurrently.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/135627

#### Special notes for your reviewer:

The fix is the unmodified commit from @tennisleng in [the original PR](https://github.com/kubernetes/kubernetes/pull/135637). This PR adds a unit test. It fails on master with:
    
        WARNING: DATA RACE
        Read at 0x00c00038ccf8 by goroutine 10:
          k8s.io/apiserver/pkg/cel/openapi/resolver.populateRefs()
              /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go:82 +0xb0a
          k8s.io/apiserver/pkg/cel/openapi/resolver.PopulateRefs()
              /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go:37 +0x325
          k8s.io/apiserver/pkg/cel/openapi/resolver.TestPopulateRefs.func2()
              /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs_test.go:99 +0x4f
          sync.(*WaitGroup).Go.func1()
              /nvme/gopath/go-1.25.2/src/sync/waitgroup.go:239 +0x5d
    
        Previous write at 0x00c00038ccf8 by goroutine 11:
          k8s.io/apiserver/pkg/cel/openapi/resolver.populateRefs()
              /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go:89 +0xc1c
          k8s.io/apiserver/pkg/cel/openapi/resolver.PopulateRefs()
              /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs.go:37 +0x325
          k8s.io/apiserver/pkg/cel/openapi/resolver.TestPopulateRefs.func3()
              /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/refs_test.go:106 +0x3a
          sync.(*WaitGroup).Go.func1()
              /nvme/gopath/go-1.25.2/src/sync/waitgroup.go:239 +0x5d
    
        ...
    
        --- FAIL: TestPopulateRefs (0.00s)
            refs_test.go:115: read-only input schema got modified (- original, + modification):
                  &spec.Schema{
                    VendorExtensible: {},
                    SchemaProps: spec.SchemaProps{
                            ... // 22 identical fields
                            MinProperties: nil,
                            Required:      nil,
                            Items: &spec.SchemaOrArray{
                                    Schema: &spec.Schema{
                                            VendorExtensible: {},
                                            SchemaProps: spec.SchemaProps{
                -                                   ID: "",
                +                                   ID: "item",
                                                    Ref: spec.Ref{
                                                            Ref: jsonreference.Ref{
                                                                    ... // 2 ignored fields
                                                                    HasFullURL:      false,
                -                                                   HasURLPathOnly:  true,
                +                                                   HasURLPathOnly:  false,
                                                                    HasFragmentOnly: false,
                                                                    HasFileScheme:   false,
                                                                    HasFullFilePath: false,
                                                            },
                                                    },
                                                    Schema:      "",
                                                    Description: "",
                                                    ... // 31 identical fields
                                            },
                                            SwaggerSchemaProps: {},
                                            ExtraProps:         nil,
                                    },
                                    Schemas: nil,
                            },
                            AllOf:      nil,
                            OneOf:      nil,
                            AnyOf:      nil,
                            Not:        nil,
                            Properties: {"a": {SchemaProps: {Ref: {Ref: {HasURLPathOnly: true, ...}}}}},
                            AdditionalProperties: &spec.SchemaOrBool{
                                    Allows: false,
                                    Schema: &spec.Schema{
                                            VendorExtensible: {},
                                            SchemaProps: spec.SchemaProps{
                -                                   ID: "",
                +                                   ID: "additional",
                                                    Ref: spec.Ref{
                                                            Ref: jsonreference.Ref{
                                                                    ... // 2 ignored fields
                                                                    HasFullURL:      false,
                -                                                   HasURLPathOnly:  true,
                +                                                   HasURLPathOnly:  false,
                                                                    HasFragmentOnly: false,
                                                                    HasFileScheme:   false,
                                                                    HasFullFilePath: false,
                                                            },
                                                    },
                                                    Schema:      "",
                                                    Description: "",
                                                    ... // 31 identical fields
                                            },
                                            SwaggerSchemaProps: {},
                                            ExtraProps:         nil,
                                    },
                            },
                            PatternProperties: nil,
                            Dependencies:      nil,
                            ... // 2 identical fields
                    },
                    SwaggerSchemaProps: {},
                    ExtraProps:         nil,
                  }
            testing.go:1617: race detected during execution of test
        FAIL


#### Does this PR introduce a user-facing change?

```release-note
Fixed a data race in k8s.io/apiserver/pkg/cel/openapi/resolver with (probably) no real-world impact.
```

/assign @liggitt 
/cc @tennisleng
