### PR TITLE
Validation-gen: migrate ControllerRevision.Data to declarative validation

### DIFF
--- a/pkg/apis/apps/v1/zz_generated.validations.go
+++ b/pkg/apis/apps/v1/zz_generated.validations.go
@@ -151,7 +151,35 @@ func Validate_ControllerRevision(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field appsv1.ControllerRevision.Data has no validation
+	{ // field appsv1.ControllerRevision.Data
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *runtime.RawExtension,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *appsv1.ControllerRevision) *runtime.RawExtension {
+				return &oldObj.Data
+			})
+		errs = append(errs, fn(fldPath.Child("data"), &obj.Data, oldVal, oldObj != nil)...)
+	}
+
 	// field appsv1.ControllerRevision.Revision has no validation
 	return errs
 }

--- a/pkg/apis/apps/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.validations.go
@@ -136,7 +136,35 @@ func Validate_ControllerRevision(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field appsv1beta1.ControllerRevision.Data has no validation
+	{ // field appsv1beta1.ControllerRevision.Data
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *runtime.RawExtension,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *appsv1beta1.ControllerRevision) *runtime.RawExtension {
+				return &oldObj.Data
+			})
+		errs = append(errs, fn(fldPath.Child("data"), &obj.Data, oldVal, oldObj != nil)...)
+	}
+
 	// field appsv1beta1.ControllerRevision.Revision has no validation
 	return errs
 }

--- a/pkg/apis/apps/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.validations.go
@@ -166,7 +166,35 @@ func Validate_ControllerRevision(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field appsv1beta2.ControllerRevision.Data has no validation
+	{ // field appsv1beta2.ControllerRevision.Data
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *runtime.RawExtension,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *appsv1beta2.ControllerRevision) *runtime.RawExtension {
+				return &oldObj.Data
+			})
+		errs = append(errs, fn(fldPath.Child("data"), &obj.Data, oldVal, oldObj != nil)...)
+	}
+
 	// field appsv1beta2.ControllerRevision.Revision has no validation
 	return errs
 }

