### PR TITLE
node: e2e: fix podresources api test

### DIFF
--- a/pkg/kubelet/apis/podresources/server_v1.go
+++ b/pkg/kubelet/apis/podresources/server_v1.go
@@ -67,17 +67,7 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 		// GetActivePods already filters out terminal pods, so no need for additional filtering.
 		pods = p.podsProvider.GetActivePods()
 	} else {
-		// GetPods may include terminal pods, so we filter them out ourselves.
-		allPods := p.podsProvider.GetPods()
-		pods = make([]*v1.Pod, 0, len(allPods))
-		for _, pod := range allPods {
-			// Skip terminal pods (Failed or Succeeded).
-			// Terminal pods should not appear in podresources as they no longer consume resources.
-			if podutil.IsPodTerminal(pod) {
-				continue
-			}
-			pods = append(pods, pod)
-		}
+		pods = p.podsProvider.GetPods()
 	}
 
 	podResources := make([]*podresourcesv1.PodResources, len(pods))

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3197,7 +3197,15 @@ func (pp *kubeletPodsProvider) GetPods() []*v1.Pod {
 }
 
 func (pp *kubeletPodsProvider) GetPodByName(namespace, name string) (*v1.Pod, bool) {
-	return pp.kl.podManager.GetPodByName(namespace, name)
+	pod, found := pp.kl.podManager.GetPodByName(namespace, name)
+	if !found {
+		return nil, false
+	}
+	// use the same filtering logic as GetActivePods
+	if pp.kl.isPodInactive(pod) {
+		return nil, false
+	}
+	return pod, true
 }
 
 // ListenAndServePodResources runs the kubelet podresources grpc service

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1126,20 +1126,29 @@ func (kl *Kubelet) PodIsFinished(pod *v1.Pod) bool {
 func (kl *Kubelet) filterOutInactivePods(pods []*v1.Pod) []*v1.Pod {
 	filteredPods := make([]*v1.Pod, 0, len(pods))
 	for _, p := range pods {
-		// if a pod is fully terminated by UID, it should be excluded from the
-		// list of pods
-		if kl.podWorkers.IsPodKnownTerminated(p.UID) {
+		if kl.isPodInactive(p) {
 			continue
 		}
-
-		// terminal pods are considered inactive UNLESS they are actively terminating
-		if kl.isAdmittedPodTerminal(p) && !kl.podWorkers.IsPodTerminationRequested(p.UID) {
-			continue
-		}
-
 		filteredPods = append(filteredPods, p)
 	}
 	return filteredPods
+}
+
+// isPodInactive returns true if the pod is in a terminal phase
+// or is known to be fully terminated. This method should only be used
+// when the pod being processed is upstream of the pod worker, i.e.
+// the pods the pod manager is aware of.
+func (kl *Kubelet) isPodInactive(p *v1.Pod) bool {
+	// if a pod is fully terminated by UID, it should be excluded from the
+	// list of pods
+	if kl.podWorkers.IsPodKnownTerminated(p.UID) {
+		return true
+	}
+	// terminal pods are considered inactive UNLESS they are actively terminating
+	if kl.isAdmittedPodTerminal(p) && !kl.podWorkers.IsPodTerminationRequested(p.UID) {
+		return true
+	}
+	return false
 }
 
 // isAdmittedPodTerminal returns true if the provided config source pod is in

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -1082,7 +1082,7 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 			})
 
 			// empty context to apply kubelet config changes
