### PR TITLE
Fix LastTerminationStatus for RestartAllContainers

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2291,6 +2291,14 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 				if oldStatus.RestartCount > status.RestartCount {
 					status.RestartCount = oldStatus.RestartCount
 				}
+				// Normal container restarts preserve the old container in the runtime so kubelet
+				// can query its termination status. RestartAllContainers removes old containers,
+				// so we must manually propagate LastTerminationState when the container ID changes.
+				if oldStatus.ContainerID != status.ContainerID && oldStatus.State.Terminated != nil {
+					status.LastTerminationState.Terminated = oldStatus.State.Terminated
+				} else if oldStatus.LastTerminationState.Terminated != nil {
+					status.LastTerminationState.Terminated = oldStatus.LastTerminationState.Terminated
+				}
 			}
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.ImageVolumeWithDigest) && imageVolumeNames.Len() > 0 {

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -2204,6 +2204,10 @@ func withRestartCount(status v1.ContainerStatus, restartCount int32) v1.Containe
 	status.RestartCount = restartCount
 	return status
 }
+func withLastTerminationState(status v1.ContainerStatus, lastState v1.ContainerState) v1.ContainerStatus {
+	status.LastTerminationState = lastState
+	return status
+}
 
 func TestPodPhaseWithRestartAlways(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
@@ -3914,7 +3918,7 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 			},
 		},
 		{
-			name: "currently running with lower reset restartCount; should keeping previous restartCount",
+			name: "currently running with lower restartCount; should keeping previous restartCount",
 			pod: &v1.Pod{
 				Spec: desiredState,
 			},
@@ -3939,8 +3943,16 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 			// no init containers
 			// is not an init container
 			expected: []v1.ContainerStatus{
-				withRestartCount(runningState("containerA"), 6),
-				withRestartCount(runningState("containerB"), 6),
+				withRestartCount(withLastTerminationState(runningState("containerA"), v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						ExitCode: -1,
+					},
+				}), 6),
+				withRestartCount(withLastTerminationState(runningState("containerB"), v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						ExitCode: -1,
+					},
+				}), 6),
 			},
 		},
 		{
@@ -4034,17 +4046,24 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 			currentStatus: &kubecontainer.PodStatus{
 				ContainerStatuses: []*kubecontainer.Status{{
 					Name:  "containerA",
+					ID:    kubecontainer.ContainerID{ID: "containerA-new"},
 					State: kubecontainer.ContainerStateRunning,
 				}},
 			},
 			previousStatus: []v1.ContainerStatus{
-				withRestartCount(waitingState("containerA"), 1),
+				withRestartCount(waitingStateWithRestartingAllContainers("containerA"), 1),
 				failedStateWithExitCode("containerB", 42),
 			},
 			containers:    desiredState.Containers,
 			podRestarting: true,
 			expected: []v1.ContainerStatus{
-				withRestartCount(runningState("containerA"), 1),
+				withRestartCount(withLastTerminationState(runningState("containerA"), v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						Reason:   RestartingAllContainers,
+						Message:  "The container is removed because RestartAllContainers in place",
+						ExitCode: 137,
+					},
+				}), 1),
 				withRestartCount(waitingStateWithRestartingAllContainers("containerB"), 1),
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The last termination status of containers restarted by RestartAllContainers are not preserved. This PR preserves the lastTerminationStatus to ensure the container restarts are observable. 

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5532

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed the lastTerminationStatus to match RestartAllContainers action if the container was restarted this way.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5532
```
