### PR TITLE
WIP: Use notifications to avoid polling delays in volumemanager

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1112,6 +1112,8 @@ func kubeClientConfigOverrides(s *options.KubeletServer, clientConfig *restclien
 	// Override kubeconfig qps/burst settings from flags
 	clientConfig.QPS = float32(s.KubeAPIQPS)
 	clientConfig.Burst = int(s.KubeAPIBurst)
+
+	klog.Infof("client QPS set to %v, client Burst set to %d, content type set to %s", clientConfig.QPS, clientConfig.Burst, clientConfig.ContentType)
 }
 
 // InitializeTLS checks for a configured TLSCertFile and TLSPrivateKeyFile: if unspecified a new self-signed

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -193,10 +193,10 @@ type ActualStateOfWorld interface {
 	// UpdateReconstructedVolumeAttachability updates volume attachability from the API server.
 	UpdateReconstructedVolumeAttachability(volumeName v1.UniqueVolumeName, volumeAttachable bool)
 
-	// SetVolumeStateChangedNotify sets a callback that is invoked whenever
-	// a volume mount or unmount state changes (e.g. AddPodToVolume or
-	// DeletePodFromVolume). The callback must be non-blocking.
-	SetVolumeStateChangedNotify(fn func())
+	// SetStateChangedNotify sets a callback that is invoked whenever
+	// the externally visible state changes.
+	// The callback must be non-blocking.
+	SetStateChangedNotify(fn func())
 }
 
 // MountedVolume represents a volume that has successfully been mounted to a pod.
@@ -271,9 +271,13 @@ type actualStateOfWorld struct {
 	// volumePluginMgr is the volume plugin manager used to create volume
 	// plugin objects.
 	volumePluginMgr *volume.VolumePluginMgr
-	// onVolumeStateChanged is an optional callback invoked when a volume
-	// mount or unmount state changes. It must be non-blocking.
-	onVolumeStateChanged func()
+
+	// onStateChanged is an optional callback invoked when this struct changes.
+	// This is used to move from polling to event-driven updates in the kubelet volume manager.
+	// It must be non-blocking.
+	onStateChanged func()
+
+	// RWMutex protects access to the fields of this struct.
 	sync.RWMutex
 }
 