-			ginkgo.Context("", func() {
+			ginkgo.Context("with reserved system CPUs", func() {
 				tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 					// Set the CPU Manager policy to static.
 					initialConfig.CPUManagerPolicy = string(cpumanager.PolicyStatic)
@@ -1093,31 +1093,6 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 					cpus := reservedSystemCPUs.String()
 					framework.Logf("configurePodResourcesInKubelet: using reservedSystemCPUs=%q", cpus)
 					initialConfig.ReservedSystemCPUs = cpus
-				})
-
-				ginkgo.It("should return the expected responses", func(ctx context.Context) {
-					onlineCPUs, err := getOnlineCPUs()
-					framework.ExpectNoError(err, "getOnlineCPUs() failed err: %v", err)
-
-					configMap := getSRIOVDevicePluginConfigMap(framework.TestContext.SriovdpConfigMapFile)
-					sd := setupSRIOVConfigOrFail(ctx, f, configMap)
-					ginkgo.DeferCleanup(teardownSRIOVConfigOrFail, f, sd)
-
-					waitForSRIOVResources(ctx, f, sd)
-
-					endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
-					framework.ExpectNoError(err, "LocalEndpoint() failed err: %v", err)
-
-					cli, conn, err := podresources.GetV1Client(endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
-					framework.ExpectNoError(err, "GetV1Client() failed err: %v", err)
-					defer conn.Close()
-
-					waitForSRIOVResources(ctx, f, sd)
-
-					ginkgo.By("checking List()")
-					podresourcesListTests(ctx, f, cli, sd, false)
-					ginkgo.By("checking GetAllocatableResources()")
-					podresourcesGetAllocatableResourcesTests(ctx, cli, sd, onlineCPUs, reservedSystemCPUs)
 				})
 
 				framework.It("should return the expected responses", framework.WithNodeConformance(), func(ctx context.Context) {
@@ -1190,8 +1165,7 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 				}
 			})
 
-			// empty context to apply kubelet config changes
-			ginkgo.Context("", func() {
+			ginkgo.Context("with reserved system CPUs", func() {
 				tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 					// Set the CPU Manager policy to static.
 					initialConfig.CPUManagerPolicy = string(cpumanager.PolicyStatic)
@@ -1248,22 +1222,6 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 						gomega.Expect(container.CpuIds).To(gomega.HaveLen(pd.CPURequestExclusive()), "expected one exclusive CPU")
 						gomega.Expect(container.Devices).To(gomega.BeEmpty(), "expected no devices")
 					})
-				})
-
-				ginkgo.It("should return the expected responses", func(ctx context.Context) {
-					onlineCPUs, err := getOnlineCPUs()
-					framework.ExpectNoError(err, "getOnlineCPUs() failed err: %v", err)
-
-					endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
-					framework.ExpectNoError(err, "LocalEndpoint() failed err: %v", err)
-
-					cli, conn, err := podresources.GetV1Client(endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
-					framework.ExpectNoError(err, "GetV1Client() failed err: %v", err)
-					defer conn.Close()
-
-					podresourcesListTests(ctx, f, cli, nil, false)
-					podresourcesGetAllocatableResourcesTests(ctx, cli, nil, onlineCPUs, reservedSystemCPUs)
-					podresourcesGetTests(ctx, f, cli, false)
 				})
 
 				framework.It("should return the expected responses", framework.WithNodeConformance(), func(ctx context.Context) {

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -337,6 +337,7 @@ func newTestPodData() *testPodData {
 }
 
 func (tpd *testPodData) createPodsForTest(ctx context.Context, f *framework.Framework, podReqs []podDesc) {
+	ginkgo.GinkgoHelper()
 	for _, podReq := range podReqs {
 		pod := makePodResourcesTestPod(podReq)
 		pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
@@ -348,11 +349,13 @@ func (tpd *testPodData) createPodsForTest(ctx context.Context, f *framework.Fram
 
 /* deletePodsForTest clean up all the pods run for a testcase. Must ensure proper cleanup */
 func (tpd *testPodData) deletePodsForTest(ctx context.Context, f *framework.Framework) {
+	ginkgo.GinkgoHelper()
 	deletePodsAsync(ctx, f, tpd.PodMap)
 }
 
 /* deletePod removes pod during a test. Should do a best-effort clean up */
 func (tpd *testPodData) deletePod(ctx context.Context, f *framework.Framework, podName string) {
+	ginkgo.GinkgoHelper()
 	_, ok := tpd.PodMap[podName]
 	if !ok {
 		return
@@ -499,8 +502,9 @@ func matchPodDescWithResources(expected []podDesc, found podResMap) error {
 	return nil
 }
 
-func expectPodResources(ctx context.Context, offset int, cli kubeletpodresourcesv1.PodResourcesListerClient, expected []podDesc) {
-	gomega.EventuallyWithOffset(1+offset, ctx, func(ctx context.Context) error {
+func expectPodResources(ctx context.Context, cli kubeletpodresourcesv1.PodResourcesListerClient, expected []podDesc) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(ctx, func(ctx context.Context) error {
 		found, err := getPodResourcesValues(ctx, cli)
 		if err != nil {
 			return err
@@ -521,6 +525,8 @@ func filterOutDesc(descs []podDesc, name string) []podDesc {
 }
 
 func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kubeletpodresourcesv1.PodResourcesListerClient, sd *sriovData, sidecarContainersEnabled bool) {
+	ginkgo.GinkgoHelper()
+
 	var tpd *testPodData
 
 	var found podResMap
@@ -552,7 +558,7 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 	}
 
 	tpd.createPodsForTest(ctx, f, expected)
-	expectPodResources(ctx, 1, cli, expected)
+	expectPodResources(ctx, cli, expected)
 	tpd.deletePodsForTest(ctx, f)
 
 	tpd = newTestPodData()
@@ -608,7 +614,7 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 
 	}
 	tpd.createPodsForTest(ctx, f, expected)
-	expectPodResources(ctx, 1, cli, expected)
+	expectPodResources(ctx, cli, expected)
 	tpd.deletePodsForTest(ctx, f)
 
 	tpd = newTestPodData()
@@ -652,7 +658,7 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 	}
 
 	tpd.createPodsForTest(ctx, f, expected)
-	expectPodResources(ctx, 1, cli, expected)
+	expectPodResources(ctx, cli, expected)
 
 	if sd != nil {
 		extra = podDesc{
@@ -676,7 +682,7 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 	})
 
 	expected = append(expected, extra)
-	expectPodResources(ctx, 1, cli, expected)
+	expectPodResources(ctx, cli, expected)
 	tpd.deletePodsForTest(ctx, f)
 
 	tpd = newTestPodData()
@@ -732,11 +738,11 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 		}
 	}
 	tpd.createPodsForTest(ctx, f, expected)
-	expectPodResources(ctx, 1, cli, expected)
+	expectPodResources(ctx, cli, expected)
 
 	tpd.deletePod(ctx, f, "pod-01")
 	expectedPostDelete := filterOutDesc(expected, "pod-01")
-	expectPodResources(ctx, 1, cli, expectedPostDelete)
+	expectPodResources(ctx, cli, expectedPostDelete)
 	tpd.deletePodsForTest(ctx, f)
 
 	tpd = newTestPodData()
@@ -767,7 +773,7 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 
 	}
 	tpd.createPodsForTest(ctx, f, expected)
-	expectPodResources(ctx, 1, cli, expected)
+	expectPodResources(ctx, cli, expected)
 	tpd.deletePodsForTest(ctx, f)
 
 	if sidecarContainersEnabled {
@@ -834,7 +840,7 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 		}
 
 		tpd.createPodsForTest(ctx, f, expected)
-		expectPodResources(ctx, 1, cli, expected)
+		expectPodResources(ctx, cli, expected)
 		tpd.deletePodsForTest(ctx, f)
 	}
 }
@@ -885,7 +891,8 @@ func demuxCPUsAndDevicesFromGetAllocatableResources(resp *kubeletpodresourcesv1.
 }
 
 func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubeletpodresourcesv1.PodResourcesListerClient, sidecarContainersEnabled bool) {
-	//var err error
+	ginkgo.GinkgoHelper()
+
 	ginkgo.By("checking the output when no pods are present")
 	expected := []podDesc{}
 	resp, err := cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "test", PodNamespace: f.Namespace.Name})
@@ -1920,7 +1927,7 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 						desc,
 					})
 
-					expectPodResources(ctx, 0, cli, []podDesc{desc})
+					expectPodResources(ctx, cli, []podDesc{desc})
 
 					ginkgo.By("Restarting Kubelet")
 					restartKubelet(ctx, true)
@@ -1930,7 +1937,7 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 					ginkgo.By("Wait for node to be ready")
 					waitForTopologyUnawareResources(ctx, f)
 
-					expectPodResources(ctx, 0, cli, []podDesc{desc})
+					expectPodResources(ctx, cli, []podDesc{desc})
 					tpd.deletePodsForTest(ctx, f)
 				})
 			})
