### PR TITLE
api: enable optionalorrequired linter for resource API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15950,9 +15950,6 @@
           "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -16388,9 +16385,6 @@
           "description": "Status describes whether the claim is ready to use and what has been allocated."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -16529,9 +16523,6 @@
           "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -16588,9 +16579,6 @@
           "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object"
     },
     "io.k8s.api.resource.v1.ResourcePool": {
@@ -17297,9 +17285,6 @@
           "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -17722,9 +17707,6 @@
           "description": "Status describes whether the claim is ready to use and what has been allocated."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -17863,9 +17845,6 @@
           "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -17922,9 +17901,6 @@
           "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object"
     },
     "io.k8s.api.resource.v1beta1.ResourcePool": {
@@ -18470,9 +18446,6 @@
           "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -18908,9 +18881,6 @@
           "description": "Status describes whether the claim is ready to use and what has been allocated."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -19049,9 +19019,6 @@
           "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -19108,9 +19075,6 @@
           "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object"
     },
     "io.k8s.api.resource.v1beta2.ResourcePool": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
@@ -628,9 +628,6 @@
             "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1181,9 +1178,6 @@
             "description": "Status describes whether the claim is ready to use and what has been allocated."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1364,9 +1358,6 @@
             "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1443,9 +1434,6 @@
             "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object"
       },
       "io.k8s.api.resource.v1.ResourcePool": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
@@ -642,9 +642,6 @@
             "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1178,9 +1175,6 @@
             "description": "Status describes whether the claim is ready to use and what has been allocated."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1361,9 +1355,6 @@
             "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1440,9 +1431,6 @@
             "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object"
       },
       "io.k8s.api.resource.v1beta1.ResourcePool": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