@@ -420,6 +424,7 @@ func (asw *actualStateOfWorld) MarkVolumeExpansionFailedWithFinalError(volumeNam
 	defer asw.Unlock()
 
 	asw.volumesWithFinalExpansionErrors.Insert(volumeName)
+	asw.broadcastStateChanged()
 }
 
 func (asw *actualStateOfWorld) RemoveVolumeFromFailedWithFinalErrors(volumeName v1.UniqueVolumeName) {
@@ -427,6 +432,7 @@ func (asw *actualStateOfWorld) RemoveVolumeFromFailedWithFinalErrors(volumeName 
 	defer asw.Unlock()
 
 	asw.volumesWithFinalExpansionErrors.Delete(volumeName)
+	asw.broadcastStateChanged()
 }
 
 func (asw *actualStateOfWorld) CheckVolumeInFailedExpansionWithFinalErrors(volumeName v1.UniqueVolumeName) bool {
@@ -514,6 +520,9 @@ func (asw *actualStateOfWorld) CheckAndMarkVolumeAsUncertainViaReconstruction(op
 	}
 	podMap[opts.PodName] = opts.PodUID
 	asw.foundDuringReconstruction[opts.VolumeName] = podMap
+
+	asw.broadcastStateChanged()
+
 	return true, nil
 }
 
@@ -533,14 +542,30 @@ func (asw *actualStateOfWorld) CheckAndMarkDeviceUncertainViaReconstruction(volu
 	// determined from node object.
 	volumeObj.deviceMountPath = deviceMountPath
 	asw.attachedVolumes[volumeName] = volumeObj
+
+	asw.broadcastStateChanged()
+
 	return true
 
 }
 
-func (asw *actualStateOfWorld) SetVolumeStateChangedNotify(fn func()) {
+// broadcastStateChanged calls the callback function if it is set.
+// This should be called with the lock held (presumably a write lock, because we should not be writing while only holding the read lock).
+func (asw *actualStateOfWorld) broadcastStateChanged() {
+	if asw.onStateChanged != nil {
+		asw.onStateChanged()
+	}
+}
+
+func (asw *actualStateOfWorld) SetStateChangedNotify(fn func()) {
 	asw.Lock()
 	defer asw.Unlock()
-	asw.onVolumeStateChanged = fn
+	if asw.onStateChanged != nil {
+		// We could support a list of callbacks, but we don't need it today.
+		// It's better to know if we have a bug with multiple "watchers" here.
+		panic("Volume state changed callback is already set")
+	}
+	asw.onStateChanged = fn
 }
 
 func (asw *actualStateOfWorld) MarkVolumeAsMounted(markVolumeOpts operationexecutor.MarkVolumeOpts) error {
@@ -597,6 +622,8 @@ func (asw *actualStateOfWorld) UpdateReconstructedDevicePath(volumeName v1.Uniqu
 
 	volumeObj.devicePath = devicePath
 	asw.attachedVolumes[volumeName] = volumeObj
+
+	asw.broadcastStateChanged()
 }
 
 func (asw *actualStateOfWorld) UpdateReconstructedVolumeAttachability(volumeName v1.UniqueVolumeName, attachable bool) {
@@ -619,6 +646,8 @@ func (asw *actualStateOfWorld) UpdateReconstructedVolumeAttachability(volumeName
 		volumeObj.pluginIsAttachable = volumeAttachabilityFalse
 	}
 	asw.attachedVolumes[volumeName] = volumeObj
+
+	asw.broadcastStateChanged()
 }
 
 func (asw *actualStateOfWorld) GetDeviceMountState(volumeName v1.UniqueVolumeName) operationexecutor.DeviceMountState {
@@ -642,6 +671,8 @@ func (asw *actualStateOfWorld) MarkForInUseExpansionError(volumeName v1.UniqueVo
 		volumeObj.volumeInUseErrorForExpansion = true
 		asw.attachedVolumes[volumeName] = volumeObj
 	}
+
+	asw.broadcastStateChanged()
 }
 
 func (asw *actualStateOfWorld) GetVolumeMountState(volumeName v1.UniqueVolumeName, podName volumetypes.UniquePodName) operationexecutor.VolumeMountState {
@@ -728,6 +759,8 @@ func (asw *actualStateOfWorld) addVolume(logger klog.Logger,
 	}
 	asw.attachedVolumes[volumeName] = volumeObj
 
+	asw.broadcastStateChanged()
+
 	return nil
 }
 
@@ -795,9 +828,8 @@ func (asw *actualStateOfWorld) AddPodToVolume(markVolumeOpts operationexecutor.M
 		}
 	}
 
-	if asw.onVolumeStateChanged != nil {
-		asw.onVolumeStateChanged()
-	}
+	asw.broadcastStateChanged()
+
 	return nil
 }
 
@@ -809,6 +841,9 @@ func (asw *actualStateOfWorld) MarkVolumeAsResized(volumeName v1.UniqueVolumeNam
 	if ok {
 		volumeObj.persistentVolumeSize = claimSize
 		asw.attachedVolumes[volumeName] = volumeObj
+
+		asw.broadcastStateChanged()
+
 		return true
 	}
 	return false
@@ -835,6 +870,8 @@ func (asw *actualStateOfWorld) MarkRemountRequired(
 			}
 		}
 	}
+
+	asw.broadcastStateChanged()
 }
 
 func (asw *actualStateOfWorld) SetDeviceMountState(
@@ -861,6 +898,9 @@ func (asw *actualStateOfWorld) SetDeviceMountState(
 	}
 
 	asw.attachedVolumes[volumeName] = volumeObj
+
+	asw.broadcastStateChanged()
+
 	return nil
 }
 
