### PR TITLE
Validationo-gen: Migrate handwritten validation to declarative validation in StorageClass  

### DIFF
--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -101,6 +101,9 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -118,6 +121,9 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			earlyReturn := false
 			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -142,6 +148,9 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			earlyReturn := false
 			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -87,7 +87,25 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			return
 		}(fldPath.Child("provisioner"), &obj.Provisioner, safe.Field(oldObj, func(oldObj *storagev1.StorageClass) *string { return &oldObj.Provisioner }), oldObj != nil)...)
 
-	// field storagev1.StorageClass.Parameters has no validation
+	// field storagev1.StorageClass.Parameters
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj map[string]string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("parameters"), obj.Parameters, safe.Field(oldObj, func(oldObj *storagev1.StorageClass) map[string]string { return oldObj.Parameters }), oldObj != nil)...)
+
 	// field storagev1.StorageClass.ReclaimPolicy has no validation
 	// field storagev1.StorageClass.MountOptions has no validation
 	// field storagev1.StorageClass.AllowVolumeExpansion has no validation

--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -73,6 +73,10 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true

--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -130,7 +130,26 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 
 	// field storagev1.StorageClass.MountOptions has no validation
 	// field storagev1.StorageClass.AllowVolumeExpansion has no validation
-	// field storagev1.StorageClass.VolumeBindingMode has no validation
+
+	// field storagev1.StorageClass.VolumeBindingMode
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *storagev1.VolumeBindingMode, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("volumeBindingMode"), obj.VolumeBindingMode, safe.Field(oldObj, func(oldObj *storagev1.StorageClass) *storagev1.VolumeBindingMode { return oldObj.VolumeBindingMode }), oldObj != nil)...)
+
 	// field storagev1.StorageClass.AllowedTopologies has no validation
 	return errs
 }

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -101,6 +101,9 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -118,6 +121,9 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			earlyReturn := false
 			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -142,6 +148,9 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			earlyReturn := false
 			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -87,7 +87,25 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			return
 		}(fldPath.Child("provisioner"), &obj.Provisioner, safe.Field(oldObj, func(oldObj *storagev1beta1.StorageClass) *string { return &oldObj.Provisioner }), oldObj != nil)...)
 
-	// field storagev1beta1.StorageClass.Parameters has no validation
+	// field storagev1beta1.StorageClass.Parameters
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj map[string]string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("parameters"), obj.Parameters, safe.Field(oldObj, func(oldObj *storagev1beta1.StorageClass) map[string]string { return oldObj.Parameters }), oldObj != nil)...)
+
 	// field storagev1beta1.StorageClass.ReclaimPolicy has no validation
 	// field storagev1beta1.StorageClass.MountOptions has no validation
 	// field storagev1beta1.StorageClass.AllowVolumeExpansion has no validation

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -25,6 +25,7 @@ import (
 	context "context"
 	fmt "fmt"
 
+	v1 "k8s.io/api/core/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
@@ -106,7 +107,27 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			return
 		}(fldPath.Child("parameters"), obj.Parameters, safe.Field(oldObj, func(oldObj *storagev1beta1.StorageClass) map[string]string { return oldObj.Parameters }), oldObj != nil)...)
 
-	// field storagev1beta1.StorageClass.ReclaimPolicy has no validation
+	// field storagev1beta1.StorageClass.ReclaimPolicy
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *v1.PersistentVolumeReclaimPolicy, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("reclaimPolicy"), obj.ReclaimPolicy, safe.Field(oldObj, func(oldObj *storagev1beta1.StorageClass) *v1.PersistentVolumeReclaimPolicy {
+			return oldObj.ReclaimPolicy
+		}), oldObj != nil)...)
+
 	// field storagev1beta1.StorageClass.MountOptions has no validation
 	// field storagev1beta1.StorageClass.AllowVolumeExpansion has no validation
 	// field storagev1beta1.StorageClass.VolumeBindingMode has no validation

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -130,7 +130,28 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 
 	// field storagev1beta1.StorageClass.MountOptions has no validation
 	// field storagev1beta1.StorageClass.AllowVolumeExpansion has no validation
