### PR TITLE
Cap nf_conntrack limits to prevent excessive memory usage on high-core machines

### DIFF
--- a/pkg/proxy/conntrack/sysctls.go
+++ b/pkg/proxy/conntrack/sysctls.go
@@ -58,7 +58,7 @@ type conntrackConfigurer interface {
 }
 
 func setSysctls(ctx context.Context, ct conntrackConfigurer, config *proxyconfigapi.KubeProxyConntrackConfiguration) error {
-	max, err := getConntrackMax(ctx, config)
+	max, err := getConntrackMax(ctx, config, detectNumCPU())
 	if err != nil {
 		return err
 	}
@@ -106,14 +106,20 @@ func setSysctls(ctx context.Context, ct conntrackConfigurer, config *proxyconfig
 	return nil
 }
 
-func getConntrackMax(ctx context.Context, config *proxyconfigapi.KubeProxyConntrackConfiguration) (int, error) {
+func getConntrackMax(ctx context.Context, config *proxyconfigapi.KubeProxyConntrackConfiguration, numCPU int) (int, error) {
 	logger := klog.FromContext(ctx)
 	if config.MaxPerCore != nil && *config.MaxPerCore > 0 {
 		floor := 0
 		if config.Min != nil {
 			floor = int(*config.Min)
 		}
-		scaled := int(*config.MaxPerCore) * detectNumCPU()
+		scaled := int(*config.MaxPerCore) * numCPU
+		// Cap the value to 1M to avoid excessive memory usage on high-core machines
+		const maxLimit = 1048576
+		if scaled > maxLimit {
+			logger.V(3).Info("GetConntrackMax: capping scaled conntrack-max-per-core", "scaled", scaled, "limit", maxLimit)
+			return maxLimit, nil
+		}
 		if scaled > floor {
 			logger.V(3).Info("GetConntrackMax: using scaled conntrack-max-per-core")
 			return scaled, nil

--- a/pkg/proxy/conntrack/sysctls_test.go
+++ b/pkg/proxy/conntrack/sysctls_test.go
@@ -69,7 +69,7 @@ func TestGetConntrackMax(t *testing.T) {
 			MaxPerCore: ptr.To(tc.maxPerCore),
 		}
 		_, ctx := ktesting.NewTestContext(t)
-		x, e := getConntrackMax(ctx, &cfg)
+		x, e := getConntrackMax(ctx, &cfg, ncores)
 		if e != nil {
 			if tc.err == "" {
 				t.Errorf("[%d] unexpected error: %v", i, e)
@@ -236,5 +236,28 @@ func TestSetupConntrack(t *testing.T) {
 				t.Errorf("Test %q: Expected conntrack calls: %v, got: %v", test.name, test.expect, fc.called)
 			}
 		})
+	}
+}
+
+func TestGetConntrackMax_Capped(t *testing.T) {
+	// Simulate 512 cores
+	numCPU := 512
+
+	maxPerCore := int32(32768)
+	cfg := proxyconfigapi.KubeProxyConntrackConfiguration{
+		MaxPerCore: ptr.To(maxPerCore),
+		Min:        ptr.To(int32(0)),
+	}
+
+	_, ctx := ktesting.NewTestContext(t)
+	val, err := getConntrackMax(ctx, &cfg, numCPU)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// 512 * 32768 = 16,777,216. Cap is 1,048,576
+	expected := 1048576
+	if val != expected {
+		t.Errorf("Expected capped value %d, got %d", expected, val)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

On machines with a very high number of cores (e.g., 512 cores), the default calculation for `nf_conntrack_max` (based on `MaxPerCore`) can result in excessively large values that consume significant system memory.

This PR introduces a hard cap of 1,048,576 for the automatically calculated `nf_conntrack_max` value to prevent these edge cases, while still allowing for high-performance networking on most configurations.

#### Which issue(s) this PR fixes:

Fixes #136228

#### Special notes for your reviewer:

A new test case `TestGetConntrackMax_Capped` has been added to `pkg/proxy/conntrack/sysctls_test.go` to verify the capping logic with mocked high core counts.

#### Does this PR introduce a user-facing change?

```release-note
Capped nf_conntrack_max to 1,048,576 to prevent excessive memory consumption on high-core machines when using automatic calculation.
```
