### PR TITLE
Enable the `optionalorrequired` linter for the `autoscaling` API group

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -201,9 +201,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "replicas"
-        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -1285,9 +1285,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "replicas"
-        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {

--- a/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
@@ -186,10 +186,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "currentReplicas",
-          "desiredReplicas"
-        ],
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {

--- a/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
@@ -54,11 +54,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "name",
-          "current",
-          "container"
-        ],
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.CrossVersionObjectReference": {
@@ -135,10 +130,6 @@
             "description": "metric identifies the target metric by name and selector"
           }
         },
-        "required": [
-          "metric",
-          "current"
-        ],
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.HPAScalingPolicy": {
@@ -163,9 +154,7 @@
           }
         },
         "required": [
-          "type",
-          "value",
-          "periodSeconds"
+          "type"
         ],
         "type": "object"
       },
@@ -299,7 +288,7 @@
           },
           "status": {
             "default": "",
-            "description": "status is the status of the condition (True, False, Unknown)",
+            "description": "status is the status of the condition, one of True, False, Unknown.",
             "type": "string"
           },
           "type": {
@@ -308,10 +297,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "status"
-        ],
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList": {
@@ -449,9 +434,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "desiredReplicas"
-        ],
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.MetricIdentifier": {
@@ -579,9 +561,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "type"
-        ],
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.MetricTarget": {
@@ -715,11 +694,6 @@
             "description": "metric identifies the target metric by name and selector"
           }
         },
-        "required": [
-          "metric",
-          "current",
-          "describedObject"
-        ],
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.PodsMetricSource": {
@@ -772,10 +746,6 @@
             "description": "metric identifies the target metric by name and selector"
           }
         },
-        "required": [
-          "metric",
-          "current"
-        ],
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.ResourceMetricSource": {
@@ -820,10 +790,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "name",
-          "current"
-        ],
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.api.resource.Quantity": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -232,7 +232,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|batch|certificates|core|discovery|events|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -275,6 +275,17 @@ linters:
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
       - text: "optionalfields: field Eviction.Status should be a pointer."
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
+      
+      # These status fields are non-pointer structs whose inner fields are required, but the status structs themselves
+      # have no validation, so the fields must be marked optional rather than required.
+      - text: "nonpointerstructs: field ObjectMetricStatus.Target is a non-pointer struct with required fields. It must be marked as required."
+        path: "staging/src/k8s.io/api/autoscaling/v1/types.go"
+      - text: "nonpointerstructs: field ObjectMetricStatus.(Metric|DescribedObject) is a non-pointer struct with required fields. It must be marked as required."
+        path: "staging/src/k8s.io/api/autoscaling/v2/types.go"
+      - text: "nonpointerstructs: field PodsMetricStatus.Metric is a non-pointer struct with required fields. It must be marked as required."
+        path: "staging/src/k8s.io/api/autoscaling/v2/types.go"
+      - text: "nonpointerstructs: field ExternalMetricStatus.Metric is a non-pointer struct with required fields. It must be marked as required."
+        path: "staging/src/k8s.io/api/autoscaling/v2/types.go"
 
       - linters:
         - forbidigo

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -290,6 +290,17 @@ linters:
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
       - text: "optionalfields: field Eviction.Status should be a pointer."
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
+      
+      # These status fields are non-pointer structs whose inner fields are required, but the status structs themselves
+      # have no validation, so the fields must be marked optional rather than required.
+      - text: "nonpointerstructs: field ObjectMetricStatus.Target is a non-pointer struct with required fields. It must be marked as required."
+        path: "staging/src/k8s.io/api/autoscaling/v1/types.go"
+      - text: "nonpointerstructs: field ObjectMetricStatus.(Metric|DescribedObject) is a non-pointer struct with required fields. It must be marked as required."
+        path: "staging/src/k8s.io/api/autoscaling/v2/types.go"
+      - text: "nonpointerstructs: field PodsMetricStatus.Metric is a non-pointer struct with required fields. It must be marked as required."
+        path: "staging/src/k8s.io/api/autoscaling/v2/types.go"
+      - text: "nonpointerstructs: field ExternalMetricStatus.Metric is a non-pointer struct with required fields. It must be marked as required."
+        path: "staging/src/k8s.io/api/autoscaling/v2/types.go"
 
       - linters:
         - forbidigo

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -247,7 +247,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|batch|certificates|core|discovery|events|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -108,7 +108,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|authorization|batch|certificates|core|discovery|events|extensions|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -151,3 +151,14 @@
   path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
 - text: "optionalfields: field Eviction.Status should be a pointer."
   path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
+
+# These status fields are non-pointer structs whose inner fields are required, but the status structs themselves
+# have no validation, so the fields must be marked optional rather than required.
+- text: "nonpointerstructs: field ObjectMetricStatus.Target is a non-pointer struct with required fields. It must be marked as required."
+  path: "staging/src/k8s.io/api/autoscaling/v1/types.go"
+- text: "nonpointerstructs: field ObjectMetricStatus.(Metric|DescribedObject) is a non-pointer struct with required fields. It must be marked as required."
+  path: "staging/src/k8s.io/api/autoscaling/v2/types.go"
+- text: "nonpointerstructs: field PodsMetricStatus.Metric is a non-pointer struct with required fields. It must be marked as required."
+  path: "staging/src/k8s.io/api/autoscaling/v2/types.go"
+- text: "nonpointerstructs: field ExternalMetricStatus.Metric is a non-pointer struct with required fields. It must be marked as required."
+  path: "staging/src/k8s.io/api/autoscaling/v2/types.go"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -14606,7 +14606,6 @@ func schema_k8sio_api_autoscaling_v1_ContainerResourceMetricStatus(ref common.Re
 						},
 					},
 				},
-				Required: []string{"name", "currentAverageValue", "container"},
 			},
 		},
 		Dependencies: []string{
@@ -14732,7 +14731,6 @@ func schema_k8sio_api_autoscaling_v1_ExternalMetricStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"metricName", "currentValue"},
 			},
 		},
 		Dependencies: []string{
@@ -14808,7 +14806,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerCondition(ref common
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "status is the status of the condition (True, False, Unknown)",
+							Description: "status is the status of the condition, one of True, False, Unknown.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -14842,7 +14840,6 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerCondition(ref common
 						},
 					},
 				},
