### PR TITLE
kubectl get: add --ignore-forbidden flag to suppress 403 errors on category queries

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -78,8 +78,9 @@ type GetOptions struct {
 
 	ServerPrint bool
 
-	NoHeaders      bool
-	IgnoreNotFound bool
+	NoHeaders       bool
+	IgnoreNotFound  bool
+	IgnoreForbidden bool
 
 	genericiooptions.IOStreams
 }
@@ -183,6 +184,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericiooptions.IOStre
 	cmd.Flags().BoolVar(&o.WatchOnly, "watch-only", o.WatchOnly, "Watch for changes to the requested object(s), without listing/getting first.")
 	cmd.Flags().BoolVar(&o.OutputWatchEvents, "output-watch-events", o.OutputWatchEvents, "Output watch event objects when --watch or --watch-only is used. Existing objects are output as initial ADDED events.")
 	cmd.Flags().BoolVar(&o.IgnoreNotFound, "ignore-not-found", o.IgnoreNotFound, "If set to true, suppresses NotFound error for specific objects that do not exist. Using this flag with commands that query for collections of resources has no effect when no resources are found.")
+	cmd.Flags().BoolVar(&o.IgnoreForbidden, "ignore-forbidden", o.IgnoreForbidden, "If set to true, suppresses Forbidden errors for resource types the current user is not authorized to access. Useful when querying resources by category across multiple resource types with varying permissions.")
 	cmd.Flags().StringVar(&o.FieldSelector, "field-selector", o.FieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	addServerPrintColumnFlags(cmd, o)
@@ -476,6 +478,9 @@ func (o *GetOptions) Run(f cmdutil.Factory, args []string) error {
 
 	if o.IgnoreNotFound {
 		r.IgnoreErrors(apierrors.IsNotFound)
+	}
+	if o.IgnoreForbidden {
+		r.IgnoreErrors(apierrors.IsForbidden)
 	}
 	if err := r.Err(); err != nil {
 		return err


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When using `kubectl get <category>`, the API discovery endpoint returns all resource types matching the category, including those the current user is not authorized to access. This causes 403 Forbidden errors to be printed to stderr alongside authorized results, and forces a non-zero exit code.

This PR adds an `--ignore-forbidden` flag to `kubectl get` that suppresses Forbidden errors, similar to how `--ignore-not-found` suppresses NotFound errors. It reuses the existing `Result.IgnoreErrors()` mechanism with `apierrors.IsForbidden`.

#### Which issue(s) this PR fixes:
Fixes kubernetes/kubectl#1853

#### Special notes for your reviewer:
The implementation follows the exact same pattern as `--ignore-not-found`:
1. Add `IgnoreForbidden bool` field to `GetOptions`
2. Register `--ignore-forbidden` flag in `NewCmdGet`
3. Call `r.IgnoreErrors(apierrors.IsForbidden)` in `Run()` when the flag is set

#### Does this PR introduce a user-facing change?
```release-note
Add --ignore-forbidden flag to kubectl get that suppresses Forbidden (403) errors for unauthorized resource types. This is useful when querying resources by category across multiple resource types with varying permissions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```