### PR TITLE
Automated cherry pick of #134754: Use fast policy refresh interval for TestParamRef

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -360,6 +360,7 @@ func setupTestCommon(
 	matcher generic.PolicyMatcher,
 	shouldStartInformers bool,
 ) *generic.PolicyTestContext[*validating.Policy, *validating.PolicyBinding, validating.Validator] {
+	t.Cleanup(generic.SetPolicyRefreshIntervalForTests(10 * time.Millisecond))
 	testContext, testContextCancel, err := generic.NewPolicyTestContext(
 		t,
 		validating.NewValidatingAdmissionPolicyAccessor,
@@ -1508,7 +1509,6 @@ func TestParamRef(t *testing.T) {
 						}
 
 						t.Run(name, func(t *testing.T) {
-							t.Parallel()
 							// Test creating a policy with a cluster or namesapce-scoped param
 							// and binding with the provided configuration. Test will ensure
 							// that the provided configuration is capable of matching


### PR DESCRIPTION
Cherry pick of #134754 on release-1.34.

#134754: Use fast policy refresh interval for TestParamRef

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```