-				Required: []string{"type", "status"},
 			},
 		},
 		Dependencies: []string{
@@ -14989,7 +14986,6 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerStatus(ref common.Re
 						},
 					},
 				},
-				Required: []string{"currentReplicas", "desiredReplicas"},
 			},
 		},
 		Dependencies: []string{
@@ -15061,7 +15057,7 @@ func schema_k8sio_api_autoscaling_v1_MetricStatus(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "type is the type of metric source.  It will be one of \"ContainerResource\", \"External\", \"Object\", \"Pods\" or \"Resource\", each corresponds to a matching field in the object.\n\nPossible enum values:\n - `\"ContainerResource\"` is a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics (the \"pods\" source).\n - `\"External\"` is a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).\n - `\"Object\"` is a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).\n - `\"Pods\"` is a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.\n - `\"Resource\"` is a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics (the \"pods\" source).",
+							Description: "type is the type of metric source.  It should be one of \"ContainerResource\", \"External\", \"Object\", \"Pods\" or \"Resource\", each corresponds to a matching field in the object.\n\nPossible enum values:\n - `\"ContainerResource\"` is a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics (the \"pods\" source).\n - `\"External\"` is a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).\n - `\"Object\"` is a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).\n - `\"Pods\"` is a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.\n - `\"Resource\"` is a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics (the \"pods\" source).",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -15099,7 +15095,6 @@ func schema_k8sio_api_autoscaling_v1_MetricStatus(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -15148,7 +15143,7 @@ func schema_k8sio_api_autoscaling_v1_ObjectMetricSource(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"target", "metricName", "targetValue"},
+				Required: []string{"target", "metricName"},
 			},
 		},
 		Dependencies: []string{
@@ -15197,7 +15192,6 @@ func schema_k8sio_api_autoscaling_v1_ObjectMetricStatus(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"target", "metricName", "currentValue"},
 			},
 		},
 		Dependencies: []string{
@@ -15269,7 +15263,6 @@ func schema_k8sio_api_autoscaling_v1_PodsMetricStatus(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"metricName", "currentAverageValue"},
 			},
 		},
 		Dependencies: []string{
@@ -15343,7 +15336,6 @@ func schema_k8sio_api_autoscaling_v1_ResourceMetricStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"name", "currentAverageValue"},
 			},
 		},
 		Dependencies: []string{
@@ -15445,7 +15437,6 @@ func schema_k8sio_api_autoscaling_v1_ScaleStatus(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"replicas"},
 			},
 		},
 	}
@@ -15521,7 +15512,6 @@ func schema_k8sio_api_autoscaling_v2_ContainerResourceMetricStatus(ref common.Re
 						},
 					},
 				},
-				Required: []string{"name", "current", "container"},
 			},
 		},
 		Dependencies: []string{
@@ -15618,7 +15608,6 @@ func schema_k8sio_api_autoscaling_v2_ExternalMetricStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"metric", "current"},
 			},
 		},
 		Dependencies: []string{
@@ -15658,7 +15647,7 @@ func schema_k8sio_api_autoscaling_v2_HPAScalingPolicy(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"type", "value", "periodSeconds"},
+				Required: []string{"type"},
 			},
 		},
 	}
@@ -15812,7 +15801,7 @@ func schema_k8sio_api_autoscaling_v2_HorizontalPodAutoscalerCondition(ref common
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "status is the status of the condition (True, False, Unknown)",
+							Description: "status is the status of the condition, one of True, False, Unknown.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -15846,7 +15835,6 @@ func schema_k8sio_api_autoscaling_v2_HorizontalPodAutoscalerCondition(ref common
 						},
 					},
 				},
-				Required: []string{"type", "status"},
 			},
 		},
 		Dependencies: []string{
@@ -16043,7 +16031,6 @@ func schema_k8sio_api_autoscaling_v2_HorizontalPodAutoscalerStatus(ref common.Re
 						},
 					},
 				},
