### PR TITLE
api: enable optionalorrequired linter for discovery API

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -234,7 +234,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|events|extensions|flowcontrol|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -241,7 +241,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -249,7 +249,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|events|extensions|flowcontrol|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -256,7 +256,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -110,7 +110,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|events|extensions|flowcontrol|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -117,7 +117,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|extensions|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -33757,7 +33757,7 @@ func schema_k8sio_api_discovery_v1beta1_EndpointSlice(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"addressType", "endpoints"},
+				Required: []string{"addressType"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -34819,7 +34819,7 @@ func schema_k8sio_api_discovery_v1beta1_EndpointSlice(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"addressType", "endpoints"},
+				Required: []string{"addressType"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/discovery/v1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1/generated.proto
@@ -44,6 +44,7 @@ message Endpoint {
   repeated string addresses = 1;
 
   // conditions contains information about the current status of the endpoint.
+  // +optional
   optional EndpointConditions conditions = 2;
 
   // hostname of this endpoint. This field may be used by consumers of
@@ -112,11 +113,13 @@ message EndpointConditions {
 message EndpointHints {
   // forZones indicates the zone(s) this endpoint should be consumed by when
   // using topology aware routing. May contain a maximum of 8 entries.
+  // +optional
   // +listType=atomic
   repeated ForZone forZones = 1;
 
   // forNodes indicates the node(s) this endpoint should be consumed by when
   // using topology aware routing. May contain a maximum of 8 entries.
+  // +optional
   // +listType=atomic
   repeated ForNode forNodes = 2;
 }
@@ -131,17 +134,20 @@ message EndpointPort {
   // * must consist of lower case alphanumeric characters or '-'.
   // * must start and end with an alphanumeric character.
   // Default is empty string.
+  // +optional
   optional string name = 1;
 
   // protocol represents the IP protocol for this port.
   // Must be UDP, TCP, or SCTP.
   // Default is TCP.
+  // +optional
   optional string protocol = 2;
 
   // port represents the port number of the endpoint.
   // If the EndpointSlice is derived from a Kubernetes service, this must be set
   // to the service's target port. EndpointSlices used for other purposes may have
   // a nil port.
+  // +optional
   optional int32 port = 3;
 
   // The application protocol for this port.
@@ -220,12 +226,14 @@ message EndpointSliceList {
 // ForNode provides information about which nodes should consume this endpoint.
 message ForNode {
   // name represents the name of the node.
+  // +required
   optional string name = 1;
 }
 
 // ForZone provides information about which zones should consume this endpoint.
 message ForZone {
   // name represents the name of the zone.
+  // +required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -102,6 +102,7 @@ type Endpoint struct {
 	Addresses []string `json:"addresses" protobuf:"bytes,1,rep,name=addresses"`
 
 	// conditions contains information about the current status of the endpoint.
+	// +optional
 	Conditions EndpointConditions `json:"conditions,omitempty" protobuf:"bytes,2,opt,name=conditions"`
 
 	// hostname of this endpoint. This field may be used by consumers of
@@ -170,11 +171,13 @@ type EndpointConditions struct {
 type EndpointHints struct {
 	// forZones indicates the zone(s) this endpoint should be consumed by when
 	// using topology aware routing. May contain a maximum of 8 entries.
+	// +optional
 	// +listType=atomic
 	ForZones []ForZone `json:"forZones,omitempty" protobuf:"bytes,1,name=forZones"`
 
 	// forNodes indicates the node(s) this endpoint should be consumed by when
 	// using topology aware routing. May contain a maximum of 8 entries.
+	// +optional
 	// +listType=atomic
 	ForNodes []ForNode `json:"forNodes,omitempty" protobuf:"bytes,2,name=forNodes"`
 }
@@ -182,12 +185,14 @@ type EndpointHints struct {
 // ForZone provides information about which zones should consume this endpoint.
 type ForZone struct {
 	// name represents the name of the zone.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 }
 
 // ForNode provides information about which nodes should consume this endpoint.
 type ForNode struct {
 	// name represents the name of the node.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 }
 
@@ -201,17 +206,20 @@ type EndpointPort struct {
 	// * must consist of lower case alphanumeric characters or '-'.
 	// * must start and end with an alphanumeric character.
 	// Default is empty string.
+	// +optional
 	Name *string `json:"name,omitempty" protobuf:"bytes,1,name=name"`
 
 	// protocol represents the IP protocol for this port.
 	// Must be UDP, TCP, or SCTP.
 	// Default is TCP.
+	// +optional
 	Protocol *v1.Protocol `json:"protocol,omitempty" protobuf:"bytes,2,name=protocol"`
 
 	// port represents the port number of the endpoint.
 	// If the EndpointSlice is derived from a Kubernetes service, this must be set
 	// to the service's target port. EndpointSlices used for other purposes may have
 	// a nil port.
+	// +optional
 	Port *int32 `json:"port,omitempty" protobuf:"bytes,3,opt,name=port"`
 
 	// The application protocol for this port.

--- a/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
@@ -44,6 +44,7 @@ message Endpoint {
   repeated string addresses = 1;
 
   // conditions contains information about the current status of the endpoint.
+  // +optional
   optional EndpointConditions conditions = 2;
 
   // hostname of this endpoint. This field may be used by consumers of
@@ -115,11 +116,13 @@ message EndpointConditions {
 message EndpointHints {
   // forZones indicates the zone(s) this endpoint should be consumed by to
   // enable topology aware routing. May contain a maximum of 8 entries.
+  // +optional
   // +listType=atomic
   repeated ForZone forZones = 1;
 
   // forNodes indicates the node(s) this endpoint should be consumed by when
   // using topology aware routing. May contain a maximum of 8 entries.
+  // +optional
   // +listType=atomic
   repeated ForNode forNodes = 2;
 }
@@ -133,16 +136,19 @@ message EndpointPort {
   // * must consist of lower case alphanumeric characters or '-'.
   // * must start and end with an alphanumeric character.
   // Default is empty string.
+  // +optional
   optional string name = 1;
 
   // protocol represents the IP protocol for this port.
   // Must be UDP, TCP, or SCTP.
   // Default is TCP.
+  // +optional
   optional string protocol = 2;
 
   // port represents the port number of the endpoint.
   // If this is not specified, ports are not restricted and must be
   // interpreted in the context of the specific consumer.
+  // +optional
   optional int32 port = 3;
 
   // appProtocol represents the application protocol for this port.
@@ -177,6 +183,7 @@ message EndpointSlice {
 
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
+  // +optional
   // +listType=atomic
   // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated Endpoint endpoints = 2;
@@ -204,12 +211,14 @@ message EndpointSliceList {
 // ForNode provides information about which nodes should consume this endpoint.
 message ForNode {
   // name represents the name of the node.
+  // +required
   optional string name = 1;
 }
 
 // ForZone provides information about which zones should consume this endpoint.
 message ForZone {
   // name represents the name of the zone.
+  // +required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
@@ -44,6 +44,7 @@ message Endpoint {
   repeated string addresses = 1;
 
   // conditions contains information about the current status of the endpoint.
+  // +optional
   optional EndpointConditions conditions = 2;
 
   // hostname of this endpoint. This field may be used by consumers of
@@ -115,11 +116,13 @@ message EndpointConditions {
 message EndpointHints {
   // forZones indicates the zone(s) this endpoint should be consumed by to
   // enable topology aware routing. May contain a maximum of 8 entries.
+  // +optional
   // +listType=atomic
   repeated ForZone forZones = 1;
 
   // forNodes indicates the node(s) this endpoint should be consumed by when
   // using topology aware routing. May contain a maximum of 8 entries.
+  // +optional
   // +listType=atomic
   repeated ForNode forNodes = 2;
 }
@@ -133,16 +136,19 @@ message EndpointPort {
   // * must consist of lower case alphanumeric characters or '-'.
   // * must start and end with an alphanumeric character.
   // Default is empty string.
+  // +optional
   optional string name = 1;
 
   // protocol represents the IP protocol for this port.
   // Must be UDP, TCP, or SCTP.
   // Default is TCP.
+  // +optional
   optional string protocol = 2;
 
   // port represents the port number of the endpoint.
   // If this is not specified, ports are not restricted and must be
   // interpreted in the context of the specific consumer.
+  // +optional
   optional int32 port = 3;
 
   // appProtocol represents the application protocol for this port.
@@ -177,6 +183,7 @@ message EndpointSlice {
 
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
+  // +optional
   // +listType=atomic
   // +k8s:beta(since: "1.37")=+k8s:optional
   repeated Endpoint endpoints = 2;
@@ -204,12 +211,14 @@ message EndpointSliceList {
 // ForNode provides information about which nodes should consume this endpoint.
 message ForNode {
   // name represents the name of the node.
+  // +required
   optional string name = 1;
 }
 
 // ForZone provides information about which zones should consume this endpoint.
 message ForZone {
   // name represents the name of the zone.
+  // +required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -52,6 +52,7 @@ type EndpointSlice struct {
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
+	// +optional
 	// +listType=atomic
 	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
@@ -97,6 +98,7 @@ type Endpoint struct {
 	Addresses []string `json:"addresses" protobuf:"bytes,1,rep,name=addresses"`
 
 	// conditions contains information about the current status of the endpoint.
+	// +optional
 	Conditions EndpointConditions `json:"conditions,omitempty" protobuf:"bytes,2,opt,name=conditions"`
 
 	// hostname of this endpoint. This field may be used by consumers of
@@ -168,11 +170,13 @@ type EndpointConditions struct {
 type EndpointHints struct {
 	// forZones indicates the zone(s) this endpoint should be consumed by to
 	// enable topology aware routing. May contain a maximum of 8 entries.
+	// +optional
 	// +listType=atomic
 	ForZones []ForZone `json:"forZones,omitempty" protobuf:"bytes,1,name=forZones"`
 
 	// forNodes indicates the node(s) this endpoint should be consumed by when
 	// using topology aware routing. May contain a maximum of 8 entries.
+	// +optional
 	// +listType=atomic
 	ForNodes []ForNode `json:"forNodes,omitempty" protobuf:"bytes,2,name=forNodes"`
 }
@@ -180,12 +184,14 @@ type EndpointHints struct {
 // ForZone provides information about which zones should consume this endpoint.
 type ForZone struct {
 	// name represents the name of the zone.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 }
 
 // ForNode provides information about which nodes should consume this endpoint.
 type ForNode struct {
 	// name represents the name of the node.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 }
 
@@ -198,16 +204,19 @@ type EndpointPort struct {
 	// * must consist of lower case alphanumeric characters or '-'.
 	// * must start and end with an alphanumeric character.
 	// Default is empty string.
+	// +optional
 	Name *string `json:"name,omitempty" protobuf:"bytes,1,name=name"`
 
 	// protocol represents the IP protocol for this port.
 	// Must be UDP, TCP, or SCTP.
 	// Default is TCP.
+	// +optional
 	Protocol *v1.Protocol `json:"protocol,omitempty" protobuf:"bytes,2,name=protocol"`
 
 	// port represents the port number of the endpoint.
 	// If this is not specified, ports are not restricted and must be
 	// interpreted in the context of the specific consumer.
+	// +optional
 	Port *int32 `json:"port,omitempty" protobuf:"bytes,3,opt,name=port"`
 
 	// appProtocol represents the application protocol for this port.

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -52,6 +52,7 @@ type EndpointSlice struct {
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
+	// +optional
 	// +listType=atomic
 	// +k8s:beta(since: "1.37")=+k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
@@ -97,6 +98,7 @@ type Endpoint struct {
 	Addresses []string `json:"addresses" protobuf:"bytes,1,rep,name=addresses"`
 
 	// conditions contains information about the current status of the endpoint.
+	// +optional
 	Conditions EndpointConditions `json:"conditions,omitempty" protobuf:"bytes,2,opt,name=conditions"`
 
 	// hostname of this endpoint. This field may be used by consumers of
@@ -168,11 +170,13 @@ type EndpointConditions struct {
 type EndpointHints struct {
 	// forZones indicates the zone(s) this endpoint should be consumed by to
 	// enable topology aware routing. May contain a maximum of 8 entries.
+	// +optional
 	// +listType=atomic
 	ForZones []ForZone `json:"forZones,omitempty" protobuf:"bytes,1,name=forZones"`
 
 	// forNodes indicates the node(s) this endpoint should be consumed by when
 	// using topology aware routing. May contain a maximum of 8 entries.
+	// +optional
 	// +listType=atomic
 	ForNodes []ForNode `json:"forNodes,omitempty" protobuf:"bytes,2,name=forNodes"`
 }
@@ -180,12 +184,14 @@ type EndpointHints struct {
 // ForZone provides information about which zones should consume this endpoint.
 type ForZone struct {
 	// name represents the name of the zone.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 }
 
 // ForNode provides information about which nodes should consume this endpoint.
 type ForNode struct {
 	// name represents the name of the node.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 }
 
@@ -198,16 +204,19 @@ type EndpointPort struct {
 	// * must consist of lower case alphanumeric characters or '-'.
 	// * must start and end with an alphanumeric character.
 	// Default is empty string.
+	// +optional
 	Name *string `json:"name,omitempty" protobuf:"bytes,1,name=name"`
 
 	// protocol represents the IP protocol for this port.
 	// Must be UDP, TCP, or SCTP.
 	// Default is TCP.
+	// +optional
 	Protocol *v1.Protocol `json:"protocol,omitempty" protobuf:"bytes,2,name=protocol"`
 
 	// port represents the port number of the endpoint.
 	// If this is not specified, ports are not restricted and must be
 	// interpreted in the context of the specific consumer.
+	// +optional
 	Port *int32 `json:"port,omitempty" protobuf:"bytes,3,opt,name=port"`
 
 	// appProtocol represents the application protocol for this port.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add missing `+optional` and `+required` markers to the discovery API group (v1 and v1beta1) and enable the `optionalorrequired` linter for it.

#### Which issue(s) this PR fixes:

Part of #134671, #136866

#### Special notes for your reviewer:

This adds `// +required` markers to:
- `ForZone.Name` — non-pointer string validated by `IsValidLabelValue` which rejects empty values
- `ForNode.Name` — non-pointer string validated by `IsValidLabelValue` which rejects empty values

This adds `// +optional` markers to:
- `Endpoint.Conditions` — omitempty, no validation requiring it
- `EndpointHints.ForZones` — omitempty, no validation requiring it
- `EndpointHints.ForNodes` — omitempty, no validation requiring it
- `EndpointPort.Name` — pointer with omitempty, defaulted to empty string
- `EndpointPort.Protocol` — pointer with omitempty, defaulted to TCP before validation
- `EndpointPort.Port` — pointer with omitempty, no validation requiring it
- `EndpointSlice.Endpoints` (v1beta1 only) — omitempty, no validation requiring it

#### Does this PR introduce a user-facing change?

```release-note
NONE
```