### PR TITLE
core/helper: fix native resource namespace prefix matching

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -197,7 +197,15 @@ func IsExtendedResourceName(name core.ResourceName) bool {
 // implicitly in the kubernetes.io/ namespace.
 func IsNativeResource(name core.ResourceName) bool {
 	return !strings.Contains(string(name), "/") ||
-		strings.Contains(string(name), core.ResourceDefaultNamespacePrefix)
+		isPrefixedNativeResourceName(string(name), core.ResourceDefaultNamespacePrefix)
+}
+
+// isPrefixedNativeResourceName checks for either kubernetes.io/<name> or
+// <subdomain>.kubernetes.io/<name>. It intentionally rejects prefixes like
+// "mykubernetes.io" that only contain "kubernetes.io" as a substring.
+func isPrefixedNativeResourceName(resourceName, nativeResourceNamespacePrefix string) bool {
+	return strings.HasPrefix(resourceName, nativeResourceNamespacePrefix) ||
+		strings.Contains(resourceName, "."+nativeResourceNamespacePrefix)
 }
 
 // IsOvercommitAllowed returns true if the resource is in the default

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -46,6 +46,44 @@ func TestSemantic(t *testing.T) {
 	}
 }
 
+func TestIsNativeResource(t *testing.T) {
+	testCases := []struct {
+		name     core.ResourceName
+		isNative bool
+	}{
+		{
+			name:     "pod.alpha.kubernetes.io/opaque-int-resource-foo",
+			isNative: true,
+		},
+		{
+			name:     "kubernetes.io/resource-foo",
+			isNative: true,
+		},
+		{
+			name:     "foo",
+			isNative: true,
+		},
+		{
+			name:     "a/b",
+			isNative: false,
+		},
+		{
+			name:     "mykubernetes.io/resource-foo",
+			isNative: false,
+		},
+		{
+			name:     "",
+			isNative: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		if got := IsNativeResource(tc.name); got != tc.isNative {
+			t.Errorf("case[%d], resource: %q, expected %v, got %v", i, tc.name, tc.isNative, got)
+		}
+	}
+}
+
 func TestIsStandardResource(t *testing.T) {
 	testCases := []struct {
 		input  string

--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -51,7 +51,7 @@ func IsExtendedResourceName(name v1.ResourceName) bool {
 // IsPrefixedNativeResource returns true if the resource name is in the
 // *kubernetes.io/ namespace.
 func IsPrefixedNativeResource(name v1.ResourceName) bool {
-	return strings.Contains(string(name), v1.ResourceDefaultNamespacePrefix)
+	return isPrefixedNativeResourceName(string(name), v1.ResourceDefaultNamespacePrefix)
 }
 
 // IsNativeResource returns true if the resource name is in the
@@ -60,6 +60,14 @@ func IsPrefixedNativeResource(name v1.ResourceName) bool {
 func IsNativeResource(name v1.ResourceName) bool {
 	return !strings.Contains(string(name), "/") ||
 		IsPrefixedNativeResource(name)
+}
+
+// isPrefixedNativeResourceName checks for either kubernetes.io/<name> or
+// <subdomain>.kubernetes.io/<name>. It intentionally rejects prefixes like
+// "mykubernetes.io" that only contain "kubernetes.io" as a substring.
+func isPrefixedNativeResourceName(resourceName, nativeResourceNamespacePrefix string) bool {
+	return strings.HasPrefix(resourceName, nativeResourceNamespacePrefix) ||
+		strings.Contains(resourceName, "."+nativeResourceNamespacePrefix)
 }
 
 // IsHugePageResourceName returns true if the resource name has the huge page

--- a/pkg/apis/core/v1/helper/helpers_test.go
+++ b/pkg/apis/core/v1/helper/helpers_test.go
@@ -48,6 +48,10 @@ func TestIsNativeResource(t *testing.T) {
 			expectVal:    false,
 		},
 		{
+			resourceName: "mykubernetes.io/resource-foo",
+			expectVal:    false,
+		},
+		{
 			resourceName: "",
 			expectVal:    true,
 		},


### PR DESCRIPTION
/kind bug
/sig api-machinery

#### What this PR does / why we need it:
`IsNativeResource` / `IsPrefixedNativeResource` previously relied on substring matching for `kubernetes.io/`, which could misclassify external domains like `mykubernetes.io/resource-foo` as native resources.

This change makes the check namespace-boundary-aware so native resources are only:
- `kubernetes.io/<name>`
- `<subdomain>.kubernetes.io/<name>`
- unqualified names (existing behavior)

The fix is applied consistently in both:
- `pkg/apis/core/helper`
- `pkg/apis/core/v1/helper`

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
- Adds regression coverage for the false-positive case (`mykubernetes.io/resource-foo` must be non-native) while preserving existing expected true cases.
- Tests:
  - `env GOCACHE=/tmp/go-build-cache go test ./pkg/apis/core/helper`
  - `env GOCACHE=/tmp/go-build-cache go test ./pkg/apis/core/v1/helper`
  - `env GOCACHE=/tmp/go-build-cache go test ./pkg/registry/core/replicationcontroller`
  - `env GOCACHE=/tmp/go-build-cache go test ./pkg/scheduler/util`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
