### PR TITLE
Revert "kubeadm: switch tests to NewClientset"

### DIFF
--- a/cmd/kubeadm/app/cmd/certs_test.go
+++ b/cmd/kubeadm/app/cmd/certs_test.go
@@ -560,7 +560,7 @@ kubernetesVersion: %s`,
 
 	// fakeClientSetFromFile returns a fake clientset with kubeadm config map
 	var fakeClientSetFromFile = func(_ string) (kubernetes.Interface, error) {
-		client := fakeclientset.NewClientset()
+		client := fakeclientset.NewSimpleClientset()
 		client.PrependReactor("get", "configmaps", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 			getAction := action.(clientgotesting.GetAction)
 			if getAction.GetNamespace() == metav1.NamespaceSystem && getAction.GetName() == kubeadmconstants.KubeadmConfigConfigMap {

--- a/cmd/kubeadm/app/componentconfigs/configset_test.go
+++ b/cmd/kubeadm/app/componentconfigs/configset_test.go
@@ -58,7 +58,7 @@ func TestFromCluster(t *testing.T) {
 			kind: KubeletConfiguration
 		`),
 	}
-	client := clientsetfake.NewClientset(objects...)
+	client := clientsetfake.NewSimpleClientset(objects...)
 	clusterCfg := testClusterCfg()
 
 	if err := FetchFromCluster(clusterCfg, client); err != nil {

--- a/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
+++ b/cmd/kubeadm/app/componentconfigs/fakeconfig_test.go
@@ -350,7 +350,7 @@ func TestGeneratedConfigFromCluster(t *testing.T) {
 					}
 				}
 