@@ -875,6 +915,8 @@ func (asw *actualStateOfWorld) InitializeClaimSize(logger klog.Logger, volumeNam
 		volumeObj.persistentVolumeSize = claimSize
 		asw.attachedVolumes[volumeName] = volumeObj
 	}
+
+	asw.broadcastStateChanged()
 }
 
 func (asw *actualStateOfWorld) GetClaimSize(volumeName v1.UniqueVolumeName) resource.Quantity {
@@ -911,9 +953,8 @@ func (asw *actualStateOfWorld) DeletePodFromVolume(
 		delete(asw.foundDuringReconstruction[volumeName], podName)
 	}
 
-	if asw.onVolumeStateChanged != nil {
-		asw.onVolumeStateChanged()
-	}
+	asw.broadcastStateChanged()
+
 	return nil
 }
 
@@ -935,6 +976,9 @@ func (asw *actualStateOfWorld) DeleteVolume(volumeName v1.UniqueVolumeName) erro
 
 	delete(asw.attachedVolumes, volumeName)
 	delete(asw.foundDuringReconstruction, volumeName)
+
+	asw.broadcastStateChanged()
+
 	return nil
 }
 

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -140,10 +140,9 @@ type DesiredStateOfWorld interface {
 	// if necessary
 	UpdatePersistentVolumeSize(volumeName v1.UniqueVolumeName, size resource.Quantity)
 
-	// SetVolumeAddedNotify sets a callback that is invoked whenever a new
-	// pod-volume pair is added via AddPodToVolume. The callback must be
-	// non-blocking.
-	SetVolumeAddedNotify(fn func())
+	// SetStateChangedNotify sets a callback that is invoked whenever the state changes.
+	// The callback must be non-blocking.
+	SetStateChangedNotify(fn func())
 }
 
 // VolumeToMount represents a volume that is attached to this node and needs to
@@ -178,9 +177,11 @@ type desiredStateOfWorld struct {
 	podErrors map[types.UniquePodName]sets.Set[string]
 	// seLinuxTranslator translates v1.SELinuxOptions to a file SELinux label.
 	seLinuxTranslator util.SELinuxLabelTranslator
-	// onVolumeAdded is an optional callback invoked when a new pod-volume
-	// pair is added. It must be non-blocking.
-	onVolumeAdded func()
+
+	// onStateChanged is an optional callback invoked when this struct changes.
+	// This is used to move from polling to event-driven updates in the kubelet volume manager.
+	// It must be non-blocking.
+	onStateChanged func()
 
 	sync.RWMutex
 }
@@ -276,6 +277,7 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 	seLinuxContainerContexts []*v1.SELinuxOptions) (v1.UniqueVolumeName, error) {
 	dsw.Lock()
 	defer dsw.Unlock()
+	defer dsw.broadcastStateChanged()
 
 	volumePlugin, err := dsw.volumePluginMgr.FindPluginBySpec(volumeSpec)
 	if err != nil || volumePlugin == nil {
@@ -407,9 +409,7 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 		outerVolumeSpecNames: outerVolumeSpecNames,
 		mountRequestTime:     mountRequestTime,
 	}
-	if dsw.onVolumeAdded != nil {
-		dsw.onVolumeAdded()
-	}
+
 	return volumeName, nil
 }
 
@@ -447,16 +447,30 @@ func (dsw *desiredStateOfWorld) getSELinuxLabel(logger klog.Logger, volumeSpec *
 	return labelInfo.SELinuxMountLabel, labelInfo.PluginSupportsSELinuxContextMount, nil
 }
 
