### PR TITLE
WIP: client-go informers: WaitForCacheSync now also waits for event handlers

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -195,6 +195,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -195,6 +195,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -214,6 +214,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -271,6 +271,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]{{.cacheDoneChecker|raw}}, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	{{.cacheWaitFor|raw}}(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -195,6 +195,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -195,6 +195,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -198,6 +198,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
@@ -198,6 +198,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
@@ -195,6 +195,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -195,6 +195,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -195,6 +195,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -195,6 +195,9 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
 		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		for _, handler := range informer.GetEventHandlers() {
+			cacheSyncs = append(cacheSyncs, handler.HasSyncedChecker())
+		}
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is a common mistake:

    /* handle, err := */ informerFactory....AddEventHandler(...)
    informerFactory.Start(...)
    informerFactory.WaitForCacheSync(...)
    // Do something with data populated by event handlers.

Contrary to what developers expect, WaitForCacheSync returns *before* all initial Add events are processed by the event handler.

What developers need to do is an explicit:

    cache.WaitForCacheSync(handle.HasSynced)

This happened to work in the past when informerFactory.WaitForCacheSync as based on polling, because it often slept at least once, giving event handlers time to catch up.

Now that waiting is implemented through channels, WaitForCacheSync returns much faster and tests with the mistake above might start to fail more often (remains to be seen!).

Instead of identifying all broken tests and code (an exercise that all downstream consumers of client-go would need to repeat!), the behavior of informerFactory.WaitForCacheSync is now what developers have expected: it waits for the informer caches and event handlers to be synced.

This only works for event handlers that are registered at the time when informerFactory.WaitForCacheSync is called. When adding event handlers later, the caller still needs to do a manual cache.WaitForCacheSync.


#### Which issue(s) this PR is related to:

Follow-up to https://github.com/kubernetes/kubernetes/pull/135395

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
client-go: `informerFactory.WaitForCacheSync` now also waits for all registered event handlers to sync, something that developers expected before but couldn't actually count on.
```
