### PR TITLE
Add CertificateSigningRequest create log entry for default kubelet debug level V2

### DIFF
--- a/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
+++ b/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
@@ -78,13 +78,15 @@ func RequestCertificateWithContext(ctx context.Context, client clientset.Interfa
 		csr.Spec.ExpirationSeconds = DurationToExpirationSeconds(*requestedDuration)
 	}
 
+	logger := klog.FromContext(ctx)
+
 	reqName, reqUID, err = create(ctx, client, csr)
 	switch {
 	case err == nil:
+		logger.V(2).Info("Certificate signing request created", "csr", reqName)
 		return reqName, reqUID, err
 
 	case apierrors.IsAlreadyExists(err) && len(name) > 0:
-		logger := klog.FromContext(ctx)
 		logger.Info("csr for this node already exists, reusing")
 		req, err := get(ctx, client, name)
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
#### What this PR does / why we need it:
Adds a log line for CertificateSigningRequests created, which was previously only visible in control plane `Audit` logs.

#### Which issue(s) this PR is related to:

Implements #[136852](https://github.com/kubernetes/kubernetes/issues/136852)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Adds another log line when a CertificateSigningRequests is created.

Example kubelet log (default `log-level = 2`):
`# journalctl -u kubelet | grep signing`
…
`Feb 09 13:24:57 <redacted>.compute.internal kubelet[21230]: I0209 13:24:57.692781   21230 csr.go:86] "Certificate signing request created" logger="kubernetes.io/kubelet-serving" csr="csr-snjsj"`

Already existing kubelet log lines without PR:
`# journalctl -u kubelet | grep signing`
…
`Feb 09 13:25:12 <redacted>.compute.internal kubelet[21230]: I0209 13:25:12.839312   21230 csr.go:276] "Certificate signing request is approved, waiting to be issued" logger="kubernetes.io/kubelet-serving" csr="csr-snjsj"`
`Feb 09 13:25:12 <redacted>.compute.internal kubelet[21230]: I0209 13:25:12.851349   21230 csr.go:272] "Certificate signing request is issued" logger="kubernetes.io/kubelet-serving" csr="csr-snjsj"`