### PR TITLE
Enable declarative validation for apps -- Deployment Spec

### DIFF
--- a/pkg/apis/apps/v1/zz_generated.validations.go
+++ b/pkg/apis/apps/v1/zz_generated.validations.go
@@ -282,6 +282,7 @@ func Validate_Deployment(
 			fldPath *field.Path,
 			obj, oldObj *appsv1.DeploymentSpec,
 			oldValueCorrelated bool) (errs field.ErrorList) {
+			// +k8s:required on non-pointer struct fields is purely documentation
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
 				if validate.SemanticDeepEqual(obj, oldObj) {
@@ -310,7 +311,39 @@ func Validate_DeploymentSpec(
 	obj, oldObj *appsv1.DeploymentSpec) (errs field.ErrorList) {
 
 	// field appsv1.DeploymentSpec.Replicas has no validation
-	// field appsv1.DeploymentSpec.Selector has no validation
+
+	{ // field appsv1.DeploymentSpec.Selector
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *metav1.LabelSelector,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if validate.SemanticDeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *appsv1.DeploymentSpec) *metav1.LabelSelector {
+				return oldObj.Selector
+			})
+		errs = append(errs, fn(fldPath.Child("selector"), obj.Selector, oldVal, oldObj != nil)...)
+	}
 
 	{ // field appsv1.DeploymentSpec.Template
 		fn := func(

--- a/pkg/apis/apps/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.validations.go
@@ -175,6 +175,7 @@ func Validate_Deployment(
 			fldPath *field.Path,
 			obj, oldObj *appsv1beta1.DeploymentSpec,
 			oldValueCorrelated bool) (errs field.ErrorList) {
+			// +k8s:required on non-pointer struct fields is purely documentation
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
 				if validate.SemanticDeepEqual(obj, oldObj) {
@@ -203,7 +204,39 @@ func Validate_DeploymentSpec(
 	obj, oldObj *appsv1beta1.DeploymentSpec) (errs field.ErrorList) {
 
 	// field appsv1beta1.DeploymentSpec.Replicas has no validation
-	// field appsv1beta1.DeploymentSpec.Selector has no validation
+
+	{ // field appsv1beta1.DeploymentSpec.Selector
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *v1.LabelSelector,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if validate.SemanticDeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *appsv1beta1.DeploymentSpec) *v1.LabelSelector {
+				return oldObj.Selector
+			})
+		errs = append(errs, fn(fldPath.Child("selector"), obj.Selector, oldVal, oldObj != nil)...)
+	}
 
 	{ // field appsv1beta1.DeploymentSpec.Template
 		fn := func(

--- a/pkg/apis/apps/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.validations.go
@@ -297,6 +297,7 @@ func Validate_Deployment(
 			fldPath *field.Path,
 			obj, oldObj *appsv1beta2.DeploymentSpec,
 			oldValueCorrelated bool) (errs field.ErrorList) {
+			// +k8s:required on non-pointer struct fields is purely documentation
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
 				if validate.SemanticDeepEqual(obj, oldObj) {
@@ -325,7 +326,39 @@ func Validate_DeploymentSpec(
 	obj, oldObj *appsv1beta2.DeploymentSpec) (errs field.ErrorList) {
 
 	// field appsv1beta2.DeploymentSpec.Replicas has no validation
-	// field appsv1beta2.DeploymentSpec.Selector has no validation
+
+	{ // field appsv1beta2.DeploymentSpec.Selector
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *v1.LabelSelector,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if validate.SemanticDeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *appsv1beta2.DeploymentSpec) *v1.LabelSelector {
+				return oldObj.Selector
+			})
+		errs = append(errs, fn(fldPath.Child("selector"), obj.Selector, oldVal, oldObj != nil)...)
+	}
 
 	{ // field appsv1beta2.DeploymentSpec.Template
 		fn := func(

--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -635,7 +635,7 @@ func ValidateDeploymentSpec(spec, oldSpec *apps.DeploymentSpec, fldPath *field.P
 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(spec.Replicas), fldPath.Child("replicas"))...)
 
 	if spec.Selector == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("selector"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("selector"), "")).MarkCoveredByDeclarative()
 	} else {
 		// validate selector strictly, spec.selector was always required to pass LabelSelectorAsSelector below
 		allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(spec.Selector, unversionedvalidation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: false}, fldPath.Child("selector"))...)
@@ -704,7 +704,7 @@ func ValidateDeploymentStatus(status *apps.DeploymentStatus, fldPath *field.Path
 func ValidateDeploymentUpdate(update, old *apps.Deployment, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMetaUpdate(&update.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateDeploymentSpec(&update.Spec, &old.Spec, field.NewPath("spec"), opts)...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(update.Spec.Selector, old.Spec.Selector, field.NewPath("spec").Child("selector"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(update.Spec.Selector, old.Spec.Selector, field.NewPath("spec").Child("selector"))...).MarkCoveredByDeclarative()
 	return allErrs
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -9803,7 +9803,7 @@ func schema_k8sio_api_apps_v1beta1_DeploymentSpec(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				Required: []string{"template"},
+				Required: []string{"selector", "template"},
 			},
 		},
 		Dependencies: []string{
@@ -35728,6 +35728,7 @@ func schema_k8sio_api_extensions_v1beta1_Deployment(ref common.ReferenceCallback
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -35977,7 +35978,7 @@ func schema_k8sio_api_extensions_v1beta1_DeploymentSpec(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"template"},
+				Required: []string{"selector", "template"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/apps/v1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1/generated.proto
@@ -238,6 +238,7 @@ message Deployment {
 
   // Specification of the desired behavior of the Deployment.
   // +required
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional DeploymentSpec spec = 2;
 
   // Most recently observed status of the Deployment.
@@ -293,6 +294,8 @@ message DeploymentSpec {
   // selected by this will be the ones affected by this deployment.
   // It must match the pod template's labels.
   // +required
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template describes the pods that will be created.

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -405,6 +405,7 @@ type Deployment struct {
 
 	// Specification of the desired behavior of the Deployment.
 	// +required
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Spec DeploymentSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// Most recently observed status of the Deployment.
@@ -423,6 +424,8 @@ type DeploymentSpec struct {
 	// selected by this will be the ones affected by this deployment.
 	// It must match the pod template's labels.
 	// +required
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Selector *metav1.LabelSelector `json:"selector" protobuf:"bytes,2,opt,name=selector"`
 
 	// Template describes the pods that will be created.

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -78,6 +78,7 @@ message Deployment {
 
   // Specification of the desired behavior of the Deployment.
   // +required
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional DeploymentSpec spec = 2;
 
   // Most recently observed status of the Deployment.
@@ -147,7 +148,9 @@ message DeploymentSpec {
 
   // selector is the label selector for pods. Existing ReplicaSets whose pods are
   // selected by this will be the ones affected by this deployment.
-  // +optional
+  // +required
+  // +k8s:alpha(since: "1.37")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template describes the pods that will be created.

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -437,6 +437,7 @@ type Deployment struct {
 
 	// Specification of the desired behavior of the Deployment.
 	// +required
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Spec DeploymentSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// Most recently observed status of the Deployment.
@@ -453,7 +454,9 @@ type DeploymentSpec struct {
 
 	// selector is the label selector for pods. Existing ReplicaSets whose pods are
 	// selected by this will be the ones affected by this deployment.
-	// +optional
+	// +required
+	// +k8s:alpha(since: "1.37")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,2,opt,name=selector"`
 
 	// Template describes the pods that will be created.

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -243,6 +243,7 @@ message Deployment {
 
   // Specification of the desired behavior of the Deployment.
   // +required
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional DeploymentSpec spec = 2;
 
   // Most recently observed status of the Deployment.
@@ -298,6 +299,8 @@ message DeploymentSpec {
   // selected by this will be the ones affected by this deployment.
   // It must match the pod template's labels.
   // +required
+  // +k8s:alpha(since: "1.37")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template describes the pods that will be created.

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -445,6 +445,7 @@ type Deployment struct {
 
 	// Specification of the desired behavior of the Deployment.
 	// +required
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Spec DeploymentSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// Most recently observed status of the Deployment.
@@ -463,6 +464,8 @@ type DeploymentSpec struct {
 	// selected by this will be the ones affected by this deployment.
 	// It must match the pod template's labels.
 	// +required
+	// +k8s:alpha(since: "1.37")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	Selector *metav1.LabelSelector `json:"selector" protobuf:"bytes,2,opt,name=selector"`
 
 	// Template describes the pods that will be created.

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -209,7 +209,8 @@ message Deployment {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the specification of the desired behavior of the Deployment.
-  // +optional
+  // +required
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional DeploymentSpec spec = 2;
 
   // status is the most recently observed status of the Deployment.
@@ -271,7 +272,9 @@ message DeploymentSpec {
 
   // selector is the label selector for pods. Existing ReplicaSets whose pods are
   // selected by this will be the ones affected by this deployment.
-  // +optional
+  // +required
+  // +k8s:alpha(since: "1.37")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // template describes the pods that will be created.

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -96,7 +96,8 @@ type Deployment struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec is the specification of the desired behavior of the Deployment.
-	// +optional
+	// +required
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Spec DeploymentSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is the most recently observed status of the Deployment.
@@ -113,7 +114,9 @@ type DeploymentSpec struct {
 
 	// selector is the label selector for pods. Existing ReplicaSets whose pods are
 	// selected by this will be the ones affected by this deployment.
-	// +optional
+	// +required
+	// +k8s:alpha(since: "1.37")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,2,opt,name=selector"`
 
 	// template describes the pods that will be created.

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.selector": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+				{ErrorType: "FieldValueRequired"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.selector": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+				{ErrorType: "FieldValueRequired"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.selector": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+				{ErrorType: "FieldValueRequired"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
This PR enables the declarative validation migration for the network API group and migrates
Deployment.Spec 

Which issue(s) this PR is related to:
relates to https://github.com/kubernetes/kubernetes/issues/136785

NONE