### PR TITLE
DRA E2E: fix data race in test driver

### DIFF
--- a/test/e2e/dra/test-driver/app/kubeletplugin.go
+++ b/test/e2e/dra/test-driver/app/kubeletplugin.go
@@ -462,6 +462,8 @@ func (ex *ExamplePlugin) nodeUnprepareResource(ctx context.Context, claimRef kub
 
 	logger := klog.FromContext(ctx)
 
+	ex.mutex.Lock()
+	defer ex.mutex.Unlock()
 	claimID := ClaimID{Name: claimRef.Name, UID: claimRef.UID}
 	devices, ok := ex.prepared[claimID]
 	if !ok {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

UnprepareResourceClaims was not locking the mutex and thus raced with GetPreparedResources, as found when data race detection was enabled in kubernetes-kind-dra-all.

The locking gets added at the same level as in PrepareResourceClaims, i.e. in the underlying implementation right before doing the actual work.

    WARNING: DATA RACE
    Write at 0x00c0047e03c0 by goroutine 9325:
      runtime.mapdelete()
          runtime/map_swiss.go:139 +0x0
      k8s.io/kubernetes/test/e2e/dra/test-driver/app.(*ExamplePlugin).nodeUnprepareResource()
          k8s.io/kubernetes/test/e2e/dra/test-driver/app/kubeletplugin.go:483 +0x391
      k8s.io/kubernetes/test/e2e/dra/test-driver/app.(*ExamplePlugin).UnprepareResourceClaims()
          k8s.io/kubernetes/test/e2e/dra/test-driver/app/kubeletplugin.go:496 +0x19d
      k8s.io/dynamic-resource-allocation/kubeletplugin.(*nodePluginImplementation).NodeUnprepareResources()
          k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go:941 +0x4c1
      k8s.io/kubelet/pkg/apis/dra/v1._DRAPlugin_NodeUnprepareResources_Handler.func1()
          k8s.io/kubelet/pkg/apis/dra/v1/api_grpc.pb.go:181 +0xbe
      k8s.io/kubernetes/test/e2e/dra/test-driver/app.(*ExamplePlugin).recordGRPCCall()
          k8s.io/kubernetes/test/e2e/dra/test-driver/app/kubeletplugin.go:523 +0x2a6
      k8s.io/kubernetes/test/e2e/dra/test-driver/app.(*ExamplePlugin).recordGRPCCall-fm()
          <autogenerated>:1 +0x8f
      google.golang.org/grpc.getChainUnaryHandler.func1()
          google.golang.org/grpc@v1.78.0/server.go:1241 +0x23c
      k8s.io/kubernetes/test/e2e/dra/utils.(*Driver).interceptor()
          k8s.io/kubernetes/test/e2e/dra/utils/deploy.go:1045 +0x37d
      k8s.io/kubernetes/test/e2e/dra/utils.(*Driver).SetUp.func8()
          k8s.io/kubernetes/test/e2e/dra/utils/deploy.go:657 +0xb2
      google.golang.org/grpc.getChainUnaryHandler.func1.getChainUnaryHandler.1()
          google.golang.org/grpc@v1.78.0/server.go:1241 +0x11e
      k8s.io/dynamic-resource-allocation/kubeletplugin.(*grpcServer).interceptor()
          k8s.io/dynamic-resource-allocation/kubeletplugin/nonblockinggrpcserver.go:157 +0x545
      k8s.io/dynamic-resource-allocation/kubeletplugin.(*grpcServer).interceptor-fm()
          <autogenerated>:1 +0x8f
      google.golang.org/grpc.getChainUnaryHandler.func1()
          google.golang.org/grpc@v1.78.0/server.go:1241 +0x23c
      k8s.io/dynamic-resource-allocation/kubeletplugin.startGRPCServer.unaryContextInterceptor.func2()
          k8s.io/dynamic-resource-allocation/kubeletplugin/nonblockinggrpcserver.go:99 +0x7e
      google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1()
          google.golang.org/grpc@v1.78.0/server.go:1232 +0xe7
      k8s.io/kubelet/pkg/apis/dra/v1._DRAPlugin_NodeUnprepareResources_Handler()
          k8s.io/kubelet/pkg/apis/dra/v1/api_grpc.pb.go:183 +0x1e6
      google.golang.org/grpc.(*Server).processUnaryRPC()
          google.golang.org/grpc@v1.78.0/server.go:1428 +0x1a69
      google.golang.org/grpc.(*Server).handleStream()
          google.golang.org/grpc@v1.78.0/server.go:1832 +0x185b
      google.golang.org/grpc.(*Server).serveStreams.func2.1()
          google.golang.org/grpc@v1.78.0/server.go:1063 +0x149

    Previous read at 0x00c0047e03c0 by goroutine 9257:
      runtime.mapIterStart()
          runtime/map_swiss.go:160 +0x0
      k8s.io/kubernetes/test/e2e/dra/test-driver/app.(*ExamplePlugin).GetPreparedResources()
          k8s.io/kubernetes/test/e2e/dra/test-driver/app/kubeletplugin.go:506 +0x112
      k8s.io/kubernetes/test/e2e/dra/test-driver/app.(*ExamplePlugin).GetPreparedResources-fm()
          <autogenerated>:1 +0x33
      runtime.call16()
          runtime/asm_amd64.s:774 +0x42
      reflect.Value.Call()
          reflect/value.go:365 +0xb5
      github.com/onsi/gomega/internal.(*AsyncAssertion).buildActualPoller.func3()
          github.com/onsi/gomega@v1.39.0/internal/async_assertion.go:337 +0x244
      github.com/onsi/gomega/internal.(*AsyncAssertion).match()
          github.com/onsi/gomega@v1.39.0/internal/async_assertion.go:560 +0xe01
      github.com/onsi/gomega/internal.(*AsyncAssertion).Should()
          github.com/onsi/gomega@v1.39.0/internal/async_assertion.go:145 +0xc4
      k8s.io/kubernetes/test/e2e/dra.init.func1.2.4()
          k8s.io/kubernetes/test/e2e/dra/dra.go:314 +0x4fc
      k8s.io/kubernetes/test/e2e/dra.init.func1.2.4()
          k8s.io/kubernetes/test/e2e/dra/dra.go:304 +0x204
      github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func2()
          github.com/onsi/ginkgo/v2@v2.27.4/internal/node.go:517 +0x5d
      github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
          github.com/onsi/ginkgo/v2@v2.27.4/internal/suite.go:945 +0x6ed


#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