@@ -1967,7 +1974,7 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 			tpd.createPodsForTest(ctx, f, []podDesc{
 				desc,
 			})
-			expectPodResources(ctx, 1, cli, []podDesc{desc})
+			expectPodResources(ctx, cli, []podDesc{desc})
 
 			expected := []podDesc{}
 			resp, err := cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "pod-01", PodNamespace: f.Namespace.Name})

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -890,14 +890,33 @@ func demuxCPUsAndDevicesFromGetAllocatableResources(resp *kubeletpodresourcesv1.
 	return cpuset.New(cpus...), devs
 }
 
+func podresourcesGetWithRetry(ctx context.Context, cli kubeletpodresourcesv1.PodResourcesListerClient, podNamespace, podName string) *kubeletpodresourcesv1.GetPodResourcesResponse {
+	ginkgo.GinkgoHelper()
+	var err error
+	var resp *kubeletpodresourcesv1.GetPodResourcesResponse
+	gomega.Eventually(func() error {
+		resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: podName, PodNamespace: podNamespace})
+		framework.Logf("Get result: %v, err: %v", resp, err)
+		return err
+	}).WithContext(ctx).WithPolling(2*time.Second).WithTimeout(30*time.Second).Should(gomega.Succeed(), "Expected Get to succeed for %s/%s", podNamespace, podName)
+	return resp
+}
+
 func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubeletpodresourcesv1.PodResourcesListerClient, sidecarContainersEnabled bool) {
 	ginkgo.GinkgoHelper()
 
 	ginkgo.By("checking the output when no pods are present")
 	expected := []podDesc{}
-	resp, err := cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "test", PodNamespace: f.Namespace.Name})
+
+	var err error
+	var resp *kubeletpodresourcesv1.GetPodResourcesResponse
+	gomega.Eventually(func() error {
+		resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "test", PodNamespace: f.Namespace.Name})
+		framework.Logf("Get result: %v, err: %v", resp, err)
+		return err
+	}).WithContext(ctx).WithPolling(2*time.Second).WithTimeout(30*time.Second).ShouldNot(gomega.Succeed(), "Expected Get to fail for %s/%s", f.Namespace.Name, "test")
+
 	podResourceList := []*kubeletpodresourcesv1.PodResources{resp.GetPodResources()}
