### PR TITLE
[KEP 4317] Fix incorrect APIVersion in PodCertificateRequest OwnerReference

### DIFF
--- a/pkg/kubelet/podcertificate/podcertificatemanager.go
+++ b/pkg/kubelet/podcertificate/podcertificatemanager.go
@@ -760,7 +760,7 @@ func (m *IssuingManager) createPodCertificateRequest(
 			GenerateName: "req-",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "core/v1",
+					APIVersion: "v1",
 					Kind:       "Pod",
 					Name:       podName,
 					UID:        podUID,

--- a/pkg/kubelet/podcertificate/podcertificatemanager_test.go
+++ b/pkg/kubelet/podcertificate/podcertificatemanager_test.go
@@ -182,6 +182,19 @@ func TestTransitionInitialToWait(t *testing.T) {
 	if diff := cmp.Diff(gotPCRClone, wantPCR); diff != "" {
 		t.Fatalf("PodCertificateManager created a bad PCR; diff (-got +want)\n%s", diff)
 	}
+
+	// Verify OwnerReferences are set correctly for garbage collection.
+	wantOwnerRefs := []metav1.OwnerReference{
+		{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Name:       workloadPod.ObjectMeta.Name,
+			UID:        workloadPod.ObjectMeta.UID,
+		},
+	}
+	if diff := cmp.Diff(gotPCR.ObjectMeta.OwnerReferences, wantOwnerRefs); diff != "" {
+		t.Fatalf("PodCertificateRequest has incorrect OwnerReferences; diff (-got +want)\n%s", diff)
+	}
 }
 
 func TestPCRDeletedWhileWaiting(t *testing.T) {


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes the `apiVersion` in the `OwnerReference` set on `PodCertificateRequest` objects from `"core/v1"` to `"v1"`.

Pods belong to the legacy core API group, which has no group prefix, so the correct `apiVersion` is `"v1"`. The garbage collector cannot resolve `"core/v1"`, which means `PodCertificateRequest` objects are never cleaned up when their owning Pod is deleted.

Also adds an `OwnerReference` assertion to `TestTransitionInitialToWait`. The existing test blanked out `ObjectMeta` before comparing, so the `OwnerReferences` were never validated — which is how this bug went undetected.

#### Which issue(s) this PR is related to:

Fixes #136890

#### Special notes for your reviewer:

The GC controller (controller-manager) logs `unable to get REST mapping for core/v1/Pod` when it encounters these orphaned `PodCertificateRequest` objects. The fix is a one-line change; the test change adds the missing assertion to the existing test rather than a new test function.

#### Does this PR introduce a user-facing change?

```release-note
Fix PodCertificateRequest OwnerReference using incorrect apiVersion "core/v1" instead of "v1", which prevented garbage collection of PodCertificateRequests when their owning Pod was deleted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4317
```