-	// field storagev1beta1.StorageClass.VolumeBindingMode has no validation
+
+	// field storagev1beta1.StorageClass.VolumeBindingMode
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *storagev1beta1.VolumeBindingMode, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("volumeBindingMode"), obj.VolumeBindingMode, safe.Field(oldObj, func(oldObj *storagev1beta1.StorageClass) *storagev1beta1.VolumeBindingMode {
+			return oldObj.VolumeBindingMode
+		}), oldObj != nil)...)
+
 	// field storagev1beta1.StorageClass.AllowedTopologies has no validation
 	return errs
 }

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -73,6 +73,10 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -66,9 +66,7 @@ func ValidateStorageClassUpdate(storageClass, oldStorageClass *storage.StorageCl
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("parameters"), "updates to parameters are forbidden."))
 	}
 
-	if storageClass.Provisioner != oldStorageClass.Provisioner {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("provisioner"), "updates to provisioner are forbidden."))
-	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(storageClass.Provisioner, oldStorageClass.Provisioner, field.NewPath("provisioner")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 
 	if *storageClass.ReclaimPolicy != *oldStorageClass.ReclaimPolicy {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("reclaimPolicy"), "updates to reclaimPolicy are forbidden."))

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -117,6 +117,9 @@ var supportedReclaimPolicy = sets.NewString(string(api.PersistentVolumeReclaimDe
 // provisioning for storage classes with impossible reclaim policies, e.g. EBS is not Recyclable
 func validateReclaimPolicy(reclaimPolicy *api.PersistentVolumeReclaimPolicy, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	if reclaimPolicy == nil {
+		return allErrs
+	}
 	if len(string(*reclaimPolicy)) > 0 {
 		if !supportedReclaimPolicy.Has(string(*reclaimPolicy)) {
 			allErrs = append(allErrs, field.NotSupported(fldPath, reclaimPolicy, supportedReclaimPolicy.List()))

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -66,9 +66,7 @@ func ValidateStorageClassUpdate(storageClass, oldStorageClass *storage.StorageCl
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(storageClass.Provisioner, oldStorageClass.Provisioner, field.NewPath("provisioner")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 
-	if *storageClass.ReclaimPolicy != *oldStorageClass.ReclaimPolicy {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("reclaimPolicy"), "updates to reclaimPolicy are forbidden."))
-	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(storageClass.ReclaimPolicy, oldStorageClass.ReclaimPolicy, field.NewPath("reclaimPolicy")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(storageClass.VolumeBindingMode, oldStorageClass.VolumeBindingMode, field.NewPath("volumeBindingMode"))...)
 	return allErrs

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -62,9 +62,7 @@ func ValidateStorageClass(storageClass *storage.StorageClass) field.ErrorList {
 // ValidateStorageClassUpdate tests if an update to StorageClass is valid.
 func ValidateStorageClassUpdate(storageClass, oldStorageClass *storage.StorageClass) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMetaUpdate(&storageClass.ObjectMeta, &oldStorageClass.ObjectMeta, field.NewPath("metadata"))
-	if !reflect.DeepEqual(oldStorageClass.Parameters, storageClass.Parameters) {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("parameters"), "updates to parameters are forbidden."))
-	}
+	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(storageClass.Parameters, oldStorageClass.Parameters, field.NewPath("parameters")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(storageClass.Provisioner, oldStorageClass.Provisioner, field.NewPath("provisioner")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -68,7 +68,7 @@ func ValidateStorageClassUpdate(storageClass, oldStorageClass *storage.StorageCl
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(storageClass.ReclaimPolicy, oldStorageClass.ReclaimPolicy, field.NewPath("reclaimPolicy")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(storageClass.VolumeBindingMode, oldStorageClass.VolumeBindingMode, field.NewPath("volumeBindingMode"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(storageClass.VolumeBindingMode, oldStorageClass.VolumeBindingMode, field.NewPath("volumeBindingMode")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	return allErrs
 }
 

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -102,6 +102,13 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("parameters"), map[string]string{"new": "value"}, "field is immutable").WithOrigin("immutable"),
 			},
 		},
+		"invalid update reclaimPolicy changed": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakReclaimPolicy(api.PersistentVolumeReclaimRetain)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("reclaimPolicy"), api.PersistentVolumeReclaimRetain, "field is immutable").WithOrigin("immutable"),
+			},
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
@@ -147,5 +154,11 @@ func TweakProvisioner(provisioner string) func(obj *storage.StorageClass) {
 func TweakParameters(parameters map[string]string) func(obj *storage.StorageClass) {
 	return func(obj *storage.StorageClass) {
 		obj.Parameters = parameters
+	}
+}
+
+func TweakReclaimPolicy(reclaimPolicy api.PersistentVolumeReclaimPolicy) func(obj *storage.StorageClass) {
+	return func(obj *storage.StorageClass) {
+		obj.ReclaimPolicy = &reclaimPolicy
 	}
 }

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -116,6 +116,64 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("volumeBindingMode"), storage.VolumeBindingWaitForFirstConsumer, "field is immutable").WithOrigin("immutable"),
 			},
 		},
+		"invalid update provisioner unset to set": {
+			oldObj:    mkValidStorageClass(TweakProvisioner("")),
+			updateObj: mkValidStorageClass(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("provisioner"), "kubernetes.io/gce-pd", "field is immutable").WithOrigin("immutable"),
+			},
+		},
+		"invalid update provisioner set to unset": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakProvisioner("")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("provisioner"), "", "field is immutable").WithOrigin("immutable"),
+				field.Required(field.NewPath("provisioner"), ""),
+			},
+		},
+		"invalid update parameters unset to set": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"foo": "bar"})),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("parameters"), map[string]string{"foo": "bar"}, "field is immutable").WithOrigin("immutable"),
+			},
+		},
+		"invalid update parameters set to unset": {
+			oldObj:    mkValidStorageClass(TweakParameters(map[string]string{"foo": "bar"})),
+			updateObj: mkValidStorageClass(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("parameters"), nil, "field is immutable").WithOrigin("immutable"),
+			},
+		},
+		"invalid update reclaimPolicy unset to set": {
+			oldObj:    mkValidStorageClass(TweakReclaimPolicyNil()),
+			updateObj: mkValidStorageClass(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("reclaimPolicy"), api.PersistentVolumeReclaimDelete, "field is immutable").WithOrigin("immutable"),
+			},
+		},
+		"invalid update reclaimPolicy set to unset": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakReclaimPolicyNil()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "field is immutable").WithOrigin("immutable"),
+			},
+		},
+		"invalid update volumeBindingMode unset to set": {
+			oldObj:    mkValidStorageClass(TweakVolumeBindingModeNil()),
+			updateObj: mkValidStorageClass(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("volumeBindingMode"), storage.VolumeBindingImmediate, "field is immutable").WithOrigin("immutable"),
+			},
+		},
+		"invalid update volumeBindingMode set to unset": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakVolumeBindingModeNil()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Required(field.NewPath("volumeBindingMode"), ""),
+			},
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
@@ -170,8 +228,20 @@ func TweakReclaimPolicy(reclaimPolicy api.PersistentVolumeReclaimPolicy) func(ob
 	}
 }
 