-func (dsw *desiredStateOfWorld) SetVolumeAddedNotify(fn func()) {
+// broadcastStateChanged calls the callback function if it is set.
+// This should be called with the lock held (presumably a write lock, because we should not be writing while only holding the read lock).
+func (dsw *desiredStateOfWorld) broadcastStateChanged() {
+	if dsw.onStateChanged != nil {
+		dsw.onStateChanged()
+	}
+}
+
+func (dsw *desiredStateOfWorld) SetStateChangedNotify(fn func()) {
 	dsw.Lock()
 	defer dsw.Unlock()
-	dsw.onVolumeAdded = fn
+	if dsw.onStateChanged != nil {
+		// We could support a list of callbacks, but we don't need it today.
+		// It's better to know if we have a bug with multiple "watchers" here.
+		panic("Volume state changed callback is already set")
+	}
+	dsw.onStateChanged = fn
 }
 
 func (dsw *desiredStateOfWorld) MarkVolumesReportedInUse(
 	reportedVolumes []v1.UniqueVolumeName) {
 	dsw.Lock()
 	defer dsw.Unlock()
+	defer dsw.broadcastStateChanged()
 
 	reportedVolumesMap := make(
 		map[v1.UniqueVolumeName]bool, len(reportedVolumes) /* capacity */)
@@ -476,6 +490,7 @@ func (dsw *desiredStateOfWorld) DeletePodFromVolume(
 	podName types.UniquePodName, volumeName v1.UniqueVolumeName) {
 	dsw.Lock()
 	defer dsw.Unlock()
+	defer dsw.broadcastStateChanged()
 
 	delete(dsw.podErrors, podName)
 
@@ -502,6 +517,7 @@ func (dsw *desiredStateOfWorld) DeletePodFromVolume(
 func (dsw *desiredStateOfWorld) UpdatePersistentVolumeSize(volumeName v1.UniqueVolumeName, size resource.Quantity) {
 	dsw.Lock()
 	defer dsw.Unlock()
+	defer dsw.broadcastStateChanged()
 
 	vol, volExists := dsw.volumesToMount[volumeName]
 	if volExists {
@@ -635,6 +651,7 @@ func (dsw *desiredStateOfWorld) GetVolumesToMount() []VolumeToMount {
 func (dsw *desiredStateOfWorld) AddErrorToPod(podName types.UniquePodName, err string) {
 	dsw.Lock()
 	defer dsw.Unlock()
+	defer dsw.broadcastStateChanged()
 
 	if errs, found := dsw.podErrors[podName]; found {
 		if errs.Len() <= maxPodErrors {
@@ -648,6 +665,7 @@ func (dsw *desiredStateOfWorld) AddErrorToPod(podName types.UniquePodName, err s
 func (dsw *desiredStateOfWorld) PopPodErrors(podName types.UniquePodName) []string {
 	dsw.Lock()
 	defer dsw.Unlock()
+	defer dsw.broadcastStateChanged()
 
 	if errs, found := dsw.podErrors[podName]; found {
 		delete(dsw.podErrors, podName)
@@ -670,6 +688,8 @@ func (dsw *desiredStateOfWorld) GetPodsWithErrors() []types.UniquePodName {
 func (dsw *desiredStateOfWorld) MarkVolumeAttachability(volumeName v1.UniqueVolumeName, attachable bool) {
 	dsw.Lock()
 	defer dsw.Unlock()
+	defer dsw.broadcastStateChanged()
+
 	volumeObj, volumeExists := dsw.volumesToMount[volumeName]
 	if !volumeExists {
 		return

--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -27,13 +27,14 @@ func (rc *reconciler) Run(ctx context.Context, stopCh <-chan struct{}) {
 	logger := klog.FromContext(ctx)
 	rc.reconstructVolumes(logger)
 	logger.Info("Reconciler: start to sync state")
+
 	for {
 		rc.reconcile(ctx)
 		select {
 		case <-stopCh:
 			return
-		case <-rc.pokeCh:
-			// Woken up early because new work arrived.
+		case <-rc.wakeUpCh:
+			// Woken up early: either new work arrived in DSW or an operation completed.
 		case <-time.After(rc.loopSleepDuration):
 		}
 	}

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_common.go
@@ -56,10 +56,10 @@ type Reconciler interface {
 	// states at least once after kubelet starts
 	StatesHasBeenSynced() bool
 
-	// Poke wakes up the reconciler loop to process any pending changes
+	// WakeUp wakes up the reconciler loop to process any pending changes
 	// immediately, rather than waiting for the next periodic tick.
 	// This is safe to call from any goroutine and is non-blocking.
-	Poke()
+	WakeUp()
 }
 
 // NewReconciler returns a new instance of Reconciler.
@@ -122,7 +122,7 @@ func NewReconciler(
 		skippedDuringReconstruction:     map[v1.UniqueVolumeName]*globalVolumeInfo{},
 		volumePluginMgr:                 volumePluginMgr,
 		kubeletPodsDir:                  kubeletPodsDir,
-		pokeCh:                          make(chan struct{}, 1),
+		wakeUpCh:                        make(chan struct{}, 1),
 		timeOfLastSync:                  time.Time{},
 		volumesFailedReconstruction:     make([]podVolume, 0),
 		volumesNeedUpdateFromNodeStatus: make([]v1.UniqueVolumeName, 0),
@@ -144,10 +144,10 @@ type reconciler struct {
 	volumePluginMgr               *volumepkg.VolumePluginMgr
 	skippedDuringReconstruction   map[v1.UniqueVolumeName]*globalVolumeInfo
 	kubeletPodsDir                string
-	// pokeCh is a buffered channel (capacity 1) used to wake up the
+	// wakeUpCh is a buffered channel (capacity 1) used to wake up the
 	// reconciler loop immediately when there is new work, rather than
 	// waiting for the next periodic tick.
-	pokeCh chan struct{}
+	wakeUpCh chan struct{}
 	// lock protects timeOfLastSync for updating and checking
 	timeOfLastSyncLock              sync.Mutex
 	timeOfLastSync                  time.Time
@@ -155,9 +155,9 @@ type reconciler struct {
 	volumesNeedUpdateFromNodeStatus []v1.UniqueVolumeName
 }
 
-func (rc *reconciler) Poke() {
+func (rc *reconciler) WakeUp() {
 	select {
-	case rc.pokeCh <- struct{}{}:
+	case rc.wakeUpCh <- struct{}{}:
 	default:
 	}
 }

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -240,12 +240,17 @@ func NewVolumeManager(
 
 	// When a new volume is added to the desired state, immediately wake the
 	// reconciler so it can start the mount without waiting for the next tick.
-	vm.desiredStateOfWorld.SetVolumeAddedNotify(vm.reconciler.Poke)
+	vm.desiredStateOfWorld.SetStateChangedNotify(vm.reconciler.WakeUp)
+
+	// When any volume operation (attach, mount, etc.) completes, immediately
+	// wake the reconciler to chain the next operation without waiting for the
+	// next tick.
+	vm.operationExecutor.SetOperationCompletionCallback(vm.reconciler.WakeUp)
 
 	// When a volume mount/unmount completes, broadcast to all goroutines
 	// waiting in WaitForAttachAndMount / WaitForUnmount so they can return
 	// immediately instead of waiting for the next poll tick.
-	vm.actualStateOfWorld.SetVolumeStateChangedNotify(vm.notifyVolumeStateChange)
+	vm.actualStateOfWorld.SetStateChangedNotify(vm.onActualStateOfWorldChange)
 
 	return vm
 }
@@ -413,19 +418,19 @@ func (vm *volumeManager) MarkVolumesAsReportedInUse(
 	vm.desiredStateOfWorld.MarkVolumesReportedInUse(volumesReportedAsInUse)
 }
 
-// waitForVolumeStateChange returns a channel that will be closed the next
-// time the actual state of world changes (volume mounted/unmounted). Callers
-// should get this channel BEFORE checking any condition to avoid missing
+// actualStateOfWorldChanges returns a channel that will be closed the next
+// time the actual state of world changes.
+// Callers should get this channel BEFORE checking any condition to avoid missing
 // changes that occur between the check and the wait.
-func (vm *volumeManager) waitForVolumeStateChange() <-chan struct{} {
+func (vm *volumeManager) actualStateOfWorldChanges() <-chan struct{} {
 	vm.volumeStateMu.Lock()
 	defer vm.volumeStateMu.Unlock()
 	return vm.volumeStateCh
 }
 
-// notifyVolumeStateChange broadcasts to all goroutines waiting on a volume
+// onActualStateOfWorldChange broadcasts to all goroutines waiting on a volume
 // state change by closing the current channel and creating a new one.
-func (vm *volumeManager) notifyVolumeStateChange() {
+func (vm *volumeManager) onActualStateOfWorldChange() {
 	vm.volumeStateMu.Lock()
 	defer vm.volumeStateMu.Unlock()
 	close(vm.volumeStateCh)
@@ -448,7 +453,7 @@ func (vm *volumeManager) waitForConditionWithNotification(
 	for {
 		// Get notification channel BEFORE checking condition to avoid
 		// missing state changes between check and wait.
-		ch := vm.waitForVolumeStateChange()
+		actualStateOfWorldChanges := vm.actualStateOfWorldChanges()
 
 		done, err := condition(deadlineCtx)
 		if err != nil {
@@ -461,8 +466,8 @@ func (vm *volumeManager) waitForConditionWithNotification(
 		select {
 		case <-deadlineCtx.Done():
 			return deadlineCtx.Err()
-		case <-ch:
-			// Volume state changed, re-check immediately.
+		case <-actualStateOfWorldChanges:
+			// ASW changed, re-check immediately.
 		case <-time.After(interval):
 			// Fallback poll for non-ASW state changes (e.g. DSW errors).
 		}

--- a/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go
+++ b/pkg/volume/util/nestedpendingoperations/nestedpendingoperations.go
@@ -50,6 +50,11 @@ const (
 // NestedPendingOperations defines the supported set of operations.
 type NestedPendingOperations interface {
 
+	// SetOperationCompletionCallback registers a callback that is invoked whenever an operation
+	// completes (whether successfully or with an error). The callback must be
+	// non-blocking. It is called without any internal locks held.
+	SetOperationCompletionCallback(fn func())
+
 	// Run adds the concatenation of volumeName, podName, and nodeName to the list
 	// of running operations and spawns a new go routine to run
 	// generatedOperations.
@@ -130,6 +135,7 @@ type nestedPendingOperations struct {
 	exponentialBackOffOnError bool
 	cond                      *sync.Cond
 	lock                      sync.RWMutex
+	onOperationCompletion     func()
 }
 
 type operation struct {
@@ -192,6 +198,22 @@ func (grm *nestedPendingOperations) Run(
 
 	return nil
 }
+
+// SetOperationCompletionCallback registers a callback that is invoked whenever an operation
+// completes (whether successfully or with an error). The callback must be
+// non-blocking.
+func (grm *nestedPendingOperations) SetOperationCompletionCallback(fn func()) {
+	grm.lock.Lock()
+	defer grm.lock.Unlock()
+
+	if grm.onOperationCompletion != nil {
+		// We could support a list of callbacks, but we don't need it today.
+		// It's better to know if we have a bug with multiple "watchers" here.
+		panic("AddOperationCompletionListener callback is already set")
+	}
+	grm.onOperationCompletion = fn
+}
+
 func (grm *nestedPendingOperations) IsOperationSafeToRetry(
 	volumeName v1.UniqueVolumeName,
 	podName volumetypes.UniquePodName,
@@ -328,25 +350,27 @@ func (grm *nestedPendingOperations) operationComplete(key operationKey, err *err
 			// Log error
 			klog.Errorf("operation %+v failed with: %v", key, *err)
 		}
-		return
+	} else {
+		// Operation completed with error and exponentialBackOffOnError Enabled
+		existingOpIndex, getOpErr := grm.getOperation(key)
+		if getOpErr != nil {
+			// Failed to find existing operation
+			klog.Errorf("Operation %+v completed. error: %v. exponentialBackOffOnError is enabled, but failed to get operation to update.",
+				key,
+				*err)
+		} else {
+			grm.operations[existingOpIndex].expBackoff.Update(err)
+			grm.operations[existingOpIndex].operationPending = false
+
+			// Log error
+			klog.Errorf("%v", grm.operations[existingOpIndex].expBackoff.
+				GenerateNoRetriesPermittedMsg(fmt.Sprintf("%+v", key)))
+		}
 	}
 
-	// Operation completed with error and exponentialBackOffOnError Enabled
-	existingOpIndex, getOpErr := grm.getOperation(key)
-	if getOpErr != nil {
-		// Failed to find existing operation
-		klog.Errorf("Operation %+v completed. error: %v. exponentialBackOffOnError is enabled, but failed to get operation to update.",
-			key,
-			*err)
-		return
+	if grm.onOperationCompletion != nil {
+		grm.onOperationCompletion()
 	}
-
-	grm.operations[existingOpIndex].expBackoff.Update(err)
-	grm.operations[existingOpIndex].operationPending = false
-
-	// Log error
-	klog.Errorf("%v", grm.operations[existingOpIndex].expBackoff.
-		GenerateNoRetriesPermittedMsg(fmt.Sprintf("%+v", key)))
 }
 
 func (grm *nestedPendingOperations) Wait() {

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -149,6 +149,10 @@ type OperationExecutor interface {
 	ExpandInUseVolume(volumeToMount VolumeToMount, actualStateOfWorld ActualStateOfWorldMounterUpdater, currentSize resource.Quantity) error
 	// ReconstructVolumeOperation construct a new volumeSpec and returns it created by plugin
 	ReconstructVolumeOperation(volumeMode v1.PersistentVolumeMode, plugin volume.VolumePlugin, mapperPlugin volume.BlockVolumePlugin, uid types.UID, podName volumetypes.UniquePodName, volumeSpecName string, volumePath string, pluginName string) (volume.ReconstructedVolume, error)
+
+	// SetOperationCompletionCallback registers a callback that is invoked whenever any
+	// pending operation completes. The callback must be non-blocking.
+	SetOperationCompletionCallback(fn func())
 }
 
 // NewOperationExecutor returns a new instance of OperationExecutor.
@@ -760,6 +764,10 @@ func (oe *operationExecutor) IsOperationSafeToRetry(
 	nodeName types.NodeName,
 	operationName string) bool {
 	return oe.pendingOperations.IsOperationSafeToRetry(volumeName, podName, nodeName, operationName)
+}
+
+func (oe *operationExecutor) SetOperationCompletionCallback(fn func()) {
+	oe.pendingOperations.SetOperationCompletionCallback(fn)
 }
 
 func (oe *operationExecutor) AttachVolume(

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -86,8 +87,9 @@ var _ = SIGDescribe("Density", framework.WithSerial(), framework.WithSlow(), fun
 		// "kubelet" 0.009 0.082 0.082 0.082 0.101
 		dTests := []densityTest{
 			{
-				podsNr:   10,
-				interval: 0 * time.Millisecond,
+				podsNr:      10,
+				interval:    0 * time.Millisecond,
+				APIQPSLimit: 1000,
 				cpuLimits: e2ekubelet.ContainersCPUSummary{
 					kubeletstatsv1alpha1.SystemContainerKubelet: {0.50: 0.1, 0.95: 0.20},
 					kubeletstatsv1alpha1.SystemContainerRuntime: {0.50: 0.1, 0.95: 1.5},
@@ -109,6 +111,13 @@ var _ = SIGDescribe("Density", framework.WithSerial(), framework.WithSlow(), fun
 
 		for _, testArg := range dTests {
 			itArg := testArg
+
+			tempSetCurrentKubeletConfig(f, func(ctx context.Context, cfg *kubeletconfig.KubeletConfiguration) {
+				framework.Logf("Old QPS limit is: %d", cfg.KubeAPIQPS)
+				// Set new API QPS limit
+				cfg.KubeAPIQPS = int32(itArg.APIQPSLimit)
+			})
+
 			desc := fmt.Sprintf("latency/resource should be within limit when create %d pods with %v interval", itArg.podsNr, itArg.interval)
 			ginkgo.It(desc, func(ctx context.Context) {
 				itArg.createMethod = "batch"
@@ -347,6 +356,15 @@ func runDensityBatchTest(ctx context.Context, f *framework.Framework, rc *Resour
 	// create test pod data structure
 	pods := newTestPods(testArg.podsNr, true, imageutils.GetPauseImageName(), podType)
 
+	// Make sure we set ImagePullPolicy to 'PullNever' for all containers, otherwise the pod creation may be delayed by pulling image.
+	// The Pause image should be present; if not, the test will fail with image pull error.
+	for _, pod := range pods {
+		for i := range pod.Spec.Containers {
+			container := &pod.Spec.Containers[i]
+			container.ImagePullPolicy = v1.PullNever
+		}
+	}
+
 	// the controller watches the change of pod status
 	controller := newInformerWatchPod(ctx, f, mutex, watchTimes, podType)
 	go controller.Run(stopCh)
@@ -456,7 +474,9 @@ func createBatchPodWithRateControl(ctx context.Context, f *framework.Framework, 
 	for i := range pods {
 		pod := pods[i]
 		createTimes[pod.ObjectMeta.Name] = metav1.Now()
-		go e2epod.NewPodClient(f).Create(ctx, pod)
+		klog.Infof("Pod %s before create", pod.Name)
+		e2epod.NewPodClient(f).Create(ctx, pod)
+		klog.Infof("Pod %s created", pod.Name)
 		time.Sleep(interval)
 	}
 	return createTimes
@@ -518,6 +538,7 @@ func newInformerWatchPod(ctx context.Context, f *framework.Framework, mutex *syn
 				if !ok {
 					framework.Failf("Failed to cast object %T to Pod", obj)
 				}
+				klog.Infof("Pod %s observed by the watch (created)", p.Name)
 				go checkPodRunning(p)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
@@ -525,6 +546,7 @@ func newInformerWatchPod(ctx context.Context, f *framework.Framework, mutex *syn
 				if !ok {
 					framework.Failf("Failed to cast object %T to Pod", newObj)
 				}
+				klog.Infof("Pod %s observed by the watch (update; state=%v)", p.Name, p.Status.Phase)
 				go checkPodRunning(p)
 			},
 		},


### PR DESCRIPTION
I noticed some delays here when setting up benchmarks in https://github.com/kubernetes-sigs/agent-sandbox

Opening the WIP PR to start the conversation, and because I may be able to plug in the PR into the agent-sandbox benchmarks once we get them more "real".

The agent-sandbox test basically is trying to look at how long it takes a pod to become ready.  I noticed a delay between the pod being scheduled and containerd being asked to start the pod, and by collecting kubelet and containerd verbose logs it looks like there's a 100 ms between volume attach and volume mount.  Looking at the code that makes sense.  This delay would be no big deal for real volumes, but I was only attaching a configmap and so I expect that to be very fast and the 100ms to dominate.

Further, I think all pods mount a configmap, because we mount the ca certificate configmap.

If this does indeed turn out to be a significant cause of delay in pod launch, I plan to create an issue, probably create a similar test to the agent-sandbox test that showed this etc.