-	gomega.Expect(err).To(gomega.HaveOccurred(), "pod not found")
 	res := convertToMap(podResourceList)
 	err = matchPodDescWithResources(expected, res)
 	framework.ExpectNoError(err, "matchPodDescWithResources() failed err %v", err)
@@ -925,9 +944,14 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 		},
 	}
 	tpd.createPodsForTest(ctx, f, descs)
-	resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "pod-AA", PodNamespace: f.Namespace.Name})
+
+	gomega.Eventually(func() error {
+		resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "pod-AA", PodNamespace: f.Namespace.Name})
+		framework.Logf("Get result: %v, err: %v", res, err)
+		return err
+	}).WithContext(ctx).WithPolling(2*time.Second).WithTimeout(30*time.Second).ShouldNot(gomega.Succeed(), "Expected Get to fail for %s/%s", f.Namespace.Name, "pod-AA")
+
 	podResourceList = []*kubeletpodresourcesv1.PodResources{resp.GetPodResources()}
-	gomega.Expect(err).To(gomega.HaveOccurred(), "pod not found")
 	res = convertToMap(podResourceList)
 	err = matchPodDescWithResources(expected, res)
 	framework.ExpectNoError(err, "matchPodDescWithResources() failed err %v", err)
@@ -942,8 +966,8 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 		},
 	}
 	tpd.createPodsForTest(ctx, f, expected)
