### PR TITLE
Add slight timeout after pods are running, and drop duplicate log lines checks

### DIFF
--- a/test/e2e/kubectl/logs.go
+++ b/test/e2e/kubectl/logs.go
@@ -296,6 +296,9 @@ var _ = SIGDescribe("Kubectl logs", func() {
 				podOne := pods.Items[0].GetName()
 				podTwo := pods.Items[1].GetName()
 
+				ginkgo.By("sleep 1s to wait for log generator produce data after pods get ready")
+				time.Sleep(time.Second)
+
 				ginkgo.By("expecting logs from the default container from both pods in a deployment")
 				out := e2ekubectl.RunKubectlOrDie(ns, "logs", fmt.Sprintf("deploy/%s", deployName), "--all-pods")
 				gomega.Expect(strings.Contains(out, fmt.Sprintf("[pod/%s/container-2]", podOne))).To(gomega.BeTrueBecause("pod 1 container 2 log should be present"))
@@ -314,6 +317,9 @@ var _ = SIGDescribe("Kubectl logs", func() {
 
 				podOne := pods.Items[0].GetName()
 				podTwo := pods.Items[1].GetName()
+
+				ginkgo.By("sleep 1s to wait for log generator produce data after pods get ready")
+				time.Sleep(time.Second)
 
 				ginkgo.By("expecting logs from all containers from both pods in a deployment")
 				out := e2ekubectl.RunKubectlOrDie(ns, "logs", fmt.Sprintf("deploy/%s", deployName), "--all-pods", "--all-containers")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:
This PR addresses 2 problems:
1. It addresses the flake from https://github.com/kubernetes/kubernetes/issues/136948, by adding a slight 1s sleep before reading the logs. This should allow the log-generator to produce some output. We might want to consider bumping this to max 3s if necessary. But let's start conservatively with 1s.
2. It cleans up the test, we were checking for the same log lines unnecessarily twice. Now this reads easier.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/136948

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
