### PR TITLE
Fix DaemonSet controller fails to recreate Pods

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -534,7 +534,6 @@ func (dsc *DaemonSetsController) addPod(logger klog.Logger, obj interface{}) {
 		// on a restart of the controller manager, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
 		dsc.deletePod(logger, pod)
-		return
 	}
 
 	// If it has a ControllerRef, that's all that matters.
@@ -553,6 +552,9 @@ func (dsc *DaemonSetsController) addPod(logger klog.Logger, obj interface{}) {
 		return
 	}
 
+	if pod.DeletionTimestamp != nil {
+		return
+	}
 	// Otherwise, it's an orphan. Get a list of all matching DaemonSets and sync
 	// them to see if anyone wants to adopt it.
 	// DO NOT observe creation because no controller should be waiting for an

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -18,17 +18,31 @@ package daemonset
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -53,6 +67,8 @@ import (
 	"k8s.io/kubernetes/test/integration/framework"
 	testutils "k8s.io/kubernetes/test/integration/util"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 )
 
 var zero = int64(0)
@@ -1326,4 +1342,252 @@ func TestDaemonSetRollingUpdateWithTolerations(t *testing.T) {
 	validateDaemonSetPodsActive(podClient, podInformer, 0, t)
 	validateDaemonSetStatus(dsClient, ds.Name, 0, t)
 	validateUpdatedNumberScheduled(ctx, dsClient, ds.Name, 0, t)
+}
+
+// TestDaemonSetRecreatesPodAfterFirstWebhookTermination verifies that a DaemonSet can
+// successfully recreate a Pod after the first Pod creation is "interrupted" by a mutating
+// webhook that adds a deletionTimestamp (simulating an immediate termination scenario).
+func TestDaemonSetRecreatesPodAfterFirstWebhookTermination(t *testing.T) {
+	ctx, closeFn, dc, informers, clientset := setup(t)
+	defer closeFn()
+
+	ns := framework.CreateNamespaceOrDie(clientset, "ds-webhook-test", t)
+	defer framework.DeleteNamespaceOrDie(clientset, ns, t)
+
+	dsClient := clientset.AppsV1().DaemonSets(ns.Name)
+	podClient := clientset.CoreV1().Pods(ns.Name)
+
+	informers.Start(ctx.Done())
+	go dc.Run(ctx, 2)
+
+	// 1. Start a local mutating webhook server
+	ca := &x509.Certificate{
+		SerialNumber:          big.NewInt(2026),
+		Subject:               pkix.Name{Organization: []string{"Test CA"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		t.Fatalf("failed to create CA cert: %v", err)
+	}
+	serverCert := &x509.Certificate{
+		SerialNumber: big.NewInt(2027),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{utilnet.ParseIPSloppy("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+	}
+
+	serverPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate server key: %v", err)
+	}
+
+	serverBytes, err := x509.CreateCertificate(rand.Reader, serverCert, ca, &serverPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		t.Fatalf("failed to create server cert: %v", err)
+	}
+
+	privDER := x509.MarshalPKCS1PrivateKey(serverPrivKey)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverBytes})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privDER})
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caBytes})
+	serverCertPair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("failed to parse server cert/key: %v", err)
+	}
+	caBundle := caPEM
+	var firstPodMutated = true
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mutate", func(w http.ResponseWriter, r *http.Request) {
+		var review admissionv1.AdmissionReview
+		if err := json.NewDecoder(r.Body).Decode(&review); err != nil {
+			admResponse(t, w, admissionResponse(false, "failed to decode", review.Request.UID))
+			return
+		}
+
+		// Default: allow everything that is not a pod creation
+		if review.Request == nil || review.Request.Resource.Resource != "pods" || review.Request.Operation != admissionv1.Create {
+			admResponse(t, w, admissionResponse(true, "", review.Request.UID))
+			return
+		}
+
+		// Parse the Pod object from the admission request
+		var pod v1.Pod
+		if err := json.Unmarshal(review.Request.Object.Raw, &pod); err != nil {
+			admResponse(t, w, admissionResponse(true, "", review.Request.UID))
+			return
+		}
+
+		// Only apply mutation to Pods owned by a DaemonSet in this test namespace
+		isDaemonSetPod := false
+		for _, ref := range pod.OwnerReferences {
+			if ref.Kind == "DaemonSet" && ref.APIVersion == "apps/v1" {
+				isDaemonSetPod = true
+				break
+			}
+		}
+
+		if isDaemonSetPod && pod.Namespace == ns.Name && firstPodMutated {
+			// On the very first Pod creation attempt, inject deletionTimestamp
+			now := metav1.Now()
+			patch := []map[string]interface{}{
+				{
+					"op":    "add",
+					"path":  "/metadata/deletionTimestamp",
+					"value": now,
+				},
+			}
+
+			patchBytes, _ := json.Marshal(patch)
+			response := admissionv1.AdmissionResponse{
+				UID:     review.Request.UID,
+				Allowed: true,
+				Patch:   patchBytes,
+				PatchType: func() *admissionv1.PatchType {
+					pt := admissionv1.PatchTypeJSONPatch
+					return &pt
+				}(),
+			}
+			review.Response = &response
+			respBytes, _ := json.Marshal(review)
+			w.Header().Set("Content-Type", "application/json")
+			if _, err = w.Write(respBytes); err != nil {
+				t.Errorf("failed to write response: %v", err)
+			}
+			firstPodMutated = false
+			return
+		}
+
+		// All other requests (including retries) are allowed without modification
+		admResponse(t, w, admissionResponse(true, "", review.Request.UID))
+	})
+
+	// httptest 的 TLS server
+	server := httptest.NewUnstartedServer(mux)
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCertPair},
+		NextProtos:   []string{"http/1.1"},
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	webhookURL := server.URL + "/mutate"
+
+	// 2. Create a MutatingWebhookConfiguration that targets only this namespace
+	mwc := &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "ds-first-pod-termination-webhook"},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
+			{
+				Name: "ds-first-termination.example.com",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					URL:      &webhookURL,
+					CABundle: []byte(caBundle),
+				},
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					},
+				},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/metadata.name": ns.Name},
+				},
+				SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+			},
+		},
+	}
+	if _, err := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, mwc, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create MutatingWebhookConfiguration: %v", err)
+	}
+	defer func() {
+		if err = clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, mwc.Name, metav1.DeleteOptions{}); err != nil {
+			t.Errorf("unexpect err: %v", err)
+		}
+	}()
+
+	// 3. Add one schedulable node (minimal setup for DaemonSet to schedule Pods)
+	addNodes(clientset.CoreV1().Nodes(), 0, 1, nil, t)
+
+	// 4. Create the DaemonSet under test
+	ds := newDaemonSet("webhook-test-ds", ns.Name)
+	_, err = dsClient.Create(ctx, ds, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create DaemonSet: %v", err)
+	}
+	defer cleanupDaemonSets(t, clientset, ds)
+
+	// 5. Wait until we see exactly one new Pod
+	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		pods, err := podClient.List(ctx, metav1.ListOptions{LabelSelector: "name=test"})
+		if err != nil {
+			return false, nil
+		}
+		// Simulating delete pod
+		for _, p := range pods.Items {
+			if !p.DeletionTimestamp.IsZero() {
+				t.Logf("Delete pod with DeletionTimestamp is not zero: %s/%s", p.Namespace, p.Name)
+				if err = podClient.Delete(ctx, p.Name, metav1.DeleteOptions{}); err != nil {
+					t.Errorf("failed to delete pod: %v", err)
+				}
+			}
+		}
+		if len(pods.Items) != 1 {
+			return false, nil
+		}
+		return pods.Items[0].DeletionTimestamp.IsZero(), nil
+	})
+	if err != nil {
+		t.Fatalf("failed to observe one terminated pod and one running pod: %v", err)
+	}
+
+	t.Log("Test passed: DaemonSet successfully recreated pod after first creation was terminated by mutating webhook")
+}
+
+func admResponse(t *testing.T, w http.ResponseWriter, review *admissionv1.AdmissionReview) {
+	respBytes, err := json.Marshal(review)
+	if err != nil {
+		http.Error(w, "could not marshal response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err = w.Write(respBytes); err != nil {
+		t.Errorf("failed to write response: %v", err)
+	}
+}
+
+func admissionResponse(allowed bool, msg string, uid types.UID) *admissionv1.AdmissionReview {
+	return &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: admissionv1.SchemeGroupVersion.String(),
+			Kind:       "AdmissionReview",
+		},
+		Response: &admissionv1.AdmissionResponse{
+			UID:     uid,
+			Allowed: allowed,
+			Result: &metav1.Status{
+				Message: msg,
+			},
+		},
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The DaemonSet controller should continue attempting to create new Pods to satisfy the desired number of replicas on each node, even if the initial Pod creation was interrupted and the Pod was immediately terminated
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #136932
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 "NONE" 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
