### PR TITLE
Replace hardcoded timeout with context.Done() in PostStartHook

### DIFF
--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -534,8 +534,12 @@ func (p *legacyProvider) PostStartHook() (string, genericapiserver.PostStartHook
 		}()
 		select {
 		case <-done:
+
+		case <-context.Done():
+			return goerrors.New("unable to perform initial IP and Port allocation check (context cancelled)")
+
 		case <-time.After(time.Minute):
-			return goerrors.New("unable to perform initial IP and Port allocation check")
+			return goerrors.New("unable to perform initial IP and Port allocation check (timeout)")
 		}
 
 		return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In `PostStartHook` within `pkg/registry/core/rest/storage_core.go`, there was a hardcoded 1-minute timeout (`time.After(time.Minute)`) waiting for the initial IP and Port allocation check to complete.

This PR replaces the hardcoded timeout with `context.Done()`, allowing the hook to respect the lifecycle/cancellation of the provided context instead of waiting for a fixed duration. This leads to cleaner termination and better integration with the server's lifecycle management.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
