### PR TITLE
Reflect expected replica count to the output of kubectl scale

### DIFF
--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -57,6 +57,7 @@ source "${KUBE_ROOT}/test/cmd/request-timeout.sh"
 source "${KUBE_ROOT}/test/cmd/results.sh"
 source "${KUBE_ROOT}/test/cmd/run.sh"
 source "${KUBE_ROOT}/test/cmd/save-config.sh"
+source "${KUBE_ROOT}/test/cmd/scale.sh"
 source "${KUBE_ROOT}/test/cmd/storage.sh"
 source "${KUBE_ROOT}/test/cmd/template-output.sh"
 source "${KUBE_ROOT}/test/cmd/version.sh"
@@ -1063,6 +1064,12 @@ runTests() {
   #######################
 
   record_command run_kuberc_tests
+
+  ###########
+  # Scale #
+  ###########
+
+  record_command run_kubectl_scale_tests
 
   cleanup_tests
 }

--- a/test/cmd/scale.sh
+++ b/test/cmd/scale.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+run_kubectl_scale_tests() {
+  set -o nounset
+  set -o errexit
+
+  kube::log::status "Testing kubectl scale"
+
+  create_and_use_new_namespace
+
+  kube::log::status "Testing kubectl scale output for Deployment"
+  kubectl create deployment test-scale-deploy --image=busybox
+  output_message=$(kubectl scale deployment test-scale-deploy --replicas=2 --dry-run=client -o yaml)
+  kube::test::if_has_string "${output_message}" 'replicas: 2'
+  kube::test::get_object_assert 'deployment test-scale-deploy' '{{.spec.replicas}}' '1'
+  output_message=$(kubectl scale deployment test-scale-deploy --replicas=3 --dry-run=server -o yaml)
+  kube::test::if_has_string "${output_message}" 'replicas: 3'
+  kube::test::get_object_assert 'deployment test-scale-deploy' '{{.spec.replicas}}' '1'
+  output_message=$(kubectl scale deployment test-scale-deploy --replicas=2 -o yaml)
+  kube::test::if_has_string "${output_message}" 'replicas: 2'
+  kube::test::get_object_assert 'deployment test-scale-deploy' '{{.spec.replicas}}' '2'
+  kubectl delete deployment test-scale-deploy
+
+  kube::log::status "Testing kubectl scale output for ReplicaSet"
+  kubectl create -f hack/testdata/frontend-replicaset.yaml
+  output_message=$(kubectl scale -f hack/testdata/frontend-replicaset.yaml --replicas=2 -o yaml)
+  kube::test::if_has_string "${output_message}" 'replicas: 2'
+  kubectl delete rs frontend
+
+  kube::log::status "Testing kubectl scale output for ReplicationController"
+  kubectl create -f hack/testdata/frontend-controller.yaml
+  output_message=$(kubectl scale rc frontend --replicas=3 -o yaml)
+  kube::test::if_has_string "${output_message}" 'replicas: 3'
+  kubectl delete rc frontend
+
+  kube::log::status "Testing kubectl scale output for StatefulSet"
+  kubectl create -f hack/testdata/rollingupdate-statefulset.yaml
+  output_message=$(kubectl scale statefulset nginx --replicas=2 -o yaml)
+  kube::test::if_has_string "${output_message}" 'replicas: 2'
+  kubectl delete statefulset nginx
+
+  set +o nounset
+  set +o errexit
+}

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -50,7 +50,7 @@ func ScaleResourceWithRetries(scalesGetter scaleclient.ScalesGetter, namespace, 
 		ResourceVersion: "",
 	}
 	waitForReplicas := scale.NewRetryParams(waitRetryInterval, waitRetryTimeout)
-	cond := RetryErrorCondition(scale.ScaleCondition(scaler, preconditions, namespace, name, size, nil, gvr, false))
+	cond := RetryErrorCondition(scale.ScaleCondition(scaler, preconditions, namespace, name, size, nil, nil, gvr, false))
 	err := wait.PollUntilContextTimeout(context.Background(), updateRetryInterval, updateRetryTimeout, true, cond)
 	if err == nil {
 		err = scale.WaitForScaleHasDesiredReplicas(scalesGetter, gvr.GroupResource(), name, namespace, size, waitForReplicas)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR is a revival of https://github.com/kubernetes/kubernetes/pull/135902 after incorporating the suggestions during review. 

This PR reflects the expected replica count into the output for built-in resources that support scaling (i.e. Deployments, etc.) by exempting CustomResourceDefinitions (because there is no standard field to be updated for them). This PR adds integration tests to verify the behavior.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1806

#### Does this PR introduce a user-facing change?
```release-note
Reflecting the expected replica count to the output of kubectl scale command
```