### PR TITLE
Use nftables in etcd failure test with iptables fallback

### DIFF
--- a/test/e2e/apimachinery/etcd_failure.go
+++ b/test/e2e/apimachinery/etcd_failure.go
@@ -65,8 +65,18 @@ var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), func() {
 		etcdFailTest(
 			ctx,
 			f,
-			"sudo iptables -A INPUT -p tcp --destination-port 2379 -j DROP",
-			"sudo iptables -D INPUT -p tcp --destination-port 2379 -j DROP",
+			`if command -v nft >/dev/null 2>&1; then
+				sudo nft add table inet e2e_failure
+				sudo nft add chain inet e2e_failure input '{ type filter hook input priority 0; }'
+				sudo nft add rule inet e2e_failure input tcp dport 2379 drop
+			else
+				sudo iptables -A INPUT -p tcp --destination-port 2379 -j DROP
+			fi`,
+			`if command -v nft >/dev/null 2>&1; then
+				sudo nft delete table inet e2e_failure
+			else
+				sudo iptables -D INPUT -p tcp --destination-port 2379 -j DROP
+			fi`,
 		)
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `etcd_failure` e2e test previously relied on a hardcoded `iptables` command to simulate network failures by dropping traffic to port 2379. This approach is brittle on modern Linux distributions that prefer `nftables` or where `iptables` might be unavailable/deprecated.

This PR updates the test to:
1. Check for the presence of the `nft` command.
2. If available, use `nftables` to create a temporary table and rule to drop traffic.
3. Fall back to the original `iptables` command if `nft` is not found.
4. Ensure proper cleanup of either the `nftables` table or the `iptables` rule.

This change improves the robustness and compatibility of the e2e test suite across different environment configurations.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The `nftables` implementation uses a dedicated table `inet e2e_failure` to avoid interfering with existing rules and to make cleanup straightforward.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
