### PR TITLE
StatefulSet: Fix OnDelete strategy not updating CurrentRevision

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -816,8 +816,8 @@ func (ssc *defaultStatefulSetControl) updateStatefulSetStatus(
 	ctx context.Context,
 	set *apps.StatefulSet,
 	status *apps.StatefulSetStatus) error {
-	// complete any in progress rolling update if necessary
-	completeRollingUpdate(set, status)
+	// complete any in progress update if necessary
+	completeUpdate(set, status)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) {
 		// Update metrics - this ensures metrics are always updated regardless of update strategy

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -1543,6 +1543,10 @@ func TestStatefulSetControlOnDeleteUpdate(t *testing.T) {
 		if err := test.validateRestart(set, pods); err != nil {
 			t.Fatalf("%s: %s", test.name, err)
 		}
+		if set.Status.CurrentRevision != set.Status.UpdateRevision {
+			t.Fatalf("%s: after OnDelete update completes, CurrentRevision %s should equal UpdateRevision %s",
+				test.name, set.Status.CurrentRevision, set.Status.UpdateRevision)
+		}
 	}
 
 	tests := []testcase{

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -632,13 +632,11 @@ func inconsistentStatus(set *apps.StatefulSet, status *apps.StatefulSetStatus) b
 		status.UpdateRevision != set.Status.UpdateRevision
 }
 
-// completeRollingUpdate completes a rolling update when all of set's replica Pods have been updated
-// to the updateRevision. status's currentRevision is set to updateRevision and its' updateRevision
-// is set to the empty string. status's currentReplicas is set to updateReplicas and its updateReplicas
-// are set to 0.
-func completeRollingUpdate(set *apps.StatefulSet, status *apps.StatefulSetStatus) {
-	if set.Spec.UpdateStrategy.Type == apps.RollingUpdateStatefulSetStrategyType &&
-		status.UpdatedReplicas == *set.Spec.Replicas &&
+// completeUpdate completes an update when all of set's replica Pods have been updated
+// to the updateRevision. status's currentRevision is set to updateRevision and status's
+// currentReplicas is set to updateReplicas.
+func completeUpdate(set *apps.StatefulSet, status *apps.StatefulSetStatus) {
+	if status.UpdatedReplicas == *set.Spec.Replicas &&
 		status.ReadyReplicas == *set.Spec.Replicas &&
 		status.Replicas == *set.Spec.Replicas {
 		status.CurrentReplicas = status.UpdatedReplicas

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -1925,10 +1925,8 @@ func TestCompleteUpdate(t *testing.T) {
 				if status.CurrentReplicas != tc.updatedReplicas {
 					t.Errorf("expected CurrentReplicas to be %d, got %d", tc.updatedReplicas, status.CurrentReplicas)
 				}
-			} else {
-				if status.CurrentRevision != tc.currentRevision {
-					t.Errorf("expected CurrentRevision to remain %q, got %q", tc.currentRevision, status.CurrentRevision)
-				}
+			} else if status.CurrentRevision != tc.currentRevision {
+				t.Errorf("expected CurrentRevision to remain %q, got %q", tc.currentRevision, status.CurrentRevision)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When a StatefulSet uses the `OnDelete` update strategy, `Status.CurrentRevision`
is never promoted to match `Status.UpdateRevision` after all pods have been
manually deleted and recreated with the new revision.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/73492, Fixes https://github.com/kubernetes/kubernetes/issues/106055
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This is a 6+ year old bug with 30+ thumbs-up. Two prior PRs (#106059, #122272) attempted a more complex fix involving a `getCurrentRevision()` function for tracking intermediate revisions during partial OnDelete updates. Both stalled during review.

This PR takes a minimal approach: just one-line change of condition removal that fixes the core bug. 

The multi-revision intermediate tracking issue mentioned above is actually an enhancement for follow-up PR, not for this bug fix.

During reviewing previous PRs,  @atiratree identified an issue of the graduated `StatefulSetMinReadySeconds` feature. I fired an issue to track that separately https://github.com/kubernetes/kubernetes/issues/136831.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where StatefulSet with OnDelete update strategy never updated
Status.CurrentRevision to match Status.UpdateRevision after all pods were
recreated with the new revision.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
