### PR TITLE
kubelet: Add GoTraceback to KubeletConfiguration

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -542,6 +543,11 @@ func Run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 	logger.Info("Kubelet version", "kubeletVersion", version.Get())
 
 	logger.Info("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
+
+	if s.KubeletConfiguration.GoTraceback != "" {
+		debug.SetTraceback(s.KubeletConfiguration.GoTraceback)
+		logger.Info("Updated GOTRACEBACK setting", "traceback", s.KubeletConfiguration.GoTraceback)
+	}
 
 	if err := initForOS(ctx, s.WindowsService, s.WindowsPriorityClass); err != nil {
 		return fmt.Errorf("failed OS init: %w", err)

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -70700,6 +70700,13 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 							Format:      "int32",
 						},
 					},
+					"goTraceback": {
+						SchemaProps: spec.SchemaProps{
+							Description: "goTraceback is the value to set the GOTRACEBACK environment variable to. Valid values are \"none\", \"single\", \"all\", \"system\", \"crash\". If not specified, the environment variable or default behavior is used.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"containerLogMaxWorkers": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ContainerLogMaxWorkers specifies the maximum number of concurrent workers to spawn for performing the log rotate operations. Set this count to 1 for disabling the concurrent log rotation workflows Default: 1",

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -545,6 +545,11 @@ type KubeletConfiguration struct {
 	// +featureGate=UserNamespacesSupport
 	// +optional
 	UserNamespaces *UserNamespaces
+
+	// GoTraceback is the value to set the GOTRACEBACK environment variable to.
+	// Valid values are "none", "single", "all", "system", "crash".
+	// If not specified, the environment variable or default behavior is used.
+	GoTraceback string
 }
 
 // KubeletAuthorizationMode denotes the authorization mode for the kubelet

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -707,6 +707,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	if err := v1.Convert_Pointer_int32_To_int32(&in.ContainerLogMaxFiles, &out.ContainerLogMaxFiles, s); err != nil {
 		return err
 	}
+	out.GoTraceback = in.GoTraceback
 	if err := v1.Convert_Pointer_int32_To_int32(&in.ContainerLogMaxWorkers, &out.ContainerLogMaxWorkers, s); err != nil {
 		return err
 	}
@@ -969,6 +970,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 		return err
 	}
 	out.UserNamespaces = (*configv1beta1.UserNamespaces)(unsafe.Pointer(in.UserNamespaces))
+	out.GoTraceback = in.GoTraceback
 	return nil
 }
 

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -395,5 +395,12 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration, featur
 		}
 	}
 
+	if kc.GoTraceback != "" {
+		validValues := sets.NewString("none", "single", "all", "system", "crash")
+		if !validValues.Has(kc.GoTraceback) {
+			allErrors = append(allErrors, fmt.Errorf("invalid configuration: goTraceback %q must be one of: %v", kc.GoTraceback, validValues.List()))
+		}
+	}
+
 	return utilerrors.NewAggregate(allErrors)
 }

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -660,6 +660,12 @@ type KubeletConfiguration struct {
 	// +optional
 	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty"`
 
+	// goTraceback is the value to set the GOTRACEBACK environment variable to.
+	// Valid values are "none", "single", "all", "system", "crash".
+	// If not specified, the environment variable or default behavior is used.
+	// +optional
+	GoTraceback string `json:"goTraceback,omitempty"`
+
 	// ContainerLogMaxWorkers specifies the maximum number of concurrent workers to spawn
 	// for performing the log rotate operations. Set this count to 1 for disabling the
 	// concurrent log rotation workflows


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This PR adds a new field [GoTraceback](cci:1://file:///Users/sidharth/Documents/kubernetes/cmd/kubelet/app/server_test.go:524:0-577:1) to the [KubeletConfiguration](cci:2://file:///Users/sidharth/Documents/kubernetes/pkg/kubelet/apis/config/types.go:81:0-552:1). This allows cluster administrators to declaratively configure the `GOTRACEBACK` environment variable via the Kubelet configuration file, which is essential for gathering detailed crash diagnostics without manual node intervention.

#### Which issue(s) this PR is related to:

Fixes #135162

#### Special notes for your reviewer:

The linked issue requested both "Log Verbosity" and "Go Runtime Traceback" settings.
- **Log Verbosity** is already supported via the existing `logging.verbosity` field.
- **Go Traceback** is implemented by this PR.

Verified with `make build` and new unit tests in [cmd/kubelet/app/server_test.go](cci:7://file:///Users/sidharth/Documents/kubernetes/cmd/kubelet/app/server_test.go:0:0-0:0).

#### Does this PR introduce a user-facing change?

```release-note
New KubeletConfiguration field `goTraceback` allows configuring the `GOTRACEBACK` environment variable declaratively. Valid values are "none", "single", "all", "system", "crash".