-	resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "pod-00", PodNamespace: f.Namespace.Name})
-	framework.ExpectNoError(err, "Get() call failed for pod %s/%s", f.Namespace.Name, "pod-00")
+
+	resp = podresourcesGetWithRetry(ctx, cli, f.Namespace.Name, "pod-00")
 	podResourceList = []*kubeletpodresourcesv1.PodResources{resp.GetPodResources()}
 	res = convertToMap(podResourceList)
 	err = matchPodDescWithResources(expected, res)
@@ -960,8 +984,8 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 		},
 	}
 	tpd.createPodsForTest(ctx, f, expected)
-	resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "pod-01", PodNamespace: f.Namespace.Name})
-	framework.ExpectNoError(err, "Get() call failed for pod %s/%s", f.Namespace.Name, "pod-01")
+
+	resp = podresourcesGetWithRetry(ctx, cli, f.Namespace.Name, "pod-01")
 	podResourceList = []*kubeletpodresourcesv1.PodResources{resp.GetPodResources()}
 	res = convertToMap(podResourceList)
 	err = matchPodDescWithResources(expected, res)
@@ -992,8 +1016,8 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 		},
 	}
 	tpd.createPodsForTest(ctx, f, expected)
-	resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "pod-01", PodNamespace: f.Namespace.Name})
-	framework.ExpectNoError(err, "Get() call failed for pod %s/%s", f.Namespace.Name, "pod-01")
+
+	resp = podresourcesGetWithRetry(ctx, cli, f.Namespace.Name, "pod-01")
 	podResourceList = []*kubeletpodresourcesv1.PodResources{resp.GetPodResources()}
 	res = convertToMap(podResourceList)
 	err = matchPodDescWithResources(expected, res)
@@ -1019,8 +1043,12 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 	err = e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, completedPod.Name, "Pod Succeeded", 2*time.Minute, testutils.PodSucceeded)
 	framework.ExpectNoError(err, "pod did not succeed as expected")
 
-	resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: completedDesc.podName, PodNamespace: f.Namespace.Name})
-	gomega.Expect(err).To(gomega.HaveOccurred(), "expected Get() to return an error for a terminated pod")
+	gomega.Eventually(func() error {
+		resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: completedDesc.podName, PodNamespace: f.Namespace.Name})
+		framework.Logf("Get result: %v, err: %v", res, err)
+		return err
+	}).WithContext(ctx).WithPolling(2*time.Second).WithTimeout(30*time.Second).ShouldNot(gomega.Succeed(), "Expected Get to fail for %s/%s", f.Namespace.Name, completedDesc.podName)
+
 	// Returned PodResources for a terminated pod must be empty.
 	pr := resp.GetPodResources()
 	if pr != nil {
@@ -1053,8 +1081,8 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 			},
 		}
 		tpd.createPodsForTest(ctx, f, expected)
-		resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "pod-01", PodNamespace: f.Namespace.Name})
-		framework.ExpectNoError(err, "Get() call failed for pod %s/%s", f.Namespace.Name, "pod-01")
+
+		resp = podresourcesGetWithRetry(ctx, cli, f.Namespace.Name, "pod-01")
 		podResourceList = []*kubeletpodresourcesv1.PodResources{resp.GetPodResources()}
 		res = convertToMap(podResourceList)
 		err = matchPodDescWithResources(expected, res)
@@ -1215,13 +1243,7 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 						err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "Ready", 2*time.Minute, testutils.PodRunningReady)
 						framework.ExpectNoError(err)
 
-						res, err := cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{
-							PodName:      pod.Name,
-							PodNamespace: pod.Namespace,
-						})
-
-						framework.Logf("Get result: %v, err: %v", res, err)
-						framework.ExpectNoError(err, "Expected Get to succeed with the feature gate enabled")
+						res := podresourcesGetWithRetry(ctx, cli, pod.Namespace, pod.Name)
 						gomega.Expect(res.PodResources.Name).To(gomega.Equal(pod.Name))
 						gomega.Expect(res.PodResources.Containers).To(gomega.HaveLen(1), "expected one container")
 						container := res.PodResources.Containers[0]
