### PR TITLE
Use `net.JoinHostPort` for host address formatting.

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
+++ b/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
@@ -17,12 +17,12 @@ limitations under the License.
 package proxy
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -230,7 +230,13 @@ func NewProxyHandler(apiProxyPrefix string, filter *FilterServer, cfg *rest.Conf
 
 // Listen is a simple wrapper around net.Listen.
 func (s *Server) Listen(address string, port int) (net.Listener, error) {
-	return net.Listen("tcp", fmt.Sprintf("%s:%d", address, port))
+	// This function used to not use net.JoinHostPort, so it wouldn't accept correct
+	// IPv6 addresses. However, it *did* accept IPv6 addresses if you manually added
+	// brackets around them. For compatibility, it now accepts both forms.
+	if strings.HasPrefix(address, "[") && strings.HasSuffix(address, "]") {
+		address = address[1 : len(address)-1]
+	}
+	return net.Listen("tcp", net.JoinHostPort(address, strconv.Itoa(port)))
 }
 
 // ListenUnix does net.Listen for a unix socket


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This was assisted with a `semgrep` rule from
https://github.com/dgryski/semgrep-go/blob/master/hostport.yml
It simplifies the code a bit by delegating IPv4/IPv6 formatting to the stdlib, instead of if-else branches in the code.

#### Which issue(s) this PR is related to:
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