-				client := clientsetfake.NewClientset(configMap)
+				client := clientsetfake.NewSimpleClientset(configMap)
 				cfg, err := clusterConfigHandler.FromCluster(client, testClusterCfg())
 				if err != nil {
 					t.Fatalf("unexpected failure of FromCluster: %v", err)
@@ -472,7 +472,7 @@ func TestLoadingFromDocumentMap(t *testing.T) {
 
 func TestLoadingFromCluster(t *testing.T) {
 	runClusterConfigFromTest(t, func(t *testing.T, in string) (kubeadmapi.ComponentConfig, error) {
-		client := clientsetfake.NewClientset(
+		client := clientsetfake.NewSimpleClientset(
 			testClusterConfigMap(in, false),
 		)
 
@@ -522,7 +522,7 @@ func TestGetVersionStates(t *testing.T) {
 
 		for _, test := range cases {
 			t.Run(test.desc, func(t *testing.T) {
-				client := clientsetfake.NewClientset(test.obj)
+				client := clientsetfake.NewSimpleClientset(test.obj)
 
 				clusterCfg := testClusterCfg()
 

--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -271,7 +271,7 @@ func TestKubeletFromDocumentMap(t *testing.T) {
 
 func TestKubeletFromCluster(t *testing.T) {
 	runKubeletFromTest(t, func(_ schema.GroupVersionKind, yaml string) (kubeadmapi.ComponentConfig, error) {
-		client := clientsetfake.NewClientset(
+		client := clientsetfake.NewSimpleClientset(
 			testKubeletConfigMap(yaml),
 		)
 		return kubeletHandler.FromCluster(client, testClusterCfg())

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
@@ -159,7 +159,7 @@ func TestKubeProxyFromDocumentMap(t *testing.T) {
 
 func TestKubeProxyFromCluster(t *testing.T) {
 	runKubeProxyFromTest(t, func(_ schema.GroupVersionKind, yaml string) (kubeadmapi.ComponentConfig, error) {
-		client := clientsetfake.NewClientset(
+		client := clientsetfake.NewSimpleClientset(
 			testKubeProxyConfigMap(yaml),
 		)
 

--- a/cmd/kubeadm/app/discovery/discovery_test.go
+++ b/cmd/kubeadm/app/discovery/discovery_test.go
@@ -77,7 +77,7 @@ func TestFor(t *testing.T) {
 			config.Timeouts = &kubeadm.Timeouts{
 				Discovery: &metav1.Duration{Duration: 1 * time.Minute},
 			}
-			client := fakeclient.NewClientset()
+			client := fakeclient.NewSimpleClientset()
 			_, actual := For(client, &config)
 			if (actual == nil) != rt.expect {
 				t.Errorf(

--- a/cmd/kubeadm/app/discovery/token/token_test.go
+++ b/cmd/kubeadm/app/discovery/token/token_test.go
@@ -268,7 +268,7 @@ users: null
 			}
 
 			// Create a fake client and create the cluster-info ConfigMap
-			client := fakeclient.NewClientset()
+			client := fakeclient.NewSimpleClientset()
 			if err = test.configMap.createOrUpdate(client); err != nil {
 				t.Fatalf("could not create ConfigMap: %v", err)
 			}

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -525,7 +525,7 @@ func TestCreateCoreDNSAddon(t *testing.T) {
 }
 
 func createClientAndCoreDNSManifest(t *testing.T, corefile, coreDNSVersion string) *clientsetfake.Clientset {
-	client := clientsetfake.NewClientset()
+	client := clientsetfake.NewSimpleClientset()
 	_, err := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Create(context.TODO(), &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubeadmconstants.CoreDNSConfigMap,
@@ -1608,7 +1608,7 @@ func TestGetCoreDNSInfo(t *testing.T) {
 				t.Errorf("GetCoreDNSInfo() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(normalizeConfigMap(got), tt.wantConfigMap) {
+			if !reflect.DeepEqual(got, tt.wantConfigMap) {
 				t.Errorf("GetCoreDNSInfo() got = %v, want %v", got, tt.wantConfigMap)
 			}
 			if got1 != tt.wantCorefile {
@@ -1619,18 +1619,6 @@ func TestGetCoreDNSInfo(t *testing.T) {
 			}
 		})
 	}
-}
-
-// normalizeConfigMap remove metadata (e.g., ManagedFields) so DeepEqual
-// assertions compare only the ConfigMap content returned by fake clients.
-func normalizeConfigMap(cm *v1.ConfigMap) *v1.ConfigMap {
-	if cm == nil {
-		return nil
-	}
-
-	clone := cm.DeepCopy()
-	clone.ManagedFields = nil
-	return clone
 }
 
 func TestIsCoreDNSConfigMapMigrationRequired(t *testing.T) {
@@ -1690,7 +1678,7 @@ func newMockClientForTest(t *testing.T, replicas int32, deploymentSize int, imag
 	if image == "" {
 		image = "registry.k8s.io/coredns/coredns:" + kubeadmconstants.CoreDNSVersion
 	}
-	client := clientsetfake.NewClientset()
+	client := clientsetfake.NewSimpleClientset()
 	for i := 0; i < deploymentSize; i++ {
 		_, err := client.AppsV1().Deployments(metav1.NamespaceSystem).Create(context.TODO(), &apps.Deployment{
 			TypeMeta: metav1.TypeMeta{

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
@@ -126,7 +126,7 @@ func TestEnsureProxyAddon(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a fake client and set up default test configuration
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 
 			// TODO: Consider using a YAML file instead for this that makes it possible to specify YAML documents for the ComponentConfigs
 			initConfiguration, err := configutil.DefaultedStaticInitConfiguration()
@@ -296,7 +296,7 @@ bar
 }
 
 func newMockClientForTest(t *testing.T) *clientsetfake.Clientset {
-	client := clientsetfake.NewClientset()
+	client := clientsetfake.NewSimpleClientset()
 	_, err := client.AppsV1().DaemonSets(metav1.NamespaceSystem).Create(context.TODO(), &apps.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSet",

--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
@@ -99,7 +99,7 @@ func TestCreateBootstrapConfigMapIfNotExists(t *testing.T) {
 
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
-				client := clientsetfake.NewClientset()
+				client := clientsetfake.NewSimpleClientset()
 				if tc.createErr != nil {
 					client.PrependReactor("create", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
 						return true, nil, tc.createErr
@@ -133,7 +133,7 @@ func TestCreateClusterInfoRBACRules(t *testing.T) {
 		},
 		{
 			name:   "the RBAC rules do not exist",
-			client: clientsetfake.NewClientset(),
+			client: clientsetfake.NewSimpleClientset(),
 		},
 	}
 	for _, tt := range tests {
@@ -146,7 +146,7 @@ func TestCreateClusterInfoRBACRules(t *testing.T) {
 }
 
 func newMockClientForTest(t *testing.T) *clientsetfake.Clientset {
-	client := clientsetfake.NewClientset()
+	client := clientsetfake.NewSimpleClientset()
 
 	_, err := client.RbacV1().Roles(metav1.NamespacePublic).Create(context.TODO(), &rbac.Role{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap_test.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap_test.go
@@ -35,7 +35,7 @@ func TestAllowBootstrapTokensToPostCSRs(t *testing.T) {
 	}{
 		{
 			name:   "ClusterRoleBindings is empty",
-			client: clientsetfake.NewClientset(),
+			client: clientsetfake.NewSimpleClientset(),
 		},
 		{
 			name: "ClusterRoleBindings already exists",
@@ -92,7 +92,7 @@ func TestAutoApproveNodeBootstrapTokens(t *testing.T) {
 	}{
 		{
 			name:   "ClusterRoleBindings is empty",
-			client: clientsetfake.NewClientset(),
+			client: clientsetfake.NewSimpleClientset(),
 		},
 		{
 			name: "ClusterRoleBindings already exists",
@@ -149,7 +149,7 @@ func TestAutoApproveNodeCertificateRotation(t *testing.T) {
 	}{
 		{
 			name:   "ClusterRoleBindings is empty",
-			client: clientsetfake.NewClientset(),
+			client: clientsetfake.NewSimpleClientset(),
 		},
 		{
 			name: "ClusterRoleBindings already exists",
@@ -206,7 +206,7 @@ func TestAllowBootstrapTokensToGetNodes(t *testing.T) {
 	}{
 		{
 			name:   "RBAC rules are empty",
-			client: clientsetfake.NewClientset(),
+			client: clientsetfake.NewSimpleClientset(),
 		},
 		{
 			name: "RBAC rules already exists",
@@ -279,7 +279,7 @@ func TestAllowBootstrapTokensToGetNodes(t *testing.T) {
 }
 
 func newMockClusterRoleBinddingClientForTest(t *testing.T, clusterRoleBinding *rbac.ClusterRoleBinding) *clientsetfake.Clientset {
-	client := clientsetfake.NewClientset()
+	client := clientsetfake.NewSimpleClientset()
 	_, err := client.RbacV1().ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{})
 
 	if err != nil {
@@ -289,7 +289,7 @@ func newMockClusterRoleBinddingClientForTest(t *testing.T, clusterRoleBinding *r
 }
 
 func newMockRbacClientForTest(t *testing.T, clusterRole *rbac.ClusterRole, clusterRoleBinding *rbac.ClusterRoleBinding) *clientsetfake.Clientset {
-	client := clientsetfake.NewClientset()
+	client := clientsetfake.NewSimpleClientset()
 	_, err := client.RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error creating ClusterRoles: %v", err)

--- a/cmd/kubeadm/app/phases/bootstraptoken/node/token_test.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/token_test.go
@@ -116,7 +116,7 @@ func TestUpdateOrCreateTokens(t *testing.T) {
 }
 
 func newMockClientForTest(t *testing.T) *clientsetfake.Clientset {
-	client := clientsetfake.NewClientset()
+	client := clientsetfake.NewSimpleClientset()
 	_, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Create(context.TODO(), &v1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",

--- a/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
+++ b/cmd/kubeadm/app/phases/copycerts/copycerts_test.go
@@ -172,7 +172,7 @@ func TestUploadCerts(t *testing.T) {
 		t.Fatalf("error creating PKI assets: %v", err)
 	}
 
-	cs := fakeclient.NewClientset()
+	cs := fakeclient.NewSimpleClientset()
 	if err := UploadCerts(cs, initConfiguration, secretKey); err != nil {
 		t.Fatalf("error uploading certs: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestDownloadCerts(t *testing.T) {
 	}
 
 	kubeadmCertsSecret := createKubeadmCertsSecret(t, initConfiguration, secretKey)
-	cs := fakeclient.NewClientset(kubeadmCertsSecret)
+	cs := fakeclient.NewSimpleClientset(kubeadmCertsSecret)
 	if err := DownloadCerts(cs, initForDownloadConfiguration, secretKey); err != nil {
 		t.Fatalf("error downloading certs: %v", err)
 	}

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -1097,12 +1097,12 @@ func TestEnsureAdminClusterRoleBindingImpl(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			adminClient := clientsetfake.NewClientset()
+			adminClient := clientsetfake.NewSimpleClientset()
 			tc.setupAdminClient(adminClient)
 
 			var superAdminClient clientset.Interface // ensure superAdminClient is nil by default
 			if tc.setupSuperAdminClient != nil {
-				fakeSuperAdminClient := clientsetfake.NewClientset()
+				fakeSuperAdminClient := clientsetfake.NewSimpleClientset()
 				tc.setupSuperAdminClient(fakeSuperAdminClient)
 				superAdminClient = fakeSuperAdminClient
 			}

--- a/cmd/kubeadm/app/phases/kubelet/config_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_test.go
@@ -41,7 +41,7 @@ import (
 
 func TestCreateConfigMap(t *testing.T) {
 	nodeName := "fake-node"
-	client := fake.NewClientset()
+	client := fake.NewSimpleClientset()
 	client.PrependReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
 		return true, &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -71,7 +71,7 @@ func TestCreateConfigMap(t *testing.T) {
 }
 
 func TestCreateConfigMapRBACRules(t *testing.T) {
-	client := fake.NewClientset()
+	client := fake.NewSimpleClientset()
 	client.PrependReactor("create", "roles", func(action core.Action) (bool, runtime.Object, error) {
 		return true, nil, nil
 	})

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
@@ -372,7 +372,7 @@ func TestUnupgradedControlPlaneInstances(t *testing.T) {
 			for _, pod := range tc.pods {
 				runtimeObjs = append(runtimeObjs, &pod) // Use pointer
 			}
-			client := fake.NewClientset(runtimeObjs...)
+			client := fake.NewSimpleClientset(runtimeObjs...)
 
 			nodes, err := UnupgradedControlPlaneInstances(client, tc.currentNode)
 			if tc.expectError != (err != nil) {

--- a/cmd/kubeadm/app/phases/upgrade/versiongetter_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/versiongetter_test.go
@@ -64,7 +64,7 @@ func TestKubeVersionGetterClusterVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			client.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = tt.version
 
 			g := &KubeVersionGetter{
@@ -123,7 +123,7 @@ func TestKubeVersionGetterVersionFromCILabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := &KubeVersionGetter{
-				client: clientsetfake.NewClientset(),
+				client: clientsetfake.NewSimpleClientset(),
 			}
 			cliVersion, parsedVersion, err := g.VersionFromCILabel(tt.ciVersionLabel, "test VersionFromCILabel")
 			if (err != nil) != tt.wantErr {
@@ -214,7 +214,7 @@ func TestKubeVersionGetterKubeletVersions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		client := clientsetfake.NewClientset()
+		client := clientsetfake.NewSimpleClientset()
 		t.Run(tt.name, func(t *testing.T) {
 			for _, node := range tt.nodes.Items {
 				err := client.Tracker().Create(schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, &node, "")

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
@@ -58,7 +58,7 @@ func TestUploadConfiguration(t *testing.T) {
 			cfg.NodeRegistration.Name = "node-foo"
 			cfg.NodeRegistration.CRISocket = kubeadmconstants.DefaultCRISocket
 
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			// For idempotent test, we check the result of the second call.
 			if err := UploadConfiguration(cfg, client); err != nil {
 				t2.Fatalf("UploadConfiguration() error = %v", err)

--- a/cmd/kubeadm/app/util/apiclient/dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrun.go
@@ -68,7 +68,7 @@ type DryRun struct {
 // NewDryRun creates a new DryRun object that only has a fake client.
 func NewDryRun() *DryRun {
 	d := &DryRun{}
-	d.fakeClient = fake.NewClientset()
+	d.fakeClient = fake.NewSimpleClientset()
 	d.addReactors()
 	return d
 }

--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -110,7 +110,7 @@ func testCreateOrUpdate[T kubernetesObject](t *testing.T, resource, resources st
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf(tc.nameFormat, resource), func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			tc.setupClient(client, resources)
 			err := CreateOrUpdate(clientBuilder(client, empty), empty)
 			if (err != nil) != tc.expectedError {
@@ -203,7 +203,7 @@ func testCreateOrMutate[T kubernetesObject](t *testing.T, resource, resources st
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf(tc.nameFormat, resource), func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			tc.setupClient(client)
 			err := CreateOrMutate[T](clientBuilder(client, empty), empty, tc.mutator)
 			if (err != nil) != tc.expectedError {
@@ -272,7 +272,7 @@ func testCreateOrRetain[T kubernetesObject](t *testing.T, resource, resources st
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf(tc.nameFormat, resource), func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			tc.setupClient(client)
 			err := CreateOrRetain[T](clientBuilder(client, empty), empty, resource)
 			if (err != nil) != tc.expectedError {
@@ -402,7 +402,7 @@ func TestPatchNodeOnce(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			_, err := client.CoreV1().Nodes().Create(context.Background(), &tc.node, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("failed to create node to fake client: %v", err)
@@ -465,7 +465,7 @@ func TestPatchNode(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			tc.setupClient(client)
 			patchFn := func(*v1.Node) {}
 			err := PatchNode(client, "some-node", patchFn)
@@ -512,7 +512,7 @@ func TestGetConfigMapWithShortRetry(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			tc.setupClient(client)
 			actual, err := GetConfigMapWithShortRetry(client, "ns", "some-cm")
 			if (err != nil) != tc.expectedError {

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -319,7 +319,7 @@ func TestGetNodeRegistration(t *testing.T) {
 				}
 			}
 
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 
 			if rt.node != nil {
 				_, err := client.CoreV1().Nodes().Create(context.TODO(), rt.node, metav1.CreateOptions{})
@@ -457,7 +457,7 @@ func TestGetAPIEndpointWithBackoff(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			if rt.staticPod != nil {
 				rt.staticPod.NodeName = rt.nodeName
 				if err := rt.staticPod.Create(client); err != nil {
@@ -607,7 +607,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 				}
 			}
 
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 
 			if rt.node != nil {
 				_, err := client.CoreV1().Nodes().Create(context.TODO(), rt.node, metav1.CreateOptions{})
@@ -717,7 +717,7 @@ func TestGetAPIEndpointFromPodAnnotation(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			for i, pod := range rt.pods {
 				pod.NodeName = rt.nodeName
 				if err := pod.CreateWithPodSuffix(client, strconv.Itoa(i)); err != nil {
@@ -833,7 +833,7 @@ func TestGetRawAPIEndpointFromPodAnnotationWithoutRetry(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			for i, pod := range rt.pods {
 				pod.NodeName = rt.nodeName
 				if err := pod.CreateWithPodSuffix(client, strconv.Itoa(i)); err != nil {
@@ -918,7 +918,7 @@ func TestGetNodeNameFromSSR(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			rt.clientSetup(client)
 
 			nodeName, err := getNodeNameFromSSR(client)

--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -202,7 +202,7 @@ func TestGetEtcdEndpointsWithBackoff(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			for _, pod := range rt.pods {
 				if err := pod.Create(client); err != nil {
 					t.Errorf("error setting up test creating pod for node %q", pod.NodeName)
@@ -284,7 +284,7 @@ func TestGetRawEtcdEndpointsFromPodAnnotation(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			for i, pod := range rt.pods {
 				if err := pod.CreateWithPodSuffix(client, strconv.Itoa(i)); err != nil {
 					t.Errorf("error setting up test creating pod for node %q", pod.NodeName)
@@ -383,7 +383,7 @@ func TestGetRawEtcdEndpointsFromPodAnnotationWithoutRetry(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			client := clientsetfake.NewClientset()
+			client := clientsetfake.NewSimpleClientset()
 			for _, pod := range rt.pods {
 				if err := pod.Create(client); err != nil {
 					t.Errorf("error setting up test creating pod for node %q", pod.NodeName)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#136130

this PR is merging to un-deprecate the NewSimpleClientSet:
- https://github.com/kubernetes/kubernetes/pull/136455

slack discussion:
- https://kubernetes.slack.com/archives/CHGFYJVAN/p1769762525031889

/cc @LoginovIlia 