### PR TITLE
proxy/utils: Use net.JoinHostPort to format address.

### DIFF
--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -169,10 +170,7 @@ func AppendPortIfNeeded(addr string, port int32) string {
 	}
 
 	// Append port to address.
-	if ip.To4() != nil {
-		return fmt.Sprintf("%s:%d", addr, port)
-	}
-	return fmt.Sprintf("[%s]:%d", addr, port)
+	return net.JoinHostPort(addr, strconv.Itoa(int(port)))
 }
 
 // EnsureSysctl sets a kernel sysctl to a given numeric value.


### PR DESCRIPTION
#### What type of PR is this?

Taken out from #136891 to quickly get this fix merged.

/kind cleanup

#### What this PR does / why we need it:

`net.JoinHostPort` handles IPv4 and IPv6 easily.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
