### PR TITLE
Enable optionalorrequired linter certificates

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5262,7 +5262,8 @@
       },
       "required": [
         "request",
-        "signerName"
+        "signerName",
+        "usages"
       ],
       "type": "object"
     },
@@ -5593,8 +5594,7 @@
         "serviceAccountName",
         "serviceAccountUID",
         "nodeName",
-        "nodeUID",
-        "stubPKCS10Request"
+        "nodeUID"
       ],
       "type": "object"
     },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5297,7 +5297,8 @@
       },
       "required": [
         "request",
-        "signerName"
+        "signerName",
+        "usages"
       ],
       "type": "object"
     },
@@ -5795,8 +5796,7 @@
         "serviceAccountName",
         "serviceAccountUID",
         "nodeName",
-        "nodeUID",
-        "stubPKCS10Request"
+        "nodeUID"
       ],
       "type": "object"
     },

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
@@ -197,7 +197,8 @@
         },
         "required": [
           "request",
-          "signerName"
+          "signerName",
+          "usages"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
@@ -189,7 +189,8 @@
         },
         "required": [
           "request",
-          "signerName"
+          "signerName",
+          "usages"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1beta1_openapi.json
@@ -277,8 +277,7 @@
           "serviceAccountName",
           "serviceAccountUID",
           "nodeName",
-          "nodeUID",
-          "stubPKCS10Request"
+          "nodeUID"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1beta1_openapi.json
@@ -266,8 +266,7 @@
           "serviceAccountName",
           "serviceAccountUID",
           "nodeName",
-          "nodeUID",
-          "stubPKCS10Request"
+          "nodeUID"
         ],
         "type": "object"
       },

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -230,7 +230,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -241,7 +241,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|core|discovery|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -245,7 +245,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -256,7 +256,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|core|discovery|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -106,7 +106,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -117,7 +117,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|core|discovery|extensions|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -17907,7 +17907,7 @@ func schema_k8sio_api_certificates_v1_CertificateSigningRequestSpec(ref common.R
 						},
 					},
 				},
-				Required: []string{"request", "signerName"},
+				Required: []string{"request", "signerName", "usages"},
 			},
 		},
 	}
@@ -18342,7 +18342,7 @@ func schema_k8sio_api_certificates_v1beta1_CertificateSigningRequestSpec(ref com
 						},
 					},
 				},
-				Required: []string{"request"},
+				Required: []string{"request", "usages"},
 			},
 		},
 	}
@@ -18726,7 +18726,7 @@ func schema_k8sio_api_certificates_v1beta1_PodCertificateRequestSpec(ref common.
 						},
 					},
 				},
-				Required: []string{"signerName", "podName", "podUID", "serviceAccountName", "serviceAccountUID", "nodeName", "nodeUID", "stubPKCS10Request"},
+				Required: []string{"signerName", "podName", "podUID", "serviceAccountName", "serviceAccountUID", "nodeName", "nodeUID"},
 			},
 		},
 	}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -17935,7 +17935,7 @@ func schema_k8sio_api_certificates_v1_CertificateSigningRequestSpec(ref common.R
 						},
 					},
 				},
-				Required: []string{"request", "signerName"},
+				Required: []string{"request", "signerName", "usages"},
 			},
 		},
 	}
@@ -19131,7 +19131,7 @@ func schema_k8sio_api_certificates_v1beta1_PodCertificateRequestSpec(ref common.
 						},
 					},
 				},
