### PR TITLE
chore: fix typo in function comment

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
@@ -151,7 +151,7 @@ func (f *PrintFlags) WithDefaultOutput(output string) *PrintFlags {
 	return f
 }
 
-// WithTypeSetter sets a wrapper than will surround the returned printer with a printer to type resources
+// WithTypeSetter sets a wrapper that will surround the returned printer with a printer to type resources
 func (f *PrintFlags) WithTypeSetter(scheme *runtime.Scheme) *PrintFlags {
 	f.TypeSetterPrinter = printers.NewTypeSetter(scheme)
 	return f


### PR DESCRIPTION
## Summary

This PR fixes a simple typo in [`print_flags`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go)

Reference: 

https://github.com/kubernetes/kubernetes/blob/1132395d4a479fdeca9c32dfda3921dbf3e0e663/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go#L154C34-L154C38