### PR TITLE
feat: added kuberc aliases in the output of kubectl command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -499,6 +499,21 @@ func searchInArgs(flagName string, shorthand string, allShorthands map[string]st
 	return false
 }
 
+// GetAliasesForDisplay returns all aliases defined in kuberc file for display purposes (e.g., in help output).
+// This function does not execute aliases, it only returns their definitions.
+func GetAliasesForDisplay(errOut io.Writer) ([]config.AliasOverride, error) {
+	kuberc, err := DefaultGetPreferences("", errOut)
+	if err != nil {
+		return nil, err
+	}
+
+	if kuberc == nil {
+		return nil, nil
+	}
+
+	return kuberc.Aliases, nil
+}
+
 func (p *Preferences) validate(plugin *config.Preference) error {
 	validateFlag := func(flags []config.CommandOptionDefault) error {
 		for _, flag := range flags {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig cli


#### What this PR does / why we need it:
  This PR displays aliases defined in kuberc in the `kubectl` help output. When users run `kubectl` without any command, the help output now includes an "Aliases" section showing all aliases configured in their kuberc file.
  
#### Which issue(s) this PR is related to:
fixes https://github.com/kubernetes/kubectl/issues/1740


#### Special notes for your reviewer:
  Example output:
  ```
  kubectl controls the Kubernetes cluster manager.
  ...
  [normal help output]
  ...

  Aliases (defined in kuberc):
    getn            get nodes
    runx            run [args...] -- custom-arg
   ```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 kubectl: Display aliases defined in kuberc file in the help output when running `kubectl` without arguments.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