@@ -1278,6 +1300,7 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 				defer conn.Close()
 
 				ginkgo.By("checking Get fail if the feature gate is not enabled")
+				// we don't use Eventually here because the call must fail consistently and quickly
 				getRes, err := cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "test", PodNamespace: f.Namespace.Name})
 				framework.Logf("Get result: %v, err: %v", getRes, err)
 				gomega.Expect(err).To(gomega.HaveOccurred(), "With feature gate disabled, the call must fail")
@@ -1943,8 +1966,8 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 			expectPodResources(ctx, cli, []podDesc{desc})
 
 			expected := []podDesc{}
-			resp, err := cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "pod-01", PodNamespace: f.Namespace.Name})
-			framework.ExpectNoError(err, "Get() call failed for pod %s/%s", f.Namespace.Name, "pod-01")
+
+			resp := podresourcesGetWithRetry(ctx, cli, f.Namespace.Name, "pod-01")
 			podResourceList := []*kubeletpodresourcesv1.PodResources{resp.GetPodResources()}
 			res := convertToMap(podResourceList)
 			err = matchPodDescWithResources(expected, res)

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -1002,23 +1002,31 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 
 	restartNever := v1.RestartPolicyNever
 	tpd = newTestPodData()
-	ginkgo.By("checking the output when only pod require CPU is terminated")
-	expected = []podDesc{
-		{
-			podName:        "pod-01",
-			cntName:        "cnt-00",
-			cpuRequest:     1000,
-			restartPolicy:  &restartNever,
-			mainCntCommand: []string{"sh", "-c", "/bin/true"},
-		},
+	ginkgo.By("checking Get() returns an error for a terminated pod")
+
+	completedDesc := podDesc{
+		podName:        "pod-01",
+		cntName:        "cnt-00",
+		cpuRequest:     1000,
+		restartPolicy:  &restartNever,
+		mainCntCommand: []string{"sh", "-c", "/bin/true"},
 	}
-	tpd.createPodsForTest(ctx, f, expected)
-	resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: "pod-01", PodNamespace: f.Namespace.Name})
-	podResourceList = []*kubeletpodresourcesv1.PodResources{resp.GetPodResources()}
-	gomega.Expect(err).To(gomega.HaveOccurred(), "pod not found")
-	res = convertToMap(podResourceList)
-	err = matchPodDescWithResources(expected, res)
-	framework.ExpectNoError(err, "matchPodDescWithResources() failed err %v", err)
+
+	completedPod := e2epod.NewPodClient(f).Create(ctx, makePodResourcesTestPod(completedDesc))
+	framework.Logf("created pod %s", completedDesc.podName)
+	tpd.PodMap[completedDesc.podName] = completedPod
+	// Wait for the pod to complete to avoid races.
+	err = e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, completedPod.Name, "Pod Succeeded", 2*time.Minute, testutils.PodSucceeded)
+	framework.ExpectNoError(err, "pod did not succeed as expected")
+
+	resp, err = cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{PodName: completedDesc.podName, PodNamespace: f.Namespace.Name})
+	gomega.Expect(err).To(gomega.HaveOccurred(), "expected Get() to return an error for a terminated pod")
+	// Returned PodResources for a terminated pod must be empty.
+	pr := resp.GetPodResources()
+	if pr != nil {
+		gomega.Expect(pr.GetContainers()).To(gomega.BeEmpty(),
+			"expected no container resources in response for terminated pod; got: %#v", pr.GetContainers())
+	}
 	tpd.deletePodsForTest(ctx, f)
 
 	if sidecarContainersEnabled {

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -500,6 +500,7 @@ func runTopologyManagerPositiveTest(ctx context.Context, f *framework.Framework,
 }
 
 func deletePodsAsync(ctx context.Context, f *framework.Framework, podMap map[string]*v1.Pod) {
+	ginkgo.GinkgoHelper()
 	var wg sync.WaitGroup
 	for _, pod := range podMap {
 		wg.Add(1)

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -24,7 +24,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -497,27 +496,6 @@ func runTopologyManagerPositiveTest(ctx context.Context, f *framework.Framework,
 	}
 
 	deletePodsAsync(ctx, f, podMap)
-}
-
-func deletePodsAsync(ctx context.Context, f *framework.Framework, podMap map[string]*v1.Pod) {
-	ginkgo.GinkgoHelper()
-	var wg sync.WaitGroup
-	for _, pod := range podMap {
-		wg.Add(1)
-		go func(podNS, podName string) {
-			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
-			deletePodSyncAndWait(ctx, f, podNS, podName)
-		}(pod.Namespace, pod.Name)
-	}
-	wg.Wait()
-}
-
-func deletePodSyncAndWait(ctx context.Context, f *framework.Framework, podNS, podName string) {
-	framework.Logf("deleting pod: %s/%s", podNS, podName)
-	deletePodSyncByName(ctx, f, podName)
-	waitForAllContainerRemoval(ctx, podName, podNS)
-	framework.Logf("deleted pod: %s/%s", podNS, podName)
 }
 
 func runTopologyManagerNegativeTest(ctx context.Context, f *framework.Framework, ctnAttrs, initCtnAttrs []tmCtnAttribute, envInfo *testEnvInfo) {

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -596,6 +596,7 @@ func nodeNameOrIP() string {
 }
 
 func deletePodSyncByName(ctx context.Context, f *framework.Framework, podName string) {
+	ginkgo.GinkgoHelper()
 	gp := int64(0)
 	delOpts := metav1.DeleteOptions{
 		GracePeriodSeconds: &gp,

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -30,6 +30,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/kubernetes/pkg/util/procfs"
@@ -626,4 +627,25 @@ func waitForContainerRemoval(ctx context.Context, containerName, podName, podNS 
 		}
 		return len(containers) == 0
 	}, 2*time.Minute, 1*time.Second).Should(gomega.BeTrueBecause("Containers were expected to be removed"))
+}
+
+func deletePodsAsync(ctx context.Context, f *framework.Framework, podMap map[string]*v1.Pod) {
+	ginkgo.GinkgoHelper()
+	var wg sync.WaitGroup
+	for _, pod := range podMap {
+		wg.Add(1)
+		go func(podNS, podName string) {
+			defer ginkgo.GinkgoRecover()
+			defer wg.Done()
+			deletePodSyncAndWait(ctx, f, podNS, podName)
+		}(pod.Namespace, pod.Name)
+	}
+	wg.Wait()
+}
+
+func deletePodSyncAndWait(ctx context.Context, f *framework.Framework, podNS, podName string) {
+	framework.Logf("deleting pod: %s/%s", podNS, podName)
+	deletePodSyncByName(ctx, f, podName)
+	waitForAllContainerRemoval(ctx, podName, podNS)
+	framework.Logf("deleted pod: %s/%s", podNS, podName)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

since PR#135485 we now always filter non-running pod in both the flows related to the KubeletPodResourcesListUseActivePods FG. The difference is that we now roll our own terminality check in the podresources API in the legacy code path flow, instead of using the new API.

From the perspective of the e2e tests we have, however, the two flows behave the same; so update the e2e tests accordingly.

Fix other missing tests and improve the signal of the lane. Meant to complement and be a prerequisite for https://github.com/kubernetes/kubernetes/pull/136602

Both PR combined fix the podresources api lane as demonstrated in https://github.com/kubernetes/kubernetes/pull/136821#issuecomment-3962500100

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
seen in https://github.com/kubernetes/kubernetes/pull/136728 et. al

~this issue and this fix highlight a concern: should we keep the flows separated now that both flows filter out the terminal pods? perhaps we should revisit the original deflaking fix https://github.com/kubernetes/kubernetes/pull/135485~ ended up partially reverting, see the commits for details

Needed by https://github.com/kubernetes/kubernetes/pull/136602 in turn needed by the KEP 3695

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