@@ -628,9 +628,6 @@
             "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1181,9 +1178,6 @@
             "description": "Status describes whether the claim is ready to use and what has been allocated."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1364,9 +1358,6 @@
             "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1443,9 +1434,6 @@
             "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object"
       },
       "io.k8s.api.resource.v1beta2.ResourcePool": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -227,7 +227,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -242,7 +242,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -103,7 +103,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -47507,7 +47507,6 @@ func schema_k8sio_api_resource_v1_DeviceClass(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -48357,7 +48356,6 @@ func schema_k8sio_api_resource_v1_ResourceClaim(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -48589,7 +48587,6 @@ func schema_k8sio_api_resource_v1_ResourceClaimTemplate(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -48670,7 +48667,6 @@ func schema_k8sio_api_resource_v1_ResourceClaimTemplateSpec(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -50015,7 +50011,6 @@ func schema_k8sio_api_resource_v1beta1_DeviceClass(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -50843,7 +50838,6 @@ func schema_k8sio_api_resource_v1beta1_ResourceClaim(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -51075,7 +51069,6 @@ func schema_k8sio_api_resource_v1beta1_ResourceClaimTemplate(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -51156,7 +51149,6 @@ func schema_k8sio_api_resource_v1beta1_ResourceClaimTemplateSpec(ref common.Refe
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -52187,7 +52179,6 @@ func schema_k8sio_api_resource_v1beta2_DeviceClass(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -53037,7 +53028,6 @@ func schema_k8sio_api_resource_v1beta2_ResourceClaim(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -53269,7 +53259,6 @@ func schema_k8sio_api_resource_v1beta2_ResourceClaimTemplate(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -53350,7 +53339,6 @@ func schema_k8sio_api_resource_v1beta2_ResourceClaimTemplateSpec(ref common.Refe
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -657,6 +657,7 @@ message DeviceClass {
   // the time of allocation.
   //
   // Changing the spec automatically increments the metadata.generation number.
+  // +optional
   optional DeviceClassSpec spec = 2;
 }
 
@@ -1390,6 +1391,7 @@ message ResourceClaim {
   // Spec describes what is being requested and how to configure it.
   // The spec is immutable.
   // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +optional
   optional ResourceClaimSpec spec = 2;
 
   // Status describes whether the claim is ready to use and what has been allocated.
@@ -1510,6 +1512,7 @@ message ResourceClaimTemplate {
   // This field is immutable. A ResourceClaim will get created by the
   // control plane for a Pod when needed and then not get updated
   // anymore.
+  // +optional
   optional ResourceClaimTemplateSpec spec = 2;
 }
 
@@ -1534,6 +1537,7 @@ message ResourceClaimTemplateSpec {
   // Spec for the ResourceClaim. The entire content is copied unchanged
   // into the ResourceClaim that gets created from this template. The
   // same fields as in a ResourceClaim are also valid here.
+  // +optional
   optional ResourceClaimSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -758,6 +758,7 @@ type ResourceClaim struct {
 	// Spec describes what is being requested and how to configure it.
 	// The spec is immutable.
 	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +optional
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
 	// Status describes whether the claim is ready to use and what has been allocated.
@@ -1792,6 +1793,7 @@ type DeviceClass struct {
 	// the time of allocation.
 	//
 	// Changing the spec automatically increments the metadata.generation number.
+	// +optional
 	Spec DeviceClassSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 
@@ -1875,6 +1877,7 @@ type ResourceClaimTemplate struct {
 	// This field is immutable. A ResourceClaim will get created by the
 	// control plane for a Pod when needed and then not get updated
 	// anymore.
+	// +optional
 	Spec ResourceClaimTemplateSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 
@@ -1889,6 +1892,7 @@ type ResourceClaimTemplateSpec struct {
 	// Spec for the ResourceClaim. The entire content is copied unchanged
 	// into the ResourceClaim that gets created from this template. The
 	// same fields as in a ResourceClaim are also valid here.
+	// +optional
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -669,6 +669,7 @@ message DeviceClass {
   // the time of allocation.
   //
   // Changing the spec automatically increments the metadata.generation number.
+  // +optional
   optional DeviceClassSpec spec = 2;
 }
 
@@ -1413,6 +1414,7 @@ message ResourceClaim {
   // Spec describes what is being requested and how to configure it.
   // The spec is immutable.
   // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +optional
   optional ResourceClaimSpec spec = 2;
 
   // Status describes whether the claim is ready to use and what has been allocated.
@@ -1536,6 +1538,7 @@ message ResourceClaimTemplate {
   // This field is immutable. A ResourceClaim will get created by the
   // control plane for a Pod when needed and then not get updated
   // anymore.
+  // +optional
   optional ResourceClaimTemplateSpec spec = 2;
 }
 
@@ -1560,6 +1563,7 @@ message ResourceClaimTemplateSpec {
   // Spec for the ResourceClaim. The entire content is copied unchanged
   // into the ResourceClaim that gets created from this template. The
   // same fields as in a ResourceClaim are also valid here.
+  // +optional
   optional ResourceClaimSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -773,6 +773,7 @@ type ResourceClaim struct {
 	// Spec describes what is being requested and how to configure it.
 	// The spec is immutable.
 	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +optional
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
 	// Status describes whether the claim is ready to use and what has been allocated.
@@ -1816,6 +1817,7 @@ type DeviceClass struct {
 	// the time of allocation.
 	//
 	// Changing the spec automatically increments the metadata.generation number.
+	// +optional
 	Spec DeviceClassSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 
@@ -1902,6 +1904,7 @@ type ResourceClaimTemplate struct {
 	// This field is immutable. A ResourceClaim will get created by the
 	// control plane for a Pod when needed and then not get updated
 	// anymore.
+	// +optional
 	Spec ResourceClaimTemplateSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 
@@ -1916,6 +1919,7 @@ type ResourceClaimTemplateSpec struct {
 	// Spec for the ResourceClaim. The entire content is copied unchanged
 	// into the ResourceClaim that gets created from this template. The
 	// same fields as in a ResourceClaim are also valid here.
+	// +optional
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -660,6 +660,7 @@ message DeviceClass {
   // the time of allocation.
   //
   // Changing the spec automatically increments the metadata.generation number.
+  // +optional
   optional DeviceClassSpec spec = 2;
 }
 
@@ -1398,6 +1399,7 @@ message ResourceClaim {
   // Spec describes what is being requested and how to configure it.
   // The spec is immutable.
   // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +optional
   optional ResourceClaimSpec spec = 2;
 
   // Status describes whether the claim is ready to use and what has been allocated.
@@ -1521,6 +1523,7 @@ message ResourceClaimTemplate {
   // This field is immutable. A ResourceClaim will get created by the
   // control plane for a Pod when needed and then not get updated
   // anymore.
+  // +optional
   optional ResourceClaimTemplateSpec spec = 2;
 }
 
@@ -1545,6 +1548,7 @@ message ResourceClaimTemplateSpec {
   // Spec for the ResourceClaim. The entire content is copied unchanged
   // into the ResourceClaim that gets created from this template. The
   // same fields as in a ResourceClaim are also valid here.
+  // +optional
   optional ResourceClaimSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -764,6 +764,7 @@ type ResourceClaim struct {
 	// Spec describes what is being requested and how to configure it.
 	// The spec is immutable.
 	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +optional
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
 	// Status describes whether the claim is ready to use and what has been allocated.
@@ -1803,6 +1804,7 @@ type DeviceClass struct {
 	// the time of allocation.
 	//
 	// Changing the spec automatically increments the metadata.generation number.
+	// +optional
 	Spec DeviceClassSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 
@@ -1889,6 +1891,7 @@ type ResourceClaimTemplate struct {
 	// This field is immutable. A ResourceClaim will get created by the
 	// control plane for a Pod when needed and then not get updated
 	// anymore.
+	// +optional
 	Spec ResourceClaimTemplateSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 
@@ -1903,6 +1906,7 @@ type ResourceClaimTemplateSpec struct {
 	// Spec for the ResourceClaim. The entire content is copied unchanged
 	// into the ResourceClaim that gets created from this template. The
 	// same fields as in a ResourceClaim are also valid here.
+	// +optional
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add +optional marker to various specs in the resource API to satisfy the optionalorrequired linter rule and enable the linter for the resource API group.

Since `nonpointerstructs` is now enabled, these fields should be optional given that they all contain no required fields.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/136873
<!--
Please link relevant issues to help with tracking.
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```