--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -358,7 +358,7 @@ func ValidateControllerRevisionUpdate(newHistory, oldHistory *apps.ControllerRev
 
 	errs = append(errs, apivalidation.ValidateObjectMetaUpdate(&newHistory.ObjectMeta, &oldHistory.ObjectMeta, field.NewPath("metadata"))...)
 	errs = append(errs, validateControllerRevision(newHistory)...)
-	errs = append(errs, apivalidation.ValidateImmutableField(newHistory.Data, oldHistory.Data, field.NewPath("data"))...)
+	errs = append(errs, apivalidation.ValidateImmutableField(newHistory.Data, oldHistory.Data, field.NewPath("data")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	return errs
 }
 

--- a/staging/src/k8s.io/api/apps/v1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1/generated.proto
@@ -47,6 +47,7 @@ message ControllerRevision {
 
   // Data is the serialized representation of the state.
   // +required
+  // +k8s:alpha(since: "1.38")=+k8s:immutable
   optional .k8s.io.apimachinery.pkg.runtime.RawExtension data = 2;
 
   // Revision indicates the revision of the state represented by Data.

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -1024,6 +1024,7 @@ type ControllerRevision struct {
 
 	// Data is the serialized representation of the state.
 	// +required
+	// +k8s:alpha(since: "1.38")=+k8s:immutable
 	Data runtime.RawExtension `json:"data" protobuf:"bytes,2,opt,name=data"`
 
 	// Revision indicates the revision of the state represented by Data.

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -49,6 +49,7 @@ message ControllerRevision {
 
   // data is the serialized representation of the state.
   // +required
+  // +k8s:alpha(since: "1.38")=+k8s:immutable
   optional .k8s.io.apimachinery.pkg.runtime.RawExtension data = 2;
 
   // revision indicates the revision of the state represented by Data.

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -718,6 +718,7 @@ type ControllerRevision struct {
 
 	// data is the serialized representation of the state.
 	// +required
+	// +k8s:alpha(since: "1.38")=+k8s:immutable
 	Data runtime.RawExtension `json:"data" protobuf:"bytes,2,opt,name=data"`
 
 	// revision indicates the revision of the state represented by Data.

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -49,6 +49,7 @@ message ControllerRevision {
 
   // Data is the serialized representation of the state.
   // +required
+  // +k8s:alpha(since: "1.38")=+k8s:immutable
   optional .k8s.io.apimachinery.pkg.runtime.RawExtension data = 2;
 
   // Revision indicates the revision of the state represented by Data.

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -1082,6 +1082,7 @@ type ControllerRevision struct {
 
 	// Data is the serialized representation of the state.
 	// +required
+	// +k8s:alpha(since: "1.38")=+k8s:immutable
 	Data runtime.RawExtension `json:"data" protobuf:"bytes,2,opt,name=data"`
 
 	// Revision indicates the revision of the state represented by Data.

--- a/test/declarative_validation/apps/controllerrevision/declarative_validation_test.go
+++ b/test/declarative_validation/apps/controllerrevision/declarative_validation_test.go
@@ -21,7 +21,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	apps "k8s.io/kubernetes/pkg/apis/apps"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	"k8s.io/kubernetes/pkg/registry/apps/controllerrevision"
@@ -60,9 +62,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				IsResourceRequest: true,
 				Verb:              "create",
 			})
-			obj := mkControllerRevision(func(o *apps.ControllerRevision) {
-				o.Namespace = namespace
-			})
+			obj := mkControllerRevision(tweakNamespace(namespace))
 			meta.RunObjectMetaTestCases(t, ctx, &obj, strategy, meta.WithStringentFinalizerValidation())
 		})
 	}
@@ -86,10 +86,63 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 				IsResourceRequest: true,
 				Verb:              "update",
 			})
-			obj := mkControllerRevision(func(o *apps.ControllerRevision) {
-				o.Namespace = namespace
-			})
+			obj := mkControllerRevision(tweakNamespace(namespace))
 			meta.RunObjectMetaUpdateTestCases(t, ctx, &obj, strategy, meta.WithStringentFinalizerValidation())
+
+			testCases := map[string]struct {
+				old          apps.ControllerRevision
+				update       apps.ControllerRevision
+				expectedErrs field.ErrorList
+			}{
+				"valid update": {
+					old:    mkControllerRevision(tweakNamespace(namespace)),
+					update: mkControllerRevision(tweakNamespace(namespace)),
+				},
+				"data empty -> some value": {
+					old:    mkControllerRevision(tweakNamespace(namespace), tweakData("")),
+					update: mkControllerRevision(tweakNamespace(namespace)),
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("data"), nil, "").WithOrigin("immutable").MarkAlpha(),
+					},
+				},
+				"data some value -> empty": {
+					old:    mkControllerRevision(tweakNamespace(namespace)),
+					update: mkControllerRevision(tweakNamespace(namespace), tweakData("")),
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("data"), nil, "").WithOrigin("immutable").MarkAlpha(),
+					},
+				},
+				"data some value -> changed value": {
+					old:    mkControllerRevision(tweakNamespace(namespace)),
+					update: mkControllerRevision(tweakNamespace(namespace), tweakData(`{"kind":"Bar"}`)),
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("data"), nil, "").WithOrigin("immutable").MarkAlpha(),
+					},
+				},
+			}
+			for k, tc := range testCases {
+				t.Run(k, func(t *testing.T) {
+					tc.old.ResourceVersion = "1"
+					tc.update.ResourceVersion = "2"
+					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy, tc.expectedErrs)
+				})
+			}
 		})
+	}
+}
+
+func tweakData(raw string) func(*apps.ControllerRevision) {
+	return func(o *apps.ControllerRevision) {
+		if raw == "" {
+			o.Data = runtime.RawExtension{}
+		} else {
+			o.Data = runtime.RawExtension{Raw: []byte(raw)}
+		}
+	}
+}
+
+func tweakNamespace(namespace string) func(*apps.ControllerRevision) {
+	return func(o *apps.ControllerRevision) {
+		o.Namespace = namespace
 	}
 }

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
@@ -30,6 +30,9 @@ func init() {
 	coverage.RegisterDeclaredRules(
 		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ControllerRevision"},
 		coverage.FieldRules{
+			"data": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 			"metadata.creationTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
@@ -30,6 +30,9 @@ func init() {
 	coverage.RegisterDeclaredRules(
 		schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "ControllerRevision"},
 		coverage.FieldRules{
+			"data": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 			"metadata.creationTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
@@ -30,6 +30,9 @@ func init() {
 	coverage.RegisterDeclaredRules(
 		schema.GroupVersionKind{Group: "apps", Version: "v1beta2", Kind: "ControllerRevision"},
 		coverage.FieldRules{
+			"data": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 			"metadata.creationTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR migrates some fields in `apps` to declarative validation:
- `ControllerRevision.Data`
 
#### Which issue(s) this PR is related to:

relates to #136785 

```release-note
NONE
```