### PR TITLE
Fix empty namespace when fetching existing job in cronjob controller

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -618,7 +618,7 @@ func (jm *ControllerV2) syncCronJob(
 		// but failed to update the active list in the status, in which case we should reattempt to add the job
 		// into the active list and update the status.
 		jobAlreadyExists = true
-		job, err := jm.jobControl.GetJob(jobReq.GetNamespace(), jobReq.GetName())
+		job, err := jm.jobControl.GetJob(cronJob.Namespace, jobReq.GetName())
 		if err != nil {
 			return nil, updateStatus, err
 		}

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -1938,6 +1938,13 @@ func TestControllerV2JobAlreadyExistsButNotInActiveStatus(t *testing.T) {
 	if !reflect.DeepEqual(cronJobControl.Updates[0].Status.Active[0], *expectedActiveRef) {
 		t.Errorf("Unexpected job reference in cronjob active list, got: %v, expected: %v", cronJobControl.Updates[0].Status.Active[0], expectedActiveRef)
 	}
+
+	if len(jobControl.GetJobNamespace) != 1 {
+		t.Fatalf("Unexpected get job count, got: %d, expected 1", len(jobControl.GetJobNamespace))
+	}
+	if jobControl.GetJobNamespace[0] != cj.Namespace {
+		t.Fatalf("Unexpected job's namespace, got: %s, expected %s", jobControl.GetJobNamespace[0], cj.Namespace)
+	}
 }
 
 // TestControllerV2JobAlreadyExistsButDifferentOwnner validates that an already created job
@@ -1983,5 +1990,12 @@ func TestControllerV2JobAlreadyExistsButDifferentOwner(t *testing.T) {
 
 	if len(cronJobControl.Updates) != 0 {
 		t.Fatalf("Unexpected updates to cronjob, got: %d, expected 0", len(cronJobControl.Updates))
+	}
+
+	if len(jobControl.GetJobNamespace) != 1 {
+		t.Fatalf("Unexpected get job count, got: %d, expected 1", len(jobControl.GetJobNamespace))
+	}
+	if jobControl.GetJobNamespace[0] != cj.Namespace {
+		t.Fatalf("Unexpected job's namespace, got: %s, expected %s", jobControl.GetJobNamespace[0], cj.Namespace)
 	}
 }

--- a/pkg/controller/cronjob/injection.go
+++ b/pkg/controller/cronjob/injection.go
@@ -111,14 +111,15 @@ func (r realJobControl) DeleteJob(namespace string, name string) error {
 
 type fakeJobControl struct {
 	sync.Mutex
-	Job           *batchv1.Job
-	Jobs          []batchv1.Job
-	DeleteJobName []string
-	Err           error
-	CreateErr     error
-	UpdateJobName []string
-	PatchJobName  []string
-	Patches       [][]byte
+	Job             *batchv1.Job
+	Jobs            []batchv1.Job
+	DeleteJobName   []string
+	Err             error
+	CreateErr       error
+	UpdateJobName   []string
+	PatchJobName    []string
+	Patches         [][]byte
+	GetJobNamespace []string
 }
 
 var _ jobControlInterface = &fakeJobControl{}
@@ -140,6 +141,7 @@ func (f *fakeJobControl) GetJob(namespace, name string) (*batchv1.Job, error) {
 	if f.Err != nil {
 		return nil, f.Err
 	}
+	f.GetJobNamespace = append(f.GetJobNamespace, namespace)
 	return f.Job, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes the issue that Cronjob controller would use empty `namespace` when trying to get a existed job. Use the `namespace` from Cronjob object to fix the issue. (#136918)

#### Which issue(s) this PR is related to:
Fixes #136918

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
Fixed an issue in the CronJob controller where it failed to adopt existing Jobs by erroneously using the empty namespace from the JobTemplate.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A