-				Required: []string{"signerName", "podName", "podUID", "serviceAccountName", "serviceAccountUID", "nodeName", "nodeUID", "stubPKCS10Request"},
+				Required: []string{"signerName", "podName", "podUID", "serviceAccountName", "serviceAccountUID", "nodeName", "nodeUID"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -48,6 +48,7 @@ message CertificateSigningRequest {
   // spec contains the certificate request, and is immutable after creation.
   // Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
   // Other fields are derived by Kubernetes and cannot be modified by users.
+  // +required
   optional CertificateSigningRequestSpec spec = 2;
 
   // status contains information about whether the request is approved or denied,
@@ -73,10 +74,12 @@ message CertificateSigningRequestCondition {
   // Approved, Denied, and Failed conditions cannot be removed once added.
   //
   // Only one condition of a given type is allowed.
+  // +required
   optional string type = 1;
 
   // status of the condition, one of True, False, Unknown.
   // Approved, Denied, and Failed conditions may not be "False" or "Unknown".
+  // +required
   optional string status = 6;
 
   // reason indicates a brief reason for the request state
@@ -111,6 +114,7 @@ message CertificateSigningRequestList {
 message CertificateSigningRequestSpec {
   // request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block.
   // When serialized as JSON or YAML, the data is additionally base64-encoded.
+  // +required
   optional bytes request = 1;
 
   // signerName indicates the requested signer, and is a qualified name.
@@ -134,6 +138,7 @@ message CertificateSigningRequestSpec {
   //  4. Required, permitted, or forbidden key usages / extended key usages.
   //  5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
   //  6. Whether or not requests for CA certificates are allowed.
+  // +required
   optional string signerName = 7;
 
   // expirationSeconds is the requested duration of validity of the issued
@@ -172,6 +177,7 @@ message CertificateSigningRequestSpec {
   //  "code signing", "email protection", "s/mime",
   //  "ipsec end system", "ipsec tunnel", "ipsec user",
   //  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
+  // +required
   // +listType=atomic
   repeated string usages = 5;
 

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -48,6 +48,7 @@ message CertificateSigningRequest {
   // spec contains the certificate request, and is immutable after creation.
   // Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
   // Other fields are derived by Kubernetes and cannot be modified by users.
+  // +required
   optional CertificateSigningRequestSpec spec = 2;
 
   // status contains information about whether the request is approved or denied,
@@ -73,10 +74,12 @@ message CertificateSigningRequestCondition {
   // Approved, Denied, and Failed conditions cannot be removed once added.
   //
   // Only one condition of a given type is allowed.
+  // +required
   optional string type = 1;
 
   // status of the condition, one of True, False, Unknown.
   // Approved, Denied, and Failed conditions may not be "False" or "Unknown".
+  // +required
   optional string status = 6;
 
   // reason indicates a brief reason for the request state
@@ -111,6 +114,7 @@ message CertificateSigningRequestList {
 message CertificateSigningRequestSpec {
   // request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block.
   // When serialized as JSON or YAML, the data is additionally base64-encoded.
+  // +required
   optional bytes request = 1;
 
   // signerName indicates the requested signer, and is a qualified name.
@@ -134,6 +138,7 @@ message CertificateSigningRequestSpec {
   //  4. Required, permitted, or forbidden key usages / extended key usages.
   //  5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
   //  6. Whether or not requests for CA certificates are allowed.
+  // +required
   optional string signerName = 7;
 
   // expirationSeconds is the requested duration of validity of the issued
@@ -172,6 +177,7 @@ message CertificateSigningRequestSpec {
   //  "code signing", "email protection", "s/mime",
   //  "ipsec end system", "ipsec tunnel", "ipsec user",
   //  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
+  // +required
   // +listType=atomic
   repeated string usages = 5;
 
@@ -264,6 +270,7 @@ message ClusterTrustBundle {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the signer (if any) and trust anchors.
+  // +required
   optional ClusterTrustBundleSpec spec = 2;
 }
 
@@ -315,6 +322,7 @@ message ClusterTrustBundleSpec {
   // Users of ClusterTrustBundles, including Kubelet, are free to reorder and
   // deduplicate certificate blocks in this file according to their own logic,
   // as well as to drop PEM block headers and inter-block data.
+  // +required
   optional string trustBundle = 2;
 }
 

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -49,6 +49,7 @@ type CertificateSigningRequest struct {
 	// spec contains the certificate request, and is immutable after creation.
 	// Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
 	// Other fields are derived by Kubernetes and cannot be modified by users.
+	// +required
 	Spec CertificateSigningRequestSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status contains information about whether the request is approved or denied,
@@ -61,6 +62,7 @@ type CertificateSigningRequest struct {
 type CertificateSigningRequestSpec struct {
 	// request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block.
 	// When serialized as JSON or YAML, the data is additionally base64-encoded.
+	// +required
 	Request []byte `json:"request" protobuf:"bytes,1,opt,name=request"`
 
 	// signerName indicates the requested signer, and is a qualified name.
@@ -84,6 +86,7 @@ type CertificateSigningRequestSpec struct {
 	//  4. Required, permitted, or forbidden key usages / extended key usages.
 	//  5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
 	//  6. Whether or not requests for CA certificates are allowed.
+	// +required
 	SignerName string `json:"signerName" protobuf:"bytes,7,opt,name=signerName"`
 
 	// expirationSeconds is the requested duration of validity of the issued
@@ -122,6 +125,7 @@ type CertificateSigningRequestSpec struct {
 	//  "code signing", "email protection", "s/mime",
 	//  "ipsec end system", "ipsec tunnel", "ipsec user",
 	//  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
+	// +required
 	// +listType=atomic
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 
@@ -248,9 +252,11 @@ type CertificateSigningRequestCondition struct {
 	// Approved, Denied, and Failed conditions cannot be removed once added.
 	//
 	// Only one condition of a given type is allowed.
+	// +required
 	Type RequestConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=RequestConditionType"`
 	// status of the condition, one of True, False, Unknown.
 	// Approved, Denied, and Failed conditions may not be "False" or "Unknown".
+	// +required
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,6,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
 	// reason indicates a brief reason for the request state
 	// +optional

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -50,6 +50,7 @@ type CertificateSigningRequest struct {
 	// spec contains the certificate request, and is immutable after creation.
 	// Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
 	// Other fields are derived by Kubernetes and cannot be modified by users.
+	// +required
 	Spec CertificateSigningRequestSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status contains information about whether the request is approved or denied,
@@ -62,6 +63,7 @@ type CertificateSigningRequest struct {
 type CertificateSigningRequestSpec struct {
 	// request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block.
 	// When serialized as JSON or YAML, the data is additionally base64-encoded.
+	// +required
 	Request []byte `json:"request" protobuf:"bytes,1,opt,name=request"`
 
 	// signerName indicates the requested signer, and is a qualified name.
@@ -85,6 +87,7 @@ type CertificateSigningRequestSpec struct {
 	//  4. Required, permitted, or forbidden key usages / extended key usages.
 	//  5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
 	//  6. Whether or not requests for CA certificates are allowed.
+	// +required
 	SignerName string `json:"signerName" protobuf:"bytes,7,opt,name=signerName"`
 
 	// expirationSeconds is the requested duration of validity of the issued
@@ -123,6 +126,7 @@ type CertificateSigningRequestSpec struct {
 	//  "code signing", "email protection", "s/mime",
 	//  "ipsec end system", "ipsec tunnel", "ipsec user",
 	//  "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
+	// +required
 	// +listType=atomic
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 
@@ -249,9 +253,11 @@ type CertificateSigningRequestCondition struct {
 	// Approved, Denied, and Failed conditions cannot be removed once added.
 	//
 	// Only one condition of a given type is allowed.
+	// +required
 	Type RequestConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=RequestConditionType"`
 	// status of the condition, one of True, False, Unknown.
 	// Approved, Denied, and Failed conditions may not be "False" or "Unknown".
+	// +required
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,6,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
 	// reason indicates a brief reason for the request state
 	// +optional
@@ -346,6 +352,7 @@ type ClusterTrustBundle struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec contains the signer (if any) and trust anchors.
+	// +required
 	Spec ClusterTrustBundleSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -386,6 +393,7 @@ type ClusterTrustBundleSpec struct {
 	// Users of ClusterTrustBundles, including Kubelet, are free to reorder and
 	// deduplicate certificate blocks in this file according to their own logic,
 	// as well as to drop PEM block headers and inter-block data.
+	// +required
 	TrustBundle string `json:"trustBundle" protobuf:"bytes,2,opt,name=trustBundle"`
 }
 

--- a/staging/src/k8s.io/api/certificates/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1alpha1/generated.proto
@@ -49,6 +49,7 @@ message ClusterTrustBundle {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the signer (if any) and trust anchors.
+  // +required
   optional ClusterTrustBundleSpec spec = 2;
 }
 
@@ -98,6 +99,7 @@ message ClusterTrustBundleSpec {
   // Users of ClusterTrustBundles, including Kubelet, are free to reorder and
   // deduplicate certificate blocks in this file according to their own logic,
   // as well as to drop PEM block headers and inter-block data.
+  // +required
   optional string trustBundle = 2;
 }
 

--- a/staging/src/k8s.io/api/certificates/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1alpha1/generated.proto
@@ -49,6 +49,7 @@ message ClusterTrustBundle {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the signer (if any) and trust anchors.
+  // +required
   optional ClusterTrustBundleSpec spec = 2;
 }
 
@@ -100,6 +101,7 @@ message ClusterTrustBundleSpec {
   // Users of ClusterTrustBundles, including Kubelet, are free to reorder and
   // deduplicate certificate blocks in this file according to their own logic,
   // as well as to drop PEM block headers and inter-block data.
+  // +required
   optional string trustBundle = 2;
 }
 

--- a/staging/src/k8s.io/api/certificates/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1alpha1/types.go
@@ -49,6 +49,7 @@ type ClusterTrustBundle struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec contains the signer (if any) and trust anchors.
+	// +required
 	Spec ClusterTrustBundleSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -87,6 +88,7 @@ type ClusterTrustBundleSpec struct {
 	// Users of ClusterTrustBundles, including Kubelet, are free to reorder and
 	// deduplicate certificate blocks in this file according to their own logic,
 	// as well as to drop PEM block headers and inter-block data.
+	// +required
 	TrustBundle string `json:"trustBundle" protobuf:"bytes,2,opt,name=trustBundle"`
 }
 

--- a/staging/src/k8s.io/api/certificates/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1alpha1/types.go
@@ -49,6 +49,7 @@ type ClusterTrustBundle struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec contains the signer (if any) and trust anchors.
+	// +required
 	Spec ClusterTrustBundleSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -89,6 +90,7 @@ type ClusterTrustBundleSpec struct {
 	// Users of ClusterTrustBundles, including Kubelet, are free to reorder and
 	// deduplicate certificate blocks in this file according to their own logic,
 	// as well as to drop PEM block headers and inter-block data.
+	// +required
 	TrustBundle string `json:"trustBundle" protobuf:"bytes,2,opt,name=trustBundle"`
 }
 

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -39,6 +39,7 @@ message CertificateSigningRequest {
   // spec contains the certificate request, and is immutable after creation.
   // Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
   // Other fields are derived by Kubernetes and cannot be modified by users.
+  // +required
   optional CertificateSigningRequestSpec spec = 2;
 
   // Derived information about the request.
@@ -48,6 +49,7 @@ message CertificateSigningRequest {
 
 message CertificateSigningRequestCondition {
   // type of the condition. Known conditions include "Approved", "Denied", and "Failed".
+  // +required
   optional string type = 1;
 
   // Status of the condition, one of True, False, Unknown.
@@ -86,6 +88,7 @@ message CertificateSigningRequestList {
 // CertificateSigningRequestSpec contains the certificate request.
 message CertificateSigningRequestSpec {
   // Base64-encoded PKCS#10 CSR data
+  // +required
   optional bytes request = 1;
 
   // Requested signer for the request. It is a qualified name in the form:
@@ -153,6 +156,7 @@ message CertificateSigningRequestSpec {
   //  "ocsp signing",
   //  "microsoft sgc",
   //  "netscape sgc"
+  // +required
   // +listType=atomic
   repeated string usages = 5;
 
@@ -217,6 +221,7 @@ message ClusterTrustBundle {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the signer (if any) and trust anchors.
+  // +required
   optional ClusterTrustBundleSpec spec = 2;
 }
 
@@ -266,6 +271,7 @@ message ClusterTrustBundleSpec {
   // Users of ClusterTrustBundles, including Kubelet, are free to reorder and
   // deduplicate certificate blocks in this file according to their own logic,
   // as well as to drop PEM block headers and inter-block data.
+  // +required
   optional string trustBundle = 2;
 }
 
@@ -435,6 +441,7 @@ message PodCertificateRequestSpec {
   // setting a status.conditions entry with a type of "Denied" and a reason of
   // "UnsupportedKeyType". It may also suggest a key type that it does support
   // in the message field.
+  // +optional
   optional bytes stubPKCS10Request = 12;
 
   // unverifiedUserAnnotations allow pod authors to pass additional information to
@@ -447,6 +454,7 @@ message PodCertificateRequestSpec {
   //
   // Signers should document the keys and values they support.  Signers should
   // deny requests that contain keys they do not recognize.
+  // +optional
   map<string, string> unverifiedUserAnnotations = 11;
 }
 

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -39,6 +39,7 @@ message CertificateSigningRequest {
   // spec contains the certificate request, and is immutable after creation.
   // Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
   // Other fields are derived by Kubernetes and cannot be modified by users.
+  // +required
   optional CertificateSigningRequestSpec spec = 2;
 
   // Derived information about the request.
@@ -48,6 +49,7 @@ message CertificateSigningRequest {
 
 message CertificateSigningRequestCondition {
   // type of the condition. Known conditions include "Approved", "Denied", and "Failed".
+  // +required
   optional string type = 1;
 
   // Status of the condition, one of True, False, Unknown.
@@ -86,6 +88,7 @@ message CertificateSigningRequestList {
 // CertificateSigningRequestSpec contains the certificate request.
 message CertificateSigningRequestSpec {
   // Base64-encoded PKCS#10 CSR data
+  // +required
   optional bytes request = 1;
 
   // Requested signer for the request. It is a qualified name in the form:
@@ -153,6 +156,7 @@ message CertificateSigningRequestSpec {
   //  "ocsp signing",
   //  "microsoft sgc",
   //  "netscape sgc"
+  // +optional
   // +listType=atomic
   repeated string usages = 5;
 
@@ -217,6 +221,7 @@ message ClusterTrustBundle {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the signer (if any) and trust anchors.
+  // +required
   optional ClusterTrustBundleSpec spec = 2;
 }
 
@@ -268,6 +273,7 @@ message ClusterTrustBundleSpec {
   // Users of ClusterTrustBundles, including Kubelet, are free to reorder and
   // deduplicate certificate blocks in this file according to their own logic,
   // as well as to drop PEM block headers and inter-block data.
+  // +required
   optional string trustBundle = 2;
 }
 
@@ -438,6 +444,7 @@ message PodCertificateRequestSpec {
   // setting a status.conditions entry with a type of "Denied" and a reason of
   // "UnsupportedKeyType". It may also suggest a key type that it does support
   // in the message field.
+  // +optional
   optional bytes stubPKCS10Request = 12;
 
   // unverifiedUserAnnotations allow pod authors to pass additional information to
@@ -450,6 +457,7 @@ message PodCertificateRequestSpec {
   //
   // Signers should document the keys and values they support.  Signers should
   // deny requests that contain keys they do not recognize.
+  // +optional
   map<string, string> unverifiedUserAnnotations = 11;
 }
 

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -42,6 +42,7 @@ type CertificateSigningRequest struct {
 	// spec contains the certificate request, and is immutable after creation.
 	// Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
 	// Other fields are derived by Kubernetes and cannot be modified by users.
+	// +required
 	Spec CertificateSigningRequestSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// Derived information about the request.
@@ -52,6 +53,7 @@ type CertificateSigningRequest struct {
 // CertificateSigningRequestSpec contains the certificate request.
 type CertificateSigningRequestSpec struct {
 	// Base64-encoded PKCS#10 CSR data
+	// +required
 	Request []byte `json:"request" protobuf:"bytes,1,opt,name=request"`
 
 	// Requested signer for the request. It is a qualified name in the form:
@@ -119,6 +121,7 @@ type CertificateSigningRequestSpec struct {
 	//  "ocsp signing",
 	//  "microsoft sgc",
 	//  "netscape sgc"
+	// +required
 	// +listType=atomic
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 
@@ -201,6 +204,7 @@ const (
 
 type CertificateSigningRequestCondition struct {
 	// type of the condition. Known conditions include "Approved", "Denied", and "Failed".
+	// +required
 	Type RequestConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=RequestConditionType"`
 	// Status of the condition, one of True, False, Unknown.
 	// Approved, Denied, and Failed conditions may not be "False" or "Unknown".
@@ -299,6 +303,7 @@ type ClusterTrustBundle struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec contains the signer (if any) and trust anchors.
+	// +required
 	Spec ClusterTrustBundleSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -337,6 +342,7 @@ type ClusterTrustBundleSpec struct {
 	// Users of ClusterTrustBundles, including Kubelet, are free to reorder and
 	// deduplicate certificate blocks in this file according to their own logic,
 	// as well as to drop PEM block headers and inter-block data.
+	// +required
 	TrustBundle string `json:"trustBundle" protobuf:"bytes,2,opt,name=trustBundle"`
 }
 
@@ -506,6 +512,7 @@ type PodCertificateRequestSpec struct {
 	// setting a status.conditions entry with a type of "Denied" and a reason of
 	// "UnsupportedKeyType". It may also suggest a key type that it does support
 	// in the message field.
+	// +optional
 	StubPKCS10Request []byte `json:"stubPKCS10Request" protobuf:"bytes,12,opt,name=stubPKCS10Request"`
 
 	// unverifiedUserAnnotations allow pod authors to pass additional information to
@@ -518,6 +525,7 @@ type PodCertificateRequestSpec struct {
 	//
 	// Signers should document the keys and values they support.  Signers should
 	// deny requests that contain keys they do not recognize.
+	// +optional
 	UnverifiedUserAnnotations map[string]string `json:"unverifiedUserAnnotations,omitempty" protobuf:"bytes,11,opt,name=unverifiedUserAnnotations"`
 }
 

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -42,6 +42,7 @@ type CertificateSigningRequest struct {
 	// spec contains the certificate request, and is immutable after creation.
 	// Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
 	// Other fields are derived by Kubernetes and cannot be modified by users.
+	// +required
 	Spec CertificateSigningRequestSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// Derived information about the request.
@@ -52,6 +53,7 @@ type CertificateSigningRequest struct {
 // CertificateSigningRequestSpec contains the certificate request.
 type CertificateSigningRequestSpec struct {
 	// Base64-encoded PKCS#10 CSR data
+	// +required
 	Request []byte `json:"request" protobuf:"bytes,1,opt,name=request"`
 
 	// Requested signer for the request. It is a qualified name in the form:
@@ -119,6 +121,7 @@ type CertificateSigningRequestSpec struct {
 	//  "ocsp signing",
 	//  "microsoft sgc",
 	//  "netscape sgc"
+	// +optional
 	// +listType=atomic
 	Usages []KeyUsage `json:"usages,omitempty" protobuf:"bytes,5,opt,name=usages"`
 
@@ -201,6 +204,7 @@ const (
 
 type CertificateSigningRequestCondition struct {
 	// type of the condition. Known conditions include "Approved", "Denied", and "Failed".
+	// +required
 	Type RequestConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=RequestConditionType"`
 	// Status of the condition, one of True, False, Unknown.
 	// Approved, Denied, and Failed conditions may not be "False" or "Unknown".
@@ -300,6 +304,7 @@ type ClusterTrustBundle struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec contains the signer (if any) and trust anchors.
+	// +required
 	Spec ClusterTrustBundleSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -340,6 +345,7 @@ type ClusterTrustBundleSpec struct {
 	// Users of ClusterTrustBundles, including Kubelet, are free to reorder and
 	// deduplicate certificate blocks in this file according to their own logic,
 	// as well as to drop PEM block headers and inter-block data.
+	// +required
 	TrustBundle string `json:"trustBundle" protobuf:"bytes,2,opt,name=trustBundle"`
 }
 
@@ -513,6 +519,7 @@ type PodCertificateRequestSpec struct {
 	// setting a status.conditions entry with a type of "Denied" and a reason of
 	// "UnsupportedKeyType". It may also suggest a key type that it does support
 	// in the message field.
+	// +optional
 	StubPKCS10Request []byte `json:"stubPKCS10Request" protobuf:"bytes,12,opt,name=stubPKCS10Request"`
 
 	// unverifiedUserAnnotations allow pod authors to pass additional information to
@@ -525,6 +532,7 @@ type PodCertificateRequestSpec struct {
 	//
 	// Signers should document the keys and values they support.  Signers should
 	// deny requests that contain keys they do not recognize.
+	// +optional
 	UnverifiedUserAnnotations map[string]string `json:"unverifiedUserAnnotations,omitempty" protobuf:"bytes,11,opt,name=unverifiedUserAnnotations"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add +required marker to various specs in the certificates API to satisfy the `optionalorrequired` linter rule and enable the linter for the certificates API group.

#### Which issue(s) this PR is related to:
Fixes #136863

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


##### Special notes for your reviewer:

Fields marked as `+required`

- `CertificateSigningRequest.Spec` (v1, v1beta1)
- `CertificateSigningRequestSpec.Request` (v1, v1beta1)
- `CertificateSigningRequestSpec.SignerName` (v1)
- `CertificateSigningRequestCondition.Type` (v1, v1beta1)
- `CertificateSigningRequestCondition.Status` (v1)
- `ClusterTrustBundle.Spec` (v1alpha1, v1beta1)
- `ClusterTrustBundleSpec.TrustBundle` (v1alpha1, v1beta1)
- `PodCertificateRequestSpec.StubPKCS10Request` (v1beta1)

Fields marked as `+optional`

- `CertificateSigningRequestSpec.Usages` (v1, v1beta1)
- `PodCertificateRequestSpec.UnverifiedUserAnnotations` (v1beta1)
