### PR TITLE
Use for-range in `cmd/{kubelet,kubeadm,kubemark}`

### DIFF
--- a/cmd/kubeadm/app/cmd/certs_test.go
+++ b/cmd/kubeadm/app/cmd/certs_test.go
@@ -690,7 +690,6 @@ kubernetesVersion: %s`,
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.brokenCertName != "" {
 				// remove the file to simulate a missing certificate

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -1679,7 +1679,7 @@ func newMockClientForTest(t *testing.T, replicas int32, deploymentSize int, imag
 		image = "registry.k8s.io/coredns/coredns:" + kubeadmconstants.CoreDNSVersion
 	}
 	client := clientsetfake.NewSimpleClientset()
-	for i := 0; i < deploymentSize; i++ {
+	for i := range deploymentSize {
 		_, err := client.AppsV1().Deployments(metav1.NamespaceSystem).Create(context.TODO(), &apps.Deployment{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Deployment",

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -315,7 +315,7 @@ func (w *KubeWaiter) WaitForControlPlaneComponents(podMap map[string]*v1.Pod, ap
 		}(comp)
 	}
 
-	for i := 0; i < len(components); i++ {
+	for range components {
 		if err := <-errChan; err != nil {
 			errs = append(errs, err)
 		}

--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -677,7 +677,7 @@ func (c *Client) getClusterStatus() (map[string]*clientv3.StatusResponse, error)
 
 // WaitForClusterAvailable returns true if all endpoints in the cluster are available after retry attempts, an error is returned otherwise
 func (c *Client) WaitForClusterAvailable(retries int, retryInterval time.Duration) (bool, error) {
-	for i := 0; i < retries; i++ {
+	for i := range retries {
 		if i > 0 {
 			klog.V(1).Infof("[etcd] Waiting %v until next retry\n", retryInterval)
 			time.Sleep(retryInterval)

--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -157,7 +157,7 @@ func (runtime *CRIRuntime) RemoveContainers(containers []string) error {
 	errs := []error{}
 	for _, container := range containers {
 		var lastErr error
-		for i := 0; i < constants.RemoveContainerRetry; i++ {
+		for range constants.RemoveContainerRetry {
 			klog.V(5).Infof("Attempting to remove container %v", container)
 
 			ctx, cancel := defaultContext()
@@ -189,7 +189,7 @@ func (runtime *CRIRuntime) RemoveContainers(containers []string) error {
 
 // PullImage pulls the image
 func (runtime *CRIRuntime) PullImage(image string) (err error) {
-	for i := 0; i < constants.PullImageRetry; i++ {
+	for range constants.PullImageRetry {
 		if _, err = runtime.impl.PullImage(context.Background(), runtime.imageService, &runtimeapi.ImageSpec{Image: image}, nil, nil); err == nil {
 			return nil
 		}
@@ -235,7 +235,7 @@ func pullImagesInParallelImpl(images []string, ifNotPresent bool,
 		}()
 	}
 
-	for i := 0; i < len(images); i++ {
+	for range images {
 		if err := <-errChan; err != nil {
 			errs = append(errs, err)
 		}

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -845,7 +845,7 @@ func TestManifestFilesAreEqual(t *testing.T) {
 			tmpdir := t.TempDir()
 
 			// write 2 manifests
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				if rt.podYamls[i] != "" {
 					manifestPath := filepath.Join(tmpdir, strconv.Itoa(i)+".yaml")
 					err := os.WriteFile(manifestPath, []byte(rt.podYamls[i]), 0644)

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1155,7 +1155,7 @@ func InitializeTLS(ctx context.Context, kf *options.KubeletFlags, kc *kubeletcon
 
 	if len(tlsCipherSuites) > 0 {
 		insecureCiphers := cliflag.InsecureTLSCiphers()
-		for i := 0; i < len(tlsCipherSuites); i++ {
+		for i := range tlsCipherSuites {
 			for cipherName, cipherID := range insecureCiphers {
 				if tlsCipherSuites[i] == cipherID {
 					logger.Info("Use of insecure cipher detected.", "cipher", cipherName)
@@ -1395,7 +1395,7 @@ func getCgroupDriverFromCRI(ctx context.Context, s *options.KubeletServer, kubeD
 	)
 	// Retry a couple of times, hoping that any errors are transient.
 	// Fail quickly on known, non transient errors.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		runtimeConfig, err = kubeDeps.RemoteRuntimeService.RuntimeConfig(ctx)
 		if err != nil {
 			s, ok := status.FromError(err)

--- a/cmd/kubemark/app/hollow_node_test.go
+++ b/cmd/kubemark/app/hollow_node_test.go
@@ -72,7 +72,6 @@ func TestHollowNode(t *testing.T) {
 	}
 
 	for morph := range knownMorphs {
-		morph := morph
 		t.Run(morph, func(t *testing.T) {
 			s := &hollowNodeConfig{
 				KubeconfigPath: kubeconfigPath,


### PR DESCRIPTION
#### What type of PR is this?

Fixed using the modernize tool. These were the only instances under cmd/

```sh
cd cmd
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -rangeint -fix -test ./...
```

There are two cases for redundant variable declaration inside a for-loop. This is the `forvar` rule from `modernize`.

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
