### PR TITLE
Revert DV native error matcher and errors

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
@@ -44,7 +44,6 @@ type ErrorMatcher struct {
 	matchOrigin                   bool
 	matchDetail                   func(want, got string) bool
 	requireOriginWhenInvalid      bool
-	matchDeclarativeNative        bool
 	matchValidationStabilityLevel bool
 	// normalizationRules holds the pre-compiled regex patterns for path normalization.
 	normalizationRules []NormalizationRule
@@ -86,9 +85,6 @@ func (m ErrorMatcher) Matches(want, got *Error) bool {
 		}
 	}
 	if m.matchDetail != nil && !m.matchDetail(want.Detail, got.Detail) {
-		return false
-	}
-	if m.matchDeclarativeNative && want.DeclarativeNative != got.DeclarativeNative {
 		return false
 	}
 	if m.matchValidationStabilityLevel && want.ValidationStabilityLevel != got.ValidationStabilityLevel {
@@ -156,10 +152,6 @@ func (m ErrorMatcher) Render(e *Error) string {
 	if m.matchDetail != nil {
 		comma()
 		buf.WriteString(fmt.Sprintf("Detail=%q", e.Detail))
-	}
-	if m.matchDeclarativeNative {
-		comma()
-		buf.WriteString(fmt.Sprintf("DeclarativeNative=%t", e.DeclarativeNative))
 	}
 	if m.matchValidationStabilityLevel {
 		comma()
@@ -238,13 +230,6 @@ func (m ErrorMatcher) ByOrigin() ErrorMatcher {
 // matching by Origin.
 func (m ErrorMatcher) RequireOriginWhenInvalid() ErrorMatcher {
 	m.requireOriginWhenInvalid = true
-	return m
-}
-
-// ByDeclarativeNative returns a derived ErrorMatcher which also matches by the DeclarativeNative
-// value of field errors.
-func (m ErrorMatcher) ByDeclarativeNative() ErrorMatcher {
-	m.matchDeclarativeNative = true
 	return m
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
@@ -304,26 +304,6 @@ func TestErrorMatcher_Matches(t *testing.T) {
 		actualErr: &Error{Type: ErrorTypeRequired, Field: "field", BadValue: "value", Detail: "detail", Origin: "origin"},
 		matches:   false,
 	}, {
-		name:    "ByDeclarativeNative: match",
-		matcher: ErrorMatcher{}.ByDeclarativeNative(),
-		wantedErr: func() *Error {
-			e := baseErr()
-			e.DeclarativeNative = true
-			return e
-		},
-		actualErr: &Error{DeclarativeNative: true},
-		matches:   true,
-	}, {
-		name:    "ByDeclarativeNative: no match",
-		matcher: ErrorMatcher{}.ByDeclarativeNative(),
-		wantedErr: func() *Error {
-			e := baseErr()
-			e.DeclarativeNative = true
-			return e
-		},
-		actualErr: &Error{DeclarativeNative: false},
-		matches:   false,
-	}, {
 		name:      "RequireOriginWhenInvalid: match",
 		matcher:   ErrorMatcher{}.ByOrigin().RequireOriginWhenInvalid(),
 		wantedErr: baseErr,
@@ -425,17 +405,6 @@ func TestErrorMatcher_Test(t *testing.T) {
 		}),
 		want:           ErrorList{Invalid(NewPath("f").Index(0).Child("x", "a"), nil, "")},
 		got:            ErrorList{Invalid(NewPath("f").Index(1).Child("a"), "v", "d")},
-		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
-	}, {
-		name:    "declarative native: match",
-		matcher: ErrorMatcher{}.ByDeclarativeNative(),
-		want:    ErrorList{{DeclarativeNative: true}},
-		got:     ErrorList{{DeclarativeNative: true}},
-	}, {
-		name:           "declarative native: no match",
-		matcher:        ErrorMatcher{}.ByDeclarativeNative(),
-		want:           ErrorList{{DeclarativeNative: true}},
-		got:            ErrorList{{DeclarativeNative: false}},
 		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
 	}, {
 		name:    "validation level: match",
@@ -575,25 +544,6 @@ func TestErrorMatcher_Render(t *testing.T) {
 			expected: `{Field="f[0].x.a"}`,
 		},
 		{
-			name:    "with covered by declarative",
-			matcher: ErrorMatcher{}.ByDeclarativeNative(),
-			err: func() *Error {
-				e := Invalid(NewPath("field"), "value", "detail")
-				e.DeclarativeNative = true
-				return e
-			}(),
-			expected: `{DeclarativeNative=true}`,
-		},
-		{
-			name:    "all fields with covered by declarative",
-			matcher: ErrorMatcher{}.ByType().ByField().ByValue().ByOrigin().ByDetailExact().ByDeclarativeNative(),
-			err: func() *Error {
-				e := Invalid(NewPath("field"), "value", "detail").WithOrigin("origin")
-				e.DeclarativeNative = true
-				return e
-			}(),
-			expected: `{Type="Invalid value", Field="field", Value="value", Origin="origin", Detail="detail", DeclarativeNative=true}`,
-		}, {
 			name:     "requireOriginWhenInvalid with origin",
 			matcher:  ErrorMatcher{}.ByOrigin().RequireOriginWhenInvalid(),
 			err:      Invalid(NewPath("field"), "value", "detail").WithOrigin("origin"),

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -56,10 +56,6 @@ type Error struct {
 	// that should also be caught by declarative validation.
 	CoveredByDeclarative bool
 
-	// DeclarativeNative is true when this error originates from a declarative-native validation.
-	// This field is used to distinguish errors that are exclusively declarative and lack an imperative counterpart.
-	DeclarativeNative bool
-
 	// ValidationStabilityLevel denotes the validation stability level of the declarative validation from this error is returned. This should be used in the declarative validations only.
 	ValidationStabilityLevel ValidationStabilityLevel
 }
@@ -482,20 +478,6 @@ func (list ErrorList) ExtractCoveredByDeclarative() ErrorList {
 		}
 	}
 	return newList
-}
-
-// MarkDeclarativeNative marks the error as originating from a declarative-native validation.
-func (e *Error) MarkDeclarativeNative() *Error {
-	e.DeclarativeNative = true
-	return e
-}
-
-// MarkDeclarativeNative marks all errors in the list as originating from declarative-native validations.
-func (list ErrorList) MarkDeclarativeNative() ErrorList {
-	for _, err := range list {
-		err.DeclarativeNative = true
-	}
-	return list
 }
 
 // MarkAlpha marks the error as an alpha validation error.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This is a follow-up PR to the revert of the `dvNative` validation logic. Now that the `+k8s:declarativeValidationNative` tag is deprecated and its code generation logic has been removed in favor of granular stability levels (`+k8s:alpha`, `+k8s:beta`), this PR cleans up the supporting infrastructure in `k8s.io/apimachinery`.

Specifically, it removes the `DeclarativeNative` field and its associated helper methods which are no longer required.

**Key Technical Changes:**
*   **Error Struct Cleanup**: Removed the `DeclarativeNative` boolean field from the `field.Error` struct.
*   **Method Removal**: Deleted the `MarkDeclarativeNative()` helper methods for both `*Error` and `ErrorList`.
*   **Error Matcher Cleanup**: Removed `matchDeclarativeNative` from the `ErrorMatcher` struct and deleted the `ByDeclarativeNative()` configuration method.
*   **Test Updates**: Removed all test cases in `error_matcher_test.go` that relied on declarative native matching.

#### Which issue(s) this PR is related to:
Follows: `revert-dv-native` (generator revert)

#### Special notes for your reviewer:
This PR focuses strictly on the removal of the API machinery fields and matching logic that supported the old `dvNative` system. The `ValidationStabilityLevel` field remains intact as it is the current standard for marking validation stability.

#### Does this PR introduce a user-facing change?
```release-note
None.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
None.
```