### PR TITLE
Bump images and versions to go 1.25.7 and distroless iptables

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.36.0-go1.25.6-bullseye.0
+v1.36.0-go1.25.7-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -77,8 +77,8 @@ readonly REMOTE_OUTPUT_BINPATH="${REMOTE_OUTPUT_SUBPATH}/bin"
 readonly REMOTE_OUTPUT_GOPATH="${REMOTE_OUTPUT_SUBPATH}/go"
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.8.7
-readonly __default_go_runner_version=v2.4.0-go1.25.6-bookworm.0
+readonly __default_distroless_iptables_version=v0.8.8
+readonly __default_go_runner_version=v2.4.0-go1.25.7-bookworm.0
 readonly __default_setcap_version=bookworm-v1.0.6
 
 # The default image for all binaries which are dynamically linked.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -164,7 +164,7 @@ dependencies:
   # should also be updated, but go-runner is much harder to exploit and has
   # far less relevancy to go updates for Kubernetes more generally.
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.36.0-go1.25.6-bullseye.0
+    version: v1.36.0-go1.25.7-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -202,7 +202,7 @@ dependencies:
       match: registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.8.7
+    version: v0.8.8
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=
@@ -210,7 +210,7 @@ dependencies:
       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
-    version: v2.4.0-go1.25.6-bookworm.0
+    version: v2.4.0-go1.25.7-bookworm.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -214,7 +214,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-1"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.8.7"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.8.8"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.6.7-0"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{list.PromoterE2eRegistry, "ipc-utils", "1.4"}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Bump images and versions to go 1.25.7 and distroless iptables

/assign @liggitt @dims @saschagrunert @puerco 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/4265

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubernetes is now built using Go 1.25.7
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
