### PR TITLE
kubeadm: trim whitespace from interactive confirmation input

### DIFF
--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -103,7 +103,8 @@ func InteractivelyConfirmAction(action, question string, r io.Reader) error {
 	if err := scanner.Err(); err != nil {
 		return errors.Wrap(err, "couldn't read from standard input")
 	}
-	answer := scanner.Text()
+    // Trim whitespace so " y " becomes "y"
+	answer := strings.TrimSpace(scanner.Text()) 
 	if strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes") {
 		return nil
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
This PR fixes a usability issue in [InteractivelyConfirmAction](cci:1://file:///home/ksauraj/kubernetes/cmd/kubeadm/app/cmd/util/cmdutil.go:97:0-112:1) where leading or trailing whitespace (e.g., typing " y " or hitting space before enter) would cause the confirmation to fail. 
It adds `strings.TrimSpace()` to the scanner input, ensuring that valid answers like `" y"` or `"yes "` are correctly accepted as confirmation.
#### Which issue(s) this PR is related to:
N/A
#### Special notes for your reviewer:
None.
#### Does this PR introduce a user-facing change?
```release-note
kubeadm: trim whitespace from interactive confirmation input to allow answers with leading/trailing spaces (e.g. " y ")