### PR TITLE
api: enable optionalorrequired linter for events API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13247,7 +13247,12 @@
         }
       },
       "required": [
-        "eventTime"
+        "eventTime",
+        "reportingController",
+        "reportingInstance",
+        "action",
+        "reason",
+        "type"
       ],
       "type": "object",
       "x-kubernetes-group-version-kind": [

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13735,7 +13735,12 @@
         }
       },
       "required": [
-        "eventTime"
+        "eventTime",
+        "reportingController",
+        "reportingInstance",
+        "action",
+        "reason",
+        "type"
       ],
       "type": "object",
       "x-kubernetes-group-version-kind": [

--- a/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
@@ -159,7 +159,12 @@
           }
         },
         "required": [
-          "eventTime"
+          "eventTime",
+          "reportingController",
+          "reportingInstance",
+          "action",
+          "reason",
+          "type"
         ],
         "type": "object",
         "x-kubernetes-group-version-kind": [

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -234,7 +234,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|extensions|flowcontrol|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -232,7 +232,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -249,7 +249,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|extensions|flowcontrol|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -247,7 +247,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -110,7 +110,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|extensions|flowcontrol|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -108,7 +108,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -33981,7 +33981,7 @@ func schema_k8sio_api_events_v1_Event(ref common.ReferenceCallback) common.OpenA
 						},
 					},
 				},
-				Required: []string{"eventTime"},
+				Required: []string{"eventTime", "reportingController", "reportingInstance", "action", "reason", "type"},
 			},
 		},
 		Dependencies: []string{
@@ -34191,7 +34191,6 @@ func schema_k8sio_api_events_v1beta1_Event(ref common.ReferenceCallback) common.
 						},
 					},
 				},
-				Required: []string{"eventTime"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -34270,7 +34270,6 @@ func schema_k8sio_api_events_v1beta1_EventSeries(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"count", "lastObservedTime"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -35055,7 +35055,7 @@ func schema_k8sio_api_events_v1_Event(ref common.ReferenceCallback) common.OpenA
 						},
 					},
 				},
-				Required: []string{"eventTime"},
+				Required: []string{"eventTime", "reportingController", "reportingInstance", "action", "reason", "type"},
 			},
 		},
 		Dependencies: []string{
@@ -35265,7 +35265,6 @@ func schema_k8sio_api_events_v1beta1_Event(ref common.ReferenceCallback) common.
 						},
 					},
 				},
