### PR TITLE
kubectl wait: Support multiple conditions

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -464,7 +464,7 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		Timeout:        effectiveTimeout,
 
 		Printer:     printers.NewDiscardingPrinter(),
-		ConditionFn: cmdwait.IsDeleted,
+		ConditionFn: []cmdwait.ConditionFunc{cmdwait.IsDeleted},
 		IOStreams:   o.IOStreams,
 	}
 	err = waitOptions.RunWaitContext(context.Background())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -80,7 +80,15 @@ var (
 
 		# Wait for the pod "busybox1" to be deleted, with a timeout of 60s, after having issued the "delete" command
 		kubectl delete pod/busybox1
-		kubectl wait --for=delete pod/busybox1 --timeout=60s`))
+		kubectl wait --for=delete pod/busybox1 --timeout=60s
+
+		# Wait for pod "busybox1" to be created AND reach the "Ready" status condition
+		kubectl wait --for=condition=Ready --for=create pod/busybox1
+
+		# Wait for pod "busybox1" to reach the "Ready" status OR for its containers to report a "False" readiness state
+		until kubectl wait pod/busybox1 --for=condition=Ready --timeout=1s 2>/dev/null || \
+		kubectl wait pod/busybox1 --for=condition=ContainersReady=False --timeout=1s 2>/dev/null; \
+		do echo "Checking conditions..."; sleep 1; done`))
 )
 
 // errNoMatchingResources is returned when there is no resources matching a query.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -1758,7 +1758,7 @@ func TestConditionFuncFor(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := conditionFuncFor(test.condition, io.Discard)
+			_, err := conditionFuncsFor(test.condition, io.Discard)
 			switch {
 			case err == nil && test.expectedErr != None:
 				t.Fatalf("expected error %q, got nil", test.expectedErr)
@@ -1892,12 +1892,12 @@ func TestWaitForMultipleConditions(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := test.fakeClient()
-			conditionFuncs, err := conditionFuncFor([]string{"condition=Ready", "condition=Available"}, io.Discard)
+			conditionFuncs, err := conditionFuncsFor([]string{"condition=Ready", "condition=Available"}, io.Discard)
 			require.NoError(t, err)
 
 			// For the mixed condition test, use different condition functions
 			if strings.Contains(test.name, "mixed condition") {
-				conditionFuncs, err = conditionFuncFor([]string{"condition=Ready", "jsonpath={.status.phase}=Running"}, io.Discard)
+				conditionFuncs, err = conditionFuncsFor([]string{"condition=Ready", "jsonpath={.status.phase}=Running"}, io.Discard)
 				require.NoError(t, err)
 			}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Supporting multiple conditions in `kubectl wait` is a long standing feature request. This PR adds this support by introducing multiple `for` conditions and AND'ing all of them in a sequential order. Regardless of the order, `for=create` will always be waited first due to the fact that other conditions can not be satisfied until resource is created. 

So these are some examples;

```sh
# wait for the creation of the pod AND condition is ready
kubectl wait --for=condition=Ready --for=create pod/nginx
```

```sh
# wait for the creation and deletion of the resource
kubectl wait --for=delete --for=create pod/nginx
```

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/95759

#### Special notes for your reviewer:

There is a discussion in https://groups.google.com/g/kubernetes-sig-cli/c/MY2nadrMhrM about the logical statements of multiple conditions. In my opinion, AND'ing seems more intuitive to me that all conditions more align with `for=create`. 

This PR must be backwards compatible.

#### Does this PR introduce a user-facing change?
```release-note
Adding multiple conditions support to kubectl wait command.
```