### PR TITLE
DRA integration: bump timeouts to 1 minute

### DIFF
--- a/test/integration/dra/binding_conditions_test.go
+++ b/test/integration/dra/binding_conditions_test.go
@@ -187,7 +187,7 @@ func testDeviceBindingConditionsBasicFlow(tCtx ktesting.TContext, enabled bool) 
 	tCtx.ExpectNoError(err, "add binding failure condition to second claim")
 
 	// Then wait until the scheduler has cleared the device statuses again.
-	waitForClaim(tCtx, namespace, claim2.Name, 30*time.Second,
+	waitForClaim(tCtx, namespace, claim2.Name, schedulingTimeout,
 		gomega.HaveField("Status.Devices", gomega.HaveLen(0)),
 		"claim should have cleared device conditions after rescheduling",
 	)
@@ -358,7 +358,7 @@ func testDeviceBindingFailureConditionsReschedule(tCtx ktesting.TContext, useTai
 	tCtx.ExpectNoError(err, "add binding failure condition to claim")
 
 	// Then wait until the scheduler has cleared the device statuses again.
-	waitForClaim(tCtx, namespace, claim1.Name, 30*time.Second,
+	waitForClaim(tCtx, namespace, claim1.Name, schedulingTimeout,
 		gomega.HaveField("Status.Devices", gomega.HaveLen(0)),
 		"claim should have cleared device conditions after rescheduling",
 	)

--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -112,7 +112,7 @@ const (
 
 	// schedulingTimeout is the time we grant the scheduler for one scheduling attempt,
 	// whether it's successful or not.
-	schedulingTimeout = 30 * time.Second
+	schedulingTimeout = time.Minute
 )
 
 func TestDRA(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

The 30 second timeouts in binding condition testing recently flaked, probably related to increasing parallelism in integration test jobs.

#### Which issue(s) this PR is related to:

https://testgrid.k8s.io/sig-testing-canaries#integration-race-master

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