-				Required: []string{"eventTime"},
 			},
 		},
 		Dependencies: []string{
@@ -35345,7 +35344,6 @@ func schema_k8sio_api_events_v1beta1_EventSeries(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"count", "lastObservedTime"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/events/v1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1/generated.proto
@@ -42,6 +42,7 @@ message Event {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // eventTime is the time when this Event was first observed. It is required.
+  // +required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime eventTime = 2;
 
   // series is data about the Event series this event represents or nil if it's a singleton Event.
@@ -50,18 +51,22 @@ message Event {
 
   // reportingController is the name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
   // This field cannot be empty for new Events.
+  // +required
   optional string reportingController = 4;
 
   // reportingInstance is the ID of the controller instance, e.g. `kubelet-xyzf`.
   // This field cannot be empty for new Events and it can have at most 128 characters.
+  // +required
   optional string reportingInstance = 5;
 
   // action is what action was taken/failed regarding to the regarding object. It is machine-readable.
   // This field cannot be empty for new Events and it can have at most 128 characters.
+  // +required
   optional string action = 6;
 
   // reason is why the action was taken. It is human-readable.
   // This field cannot be empty for new Events and it can have at most 128 characters.
+  // +required
   optional string reason = 7;
 
   // regarding contains the object this Event is about. In most cases it's an Object reporting controller
@@ -84,6 +89,7 @@ message Event {
   // type is the type of this event (Normal, Warning), new types could be added in the future.
   // It is machine-readable.
   // This field cannot be empty for new Events.
+  // +required
   optional string type = 11;
 
   // deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
@@ -120,9 +126,11 @@ message EventList {
 // how this struct is updated on heartbeats and can guide customized reporter implementations.
 message EventSeries {
   // count is the number of occurrences in this series up to the last heartbeat time.
+  // +required
   optional int32 count = 1;
 
   // lastObservedTime is the time when last Event from the series was seen before last heartbeat.
+  // +required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
 }
 

--- a/staging/src/k8s.io/api/events/v1/types.go
+++ b/staging/src/k8s.io/api/events/v1/types.go
@@ -40,6 +40,7 @@ type Event struct {
 	metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`
 
 	// eventTime is the time when this Event was first observed. It is required.
+	// +required
 	EventTime metav1.MicroTime `json:"eventTime" protobuf:"bytes,2,opt,name=eventTime"`
 
 	// series is data about the Event series this event represents or nil if it's a singleton Event.
@@ -48,18 +49,22 @@ type Event struct {
 
 	// reportingController is the name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
 	// This field cannot be empty for new Events.
+	// +required
 	ReportingController string `json:"reportingController,omitempty" protobuf:"bytes,4,opt,name=reportingController"`
 
 	// reportingInstance is the ID of the controller instance, e.g. `kubelet-xyzf`.
 	// This field cannot be empty for new Events and it can have at most 128 characters.
+	// +required
 	ReportingInstance string `json:"reportingInstance,omitempty" protobuf:"bytes,5,opt,name=reportingInstance"`
 
 	// action is what action was taken/failed regarding to the regarding object. It is machine-readable.
 	// This field cannot be empty for new Events and it can have at most 128 characters.
+	// +required
 	Action string `json:"action,omitempty" protobuf:"bytes,6,name=action"`
 
 	// reason is why the action was taken. It is human-readable.
 	// This field cannot be empty for new Events and it can have at most 128 characters.
+	// +required
 	Reason string `json:"reason,omitempty" protobuf:"bytes,7,name=reason"`
 
 	// regarding contains the object this Event is about. In most cases it's an Object reporting controller
@@ -82,6 +87,7 @@ type Event struct {
 	// type is the type of this event (Normal, Warning), new types could be added in the future.
 	// It is machine-readable.
 	// This field cannot be empty for new Events.
+	// +required
 	Type string `json:"type,omitempty" protobuf:"bytes,11,opt,name=type"`
 
 	// deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
@@ -104,8 +110,10 @@ type Event struct {
 // how this struct is updated on heartbeats and can guide customized reporter implementations.
 type EventSeries struct {
 	// count is the number of occurrences in this series up to the last heartbeat time.
+	// +required
 	Count int32 `json:"count" protobuf:"varint,1,opt,name=count"`
 	// lastObservedTime is the time when last Event from the series was seen before last heartbeat.
+	// +required
 	LastObservedTime metav1.MicroTime `json:"lastObservedTime" protobuf:"bytes,2,opt,name=lastObservedTime"`
 }
 

--- a/staging/src/k8s.io/api/events/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1beta1/generated.proto
@@ -42,6 +42,7 @@ message Event {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // eventTime is the time when this Event was first observed. It is required.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime eventTime = 2;
 
   // series is data about the Event series this event represents or nil if it's a singleton Event.
@@ -122,9 +123,11 @@ message EventList {
 // continuously for some time.
 message EventSeries {
   // count is the number of occurrences in this series up to the last heartbeat time.
+  // +required
   optional int32 count = 1;
 
   // lastObservedTime is the time when last Event from the series was seen before last heartbeat.
+  // +required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
 }
 

--- a/staging/src/k8s.io/api/events/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1beta1/generated.proto
@@ -123,11 +123,11 @@ message EventList {
 // continuously for some time.
 message EventSeries {
   // count is the number of occurrences in this series up to the last heartbeat time.
-  // +required
+  // +optional
   optional int32 count = 1;
 
   // lastObservedTime is the time when last Event from the series was seen before last heartbeat.
-  // +required
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
 }
 

--- a/staging/src/k8s.io/api/events/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1beta1/generated.proto
@@ -42,6 +42,7 @@ message Event {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // eventTime is the time when this Event was first observed. It is required.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime eventTime = 2;
 
   // series is data about the Event series this event represents or nil if it's a singleton Event.
@@ -122,9 +123,11 @@ message EventList {
 // continuously for some time.
 message EventSeries {
   // count is the number of occurrences in this series up to the last heartbeat time.
+  // +optional
   optional int32 count = 1;
 
   // lastObservedTime is the time when last Event from the series was seen before last heartbeat.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
 }
 

--- a/staging/src/k8s.io/api/events/v1beta1/types.go
+++ b/staging/src/k8s.io/api/events/v1beta1/types.go
@@ -41,6 +41,7 @@ type Event struct {
 	metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`
 
 	// eventTime is the time when this Event was first observed. It is required.
+	// +optional
 	EventTime metav1.MicroTime `json:"eventTime" protobuf:"bytes,2,opt,name=eventTime"`
 
 	// series is data about the Event series this event represents or nil if it's a singleton Event.
@@ -107,8 +108,10 @@ type Event struct {
 // continuously for some time.
 type EventSeries struct {
 	// count is the number of occurrences in this series up to the last heartbeat time.
+	// +required
 	Count int32 `json:"count" protobuf:"varint,1,opt,name=count"`
 	// lastObservedTime is the time when last Event from the series was seen before last heartbeat.
+	// +required
 	LastObservedTime metav1.MicroTime `json:"lastObservedTime" protobuf:"bytes,2,opt,name=lastObservedTime"`
 
 	// +k8s:deprecated=state,protobuf=3

--- a/staging/src/k8s.io/api/events/v1beta1/types.go
+++ b/staging/src/k8s.io/api/events/v1beta1/types.go
@@ -41,6 +41,7 @@ type Event struct {
 	metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`
 
 	// eventTime is the time when this Event was first observed. It is required.
+	// +optional
 	EventTime metav1.MicroTime `json:"eventTime" protobuf:"bytes,2,opt,name=eventTime"`
 
 	// series is data about the Event series this event represents or nil if it's a singleton Event.
@@ -107,8 +108,10 @@ type Event struct {
 // continuously for some time.
 type EventSeries struct {
 	// count is the number of occurrences in this series up to the last heartbeat time.
+	// +optional
 	Count int32 `json:"count" protobuf:"varint,1,opt,name=count"`
 	// lastObservedTime is the time when last Event from the series was seen before last heartbeat.
+	// +optional
 	LastObservedTime metav1.MicroTime `json:"lastObservedTime" protobuf:"bytes,2,opt,name=lastObservedTime"`
 
 	// +k8s:deprecated=state,protobuf=3

--- a/staging/src/k8s.io/api/events/v1beta1/types.go
+++ b/staging/src/k8s.io/api/events/v1beta1/types.go
@@ -108,10 +108,10 @@ type Event struct {
 // continuously for some time.
 type EventSeries struct {
 	// count is the number of occurrences in this series up to the last heartbeat time.
-	// +required
+	// +optional
 	Count int32 `json:"count" protobuf:"varint,1,opt,name=count"`
 	// lastObservedTime is the time when last Event from the series was seen before last heartbeat.
-	// +required
+	// +optional
 	LastObservedTime metav1.MicroTime `json:"lastObservedTime" protobuf:"bytes,2,opt,name=lastObservedTime"`
 
 	// +k8s:deprecated=state,protobuf=3


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add missing `+optional` and `+required` markers to the events v1 and v1beta1 API types and enable the `optionalorrequired` linter for the events API group.

#### Which issue(s) this PR fixes:

Part of #134671 , #136867 

#### Special notes for your reviewer:

This adds `// +required` markers to:
- `Event.EventTime`, `Event.ReportingController`, `Event.ReportingInstance`, `Event.Action`, `Event.Reason`, `Event.Type` in v1 — all validated by strict v1 validation in `pkg/apis/core/validation/events.go`
- `EventSeries.Count`, `EventSeries.LastObservedTime` in v1 and v1beta1 — validated when series is set

This adds `// +optional` markers to:
- `Event.EventTime` in v1beta1 — v1beta1 validation does not require EventTime (legacy path only)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```