### PR TITLE
Do not remove managedFields if conversion webhook fails

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/capmanagers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/capmanagers_test.go
@@ -35,15 +35,24 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 )
 
-type fakeManager struct{}
+type fakeManager struct {
+	Manager internal.Manager
+	Error   error
+}
 
 var _ internal.Manager = &fakeManager{}
 
-func (*fakeManager) Update(_, newObj runtime.Object, managed internal.Managed, _ string) (runtime.Object, internal.Managed, error) {
+func (f *fakeManager) Update(liveObj, newObj runtime.Object, managed internal.Managed, manager string) (runtime.Object, internal.Managed, error) {
+	if f.Error != nil {
+		return nil, nil, f.Error
+	}
+	if f.Manager != nil {
+		return f.Manager.Update(liveObj, newObj, managed, manager)
+	}
 	return newObj, managed, nil
 }
 
-func (*fakeManager) Apply(_, _ runtime.Object, _ internal.Managed, _ string, _ bool) (runtime.Object, internal.Managed, error) {
+func (f *fakeManager) Apply(_, _ runtime.Object, _ internal.Managed, _ string, _ bool) (runtime.Object, internal.Managed, error) {
 	panic("not implemented")
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager.go
@@ -140,24 +140,27 @@ func (f *FieldManager) Update(liveObj, newObj runtime.Object, manager string) (o
 }
 
 // UpdateNoErrors is the same as Update, but it will not return
-// errors. If an error happens, the object is returned with
-// managedFields cleared.
+// errors. If an error happens, we preserve the managedFields from
+// liveObj.
 func (f *FieldManager) UpdateNoErrors(liveObj, newObj runtime.Object, manager string) runtime.Object {
 	obj, err := f.Update(liveObj, newObj, manager)
 	if err != nil {
-		atMostEverySecond.Do(func() {
-			ns, name := "unknown", "unknown"
-			if accessor, err := meta.Accessor(newObj); err == nil {
-				ns = accessor.GetNamespace()
-				name = accessor.GetName()
+		// Preserve the managedFields from the live object rather than
+		// stripping them entirely, to avoid silent data loss when the
+		// managedFields update fails (e.g. due to an unavailable
+		// conversion webhook).
+		// Note: meta.Accessor for liveObj and newObj below never return an error in this code branch,
+		// because if they would f.Update above would return "newObj, nil". Accordingly, the case
+		// where one of the accessors returns an error is not handled here.
+		if liveAccessor, aErr := meta.Accessor(liveObj); aErr == nil {
+			if newAccessor, aErr := meta.Accessor(newObj); aErr == nil {
+				atMostEverySecond.Do(func() {
+					klog.ErrorS(err, "[SHOULD NOT HAPPEN] failed to update managedFields (restored previous managedFields from live object)", "versionKind",
+						newObj.GetObjectKind().GroupVersionKind(), "namespace", newAccessor.GetNamespace(), "name", newAccessor.GetName())
+				})
+				newAccessor.SetManagedFields(liveAccessor.GetManagedFields())
 			}
-
-			klog.ErrorS(err, "[SHOULD NOT HAPPEN] failed to update managedFields", "versionKind",
-				newObj.GetObjectKind().GroupVersionKind(), "namespace", ns, "name", name)
-		})
-		// Explicitly remove managedFields on failure, so that
-		// we can't have garbage in it.
-		RemoveObjectManagedFields(newObj)
+		}
 		return newObj
 	}
 	return obj

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager_test.go
@@ -18,13 +18,66 @@ package internal_test
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/managedfields/internal"
+	internaltesting "k8s.io/apimachinery/pkg/util/managedfields/internal/testing"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestFieldManagerUpdateNoErrors(t *testing.T) {
+	fm := &fakeManager{}
+	f := internaltesting.NewTestFieldManagerImpl(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"),
+		"",
+		func(m internal.Manager) internal.Manager {
+			fm.Manager = m
+			return fm
+		})
+
+	podWithLabels := func(labels ...string) runtime.Object {
+		labelMap := map[string]interface{}{}
+		for _, key := range labels {
+			labelMap[key] = "true"
+		}
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": labelMap,
+				},
+			},
+		}
+		obj.SetKind("Pod")
+		obj.SetAPIVersion("v1")
+		return obj
+	}
+
+	f.UpdateNoErrors(podWithLabels("one"), "fieldmanager_test_update_1")
+	if len(f.ManagedFields()) == 0 {
+		t.Fatalf("expected managedFields to be set, but they are empty")
+	}
+
+	before := []metav1.ManagedFieldsEntry{}
+	for _, m := range f.ManagedFields() {
+		before = append(before, *m.DeepCopy())
+	}
+
+	// Inject an error so UpdateNoErrors will hit the error code path.
+	fm.Error = errors.New("test error")
+	f.UpdateNoErrors(podWithLabels("one", "two"), "fieldmanager_test_update_1")
+
+	if after := f.ManagedFields(); !apiequality.Semantic.DeepEqual(before, after) {
+		t.Fatalf("expected idempotence, but managedFields changed:\nbefore: %v\n after: %v", mustMarshal(before), mustMarshal(after))
+	}
+}
 
 var fakeTypeConverter = func() internal.TypeConverter {
 	data, err := os.ReadFile(filepath.Join(

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testing/testfieldmanager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testing/testfieldmanager.go
@@ -106,6 +106,11 @@ func (f *TestFieldManagerImpl) Update(obj runtime.Object, manager string) error 
 	return err
 }
 
+// UpdateNoErrors is the same as Update, but it will not return errors.
+func (f *TestFieldManagerImpl) UpdateNoErrors(obj runtime.Object, manager string) {
+	f.liveObj = f.fieldManager.UpdateNoErrors(f.liveObj, obj, manager)
+}
+
 // ManagedFields returns the list of existing managed fields for the
 // liveObj.
 func (f *TestFieldManagerImpl) ManagedFields() []metav1.ManagedFieldsEntry {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com
Co-authored-by: Fabrizio Pandini fabriziopandini@gmail.com

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR ensures that managedFields of an object are not removed when an error happens during a non-SSA write operation on the object. E.g. if the object has managedFields of multiple apiVersions and the conversion webhook call is failing.

#### Which issue(s) this PR is related to:
Fixes #136919

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Also see https://github.com/kubernetes/kubernetes/issues/136919#issuecomment-3880350315