+func TweakReclaimPolicyNil() func(obj *storage.StorageClass) {
+	return func(obj *storage.StorageClass) {
+		obj.ReclaimPolicy = nil
+	}
+}
+
 func TweakVolumeBindingMode(volumeBindingMode storage.VolumeBindingMode) func(obj *storage.StorageClass) {
 	return func(obj *storage.StorageClass) {
 		obj.VolumeBindingMode = &volumeBindingMode
+	}
+}
+
+func TweakVolumeBindingModeNil() func(obj *storage.StorageClass) {
+	return func(obj *storage.StorageClass) {
+		obj.VolumeBindingMode = nil
 	}
 }

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -95,27 +95,6 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("provisioner"), "kubernetes.io/aws-ebs", "field is immutable").WithOrigin("immutable"),
 			},
 		},
-		"invalid update parameters changed": {
-			oldObj:    mkValidStorageClass(),
-			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"new": "value"})),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), map[string]string{"new": "value"}, "field is immutable").WithOrigin("immutable"),
-			},
-		},
-		"invalid update reclaimPolicy changed": {
-			oldObj:    mkValidStorageClass(),
-			updateObj: mkValidStorageClass(TweakReclaimPolicy(api.PersistentVolumeReclaimRetain)),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), api.PersistentVolumeReclaimRetain, "field is immutable").WithOrigin("immutable"),
-			},
-		},
-		"invalid update volumeBindingMode changed": {
-			oldObj:    mkValidStorageClass(),
-			updateObj: mkValidStorageClass(TweakVolumeBindingMode(storage.VolumeBindingWaitForFirstConsumer)),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("volumeBindingMode"), storage.VolumeBindingWaitForFirstConsumer, "field is immutable").WithOrigin("immutable"),
-			},
-		},
 		"invalid update provisioner unset to set": {
 			oldObj:    mkValidStorageClass(TweakProvisioner("")),
 			updateObj: mkValidStorageClass(),
@@ -129,6 +108,13 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("provisioner"), "", "field is immutable").WithOrigin("immutable"),
 				field.Required(field.NewPath("provisioner"), ""),
