### PR TITLE
Migrate HPA MinReplicas to Declarative Validation with Feature Gate Support

### DIFF
--- a/pkg/apis/autoscaling/v1/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.validations.go
@@ -102,6 +102,12 @@ func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Oper
 			if earlyReturn {
 				return // do not proceed
 			}
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
+			})...)
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
+			})...)
 			return
 		}(fldPath.Child("minReplicas"), obj.MinReplicas, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 { return oldObj.MinReplicas }), oldObj != nil)...)
 

--- a/pkg/apis/autoscaling/v2/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v2/zz_generated.validations.go
@@ -94,6 +94,12 @@ func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Oper
 			if earlyReturn {
 				return // do not proceed
 			}
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
+			})...)
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
+			})...)
 			return
 		}(fldPath.Child("minReplicas"), obj.MinReplicas, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 { return oldObj.MinReplicas }), oldObj != nil)...)
 

--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -57,7 +57,7 @@ func validateHorizontalPodAutoscalerSpec(autoscaler autoscaling.HorizontalPodAut
 
 	if autoscaler.MinReplicas != nil && *autoscaler.MinReplicas < opts.MinReplicasLowerBound {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("minReplicas"), *autoscaler.MinReplicas,
-			fmt.Sprintf("must be greater than or equal to %d", opts.MinReplicasLowerBound)))
+			fmt.Sprintf("must be greater than or equal to %d", opts.MinReplicasLowerBound)).WithOrigin("minimum").MarkCoveredByDeclarative())
 	}
 	if autoscaler.MaxReplicas == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("maxReplicas"), "must be set and greater than 0").MarkCoveredByDeclarative())

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
@@ -136,6 +136,11 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "minReplicas"), int32(0), "must be greater than or equal to 1").WithOrigin("minimum"),
 			},
 		},
+		"valid update: ratcheting minReplicas=0 when gate disabled": {
+			oldObj:            makeValidHPA(tweakMinReplicas(0), tweakMetrics(validScaleToZeroMetrics...)),
+			updateObj:         makeValidHPA(tweakMinReplicas(0), tweakMetrics(validScaleToZeroMetrics...), tweakMaxReplicas(20)),
+			enableScaleToZero: false,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -77,7 +77,11 @@ func (autoscalerStrategy) Validate(ctx context.Context, obj runtime.Object) fiel
 	autoscaler := obj.(*autoscaling.HorizontalPodAutoscaler)
 	opts := validationOptionsForHorizontalPodAutoscaler(autoscaler, nil)
 	allErrs := validation.ValidateHorizontalPodAutoscaler(autoscaler, opts)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, autoscaler, nil, allErrs, operation.Create)
+	var options []string
+	if utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero) {
+		options = append(options, "HPAScaleToZero")
+	}
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, autoscaler, nil, allErrs, operation.Create, rest.WithOptions(options))
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -110,7 +114,11 @@ func (autoscalerStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.O
 	oldHPA := old.(*autoscaling.HorizontalPodAutoscaler)
 	opts := validationOptionsForHorizontalPodAutoscaler(newHPA, oldHPA)
 	errs := validation.ValidateHorizontalPodAutoscalerUpdate(newHPA, oldHPA, opts)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newHPA, oldHPA, errs, operation.Update)
+	var options []string
+	if utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero) {
+		options = append(options, "HPAScaleToZero")
+	}
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newHPA, oldHPA, errs, operation.Update, rest.WithOptions(options))
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -115,7 +115,8 @@ func (autoscalerStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.O
 	opts := validationOptionsForHorizontalPodAutoscaler(newHPA, oldHPA)
 	errs := validation.ValidateHorizontalPodAutoscalerUpdate(newHPA, oldHPA, opts)
 	var options []string
-	if utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero) {
+	oldHasZeroMinReplicas := oldHPA.Spec.MinReplicas != nil && *oldHPA.Spec.MinReplicas == 0
+	if utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero) || oldHasZeroMinReplicas {
 		options = append(options, "HPAScaleToZero")
 	}
 	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newHPA, oldHPA, errs, operation.Update, rest.WithOptions(options))

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -203,6 +203,8 @@ message HorizontalPodAutoscalerSpec {
   // available.
   // +optional
   // +k8s:optional
+  // +k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+  // +k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
   optional int32 minReplicas = 2;
 
   // maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -48,6 +48,8 @@ type HorizontalPodAutoscalerSpec struct {
 	// available.
 	// +optional
 	// +k8s:optional
+	// +k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+	// +k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
 
 	// maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -249,6 +249,8 @@ message HorizontalPodAutoscalerSpec {
   // available.
   // +optional
   // +k8s:optional
+  // +k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+  // +k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
   optional int32 minReplicas = 2;
 
   // maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -60,6 +60,8 @@ type HorizontalPodAutoscalerSpec struct {
 	// available.
 	// +optional
 	// +k8s:optional
+	// +k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+	// +k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
 
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
  This PR migrates the validation for HorizontalPodAutoscalerSpec.MinReplicas to use declarative validation tags (+k8s:minimum, +k8s:ifEnabled, +k8s:ifDisabled), ensuring validation rules dynamically respect the HPAScaleToZero feature gate.

  Changes:
   * API Types: Added declarative tags to MinReplicas in autoscaling/v1 and v2 types to enforce min=0 when HPAScaleToZero is enabled, and min=1 when disabled.
   * Validation Logic: Updated pkg/apis/autoscaling/validation/validation.go to use .MarkCoveredByDeclarative() and .WithOrigin("minimum"), aligning manual validation errors with declarative output.
   * Registry Strategy: Updated the HPA strategy to explicitly pass the HPAScaleToZero feature gate option to the declarative validator during runtime.
   * Tests: Added comprehensive tests in declarative_validation_test.go verifying:
       * Validation equivalence for both feature gate states.
       * Correct enforcement of minimum values.
       * Ratcheting behavior for existing invalid values during updates.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
