### PR TITLE
KAL:enforce `optionalorrequired` on rbac API group

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15279,7 +15279,6 @@
         }
       },
       "required": [
-        "apiGroup",
         "kind",
         "name"
       ],

--- a/api/openapi-spec/v3/apis__rbac.authorization.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__rbac.authorization.k8s.io__v1_openapi.json
@@ -478,7 +478,6 @@
           }
         },
         "required": [
-          "apiGroup",
           "kind",
           "name"
         ],

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -215,7 +215,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -230,7 +230,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -91,7 +91,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -44879,7 +44879,7 @@ func schema_k8sio_api_rbac_v1_RoleRef(ref common.ReferenceCallback) common.OpenA
 						},
 					},
 				},
-				Required: []string{"apiGroup", "kind", "name"},
+				Required: []string{"kind", "name"},
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
@@ -45565,7 +45565,7 @@ func schema_k8sio_api_rbac_v1alpha1_RoleRef(ref common.ReferenceCallback) common
 						},
 					},
 				},
-				Required: []string{"apiGroup", "kind", "name"},
+				Required: []string{"kind", "name"},
 			},
 		},
 	}
@@ -46241,7 +46241,7 @@ func schema_k8sio_api_rbac_v1beta1_RoleRef(ref common.ReferenceCallback) common.
 						},
 					},
 				},
-				Required: []string{"apiGroup", "kind", "name"},
+				Required: []string{"kind", "name"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -183,9 +183,11 @@ message RoleList {
 // +structType=atomic
 message RoleRef {
   // APIGroup is the group for the resource being referenced
+  // +required
   optional string apiGroup = 1;
 
   // Kind is the type of resource being referenced
+  // +required
   optional string kind = 2;
 
   // Name is the name of resource being referenced
@@ -200,6 +202,7 @@ message RoleRef {
 message Subject {
   // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
   // If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+  // +required
   optional string kind = 1;
 
   // APIGroup holds the API group of the referenced subject.

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -183,7 +183,7 @@ message RoleList {
 // +structType=atomic
 message RoleRef {
   // APIGroup is the group for the resource being referenced
-  // +required
+  // +optional
   optional string apiGroup = 1;
 
   // Kind is the type of resource being referenced

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -81,6 +81,7 @@ type PolicyRule struct {
 type Subject struct {
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+	// +required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 	// APIGroup holds the API group of the referenced subject.
 	// Defaults to "" for ServiceAccount subjects.
@@ -101,8 +102,10 @@ type Subject struct {
 // +structType=atomic
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
+	// +required
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
 	// Kind is the type of resource being referenced
+	// +required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced
 	// +required

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -102,7 +102,7 @@ type Subject struct {
 // +structType=atomic
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
-	// +required
+	// +optional
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
 	// Kind is the type of resource being referenced
 	// +required

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -188,9 +188,11 @@ message RoleList {
 // RoleRef contains information that points to the role being used
 message RoleRef {
   // APIGroup is the group for the resource being referenced
+  // +required
   optional string apiGroup = 1;
 
   // Kind is the type of resource being referenced
+  // +required
   optional string kind = 2;
 
   // Name is the name of resource being referenced
@@ -204,6 +206,7 @@ message RoleRef {
 message Subject {
   // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
   // If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+  // +required
   optional string kind = 1;
 
   // APIVersion holds the API group and version of the referenced subject.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -188,7 +188,7 @@ message RoleList {
 // RoleRef contains information that points to the role being used
 message RoleRef {
   // APIGroup is the group for the resource being referenced
-  // +required
+  // +optional
   optional string apiGroup = 1;
 
   // Kind is the type of resource being referenced

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -101,7 +101,7 @@ type Subject struct {
 // RoleRef contains information that points to the role being used
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
-	// +required
+	// +optional
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
 	// Kind is the type of resource being referenced
 	// +required

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -80,6 +80,7 @@ type PolicyRule struct {
 type Subject struct {
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+	// +required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 	// APIVersion holds the API group and version of the referenced subject.
 	// Defaults to "v1" for ServiceAccount subjects.
@@ -100,8 +101,10 @@ type Subject struct {
 // RoleRef contains information that points to the role being used
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
+	// +required
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
 	// Kind is the type of resource being referenced
+	// +required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced
 	// +required

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -189,9 +189,11 @@ message RoleList {
 // RoleRef contains information that points to the role being used
 message RoleRef {
   // APIGroup is the group for the resource being referenced
+  // +required
   optional string apiGroup = 1;
 
   // Kind is the type of resource being referenced
+  // +required
   optional string kind = 2;
 
   // Name is the name of resource being referenced
@@ -205,6 +207,7 @@ message RoleRef {
 message Subject {
   // Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
   // If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+  // +required
   optional string kind = 1;
 
   // APIGroup holds the API group of the referenced subject.

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -189,7 +189,7 @@ message RoleList {
 // RoleRef contains information that points to the role being used
 message RoleRef {
   // APIGroup is the group for the resource being referenced
-  // +required
+  // +optional
   optional string apiGroup = 1;
 
   // Kind is the type of resource being referenced

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -81,6 +81,7 @@ type PolicyRule struct {
 type Subject struct {
 	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
 	// If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+	// +required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 	// APIGroup holds the API group of the referenced subject.
 	// Defaults to "" for ServiceAccount subjects.
@@ -100,8 +101,10 @@ type Subject struct {
 // RoleRef contains information that points to the role being used
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
+	// +required
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
 	// Kind is the type of resource being referenced
+	// +required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced
 	// +required

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -101,7 +101,7 @@ type Subject struct {
 // RoleRef contains information that points to the role being used
 type RoleRef struct {
 	// APIGroup is the group for the resource being referenced
-	// +required
+	// +optional
 	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
 	// Kind is the type of resource being referenced
 	// +required


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This PR enforces the `optionalorrequired` tag on the rbac API group by removing it from the exceptions and resolving the errors by marking `// +required` or `// +optional` tag on which the linter is complaining about.

#### Which issue(s) this PR is related to:

relates to https://github.com/kubernetes/kubernetes/issues/134671#issuecomment-3415486017
Fixes #136872

```release-note
NONE
```