+			},
+		},
+		"invalid update parameters changed": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"new": "value"})),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("parameters"), map[string]string{"new": "value"}, "field is immutable").WithOrigin("immutable"),
 			},
 		},
 		"invalid update parameters unset to set": {
@@ -145,6 +131,13 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("parameters"), nil, "field is immutable").WithOrigin("immutable"),
 			},
 		},
+		"invalid update reclaimPolicy changed": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakReclaimPolicy(api.PersistentVolumeReclaimRetain)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("reclaimPolicy"), api.PersistentVolumeReclaimRetain, "field is immutable").WithOrigin("immutable"),
+			},
+		},
 		"invalid update reclaimPolicy unset to set": {
 			oldObj:    mkValidStorageClass(TweakReclaimPolicyNil()),
 			updateObj: mkValidStorageClass(),
@@ -157,6 +150,13 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			updateObj: mkValidStorageClass(TweakReclaimPolicyNil()),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("reclaimPolicy"), nil, "field is immutable").WithOrigin("immutable"),
+			},
+		},
+		"invalid update volumeBindingMode changed": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakVolumeBindingMode(storage.VolumeBindingWaitForFirstConsumer)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("volumeBindingMode"), storage.VolumeBindingWaitForFirstConsumer, "field is immutable").WithOrigin("immutable"),
 			},
 		},
 		"invalid update volumeBindingMode unset to set": {

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -109,6 +109,13 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("reclaimPolicy"), api.PersistentVolumeReclaimRetain, "field is immutable").WithOrigin("immutable"),
 			},
 		},
+		"invalid update volumeBindingMode changed": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakVolumeBindingMode(storage.VolumeBindingWaitForFirstConsumer)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("volumeBindingMode"), storage.VolumeBindingWaitForFirstConsumer, "field is immutable").WithOrigin("immutable"),
+			},
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
@@ -160,5 +167,11 @@ func TweakParameters(parameters map[string]string) func(obj *storage.StorageClas
 func TweakReclaimPolicy(reclaimPolicy api.PersistentVolumeReclaimPolicy) func(obj *storage.StorageClass) {
 	return func(obj *storage.StorageClass) {
 		obj.ReclaimPolicy = &reclaimPolicy
+	}
+}
+
+func TweakVolumeBindingMode(volumeBindingMode storage.VolumeBindingMode) func(obj *storage.StorageClass) {
+	return func(obj *storage.StorageClass) {
+		obj.VolumeBindingMode = &volumeBindingMode
 	}
 }

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -95,6 +95,13 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("provisioner"), "kubernetes.io/aws-ebs", "field is immutable").WithOrigin("immutable"),
 			},
 		},
+		"invalid update parameters changed": {
+			oldObj:    mkValidStorageClass(),
+			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"new": "value"})),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("parameters"), map[string]string{"new": "value"}, "field is immutable").WithOrigin("immutable"),
+			},
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
@@ -134,5 +141,11 @@ func mkValidStorageClass(tweaks ...func(obj *storage.StorageClass)) storage.Stor
 func TweakProvisioner(provisioner string) func(obj *storage.StorageClass) {
 	return func(obj *storage.StorageClass) {
 		obj.Provisioner = provisioner
+	}
+}
+
+func TweakParameters(parameters map[string]string) func(obj *storage.StorageClass) {
+	return func(obj *storage.StorageClass) {
+		obj.Parameters = parameters
 	}
 }

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -92,21 +92,21 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakProvisioner("kubernetes.io/aws-ebs")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("provisioner"), "kubernetes.io/aws-ebs", "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update provisioner unset to set": {
 			oldObj:    mkValidStorageClass(TweakProvisioner("")),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("provisioner"), "kubernetes.io/gce-pd", "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update provisioner set to unset": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakProvisioner("")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("provisioner"), "", "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable"),
 				field.Required(field.NewPath("provisioner"), ""),
 			},
 		},
