### PR TITLE
switch server images to kube-log-runner

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -94,6 +94,7 @@ readonly __default_dynamic_base_image="$KUBE_BASE_IMAGE_REGISTRY/distroless-ipta
 # It can be overridden to change the image for all such commands.
 # When the per-command env variable is set, that env variable is
 # used without considering KUBE_GORUNNER_IMAGE.
+# TODO: this should be replaced with a plain distroless base image
 readonly KUBE_GORUNNER_IMAGE="${KUBE_GORUNNER_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/go-runner:$__default_go_runner_version}"
 
 # __default_base_image takes the canonical build target for a Kubernetes command (e.g. k8s.io/kubernetes/cmd/kube-scheduler)

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -175,6 +175,10 @@ function kube::release::package_node_tarballs() {
 function kube::release::build_server_images() {
   kube::util::ensure-docker-buildx
 
+  # exclude kube-log-runner
+  local wrapped_binaries
+  wrapped_binaries=("${KUBE_SERVER_IMAGE_BINARIES[@]:1}")
+
   # Clean out any old images
   rm -rf "${RELEASE_IMAGES}"
   local platform
@@ -192,8 +196,8 @@ function kube::release::build_server_images() {
 
     # This fancy expression will expand to prepend a path
     # (${LOCAL_OUTPUT_BINPATH}/${platform}/) to every item in the
-    # KUBE_SERVER_IMAGE_BINARIES array.
-    cp "${KUBE_SERVER_IMAGE_BINARIES[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
+    # wrapped_binaries array.
+    cp "${wrapped_binaries[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
       "${release_stage}/server/bin/"
 
     kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}"
@@ -318,6 +322,15 @@ function kube::release::create_docker_images_for_server() {
         docker_build_opts='--pull'
     fi
 
+    # kube-log-runner binary assumed to be staged here by build_server_images
+    # TODO: Windows (NOTE: We don't build Windows images currently)
+    local kube_log_runner_path="${LOCAL_OUTPUT_BINPATH}/linux/${arch}/kube-log-runner"
+    # warn if someone attempts to call this shell utility directly without building kube-log-runner ...
+    if [[ ! -f "${kube_log_runner_path}" ]]; then
+      kube::log::error "kube-log-runner missing, add staging/src/k8s.io/component-base/logs/kube-log-runner to server build targets if calling kube::build::images functions directly"
+      return 1
+    fi
+
     for wrappable in $binaries; do
 
       local binary_name=${wrappable%%,*}
@@ -336,6 +349,7 @@ function kube::release::create_docker_images_for_server() {
       (
         rm -rf "${docker_build_path}"
         mkdir -p "${docker_build_path}"
+        ln "${kube_log_runner_path}" "${docker_build_path}/kube-log-runner"
         ln "${binary_file_path}" "${docker_build_path}/${binary_name}"
 
         local build_log="${docker_build_path}/build.log"

--- a/build/server-image/Dockerfile
+++ b/build/server-image/Dockerfile
@@ -20,3 +20,6 @@ ARG BINARY
 
 FROM "${BASEIMAGE}"
 COPY --chmod=755 ${BINARY} /usr/local/bin/${BINARY}
+# NOTE: /go-runner is used here for compatibility
+COPY --chmod=755 kube-log-runner /go-runner
+ENTRYPOINT ["/go-runner"]

--- a/build/server-image/kube-apiserver/Dockerfile
+++ b/build/server-image/kube-apiserver/Dockerfile
@@ -28,3 +28,6 @@ RUN setcap cap_net_bind_service=+ep /${BINARY}
 FROM --platform=linux/$TARGETARCH ${BASEIMAGE}
 ARG BINARY
 COPY --from=0 /${BINARY} /usr/local/bin/${BINARY}
+# NOTE: /go-runner is used here for compatibility
+COPY --chmod=755 kube-log-runner /go-runner
+ENTRYPOINT ["/go-runner"]

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -89,7 +89,11 @@ readonly KUBE_SERVER_BINARIES=("${KUBE_SERVER_TARGETS[@]##*/}")
 # The set of server targets we build docker images for
 kube::golang::server_image_targets() {
   # NOTE: this contains cmd targets for kube::build::get_docker_wrapped_binaries
+  # NOTE: kube-log-runner should NOT be in kube::build::get_docker_wrapped_binaries
+  # This binary is used across all images
+  # kube-log-runner should be the first target so it can be skipped
   local targets=(
+    staging/src/k8s.io/component-base/logs/kube-log-runner
     cmd/kube-apiserver
     cmd/kube-controller-manager
     cmd/kube-scheduler


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Switches to use a go-runner compatible binary built on-demand from this repo instead of in kubernetes/release.

Ensures we can patch go quickly in a single repo*. (We do need to follow up some other changes)

This is part of a larger proposal shared with [dev@kubernetes.io](mailto:dev@kubernetes.io) / sig-release mailinglists:

https://docs.google.com/document/d/10HujH6PL0ez3vviA03I01_mbJWs9Xp99gIDWnnNXyco/edit?tab=t.0#bookmark=id.5tng133hxrbk

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Alternate to https://github.com/kubernetes/kubernetes/pull/136930

TODO: We need to figure out how we'll handle the base-image, for compat reasons we should probably still call it GO_RUNNER in the env ... but really it should just be distroless-static. We will need to mirror it into registry.k8s.io to avoid making every build take an external dependency / for compat reasons with the build options.

~~The DO NOT MERGE commit (WIP) demonstrates that we can use an image without go-runner in CI. It will be dropped later when we sort this TODO, before merge.~~
EDIT: Removed :-)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Server images now use `staging/src/k8s.io/component-base/logs/kube-log-runner` instead of `go-runner`, full compatability is maintained (including the same `/go-runner` executable path).

In the future Kubernetes will use base-images without go-runner.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: https://github.com/kubernetes/component-base/tree/master/logs/kube-log-runner
-->
```docs
- [Other doc]: https://github.com/kubernetes/component-base/tree/master/logs/kube-log-runner
```
