### PR TITLE
Add 404 handling for the statefulset controller pod deletion codepath

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -194,9 +194,12 @@ func (spc *StatefulPodControl) UpdateStatefulPod(ctx context.Context, set *apps.
 }
 
 func (spc *StatefulPodControl) DeleteStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
-	err := spc.objectMgr.DeletePod(pod)
-	spc.recordPodEvent("delete", set, pod, err)
-	return err
+	if err := spc.objectMgr.DeletePod(pod); err != nil && !apierrors.IsNotFound(err) {
+		spc.recordPodEvent("delete", set, pod, err)
+		return err
+	}
+	spc.recordPodEvent("delete", set, pod, nil)
+	return nil
 }
 
 // ClaimsMatchRetentionPolicy returns false if the PVCs for pod are not consistent with set's PVC deletion policy.

--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -193,10 +193,14 @@ func (spc *StatefulPodControl) UpdateStatefulPod(ctx context.Context, set *apps.
 	return err
 }
 
+// DeleteStatefulPod deletes a Pod. A NotFound is considered a successful response, since the
+// end result is the same: the pod is deleted.
 func (spc *StatefulPodControl) DeleteStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
-	if err := spc.objectMgr.DeletePod(pod); err != nil && !apierrors.IsNotFound(err) {
-		spc.recordPodEvent("delete", set, pod, err)
-		return err
+	if err := spc.objectMgr.DeletePod(pod); err != nil {
+		if !apierrors.IsNotFound(err) {
+			spc.recordPodEvent("delete", set, pod, err)
+			return err
+		}
 	}
 	spc.recordPodEvent("delete", set, pod, nil)
 	return nil

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -27,7 +27,6 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -719,9 +718,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(ctx context.Context, set
 			logger.V(2).Info("Pod of StatefulSet is terminating for update",
 				"statefulSet", klog.KObj(set), "pod", klog.KObj(replicas[target]))
 			if err := ssc.podControl.DeleteStatefulPod(set, replicas[target]); err != nil {
-				if !errors.IsNotFound(err) {
-					return &status, err
-				}
+				return &status, err
 			}
 			status.CurrentReplicas--
 			return &status, err
@@ -798,9 +795,7 @@ func updateStatefulSetAfterInvariantEstablished(ctx context.Context, ssc *defaul
 				"statefulSet", klog.KObj(set),
 				"pod", klog.KObj(replicas[target]))
 			if err := ssc.podControl.DeleteStatefulPod(set, replicas[target]); err != nil {
-				if !errors.IsNotFound(err) {
-					return &status, err
-				}
+				return &status, err
 			}
 			deletedPods++
 			status.CurrentReplicas--


### PR DESCRIPTION
The daemonset controller already has handling for NotFound errors.

Right now if the statefulset controller is attempting to scale down a statefulset and its informer cache is stale, it can get hard-blocked on a missing pod.

This issue will eventually self-resolve once the informer cache "catches up", but in the process of exploring this issue I realized that 404s during pod deletions don't strictly need to abort the entire sync; we can continue.

This is especially impactful for large statefulsets with podManagementStrategy: Parallel, where a single "phantom" pod (actually missing, but still present in the informer cache) can block thousands of other pods from being cleaned up.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

Practically this is more of an optimization than a bug-fix or a feature.

#### What this PR does / why we need it:

This PR improves the statefulset controller's throughput in scenarios where it has a stale informer cache.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


NONE

I'm open to disagreement but this doesn't seem like a user-facing change.