### PR TITLE
kubectl explain: render externalDocs from OpenAPI v3 schemas

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
@@ -98,6 +98,9 @@ Takes dictionary as argument with keys:
     {{- if not $.FieldPath -}}
         DESCRIPTION:{{- "\n" -}}
         {{- or (include "description" (dict "schema" $resolved "Document" $.Document)) "<empty>" | wrap 76 | indent 4 -}}{{- "\n" -}}
+        {{- with include "externalDocs" (dict "schema" $resolved) -}}
+            {{- "\n" -}}{{- . -}}
+        {{- end -}}
         {{- with include "fieldList" (dict "schema" $resolved "level" 1 "Document" $.Document "Recursive" $.Recursive) -}}
             FIELDS:{{- "\n" -}}
             {{- . -}}
@@ -211,6 +214,16 @@ Takes dictionary as argument with keys:
     {{- "\n" -}}
     {{- if not $.short -}}
         {{- or $fieldSchema.description "<no description>" | wrap (sub 78 $indentAmount) | indent (add $indentAmount 2) -}}{{- "\n" -}}
+        {{- with $fieldSchema.externalDocs -}}
+            {{- "\n" -}}
+            {{- "EXTERNAL DOCS:" | indent (add $indentAmount 2) -}}{{- "\n" -}}
+            {{- with .description -}}
+                {{- . | wrap (sub 76 $indentAmount) | indent (add $indentAmount 4) -}}{{- "\n" -}}
+            {{- end -}}
+            {{- with .url -}}
+                {{- (print "URL: " .) | indent (add $indentAmount 4) -}}{{- "\n" -}}
+            {{- end -}}
+        {{- end -}}
         {{- "\n" -}}
     {{- end -}}
 {{- end -}}
@@ -239,6 +252,30 @@ Takes dictionary as argument with keys:
         {{- end -}}
         {{- if and .additionalProperties (not (eq "bool" (printf "%T" .additionalProperties))) -}}
             {{- template "description" (set $ "schema" .additionalProperties) -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{- /*
+Renders the externalDocs section of a schema if present.
+
+Prints:
+
+EXTERNAL DOCS:
+    <description>
+    URL: <url>
+
+Takes dictionary as argument with keys:
+    schema: openapiv3 JSON schema
+*/ -}}
+{{- define "externalDocs" -}}
+    {{- with $.schema.externalDocs -}}
+        EXTERNAL DOCS:{{- "\n" -}}
+        {{- with .description -}}
+            {{- . | wrap 76 | indent 4 -}}{{- "\n" -}}
+        {{- end -}}
+        {{- with .url -}}
+            {{- (print "URL: " .) | indent 4 -}}{{- "\n" -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

CRD authors can set the externalDocs field in their [OpenAPI v3 schemas](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/)  to reference external documentation for their custom resources. However, kubectl explain did not surface this information to users.

Render externalDocs metadata in the plaintext output of `kubectl explain`. When a schema or field includes an externalDocs section, it is now displayed as:

```
    EXTERNAL DOCS:
        <description>
        URL: <url>
```

This appears after the DESCRIPTION block for top-level resources and
after the field description for individual fields. The section is
omitted in short mode and when `externalDocs` is absent.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/136977 adds `externalDocs` field (if declared on CRDs) to the responses that are consumed by `kubectl explain`.

#### Special notes for your reviewer:

It depends or acceptance of https://github.com/kubernetes/kubernetes/pull/136977

#### Does this PR introduce a user-facing change?

Yes. 

```release-note
kubectl explain: when a schema or field includes an externalDocs section, it is now displayed as:


    EXTERNAL DOCS:
        <description>
        URL: <url>


This appears after the DESCRIPTION block for top-level resources and
after the field description for individual fields. The section is
omitted in short mode and when `externalDocs` is absent.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
