### PR TITLE
Instrument flagz and statusz endpoints with apiserver request metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz.go
@@ -148,10 +148,10 @@ func handleFlagz(componentName string, reg *registry, serializer runtime.Negotia
 		var deprecated bool
 		defer func() {
 			metrics.MonitorRequest(r, "GET", group, version,
-				"",               // resource
-				DefaultFlagzPath, // subresource
-				"",               // scope
-				"",               // component
+				"flagz",       // resource
+				"",            // subresource
+				"",            // scope
+				componentName, // component
 				deprecated,
 				"", // removedRelease
 				delegate.Status(), delegate.ContentLength(), time.Since(requestReceivedTimestamp))

--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,6 +30,9 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
 	"k8s.io/apiserver/pkg/features"
 	v1alpha1 "k8s.io/apiserver/pkg/server/flagz/api/v1alpha1"
 	"k8s.io/apiserver/pkg/server/flagz/negotiate"
@@ -128,6 +132,31 @@ func (f *flagzCodecFactory) SupportedMediaTypes() []runtime.SerializerInfo {
 
 func handleFlagz(componentName string, reg *registry, serializer runtime.NegotiatedSerializer, restrictions negotiate.FlagzEndpointRestrictions) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		requestReceivedTimestamp, ok := request.ReceivedTimestampFrom(r.Context())
+		if !ok {
+			requestReceivedTimestamp = time.Now()
+		}
+		delegate := &metrics.ResponseWriterDelegator{ResponseWriter: w}
+		w = responsewriter.WrapForHTTP1Or2(delegate)
+
+		// Use MonitorRequest instead of InstrumentHandlerFunc because the group,
+		// version, and deprecated status depend on per-request content negotiation.
+		// For text/plain requests, group and version remain empty. For structured
+		// responses (JSON/YAML/CBOR), they are set to the negotiated API group and
+		// version (e.g., config.k8s.io/v1alpha1).
+		var group, version string
+		var deprecated bool
+		defer func() {
+			metrics.MonitorRequest(r, "GET", group, version,
+				"",               // resource
+				DefaultFlagzPath, // subresource
+				"",               // scope
+				"",               // component
+				deprecated,
+				"", // removedRelease
+				delegate.Status(), delegate.ContentLength(), time.Since(requestReceivedTimestamp))
+		}()
+
 		obj := flagz(componentName, reg.reader)
 		acceptHeader := r.Header.Get("Accept")
 		if strings.TrimSpace(acceptHeader) == "" {
@@ -163,8 +192,13 @@ func handleFlagz(componentName string, reg *registry, serializer runtime.Negotia
 				)
 				return
 			}
+			// Set group, version, and deprecated from the negotiated target so
+			// the deferred MonitorRequest records the actual requested API version.
 			targetGV = mediaType.Convert.GroupVersion()
-			if reg.deprecatedVersions()[targetGV.Version] {
+			group = targetGV.Group
+			version = targetGV.Version
+			deprecated = reg.deprecatedVersions()[targetGV.Version]
+			if deprecated {
 				w.Header().Set("Warning", `299 - "This version of the flagz endpoint is deprecated. Please use a newer version."`)
 			}
 			writeStructuredResponse(obj, serializer, targetGV, restrictions, w, r)

--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz_test.go
@@ -30,11 +30,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	cbordirect "k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/features"
 	v1alpha1 "k8s.io/apiserver/pkg/server/flagz/api/v1alpha1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cliflag "k8s.io/component-base/cli/flag"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 	"sigs.k8s.io/yaml"
 )
 
@@ -375,5 +378,47 @@ func TestNewFlagzCodecFactory(t *testing.T) {
 	_, err := newFlagzCodecFactory(scheme, "", nil)
 	if err != nil {
 		t.Fatalf("unknown media type(s) detected - update newFlagzCodecFactory to explicitly handle them: %v", err)
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("test-flag", "test-value", "usage")
+	fakeReader := NamedFlagSetsReader{
+		FlagSets: cliflag.NamedFlagSets{
+			FlagSets: map[string]*pflag.FlagSet{
+				"test": fs,
+			},
+		},
+	}
+
+	mux := http.NewServeMux()
+	Install(mux, "test-server", fakeReader)
+	metrics.Register()
+	metrics.Reset()
+
+	// text/plain request: group and version should be empty
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com%s", DefaultFlagzPath), nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	// structured request: group and version should reflect the negotiated version
+	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com%s", DefaultFlagzPath), nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	req.Header.Set("Accept", "application/json;v=v1alpha1;g=config.k8s.io;as=Flagz")
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	expected := strings.NewReader(`
+        # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
+        # TYPE apiserver_request_total counter
+        apiserver_request_total{code="200",component="",dry_run="",group="",resource="",scope="",subresource="/flagz",verb="GET",version=""} 1
+        apiserver_request_total{code="200",component="",dry_run="",group="config.k8s.io",resource="",scope="",subresource="/flagz",verb="GET",version="v1alpha1"} 1
+`)
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, expected, "apiserver_request_total"); err != nil {
+		t.Error(err)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz_test.go
@@ -415,8 +415,8 @@ func TestMetrics(t *testing.T) {
 	expected := strings.NewReader(`
         # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
         # TYPE apiserver_request_total counter
-        apiserver_request_total{code="200",component="",dry_run="",group="",resource="",scope="",subresource="/flagz",verb="GET",version=""} 1
-        apiserver_request_total{code="200",component="",dry_run="",group="config.k8s.io",resource="",scope="",subresource="/flagz",verb="GET",version="v1alpha1"} 1
+        apiserver_request_total{code="200",component="test-server",dry_run="",group="",resource="flagz",scope="",subresource="",verb="GET",version=""} 1
+        apiserver_request_total{code="200",component="test-server",dry_run="",group="config.k8s.io",resource="flagz",scope="",subresource="",verb="GET",version="v1alpha1"} 1
 `)
 	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, expected, "apiserver_request_total"); err != nil {
 		t.Error(err)

--- a/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz.go
@@ -172,10 +172,10 @@ func handleStatusz(componentName string, reg statuszRegistry, serializer runtime
 		var deprecated bool
 		defer func() {
 			metrics.MonitorRequest(r, "GET", group, version,
-				"",                 // resource
-				DefaultStatuszPath, // subresource
-				"",                 // scope
-				"",                 // component
+				"statusz",     // resource
+				"",            // subresource
+				"",            // scope
+				componentName, // component
 				deprecated,
 				"", // removedRelease
 				delegate.Status(), delegate.ContentLength(), time.Since(requestReceivedTimestamp))

--- a/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz.go
@@ -31,6 +31,9 @@ import (
 
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server/statusz/negotiate"
 
@@ -153,6 +156,31 @@ func (f *statuszCodecFactory) SupportedMediaTypes() []runtime.SerializerInfo {
 
 func handleStatusz(componentName string, reg statuszRegistry, serializer runtime.NegotiatedSerializer, restrictions negotiate.StatuszEndpointRestrictions) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		requestReceivedTimestamp, ok := request.ReceivedTimestampFrom(r.Context())
+		if !ok {
+			requestReceivedTimestamp = time.Now()
+		}
+		delegate := &metrics.ResponseWriterDelegator{ResponseWriter: w}
+		w = responsewriter.WrapForHTTP1Or2(delegate)
+
+		// Use MonitorRequest instead of InstrumentHandlerFunc because the group,
+		// version, and deprecated status depend on per-request content negotiation.
+		// For text/plain requests, group and version remain empty. For structured
+		// responses (JSON/YAML/CBOR), they are set to the negotiated API group and
+		// version (e.g., config.k8s.io/v1alpha1).
+		var group, version string
+		var deprecated bool
+		defer func() {
+			metrics.MonitorRequest(r, "GET", group, version,
+				"",                 // resource
+				DefaultStatuszPath, // subresource
+				"",                 // scope
+				"",                 // component
+				deprecated,
+				"", // removedRelease
+				delegate.Status(), delegate.ContentLength(), time.Since(requestReceivedTimestamp))
+		}()
+
 		obj := statusz(componentName, reg)
 		acceptHeader := r.Header.Get("Accept")
 		if strings.TrimSpace(acceptHeader) == "" {
@@ -188,8 +216,12 @@ func handleStatusz(componentName string, reg statuszRegistry, serializer runtime
 				)
 				return
 			}
+			// Set group, version, and deprecated from the negotiated target so
+			// the deferred MonitorRequest records the actual requested API version.
 			targetGV = mediaType.Convert.GroupVersion()
-			deprecated := reg.deprecatedVersions()[targetGV.Version]
+			group = targetGV.Group
+			version = targetGV.Version
+			deprecated = reg.deprecatedVersions()[targetGV.Version]
 			if deprecated {
 				w.Header().Set("Warning", `299 - "This version of the statusz endpoint is deprecated. Please use a newer version."`)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz_test.go
@@ -32,9 +32,12 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1alpha1 "k8s.io/apiserver/pkg/server/statusz/api/v1alpha1"
@@ -458,5 +461,50 @@ func TestNewStatuszCodecFactory(t *testing.T) {
 	_, err := newStatuszCodecFactory(scheme, "", nil)
 	if err != nil {
 		t.Fatalf("unknown media type(s) detected - update newStatuszCodecFactory to explicitly handle them: %v", err)
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	fakeStartTime := time.Now()
+	fakeBinaryVersion := parseVersion(t, "1.31")
+	fakeEmulationVersion := parseVersion(t, "1.30")
+	fakeListedPaths := []string{"/livez/ping", "/readyz/ping"}
+
+	reg := fakeRegistry{
+		startTime:    fakeStartTime,
+		goVer:        "1.21",
+		binaryVer:    fakeBinaryVersion,
+		emulationVer: fakeEmulationVersion,
+		listedPaths:  fakeListedPaths,
+	}
+
+	mux := http.NewServeMux()
+	Install(mux, "test-server", reg)
+	metrics.Register()
+	metrics.Reset()
+
+	// text/plain request: group and version should be empty
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com%s", DefaultStatuszPath), nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	// structured request: group and version should reflect the negotiated version
+	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com%s", DefaultStatuszPath), nil)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	req.Header.Set("Accept", "application/json;v=v1alpha1;g=config.k8s.io;as=Statusz")
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	expected := strings.NewReader(`
+        # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
+        # TYPE apiserver_request_total counter
+        apiserver_request_total{code="200",component="",dry_run="",group="",resource="",scope="",subresource="/statusz",verb="GET",version=""} 1
+        apiserver_request_total{code="200",component="",dry_run="",group="config.k8s.io",resource="",scope="",subresource="/statusz",verb="GET",version="v1alpha1"} 1
+`)
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, expected, "apiserver_request_total"); err != nil {
+		t.Error(err)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz_test.go
@@ -501,8 +501,8 @@ func TestMetrics(t *testing.T) {
 	expected := strings.NewReader(`
         # HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
         # TYPE apiserver_request_total counter
-        apiserver_request_total{code="200",component="",dry_run="",group="",resource="",scope="",subresource="/statusz",verb="GET",version=""} 1
-        apiserver_request_total{code="200",component="",dry_run="",group="config.k8s.io",resource="",scope="",subresource="/statusz",verb="GET",version="v1alpha1"} 1
+        apiserver_request_total{code="200",component="test-server",dry_run="",group="",resource="statusz",scope="",subresource="",verb="GET",version=""} 1
+        apiserver_request_total{code="200",component="test-server",dry_run="",group="config.k8s.io",resource="statusz",scope="",subresource="",verb="GET",version="v1alpha1"} 1
 `)
 	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, expected, "apiserver_request_total"); err != nil {
 		t.Error(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Instruments the /flagz and /statusz endpoints with metrics.InstrumentHandlerFunc so that requests are recorded in apiserver_request_total and apiserver_request_duration_seconds, matching the existing pattern used by /healthz, /livez, and /readyz. This enables operators to detect potential abuse or DDOS of these zpages endpoints via the standard apiserver HTTP metrics.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/4828
  https://github.com/kubernetes/enhancements/pull/5806#discussion_r2789880972

#### Special notes for your reviewer:
The instrumentation follows the exact same pattern as the health endpoints in staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go. Tests also follow the existing TestMetrics pattern in healthz_test.go.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Instrument /flagz and /statusz endpoints with apiserver request metrics (apiserver_request_total, apiserver_request_duration_seconds), with group and version labels reflecting the content-negotiated API version.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/4828-component-flagz
```
