### PR TITLE
client-go: remove GetController + Controller interface

### DIFF
--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -251,7 +251,7 @@ func (svmc *SVMController) sync(ctx context.Context, key string) error {
 		return svmc.failMigration(ctx, toBeProcessedSVM, fmt.Errorf("resource does not exist in GC: %w", errMonitor))
 	}
 
-	gcListResourceVersion := resourceMonitor.Controller.LastSyncResourceVersion()
+	gcListResourceVersion := resourceMonitor.LastSyncResourceVersion()
 	listResourceVersion := toBeProcessedSVM.Status.ResourceVersion
 
 	rvCmp, err := resourceversion.CompareResourceVersion(gcListResourceVersion, listResourceVersion)

--- a/pkg/controller/storageversionmigrator/storageversionmigrator_test.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator_test.go
@@ -65,15 +65,6 @@ type mockMonitor struct {
 	garbagecollector.Monitor
 }
 
-type mockResourceSyncer struct {
-	cache.Controller
-	lastSyncRV string
-}
-
-func (m *mockResourceSyncer) LastSyncResourceVersion() string {
-	return m.lastSyncRV
-}
-
 func newMockMonitor(lastSyncRV string, items []runtime.Object) *mockMonitor {
 	store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 	for _, item := range items {
@@ -82,10 +73,8 @@ func newMockMonitor(lastSyncRV string, items []runtime.Object) *mockMonitor {
 
 	return &mockMonitor{
 		Monitor: garbagecollector.Monitor{
-			Store: store,
-			Controller: &mockResourceSyncer{
-				lastSyncRV: lastSyncRV,
-			},
+			LastSyncResourceVersion: func() string { return lastSyncRV },
+			Store:                   store,
 		},
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The interface serves no useful purpose. There is not API in client-go which accepts it as parameter, so there is no need to support out-of-tree implementations of it. A search showed that the only out-of-tree usage seem to be forks of the Kubernetes code.

The minimize the impact in code which merely passes it around, `cache.Controller` continues to be valid. It's now a type alias for a pointer to the implementation instead of an interface.

The in-tree usage of it was to have access to `HasSynced` and `LastSyncResourceVersion`. This gets replaced with the more explicit `cache.DoneChecker` and a function handle.

GetController already was deprecated and declared useless ages ago. This follows through with removing it.


#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/pull/135395 already broke the `cache.Controller` API slightly (new methods). Finishing the transition in the same 1.36 release would be good.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
