### PR TITLE
Fix cases of nilness under pkg/controller.

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -886,7 +886,7 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 		if len(revisions) != test.expectedCount {
 			t.Errorf("%s: want %d revisions got %d", test.name, test.expectedCount, len(revisions))
 		}
-		if test.err && err == nil {
+		if test.err {
 			t.Errorf("%s: expected error", test.name)
 		}
 		if !test.err && !history.EqualRevision(current, test.expectedCurrent) {
@@ -2090,9 +2090,6 @@ func TestStatefulSetControlRollback(t *testing.T) {
 			t.Fatalf("%s: %s", test.name, err)
 		}
 		if err := updateStatefulSetControl(set, ssc, om, assertUpdateInvariants); err != nil {
-			t.Fatalf("%s: %s", test.name, err)
-		}
-		if err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
 		pods, err = om.podsLister.Pods(set.Namespace).List(selector)

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
@@ -629,7 +629,7 @@ func Test_GetAttachedVolumes_Positive_OneVolumeTwoNodes(t *testing.T) {
 		t.Fatalf("Failed to get volume plugin from spec %v, %v", volumeSpec, err)
 	}
 	uniqueVolumeName, err := volumeutil.GetUniqueVolumeNameFromSpec(plugin, volumeSpec)
-	if err != nil || plugin == nil {
+	if err != nil || uniqueVolumeName == "" {
 		t.Fatalf("Failed to get uniqueVolumeName from spec %v, %v", volumeSpec, err)
 	}
 	logger, _ := ktesting.NewTestContext(t)
@@ -927,9 +927,6 @@ func Test_MarkDesireToDetach_Positive_MarkedAddVolumeNodeReset(t *testing.T) {
 	if markDesireToDetachErr != nil {
 		t.Fatalf("RemoveVolumeFromReportAsAttached failed. Expected: <no error> Actual: <%v>", markDesireToDetachErr)
 	}
-	if addErr != nil {
-		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
-	}
 
 	// Assert
 	attachedVolumes := asw.GetAttachedVolumes()
@@ -1224,7 +1221,7 @@ func Test_GetAttachedVolumesForNode_Positive_OneVolumeTwoNodes(t *testing.T) {
 		t.Fatalf("Failed to get volume plugin from spec %v, %v", volumeSpec, err)
 	}
 	uniqueVolumeName, err := volumeutil.GetUniqueVolumeNameFromSpec(plugin, volumeSpec)
-	if err != nil || plugin == nil {
+	if err != nil || uniqueVolumeName == "" {
 		t.Fatalf("Failed to get uniqueVolumeName from spec %v, %v", volumeSpec, err)
 	}
 	generatedVolumeName1, add1Err := asw.AddVolumeNode(logger, uniqueVolumeName, volumeSpec, node1Name, devicePath, true)
@@ -1269,7 +1266,7 @@ func Test_OneVolumeTwoNodes_TwoDevicePaths(t *testing.T) {
 		t.Fatalf("Failed to get volume plugin from spec %v, %v", volumeSpec, err)
 	}
 	uniqueVolumeName, err := volumeutil.GetUniqueVolumeNameFromSpec(plugin, volumeSpec)
-	if err != nil || plugin == nil {
+	if err != nil || uniqueVolumeName == "" {
 		t.Fatalf("Failed to get uniqueVolumeName from spec %v, %v", volumeSpec, err)
 	}
 	generatedVolumeName1, add1Err := asw.AddVolumeNode(logger, uniqueVolumeName, volumeSpec, node1Name, devicePath1, true)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

There are some cases under `pkg/controller` where the findings from running the `nilness` tool are pretty straight-forward:

```bash
go install golang.org/x/tools/go/analysis/passes/nilness@latest
go vet -vettool $(which nilness) ./...
```

I think there is a bit of typos as a result of copy-paste, an `if`-branch that's dead.

#### What this PR does / why we need it:

Just general clean-up. I did already find one typo with `nilness` under `kubelet`. It's a powerful tool.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

I can split up the findings into multiple PRs if desired. I'm not really sure if I span too many SIGs.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
