### PR TITLE
DRA device taints: update unit tests

### DIFF
--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -67,6 +67,8 @@ const (
 	// updates while eviction is in progress. Once it is done, it no longer gets
 	// updated until in progress again.
 	ruleStatusPeriod = 10 * time.Second
+
+	maxUIDCacheEntries = 500
 )
 
 // Controller listens to Taint changes of DRA devices and Toleration changes of ResourceClaims,
@@ -104,6 +106,10 @@ type Controller struct {
 	hasSynced     atomic.Int32
 	metrics       metrics.Metrics
 	workqueue     workqueue.TypedRateLimitingInterface[workItem]
+
+	// The evictedPods cache keeps track of Pods for which we know that
+	// they have been evicted.
+	evictedPods *uidCache
 
 	evictPodHook    func(pod tainteviction.NamespacedObject, eviction evictionAndReason)
 	cancelEvictHook func(pod tainteviction.NamespacedObject) bool
@@ -383,10 +389,11 @@ func (tc *Controller) maybeDeletePod(ctx context.Context, podRef tainteviction.N
 	tc.mutex.Lock()
 	tc.maybeDeletePodCount++
 	eviction, ok := tc.deletePodAt[podRef]
+	evicted := tc.evictedPods.has(podRef.UID)
 	tc.mutex.Unlock()
-	logger.V(5).Info("Processing pod deletion work item", "active", ok, "eviction", eviction)
+	logger.V(5).Info("Processing pod deletion work item", "active", ok, "eviction", eviction, "evicted", evicted)
 
-	if !ok {
+	if !ok || evicted {
 		logger.V(5).Info("Work item for pod deletion obsolete, nothing to do")
 		return 0, nil
 	}
@@ -401,8 +408,12 @@ func (tc *Controller) maybeDeletePod(ctx context.Context, podRef tainteviction.N
 	defer func() {
 		if finalErr == nil {
 			// Forget the deletion time, we are done.
+			// Also remember that we don't even need to
+			// check the pod again, should it have been
+			// added to the queue again in the meantime.
 			tc.mutex.Lock()
 			delete(tc.deletePodAt, podRef)
+			tc.evictedPods.add(podRef.UID)
 			tc.mutex.Unlock()
 		}
 	}()
@@ -739,7 +750,8 @@ func New(c clientset.Interface, podInformer coreinformers.PodInformer, claimInfo
 			sliceInformer.Informer().HasSyncedChecker(),
 			classInformer.Informer().HasSyncedChecker(),
 		},
-		metrics: metrics.Global,
+		metrics:     metrics.Global,
+		evictedPods: newUIDCache(maxUIDCacheEntries),
 	}
 
 	// The informer for DeviceTaintRules only gets instantiated if the corresponding

--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -25,7 +25,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -44,7 +43,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -2106,38 +2104,8 @@ func trimRules(objs []resourcealpha.DeviceTaintRule) (trimmed []*resourcealpha.D
 	return trimmed
 }
 
-func newTestController(tCtx ktesting.TContext, clientSet *fake.Clientset) *Controller {
-	// fake.Clientset suffers from a race condition related to informers:
-	// it does not implement resource version support in its Watch
-	// implementation and instead assumes that watches are set up
-	// before further changes are made.
-	//
-	// If a test waits for caches to be synced and then immediately
-	// adds an object, that new object will never be seen by event handlers
-	// if the race goes wrong and the Watch call hadn't completed yet
-	// (can be triggered by adding a sleep before https://github.com/kubernetes/kubernetes/blob/b53b9fb5573323484af9a19cf3f5bfe80760abba/staging/src/k8s.io/client-go/tools/cache/reflector.go#L431).
-	//
-	// To work around this, we count all watches and only proceed when
-	// all of them are in place. This replaces the normal watch reactor
-	// (https://github.com/kubernetes/kubernetes/blob/b53b9fb5573323484af9a19cf3f5bfe80760abba/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go#L161-L173).
-	var numWatches atomic.Int32
-	clientSet.PrependWatchReactor("*", func(action core.Action) (handled bool, ret watch.Interface, err error) {
-		var opts metav1.ListOptions
-		if watchActcion, ok := action.(core.WatchActionImpl); ok {
-			opts = watchActcion.ListOptions
-		}
-		gvr := action.GetResource()
-		ns := action.GetNamespace()
-		watch, err := clientSet.Tracker().Watch(gvr, ns, opts)
-		if err != nil {
-			return false, nil, err
-		}
-		numWatches.Add(1)
-		return true, watch, nil
-	})
-
-	informerFactory := informers.NewSharedInformerFactory(clientSet, 0)
-
+func newTestController(tCtx ktesting.TContext) *Controller {
+	informerFactory := informers.NewSharedInformerFactory(tCtx.Client(), 0)
 	controller := New(tCtx.Client(),
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Resource().V1().ResourceClaims(),
@@ -2153,11 +2121,6 @@ func newTestController(tCtx ktesting.TContext, clientSet *fake.Clientset) *Contr
 
 	informerFactory.StartWithContext(tCtx)
 	tCtx.Cleanup(informerFactory.Shutdown)
-
-	tCtx.Log("starting to wait for watches")
-	tCtx.Wait()
-	tCtx.Expect(numWatches.Load()).To(gomega.Equal(int32(5)), "All watches should be registered.")
-	tCtx.Log("done waiting for watches")
 
 	return controller
 }
@@ -2332,7 +2295,7 @@ func testEviction(tCtx ktesting.TContext) {
 				updatedPod = obj.(*v1.Pod)
 				return false, nil, nil
 			})
-			controller := newTestController(tCtx, fakeClientset)
+			controller := newTestController(tCtx)
 
 			var wg sync.WaitGroup
 			defer func() {
@@ -2421,7 +2384,7 @@ func synctestDeviceTaintRule(tCtx ktesting.TContext, delayed bool) {
 	}
 	fakeClientset := fake.NewClientset(podWithClaimName, claim, rule)
 	tCtx = tCtx.WithClients(nil, nil, fakeClientset, nil, nil)
-	controller := newTestController(tCtx, fakeClientset)
+	controller := newTestController(tCtx)
 
 	var wg sync.WaitGroup
 	defer func() {
@@ -2574,7 +2537,7 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	})
 
 	tCtx = tCtx.WithClients(nil, nil, fakeClientset, nil, nil)
-	controller := newTestController(tCtx, fakeClientset)
+	controller := newTestController(tCtx)
 
 	var mutex sync.Mutex
 	podEvicting := false
@@ -2702,7 +2665,7 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of deleted pod")
 		return false, nil, nil
 	})
-	controller := newTestController(tCtx, fakeClientset)
+	controller := newTestController(tCtx)
 
 	var wg sync.WaitGroup
 	defer func() {
@@ -2778,7 +2741,7 @@ func synctestRetry(tCtx ktesting.TContext) {
 		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of deleted pod")
 		return false, nil, nil
 	})
-	controller := newTestController(tCtx, fakeClientset)
+	controller := newTestController(tCtx)
 
 	var wg sync.WaitGroup
 	defer func() {

--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -2603,18 +2603,13 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	tCtx = tCtx.WithClients(nil, nil, fakeClientset, nil, nil)
 	controller := newTestController(tCtx)
 
-	var mutex sync.Mutex
 	podEvicting := false
 	controller.evictPodHook = func(podRef tainteviction.NamespacedObject, eviction evictionAndReason) {
 		tCtx.Assert(podRef).Should(gomega.Equal(newObject(pod)))
-		mutex.Lock()
-		defer mutex.Unlock()
 		podEvicting = true
 	}
 	controller.cancelEvictHook = func(podRef tainteviction.NamespacedObject) bool {
 		tCtx.Assert(podRef).Should(gomega.Equal(newObject(pod)))
-		mutex.Lock()
-		defer mutex.Unlock()
 		podEvicting = false
 		return false
 	}
@@ -2632,11 +2627,8 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	}()
 
 	// Eventually the pod gets scheduled for eviction.
-	tCtx.Eventually(func(tCtx ktesting.TContext) bool {
-		mutex.Lock()
-		defer mutex.Unlock()
-		return podEvicting
-	}).WithTimeout(30 * time.Second).Should(gomega.BeTrueBecause("pod pending eviction"))
+	tCtx.Wait()
+	tCtx.Expect(podEvicting).To(gomega.BeTrueBecause("pod pending eviction"))
 
 	// Now we can delete the pod or slice.
 	if deletePod {
@@ -2646,18 +2638,13 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	}
 
 	// Shortly after deletion we should also see the cancellation.
-	tCtx.Eventually(func(tCtx ktesting.TContext) bool {
-		mutex.Lock()
-		defer mutex.Unlock()
-		return podEvicting
-	}).WithTimeout(30 * time.Second).Should(gomega.BeFalseBecause("pod no longer pending eviction"))
+	tCtx.Wait()
+	tCtx.Expect(podEvicting).To(gomega.BeFalseBecause("pod no longer pending eviction"))
 
 	// Whether we get an event depends on whether the pod still exists.
-	// If we expect an event, we need to wait for it.
 	if !deletePod {
-		tCtx.Eventually(listEvents).WithTimeout(30 * time.Second).Should(matchCancellationEvent())
+		tCtx.Expect(listEvents(tCtx)).Should(matchCancellationEvent())
 	}
-	tCtx.Wait()
 
 	matchEvents := matchCancellationEvent()
 	if deletePod {
@@ -2705,13 +2692,10 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 	tCtx.ExpectNoError(err, "get pod before eviction")
 	tCtx.Assert(pod).Should(gomega.Equal(podWithClaimName), "test pod")
 
-	var mutex sync.Mutex
 	var podGets int
 	var podDeletions int
 
 	fakeClientset.PrependReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		mutex.Lock()
-		defer mutex.Unlock()
 		podGets++
 		podName := action.(core.GetAction).GetName()
 		tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of patched pod")
@@ -2722,8 +2706,6 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 		return true, nil, apierrors.NewNotFound(v1.SchemeGroupVersion.WithResource("pods").GroupResource(), pod.Name)
 	})
 	fakeClientset.PrependReactor("delete", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		mutex.Lock()
-		defer mutex.Unlock()
 		podDeletions++
 		podName := action.(core.DeleteAction).GetName()
 		tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of deleted pod")
@@ -2742,13 +2724,6 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 		defer wg.Done()
 		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 	}()
-
-	// Eventually the pod gets deleted, in this test by us.
-	tCtx.Eventually(func(tCtx ktesting.TContext) bool {
-		mutex.Lock()
-		defer mutex.Unlock()
-		return podGets >= 1
-	}).WithTimeout(30 * time.Second).Should(gomega.BeTrueBecause("pod eviction started"))
 
 	// We don't want any events.
 	tCtx.Wait()

--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -34,8 +34,6 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
@@ -1984,12 +1982,12 @@ func testHandlers(tContext *testContext, tc testCase) {
 	assertEqual(tContext, tc.finalState.allocatedClaimsAsMap(), tContext.allocatedClaims, "allocated claims")
 	if !assertEqual(tContext, tc.finalState.slicesAsMap(), tContext.pools, "pools") {
 		for key := range tContext.pools {
-			assert.Equal(tContext, tc.finalState.slicesAsMap()[key], tContext.pools[key], "pool")
+			tContext.Assert(tContext.pools[key]).Should(gomega.Equal(tc.finalState.slicesAsMap()[key]), "pool")
 		}
 	}
 	assertEqual(tContext, tc.finalState.queued, tContext.mockQueue.State(), "work queue after event handlers", queueCmpOpts...)
-	assert.Empty(tContext, tc.finalState.pods, "pods not checked for final state")
-	assert.Empty(tContext, tc.finalState.rules, "rules not checked for final state")
+	tContext.Assert(tc.finalState.pods).Should(gomega.BeEmpty(), "pods not checked for final state")
+	tContext.Assert(tc.finalState.rules).Should(gomega.BeEmpty(), "rules not checked for final state")
 
 	process := tc.process
 	if process == nil && len(tc.finalState.queued.Ready) > 0 {
@@ -2194,8 +2192,7 @@ func testEviction(tCtx ktesting.TContext) {
 
 	do := func(tCtx ktesting.TContext, what string, action func(tCtx ktesting.TContext) error) {
 		tCtx.Log(what)
-		err := action(tCtx)
-		require.NoError(tCtx, err, what)
+		tCtx.ExpectNoError(action(tCtx))
 	}
 
 	pod := podWithClaimName.DeepCopy()
@@ -2307,7 +2304,7 @@ func testEviction(tCtx ktesting.TContext) {
 				podName := action.(core.DeleteAction).GetName()
 				tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of pod to delete")
 				obj, err := fakeClientset.Tracker().Get(v1.SchemeGroupVersion.WithResource("pods"), pod.Namespace, pod.Name)
-				require.NoError(tCtx, err)
+				tCtx.ExpectNoError(err)
 				updatedPod = obj.(*v1.Pod)
 				return false, nil, nil
 			})
@@ -2322,7 +2319,7 @@ func testEviction(tCtx ktesting.TContext) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				assert.NoError(tCtx, controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
+				tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 			}()
 
 			// Eventually the controller should have synced it's informers.
@@ -2336,9 +2333,9 @@ func testEviction(tCtx ktesting.TContext) {
 			}
 
 			// The number of API calls is deterministic.
-			assert.Equal(tCtx, 1, podGets, "get pod once")
-			assert.Equal(tCtx, 1, podUpdates, "update pod once")
-			assert.Equal(tCtx, 1, podDeletions, "delete pod once")
+			tCtx.Assert(podGets).Should(gomega.Equal(1), "get pod once")
+			tCtx.Assert(podUpdates).Should(gomega.Equal(1), "update pod once")
+			tCtx.Assert(podDeletions).Should(gomega.Equal(1), "delete pod once")
 
 			_, err := fakeClientset.CoreV1().Pods(pod.Namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
 			switch {
@@ -2368,7 +2365,7 @@ func testEviction(tCtx ktesting.TContext) {
 			// This is the last thing the controller does for a pod.
 			// We know that all goroutines are durably blocked and
 			// queues are empty => no need for a "Consistently"!
-			tCtx.Assert(controller.workqueue.Len()).To(gomega.Equal(0), "work queue empty")
+			tCtx.Assert(controller.workqueue.Len()).Should(gomega.Equal(0), "work queue empty")
 			tCtx.Assert(listEvents(tCtx)).Should(matchDeletionEvent())
 			tCtx.ExpectNoError(testPodDeletionsMetrics(controller, 0*time.Second), "pod eviction done")
 		})
@@ -2422,7 +2419,7 @@ func synctestDeviceTaintRule(tCtx ktesting.TContext, toleration, slowDelete bool
 	wg.Go(func() {
 		// Run with 1 worker to ensure sequential execution. Concurrent workers cause
 		// non-deterministic ordering of status updates, leading to flakes in Status assertions.
-		assert.NoError(tCtx, controller.Run(tCtx, 1 /* workers */), "eviction controller failed")
+		tCtx.AssertNoError(controller.Run(tCtx, 1 /* workers */), "eviction controller failed")
 	})
 
 	// Eventually the controller should have synced it's informers.
@@ -2488,7 +2485,7 @@ func synctestDeviceTaintRule(tCtx ktesting.TContext, toleration, slowDelete bool
 	tCtx.Wait()
 	deleted := metav1.Now()
 	tCtx.Logf("TIME: deleted %s since start", deleted.Sub(start.Time))
-	assert.Empty(tCtx, controller.taintRuleStats, "taint rule statistics should have dropped the deleted rule")
+	tCtx.Assert(controller.taintRuleStats).Should(gomega.BeEmpty(), "taint rule statistics should have dropped the deleted rule")
 
 	tCtx.Assert(controller.workqueue.Len()).Should(gomega.Equal(0), "work queue empty")
 	// There are no delays inside a synctest bubble. The pod always gets deleted "immediately".
@@ -2577,8 +2574,8 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 		pod,
 	)
 	pod, err := fakeClientset.CoreV1().Pods(pod.Namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-	require.NoError(tCtx, err, "get pod before eviction")
-	assert.Equal(tCtx, podWithClaimName, pod, "test pod")
+	tCtx.ExpectNoError(err, "get pod before eviction")
+	tCtx.Assert(pod).Should(gomega.Equal(podWithClaimName), "test pod")
 
 	var podGets int
 	var podUpdates int
@@ -2587,19 +2584,19 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	fakeClientset.PrependReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		podGets++
 		podName := action.(core.GetAction).GetName()
-		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of pod to patch")
+		tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of pod to patch")
 		return false, nil, nil
 	})
 	fakeClientset.PrependReactor("patch", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		podUpdates++
 		podName := action.(core.PatchAction).GetName()
-		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of pod to get")
+		tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of pod to get")
 		return false, nil, nil
 	})
 	fakeClientset.PrependReactor("delete", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		podDeletions++
 		podName := action.(core.DeleteAction).GetName()
-		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of pod to delete")
+		tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of pod to delete")
 		return false, nil, nil
 	})
 
@@ -2609,13 +2606,13 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	var mutex sync.Mutex
 	podEvicting := false
 	controller.evictPodHook = func(podRef tainteviction.NamespacedObject, eviction evictionAndReason) {
-		assert.Equal(tCtx, newObject(pod), podRef)
+		tCtx.Assert(podRef).Should(gomega.Equal(newObject(pod)))
 		mutex.Lock()
 		defer mutex.Unlock()
 		podEvicting = true
 	}
 	controller.cancelEvictHook = func(podRef tainteviction.NamespacedObject) bool {
-		assert.Equal(tCtx, newObject(pod), podRef)
+		tCtx.Assert(podRef).Should(gomega.Equal(newObject(pod)))
 		mutex.Lock()
 		defer mutex.Unlock()
 		podEvicting = false
@@ -2631,7 +2628,7 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert.NoError(tCtx, controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
+		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 	}()
 
 	// Eventually the pod gets scheduled for eviction.
@@ -2665,9 +2662,9 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	matchEvents := matchCancellationEvent()
 	if deletePod {
 		matchEvents = gomega.BeEmpty()
-		assert.Equal(tCtx, 1, podDeletions, "Pod should have been deleted exactly once by test.")
+		tCtx.Assert(podDeletions).Should(gomega.Equal(1), "Pod should have been deleted exactly once by test.")
 	} else {
-		assert.Equal(tCtx, 0, podDeletions, "Pod should not have been deleted.")
+		tCtx.Assert(podDeletions).Should(gomega.Equal(0), "Pod should not have been deleted.")
 	}
 
 	// Time does not progress in synctest.Wait because it returns when all goroutines are blocked
@@ -2679,10 +2676,10 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 
 	tCtx.Assert(controller.workqueue.Len()).Should(gomega.Equal(0), "work queue empty")
 	gomega.NewGomegaWithT(tCtx).Expect(controller.workqueue.Len()).Should(gomega.Equal(0), "work queue empty")
-	assert.Equal(tCtx, 0, podGets, "Worker should not have needed to get the pod.")
-	assert.Equal(tCtx, 0, podUpdates, "Worker should not have needed to update the pod.")
-	assert.Equal(tCtx, int64(1), controller.maybeDeletePodCount, "Work queue should have processed pod.")
-	gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(matchEvents)
+	tCtx.Assert(podGets).Should(gomega.Equal(0), "Worker should not have needed to get the pod.")
+	tCtx.Assert(podUpdates).Should(gomega.Equal(0), "Worker should not have needed to update the pod.")
+	tCtx.Assert(controller.maybeDeletePodCount).Should(gomega.Equal(int64(1)), "Work queue should have processed pod.")
+	tCtx.Assert(listEvents(tCtx)).Should(matchEvents)
 	tCtx.ExpectNoError(testPodDeletionsMetrics(controller))
 }
 
@@ -2705,8 +2702,8 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 	tCtx = tCtx.WithClients(nil, nil, fakeClientset, nil, nil)
 
 	pod, err := fakeClientset.CoreV1().Pods(pod.Namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-	require.NoError(tCtx, err, "get pod before eviction")
-	assert.Equal(tCtx, podWithClaimName, pod, "test pod")
+	tCtx.ExpectNoError(err, "get pod before eviction")
+	tCtx.Assert(pod).Should(gomega.Equal(podWithClaimName), "test pod")
 
 	var mutex sync.Mutex
 	var podGets int
@@ -2717,11 +2714,11 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 		defer mutex.Unlock()
 		podGets++
 		podName := action.(core.GetAction).GetName()
-		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of patched pod")
+		tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of patched pod")
 
 		// This gets called directly before eviction. Pretend that it is deleted.
 		err = fakeClientset.Tracker().Delete(v1.SchemeGroupVersion.WithResource("pods"), pod.Namespace, pod.Name)
-		assert.NoError(tCtx, err, "delete pod") //nolint:testifylint // Here recording an unknown error and continuing is okay.
+		tCtx.AssertNoError(err, "delete pod")
 		return true, nil, apierrors.NewNotFound(v1.SchemeGroupVersion.WithResource("pods").GroupResource(), pod.Name)
 	})
 	fakeClientset.PrependReactor("delete", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
@@ -2729,7 +2726,7 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 		defer mutex.Unlock()
 		podDeletions++
 		podName := action.(core.DeleteAction).GetName()
-		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of deleted pod")
+		tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of deleted pod")
 		return false, nil, nil
 	})
 	controller := newTestController(tCtx)