@@ -114,63 +114,63 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"new": "value"})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), map[string]string{"new": "value"}, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update parameters unset to set": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"foo": "bar"})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), map[string]string{"foo": "bar"}, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update parameters set to unset": {
 			oldObj:    mkValidStorageClass(TweakParameters(map[string]string{"foo": "bar"})),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update reclaimPolicy changed": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakReclaimPolicy(api.PersistentVolumeReclaimRetain)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), api.PersistentVolumeReclaimRetain, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update reclaimPolicy unset to set": {
 			oldObj:    mkValidStorageClass(TweakReclaimPolicyNil()),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), api.PersistentVolumeReclaimDelete, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update reclaimPolicy set to unset": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakReclaimPolicyNil()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update volumeBindingMode changed": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakVolumeBindingMode(storage.VolumeBindingWaitForFirstConsumer)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("volumeBindingMode"), storage.VolumeBindingWaitForFirstConsumer, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update volumeBindingMode unset to set": {
 			oldObj:    mkValidStorageClass(TweakVolumeBindingModeNil()),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("volumeBindingMode"), storage.VolumeBindingImmediate, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update volumeBindingMode set to unset": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakVolumeBindingModeNil()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("volumeBindingMode"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable"),
 				field.Required(field.NewPath("volumeBindingMode"), ""),
 			},
 		},

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -442,12 +442,14 @@ message StorageClass {
   // create volumes of this storage class.
   // +optional
   // +k8s:immutable
+  // +k8s:optional
   map<string, string> parameters = 3;
 
   // reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
   // Defaults to Delete.
   // +optional
   // +k8s:immutable
+  // +k8s:optional
   optional string reclaimPolicy = 4;
 
   // mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -466,6 +468,7 @@ message StorageClass {
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
   // +k8s:immutable
+  // +k8s:optional
   optional string volumeBindingMode = 7;
 
   // allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -435,16 +435,19 @@ message StorageClass {
   // provisioner indicates the type of the provisioner.
   // +required
   // +k8s:required
+  // +k8s:immutable
   optional string provisioner = 2;
 
   // parameters holds the parameters for the provisioner that should
   // create volumes of this storage class.
   // +optional
+  // +k8s:immutable
   map<string, string> parameters = 3;
 
   // reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
   // Defaults to Delete.
   // +optional
+  // +k8s:immutable
   optional string reclaimPolicy = 4;
 
   // mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -462,6 +465,7 @@ message StorageClass {
   // provisioned and bound.  When unset, VolumeBindingImmediate is used.
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
+  // +k8s:immutable
   optional string volumeBindingMode = 7;
 
   // allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -55,6 +55,7 @@ type StorageClass struct {
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
 	// Defaults to Delete.
 	// +optional
+	// +k8s:immutable
 	ReclaimPolicy *v1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy,omitempty" protobuf:"bytes,4,opt,name=reclaimPolicy,casttype=k8s.io/api/core/v1.PersistentVolumeReclaimPolicy"`
 
 	// mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -43,6 +43,7 @@ type StorageClass struct {
 	// provisioner indicates the type of the provisioner.
 	// +required
 	// +k8s:required
+	// +k8s:immutable
 	Provisioner string `json:"provisioner" protobuf:"bytes,2,opt,name=provisioner"`
 
 	// parameters holds the parameters for the provisioner that should

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -49,6 +49,7 @@ type StorageClass struct {
 	// parameters holds the parameters for the provisioner that should
 	// create volumes of this storage class.
 	// +optional
+	// +k8s:immutable
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -50,12 +50,14 @@ type StorageClass struct {
 	// create volumes of this storage class.
 	// +optional
 	// +k8s:immutable
+	// +k8s:optional
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
 	// Defaults to Delete.
 	// +optional
 	// +k8s:immutable
+	// +k8s:optional
 	ReclaimPolicy *v1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy,omitempty" protobuf:"bytes,4,opt,name=reclaimPolicy,casttype=k8s.io/api/core/v1.PersistentVolumeReclaimPolicy"`
 
 	// mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -74,6 +76,7 @@ type StorageClass struct {
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
 	// +k8s:immutable
+	// +k8s:optional
 	VolumeBindingMode *VolumeBindingMode `json:"volumeBindingMode,omitempty" protobuf:"bytes,7,opt,name=volumeBindingMode"`
 
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -73,6 +73,7 @@ type StorageClass struct {
 	// provisioned and bound.  When unset, VolumeBindingImmediate is used.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
+	// +k8s:immutable
 	VolumeBindingMode *VolumeBindingMode `json:"volumeBindingMode,omitempty" protobuf:"bytes,7,opt,name=volumeBindingMode"`
 
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -437,16 +437,19 @@ message StorageClass {
   // provisioner indicates the type of the provisioner.
   // +required
   // +k8s:required
+  // +k8s:immutable
   optional string provisioner = 2;
 
   // parameters holds the parameters for the provisioner that should
   // create volumes of this storage class.
   // +optional
+  // +k8s:immutable
   map<string, string> parameters = 3;
 
   // reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
   // Defaults to Delete.
   // +optional
+  // +k8s:immutable
   optional string reclaimPolicy = 4;
 
   // mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -464,6 +467,7 @@ message StorageClass {
   // provisioned and bound.  When unset, VolumeBindingImmediate is used.
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
+  // +k8s:immutable
   optional string volumeBindingMode = 7;
 
   // allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -444,12 +444,14 @@ message StorageClass {
   // create volumes of this storage class.
   // +optional
   // +k8s:immutable
+  // +k8s:optional
   map<string, string> parameters = 3;
 
   // reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
   // Defaults to Delete.
   // +optional
   // +k8s:immutable
+  // +k8s:optional
   optional string reclaimPolicy = 4;
 
   // mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -468,6 +470,7 @@ message StorageClass {
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
   // +k8s:immutable
+  // +k8s:optional
   optional string volumeBindingMode = 7;
 
   // allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -52,12 +52,14 @@ type StorageClass struct {
 	// create volumes of this storage class.
 	// +optional
 	// +k8s:immutable
+	// +k8s:optional
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
 	// Defaults to Delete.
 	// +optional
 	// +k8s:immutable
+	// +k8s:optional
 	ReclaimPolicy *v1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy,omitempty" protobuf:"bytes,4,opt,name=reclaimPolicy,casttype=k8s.io/api/core/v1.PersistentVolumeReclaimPolicy"`
 
 	// mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -76,6 +78,7 @@ type StorageClass struct {
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
 	// +k8s:immutable
+	// +k8s:optional
 	VolumeBindingMode *VolumeBindingMode `json:"volumeBindingMode,omitempty" protobuf:"bytes,7,opt,name=volumeBindingMode"`
 
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -45,6 +45,7 @@ type StorageClass struct {
 	// provisioner indicates the type of the provisioner.
 	// +required
 	// +k8s:required
+	// +k8s:immutable
 	Provisioner string `json:"provisioner" protobuf:"bytes,2,opt,name=provisioner"`
 
 	// parameters holds the parameters for the provisioner that should

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -51,6 +51,7 @@ type StorageClass struct {
 	// parameters holds the parameters for the provisioner that should
 	// create volumes of this storage class.
 	// +optional
+	// +k8s:immutable
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -75,6 +75,7 @@ type StorageClass struct {
 	// provisioned and bound.  When unset, VolumeBindingImmediate is used.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
+	// +k8s:immutable
 	VolumeBindingMode *VolumeBindingMode `json:"volumeBindingMode,omitempty" protobuf:"bytes,7,opt,name=volumeBindingMode"`
 
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -57,6 +57,7 @@ type StorageClass struct {
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
 	// Defaults to Delete.
 	// +optional
+	// +k8s:immutable
 	ReclaimPolicy *v1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy,omitempty" protobuf:"bytes,4,opt,name=reclaimPolicy,casttype=k8s.io/api/core/v1.PersistentVolumeReclaimPolicy"`
 
 	// mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

This PR migrate `StorageClass.Provisioner`, `StorageClass.Parameters`, `StorageClass.ReclaimPolicy`, `StorageClass.VolumeBindingMode` to declarative validation. 

#### Which issue(s) this PR is related to:

relates to #136785


```release-note
NONE
```