-				Required: []string{"desiredReplicas"},
 			},
 		},
 		Dependencies: []string{
@@ -16181,7 +16168,6 @@ func schema_k8sio_api_autoscaling_v2_MetricStatus(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -16332,7 +16318,6 @@ func schema_k8sio_api_autoscaling_v2_ObjectMetricStatus(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"metric", "current", "describedObject"},
 			},
 		},
 		Dependencies: []string{
@@ -16392,7 +16377,6 @@ func schema_k8sio_api_autoscaling_v2_PodsMetricStatus(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"metric", "current"},
 			},
 		},
 		Dependencies: []string{
@@ -16454,7 +16438,6 @@ func schema_k8sio_api_autoscaling_v2_ResourceMetricStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"name", "current"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -39,6 +39,7 @@ option go_package = "k8s.io/api/autoscaling/v1";
 // should be set.
 message ContainerResourceMetricSource {
   // name is the name of the resource in question.
+  // +required
   optional string name = 1;
 
   // targetAverageUtilization is the target value of the average of the
@@ -54,6 +55,7 @@ message ContainerResourceMetricSource {
   optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 3;
 
   // container is the name of the container in the pods of the scaling target.
+  // +required
   optional string container = 5;
 }
 
@@ -64,6 +66,7 @@ message ContainerResourceMetricSource {
 // normal per-pod metrics using the "pods" source.
 message ContainerResourceMetricStatus {
   // name is the name of the resource in question.
+  // +optional
   optional string name = 1;
 
   // currentAverageUtilization is the current value of the average of the
@@ -78,9 +81,11 @@ message ContainerResourceMetricStatus {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // It will always be set, regardless of the corresponding metric specification.
+  // +optional
   optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
 
   // container is the name of the container in the pods of the scaling taget
+  // +optional
   optional string container = 4;
 }
 
@@ -88,10 +93,12 @@ message ContainerResourceMetricStatus {
 // +structType=atomic
 message CrossVersionObjectReference {
   // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  // +required
   // +k8s:alpha(since: "1.37")=+k8s:required
   optional string kind = 1;
 
   // name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+  // +required
   // +k8s:alpha(since: "1.37")=+k8s:required
   optional string name = 2;
 
@@ -105,6 +112,7 @@ message CrossVersionObjectReference {
 // messaging service, or QPS from loadbalancer running outside of cluster).
 message ExternalMetricSource {
   // metricName is the name of the metric in question.
+  // +required
   optional string metricName = 1;
 
   // metricSelector is used to identify a specific time series
@@ -128,6 +136,7 @@ message ExternalMetricSource {
 message ExternalMetricStatus {
   // metricName is the name of a metric used for autoscaling in
   // metric system.
+  // +optional
   optional string metricName = 1;
 
   // metricSelector is used to identify a specific time series
@@ -136,6 +145,7 @@ message ExternalMetricStatus {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector metricSelector = 2;
 
   // currentValue is the current value of the metric (as a quantity)
+  // +optional
   optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
 
   // currentAverageValue is the current value of metric averaged over autoscaled pods.
@@ -163,9 +173,11 @@ message HorizontalPodAutoscaler {
 // a HorizontalPodAutoscaler at a certain point.
 message HorizontalPodAutoscalerCondition {
   // type describes the current condition
+  // +optional
   optional string type = 1;
 
-  // status is the status of the condition (True, False, Unknown)
+  // status is the status of the condition, one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // lastTransitionTime is the last time the condition transitioned from
@@ -203,6 +215,7 @@ message HorizontalPodAutoscalerList {
 message HorizontalPodAutoscalerSpec {
   // scaleTargetRef is the reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption
   // and will set the desired number of pods by using its Scale subresource.
+  // +required
   optional CrossVersionObjectReference scaleTargetRef = 1;
 
   // minReplicas is the lower limit for the number of replicas to which the autoscaler
@@ -240,9 +253,11 @@ message HorizontalPodAutoscalerStatus {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
 
   // currentReplicas is the current number of replicas of pods managed by this autoscaler.
+  // +optional
   optional int32 currentReplicas = 3;
 
   // desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.
+  // +optional
   optional int32 desiredReplicas = 4;
 
   // currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU,
@@ -256,6 +271,7 @@ message HorizontalPodAutoscalerStatus {
 message MetricSpec {
   // type is the type of metric source.  It should be one of "ContainerResource",
   // "External", "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+  // +required
   optional string type = 1;
 
   // object refers to a metric describing a single kubernetes object
@@ -296,8 +312,9 @@ message MetricSpec {
 
 // MetricStatus describes the last-read state of a single metric.
 message MetricStatus {
-  // type is the type of metric source.  It will be one of "ContainerResource",
+  // type is the type of metric source.  It should be one of "ContainerResource",
   // "External", "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
+  // +optional
   optional string type = 1;
 
   // object refers to a metric describing a single kubernetes object
@@ -340,12 +357,15 @@ message MetricStatus {
 // kubernetes object (for example, hits-per-second on an Ingress object).
 message ObjectMetricSource {
   // target is the described Kubernetes object.
+  // +required
   optional CrossVersionObjectReference target = 1;
 
   // metricName is the name of the metric in question.
+  // +required
   optional string metricName = 2;
 
   // targetValue is the target value of the metric (as a quantity).
+  // +optional
   optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetValue = 3;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric.
@@ -364,12 +384,15 @@ message ObjectMetricSource {
 // kubernetes object (for example, hits-per-second on an Ingress object).
 message ObjectMetricStatus {
   // target is the described Kubernetes object.
+  // +optional
   optional CrossVersionObjectReference target = 1;
 
   // metricName is the name of the metric in question.
+  // +optional
   optional string metricName = 2;
 
   // currentValue is the current value of the metric (as a quantity).
+  // +optional
   optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
@@ -390,10 +413,12 @@ message ObjectMetricStatus {
 // value.
 message PodsMetricSource {
   // metricName is the name of the metric in question
+  // +required
   optional string metricName = 1;
 
   // targetAverageValue is the target value of the average of the
   // metric across all relevant pods (as a quantity)
+  // +required
   optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 2;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
@@ -407,10 +432,12 @@ message PodsMetricSource {
 // the current scale target (for example, transactions-processed-per-second).
 message PodsMetricStatus {
   // metricName is the name of the metric in question
+  // +optional
   optional string metricName = 1;
 
   // currentAverageValue is the current value of the average of the
   // metric across all relevant pods (as a quantity)
+  // +optional
   optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 2;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
@@ -429,6 +456,7 @@ message PodsMetricStatus {
 // should be set.
 message ResourceMetricSource {
   // name is the name of the resource in question.
+  // +required
   optional string name = 1;
 
   // targetAverageUtilization is the target value of the average of the
@@ -451,6 +479,7 @@ message ResourceMetricSource {
 // normal per-pod metrics using the "pods" source.
 message ResourceMetricStatus {
   // name is the name of the resource in question.
+  // +optional
   optional string name = 1;
 
   // currentAverageUtilization is the current value of the average of the
@@ -465,6 +494,7 @@ message ResourceMetricStatus {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // It will always be set, regardless of the corresponding metric specification.
+  // +optional
   optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
 }
 
@@ -497,6 +527,7 @@ message ScaleSpec {
 // ScaleStatus represents the current status of a scale subresource.
 message ScaleStatus {
   // replicas is the actual number of observed instances of the scaled object.
+  // +optional
   optional int32 replicas = 1;
 
   // selector is the label query over pods that should match the replicas count. This is same

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -380,7 +380,7 @@ type ExternalMetricSource struct {
 
 // MetricStatus describes the last-read state of a single metric.
 type MetricStatus struct {
-	// type is the type of metric source.  It will be one of "ContainerResource",
+	// type is the type of metric source.  It should be one of "ContainerResource",
 	// "External", "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
 	// +optional
 	Type MetricSourceType `json:"type" protobuf:"bytes,1,name=type"`
@@ -446,7 +446,7 @@ type HorizontalPodAutoscalerCondition struct {
 	// +optional
 	Type HorizontalPodAutoscalerConditionType `json:"type" protobuf:"bytes,1,name=type"`
 
-	// status is the status of the condition (True, False, Unknown)
+	// status is the status of the condition, one of True, False, Unknown.
 	// +optional
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,name=status"`
 

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -26,10 +26,12 @@ import (
 // +structType=atomic
 type CrossVersionObjectReference struct {
 	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +required
 	// +k8s:alpha(since: "1.37")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 
 	// name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +required
 	// +k8s:alpha(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
@@ -42,6 +44,7 @@ type CrossVersionObjectReference struct {
 type HorizontalPodAutoscalerSpec struct {
 	// scaleTargetRef is the reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption
 	// and will set the desired number of pods by using its Scale subresource.
+	// +required
 	ScaleTargetRef CrossVersionObjectReference `json:"scaleTargetRef" protobuf:"bytes,1,opt,name=scaleTargetRef"`
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler
 	// can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the
@@ -78,9 +81,11 @@ type HorizontalPodAutoscalerStatus struct {
 	LastScaleTime *metav1.Time `json:"lastScaleTime,omitempty" protobuf:"bytes,2,opt,name=lastScaleTime"`
 
 	// currentReplicas is the current number of replicas of pods managed by this autoscaler.
+	// +optional
 	CurrentReplicas int32 `json:"currentReplicas" protobuf:"varint,3,opt,name=currentReplicas"`
 
 	// desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.
+	// +optional
 	DesiredReplicas int32 `json:"desiredReplicas" protobuf:"varint,4,opt,name=desiredReplicas"`
 
 	// currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU,
@@ -158,6 +163,7 @@ type ScaleSpec struct {
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatus struct {
 	// replicas is the actual number of observed instances of the scaled object.
+	// +optional
 	Replicas int32 `json:"replicas" protobuf:"varint,1,opt,name=replicas"`
 
 	// selector is the label query over pods that should match the replicas count. This is same
@@ -207,6 +213,7 @@ const (
 type MetricSpec struct {
 	// type is the type of metric source.  It should be one of "ContainerResource",
 	// "External", "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+	// +required
 	Type MetricSourceType `json:"type" protobuf:"bytes,1,name=type"`
 
 	// object refers to a metric describing a single kubernetes object
@@ -249,12 +256,15 @@ type MetricSpec struct {
 // kubernetes object (for example, hits-per-second on an Ingress object).
 type ObjectMetricSource struct {
 	// target is the described Kubernetes object.
+	// +required
 	Target CrossVersionObjectReference `json:"target" protobuf:"bytes,1,name=target"`
 
 	// metricName is the name of the metric in question.
+	// +required
 	MetricName string `json:"metricName" protobuf:"bytes,2,name=metricName"`
 
 	// targetValue is the target value of the metric (as a quantity).
+	// +optional
 	TargetValue resource.Quantity `json:"targetValue" protobuf:"bytes,3,name=targetValue"`
 
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric.
@@ -275,10 +285,12 @@ type ObjectMetricSource struct {
 // value.
 type PodsMetricSource struct {
 	// metricName is the name of the metric in question
+	// +required
 	MetricName string `json:"metricName" protobuf:"bytes,1,name=metricName"`
 
 	// targetAverageValue is the target value of the average of the
 	// metric across all relevant pods (as a quantity)
+	// +required
 	TargetAverageValue resource.Quantity `json:"targetAverageValue" protobuf:"bytes,2,name=targetAverageValue"`
 
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric
@@ -297,6 +309,7 @@ type PodsMetricSource struct {
 // should be set.
 type ResourceMetricSource struct {
 	// name is the name of the resource in question.
+	// +required
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
 
 	// targetAverageUtilization is the target value of the average of the
@@ -321,6 +334,7 @@ type ResourceMetricSource struct {
 // should be set.
 type ContainerResourceMetricSource struct {
 	// name is the name of the resource in question.
+	// +required
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
 
 	// targetAverageUtilization is the target value of the average of the
@@ -336,6 +350,7 @@ type ContainerResourceMetricSource struct {
 	TargetAverageValue *resource.Quantity `json:"targetAverageValue,omitempty" protobuf:"bytes,3,opt,name=targetAverageValue"`
 
 	// container is the name of the container in the pods of the scaling target.
+	// +required
 	Container string `json:"container" protobuf:"bytes,5,opt,name=container"`
 }
 
@@ -344,6 +359,7 @@ type ContainerResourceMetricSource struct {
 // messaging service, or QPS from loadbalancer running outside of cluster).
 type ExternalMetricSource struct {
 	// metricName is the name of the metric in question.
+	// +required
 	MetricName string `json:"metricName" protobuf:"bytes,1,name=metricName"`
 
 	// metricSelector is used to identify a specific time series
@@ -366,6 +382,7 @@ type ExternalMetricSource struct {
 type MetricStatus struct {
 	// type is the type of metric source.  It will be one of "ContainerResource",
 	// "External", "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
+	// +optional
 	Type MetricSourceType `json:"type" protobuf:"bytes,1,name=type"`
 
 	// object refers to a metric describing a single kubernetes object
@@ -426,9 +443,11 @@ const (
 // a HorizontalPodAutoscaler at a certain point.
 type HorizontalPodAutoscalerCondition struct {
 	// type describes the current condition
+	// +optional
 	Type HorizontalPodAutoscalerConditionType `json:"type" protobuf:"bytes,1,name=type"`
 
 	// status is the status of the condition (True, False, Unknown)
+	// +optional
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,name=status"`
 
 	// lastTransitionTime is the last time the condition transitioned from
@@ -456,12 +475,15 @@ type HorizontalPodAutoscalerCondition struct {
 // kubernetes object (for example, hits-per-second on an Ingress object).
 type ObjectMetricStatus struct {
 	// target is the described Kubernetes object.
+	// +optional
 	Target CrossVersionObjectReference `json:"target" protobuf:"bytes,1,name=target"`
 
 	// metricName is the name of the metric in question.
+	// +optional
 	MetricName string `json:"metricName" protobuf:"bytes,2,name=metricName"`
 
 	// currentValue is the current value of the metric (as a quantity).
+	// +optional
 	CurrentValue resource.Quantity `json:"currentValue" protobuf:"bytes,3,name=currentValue"`
 
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric
@@ -480,10 +502,12 @@ type ObjectMetricStatus struct {
 // the current scale target (for example, transactions-processed-per-second).
 type PodsMetricStatus struct {
 	// metricName is the name of the metric in question
+	// +optional
 	MetricName string `json:"metricName" protobuf:"bytes,1,name=metricName"`
 
 	// currentAverageValue is the current value of the average of the
 	// metric across all relevant pods (as a quantity)
+	// +optional
 	CurrentAverageValue resource.Quantity `json:"currentAverageValue" protobuf:"bytes,2,name=currentAverageValue"`
 
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric
@@ -500,6 +524,7 @@ type PodsMetricStatus struct {
 // normal per-pod metrics using the "pods" source.
 type ResourceMetricStatus struct {
 	// name is the name of the resource in question.
+	// +optional
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
 
 	// currentAverageUtilization is the current value of the average of the
@@ -514,6 +539,7 @@ type ResourceMetricStatus struct {
 	// resource metric across all relevant pods, as a raw value (instead of as
 	// a percentage of the request), similar to the "pods" metric source type.
 	// It will always be set, regardless of the corresponding metric specification.
+	// +optional
 	CurrentAverageValue resource.Quantity `json:"currentAverageValue" protobuf:"bytes,3,name=currentAverageValue"`
 }
 
@@ -524,6 +550,7 @@ type ResourceMetricStatus struct {
 // normal per-pod metrics using the "pods" source.
 type ContainerResourceMetricStatus struct {
 	// name is the name of the resource in question.
+	// +optional
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
 
 	// currentAverageUtilization is the current value of the average of the
@@ -538,9 +565,11 @@ type ContainerResourceMetricStatus struct {
 	// resource metric across all relevant pods, as a raw value (instead of as
 	// a percentage of the request), similar to the "pods" metric source type.
 	// It will always be set, regardless of the corresponding metric specification.
+	// +optional
 	CurrentAverageValue resource.Quantity `json:"currentAverageValue" protobuf:"bytes,3,name=currentAverageValue"`
 
 	// container is the name of the container in the pods of the scaling taget
+	// +optional
 	Container string `json:"container" protobuf:"bytes,4,opt,name=container"`
 }
 
@@ -549,6 +578,7 @@ type ContainerResourceMetricStatus struct {
 type ExternalMetricStatus struct {
 	// metricName is the name of a metric used for autoscaling in
 	// metric system.
+	// +optional
 	MetricName string `json:"metricName" protobuf:"bytes,1,name=metricName"`
 
 	// metricSelector is used to identify a specific time series
@@ -556,6 +586,7 @@ type ExternalMetricStatus struct {
 	// +optional
 	MetricSelector *metav1.LabelSelector `json:"metricSelector,omitempty" protobuf:"bytes,2,opt,name=metricSelector"`
 	// currentValue is the current value of the metric (as a quantity)
+	// +optional
 	CurrentValue resource.Quantity `json:"currentValue" protobuf:"bytes,3,name=currentValue"`
 
 	// currentAverageValue is the current value of metric averaged over autoscaled pods.

--- a/staging/src/k8s.io/api/autoscaling/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types_swagger_doc_generated.go
@@ -100,7 +100,7 @@ func (HorizontalPodAutoscaler) SwaggerDoc() map[string]string {
 var map_HorizontalPodAutoscalerCondition = map[string]string{
 	"":                   "HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.",
 	"type":               "type describes the current condition",
-	"status":             "status is the status of the condition (True, False, Unknown)",
+	"status":             "status is the status of the condition, one of True, False, Unknown.",
 	"lastTransitionTime": "lastTransitionTime is the last time the condition transitioned from one status to another",
 	"reason":             "reason is the reason for the condition's last transition.",
 	"message":            "message is a human-readable explanation containing details about the transition",
@@ -162,7 +162,7 @@ func (MetricSpec) SwaggerDoc() map[string]string {
 
 var map_MetricStatus = map[string]string{
 	"":                  "MetricStatus describes the last-read state of a single metric.",
-	"type":              "type is the type of metric source.  It will be one of \"ContainerResource\", \"External\", \"Object\", \"Pods\" or \"Resource\", each corresponds to a matching field in the object.",
+	"type":              "type is the type of metric source.  It should be one of \"ContainerResource\", \"External\", \"Object\", \"Pods\" or \"Resource\", each corresponds to a matching field in the object.",
 	"object":            "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).",
 	"pods":              "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.",
 	"resource":          "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -39,12 +39,15 @@ option go_package = "k8s.io/api/autoscaling/v2";
 // should be set.
 message ContainerResourceMetricSource {
   // name is the name of the resource in question.
+  // +required
   optional string name = 1;
 
   // target specifies the target value for the given metric
+  // +required
   optional MetricTarget target = 2;
 
   // container is the name of the container in the pods of the scaling target
+  // +required
   optional string container = 3;
 }
 
@@ -55,22 +58,27 @@ message ContainerResourceMetricSource {
 // normal per-pod metrics using the "pods" source.
 message ContainerResourceMetricStatus {
   // name is the name of the resource in question.
+  // +optional
   optional string name = 1;
 
   // current contains the current value for the given metric
+  // +optional
   optional MetricValueStatus current = 2;
 
   // container is the name of the container in the pods of the scaling target
+  // +optional
   optional string container = 3;
 }
 
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 message CrossVersionObjectReference {
   // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  // +required
   // +k8s:alpha(since: "1.37")=+k8s:required
   optional string kind = 1;
 
   // name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+  // +required
   // +k8s:alpha(since: "1.37")=+k8s:required
   optional string name = 2;
 
@@ -84,9 +92,11 @@ message CrossVersionObjectReference {
 // messaging service, or QPS from loadbalancer running outside of cluster).
 message ExternalMetricSource {
   // metric identifies the target metric by name and selector
+  // +required
   optional MetricIdentifier metric = 1;
 
   // target specifies the target value for the given metric
+  // +required
   optional MetricTarget target = 2;
 }
 
@@ -94,23 +104,28 @@ message ExternalMetricSource {
 // not associated with any Kubernetes object.
 message ExternalMetricStatus {
   // metric identifies the target metric by name and selector
+  // +optional
   optional MetricIdentifier metric = 1;
 
   // current contains the current value for the given metric
+  // +optional
   optional MetricValueStatus current = 2;
 }
 
 // HPAScalingPolicy is a single policy which must hold true for a specified past interval.
 message HPAScalingPolicy {
   // type is used to specify the scaling policy.
+  // +required
   optional string type = 1;
 
   // value contains the amount of change which is permitted by the policy.
   // It must be greater than zero
+  // +optional
   optional int32 value = 2;
 
   // periodSeconds specifies the window of time for which the policy should hold true.
   // PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+  // +optional
   optional int32 periodSeconds = 3;
 }
 
@@ -205,9 +220,11 @@ message HorizontalPodAutoscalerBehavior {
 // a HorizontalPodAutoscaler at a certain point.
 message HorizontalPodAutoscalerCondition {
   // type describes the current condition
+  // +optional
   optional string type = 1;
 
-  // status is the status of the condition (True, False, Unknown)
+  // status is the status of the condition, one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // lastTransitionTime is the last time the condition transitioned from
@@ -245,6 +262,7 @@ message HorizontalPodAutoscalerList {
 message HorizontalPodAutoscalerSpec {
   // scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics
   // should be collected, as well as to actually change the replica count.
+  // +required
   optional CrossVersionObjectReference scaleTargetRef = 1;
 
   // minReplicas is the lower limit for the number of replicas to which the autoscaler
@@ -303,6 +321,7 @@ message HorizontalPodAutoscalerStatus {
 
   // desiredReplicas is the desired number of replicas of pods managed by this autoscaler,
   // as last calculated by the autoscaler.
+  // +optional
   optional int32 desiredReplicas = 4;
 
   // currentMetrics is the last read state of the metrics used by this autoscaler.
@@ -324,6 +343,7 @@ message HorizontalPodAutoscalerStatus {
 // MetricIdentifier defines the name and optionally selector for a metric
 message MetricIdentifier {
   // name is the name of the given metric
+  // +required
   optional string name = 1;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
@@ -338,6 +358,7 @@ message MetricIdentifier {
 message MetricSpec {
   // type is the type of metric source.  It should be one of "ContainerResource", "External",
   // "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+  // +required
   optional string type = 1;
 
   // object refers to a metric describing a single kubernetes object
@@ -382,6 +403,7 @@ message MetricSpec {
 message MetricStatus {
   // type is the type of metric source.  It will be one of "ContainerResource", "External",
   // "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
+  // +optional
   optional string type = 1;
 
   // object refers to a metric describing a single kubernetes object
@@ -425,6 +447,7 @@ message MetricStatus {
 // MetricTarget defines the target value, average value, or average utilization of a specific metric
 message MetricTarget {
   // type represents whether the metric type is Utilization, Value, or AverageValue
+  // +required
   optional string type = 1;
 
   // value is the target value of the metric (as a quantity).
@@ -466,12 +489,15 @@ message MetricValueStatus {
 // kubernetes object (for example, hits-per-second on an Ingress object).
 message ObjectMetricSource {
   // describedObject specifies the descriptions of a object,such as kind,name apiVersion
+  // +required
   optional CrossVersionObjectReference describedObject = 1;
 
   // target specifies the target value for the given metric
+  // +required
   optional MetricTarget target = 2;
 
   // metric identifies the target metric by name and selector
+  // +required
   optional MetricIdentifier metric = 3;
 }
 
@@ -479,12 +505,15 @@ message ObjectMetricSource {
 // kubernetes object (for example, hits-per-second on an Ingress object).
 message ObjectMetricStatus {
   // metric identifies the target metric by name and selector
+  // +optional
   optional MetricIdentifier metric = 1;
 
   // current contains the current value for the given metric
+  // +optional
   optional MetricValueStatus current = 2;
 
   // describedObject specifies the descriptions of a object,such as kind,name apiVersion
+  // +optional
   optional CrossVersionObjectReference describedObject = 3;
 }
 
@@ -494,9 +523,11 @@ message ObjectMetricStatus {
 // value.
 message PodsMetricSource {
   // metric identifies the target metric by name and selector
+  // +required
   optional MetricIdentifier metric = 1;
 
   // target specifies the target value for the given metric
+  // +required
   optional MetricTarget target = 2;
 }
 
@@ -504,9 +535,11 @@ message PodsMetricSource {
 // the current scale target (for example, transactions-processed-per-second).
 message PodsMetricStatus {
   // metric identifies the target metric by name and selector
+  // +optional
   optional MetricIdentifier metric = 1;
 
   // current contains the current value for the given metric
+  // +optional
   optional MetricValueStatus current = 2;
 }
 
@@ -519,9 +552,11 @@ message PodsMetricStatus {
 // should be set.
 message ResourceMetricSource {
   // name is the name of the resource in question.
+  // +required
   optional string name = 1;
 
   // target specifies the target value for the given metric
+  // +required
   optional MetricTarget target = 2;
 }
 
@@ -532,9 +567,11 @@ message ResourceMetricSource {
 // normal per-pod metrics using the "pods" source.
 message ResourceMetricStatus {
   // name is the name of the resource in question.
+  // +optional
   optional string name = 1;
 
   // current contains the current value for the given metric
+  // +optional
   optional MetricValueStatus current = 2;
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -486,7 +486,7 @@ type HorizontalPodAutoscalerCondition struct {
 	// +optional
 	Type HorizontalPodAutoscalerConditionType `json:"type" protobuf:"bytes,1,name=type"`
 
-	// status is the status of the condition (True, False, Unknown)
+	// status is the status of the condition, one of True, False, Unknown.
 	// +optional
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,name=status"`
 

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -53,6 +53,7 @@ type HorizontalPodAutoscaler struct {
 type HorizontalPodAutoscalerSpec struct {
 	// scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics
 	// should be collected, as well as to actually change the replica count.
+	// +required
 	ScaleTargetRef CrossVersionObjectReference `json:"scaleTargetRef" protobuf:"bytes,1,opt,name=scaleTargetRef"`
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler
 	// can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the
@@ -95,10 +96,12 @@ type HorizontalPodAutoscalerSpec struct {
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 type CrossVersionObjectReference struct {
 	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +required
 	// +k8s:alpha(since: "1.37")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 
 	// name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +required
 	// +k8s:alpha(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
@@ -112,6 +115,7 @@ type CrossVersionObjectReference struct {
 type MetricSpec struct {
 	// type is the type of metric source.  It should be one of "ContainerResource", "External",
 	// "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+	// +required
 	Type MetricSourceType `json:"type" protobuf:"bytes,1,name=type"`
 
 	// object refers to a metric describing a single kubernetes object
@@ -245,14 +249,17 @@ const (
 // HPAScalingPolicy is a single policy which must hold true for a specified past interval.
 type HPAScalingPolicy struct {
 	// type is used to specify the scaling policy.
+	// +required
 	Type HPAScalingPolicyType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=HPAScalingPolicyType"`
 
 	// value contains the amount of change which is permitted by the policy.
 	// It must be greater than zero
+	// +optional
 	Value int32 `json:"value" protobuf:"varint,2,opt,name=value"`
 
 	// periodSeconds specifies the window of time for which the policy should hold true.
 	// PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+	// +optional
 	PeriodSeconds int32 `json:"periodSeconds" protobuf:"varint,3,opt,name=periodSeconds"`
 }
 
@@ -291,12 +298,15 @@ const (
 // kubernetes object (for example, hits-per-second on an Ingress object).
 type ObjectMetricSource struct {
 	// describedObject specifies the descriptions of a object,such as kind,name apiVersion
+	// +required
 	DescribedObject CrossVersionObjectReference `json:"describedObject" protobuf:"bytes,1,name=describedObject"`
 
 	// target specifies the target value for the given metric
+	// +required
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 
 	// metric identifies the target metric by name and selector
+	// +required
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,3,name=metric"`
 }
 
@@ -306,9 +316,11 @@ type ObjectMetricSource struct {
 // value.
 type PodsMetricSource struct {
 	// metric identifies the target metric by name and selector
+	// +required
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
 
 	// target specifies the target value for the given metric
+	// +required
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 }
 
@@ -321,9 +333,11 @@ type PodsMetricSource struct {
 // should be set.
 type ResourceMetricSource struct {
 	// name is the name of the resource in question.
+	// +required
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
 
 	// target specifies the target value for the given metric
+	// +required
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 }
 
@@ -336,12 +350,15 @@ type ResourceMetricSource struct {
 // should be set.
 type ContainerResourceMetricSource struct {
 	// name is the name of the resource in question.
+	// +required
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
 
 	// target specifies the target value for the given metric
+	// +required
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 
 	// container is the name of the container in the pods of the scaling target
+	// +required
 	Container string `json:"container" protobuf:"bytes,3,opt,name=container"`
 }
 
@@ -350,15 +367,18 @@ type ContainerResourceMetricSource struct {
 // messaging service, or QPS from loadbalancer running outside of cluster).
 type ExternalMetricSource struct {
 	// metric identifies the target metric by name and selector
+	// +required
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
 
 	// target specifies the target value for the given metric
+	// +required
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 }
 
 // MetricIdentifier defines the name and optionally selector for a metric
 type MetricIdentifier struct {
 	// name is the name of the given metric
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric
@@ -371,6 +391,7 @@ type MetricIdentifier struct {
 // MetricTarget defines the target value, average value, or average utilization of a specific metric
 type MetricTarget struct {
 	// type represents whether the metric type is Utilization, Value, or AverageValue
+	// +required
 	Type MetricTargetType `json:"type" protobuf:"bytes,1,name=type"`
 
 	// value is the target value of the metric (as a quantity).
@@ -421,6 +442,7 @@ type HorizontalPodAutoscalerStatus struct {
 
 	// desiredReplicas is the desired number of replicas of pods managed by this autoscaler,
 	// as last calculated by the autoscaler.
+	// +optional
 	DesiredReplicas int32 `json:"desiredReplicas" protobuf:"varint,4,opt,name=desiredReplicas"`
 
 	// currentMetrics is the last read state of the metrics used by this autoscaler.
@@ -461,9 +483,11 @@ const (
 // a HorizontalPodAutoscaler at a certain point.
 type HorizontalPodAutoscalerCondition struct {
 	// type describes the current condition
+	// +optional
 	Type HorizontalPodAutoscalerConditionType `json:"type" protobuf:"bytes,1,name=type"`
 
 	// status is the status of the condition (True, False, Unknown)
+	// +optional
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,name=status"`
 
 	// lastTransitionTime is the last time the condition transitioned from
@@ -491,6 +515,7 @@ type HorizontalPodAutoscalerCondition struct {
 type MetricStatus struct {
 	// type is the type of metric source.  It will be one of "ContainerResource", "External",
 	// "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
+	// +optional
 	Type MetricSourceType `json:"type" protobuf:"bytes,1,name=type"`
 
 	// object refers to a metric describing a single kubernetes object
@@ -535,12 +560,15 @@ type MetricStatus struct {
 // kubernetes object (for example, hits-per-second on an Ingress object).
 type ObjectMetricStatus struct {
 	// metric identifies the target metric by name and selector
+	// +optional
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
 
 	// current contains the current value for the given metric
+	// +optional
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 
 	// describedObject specifies the descriptions of a object,such as kind,name apiVersion
+	// +optional
 	DescribedObject CrossVersionObjectReference `json:"describedObject" protobuf:"bytes,3,name=describedObject"`
 }
 
@@ -548,9 +576,11 @@ type ObjectMetricStatus struct {
 // the current scale target (for example, transactions-processed-per-second).
 type PodsMetricStatus struct {
 	// metric identifies the target metric by name and selector
+	// +optional
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
 
 	// current contains the current value for the given metric
+	// +optional
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 }
 
@@ -561,9 +591,11 @@ type PodsMetricStatus struct {
 // normal per-pod metrics using the "pods" source.
 type ResourceMetricStatus struct {
 	// name is the name of the resource in question.
+	// +optional
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
 
 	// current contains the current value for the given metric
+	// +optional
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 }
 
@@ -574,12 +606,15 @@ type ResourceMetricStatus struct {
 // normal per-pod metrics using the "pods" source.
 type ContainerResourceMetricStatus struct {
 	// name is the name of the resource in question.
+	// +optional
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
 
 	// current contains the current value for the given metric
+	// +optional
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 
 	// container is the name of the container in the pods of the scaling target
+	// +optional
 	Container string `json:"container" protobuf:"bytes,3,opt,name=container"`
 }
 
@@ -587,9 +622,11 @@ type ContainerResourceMetricStatus struct {
 // not associated with any Kubernetes object.
 type ExternalMetricStatus struct {
 	// metric identifies the target metric by name and selector
+	// +optional
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
 
 	// current contains the current value for the given metric
+	// +optional
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types_swagger_doc_generated.go
@@ -127,7 +127,7 @@ func (HorizontalPodAutoscalerBehavior) SwaggerDoc() map[string]string {
 var map_HorizontalPodAutoscalerCondition = map[string]string{
 	"":                   "HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.",
 	"type":               "type describes the current condition",
-	"status":             "status is the status of the condition (True, False, Unknown)",
+	"status":             "status is the status of the condition, one of True, False, Unknown.",
 	"lastTransitionTime": "lastTransitionTime is the last time the condition transitioned from one status to another",
 	"reason":             "reason is the reason for the condition's last transition.",
 	"message":            "message is a human-readable explanation containing details about the transition",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -249,7 +249,6 @@ func schema_k8sio_api_autoscaling_v1_ContainerResourceMetricStatus(ref common.Re
 						},
 					},
 				},
-				Required: []string{"name", "currentAverageValue", "container"},
 			},
 		},
 		Dependencies: []string{
@@ -375,7 +374,6 @@ func schema_k8sio_api_autoscaling_v1_ExternalMetricStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"metricName", "currentValue"},
 			},
 		},
 		Dependencies: []string{
@@ -451,7 +449,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerCondition(ref common
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "status is the status of the condition (True, False, Unknown)",
+							Description: "status is the status of the condition, one of True, False, Unknown.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -485,7 +483,6 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerCondition(ref common
 						},
 					},
 				},
-				Required: []string{"type", "status"},
 			},
 		},
 		Dependencies: []string{
@@ -632,7 +629,6 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerStatus(ref common.Re
 						},
 					},
 				},
-				Required: []string{"currentReplicas", "desiredReplicas"},
 			},
 		},
 		Dependencies: []string{
@@ -704,7 +700,7 @@ func schema_k8sio_api_autoscaling_v1_MetricStatus(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "type is the type of metric source.  It will be one of \"ContainerResource\", \"External\", \"Object\", \"Pods\" or \"Resource\", each corresponds to a matching field in the object.\n\nPossible enum values:\n - `\"ContainerResource\"` is a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics (the \"pods\" source).\n - `\"External\"` is a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).\n - `\"Object\"` is a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).\n - `\"Pods\"` is a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.\n - `\"Resource\"` is a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics (the \"pods\" source).",
+							Description: "type is the type of metric source.  It should be one of \"ContainerResource\", \"External\", \"Object\", \"Pods\" or \"Resource\", each corresponds to a matching field in the object.\n\nPossible enum values:\n - `\"ContainerResource\"` is a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics (the \"pods\" source).\n - `\"External\"` is a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).\n - `\"Object\"` is a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).\n - `\"Pods\"` is a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.\n - `\"Resource\"` is a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics (the \"pods\" source).",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -742,7 +738,6 @@ func schema_k8sio_api_autoscaling_v1_MetricStatus(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -791,7 +786,7 @@ func schema_k8sio_api_autoscaling_v1_ObjectMetricSource(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"target", "metricName", "targetValue"},
+				Required: []string{"target", "metricName"},
 			},
 		},
 		Dependencies: []string{
@@ -840,7 +835,6 @@ func schema_k8sio_api_autoscaling_v1_ObjectMetricStatus(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"target", "metricName", "currentValue"},
 			},
 		},
 		Dependencies: []string{
@@ -912,7 +906,6 @@ func schema_k8sio_api_autoscaling_v1_PodsMetricStatus(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"metricName", "currentAverageValue"},
 			},
 		},
 		Dependencies: []string{
@@ -986,7 +979,6 @@ func schema_k8sio_api_autoscaling_v1_ResourceMetricStatus(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"name", "currentAverageValue"},
 			},
 		},
 		Dependencies: []string{
@@ -1088,7 +1080,6 @@ func schema_k8sio_api_autoscaling_v1_ScaleStatus(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"replicas"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalercondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalercondition.go
@@ -32,7 +32,7 @@ import (
 type HorizontalPodAutoscalerConditionApplyConfiguration struct {
 	// type describes the current condition
 	Type *autoscalingv2.HorizontalPodAutoscalerConditionType `json:"type,omitempty"`
-	// status is the status of the condition (True, False, Unknown)
+	// status is the status of the condition, one of True, False, Unknown.
 	Status *v1.ConditionStatus `json:"status,omitempty"`
 	// lastTransitionTime is the last time the condition transitioned from
 	// one status to another


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enable the `optionalorrequired` linter for the `autoscaling` API group

#### Which issue(s) this PR is related to:

Fixed #136862

#### Special notes for your reviewer:

I only found 65 lint errors here, I don't see other 75 lint errors.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