@@ -2743,7 +2740,7 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert.NoError(tCtx, controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
+		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 	}()
 
 	// Eventually the pod gets deleted, in this test by us.
@@ -2755,10 +2752,10 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 
 	// We don't want any events.
 	tCtx.Wait()
-	assert.Equal(tCtx, 1, podGets, "number of pod get calls")
-	assert.Equal(tCtx, 0, podDeletions, "number of pod delete calls")
-	assert.Equal(tCtx, 0, controller.workqueue.Len(), "Work queue should be empty now.")
-	gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(gomega.BeEmpty())
+	tCtx.Assert(podGets).Should(gomega.Equal(1), "number of pod get calls")
+	tCtx.Assert(podDeletions).Should(gomega.Equal(0), "number of pod delete calls")
+	tCtx.Assert(controller.workqueue.Len()).Should(gomega.Equal(0), "Work queue should be empty now.")
+	tCtx.Assert(listEvents(tCtx)).Should(gomega.BeEmpty())
 	tCtx.ExpectNoError(testPodDeletionsMetrics(controller))
 }
 
@@ -2780,8 +2777,8 @@ func synctestRetry(tCtx ktesting.TContext) {
 	tCtx = tCtx.WithClients(nil, nil, fakeClientset, nil, nil)
 
 	pod, err := fakeClientset.CoreV1().Pods(pod.Namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-	require.NoError(tCtx, err, "get pod before eviction")
-	assert.Equal(tCtx, podWithClaimName, pod, "test pod")
+	tCtx.ExpectNoError(err, "get pod before eviction")
+	tCtx.Assert(pod).Should(gomega.Equal(podWithClaimName), "test pod")
 
 	var mutex sync.Mutex
 	var podGets int
@@ -2792,7 +2789,7 @@ func synctestRetry(tCtx ktesting.TContext) {
 		defer mutex.Unlock()
 		podGets++
 		podName := action.(core.GetAction).GetName()
-		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of patched pod")
+		tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of patched pod")
 
 		// This gets called directly before eviction. Pretend that there is an intermittent error.
 		if podGets == 1 {
@@ -2805,7 +2802,7 @@ func synctestRetry(tCtx ktesting.TContext) {
 		defer mutex.Unlock()
 		podDeletions++
 		podName := action.(core.DeleteAction).GetName()
-		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of deleted pod")
+		tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of deleted pod")
 		return false, nil, nil
 	})
 	controller := newTestController(tCtx)
@@ -2819,23 +2816,23 @@ func synctestRetry(tCtx ktesting.TContext) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		assert.NoError(tCtx, controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
+		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 	}()
 
 	expectLatencies := []time.Duration{5 * time.Millisecond /* default exponential retry */}
 
 	// Eventually the pod gets deleted and the event is recorded.
 	tCtx.Eventually(func(tCtx ktesting.TContext) error {
-		gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(matchDeletionEvent())
+		tCtx.Expect(listEvents(tCtx)).To(matchDeletionEvent())
 		return testPodDeletionsMetrics(controller, expectLatencies...)
 	}).WithTimeout(30*time.Second).Should(gomega.Succeed(), "pod eviction done")
 
 	// Now we can check the API calls.
 	tCtx.Wait()
-	assert.Equal(tCtx, 2, podGets, "number of pod get calls")
-	assert.Equal(tCtx, 1, podDeletions, "number of pod delete calls")
-	gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(matchDeletionEvent())
-	assert.Equal(tCtx, 0, controller.workqueue.Len(), "Work queue should be empty now.")
+	tCtx.Assert(podGets).Should(gomega.Equal(2), "number of pod get calls")
+	tCtx.Assert(podDeletions).Should(gomega.Equal(1), "number of pod delete calls")
+	tCtx.Assert(listEvents(tCtx)).Should(matchDeletionEvent())
+	tCtx.Assert(controller.workqueue.Len()).Should(gomega.Equal(0), "Work queue should be empty now.")
 	tCtx.ExpectNoError(testPodDeletionsMetrics(controller, expectLatencies...))
 }
 
@@ -2855,22 +2852,22 @@ func BenchmarkTaintUntaint(b *testing.B) {
 		// Add objects...
 		tContext.handleSliceChange(nil, slice)
 		tContext.handleClaimChange(nil, inUseClaimWithToleration)
-		require.NoError(tContext, podStore.Add(podWithClaimName), "add pod")
+		tContext.ExpectNoError(podStore.Add(podWithClaimName), "add pod")
 		tContext.handlePodChange(nil, podWithClaimName)
-		require.Empty(tContext, tContext.deletePodAt)
+		tContext.Expect(tContext.deletePodAt).To(gomega.BeEmpty())
 
 		// Now evict.
 		tContext.handleSliceChange(slice, sliceTainted)
 
 		// Because informer event handlers are synchronous, we get the expected result immediately.
-		require.NotEmpty(tContext, tContext.deletePodAt)
+		tContext.Expect(tContext.deletePodAt).NotTo(gomega.BeEmpty())
 
 		// ... and remove them again.
 		tContext.handleSliceChange(sliceTainted, slice)
-		require.Empty(tContext, tContext.deletePodAt)
+		tContext.Expect(tContext.deletePodAt).To(gomega.BeEmpty())
 
 		tContext.handlePodChange(podWithClaimName, nil)
-		require.NoError(tContext, podStore.Delete(podWithClaimName), "remove pod")
+		tContext.ExpectNoError(podStore.Delete(podWithClaimName), "remove pod")
 		tContext.handleClaimChange(inUseClaimWithToleration, nil)
 		tContext.handleSliceChange(slice, nil)
 	}

--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package devicetainteviction
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -44,8 +45,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	core "k8s.io/client-go/testing"
 	"k8s.io/component-base/featuregate"
 	metricstestutil "k8s.io/component-base/metrics/testutil"
@@ -66,6 +70,18 @@ func init() {
 		string(features.DRADeviceTaints):     true,
 		string(features.DRADeviceTaintRules): true,
 	}); err != nil {
+		panic(err)
+	}
+
+	// Disabled because we not only use the fake client, we also wrap it:
+	// that prevents auto-detection via IsWatchListSemanticsUnSupported.
+	// This here is simpler than implementing IsWatchListSemanticsUnSupported.
+	//
+	// We cannot use clientfeaturestesting.SetFeatureDuringTest (needs testing.TB),
+	// so here we just do it ourselves.
+	if err := clientfeatures.FeatureGates().(interface {
+		Set(clientfeatures.Feature, bool) error
+	}).Set(clientfeatures.WatchListClient, false); err != nil {
 		panic(err)
 	}
 }
