### PR TITLE
api: enable optionalorrequired linter for extensions/v1beta1

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -227,7 +227,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -243,6 +243,11 @@ linters:
       # Validation makes this require at least one of the fields within to be set.
       - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate).SchedulingPolicy is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/scheduling/v1alpha2/types.go"
+      
+      # The HTTPIngressPath.Backend field is a union type, but is not marked up as a union, nor does nonpointerstructs understand unions today.
+      # Validation makes this require at least one of the fields within to be set.
+      - text: "nonpointerstructs: field HTTPIngressPath.Backend is a non-pointer struct with no required fields."
+        path: "staging/src/k8s.io/api/extensions/v1beta1/types.go"
 
       - linters:
         - forbidigo

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -242,7 +242,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -258,6 +258,11 @@ linters:
       # Validation makes this require at least one of the fields within to be set.
       - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate).SchedulingPolicy is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/scheduling/v1alpha2/types.go"
+      
+      # The HTTPIngressPath.Backend field is a union type, but is not marked up as a union, nor does nonpointerstructs understand unions today.
+      # Validation makes this require at least one of the fields within to be set.
+      - text: "nonpointerstructs: field HTTPIngressPath.Backend is a non-pointer struct with no required fields."
+        path: "staging/src/k8s.io/api/extensions/v1beta1/types.go"
 
       - linters:
         - forbidigo

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -103,7 +103,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|flowcontrol|networking|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -119,3 +119,8 @@
 # Validation makes this require at least one of the fields within to be set.
 - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate).SchedulingPolicy is a non-pointer struct with no required fields."
   path: "staging/src/k8s.io/api/scheduling/v1alpha2/types.go"
+
+# The HTTPIngressPath.Backend field is a union type, but is not marked up as a union, nor does nonpointerstructs understand unions today.
+# Validation makes this require at least one of the fields within to be set.
+- text: "nonpointerstructs: field HTTPIngressPath.Backend is a non-pointer struct with no required fields."
+  path: "staging/src/k8s.io/api/extensions/v1beta1/types.go"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -34822,7 +34822,6 @@ func schema_k8sio_api_extensions_v1beta1_DaemonSetSpec(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"template"},
 			},
 		},
 		Dependencies: []string{
@@ -34929,7 +34928,6 @@ func schema_k8sio_api_extensions_v1beta1_DaemonSetStatus(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"currentNumberScheduled", "numberMisscheduled", "desiredNumberScheduled", "numberReady"},
 			},
 		},
 		Dependencies: []string{
@@ -35177,7 +35175,7 @@ func schema_k8sio_api_extensions_v1beta1_DeploymentRollback(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"name", "rollbackTo"},
+				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{
@@ -35259,7 +35257,6 @@ func schema_k8sio_api_extensions_v1beta1_DeploymentSpec(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"template"},
 			},
 		},
 		Dependencies: []string{
@@ -35753,7 +35750,6 @@ func schema_k8sio_api_extensions_v1beta1_IngressPortStatus(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"port", "protocol"},
 			},
 		},
 	}
