### PR TITLE
Keep logs when containers removed by RestartAllContainers

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -147,7 +147,7 @@ func (cgc *containerGC) removeOldestN(ctx context.Context, containers []containe
 				continue
 			}
 		}
-		if err := cgc.manager.removeContainer(ctx, containers[i].id); err != nil {
+		if err := cgc.manager.removeContainer(ctx, containers[i].id, false); err != nil {
 			logger.Error(err, "Failed to remove container", "containerID", containers[i].id)
 		}
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1456,8 +1456,8 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 						return
 					}
 				}
-				// TODO(yuanwang04): Revisit whether container logs should be persisted.
-				if err := m.removeContainer(ctx, containerInfo.containerID.ID); err != nil {
+				// The logs of removed containers will be preserved until the pod is deleted and GC is triggered.
+				if err := m.removeContainer(ctx, containerInfo.containerID.ID, true); err != nil {
 					removeContainerResult.Fail(kubecontainer.ErrRemoveContainer, err.Error())
 					logger.Error(err, "removeContainer for pod failed", "containerName", cName, "containerID", containerInfo.containerID, "pod", klog.KObj(pod))
 					return


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In alpha, restarted containers of feature RestartAllContainers will clean up the logs when it is removed. This makes debugging harder if the logs are not streamed to an outside storage. This PR will preserve the logs of restarted containers. The logs will be cleaned up after the pod is deleted and a kubelet periodic GC is triggered.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5532

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Preserve the logs of restarted containers for containers restarted by feature RestartAllContainers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5532
```