@@ -2367,14 +2383,15 @@ func testEviction(tCtx ktesting.TContext) {
 func TestDeviceTaintRule(t *testing.T) { testDeviceTaintRule(ktesting.Init(t)) }
 func testDeviceTaintRule(tCtx ktesting.TContext) {
 	tCtx.Parallel()
-	tCtx.SyncTest("immediate", func(tCtx ktesting.TContext) { synctestDeviceTaintRule(tCtx, false) })
-	tCtx.SyncTest("delayed", func(tCtx ktesting.TContext) { synctestDeviceTaintRule(tCtx, true) })
+	tCtx.SyncTest("immediate", func(tCtx ktesting.TContext) { synctestDeviceTaintRule(tCtx, false, false) })
+	tCtx.SyncTest("delayed", func(tCtx ktesting.TContext) { synctestDeviceTaintRule(tCtx, true, false) })
+	tCtx.SyncTest("slow", func(tCtx ktesting.TContext) { synctestDeviceTaintRule(tCtx, true, true) })
 }
-func synctestDeviceTaintRule(tCtx ktesting.TContext, delayed bool) {
+func synctestDeviceTaintRule(tCtx ktesting.TContext, toleration, slowDelete bool) {
 	rule := ruleNone.DeepCopy()
 	claim := inUseClaim.DeepCopy()
 	tolerationSeconds := int64(0)
-	if delayed {
+	if toleration {
 		tolerationSeconds = 30
 		claim.Status.Allocation.Devices.Results[0].Tolerations = []resourceapi.DeviceToleration{{
 			Effect:            resourceapi.DeviceTaintEffectNoExecute,
@@ -2383,7 +2400,17 @@ func synctestDeviceTaintRule(tCtx ktesting.TContext, delayed bool) {
 		}}
 	}
 	fakeClientset := fake.NewClientset(podWithClaimName, claim, rule)
-	tCtx = tCtx.WithClients(nil, nil, fakeClientset, nil, nil)
+	blockDelete := make(chan struct{})
+	client := clientset.Interface(fakeClientset)
+	if slowDelete {
+		client = &myFakeClient{client, func() {
+			// This coordinates with the main goroutine to move forward after a certain delay.
+			tCtx.Logf("Delaying pod deletion")
+			<-blockDelete
+			tCtx.Logf("Proceeding with pod deletion")
+		}}
+	}
+	tCtx = tCtx.WithClients(nil, nil, client, nil, nil)
 	controller := newTestController(tCtx)
 
 	var wg sync.WaitGroup
@@ -2430,9 +2457,16 @@ func synctestDeviceTaintRule(tCtx ktesting.TContext, delayed bool) {
 	}
 	check(tCtx, "evict: ", l(inProgress(rule, true, "PodsPendingEviction", "1 pod needs to be evicted in 1 namespace.", &updated)), expectedPods)
 
+	var slowDeleteDelay time.Duration
 	if tolerationSeconds > 0 {
-		// Need to move forward in time past the delay.
+		// Need to move forward in time past the delay(s)
 		time.Sleep(time.Duration(tolerationSeconds) * time.Second)
+		if slowDelete {
+			// This is going to show up in the histogram.
+			slowDeleteDelay = 3 * time.Second
+			time.Sleep(slowDeleteDelay)
+			close(blockDelete)
+		}
 		tCtx.Wait()
 		// Now the pod is deleted. Status gets updated later.
 		check(tCtx, "evict: ", l(inProgress(rule, true, "PodsPendingEviction", "1 pod needs to be evicted in 1 namespace.", &updated)), nil)
@@ -2458,8 +2492,7 @@ func synctestDeviceTaintRule(tCtx ktesting.TContext, delayed bool) {
 
 	tCtx.Assert(controller.workqueue.Len()).Should(gomega.Equal(0), "work queue empty")
 	// There are no delays inside a synctest bubble. The pod always gets deleted "immediately".
-	// TODO: simulate delays?
-	tCtx.ExpectNoError(testPodDeletionsMetrics(controller, 0))
+	tCtx.ExpectNoError(testPodDeletionsMetrics(controller, slowDeleteDelay))
 }
 
 func check(tCtx ktesting.TContext, prefix string, expectRules []*resourcealpha.DeviceTaintRule, expectPods []*v1.Pod) {
@@ -2480,6 +2513,40 @@ func check(tCtx ktesting.TContext, prefix string, expectRules []*resourcealpha.D
 	rules, err := tCtx.Client().ResourceV1alpha3().DeviceTaintRules().List(tCtx, metav1.ListOptions{})
 	tCtx.ExpectNoError(err, prefix+"list rules")
 	assertEqual(tCtx, expectRules, trimRules(rules.Items), prefix+"rules", opts...)
+}
+
+// myFakeClient and it's children have a single purpose: inject a callback into
+// CoreV1().Pods().Delete. We cannot use fakeClientset.PrependReactor for that
+// because it invokes the callback while holding the fake's mutex. If any other
+// goroutine then also makes an API call, a synctest bubble deadlocks because
+// holding the mutex is not considered "durably blocking" even though it is
+// in our case.
+type myFakeClient struct {
+	clientset.Interface
+	deletePodCallback func()
+}
+
+func (mf *myFakeClient) CoreV1() corev1.CoreV1Interface {
+	return &myFakeCoreV1{mf.Interface.CoreV1(), mf.deletePodCallback}
+}
+
+type myFakeCoreV1 struct {
+	corev1.CoreV1Interface
+	deletePodCallback func()
+}
+
+func (mf *myFakeCoreV1) Pods(namespace string) corev1.PodInterface {
+	return &myFakePods{mf.CoreV1Interface.Pods(namespace), mf.deletePodCallback}
+}
+
+type myFakePods struct {
+	corev1.PodInterface
+	deletePodCallback func()
+}
+
+func (mf *myFakePods) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	mf.deletePodCallback()
+	return mf.PodInterface.Delete(ctx, name, opts)
 }
 
 // TestCancelEviction deletes the pod before the controller deletes it

--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -49,7 +49,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/featuregate"
 	metricstestutil "k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/devicetainteviction/metrics"
@@ -60,6 +60,17 @@ import (
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
+
+func init() {
+	// We must not use Default*Mutable*FeatureGate directly here,
+	// otherwise hack/verify-test-featuregates.sh complains.
+	if err := utilfeature.DefaultFeatureGate.(featuregate.MutableVersionedFeatureGate).SetFromMap(map[string]bool{
+		string(features.DRADeviceTaints):     true,
+		string(features.DRADeviceTaintRules): true,
+	}); err != nil {
+		panic(err)
+	}
+}
 
 // Reduce typing with some constructors.
 
@@ -87,13 +98,6 @@ func l[T any](items ...T) []T {
 
 // setup creates a controller which is ready to have its handle* methods called.
 func setup(tCtx ktesting.TContext) *testContext {
-	featuregatetesting.SetFeatureGatesDuringTest(tCtx, utilfeature.DefaultFeatureGate,
-		featuregatetesting.FeatureOverrides{
-			features.DRADeviceTaints:     true,
-			features.DRADeviceTaintRules: true,
-		},
-	)
-
 	fakeClientset := fake.NewClientset()
 	informerFactory := informers.NewSharedInformerFactory(fakeClientset, 0)
 	controller := New(fakeClientset,
@@ -762,6 +766,8 @@ func inProgress(rule *resourcealpha.DeviceTaintRule, status bool, reason, messag
 // advancing time to reach "later" work items.
 func TestController(t *testing.T) { testController(ktesting.Init(t)) }
 func testController(tCtx ktesting.TContext) {
+	tCtx.Parallel()
+
 	for name, tc := range map[string]testCase{
 		"empty": {},
 		"populate-pools": {
@@ -1860,6 +1866,7 @@ func testController(tCtx ktesting.TContext) {
 		},
 	} {
 		tCtx.Run(name, func(tCtx ktesting.TContext) {
+			tCtx.Parallel()
 			numEvents := len(tc.events)
 			if numEvents <= 1 {
 				// No permutations.
@@ -1882,9 +1889,12 @@ func testController(tCtx ktesting.TContext) {
 					tc := tc
 					tc.events = events
 					name := strings.Trim(fmt.Sprintf("%v", permutation), "[]")
-					tCtx.SyncTest(name, func(tCtx ktesting.TContext) {
-						tContext := setup(tCtx)
-						testHandlers(tContext, tc)
+					tCtx.Run(name, func(tCtx ktesting.TContext) {
+						tCtx.Parallel()
+						tCtx.SyncTest("", func(tCtx ktesting.TContext) {
+							tContext := setup(tCtx)
+							testHandlers(tContext, tc)
+						})
 					})
 					return
 				}
@@ -2043,28 +2053,32 @@ func applyEventPair(tContext *testContext, event any) {
 		store := tContext.informerFactory.Core().V1().Pods().Informer().GetStore()
 		switch {
 		case pair[0] != nil && pair[1] != nil:
-			tContext.ExpectNoError(store.Update(pair[1]))
-			tContext.ExpectNoError(tContext.client.Tracker().Update(v1.SchemeGroupVersion.WithResource("pods"), pair[1], pair[1].Namespace))
+			obj := pair[1].DeepCopy()
+			tContext.ExpectNoError(store.Update(obj))
+			tContext.ExpectNoError(tContext.client.Tracker().Update(v1.SchemeGroupVersion.WithResource("pods"), obj, pair[1].Namespace))
 		case pair[0] != nil:
 			tContext.ExpectNoError(store.Delete(pair[0]))
 			tContext.ExpectNoError(tContext.client.Tracker().Delete(v1.SchemeGroupVersion.WithResource("pods"), pair[0].Namespace, pair[0].Name))
 		default:
-			tContext.ExpectNoError(store.Add(pair[1]))
-			tContext.ExpectNoError(tContext.client.Tracker().Add(pair[1]))
+			obj := pair[1].DeepCopy()
+			tContext.ExpectNoError(store.Add(obj))
+			tContext.ExpectNoError(tContext.client.Tracker().Add(obj))
 		}
 		tContext.handlePodChange(pair[0], pair[1])
 	case [2]*resourcealpha.DeviceTaintRule:
 		store := tContext.informerFactory.Resource().V1alpha3().DeviceTaintRules().Informer().GetStore()
 		switch {
 		case pair[0] != nil && pair[1] != nil:
-			tContext.ExpectNoError(store.Update(pair[1]))
-			tContext.ExpectNoError(tContext.client.Tracker().Update(resourcealpha.SchemeGroupVersion.WithResource("devicetaintrules"), pair[1], pair[1].Namespace))
+			obj := pair[1].DeepCopy()
+			tContext.ExpectNoError(store.Update(obj))
+			tContext.ExpectNoError(tContext.client.Tracker().Update(resourcealpha.SchemeGroupVersion.WithResource("devicetaintrules"), obj, pair[1].Namespace))
 		case pair[0] != nil:
 			tContext.ExpectNoError(store.Delete(pair[0]))
 			tContext.ExpectNoError(tContext.client.Tracker().Delete(resourcealpha.SchemeGroupVersion.WithResource("devicetaintrules"), pair[0].Namespace, pair[0].Name))
 		default:
-			tContext.ExpectNoError(store.Add(pair[1]))
-			tContext.ExpectNoError(tContext.client.Tracker().Add(pair[1]))
+			obj := pair[1].DeepCopy()
+			tContext.ExpectNoError(store.Add(obj))
+			tContext.ExpectNoError(tContext.client.Tracker().Add(obj))
 		}
 		tContext.handleRuleChange(pair[0], pair[1])
 	default:
@@ -2124,12 +2138,6 @@ func newTestController(tCtx ktesting.TContext, clientSet *fake.Clientset) *Contr
 
 	informerFactory := informers.NewSharedInformerFactory(clientSet, 0)
 
-	featuregatetesting.SetFeatureGatesDuringTest(tCtx, utilfeature.DefaultFeatureGate,
-		featuregatetesting.FeatureOverrides{
-			features.DRADeviceTaints:     true,
-			features.DRADeviceTaintRules: true,
-		},
-	)
 	controller := New(tCtx.Client(),
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Resource().V1().ResourceClaims(),
@@ -2138,59 +2146,60 @@ func newTestController(tCtx ktesting.TContext, clientSet *fake.Clientset) *Contr
 		informerFactory.Resource().V1().DeviceClasses(),
 		"device-taint-eviction",
 	)
-	controller.metrics = metrics.New(300 /* one large initial bucket for testing */) // TODO: inside a synctest bubble we should have deterministic delays and shouldn't need this trick. The remaining uncertainty comes from polling for informer cache sync.
+	controller.metrics = metrics.New()
 	// Always log, not matter what the -v value is.
 	logger := klog.FromContext(tCtx)
 	controller.eventLogger = &logger
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	tCtx.Cleanup(informerFactory.Shutdown)
 
 	tCtx.Log("starting to wait for watches")
-	if tCtx.IsSyncTest() {
-		tCtx.Wait()
-		require.Equal(tCtx, int32(5), numWatches.Load(), "All watches should be registered.")
-	} else {
-		tCtx.Eventually(func(tCtx ktesting.TContext) int32 {
-			return numWatches.Load()
-		}).WithTimeout(5*time.Second).Should(gomega.Equal(int32(5)), "All watches should be registered.")
-	}
+	tCtx.Wait()
+	tCtx.Expect(numWatches.Load()).To(gomega.Equal(int32(5)), "All watches should be registered.")
 	tCtx.Log("done waiting for watches")
 
 	return controller
 }
 
-func testPodDeletionsMetrics(controller *Controller, total int) error {
-	// We cannot predict the sum of the latencies. Therefore we leave it at zero here
-	// and replace expected (>= 0) values when gathering.
-	expectedMetric := fmt.Sprintf(`# HELP device_taint_eviction_controller_pod_deletion_duration_seconds [ALPHA] Latency, in seconds, between the time when a device taint effect has been activated and a Pod's deletion via DeviceTaintEvictionController.
+// testPodDeletionsMetrics verifies the metrics recorded by the controller based on
+// the expected pod deletion latencies. Each entry in latencies represents one deleted pod.
+func testPodDeletionsMetrics(controller *Controller, latencies ...time.Duration) error {
+	countLE := func(le float64) int {
+		total := 0
+		for _, latency := range latencies {
+			if le == -1 || latency.Seconds() <= le {
+				total++
+			}
+		}
+		return total
+	}
+	var totalDuration time.Duration
+	for _, latency := range latencies {
+		totalDuration += latency
+	}
+
+	var expected strings.Builder
+	expected.WriteString(`# HELP device_taint_eviction_controller_pod_deletion_duration_seconds [ALPHA] Latency, in seconds, between the time when a device taint effect has been activated and a Pod's deletion via DeviceTaintEvictionController.
 # TYPE device_taint_eviction_controller_pod_deletion_duration_seconds histogram
-device_taint_eviction_controller_pod_deletion_duration_seconds_bucket{le="300"} %[1]d
-device_taint_eviction_controller_pod_deletion_duration_seconds_bucket{le="+Inf"} %[1]d
-device_taint_eviction_controller_pod_deletion_duration_seconds_sum 0
-device_taint_eviction_controller_pod_deletion_duration_seconds_count %[1]d
-# HELP device_taint_eviction_controller_pod_deletions_total [ALPHA] Total number of Pods deleted by DeviceTaintEvictionController since its start.
+`)
+	for _, le := range []float64{0.005, 0.025, 0.1, 0.5, 1, 2.5, 10, 30, 60, 120, 180, 240} {
+		expected.WriteString(fmt.Sprintf("device_taint_eviction_controller_pod_deletion_duration_seconds_bucket{le=\"%f\"} %d\n", le, countLE(le)))
+	}
+	expected.WriteString(fmt.Sprintf("device_taint_eviction_controller_pod_deletion_duration_seconds_bucket{le=\"+Inf\"} %d\n", countLE(-1)))
+	expected.WriteString(fmt.Sprintf("device_taint_eviction_controller_pod_deletion_duration_seconds_sum %f\n", totalDuration.Seconds()))
+	expected.WriteString(fmt.Sprintf("device_taint_eviction_controller_pod_deletion_duration_seconds_count %d\n", len(latencies)))
+	expected.WriteString(fmt.Sprintf(`# HELP device_taint_eviction_controller_pod_deletions_total [ALPHA] Total number of Pods deleted by DeviceTaintEvictionController since its start.
 # TYPE device_taint_eviction_controller_pod_deletions_total counter
-device_taint_eviction_controller_pod_deletions_total %[1]d
-`, total)
+device_taint_eviction_controller_pod_deletions_total %d
+`, len(latencies)))
+
 	names := []string{
 		controller.metrics.PodDeletionsTotal.FQName(),
 		controller.metrics.PodDeletionsLatency.FQName(),
 	}
-	gather := func() ([]*metricstestutil.MetricFamily, error) {
-		got, err := controller.metrics.Gather()
-		for _, mf := range got {
-			for _, m := range mf.Metric {
-				if m.Histogram == nil || m.Histogram.SampleSum == nil || *m.Histogram.SampleSum < 0 {
-					continue
-				}
-				m.Histogram.SampleSum = ptr.To(float64(0))
-			}
-		}
-		return got, err
-	}
 
-	return metricstestutil.GatherAndCompare(metricstestutil.GathererFunc(gather), strings.NewReader(expectedMetric), names...)
+	return metricstestutil.GatherAndCompare(controller.metrics, strings.NewReader(expected.String()), names...)
 }
 
 // TestEviction runs through the full flow of starting the controller and evicting one pod.
@@ -2202,6 +2211,8 @@ device_taint_eviction_controller_pod_deletions_total %[1]d
 // activity to settle down and then check the state.
 func TestEviction(t *testing.T) { testEviction(ktesting.Init(t)) }
 func testEviction(tCtx ktesting.TContext) {
+	tCtx.Parallel()
+
 	do := func(tCtx ktesting.TContext, what string, action func(tCtx ktesting.TContext) error) {
 		tCtx.Log(what)
 		err := action(tCtx)
@@ -2303,19 +2314,19 @@ func testEviction(tCtx ktesting.TContext) {
 			fakeClientset.PrependReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 				podGets++
 				podName := action.(core.GetAction).GetName()
-				assert.Equal(tCtx, podWithClaimName.Name, podName, "name of pod to patch")
+				tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of pod to patch")
 				return false, nil, nil
 			})
 			fakeClientset.PrependReactor("patch", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 				podUpdates++
 				podName := action.(core.PatchAction).GetName()
-				assert.Equal(tCtx, podWithClaimName.Name, podName, "name of pod to get")
+				tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of pod to get")
 				return false, nil, nil
 			})
 			fakeClientset.PrependReactor("delete", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 				podDeletions++
 				podName := action.(core.DeleteAction).GetName()
-				assert.Equal(tCtx, podWithClaimName.Name, podName, "name of pod to delete")
+				tCtx.Assert(podName).Should(gomega.Equal(podWithClaimName.Name), "name of pod to delete")
 				obj, err := fakeClientset.Tracker().Get(v1.SchemeGroupVersion.WithResource("pods"), pod.Namespace, pod.Name)
 				require.NoError(tCtx, err)
 				updatedPod = obj.(*v1.Pod)
@@ -2336,27 +2347,14 @@ func testEviction(tCtx ktesting.TContext) {
 			}()
 
 			// Eventually the controller should have synced it's informers.
-			if false {
-				// This feels like it should work (controller should run until it has started up, then block durably), but it doesn't.
-				// Time progresses while the controller is blocked in cache.WaitForNamedCacheSyncWithContext, so this is
-				// probably a good place to start looking.
-				// TODO: make "wait for cache sync" block on a channel. Alternatively, use a context and let `context.Cause`
-				// report success or failure (might be too hacky).
-				tCtx.Wait()
-				if controller.hasSynced.Load() <= 0 {
-					tCtx.Fatal("controller should have synced")
-				}
-			} else {
-				tCtx.Eventually(func(tCtx ktesting.TContext) bool {
-					return controller.hasSynced.Load() > 0
-				}).WithTimeout(30 * time.Second).Should(gomega.BeTrueBecause("controller synced"))
-				if tt.afterSync != nil {
-					tt.afterSync(tCtx)
-				}
-			}
-
-			// We can wait for the controller to be idle.
 			tCtx.Wait()
+			if controller.hasSynced.Load() <= 0 {
+				tCtx.Fatal("controller should have synced")
+			}
+			if tt.afterSync != nil {
+				tt.afterSync(tCtx)
+				tCtx.Wait()
+			}
 
 			// The number of API calls is deterministic.
 			assert.Equal(tCtx, 1, podGets, "get pod once")
@@ -2384,19 +2382,16 @@ func testEviction(tCtx ktesting.TContext) {
 				tCtx.Errorf("unexpected modified pod (-want, +got):\n%s", diff)
 			}
 
+			// Timing is perfectly predictable.
+			tCtx.Expect(time.Since(start)).To(gomega.Equal(0*time.Second), "time to evict pod")
+
 			// Shortly after deletion we should also see updated metrics.
 			// This is the last thing the controller does for a pod.
-			// Because of Wait we know that all goroutines are durably blocked and won't
-			// wake up again to change the metrics => no need for a "Consistently"!
-			gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(matchDeletionEvent())
-			tCtx.ExpectNoError(testPodDeletionsMetrics(controller, 1), "pod eviction done")
-
-			// Depending on timing, some of the "wait for cache synced" polling sleep a bit more or less,
-			// so there is a certain delta of uncertainty about the overall duration. Without that polling
-			// we probably could assert zero runtime here.
-			tCtx.Logf("eviction duration: %s", time.Since(start))
-			delta := time.Second
-			require.WithinRange(tCtx, time.Now(), start, start.Add(delta), "time to evict pod")
+			// We know that all goroutines are durably blocked and
+			// queues are empty => no need for a "Consistently"!
+			tCtx.Assert(controller.workqueue.Len()).To(gomega.Equal(0), "work queue empty")
+			tCtx.Assert(listEvents(tCtx)).Should(matchDeletionEvent())
+			tCtx.ExpectNoError(testPodDeletionsMetrics(controller, 0*time.Second), "pod eviction done")
 		})
 	}
 }
@@ -2406,10 +2401,25 @@ func testEviction(tCtx ktesting.TContext) {
 //
 // This runs in a bubble (https://pkg.go.dev/testing/synctest), so we can wait for goroutine
 // activity to settle down and then check the state.
-func TestDeviceTaintRule(t *testing.T) { ktesting.Init(t).SyncTest("", synctestDeviceTaintRule) }
-func synctestDeviceTaintRule(tCtx ktesting.TContext) {
+func TestDeviceTaintRule(t *testing.T) { testDeviceTaintRule(ktesting.Init(t)) }
+func testDeviceTaintRule(tCtx ktesting.TContext) {
+	tCtx.Parallel()
+	tCtx.SyncTest("immediate", func(tCtx ktesting.TContext) { synctestDeviceTaintRule(tCtx, false) })
+	tCtx.SyncTest("delayed", func(tCtx ktesting.TContext) { synctestDeviceTaintRule(tCtx, true) })
+}
+func synctestDeviceTaintRule(tCtx ktesting.TContext, delayed bool) {
 	rule := ruleNone.DeepCopy()
-	fakeClientset := fake.NewClientset(podWithClaimName, inUseClaim, rule)
+	claim := inUseClaim.DeepCopy()
+	tolerationSeconds := int64(0)
+	if delayed {
+		tolerationSeconds = 30
+		claim.Status.Allocation.Devices.Results[0].Tolerations = []resourceapi.DeviceToleration{{
+			Effect:            resourceapi.DeviceTaintEffectNoExecute,
+			Value:             rule.Spec.Taint.Value,
+			TolerationSeconds: &tolerationSeconds,
+		}}
+	}
+	fakeClientset := fake.NewClientset(podWithClaimName, claim, rule)
 	tCtx = tCtx.WithClients(nil, nil, fakeClientset, nil, nil)
 	controller := newTestController(tCtx, fakeClientset)
 
@@ -2426,48 +2436,52 @@ func synctestDeviceTaintRule(tCtx ktesting.TContext) {
 	})
 
 	// Eventually the controller should have synced it's informers.
-	if false {
-		// This feels like it should work (controller should run until it has started up, then block durably), but it doesn't.
-		// Time progresses while the controller is blocked in cache.WaitForNamedCacheSyncWithContext, so this is
-		// probably a good place to start looking.
-		// TODO: make "wait for cache sync" block on a channel. Alternatively, use a context and let `context.Cause`
-		// report success or failure (might be too hacky).
-		tCtx.Wait()
-		if controller.hasSynced.Load() <= 0 {
-			tCtx.Fatal("controller should have synced")
-		}
-	} else {
-		tCtx.Eventually(func(tCtx ktesting.TContext) bool {
-			return controller.hasSynced.Load() > 0
-		}).WithTimeout(30 * time.Second).Should(gomega.BeTrueBecause("controller synced"))
+	tCtx.Wait()
+	if controller.hasSynced.Load() <= 0 {
+		tCtx.Fatal("controller should have synced")
 	}
 
-	// We can wait for the controller to be idle.
-	tCtx.Wait()
 	start := metav1.Now()
-	tCtx.Logf("TIME: start at %s", start)
+	tCtx.Logf("TIME: start")
 	check(tCtx, "initial processing: ", l(inProgress(ruleNone, false, "NoEffect", "0 published devices selected. 1 allocated device selected. 1 pod would be evicted in 1 namespace if the effect was NoExecute. This information will not be updated again. Recreate the DeviceTaintRule to trigger an update.", &start /* processed before waiting for cache sync completion */)), l(podWithClaimName))
 
 	// Move time forward to ensure that we get different time stamps.
 	time.Sleep(20 * time.Second)
+	updated := metav1.Now()
+	rule = rule.DeepCopy() // fake.NewClientset does not copy! Perhaps it should?!
 	rule.Spec.Taint.Effect = resourcealpha.DeviceTaintEffectNoExecute
+	// The real apiserver is going to bump this automatically in 1.36,
+	// but in a unit test we have to do it manually.
+	rule.Spec.Taint.TimeAdded = &updated
 	rule, err := tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Update(tCtx, rule, metav1.UpdateOptions{})
 	tCtx.ExpectNoError(err, "update rule")
 
 	// Wait for eviction.
 	tCtx.Wait()
-	evicted := metav1.Now()
-	tCtx.Logf("TIME: eviction done at %s", evicted)
+	tCtx.Logf("TIME: eviction %s since start", updated.Sub(start.Time))
 	// The rule status got updated once before evicting pods, but not yet after evicting it.
-	check(tCtx, "evict: ", l(inProgress(rule, true, "PodsPendingEviction", "1 pod needs to be evicted in 1 namespace.", &evicted)), nil)
+	var expectedPods []*v1.Pod
+	if tolerationSeconds > 0 {
+		// Eviction is delayed, pod not deleted yet.
+		expectedPods = append(expectedPods, podWithClaimName)
+	}
+	check(tCtx, "evict: ", l(inProgress(rule, true, "PodsPendingEviction", "1 pod needs to be evicted in 1 namespace.", &updated)), expectedPods)
+
+	if tolerationSeconds > 0 {
+		// Need to move forward in time past the delay.
+		time.Sleep(time.Duration(tolerationSeconds) * time.Second)
+		tCtx.Wait()
+		// Now the pod is deleted. Status gets updated later.
+		check(tCtx, "evict: ", l(inProgress(rule, true, "PodsPendingEviction", "1 pod needs to be evicted in 1 namespace.", &updated)), nil)
+	}
 
 	// AddAfter does not move time forward. Do it ourselves...
 	time.Sleep(ruleStatusPeriod)
 	slept := metav1.Now()
-	tCtx.Logf("TIME: slept till %s", slept)
+	tCtx.Logf("TIME: slept %s since start", slept.Sub(start.Time))
 	tCtx.Wait()
 	done := metav1.Now()
-	tCtx.Logf("TIME: done at %s", done)
+	tCtx.Logf("TIME: done %s since start", done.Sub(start.Time))
 	check(tCtx, "done: ", l(inProgress(rule, false, "Completed", "1 pod evicted since starting the controller.", &done)), nil)
 	assertEqual(tCtx, map[types.UID]taintRuleStats{rule.UID: {numEvictedPods: 1}}, controller.taintRuleStats, "taint rule statistics should have counted the pod")
 
@@ -2476,8 +2490,13 @@ func synctestDeviceTaintRule(tCtx ktesting.TContext) {
 	tCtx.ExpectNoError(err, "delete rule")
 	tCtx.Wait()
 	deleted := metav1.Now()
-	tCtx.Logf("TIME: deleted at %s", deleted)
+	tCtx.Logf("TIME: deleted %s since start", deleted.Sub(start.Time))
 	assert.Empty(tCtx, controller.taintRuleStats, "taint rule statistics should have dropped the deleted rule")
+
+	tCtx.Assert(controller.workqueue.Len()).Should(gomega.Equal(0), "work queue empty")
+	// There are no delays inside a synctest bubble. The pod always gets deleted "immediately".
+	// TODO: simulate delays?
+	tCtx.ExpectNoError(testPodDeletionsMetrics(controller, 0))
 }
 
 func check(tCtx ktesting.TContext, prefix string, expectRules []*resourcealpha.DeviceTaintRule, expectPods []*v1.Pod) {
@@ -2504,6 +2523,7 @@ func check(tCtx ktesting.TContext, prefix string, expectRules []*resourcealpha.D
 // or removes the slice. Either way, eviction gets cancelled.
 func TestCancelEviction(t *testing.T) { testCancelEviction(ktesting.Init(t)) }
 func testCancelEviction(tCtx ktesting.TContext) {
+	tCtx.Parallel()
 	tCtx.SyncTest("pod-deleted", func(tCtx ktesting.TContext) { doCancelEviction(tCtx, true) })
 	tCtx.SyncTest("slice-deleted", func(tCtx ktesting.TContext) { doCancelEviction(tCtx, false) })
 }
@@ -2620,22 +2640,20 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 		assert.Equal(tCtx, 0, podDeletions, "Pod should not have been deleted.")
 	}
 
-	// Naively (?) one could expect synctest.Wait to have blocked until the work item added via AddAfter
-	// got processed because before that the overall state isn't stable yet. But the workqueue package
-	// seems to implement AddAfter in a way which is not detected as "blocking on time to pass" by
-	// by synctest and therefore it returns without advancing time enough.
-	//
-	// Here we trigger that manually as a workaround (?). The factor doesn't really matter.
-	// Commenting this out causes the controller.maybeDeletePodCount check to fail.
+	// Time does not progress in synctest.Wait because it returns when all goroutines are blocked
+	// waiting for time to pass (for example, in a time.Sleep).
+	// To flush the workqueue, we have to move time forward by enough time to get past
+	// the delay of the AddAfter.
 	time.Sleep(10 * time.Duration(tolerationSeconds) * time.Second)
 	tCtx.Wait()
 
+	tCtx.Assert(controller.workqueue.Len()).Should(gomega.Equal(0), "work queue empty")
+	gomega.NewGomegaWithT(tCtx).Expect(controller.workqueue.Len()).Should(gomega.Equal(0), "work queue empty")
 	assert.Equal(tCtx, 0, podGets, "Worker should not have needed to get the pod.")
 	assert.Equal(tCtx, 0, podUpdates, "Worker should not have needed to update the pod.")
-	assert.Equal(tCtx, 0, controller.workqueue.Len(), "Work queue should be empty now.")
 	assert.Equal(tCtx, int64(1), controller.maybeDeletePodCount, "Work queue should have processed pod.")
 	gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(matchEvents)
-	tCtx.ExpectNoError(testPodDeletionsMetrics(controller, 0))
+	tCtx.ExpectNoError(testPodDeletionsMetrics(controller))
 }
 
 // TestParallelPodDeletion covers the scenario that a pod gets deleted right before
@@ -2643,78 +2661,83 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 func TestParallelPodDeletion(t *testing.T) { testParallelPodDeletion(ktesting.Init(t)) }
 func testParallelPodDeletion(tCtx ktesting.TContext) {
 	tCtx.Parallel()
+	tCtx.SyncTest("", synctestParallelPodDeletion)
+}
+func synctestParallelPodDeletion(tCtx ktesting.TContext) {
+	// This scenario is the same as "evict-pod-resourceclaim" above.
+	pod := podWithClaimName.DeepCopy()
+	fakeClientset := fake.NewClientset(
+		sliceTainted,
+		slice2,
+		inUseClaim,
+		pod,
+	)
+	tCtx = tCtx.WithClients(nil, nil, fakeClientset, nil, nil)
 
-	tCtx.SyncTest("", func(tCtx ktesting.TContext) {
-		// This scenario is the same as "evict-pod-resourceclaim" above.
-		pod := podWithClaimName.DeepCopy()
-		fakeClientset := fake.NewClientset(
-			sliceTainted,
-			slice2,
-			inUseClaim,
-			pod,
-		)
-		tCtx = tCtx.WithClients(nil, nil, fakeClientset, nil, nil)
+	pod, err := fakeClientset.CoreV1().Pods(pod.Namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
+	require.NoError(tCtx, err, "get pod before eviction")
+	assert.Equal(tCtx, podWithClaimName, pod, "test pod")
 
-		pod, err := fakeClientset.CoreV1().Pods(pod.Namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
-		require.NoError(tCtx, err, "get pod before eviction")
-		assert.Equal(tCtx, podWithClaimName, pod, "test pod")
+	var mutex sync.Mutex
+	var podGets int
+	var podDeletions int
 
-		var mutex sync.Mutex
-		var podGets int
-		var podDeletions int
+	fakeClientset.PrependReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		mutex.Lock()
+		defer mutex.Unlock()
+		podGets++
+		podName := action.(core.GetAction).GetName()
+		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of patched pod")
 
-		fakeClientset.PrependReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-			mutex.Lock()
-			defer mutex.Unlock()
-			podGets++
-			podName := action.(core.GetAction).GetName()
-			assert.Equal(tCtx, podWithClaimName.Name, podName, "name of patched pod")
-
-			// This gets called directly before eviction. Pretend that it is deleted.
-			err = fakeClientset.Tracker().Delete(v1.SchemeGroupVersion.WithResource("pods"), pod.Namespace, pod.Name)
-			assert.NoError(tCtx, err, "delete pod") //nolint:testifylint // Here recording an unknown error and continuing is okay.
-			return true, nil, apierrors.NewNotFound(v1.SchemeGroupVersion.WithResource("pods").GroupResource(), pod.Name)
-		})
-		fakeClientset.PrependReactor("delete", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-			mutex.Lock()
-			defer mutex.Unlock()
-			podDeletions++
-			podName := action.(core.DeleteAction).GetName()
-			assert.Equal(tCtx, podWithClaimName.Name, podName, "name of deleted pod")
-			return false, nil, nil
-		})
-		controller := newTestController(tCtx, fakeClientset)
-
-		var wg sync.WaitGroup
-		defer func() {
-			tCtx.Log("Waiting for goroutine termination...")
-			tCtx.Cancel("time to stop")
-			wg.Wait()
-		}()
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			assert.NoError(tCtx, controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
-		}()
-
-		// Eventually the pod gets deleted, in this test by us.
-		tCtx.Eventually(func(tCtx ktesting.TContext) bool {
-			mutex.Lock()
-			defer mutex.Unlock()
-			return podGets >= 1
-		}).WithTimeout(30 * time.Second).Should(gomega.BeTrueBecause("pod eviction started"))
-
-		// We don't want any events.
-		tCtx.Wait()
-		assert.Equal(tCtx, 1, podGets, "number of pod get calls")
-		assert.Equal(tCtx, 0, podDeletions, "number of pod delete calls")
-		gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(gomega.BeEmpty())
-		tCtx.ExpectNoError(testPodDeletionsMetrics(controller, 0))
+		// This gets called directly before eviction. Pretend that it is deleted.
+		err = fakeClientset.Tracker().Delete(v1.SchemeGroupVersion.WithResource("pods"), pod.Namespace, pod.Name)
+		assert.NoError(tCtx, err, "delete pod") //nolint:testifylint // Here recording an unknown error and continuing is okay.
+		return true, nil, apierrors.NewNotFound(v1.SchemeGroupVersion.WithResource("pods").GroupResource(), pod.Name)
 	})
+	fakeClientset.PrependReactor("delete", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		mutex.Lock()
+		defer mutex.Unlock()
+		podDeletions++
+		podName := action.(core.DeleteAction).GetName()
+		assert.Equal(tCtx, podWithClaimName.Name, podName, "name of deleted pod")
+		return false, nil, nil
+	})
+	controller := newTestController(tCtx, fakeClientset)
+
+	var wg sync.WaitGroup
+	defer func() {
+		tCtx.Log("Waiting for goroutine termination...")
+		tCtx.Cancel("time to stop")
+		wg.Wait()
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(tCtx, controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
+	}()
+
+	// Eventually the pod gets deleted, in this test by us.
+	tCtx.Eventually(func(tCtx ktesting.TContext) bool {
+		mutex.Lock()
+		defer mutex.Unlock()
+		return podGets >= 1
+	}).WithTimeout(30 * time.Second).Should(gomega.BeTrueBecause("pod eviction started"))
+
+	// We don't want any events.
+	tCtx.Wait()
+	assert.Equal(tCtx, 1, podGets, "number of pod get calls")
+	assert.Equal(tCtx, 0, podDeletions, "number of pod delete calls")
+	assert.Equal(tCtx, 0, controller.workqueue.Len(), "Work queue should be empty now.")
+	gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(gomega.BeEmpty())
+	tCtx.ExpectNoError(testPodDeletionsMetrics(controller))
 }
 
 // TestRetry covers the scenario that an eviction attempt must be retried.
-func TestRetry(t *testing.T) { ktesting.Init(t).SyncTest("", synctestRetry) }
+func TestRetry(t *testing.T) { testRetry(ktesting.Init(t)) }
+func testRetry(tCtx ktesting.TContext) {
+	tCtx.Parallel()
+	tCtx.SyncTest("", synctestRetry)
+}
 func synctestRetry(tCtx ktesting.TContext) {
 	// This scenario is the same as "evict-pod-resourceclaim" above.
 	pod := podWithClaimName.DeepCopy()
@@ -2769,10 +2792,12 @@ func synctestRetry(tCtx ktesting.TContext) {
 		assert.NoError(tCtx, controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 	}()
 
+	expectLatencies := []time.Duration{5 * time.Millisecond /* default exponential retry */}
+
 	// Eventually the pod gets deleted and the event is recorded.
 	tCtx.Eventually(func(tCtx ktesting.TContext) error {
 		gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(matchDeletionEvent())
-		return testPodDeletionsMetrics(controller, 1)
+		return testPodDeletionsMetrics(controller, expectLatencies...)
 	}).WithTimeout(30*time.Second).Should(gomega.Succeed(), "pod eviction done")
 
 	// Now we can check the API calls.
@@ -2780,7 +2805,8 @@ func synctestRetry(tCtx ktesting.TContext) {
 	assert.Equal(tCtx, 2, podGets, "number of pod get calls")
 	assert.Equal(tCtx, 1, podDeletions, "number of pod delete calls")
 	gomega.NewWithT(tCtx).Expect(listEvents(tCtx)).Should(matchDeletionEvent())
-	tCtx.ExpectNoError(testPodDeletionsMetrics(controller, 1))
+	assert.Equal(tCtx, 0, controller.workqueue.Len(), "Work queue should be empty now.")
+	tCtx.ExpectNoError(testPodDeletionsMetrics(controller, expectLatencies...))
 }
 
 // BenchTaintUntaint checks the full flow of detecting a claim as

--- a/pkg/controller/devicetainteviction/uid_cache.go
+++ b/pkg/controller/devicetainteviction/uid_cache.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devicetainteviction
+
+import (
+	"k8s.io/utils/lru"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// uidCache is an LRU cache for uid.
+type uidCache struct {
+	cache *lru.Cache
+}
+
+// newUIDCache returns a uidCache.
+func newUIDCache(maxCacheEntries int) *uidCache {
+	return &uidCache{
+		cache: lru.New(maxCacheEntries),
+	}
+}
+
+// add adds a uid to the cache.
+func (c *uidCache) add(uid types.UID) {
+	c.cache.Add(uid, nil)
+}
+
+// has returns if a uid is in the cache.
+func (c *uidCache) has(uid types.UID) bool {
+	_, found := c.cache.Get(uid)
+	return found
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Thanks for waiting for cache sync via channels the random delays caused by polling are gone, making the initial setup including cache sync happen "immediately" when a test starts (= same virtual time). This makes the tests more predictable and simplifies making further assertions about when something happens or how long it takes.

While at it, restore previous performance by setting feature gates once and running tests in parallel again.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5055

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