@@ -36278,7 +36274,6 @@ func schema_k8sio_api_extensions_v1beta1_NetworkPolicySpec(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"podSelector"},
 			},
 		},
 		Dependencies: []string{
@@ -36556,7 +36551,6 @@ func schema_k8sio_api_extensions_v1beta1_ReplicaSetStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"replicas"},
 			},
 		},
 		Dependencies: []string{
@@ -36753,7 +36747,6 @@ func schema_k8sio_api_extensions_v1beta1_ScaleStatus(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"replicas"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -56,9 +56,11 @@ message DaemonSet {
 // DaemonSetCondition describes the state of a DaemonSet at a certain point.
 message DaemonSetCondition {
   // Type of DaemonSet condition.
+  // +required
   optional string type = 1;
 
   // Status of the condition, one of True, False, Unknown.
+  // +required
   optional string status = 2;
 
   // Last time the condition transitioned from one status to another.
@@ -99,6 +101,7 @@ message DaemonSetSpec {
   // that matches the template's node selector (or on every node if no node
   // selector is specified).
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+  // +optional
   optional .k8s.io.api.core.v1.PodTemplateSpec template = 2;
 
   // An update strategy to replace existing DaemonSet pods with new pods.
@@ -130,20 +133,24 @@ message DaemonSetStatus {
   // The number of nodes that are running at least 1
   // daemon pod and are supposed to run the daemon pod.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+  // +optional
   optional int32 currentNumberScheduled = 1;
 
   // The number of nodes that are running the daemon pod, but are
   // not supposed to run the daemon pod.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+  // +optional
   optional int32 numberMisscheduled = 2;
 
   // The total number of nodes that should be running the daemon
   // pod (including nodes correctly running the daemon pod).
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+  // +optional
   optional int32 desiredNumberScheduled = 3;
 
   // The number of nodes that should be running the daemon pod and have one
   // or more of the daemon pod running and ready.
+  // +optional
   optional int32 numberReady = 4;
 
   // The most recent generation observed by the daemon set controller.
@@ -219,21 +226,27 @@ message Deployment {
 // DeploymentCondition describes the state of a deployment at a certain point.
 message DeploymentCondition {
   // Type of deployment condition.
+  // +required
   optional string type = 1;
 
   // Status of the condition, one of True, False, Unknown.
+  // +required
   optional string status = 2;
 
   // The last time this condition was updated.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 6;
 
   // Last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 7;
 
   // The reason for the condition's last transition.
+  // +optional
   optional string reason = 4;
 
   // A human readable message indicating details about the transition.
+  // +optional
   optional string message = 5;
 }
 
@@ -251,6 +264,7 @@ message DeploymentList {
 // DeploymentRollback stores the information required to rollback a deployment.
 message DeploymentRollback {
   // Required: This must match the Name of a deployment.
+  // +required
   optional string name = 1;
 
   // The annotations to be updated to a deployment
@@ -258,6 +272,7 @@ message DeploymentRollback {
   map<string, string> updatedAnnotations = 2;
 
   // The config of this deployment rollback.
+  // +optional
   optional RollbackConfig rollbackTo = 3;
 }
 
@@ -274,6 +289,7 @@ message DeploymentSpec {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template describes the pods that will be created.
+  // +optional
   optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 
   // The deployment strategy to use to replace existing pods with new ones.
@@ -350,6 +366,7 @@ message DeploymentStatus {
   optional int32 terminatingReplicas = 9;
 
   // Represents the latest available observations of a deployment's current state.
+  // +optional
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +listType=map
@@ -403,10 +420,12 @@ message HTTPIngressPath {
   //   or treat it identically to Prefix or Exact path types.
   // Implementations are required to support all path types.
   // Defaults to ImplementationSpecific.
+  // +optional
   optional string pathType = 3;
 
   // Backend defines the referenced service endpoint to which the traffic
   // will be forwarded to.
+  // +required
   optional IngressBackend backend = 2;
 }
 
@@ -417,6 +436,7 @@ message HTTPIngressPath {
 // or '#'.
 message HTTPIngressRuleValue {
   // A collection of paths that map requests to backends.
+  // +required
   // +listType=atomic
   repeated HTTPIngressPath paths = 1;
 }
@@ -517,10 +537,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // Port is the port number of the ingress port.
+  // +optional
   optional int32 port = 1;
 
   // Protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
+  // +optional
   optional string protocol = 2;
 
   // Error is to record the problem with the service port
@@ -587,6 +609,7 @@ message IngressRuleValue {
   // as defined by RFC 3986. Paths must begin with a '/'.
   // A backend defines the referenced service endpoint to which the traffic
   // will be forwarded to.
+  // +optional
   optional HTTPIngressRuleValue http = 1;
 }
 
@@ -783,6 +806,7 @@ message NetworkPolicySpec {
   // same set of pods.  In this case, the ingress rules for each are combined additively.
   // This field is NOT optional and follows standard label selector semantics.
   // An empty podSelector matches all pods in this namespace.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
 
   // List of ingress rules to be applied to the selected pods.
@@ -851,9 +875,11 @@ message ReplicaSet {
 // ReplicaSetCondition describes the state of a replica set at a certain point.
 message ReplicaSetCondition {
   // Type of replica set condition.
+  // +required
   optional string type = 1;
 
   // Status of the condition, one of True, False, Unknown.
+  // +required
   optional string status = 2;
 
   // The last time the condition transitioned from one status to another.
@@ -914,6 +940,7 @@ message ReplicaSetSpec {
 message ReplicaSetStatus {
   // Replicas is the most recently observed number of non-terminating pods.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset
+  // +optional
   optional int32 replicas = 1;
 
   // The number of non-terminating pods that have labels matching the labels of the pod template of the replicaset.
@@ -1055,6 +1082,7 @@ message ScaleSpec {
 // represents the current status of a scale subresource.
 message ScaleStatus {
   // actual number of observed instances of the scaled object.
+  // +optional
   optional int32 replicas = 1;
 
   // selector is a label query over pods that should match the replicas count. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -36,6 +36,7 @@ type ScaleSpec struct {
 // represents the current status of a scale subresource.
 type ScaleStatus struct {
 	// actual number of observed instances of the scaled object.
+	// +optional
 	Replicas int32 `json:"replicas" protobuf:"varint,1,opt,name=replicas"`
 
 	// selector is a label query over pods that should match the replicas count. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -116,6 +117,7 @@ type DeploymentSpec struct {
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,2,opt,name=selector"`
 
 	// Template describes the pods that will be created.
+	// +optional
 	Template v1.PodTemplateSpec `json:"template" protobuf:"bytes,3,opt,name=template"`
 
 	// The deployment strategy to use to replace existing pods with new ones.
@@ -166,11 +168,13 @@ type DeploymentSpec struct {
 type DeploymentRollback struct {
 	metav1.TypeMeta `json:",inline"`
 	// Required: This must match the Name of a deployment.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// The annotations to be updated to a deployment
 	// +optional
 	UpdatedAnnotations map[string]string `json:"updatedAnnotations,omitempty" protobuf:"bytes,2,rep,name=updatedAnnotations"`
 	// The config of this deployment rollback.
+	// +optional
 	RollbackTo RollbackConfig `json:"rollbackTo" protobuf:"bytes,3,opt,name=rollbackTo"`
 }
 
@@ -279,6 +283,7 @@ type DeploymentStatus struct {
 	TerminatingReplicas *int32 `json:"terminatingReplicas,omitempty" protobuf:"varint,9,opt,name=terminatingReplicas"`
 
 	// Represents the latest available observations of a deployment's current state.
+	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
@@ -312,16 +317,22 @@ const (
 // DeploymentCondition describes the state of a deployment at a certain point.
 type DeploymentCondition struct {
 	// Type of deployment condition.
+	// +required
 	Type DeploymentConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=DeploymentConditionType"`
 	// Status of the condition, one of True, False, Unknown.
+	// +required
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
 	// The last time this condition was updated.
+	// +optional
 	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty" protobuf:"bytes,6,opt,name=lastUpdateTime"`
 	// Last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,7,opt,name=lastTransitionTime"`
 	// The reason for the condition's last transition.
+	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
 	// A human readable message indicating details about the transition.
+	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 
@@ -426,6 +437,7 @@ type DaemonSetSpec struct {
 	// that matches the template's node selector (or on every node if no node
 	// selector is specified).
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+	// +optional
 	Template v1.PodTemplateSpec `json:"template" protobuf:"bytes,2,opt,name=template"`
 
 	// An update strategy to replace existing DaemonSet pods with new pods.
@@ -457,20 +469,24 @@ type DaemonSetStatus struct {
 	// The number of nodes that are running at least 1
 	// daemon pod and are supposed to run the daemon pod.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+	// +optional
 	CurrentNumberScheduled int32 `json:"currentNumberScheduled" protobuf:"varint,1,opt,name=currentNumberScheduled"`
 
 	// The number of nodes that are running the daemon pod, but are
 	// not supposed to run the daemon pod.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+	// +optional
 	NumberMisscheduled int32 `json:"numberMisscheduled" protobuf:"varint,2,opt,name=numberMisscheduled"`
 
 	// The total number of nodes that should be running the daemon
 	// pod (including nodes correctly running the daemon pod).
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+	// +optional
 	DesiredNumberScheduled int32 `json:"desiredNumberScheduled" protobuf:"varint,3,opt,name=desiredNumberScheduled"`
 
 	// The number of nodes that should be running the daemon pod and have one
 	// or more of the daemon pod running and ready.
+	// +optional
 	NumberReady int32 `json:"numberReady" protobuf:"varint,4,opt,name=numberReady"`
 
 	// The most recent generation observed by the daemon set controller.
@@ -515,8 +531,10 @@ type DaemonSetConditionType string
 // DaemonSetCondition describes the state of a DaemonSet at a certain point.
 type DaemonSetCondition struct {
 	// Type of DaemonSet condition.
+	// +required
 	Type DaemonSetConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=DaemonSetConditionType"`
 	// Status of the condition, one of True, False, Unknown.
+	// +required
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
 	// Last time the condition transitioned from one status to another.
 	// +optional
@@ -731,10 +749,12 @@ type IngressLoadBalancerIngress struct {
 // IngressPortStatus represents the error condition of a service port
 type IngressPortStatus struct {
 	// Port is the port number of the ingress port.
+	// +optional
 	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// Protocol is the protocol of the ingress port.
 	// The supported values are: "TCP", "UDP", "SCTP"
+	// +optional
 	Protocol v1.Protocol `json:"protocol" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 
 	// Error is to record the problem with the service port
@@ -806,6 +826,7 @@ type IngressRuleValue struct {
 	// as defined by RFC 3986. Paths must begin with a '/'.
 	// A backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
+	// +optional
 	HTTP *HTTPIngressRuleValue `json:"http,omitempty" protobuf:"bytes,1,opt,name=http"`
 }
 
@@ -816,6 +837,7 @@ type IngressRuleValue struct {
 // or '#'.
 type HTTPIngressRuleValue struct {
 	// A collection of paths that map requests to backends.
+	// +required
 	// +listType=atomic
 	Paths []HTTPIngressPath `json:"paths" protobuf:"bytes,1,rep,name=paths"`
 	// TODO: Consider adding fields for ingress-type specific global
@@ -877,10 +899,12 @@ type HTTPIngressPath struct {
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.
 	// Defaults to ImplementationSpecific.
+	// +optional
 	PathType *PathType `json:"pathType,omitempty" protobuf:"bytes,3,opt,name=pathType"`
 
 	// Backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
+	// +required
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -989,6 +1013,7 @@ type ReplicaSetSpec struct {
 type ReplicaSetStatus struct {
 	// Replicas is the most recently observed number of non-terminating pods.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset
+	// +optional
 	Replicas int32 `json:"replicas" protobuf:"varint,1,opt,name=replicas"`
 
 	// The number of non-terminating pods that have labels matching the labels of the pod template of the replicaset.
@@ -1036,8 +1061,10 @@ const (
 // ReplicaSetCondition describes the state of a replica set at a certain point.
 type ReplicaSetCondition struct {
 	// Type of replica set condition.
+	// +required
 	Type ReplicaSetConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=ReplicaSetConditionType"`
 	// Status of the condition, one of True, False, Unknown.
+	// +required
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
 	// The last time the condition transitioned from one status to another.
 	// +optional
@@ -1095,6 +1122,7 @@ type NetworkPolicySpec struct {
 	// same set of pods.  In this case, the ingress rules for each are combined additively.
 	// This field is NOT optional and follows standard label selector semantics.
 	// An empty podSelector matches all pods in this namespace.
+	// +optional
 	PodSelector metav1.LabelSelector `json:"podSelector" protobuf:"bytes,1,opt,name=podSelector"`
 
 	// List of ingress rules to be applied to the selected pods.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add missing `+optional` and `+required` markers to all 29 unmarked fields in the extensions/v1beta1 API types and enable the `optionalorrequired` linter for the extensions API group.

#### Which issue(s) this PR fixes:

Part of #134671 , #136869

#### Special notes for your reviewer:

This adds `// +required` markers to:
- `DeploymentRollback.Name`
- `DeploymentCondition.{Type, Status}`
- `DaemonSetCondition.{Type, Status}`
- `HTTPIngressRuleValue.Paths`
- `HTTPIngressPath.Backend`
- `IPBlock.CIDR`
- `ReplicaSetCondition.{Type, Status}`

This adds `// +optional` markers to:
- `ScaleStatus.Replicas` — status field, zero is valid
- `DeploymentSpec.Template` — non-pointer struct, unverifiable as required
- `DeploymentRollback.RollbackTo` — non-pointer struct, inner field optional
- `DeploymentStatus.Conditions` — has omitempty, missing marker
- `DeploymentCondition.{LastUpdateTime, LastTransitionTime, Reason, Message}` — has omitempty, missing markers
- `DaemonSetSpec.Template` — non-pointer struct, unverifiable as required
- `DaemonSetStatus.{CurrentNumberScheduled, NumberMisscheduled, DesiredNumberScheduled, NumberReady}` — status fields, zero is valid
- `IngressPortStatus.{Port, Protocol}` — status fields set by controller
- `IngressRuleValue.HTTP` — pointer with omitempty
- `HTTPIngressPath.PathType` — pointer with omitempty, has default
- `NetworkPolicySpec.PodSelector` — non-pointer struct, all inner fields optional
- `ReplicaSetStatus.Replicas` — status field, zero is valid

#### Does this PR introduce a user-facing change?

```release-note
NONE
```