### PR TITLE
[duplicate] Improve Job validation error message for startTime

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -741,7 +741,7 @@ func ValidateJobStatusUpdate(job, oldJob *batch.Job, opts JobStatusValidationOpt
 		// Note that we check `oldJob.Status.StartTime != nil` to allow transitioning from
 		// startTime = nil to startTime != nil for unsuspended jobs, which is a desired transition.
 		if oldJob.Status.StartTime != nil && !ptr.Equal(oldJob.Status.StartTime, job.Status.StartTime) && !ptr.Deref(job.Spec.Suspend, false) {
-			allErrs = append(allErrs, field.Required(statusFld.Child("startTime"), "startTime cannot be removed for unsuspended job"))
+			allErrs = append(allErrs, field.Invalid(statusFld.Child("startTime"), job.Status.StartTime, "field is immutable for unsuspended jobs"))
 		}
 	}
 	if isJobSuccessCriteriaMet(oldJob) && !isJobSuccessCriteriaMet(job) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
Fixes issue #136527 by improving the validation error message for Job startTime updates.

The error message was misleading when updating job.status.startTime. It stated "startTime cannot be removed" when actually the validation checks for any modification, not just removal.

**Which issue(s) this PR fixes:**
 #136527

**Special notes for your reviewer:**
This is a simple error message improvement. The validation logic remains unchanged - only the error message is more accurate now. Changed from field.Required to field.Invalid to better represent the nature of the validation failure.