### PR TITLE
api: enable optionalorrequired for admission API group

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -215,7 +215,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -215,7 +215,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -230,7 +230,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -230,7 +230,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -91,7 +91,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -91,7 +91,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+  path: "staging/src/k8s.io/api/(apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/staging/src/k8s.io/api/admission/v1/generated.proto
+++ b/staging/src/k8s.io/api/admission/v1/generated.proto
@@ -35,12 +35,15 @@ message AdmissionRequest {
   // otherwise identical (parallel requests, requests when earlier requests did not modify etc)
   // The UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.
   // It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
+  // +optional
   optional string uid = 1;
 
   // kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind kind = 2;
 
   // resource is the fully-qualified resource being requested (for example, v1.pods)
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource resource = 3;
 
   // subResource is the subresource being requested, if any (for example, "status" or "scale")
@@ -90,9 +93,11 @@ message AdmissionRequest {
 
   // operation is the operation being performed. This may be different than the operation
   // requested. e.g. a patch can result in either a CREATE or UPDATE Operation.
+  // +optional
   optional string operation = 7;
 
   // userInfo is information about the requesting user
+  // +optional
   optional .k8s.io.api.authentication.v1.UserInfo userInfo = 8;
 
   // object is the object from the incoming request.
@@ -121,9 +126,11 @@ message AdmissionRequest {
 message AdmissionResponse {
   // uid is an identifier for the individual request/response.
   // This must be copied over from the corresponding AdmissionRequest.
+  // +optional
   optional string uid = 1;
 
   // allowed indicates whether or not the admission request was permitted.
+  // +optional
   optional bool allowed = 2;
 
   // status is the result contains extra details into why an admission request was denied.

--- a/staging/src/k8s.io/api/admission/v1/types.go
+++ b/staging/src/k8s.io/api/admission/v1/types.go
@@ -43,10 +43,13 @@ type AdmissionRequest struct {
 	// otherwise identical (parallel requests, requests when earlier requests did not modify etc)
 	// The UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.
 	// It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
+	// +optional
 	UID types.UID `json:"uid" protobuf:"bytes,1,opt,name=uid"`
 	// kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)
+	// +optional
 	Kind metav1.GroupVersionKind `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// resource is the fully-qualified resource being requested (for example, v1.pods)
+	// +optional
 	Resource metav1.GroupVersionResource `json:"resource" protobuf:"bytes,3,opt,name=resource"`
 	// subResource is the subresource being requested, if any (for example, "status" or "scale")
 	// +optional
@@ -91,8 +94,10 @@ type AdmissionRequest struct {
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,6,opt,name=namespace"`
 	// operation is the operation being performed. This may be different than the operation
 	// requested. e.g. a patch can result in either a CREATE or UPDATE Operation.
+	// +optional
 	Operation Operation `json:"operation" protobuf:"bytes,7,opt,name=operation"`
 	// userInfo is information about the requesting user
+	// +optional
 	UserInfo authenticationv1.UserInfo `json:"userInfo" protobuf:"bytes,8,opt,name=userInfo"`
 	// object is the object from the incoming request.
 	// +optional
@@ -117,9 +122,11 @@ type AdmissionRequest struct {
 type AdmissionResponse struct {
 	// uid is an identifier for the individual request/response.
 	// This must be copied over from the corresponding AdmissionRequest.
+	// +optional
 	UID types.UID `json:"uid" protobuf:"bytes,1,opt,name=uid"`
 
 	// allowed indicates whether or not the admission request was permitted.
+	// +optional
 	Allowed bool `json:"allowed" protobuf:"varint,2,opt,name=allowed"`
 
 	// status is the result contains extra details into why an admission request was denied.

--- a/staging/src/k8s.io/api/admission/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admission/v1beta1/generated.proto
@@ -35,12 +35,15 @@ message AdmissionRequest {
   // otherwise identical (parallel requests, requests when earlier requests did not modify etc)
   // The UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.
   // It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
+  // +optional
   optional string uid = 1;
 
   // kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind kind = 2;
 
   // resource is the fully-qualified resource being requested (for example, v1.pods)
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource resource = 3;
 
   // subResource is the subresource being requested, if any (for example, "status" or "scale")
@@ -90,9 +93,11 @@ message AdmissionRequest {
 
   // operation is the operation being performed. This may be different than the operation
   // requested. e.g. a patch can result in either a CREATE or UPDATE Operation.
+  // +optional
   optional string operation = 7;
 
   // userInfo is information about the requesting user
+  // +optional
   optional .k8s.io.api.authentication.v1.UserInfo userInfo = 8;
 
   // object is the object from the incoming request.
@@ -121,9 +126,11 @@ message AdmissionRequest {
 message AdmissionResponse {
   // uid is an identifier for the individual request/response.
   // This should be copied over from the corresponding AdmissionRequest.
+  // +optional
   optional string uid = 1;
 
   // allowed indicates whether or not the admission request was permitted.
+  // +optional
   optional bool allowed = 2;
 
   // status is the result contains extra details into why an admission request was denied.

--- a/staging/src/k8s.io/api/admission/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admission/v1beta1/types.go
@@ -47,10 +47,13 @@ type AdmissionRequest struct {
 	// otherwise identical (parallel requests, requests when earlier requests did not modify etc)
 	// The UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.
 	// It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
+	// +optional
 	UID types.UID `json:"uid" protobuf:"bytes,1,opt,name=uid"`
 	// kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)
+	// +optional
 	Kind metav1.GroupVersionKind `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// resource is the fully-qualified resource being requested (for example, v1.pods)
+	// +optional
 	Resource metav1.GroupVersionResource `json:"resource" protobuf:"bytes,3,opt,name=resource"`
 	// subResource is the subresource being requested, if any (for example, "status" or "scale")
 	// +optional
@@ -95,8 +98,10 @@ type AdmissionRequest struct {
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,6,opt,name=namespace"`
 	// operation is the operation being performed. This may be different than the operation
 	// requested. e.g. a patch can result in either a CREATE or UPDATE Operation.
+	// +optional
 	Operation Operation `json:"operation" protobuf:"bytes,7,opt,name=operation"`
 	// userInfo is information about the requesting user
+	// +optional
 	UserInfo authenticationv1.UserInfo `json:"userInfo" protobuf:"bytes,8,opt,name=userInfo"`
 	// object is the object from the incoming request.
 	// +optional
@@ -121,9 +126,11 @@ type AdmissionRequest struct {
 type AdmissionResponse struct {
 	// uid is an identifier for the individual request/response.
 	// This should be copied over from the corresponding AdmissionRequest.
+	// +optional
 	UID types.UID `json:"uid" protobuf:"bytes,1,opt,name=uid"`
 
 	// allowed indicates whether or not the admission request was permitted.
+	// +optional
 	Allowed bool `json:"allowed" protobuf:"varint,2,opt,name=allowed"`
 
 	// status is the result contains extra details into why an admission request was denied.


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

- Enable the optionalorrequired linter for the admission API group.
- Add missing `+optional` markers to admission API types and remove the admission group from the linter exception list.

#### Which issue(s) this PR is related to:

Fixes #136857  
Related to #134671

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```