### PR TITLE
Fix CRD naming controller false conflict when shortName matches own plural/singular

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -165,6 +165,10 @@ func (c *NamingConditionController) calculateNamesAndConditions(in *apiextension
 			if existingShortNames.Has(shortName) {
 				continue
 			}
+			// if the shortname matches our own plural or singular, it's not a conflict
+			if shortName == newNames.Plural || shortName == newNames.Singular {
+				continue
+			}
 			if err := equalToAcceptedOrFresh(shortName, "", allResources); err != nil {
 				errs = append(errs, err)
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller_test.go
@@ -308,6 +308,60 @@ func TestSync(t *testing.T) {
 			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
+			name: "no conflict on shortName equal to own singular",
+			in: newCRD("bugs.bravo.com").
+				SpecNames("bugs", "bug", "Bug", "BugList", "bug").
+				StatusNames("bugs", "bug", "Bug", "BugList").
+				NewOrDie(),
+			existing: []*apiextensionsv1.CustomResourceDefinition{
+				newCRD("bugs.bravo.com").
+					SpecNames("bugs", "bug", "Bug", "BugList", "bug").
+					StatusNames("bugs", "bug", "Bug", "BugList").
+					NewOrDie(),
+			},
+			expectedNames:                 names("bugs", "bug", "Bug", "BugList", "bug"),
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  installingCondition,
+		},
+		{
+			name: "no conflict on shortName equal to own plural",
+			in: newCRD("bugs.bravo.com").
+				SpecNames("bugs", "bug", "Bug", "BugList", "bugs").
+				StatusNames("bugs", "bug", "Bug", "BugList").
+				NewOrDie(),
+			existing: []*apiextensionsv1.CustomResourceDefinition{
+				newCRD("bugs.bravo.com").
+					SpecNames("bugs", "bug", "Bug", "BugList", "bugs").
+					StatusNames("bugs", "bug", "Bug", "BugList").
+					NewOrDie(),
+			},
+			expectedNames:                 names("bugs", "bug", "Bug", "BugList", "bugs"),
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  installingCondition,
+		},
+		{
+			name: "no conflict on shortName equal to own singular on first creation",
+			in: newCRD("bugs.bravo.com").
+				SpecNames("bugs", "bug", "Bug", "BugList", "bug").
+				NewOrDie(),
+			existing:                      []*apiextensionsv1.CustomResourceDefinition{},
+			expectedNames:                 names("bugs", "bug", "Bug", "BugList", "bug"),
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  installingCondition,
+		},
+		{
+			name: "conflict on shortName equal to another CRDs plural",
+			in: newCRD("alfa.bravo.com").
+				SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "india").
+				NewOrDie(),
+			existing: []*apiextensionsv1.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "indias", "", "").NewOrDie(),
+			},
+			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind"),
+			expectedNameConflictCondition: nameConflictCondition("ShortNamesConflict", `"india" is already in use`),
+			expectedEstablishedCondition:  notEstablishedCondition,
+		},
+		{
 			name: "conflicting, not installing before with false condition",
 			in: newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
 				Condition(notAcceptedCondition).


### PR DESCRIPTION
## Summary

- Fix false `ShortNamesConflict` when a CRD's shortName matches its own plural or singular name
- `getAcceptedNamesForGroup()` collects all names (including the current CRD's) into `allResources`, and `equalToAcceptedOrFresh()` for shortNames is called with an empty `acceptedName`, so it cannot recognize the name as the CRD's own
- Skip conflict check for shortNames that match the CRD's already-validated `newNames.Plural` or `newNames.Singular`

/kind bug

## Test plan

- [x] Added test: shortName equals own singular — no false conflict on second reconciliation
- [x] Added test: shortName equals own plural — no false conflict on second reconciliation  
- [x] Added test: shortName equals own singular on first creation (empty status) — accepted
- [x] Added test: shortName equals another CRD's plural — still correctly produces `ShortNamesConflict`
- [x] All existing tests continue to pass

```release-note
Fix CRD naming controller incorrectly rejecting shortNames that match the CRD's own plural or singular name
```