### PR TITLE
Fix: consider prefilter result when evaluateNominatedNode

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/kubernetes/pkg/util/slice"
 	utiltrace "k8s.io/utils/trace"
 )
 
@@ -661,14 +662,16 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 	// "NominatedNodeName" can potentially be set in a previous scheduling cycle as a result of preemption.
 	// This node is likely the only candidate that will fit the pod, and hence we try it first before iterating over all nodes.
 	// We take the same tack for hinted nodes from the batch module.
-	if len(pod.Status.NominatedNodeName) > 0 || len(nodeHint) > 0 {
-		feasibleNodes, err := sched.evaluateNominatedNode(ctx, pod, schedFramework, state, nodeHint, diagnosis)
-		if err != nil {
-			utilruntime.HandleErrorWithContext(ctx, err, "Evaluation failed on nominated node", "pod", klog.KObj(pod), "node", pod.Status.NominatedNodeName)
-		}
-		// Nominated node passes all the filters, scheduler is good to assign this node to the pod.
-		if len(feasibleNodes) != 0 {
-			return feasibleNodes, diagnosis, nodeHint, signature, nil
+	for _, nominated := range slice.UniqueString([]string{pod.Status.NominatedNodeName, nodeHint}) {
+		if len(nominated) > 0 {
+			feasibleNodes, err := sched.evaluateNominatedNode(ctx, pod, schedFramework, state, preRes, nominated, diagnosis)
+			if err != nil {
+				utilruntime.HandleErrorWithContext(ctx, err, "Evaluation failed on nominated node", "pod", klog.KObj(pod), "node", nominated)
+			}
+			// Nominated node passes all the filters, scheduler is good to assign this node to the pod.
+			if len(feasibleNodes) != 0 {
+				return feasibleNodes, diagnosis, nodeHint, signature, nil
+			}
 		}
 	}
 
@@ -715,19 +718,23 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 	return feasibleNodesAfterExtender, diagnosis, nodeHint, signature, nil
 }
 
-func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeHint string, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
-	// In the future we could potentially use the hint if the nominated node failed.
-	// https://github.com/kubernetes/kubernetes/issues/135163
-	nnn := pod.Status.NominatedNodeName
-	if len(nnn) == 0 {
-		nnn = nodeHint
-	}
-
-	nodeInfo, err := sched.nodeInfoSnapshot.Get(nnn)
+func (sched *Scheduler) evaluateNominatedNode(
+	ctx context.Context,
+	pod *v1.Pod,
+	schedFramework framework.Framework,
+	state fwk.CycleState,
+	preRes *fwk.PreFilterResult,
+	nominated string,
+	diagnosis framework.Diagnosis,
+) ([]fwk.NodeInfo, error) {
+	nodeInfo, err := sched.nodeInfoSnapshot.Get(nominated)
 	if err != nil {
 		return nil, err
 	}
 	node := []fwk.NodeInfo{nodeInfo}
+	if !preRes.AllNodes() && !preRes.NodeNames.Has(nominated) {
+		return nil, errors.New("nominated node is absent in PreFilterResult")
+	}
 	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, node)
 	if err != nil {
 		return nil, err

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -4398,6 +4398,7 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 	tests := []struct {
 		name              string
 		pod               *v1.Pod
+		preFilterResult   *fwk.PreFilterResult
 		nodeReturnCodeMap map[string]fwk.Code
 		expectedCount     int32
 	}{
@@ -4417,6 +4418,12 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 			nodeReturnCodeMap: map[string]fwk.Code{"node1": fwk.Unschedulable},
 			expectedCount:     4,
 		},
+		{
+			name:            "nominated pod absent in preFilter result, filter is called for nodes in preFilter result",
+			pod:             st.MakePod().Name("p_with_nominated_node").UID("p").Priority(highPriority).NominatedNodeName("node1").Obj(),
+			preFilterResult: &fwk.PreFilterResult{NodeNames: sets.New("node2", "node3")},
+			expectedCount:   2,
+		},
 	}
 
 	for _, test := range tests {
@@ -4433,12 +4440,16 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 			for _, n := range nodes {
 				cache.AddNode(logger, n)
 			}
-			plugin := tf.FakeFilterPlugin{FailedNodeReturnCodeMap: test.nodeReturnCodeMap}
-			registerFakeFilterFunc := tf.RegisterFilterPlugin(
+			plugin := tf.FakePreFilterAndFilterPlugin{
+				FakePreFilterPlugin: &tf.FakePreFilterPlugin{Result: test.preFilterResult},
+				FakeFilterPlugin:    &tf.FakeFilterPlugin{FailedNodeReturnCodeMap: test.nodeReturnCodeMap},
+			}
+			registerFakeFilterFunc := tf.RegisterPluginAsExtensions(
 				"FakeFilter",
 				func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
 					return &plugin, nil
 				},
+				"PreFilter", "Filter",
 			)
 			registerPlugins := []tf.RegisterPluginFunc{
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -19,6 +19,8 @@ package slice
 
 import (
 	"slices"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // CopyStrings copies the contents of the specified string slice
@@ -71,6 +73,22 @@ func RemoveString(slice []string, s string, modifier func(s string) string) []st
 		// Sanitize for unit tests so we don't need to distinguish empty array
 		// and nil.
 		newSlice = nil
+	}
+	return newSlice
+}
+
+func UniqueString(slice []string) []string {
+	if slice == nil {
+		return nil
+	}
+	newSlice := make([]string, 0, len(slice))
+	uniqKeys := sets.New[string]()
+	for _, item := range slice {
+		if uniqKeys.Has(item) {
+			continue
+		}
+		newSlice = append(newSlice, item)
+		uniqKeys.Insert(item)
 	}
 	return newSlice
 }

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -148,3 +148,32 @@ func TestRemoveString(t *testing.T) {
 		}
 	}
 }
+
+func TestUniqueString(t *testing.T) {
+	tests := []struct {
+		testName string
+		input    []string
+		want     []string
+	}{
+		{
+			testName: "Nil input slice",
+			input:    nil,
+			want:     nil,
+		},
+		{
+			testName: "Empty input slice",
+			input:    []string{},
+			want:     []string{},
+		},
+		{
+			testName: "Duplicate strings",
+			input:    []string{"a", "b", "a", "c", "b"},
+			want:     []string{"a", "b", "c"},
+		},
+	}
+	for _, tt := range tests {
+		if got := UniqueString(tt.input); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("%v: UniqueString(%v) = %v WANT %v", tt.testName, tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Gang scheduling or Preempt may set NominatedNodeName for pod, but PreFilter Result could be different for each schedulingCycle. When evaluate nominated node, we should consider if it is in NodeNames of PreFilterResult.

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
fix bug of evaluate NominatedNode, keep semantics for PreFilterResult


#### Which issue(s) this PR is related to:
N/A


#### Special notes for your reviewer:
NONE


#### Does this PR introduce a user-facing change?
NONE


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
