### PR TITLE
Fix a bunch of `errorlint` warnings in `test/{e2e,images,integration,utils}`

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -574,7 +574,7 @@ func setupCRDAndVerifySchemaWithOptions(f *framework.Framework, schema, expect [
 
 	for _, v := range crd.Crd.Spec.Versions {
 		if err := waitForDefinition(f.ClientSet, definitionName(crd, v.Name), expect); err != nil {
-			return nil, fmt.Errorf("%v", err)
+			return nil, fmt.Errorf("%w", err)
 		}
 	}
 	return crd, nil
@@ -585,7 +585,7 @@ func cleanupCRD(ctx context.Context, f *framework.Framework, crd *crd.TestCrd) e
 	for _, v := range crd.Crd.Spec.Versions {
 		name := definitionName(crd, v.Name)
 		if err := waitForDefinitionCleanup(f.ClientSet, name); err != nil {
-			return fmt.Errorf("%v", err)
+			return fmt.Errorf("%w", err)
 		}
 	}
 	return nil

--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -769,7 +769,7 @@ func getPriorityLevelNominalConcurrency(ctx context.Context, c clientset.Interfa
 		var v model.Vector
 		err := sampleDecoder.Decode(&v)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return 0, err

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -955,7 +955,7 @@ func waitForScaleUpStatus(ctx context.Context, c clientset.Interface, cond func(
 		return cond(status), nil
 	})
 	if err != nil {
-		err = fmt.Errorf("failed to find expected scale up status: %v, last status: %v, final err: %v", err, status, finalErr)
+		err = fmt.Errorf("failed to find expected scale up status: %v, last status: %v, final err: %w", err, status, finalErr)
 	}
 	return status, err
 }

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"runtime/debug"
@@ -584,7 +585,7 @@ var _ = SIGDescribe("Pods", func() {
 			for {
 				var msg []byte
 				if err := websocket.Message.Receive(ws, &msg); err != nil {
-					if err == io.EOF {
+					if errors.Is(err, io.EOF) {
 						break
 					}
 					framework.Failf("Failed to read completely from websocket %s: %v", url.String(), err)
@@ -665,7 +666,7 @@ var _ = SIGDescribe("Pods", func() {
 		for {
 			var msg []byte
 			if err := websocket.Message.Receive(ws, &msg); err != nil {
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 				framework.Failf("Failed to read completely from websocket %s: %v", url.String(), err)

--- a/test/e2e/framework/bugs.go
+++ b/test/e2e/framework/bugs.go
@@ -73,7 +73,7 @@ func FormatBugs() error {
 	lines := make([]string, 0, len(bugs))
 	wd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("get current directory: %v", err)
+		return fmt.Errorf("get current directory: %w", err)
 	}
 	// Sort by file name, line number, message. For the sake of simplicity
 	// this uses the full file name even though the output the may use a

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -581,7 +581,7 @@ func (f *Framework) CreateNamespace(ctx context.Context, baseName string, labels
 		// is patched with the secret and can then be referenced by all the pods spawned by E2E process, and repository authentication should be successful.
 		secret, err := f.createSecretFromDockerConfig(ctx, ns.Name)
 		if err != nil {
-			return ns, fmt.Errorf("failed to create secret from docker config file: %v", err)
+			return ns, fmt.Errorf("failed to create secret from docker config file: %w", err)
 		}
 
 		serviceAccountClient := f.ClientSet.CoreV1().ServiceAccounts(ns.Name)
@@ -612,7 +612,7 @@ func firstNonEmptyPSaLevelOrRestricted(levelConfig ...admissionapi.Level) string
 func (f *Framework) createSecretFromDockerConfig(ctx context.Context, namespace string) (*v1.Secret, error) {
 	contents, err := os.ReadFile(TestContext.E2EDockerConfigFile)
 	if err != nil {
-		return nil, fmt.Errorf("error reading docker config file: %v", err)
+		return nil, fmt.Errorf("error reading docker config file: %w", err)
 	}
 
 	secretObject := &v1.Secret{

--- a/test/e2e/node/ssh.go
+++ b/test/e2e/node/ssh.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -87,7 +88,7 @@ var _ = SIGDescribe("SSH", func() {
 
 				result, err := e2essh.SSH(ctx, testCase.cmd, host, framework.TestContext.Provider)
 				stdout, stderr := strings.TrimSpace(result.Stdout), strings.TrimSpace(result.Stderr)
-				if err != testCase.expectedError {
+				if !errors.Is(err, testCase.expectedError) {
 					framework.Failf("Ran %s on %s, got error %v, expected %v", testCase.cmd, host, err, testCase.expectedError)
 				}
 				if testCase.checkStdout && stdout != testCase.expectedStdout {

--- a/test/e2e/storage/drivers/csi-test/driver/driver.go
+++ b/test/e2e/storage/drivers/csi-test/driver/driver.go
@@ -208,10 +208,10 @@ func authInterceptor(creds *CSICreds, req interface{}) error {
 	if creds != nil {
 		authenticated, authErr := isAuthenticated(req, creds)
 		if !authenticated {
-			if authErr == ErrNoCredentials {
+			if errors.Is(authErr, ErrNoCredentials) {
 				return status.Error(codes.InvalidArgument, authErr.Error())
 			}
-			if authErr == ErrAuthFailed {
+			if errors.Is(authErr, ErrAuthFailed) {
 				return status.Error(codes.Unauthenticated, authErr.Error())
 			}
 		}

--- a/test/e2e_node/builder/build.go
+++ b/test/e2e_node/builder/build.go
@@ -59,7 +59,7 @@ func BuildTargets(cgo bool) error {
 	klog.Infof("Building k8s binaries...")
 	k8sRoot, err := utils.GetK8sRootDir()
 	if err != nil {
-		return fmt.Errorf("failed to locate kubernetes root directory %v", err)
+		return fmt.Errorf("failed to locate kubernetes root directory %w", err)
 	}
 	targets := buildCGOTargets
 	if !cgo {
@@ -84,7 +84,7 @@ func BuildTargets(cgo bool) error {
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to build go packages %v", err)
+		return fmt.Errorf("failed to build go packages %w", err)
 	}
 	return nil
 }

--- a/test/e2e_node/checkpoint_container.go
+++ b/test/e2e_node/checkpoint_container.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -289,7 +290,7 @@ var _ = SIGDescribe("Checkpoint Container", feature.CheckpointContainer, func() 
 			tr := tar.NewReader(fileReader)
 			for {
 				hdr, err := tr.Next()
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					// End of archive
 					break
 				}

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -151,12 +151,12 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			gomega.Eventually(ctx, func(ctx context.Context) error {
 				v1alphaPodResources, err = getV1alpha1NodeDevices(ctx)
 				if err != nil {
-					return fmt.Errorf("failed to get node local podresources by accessing the (v1alpha) podresources API endpoint: %v", err)
+					return fmt.Errorf("failed to get node local podresources by accessing the (v1alpha) podresources API endpoint: %w", err)
 				}
 
 				v1PodResources, err = getV1NodeDevices(ctx)
 				if err != nil {
-					return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %v", err)
+					return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %w", err)
 				}
 
 				if len(v1alphaPodResources.PodResources) > 0 {
@@ -810,7 +810,7 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			gomega.Eventually(ctx, func(ctx context.Context) error {
 				v1PodResources, err = getV1NodeDevices(ctx)
 				if err != nil {
-					return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %v", err)
+					return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %w", err)
 				}
 
 				if len(v1PodResources.PodResources) > 0 {

--- a/test/e2e_node/mirror_pod_grace_period_test.go
+++ b/test/e2e_node/mirror_pod_grace_period_test.go
@@ -143,7 +143,7 @@ var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
 				gomega.Eventually(ctx, func(ctx context.Context) error {
 					podList, err := e2epod.NewPodClient(f).List(ctx, metav1.ListOptions{})
 					if err != nil {
-						return fmt.Errorf("failed listing pods while waiting for all pods to be terminated: %v", err)
+						return fmt.Errorf("failed listing pods while waiting for all pods to be terminated: %w", err)
 					}
 					var remainingPods []string
 
@@ -320,7 +320,7 @@ var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
 				gomega.Eventually(ctx, func(ctx context.Context) error {
 					_, _, err := getCRIClient()
 					if err != nil {
-						return fmt.Errorf("error getting cri client: %v", err)
+						return fmt.Errorf("error getting cri client: %w", err)
 					}
 					return nil
 				}, 2*time.Minute, time.Second*5).Should(gomega.Succeed())

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -140,7 +140,7 @@ func expectFileValToEqual(filePath string, expectedValue, delta int64) error {
 	}
 	actual, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
 	if err != nil {
-		return fmt.Errorf("failed to parse output %v", err)
+		return fmt.Errorf("failed to parse output %w", err)
 	}
 
 	// Ensure that values are within a delta range to work around rounding errors.

--- a/test/e2e_node/remote/gce/gce_runner.go
+++ b/test/e2e_node/remote/gce/gce_runner.go
@@ -540,7 +540,7 @@ func (g *GCERunner) createGCEInstance(imageConfig *internalGCEImage) (string, er
 				strings.ContainsAny(item.Value, ",:") {
 				dataFile, err := os.CreateTemp("", "metadata")
 				if err != nil {
-					return "", fmt.Errorf("unable to create temp file %v", err)
+					return "", fmt.Errorf("unable to create temp file %w", err)
 				}
 				defer os.Remove(dataFile.Name()) // clean up
 				if err = dataFile.Close(); err != nil {
@@ -548,7 +548,7 @@ func (g *GCERunner) createGCEInstance(imageConfig *internalGCEImage) (string, er
 				}
 
 				if err = os.WriteFile(dataFile.Name(), []byte(item.Value), 0666); err != nil {
-					return "", fmt.Errorf("could not write contents of metadata item into file %v", err)
+					return "", fmt.Errorf("could not write contents of metadata item into file %w", err)
 				}
 				itemFileArgs = append(itemFileArgs, item.Key+"="+dataFile.Name())
 			} else {
@@ -753,7 +753,7 @@ func (g *GCERunner) rebootInstance(instance *gceInstance) error {
 
 		return false, nil
 	}); waitErr != nil {
-		return fmt.Errorf("the instance %s still response to SSH: %v", instance.Name, waitErr)
+		return fmt.Errorf("the instance %s still response to SSH: %w", instance.Name, waitErr)
 	}
 
 	// wait until the instance will response again to SSH

--- a/test/e2e_node/remote/node_conformance.go
+++ b/test/e2e_node/remote/node_conformance.go
@@ -111,7 +111,7 @@ func (c *ConformanceRemote) SetupTestPackage(tardir, systemSpecName string) erro
 	// Make sure we can find the newly built binaries
 	buildOutputDir, err := utils.GetK8sBuildOutputDir(builder.IsDockerizedBuild(), builder.GetTargetBuildArch())
 	if err != nil {
-		return fmt.Errorf("failed to locate kubernetes build output directory %v", err)
+		return fmt.Errorf("failed to locate kubernetes build output directory %w", err)
 	}
 
 	// Build node conformance tarball.

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -72,7 +72,7 @@ func CreateTestArchive(suite TestSuite, systemSpecName, kubeletConfigFile string
 	klog.V(2).Infof("Building archive...")
 	tardir, err := os.MkdirTemp("", "node-e2e-archive")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temporary directory %v", err)
+		return "", fmt.Errorf("failed to create temporary directory %w", err)
 	}
 	defer os.RemoveAll(tardir)
 
@@ -95,7 +95,7 @@ func CreateTestArchive(suite TestSuite, systemSpecName, kubeletConfigFile string
 
 	dir, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("failed to get working directory %v", err)
+		return "", fmt.Errorf("failed to get working directory %w", err)
 	}
 	return filepath.Join(dir, archiveName), nil
 }

--- a/test/e2e_node/remote/utils.go
+++ b/test/e2e_node/remote/utils.go
@@ -114,7 +114,7 @@ func setupCNI(host, workspace string) error {
 		fmt.Sprintf("curl -s -L %s | tar -xz -C %s", getCNIURL(), cniPath),
 	)
 	if output, err := SSH(host, "sh", "-c", cmd); err != nil {
-		return fmt.Errorf("failed to install cni plugin on %q: %v output: %q", host, err, output)
+		return fmt.Errorf("failed to install cni plugin on %q: %w output: %q", host, err, output)
 	}
 
 	// The added CNI network config is not needed for kubenet. It is only
@@ -127,7 +127,7 @@ func setupCNI(host, workspace string) error {
 		fmt.Sprintf("echo %s > %s", quote(cniConfig), filepath.Join(cniConfigPath, "mynet.conf")),
 	)
 	if output, err := SSH(host, "sh", "-c", cmd); err != nil {
-		return fmt.Errorf("failed to write cni configuration on %q: %v output: %q", host, err, output)
+		return fmt.Errorf("failed to write cni configuration on %q: %w output: %q", host, err, output)
 	}
 	return nil
 }
@@ -147,7 +147,7 @@ func setupECRCredentialProvider(host, workspace string) error {
 		fmt.Sprintf("chmod a+x %s/ecr-credential-provider", workspace),
 	)
 	if output, err := SSH(host, "sh", "-c", cmd); err != nil {
-		return fmt.Errorf("failed to install ecr-credential-provider plugin on %q: %v output: %q", host, err, output)
+		return fmt.Errorf("failed to install ecr-credential-provider plugin on %q: %w output: %q", host, err, output)
 	}
 	return nil
 }
@@ -168,7 +168,7 @@ func configureCredentialProvider(host, workspace string) error {
 		fmt.Sprintf("echo %s > %s", quote(credentialProviderConfig), filepath.Join(workspace, "credential-provider.yaml")),
 	)
 	if output, err := SSH(host, "sh", "-c", cmd); err != nil {
-		return fmt.Errorf("failed to write credential provider configuration on %q: %v output: %q", host, err, output)
+		return fmt.Errorf("failed to write credential provider configuration on %q: %w output: %q", host, err, output)
 	}
 
 	return nil
@@ -190,7 +190,7 @@ func configureFirewall(host string) error {
 	)
 	output, err := SSH(host, "sh", "-c", cmd)
 	if err != nil {
-		return fmt.Errorf("failed to configured firewall on %q: %v output: %v", host, err, output)
+		return fmt.Errorf("failed to configured firewall on %q: %w output: %v", host, err, output)
 	}
 	return nil
 }

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -108,7 +108,7 @@ func (a *APIServer) Start(ctx context.Context) error {
 			return
 		}
 		if errs := completedOptions.Validate(); len(errs) != 0 {
-			errCh <- fmt.Errorf("failed to validate ServerRunOptions: %v", utilerrors.NewAggregate(errs))
+			errCh <- fmt.Errorf("failed to validate ServerRunOptions: %w", utilerrors.NewAggregate(errs))
 			return
 		}
 

--- a/test/e2e_node/standalone_test.go
+++ b/test/e2e_node/standalone_test.go
@@ -591,17 +591,17 @@ func getPodFromStandaloneKubelet(ctx context.Context, podNamespace string, podNa
 
 	if resp.StatusCode != 200 {
 		framework.Logf("/pods response status not 200. Response was: %+v", resp)
-		return nil, fmt.Errorf("/pods response was not 200: %v", err)
+		return nil, fmt.Errorf("/pods response was not 200: %w", err)
 	}
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("/pods response was unable to be read: %v", err)
+		return nil, fmt.Errorf("/pods response was unable to be read: %w", err)
 	}
 
 	pods, err := decodePods(respBody)
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode /pods: %v", err)
+		return nil, fmt.Errorf("unable to decode /pods: %w", err)
 	}
 
 	for _, p := range pods.Items {

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -159,7 +159,7 @@ func getV1NodeDevices(ctx context.Context) (*kubeletpodresourcesv1.ListPodResour
 	defer cancel()
 	resp, err := client.List(ctx, &kubeletpodresourcesv1.ListPodResourcesRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("%v.Get(_) = _, %v", client, err)
+		return nil, fmt.Errorf("%v.Get(_) = _, %w", client, err)
 	}
 	return resp, nil
 }
@@ -498,7 +498,7 @@ func waitForAllContainerRemoval(ctx context.Context, podName, podNS string) {
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("got error waiting for all containers to be removed from CRI: %v", err)
+			return fmt.Errorf("got error waiting for all containers to be removed from CRI: %w", err)
 		}
 
 		if len(containers) > 0 {

--- a/test/images/agnhost/net/main.go
+++ b/test/images/agnhost/net/main.go
@@ -134,7 +134,7 @@ func executeRunner(name string, rawOptions string) (logOutput, error) {
 	if ok {
 		options := runner.NewOptions()
 		if err := json.Unmarshal([]byte(rawOptions), options); err != nil {
-			return logOutput{}, fmt.Errorf("Invalid options JSON: %v", err)
+			return logOutput{}, fmt.Errorf("Invalid options JSON: %w", err)
 		}
 
 		log.Printf("Options: %+v", options)

--- a/test/images/agnhost/net/nat/closewait.go
+++ b/test/images/agnhost/net/nat/closewait.go
@@ -173,7 +173,7 @@ func (client *closeWaitClient) Run(logger *log.Logger, rawOptions interface{}) e
 	buf := make([]byte, 1, 1)
 	size, err := conn.Read(buf)
 
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
 

--- a/test/images/agnhost/netexec/netexec.go
+++ b/test/images/agnhost/netexec/netexec.go
@@ -19,6 +19,7 @@ package netexec
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -239,7 +240,7 @@ func startServer(server *http.Server, exitCh chan shutdownRequest, fn func() err
 	}()
 
 	if err := fn(); err != nil {
-		if err == http.ErrServerClosed {
+		if errors.Is(err, http.ErrServerClosed) {
 			// wait until the goroutine calls os.Exit()
 			select {}
 		}
@@ -473,14 +474,14 @@ func createHTTPClient(transport *http.Transport) *http.Client {
 func dialUDP(request string, addr net.Addr) (string, error) {
 	Conn, err := net.DialUDP("udp", nil, addr.(*net.UDPAddr))
 	if err != nil {
-		return "", fmt.Errorf("udp dial failed. err:%v", err)
+		return "", fmt.Errorf("udp dial failed. err:%w", err)
 	}
 
 	defer Conn.Close()
 	buf := []byte(request)
 	_, err = Conn.Write(buf)
 	if err != nil {
-		return "", fmt.Errorf("udp connection write failed. err:%v", err)
+		return "", fmt.Errorf("udp connection write failed. err:%w", err)
 	}
 	udpResponse := make([]byte, 2048)
 	Conn.SetReadDeadline(time.Now().Add(5 * time.Second))
@@ -494,20 +495,20 @@ func dialUDP(request string, addr net.Addr) (string, error) {
 func dialSCTP(request string, addr net.Addr) (string, error) {
 	Conn, err := sctp.DialSCTP("sctp", nil, addr.(*sctp.SCTPAddr))
 	if err != nil {
-		return "", fmt.Errorf("sctp dial failed. err:%v", err)
+		return "", fmt.Errorf("sctp dial failed. err:%w", err)
 	}
 
 	defer Conn.Close()
 	buf := []byte(request)
 	_, err = Conn.Write(buf)
 	if err != nil {
-		return "", fmt.Errorf("sctp connection write failed. err:%v", err)
+		return "", fmt.Errorf("sctp connection write failed. err:%w", err)
 	}
 	sctpResponse := make([]byte, 1024)
 	Conn.SetReadDeadline(time.Now().Add(5 * time.Second))
 	count, err := Conn.Read(sctpResponse)
 	if err != nil || count == 0 {
-		return "", fmt.Errorf("reading from sctp connection failed. err:'%v'", err)
+		return "", fmt.Errorf("reading from sctp connection failed. err:'%w'", err)
 	}
 	return string(sctpResponse[0:count]), nil
 }

--- a/test/images/agnhost/openidmetadata/openidmetadata.go
+++ b/test/images/agnhost/openidmetadata/openidmetadata.go
@@ -186,7 +186,7 @@ func withInClusterOauth2Client(ctx context.Context) (context.Context, error) {
 
 	rt, err := rest.TransportFor(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("could not get roundtripper: %v", err)
+		return nil, fmt.Errorf("could not get roundtripper: %w", err)
 	}
 
 	return context.WithValue(ctx,

--- a/test/images/apparmor-loader/loader.go
+++ b/test/images/apparmor-loader/loader.go
@@ -209,7 +209,7 @@ func loadProfiles(path string) error {
 func resolveSymlink(basePath string, entry os.DirEntry) (os.FileInfo, error) {
 	info, err := entry.Info()
 	if err != nil {
-		return nil, fmt.Errorf("error getting the fileInfo: %v", err)
+		return nil, fmt.Errorf("error getting the fileInfo: %w", err)
 	}
 	if info.Mode()&os.ModeSymlink == 0 {
 		// Not a symlink.

--- a/test/images/sample-device-plugin/sampledeviceplugin.go
+++ b/test/images/sample-device-plugin/sampledeviceplugin.go
@@ -58,12 +58,12 @@ func stubAllocFunc(r *pluginapi.AllocateRequest, devs map[string]*pluginapi.Devi
 
 			// clean first
 			if err := os.RemoveAll(fpath); err != nil {
-				return nil, fmt.Errorf("failed to clean fake device file from previous run: %s", err)
+				return nil, fmt.Errorf("failed to clean fake device file from previous run: %w", err)
 			}
 
 			f, err := os.Create(fpath)
 			if err != nil && !os.IsExist(err) {
-				return nil, fmt.Errorf("failed to create fake device file: %s", err)
+				return nil, fmt.Errorf("failed to create fake device file: %w", err)
 			}
 
 			f.Close()
@@ -244,7 +244,7 @@ func createCDIFile(logger klog.Logger, devs []*pluginapi.Device) error {
 	}
 	content += "]}"
 	if err := os.WriteFile(cdiPath, []byte(content), 0644); err != nil {
-		return fmt.Errorf("failed to create CDI file: %s", err)
+		return fmt.Errorf("failed to create CDI file: %w", err)
 	}
 	logger.Info("Created CDI file", "path", cdiPath, "devices", devs)
 	return nil

--- a/test/integration/apimachinery/watch_timeout_test.go
+++ b/test/integration/apimachinery/watch_timeout_test.go
@@ -19,6 +19,7 @@ package apimachinery
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -75,7 +76,7 @@ func headersForConfig(c *restclient.Config, url *url.URL) (http.Header, error) {
 func websocketConfig(url *url.URL, config *restclient.Config, protocols []string) (*websocket.Config, error) {
 	tlsConfig, err := restclient.TLSConfigFor(config)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create tls config: %v", err)
+		return nil, fmt.Errorf("Failed to create tls config: %w", err)
 	}
 	if url.Scheme == "https" {
 		url.Scheme = "wss"
@@ -84,11 +85,11 @@ func websocketConfig(url *url.URL, config *restclient.Config, protocols []string
 	}
 	headers, err := headersForConfig(config, url)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to load http headers: %v", err)
+		return nil, fmt.Errorf("Failed to load http headers: %w", err)
 	}
 	cfg, err := websocket.NewConfig(url.String(), "http://localhost")
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create websocket config: %v", err)
+		return nil, fmt.Errorf("Failed to create websocket config: %w", err)
 	}
 	cfg.Header = headers
 	cfg.TlsConfig = tlsConfig
@@ -166,7 +167,7 @@ func TestWebsocketWatchClientTimeout(t *testing.T) {
 				for {
 					var msg []byte
 					if err := websocket.Message.Receive(wsConn, &msg); err != nil {
-						if err == io.EOF {
+						if errors.Is(err, io.EOF) {
 							resultCh <- buf.String()
 							return
 						}

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -374,7 +374,7 @@ func (h *holder) verifyRequest(webhookOptions webhookOptions, request *admission
 
 	if h.expectObject {
 		if err := h.verifyObject(converted, request.Object.Object); err != nil {
-			return fmt.Errorf("object error: %v", err)
+			return fmt.Errorf("object error: %w", err)
 		}
 	} else if request.Object.Object != nil {
 		return fmt.Errorf("unexpected object: %#v", request.Object.Object)
@@ -382,7 +382,7 @@ func (h *holder) verifyRequest(webhookOptions webhookOptions, request *admission
 
 	if h.expectOldObject {
 		if err := h.verifyObject(converted, request.OldObject.Object); err != nil {
-			return fmt.Errorf("old object error: %v", err)
+			return fmt.Errorf("old object error: %w", err)
 		}
 	} else if request.OldObject.Object != nil {
 		return fmt.Errorf("unexpected old object: %#v", request.OldObject.Object)
@@ -390,7 +390,7 @@ func (h *holder) verifyRequest(webhookOptions webhookOptions, request *admission
 
 	if h.expectOptions {
 		if err := h.verifyOptions(request.Options.Object); err != nil {
-			return fmt.Errorf("options error: %v", err)
+			return fmt.Errorf("options error: %w", err)
 		}
 	} else if request.Options.Object != nil {
 		return fmt.Errorf("unexpected options: %#v", request.Options.Object)

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -3043,14 +3043,14 @@ func createNamespace(client clientset.Interface, name string) error {
 	namespace := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	namespaceBytes, err := yaml.Marshal(namespace)
 	if err != nil {
-		return fmt.Errorf("Failed to marshal namespace: %v", err)
+		return fmt.Errorf("Failed to marshal namespace: %w", err)
 	}
 	_, err = client.CoreV1().RESTClient().Get().
 		Resource("namespaces").
 		SetHeader("Content-Type", "application/yaml").
 		Body(namespaceBytes).Do(context.TODO()).Get()
 	if err != nil {
-		return fmt.Errorf("Failed to create namespace: %v", err)
+		return fmt.Errorf("Failed to create namespace: %w", err)
 	}
 	return nil
 }

--- a/test/integration/apiserver/apply/reset_fields_test.go
+++ b/test/integration/apiserver/apply/reset_fields_test.go
@@ -448,7 +448,7 @@ func expectConflict(objRet *unstructured.Unstructured, err error, dynamicClient 
 			Namespace(namespace).
 			Get(context.TODO(), name, metav1.GetOptions{})
 		if err2 != nil {
-			return fmt.Errorf("instead got error %w, and failed to Get object: %v", err, err2)
+			return fmt.Errorf("instead got error %w, and failed to Get object: %w", err, err2)
 		}
 	}
 	marshBytes, marshErr := json.Marshal(objRet)

--- a/test/integration/apiserver/cel/admission_test_util.go
+++ b/test/integration/apiserver/cel/admission_test_util.go
@@ -387,7 +387,7 @@ func (h *holder) verifyRequest(webhookOptions webhookOptions, request *admission
 
 	if h.expectObject {
 		if err := h.verifyObject(converted, request.Object.Object); err != nil {
-			return fmt.Errorf("object error: %v", err)
+			return fmt.Errorf("object error: %w", err)
 		}
 	} else if request.Object.Object != nil {
 		return fmt.Errorf("unexpected object: %#v", request.Object.Object)
@@ -395,7 +395,7 @@ func (h *holder) verifyRequest(webhookOptions webhookOptions, request *admission
 
 	if h.expectOldObject {
 		if err := h.verifyObject(converted, request.OldObject.Object); err != nil {
-			return fmt.Errorf("old object error: %v", err)
+			return fmt.Errorf("old object error: %w", err)
 		}
 	} else if request.OldObject.Object != nil {
 		return fmt.Errorf("unexpected old object: %#v", request.OldObject.Object)
@@ -403,7 +403,7 @@ func (h *holder) verifyRequest(webhookOptions webhookOptions, request *admission
 
 	if h.expectOptions {
 		if err := h.verifyOptions(request.Options.Object); err != nil {
-			return fmt.Errorf("options error: %v", err)
+			return fmt.Errorf("options error: %w", err)
 		}
 	} else if request.Options.Object != nil {
 		return fmt.Errorf("unexpected options: %#v", request.Options.Object)
@@ -482,7 +482,7 @@ func getStubObj(gvr schema.GroupVersionResource, resource metav1.APIResource, em
 
 	stubObj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	if err := json.Unmarshal([]byte(stub), &stubObj.Object); err != nil {
-		return nil, fmt.Errorf("error unmarshaling stub for %#v: %v", gvr, err)
+		return nil, fmt.Errorf("error unmarshaling stub for %#v: %w", gvr, err)
 	}
 	return stubObj, nil
 }

--- a/test/integration/apiserver/flowcontrol/concurrency_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_test.go
@@ -18,6 +18,7 @@ package flowcontrol
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -184,11 +185,11 @@ func getNominalConcurrencyOfPriorityLevel(c clientset.Interface) (map[string]int
 	for {
 		var v model.Vector
 		if err := decoder.Decode(&v); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				// Expected loop termination condition.
 				return concurrency, nil
 			}
-			return nil, fmt.Errorf("failed decoding metrics: %v", err)
+			return nil, fmt.Errorf("failed decoding metrics: %w", err)
 		}
 		for _, metric := range v {
 			switch name := string(metric.Metric[model.MetricNameLabel]); name {
@@ -216,11 +217,11 @@ func getRequestCountOfPriorityLevel(c clientset.Interface) (map[string]int, map[
 	for {
 		var v model.Vector
 		if err := decoder.Decode(&v); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				// Expected loop termination condition.
 				return allReqCounts, rejectReqCounts, nil
 			}
-			return nil, nil, fmt.Errorf("failed decoding metrics: %v", err)
+			return nil, nil, fmt.Errorf("failed decoding metrics: %w", err)
 		}
 		for _, metric := range v {
 			switch name := string(metric.Metric[model.MetricNameLabel]); name {

--- a/test/integration/apiserver/flowcontrol/concurrency_util_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_util_test.go
@@ -18,6 +18,7 @@ package flowcontrol
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -324,11 +325,11 @@ func getRequestMetricsSnapshot(c clientset.Interface) (metricSnapshot, error) {
 	for {
 		var v model.Vector
 		if err := decoder.Decode(&v); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				// Expected loop termination condition.
 				return snapshot, nil
 			}
-			return nil, fmt.Errorf("failed decoding metrics: %v", err)
+			return nil, fmt.Errorf("failed decoding metrics: %w", err)
 		}
 		for _, metric := range v {
 			plLabel := string(metric.Metric[labelPriorityLevel])

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -532,7 +532,7 @@ func parseResourceVersion(response []byte) (string, float64, error) {
 	var resultBodyMap map[string]interface{}
 	err := json.Unmarshal(response, &resultBodyMap)
 	if err != nil {
-		return "", 0, fmt.Errorf("unexpected error unmarshaling resultBody: %v", err)
+		return "", 0, fmt.Errorf("unexpected error unmarshaling resultBody: %w", err)
 	}
 	metadata, ok := resultBodyMap["metadata"].(map[string]interface{})
 	if !ok {
@@ -548,7 +548,7 @@ func parseResourceVersion(response []byte) (string, float64, error) {
 	}
 	resourceVersion, err := strconv.ParseFloat(resourceVersionString, 64)
 	if err != nil {
-		return "", 0, fmt.Errorf("unexpected error, could not parse resourceVersion as float64, err: %s. JSON response: %v", err, string(response))
+		return "", 0, fmt.Errorf("unexpected error, could not parse resourceVersion as float64, err: %w. JSON response: %v", err, string(response))
 	}
 	return id, resourceVersion, nil
 }

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -90,7 +90,7 @@ type testRESTOptionsGetter struct {
 func (getter *testRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource, example runtime.Object) (generic.RESTOptions, error) {
 	storageConfig, err := getter.config.ControlPlane.Extra.StorageFactory.NewConfig(resource, example)
 	if err != nil {
-		return generic.RESTOptions{}, fmt.Errorf("failed to get storage: %v", err)
+		return generic.RESTOptions{}, fmt.Errorf("failed to get storage: %w", err)
 	}
 	return generic.RESTOptions{StorageConfig: storageConfig, Decorator: generic.UndecoratedStorage, ResourcePrefix: resource.Resource}, nil
 }
@@ -143,25 +143,25 @@ func (b bootstrapRoles) bootstrap(client clientset.Interface) error {
 	for _, r := range b.clusterRoles {
 		_, err := client.RbacV1().ClusterRoles().Create(ctx, &r, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to make request: %v", err)
+			return fmt.Errorf("failed to make request: %w", err)
 		}
 	}
 	for _, r := range b.roles {
 		_, err := client.RbacV1().Roles(r.Namespace).Create(ctx, &r, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to make request: %v", err)
+			return fmt.Errorf("failed to make request: %w", err)
 		}
 	}
 	for _, r := range b.clusterRoleBindings {
 		_, err := client.RbacV1().ClusterRoleBindings().Create(ctx, &r, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to make request: %v", err)
+			return fmt.Errorf("failed to make request: %w", err)
 		}
 	}
 	for _, r := range b.roleBindings {
 		_, err := client.RbacV1().RoleBindings(r.Namespace).Create(ctx, &r, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to make request: %v", err)
+			return fmt.Errorf("failed to make request: %w", err)
 		}
 	}
 

--- a/test/integration/controlplane/audit/audit_test.go
+++ b/test/integration/controlplane/audit/audit_test.go
@@ -426,12 +426,12 @@ func testAudit(t *testing.T, version string, level auditinternal.Level, enableMu
 		// check for corresponding audit logs
 		stream, err := os.Open(logFile.Name())
 		if err != nil {
-			return false, fmt.Errorf("unexpected error: %v", err)
+			return false, fmt.Errorf("unexpected error: %w", err)
 		}
 		defer stream.Close()
 		missingReport, err := utils.CheckAuditLines(stream, getExpectedEvents(level, enableMutatingWebhook, namespace), versions[version])
 		if err != nil {
-			return false, fmt.Errorf("unexpected error: %v", err)
+			return false, fmt.Errorf("unexpected error: %w", err)
 		}
 		if len(missingReport.MissingEvents) > 0 {
 			lastMissingReport = missingReport.String()
@@ -472,12 +472,12 @@ func testAuditCrossGroupSubResource(t *testing.T, version string, expEvents []ut
 		// check for corresponding audit logs
 		stream, err := os.Open(logFile.Name())
 		if err != nil {
-			return false, fmt.Errorf("unexpected error: %v", err)
+			return false, fmt.Errorf("unexpected error: %w", err)
 		}
 		defer stream.Close()
 		missingReport, err := utils.CheckAuditLines(stream, expEvents, versions[version])
 		if err != nil {
-			return false, fmt.Errorf("unexpected error: %v", err)
+			return false, fmt.Errorf("unexpected error: %w", err)
 		}
 		if len(missingReport.MissingEvents) > 0 {
 			lastMissingReport = missingReport.String()

--- a/test/integration/controlplane/kube_apiserver_test.go
+++ b/test/integration/controlplane/kube_apiserver_test.go
@@ -629,7 +629,7 @@ func triggerSpecUpdateWithProbeCRD(t *testing.T, apiextensionsclient *apiextensi
 		}
 		return exist, nil
 	}); err != nil {
-		return fmt.Errorf("failed to observe probe CRD path in the spec: %v", err)
+		return fmt.Errorf("failed to observe probe CRD path in the spec: %w", err)
 	}
 	return nil
 }

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -100,14 +100,14 @@ func (r envelope) cipherTextPayload() []byte {
 func (r envelope) plainTextPayload(secretETCDPath string) ([]byte, error) {
 	block, err := aes.NewCipher(r.plainTextDEK)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize AES Cipher: %v", err)
+		return nil, fmt.Errorf("failed to initialize AES Cipher: %w", err)
 	}
 	// etcd path of the key is used as the authenticated context - need to pass it to decrypt
 	ctx := context.Background()
 	dataCtx := value.DefaultContext([]byte(secretETCDPath))
 	aesgcmTransformer, err := aestransformer.NewGCMTransformer(block)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create transformer from block: %v", err)
+		return nil, fmt.Errorf("failed to create transformer from block: %w", err)
 	}
 	plainSecret, _, err := aesgcmTransformer.TransformFromStorage(ctx, r.cipherTextPayload(), dataCtx)
 	if err != nil {

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -151,7 +151,7 @@ func (r envelopekmsv2) plainTextPayload(secretETCDPath string) ([]byte, error) {
 
 	data, err := r.cipherTextPayload()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cipher text payload: %v", err)
+		return nil, fmt.Errorf("failed to get cipher text payload: %w", err)
 	}
 	plainSecret, _, err := transformer.TransformFromStorage(ctx, data, dataCtx)
 	if err != nil {

--- a/test/integration/controlplane/transformation/secrets_transformation_test.go
+++ b/test/integration/controlplane/transformation/secrets_transformation_test.go
@@ -663,17 +663,17 @@ func unSealWithGCMTransformer(ctx context.Context, cipherText []byte, dataCtx va
 
 	block, err := newAESCipher(transformerConfig.AESGCM.Keys[0].Secret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create block cipher: %v", err)
+		return nil, fmt.Errorf("failed to create block cipher: %w", err)
 	}
 
 	gcmTransformer, err := aestransformer.NewGCMTransformer(block)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create transformer from block: %v", err)
+		return nil, fmt.Errorf("failed to create transformer from block: %w", err)
 	}
 
 	clearText, _, err := gcmTransformer.TransformFromStorage(ctx, cipherText, dataCtx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decypt secret: %v", err)
+		return nil, fmt.Errorf("failed to decypt secret: %w", err)
 	}
 
 	return clearText, nil
@@ -691,7 +691,7 @@ func unSealWithCBCTransformer(ctx context.Context, cipherText []byte, dataCtx va
 
 	clearText, _, err := cbcTransformer.TransformFromStorage(ctx, cipherText, dataCtx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decypt secret: %v", err)
+		return nil, fmt.Errorf("failed to decypt secret: %w", err)
 	}
 
 	return clearText, nil
@@ -700,12 +700,12 @@ func unSealWithCBCTransformer(ctx context.Context, cipherText []byte, dataCtx va
 func newAESCipher(key string) (cipher.Block, error) {
 	k, err := base64.StdEncoding.DecodeString(key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode config secret: %v", err)
+		return nil, fmt.Errorf("failed to decode config secret: %w", err)
 	}
 
 	block, err := aes.NewCipher(k)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create AES cipher: %v", err)
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
 	}
 
 	return block, nil

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -305,12 +305,12 @@ func (e *transformTest) createEncryptionConfig() (
 ) {
 	tempDir, err := os.MkdirTemp("", "secrets-encryption-test")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp directory: %v", err)
+		return "", fmt.Errorf("failed to create temp directory: %w", err)
 	}
 
 	if err = os.WriteFile(filepath.Join(tempDir, encryptionConfigFileName), []byte(e.transformerConfig), 0644); err != nil {
 		os.RemoveAll(tempDir)
-		return tempDir, fmt.Errorf("error while writing encryption config: %v", err)
+		return tempDir, fmt.Errorf("error while writing encryption config: %w", err)
 	}
 
 	return tempDir, nil
@@ -320,7 +320,7 @@ func (e *transformTest) getEncryptionConfig() (*apiserverv1.ProviderConfiguratio
 	var config apiserverv1.EncryptionConfiguration
 	err := yaml.Unmarshal([]byte(e.transformerConfig), &config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract transformer key: %v", err)
+		return nil, fmt.Errorf("failed to extract transformer key: %w", err)
 	}
 
 	return &config.Resources[0].Providers[0], nil
@@ -358,7 +358,7 @@ func (e *transformTest) createSecret(name, namespace string) (*corev1.Secret, er
 		},
 	}
 	if _, err := e.restClient.CoreV1().Secrets(secret.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("error while writing secret: %v", err)
+		return nil, fmt.Errorf("error while writing secret: %w", err)
 	}
 
 	return secret, nil
@@ -375,7 +375,7 @@ func (e *transformTest) createConfigMap(name, namespace string) (*corev1.ConfigM
 		},
 	}
 	if _, err := e.restClient.CoreV1().ConfigMaps(cm.Namespace).Create(context.TODO(), cm, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("error while writing configmap: %v", err)
+		return nil, fmt.Errorf("error while writing configmap: %w", err)
 	}
 
 	return cm, nil
@@ -403,7 +403,7 @@ func (e *transformTest) createJob(name, namespace string) (*batchv1.Job, error) 
 		},
 	}
 	if _, err := e.restClient.BatchV1().Jobs(job.Namespace).Create(context.TODO(), job, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("error while creating job: %v", err)
+		return nil, fmt.Errorf("error while creating job: %w", err)
 	}
 
 	return job, nil
@@ -448,7 +448,7 @@ func (e *transformTest) createDeployment(name, namespace string) (*appsv1.Deploy
 		},
 	}
 	if _, err := e.restClient.AppsV1().Deployments(deployment.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("error while creating deployment: %v", err)
+		return nil, fmt.Errorf("error while creating deployment: %w", err)
 	}
 
 	return deployment, nil
@@ -490,7 +490,7 @@ func (e *transformTest) createPod(namespace string, dynamicInterface dynamic.Int
 	podGVR := gvr("", "v1", "pods")
 	pod, err := createResource(dynamicInterface, podGVR, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("error while writing pod: %v", err)
+		return nil, fmt.Errorf("error while writing pod: %w", err)
 	}
 	return pod, nil
 }
@@ -508,7 +508,7 @@ func (e *transformTest) inplaceUpdatePod(namespace string, obj *unstructured.Uns
 	podGVR := gvr("", "v1", "pods")
 	pod, err := inplaceUpdateResource(dynamicInterface, podGVR, namespace, obj)
 	if err != nil {
-		return nil, fmt.Errorf("error while writing pod: %v", err)
+		return nil, fmt.Errorf("error while writing pod: %w", err)
 	}
 	return pod, nil
 }
@@ -516,7 +516,7 @@ func (e *transformTest) inplaceUpdatePod(namespace string, obj *unstructured.Uns
 func (e *transformTest) readRawRecordFromETCD(path string) (*clientv3.GetResponse, error) {
 	rawClient, etcdClient, err := integration.GetEtcdClients(e.kubeAPIServer.ServerOpts.Etcd.StorageConfig.Transport)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create etcd client: %v", err)
+		return nil, fmt.Errorf("failed to create etcd client: %w", err)
 	}
 	// kvClient is a wrapper around rawClient and to avoid leaking goroutines we need to
 	// close the client (which we can do by closing rawClient).
@@ -524,7 +524,7 @@ func (e *transformTest) readRawRecordFromETCD(path string) (*clientv3.GetRespons
 
 	response, err := etcdClient.Get(context.Background(), path, clientv3.WithPrefix())
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve secret from etcd %v", err)
+		return nil, fmt.Errorf("failed to retrieve secret from etcd %w", err)
 	}
 
 	return response, nil
@@ -533,7 +533,7 @@ func (e *transformTest) readRawRecordFromETCD(path string) (*clientv3.GetRespons
 func (e *transformTest) writeRawRecordToETCD(path string, data []byte) (*clientv3.PutResponse, error) {
 	rawClient, etcdClient, err := integration.GetEtcdClients(e.kubeAPIServer.ServerOpts.Etcd.StorageConfig.Transport)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create etcd client: %v", err)
+		return nil, fmt.Errorf("failed to create etcd client: %w", err)
 	}
 	// kvClient is a wrapper around rawClient and to avoid leaking goroutines we need to
 	// close the client (which we can do by closing rawClient).
@@ -541,7 +541,7 @@ func (e *transformTest) writeRawRecordToETCD(path string, data []byte) (*clientv
 
 	response, err := etcdClient.Put(context.Background(), path, string(data))
 	if err != nil {
-		return nil, fmt.Errorf("failed to write secret to etcd %v", err)
+		return nil, fmt.Errorf("failed to write secret to etcd %w", err)
 	}
 
 	return response, nil
@@ -551,7 +551,7 @@ func (e *transformTest) printMetrics() error {
 	e.Logf("Transformation Metrics:")
 	metrics, err := legacyregistry.DefaultGatherer.Gather()
 	if err != nil {
-		return fmt.Errorf("failed to gather metrics: %s", err)
+		return fmt.Errorf("failed to gather metrics: %w", err)
 	}
 
 	for _, mf := range metrics {
@@ -632,7 +632,7 @@ func mustNotHaveLivez(t kubeapiservertesting.Logger, checkName, wantBodyContains
 func getHealthz(checkName string, clientConfig *rest.Config, excludes ...string) (string, bool, error) {
 	client, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to create a client: %v", err)
+		return "", false, fmt.Errorf("failed to create a client: %w", err)
 	}
 
 	req := client.CoreV1().RESTClient().Get().AbsPath(fmt.Sprintf("/healthz%v", checkName)).Param("verbose", "true")
@@ -646,7 +646,7 @@ func getHealthz(checkName string, clientConfig *rest.Config, excludes ...string)
 func getLivez(checkName string, clientConfig *rest.Config, excludes ...string) (string, bool, error) {
 	client, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to create a client: %v", err)
+		return "", false, fmt.Errorf("failed to create a client: %w", err)
 	}
 
 	req := client.CoreV1().RESTClient().Get().AbsPath(fmt.Sprintf("/livez%v", checkName)).Param("verbose", "true")

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -1026,7 +1026,7 @@ func TestDSCUpdatesPodLabelAfterDedupCurHistories(t *testing.T) {
 	err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
 		revs, err := clientset.AppsV1().ControllerRevisions(ds.Namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to list controllerrevision: %v", err)
+			return false, fmt.Errorf("failed to list controllerrevision: %w", err)
 		}
 		if revs.Size() == 0 {
 			return false, fmt.Errorf("no avaialable controllerrevision")

--- a/test/integration/deployment/deployment_test.go
+++ b/test/integration/deployment/deployment_test.go
@@ -1280,7 +1280,7 @@ func TestReplicaSetOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
 	if err = wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
 		newRS, err = testutil.GetNewReplicaSet(tester.deployment, c)
 		if err != nil {
-			return false, fmt.Errorf("failed to get new replicaset of deployment %q after orphaning: %v", deploymentName, err)
+			return false, fmt.Errorf("failed to get new replicaset of deployment %q after orphaning: %w", deploymentName, err)
 		}
 		return newRS != nil, nil
 	}); err != nil {

--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -174,7 +174,7 @@ func addPodConditionReady(pod *v1.Pod, time metav1.Time) {
 
 func (d *deploymentTester) waitForDeploymentRevisionAndImage(revision, image string) error {
 	if err := testutil.WaitForDeploymentRevisionAndImage(d.c, d.deployment.Namespace, d.deployment.Name, revision, image, d.t.Logf, pollInterval, pollTimeout); err != nil {
-		return fmt.Errorf("failed to wait for Deployment revision %s: %v", d.deployment.Name, err)
+		return fmt.Errorf("failed to wait for Deployment revision %s: %w", d.deployment.Name, err)
 	}
 	return nil
 }
@@ -399,11 +399,11 @@ func (d *deploymentTester) waitForDeploymentWithCondition(reason string, condTyp
 func (d *deploymentTester) listUpdatedPods() ([]v1.Pod, error) {
 	selector, err := metav1.LabelSelectorAsSelector(d.deployment.Spec.Selector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse deployment selector: %v", err)
+		return nil, fmt.Errorf("failed to parse deployment selector: %w", err)
 	}
 	pods, err := d.c.CoreV1().Pods(d.deployment.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list deployment pods, will retry later: %v", err)
+		return nil, fmt.Errorf("failed to list deployment pods, will retry later: %w", err)
 	}
 	newRS, err := d.getNewReplicaSet()
 	if err != nil {
@@ -455,11 +455,11 @@ func (d *deploymentTester) waitForReadyReplicas() error {
 	if err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
 		deployment, err := d.c.AppsV1().Deployments(d.deployment.Namespace).Get(context.TODO(), d.deployment.Name, metav1.GetOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to get deployment %q: %v", d.deployment.Name, err)
+			return false, fmt.Errorf("failed to get deployment %q: %w", d.deployment.Name, err)
 		}
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas, nil
 	}); err != nil {
-		return fmt.Errorf("failed to wait for .readyReplicas to equal .replicas: %v", err)
+		return fmt.Errorf("failed to wait for .readyReplicas to equal .replicas: %w", err)
 	}
 	return nil
 }
@@ -483,7 +483,7 @@ func (d *deploymentTester) markUpdatedPodsReadyWithoutComplete() error {
 		}
 		return true, nil
 	}); err != nil {
-		return fmt.Errorf("failed to mark all updated pods as ready: %v", err)
+		return fmt.Errorf("failed to mark all updated pods as ready: %w", err)
 	}
 	return nil
 }

--- a/test/integration/evictions/evictions_test.go
+++ b/test/integration/evictions/evictions_test.go
@@ -163,7 +163,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 	close(errCh)
 	var errList []error
 	if err := clientSet.PolicyV1().PodDisruptionBudgets(ns.Name).Delete(context.TODO(), pdb.Name, deleteOption); err != nil {
-		errList = append(errList, fmt.Errorf("Failed to delete PodDisruptionBudget: %v", err))
+		errList = append(errList, fmt.Errorf("Failed to delete PodDisruptionBudget: %w", err))
 	}
 	for err := range errCh {
 		errList = append(errList, err)

--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -103,7 +103,7 @@ func RunCustomEtcd(logger klog.Logger, dataDir string, customFlags []string) (ur
 	etcdPath, err := getEtcdPath()
 	if err != nil {
 		fmt.Fprint(os.Stderr, installEtcd)
-		return "", nil, fmt.Errorf("could not find etcd in PATH: %v", err)
+		return "", nil, fmt.Errorf("could not find etcd in PATH: %w", err)
 	}
 	etcdDataDir, err := os.MkdirTemp(os.TempDir(), dataDir)
 	if err != nil {
@@ -171,7 +171,7 @@ func RunCustomEtcd(logger klog.Logger, dataDir string, customFlags []string) (ur
 				// Try to parse as JSON object. If we get anything that isn't JSON or an object, we just dump the remaining output.
 				var msg map[string]any
 				err := dec.Decode(&msg)
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					// all done
 					break
 				}
@@ -226,7 +226,7 @@ func RunCustomEtcd(logger klog.Logger, dataDir string, customFlags []string) (ur
 	}
 
 	if err := cmd.Start(); err != nil {
-		return "", nil, fmt.Errorf("failed to run etcd: %v", err)
+		return "", nil, fmt.Errorf("failed to run etcd: %w", err)
 	}
 
 	var i int32 = 1

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -671,7 +671,7 @@ func verifyRemainingObjects(t *testing.T, clientSet clientset.Interface, namespa
 	podClient := clientSet.CoreV1().Pods(namespace)
 	pods, err := podClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return false, fmt.Errorf("Failed to list pods: %v", err)
+		return false, fmt.Errorf("Failed to list pods: %w", err)
 	}
 	var ret = true
 	if len(pods.Items) != podNum {
@@ -680,7 +680,7 @@ func verifyRemainingObjects(t *testing.T, clientSet clientset.Interface, namespa
 	}
 	rcs, err := rcClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return false, fmt.Errorf("Failed to list replication controllers: %v", err)
+		return false, fmt.Errorf("Failed to list replication controllers: %w", err)
 	}
 	if len(rcs.Items) != rcNum {
 		ret = false

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -130,7 +130,7 @@ func TestWatchBasedManager(t *testing.T) {
 				})
 				if err != nil {
 					select {
-					case errCh <- fmt.Errorf("failed on :%s: %v", name, err):
+					case errCh <- fmt.Errorf("failed on :%s: %w", name, err):
 					default:
 					}
 				}

--- a/test/integration/logs/benchmark/benchmark_test.go
+++ b/test/integration/logs/benchmark/benchmark_test.go
@@ -353,7 +353,7 @@ func generateOutput(b *testing.B, config loadGeneratorConfig, files ...*os.File)
 			buffer := make([]byte, max)
 			actual, err := file.Read(buffer)
 			if err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					b.Fatal(err)
 				}
 				buffer = nil

--- a/test/integration/metrics/metrics_test.go
+++ b/test/integration/metrics/metrics_test.go
@@ -55,7 +55,7 @@ func scrapeMetrics(s *kubeapiservertesting.TestServer) (testutil.Metrics, error)
 
 	body, err := client.RESTClient().Get().AbsPath("metrics").DoRaw(context.TODO())
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %v", err)
+		return nil, fmt.Errorf("request failed: %w", err)
 	}
 	metrics := testutil.NewMetrics()
 	err = testutil.ParseMetrics(string(body), &metrics)

--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -409,7 +409,7 @@ func TestPodCreateEphemeralContainers(t *testing.T) {
 func setUpEphemeralContainers(podsClient typedv1.PodInterface, pod *v1.Pod, containers []v1.EphemeralContainer) (*v1.Pod, error) {
 	result, err := podsClient.Create(context.TODO(), pod, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create pod: %v", err)
+		return nil, fmt.Errorf("failed to create pod: %w", err)
 	}
 
 	if len(containers) == 0 {
@@ -418,12 +418,12 @@ func setUpEphemeralContainers(podsClient typedv1.PodInterface, pod *v1.Pod, cont
 
 	pod.Spec.EphemeralContainers = containers
 	if _, err := podsClient.Update(context.TODO(), pod, metav1.UpdateOptions{}); err == nil {
-		return nil, fmt.Errorf("unexpected allowed direct update of ephemeral containers during set up: %v", err)
+		return nil, fmt.Errorf("unexpected allowed direct update of ephemeral containers during set up: %w", err)
 	}
 
 	result, err = podsClient.UpdateEphemeralContainers(context.TODO(), pod.Name, pod, metav1.UpdateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to update ephemeral containers for test case set up: %v", err)
+		return nil, fmt.Errorf("failed to update ephemeral containers for test case set up: %w", err)
 	}
 
 	return result, nil

--- a/test/integration/scheduler/filters/filters_test.go
+++ b/test/integration/scheduler/filters/filters_test.go
@@ -2382,7 +2382,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 			update: func(cs kubernetes.Interface, _ string) error {
 				_, err := createNode(cs, st.MakeNode().Name("node-added").Obj())
 				if err != nil {
-					return fmt.Errorf("cannot create node: %v", err)
+					return fmt.Errorf("cannot create node: %w", err)
 				}
 				return nil
 			},
@@ -2392,11 +2392,11 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 			init: func(cs kubernetes.Interface, _ string) error {
 				node, err := createNode(cs, st.MakeNode().Name("node-tainted").Obj())
 				if err != nil {
-					return fmt.Errorf("cannot create node: %v", err)
+					return fmt.Errorf("cannot create node: %w", err)
 				}
 				taint := v1.Taint{Key: "test", Value: "test", Effect: v1.TaintEffectNoSchedule}
 				if err := testutils.AddTaintToNode(cs, node.Name, taint); err != nil {
-					return fmt.Errorf("cannot add taint to node: %v", err)
+					return fmt.Errorf("cannot add taint to node: %w", err)
 				}
 				return nil
 			},
@@ -2406,7 +2406,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 			update: func(cs kubernetes.Interface, _ string) error {
 				taint := v1.Taint{Key: "test", Value: "test", Effect: v1.TaintEffectNoSchedule}
 				if err := testutils.RemoveTaintOffNode(cs, "node-tainted", taint); err != nil {
-					return fmt.Errorf("cannot remove taint off node: %v", err)
+					return fmt.Errorf("cannot remove taint off node: %w", err)
 				}
 				return nil
 			},
@@ -2417,11 +2417,11 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 				nodeObject := st.MakeNode().Name("node-scheduler-integration-test").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "1"}).Obj()
 				_, err := createNode(cs, nodeObject)
 				if err != nil {
-					return fmt.Errorf("cannot create node: %v", err)
+					return fmt.Errorf("cannot create node: %w", err)
 				}
 				_, err = createPausePod(cs, initPausePod(&testutils.PausePodConfig{Name: "pod-to-be-deleted", Namespace: ns}))
 				if err != nil {
-					return fmt.Errorf("cannot create pod: %v", err)
+					return fmt.Errorf("cannot create pod: %w", err)
 				}
 				return nil
 			},
@@ -2430,7 +2430,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 			},
 			update: func(cs kubernetes.Interface, ns string) error {
 				if err := deletePod(cs, "pod-to-be-deleted", ns); err != nil {
-					return fmt.Errorf("cannot delete pod: %v", err)
+					return fmt.Errorf("cannot delete pod: %w", err)
 				}
 				return nil
 			},
@@ -2440,7 +2440,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 			init: func(cs kubernetes.Interface, _ string) error {
 				_, err := createNode(cs, st.MakeNode().Name("node-1").Label("region", "test").Obj())
 				if err != nil {
-					return fmt.Errorf("cannot create node: %v", err)
+					return fmt.Errorf("cannot create node: %w", err)
 				}
 				return nil
 			},
@@ -2470,7 +2470,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 					},
 				}
 				if _, err := createPausePod(cs, initPausePod(podConfig)); err != nil {
-					return fmt.Errorf("cannot create pod: %v", err)
+					return fmt.Errorf("cannot create pod: %w", err)
 				}
 				return nil
 			},
@@ -2480,10 +2480,10 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 			init: func(cs kubernetes.Interface, ns string) error {
 				_, err := createNode(cs, st.MakeNode().Name("node-1").Label("region", "test").Obj())
 				if err != nil {
-					return fmt.Errorf("cannot create node: %v", err)
+					return fmt.Errorf("cannot create node: %w", err)
 				}
 				if _, err := createPausePod(cs, initPausePod(&testutils.PausePodConfig{Name: "pod-to-be-updated", Namespace: ns})); err != nil {
-					return fmt.Errorf("cannot create pod: %v", err)
+					return fmt.Errorf("cannot create pod: %w", err)
 				}
 				return nil
 			},
@@ -2507,11 +2507,11 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 			update: func(cs kubernetes.Interface, ns string) error {
 				pod, err := getPod(cs, "pod-to-be-updated", ns)
 				if err != nil {
-					return fmt.Errorf("cannot get pod: %v", err)
+					return fmt.Errorf("cannot get pod: %w", err)
 				}
 				pod.Labels = map[string]string{"pod-with-affinity": "true"}
 				if _, err := cs.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
-					return fmt.Errorf("cannot update pod: %v", err)
+					return fmt.Errorf("cannot update pod: %w", err)
 				}
 				return nil
 			},
@@ -2521,7 +2521,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 			init: func(cs kubernetes.Interface, ns string) error {
 				_, err := createNode(cs, st.MakeNode().Name("node").Obj())
 				if err != nil {
-					return fmt.Errorf("cannot create node: %v", err)
+					return fmt.Errorf("cannot create node: %w", err)
 				}
 
 				storage := v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}
@@ -2533,7 +2533,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 					HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/mnt", Type: &volType}).
 					Obj())
 				if err != nil {
-					return fmt.Errorf("cannot create pv: %v", err)
+					return fmt.Errorf("cannot create pv: %w", err)
 				}
 				pvc, err := testutils.CreatePVC(cs, st.MakePersistentVolumeClaim().
 					Name("pvc-with-read-write-once-pod").
@@ -2545,7 +2545,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 					Resources(storage).
 					Obj())
 				if err != nil {
-					return fmt.Errorf("cannot create pvc: %v", err)
+					return fmt.Errorf("cannot create pvc: %w", err)
 				}
 
 				pod := initPausePod(&testutils.PausePodConfig{
@@ -2561,7 +2561,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 					}},
 				})
 				if _, err := createPausePod(cs, pod); err != nil {
-					return fmt.Errorf("cannot create pod: %v", err)
+					return fmt.Errorf("cannot create pod: %w", err)
 				}
 				return nil
 			},

--- a/test/integration/scheduler/preemption/misc/miscpreemption_test.go
+++ b/test/integration/scheduler/preemption/misc/miscpreemption_test.go
@@ -963,11 +963,11 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 			init: func() error {
 				_, err := testutils.CreatePV(cs, pv1)
 				if err != nil {
-					return fmt.Errorf("cannot create pv: %v", err)
+					return fmt.Errorf("cannot create pv: %w", err)
 				}
 				_, err = testutils.CreatePVC(cs, pvc1)
 				if err != nil {
-					return fmt.Errorf("cannot create pvc: %v", err)
+					return fmt.Errorf("cannot create pvc: %w", err)
 				}
 				return nil
 			},
@@ -1002,10 +1002,10 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 			preemptedPodIndexes: map[int]struct{}{0: {}},
 			cleanup: func() error {
 				if err := testutils.DeletePVC(cs, pvc1.Name, pvc1.Namespace); err != nil {
-					return fmt.Errorf("cannot delete pvc: %v", err)
+					return fmt.Errorf("cannot delete pvc: %w", err)
 				}
 				if err := testutils.DeletePV(cs, pv1.Name); err != nil {
-					return fmt.Errorf("cannot delete pv: %v", err)
+					return fmt.Errorf("cannot delete pv: %w", err)
 				}
 				return nil
 			},
@@ -1016,13 +1016,13 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 				for _, pv := range []*v1.PersistentVolume{pv1, pv2} {
 					_, err := testutils.CreatePV(cs, pv)
 					if err != nil {
-						return fmt.Errorf("cannot create pv: %v", err)
+						return fmt.Errorf("cannot create pv: %w", err)
 					}
 				}
 				for _, pvc := range []*v1.PersistentVolumeClaim{pvc1, pvc2} {
 					_, err := testutils.CreatePVC(cs, pvc)
 					if err != nil {
-						return fmt.Errorf("cannot create pvc: %v", err)
+						return fmt.Errorf("cannot create pvc: %w", err)
 					}
 				}
 				return nil
@@ -1082,12 +1082,12 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 			cleanup: func() error {
 				for _, pvc := range []*v1.PersistentVolumeClaim{pvc1, pvc2} {
 					if err := testutils.DeletePVC(cs, pvc.Name, pvc.Namespace); err != nil {
-						return fmt.Errorf("cannot delete pvc: %v", err)
+						return fmt.Errorf("cannot delete pvc: %w", err)
 					}
 				}
 				for _, pv := range []*v1.PersistentVolume{pv1, pv2} {
 					if err := testutils.DeletePV(cs, pv.Name); err != nil {
-						return fmt.Errorf("cannot delete pv: %v", err)
+						return fmt.Errorf("cannot delete pv: %w", err)
 					}
 				}
 				return nil
@@ -1099,13 +1099,13 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 				for _, pv := range []*v1.PersistentVolume{pv1, pv2} {
 					_, err := testutils.CreatePV(cs, pv)
 					if err != nil {
-						return fmt.Errorf("cannot create pv: %v", err)
+						return fmt.Errorf("cannot create pv: %w", err)
 					}
 				}
 				for _, pvc := range []*v1.PersistentVolumeClaim{pvc1, pvc2} {
 					_, err := testutils.CreatePVC(cs, pvc)
 					if err != nil {
-						return fmt.Errorf("cannot create pvc: %v", err)
+						return fmt.Errorf("cannot create pvc: %w", err)
 					}
 				}
 				return nil
@@ -1162,12 +1162,12 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 			cleanup: func() error {
 				for _, pvc := range []*v1.PersistentVolumeClaim{pvc1, pvc2} {
 					if err := testutils.DeletePVC(cs, pvc.Name, pvc.Namespace); err != nil {
-						return fmt.Errorf("cannot delete pvc: %v", err)
+						return fmt.Errorf("cannot delete pvc: %w", err)
 					}
 				}
 				for _, pv := range []*v1.PersistentVolume{pv1, pv2} {
 					if err := testutils.DeletePV(cs, pv.Name); err != nil {
-						return fmt.Errorf("cannot delete pv: %v", err)
+						return fmt.Errorf("cannot delete pv: %w", err)
 					}
 				}
 				return nil

--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -109,7 +109,7 @@ func (op *createResourceClaimsOp) run(tCtx ktesting.TContext) {
 	create := func(i int) {
 		err := func() error {
 			if _, err := tCtx.Client().ResourceV1().ResourceClaims(op.Namespace).Create(tCtx, claimTemplate.DeepCopy(), metav1.CreateOptions{}); err != nil {
-				return fmt.Errorf("create claim: %v", err)
+				return fmt.Errorf("create claim: %w", err)
 			}
 			return nil
 		}()

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -299,7 +299,7 @@ func dataItems2JSONFile(dataItems DataItems, namePrefix string) error {
 	}
 	formatted := &bytes.Buffer{}
 	if err := json.Indent(formatted, b, "", "  "); err != nil {
-		return fmt.Errorf("indenting error: %v", err)
+		return fmt.Errorf("indenting error: %w", err)
 	}
 	return os.WriteFile(destFile, formatted.Bytes(), 0644)
 }

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -792,7 +792,7 @@ func CreateAndWaitForNodesInCache(testCtx *TestContext, prefix string, wrapper *
 	existingNodes := testCtx.Scheduler.Cache.NodeCount()
 	nodes, err := createNodes(testCtx.ClientSet, prefix, wrapper, numNodes)
 	if err != nil {
-		return nodes, fmt.Errorf("cannot create nodes: %v", err)
+		return nodes, fmt.Errorf("cannot create nodes: %w", err)
 	}
 	return nodes, WaitForNodesInCache(testCtx.Ctx, testCtx.Scheduler, numNodes+existingNodes)
 }
@@ -804,7 +804,7 @@ func WaitForNodesInCache(ctx context.Context, sched *scheduler.Scheduler, nodeCo
 		return sched.Cache.NodeCount() >= nodeCount, nil
 	})
 	if err != nil {
-		return fmt.Errorf("cannot obtain available nodes in scheduler cache: %v", err)
+		return fmt.Errorf("cannot obtain available nodes in scheduler cache: %w", err)
 	}
 	return nil
 }
@@ -938,7 +938,7 @@ func DeletePV(cs clientset.Interface, pvName string) error {
 func RunPausePod(cs clientset.Interface, pod *v1.Pod) (*v1.Pod, error) {
 	pod, err := cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create pause pod: %v", err)
+		return nil, fmt.Errorf("failed to create pause pod: %w", err)
 	}
 	if err = WaitForPodToSchedule(context.TODO(), cs, pod); err != nil {
 		return pod, fmt.Errorf("Pod %v/%v didn't schedule successfully. Error: %v", pod.Namespace, pod.Name, err)
@@ -975,7 +975,7 @@ func InitPodWithContainers(cs clientset.Interface, conf *PodWithContainersConfig
 func RunPodWithContainers(cs clientset.Interface, pod *v1.Pod) (*v1.Pod, error) {
 	pod, err := cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create pod-with-containers: %v", err)
+		return nil, fmt.Errorf("failed to create pod-with-containers: %w", err)
 	}
 	if err = WaitForPodToSchedule(context.TODO(), cs, pod); err != nil {
 		return pod, fmt.Errorf("Pod %v didn't schedule successfully. Error: %v", pod.Name, err)

--- a/test/utils/create_resources.go
+++ b/test/utils/create_resources.go
@@ -79,7 +79,7 @@ func CreateRCWithRetries(c clientset.Interface, namespace string, obj *v1.Replic
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
+		return false, fmt.Errorf("failed to create object with non-retriable error: %w", err)
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -96,7 +96,7 @@ func CreateReplicaSetWithRetries(c clientset.Interface, namespace string, obj *a
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
+		return false, fmt.Errorf("failed to create object with non-retriable error: %w", err)
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -113,7 +113,7 @@ func CreateDeploymentWithRetries(c clientset.Interface, namespace string, obj *a
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
+		return false, fmt.Errorf("failed to create object with non-retriable error: %w", err)
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -130,7 +130,7 @@ func CreateServiceWithRetries(c clientset.Interface, namespace string, obj *v1.S
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
+		return false, fmt.Errorf("failed to create object with non-retriable error: %w", err)
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -147,7 +147,7 @@ func CreatePersistentVolumeWithRetries(c clientset.Interface, obj *v1.Persistent
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
+		return false, fmt.Errorf("failed to create object with non-retriable error: %w", err)
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }
@@ -164,7 +164,7 @@ func CreatePersistentVolumeClaimWithRetries(c clientset.Interface, namespace str
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
+		return false, fmt.Errorf("failed to create object with non-retriable error: %w", err)
 	}
 	return RetryWithExponentialBackOff(createFunc)
 }

--- a/test/utils/oidc/testserver.go
+++ b/test/utils/oidc/testserver.go
@@ -73,7 +73,7 @@ func (ts *TestServer) URL() string {
 func (ts *TestServer) TokenURL() (string, error) {
 	url, err := url.JoinPath(ts.httpServer.URL, tokenWebPath)
 	if err != nil {
-		return "", fmt.Errorf("error joining paths: %v", err)
+		return "", fmt.Errorf("error joining paths: %w", err)
 	}
 
 	return url, nil

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -346,7 +346,7 @@ func (config *DeploymentConfig) create() error {
 	config.applyTo(&deployment.Spec.Template)
 
 	if err := CreateDeploymentWithRetries(config.Client, config.Namespace, deployment); err != nil {
-		return fmt.Errorf("error creating deployment: %v", err)
+		return fmt.Errorf("error creating deployment: %w", err)
 	}
 	config.RCConfigLog("Created deployment with name: %v, namespace: %v, replica count: %v", deployment.Name, config.Namespace, ptr.Deref(deployment.Spec.Replicas, 0))
 	return nil
@@ -417,7 +417,7 @@ func (config *ReplicaSetConfig) create() error {
 	config.applyTo(&rs.Spec.Template)
 
 	if err := CreateReplicaSetWithRetries(config.Client, config.Namespace, rs); err != nil {
-		return fmt.Errorf("error creating replica set: %v", err)
+		return fmt.Errorf("error creating replica set: %w", err)
 	}
 	config.RCConfigLog("Created replica set with name: %v, namespace: %v, replica count: %v", rs.Name, config.Namespace, ptr.Deref(rs.Spec.Replicas, 0))
 	return nil
@@ -497,7 +497,7 @@ func (config *RCConfig) create() error {
 	config.applyTo(rc.Spec.Template)
 
 	if err := CreateRCWithRetries(config.Client, config.Namespace, rc); err != nil {
-		return fmt.Errorf("error creating replication controller: %v", err)
+		return fmt.Errorf("error creating replication controller: %w", err)
 	}
 	config.RCConfigLog("Created replication controller with name: %v, namespace: %v, replica count: %v", rc.Name, config.Namespace, ptr.Deref(rc.Spec.Replicas, 0))
 	return nil
@@ -1151,7 +1151,7 @@ func MakePodSpec() v1.PodSpec {
 
 func makeCreatePod(client clientset.Interface, namespace string, podTemplate *v1.Pod) error {
 	if err := CreatePodWithRetries(client, namespace, podTemplate); err != nil {
-		return fmt.Errorf("error creating pod: %v", err)
+		return fmt.Errorf("error creating pod: %w", err)
 	}
 	return nil
 }
@@ -1224,7 +1224,7 @@ func CreatePodWithPersistentVolume(ctx context.Context, client clientset.Interfa
 		if err := CreatePersistentVolumeClaimWithRetries(client, namespace, pvc); err != nil {
 			lock.Lock()
 			defer lock.Unlock()
-			createError = fmt.Errorf("error creating PVC: %s", err)
+			createError = fmt.Errorf("error creating PVC: %w", err)
 			return
 		}
 
@@ -1232,21 +1232,21 @@ func CreatePodWithPersistentVolume(ctx context.Context, client clientset.Interfa
 		if _, err := client.CoreV1().PersistentVolumeClaims(namespace).UpdateStatus(ctx, pvc, metav1.UpdateOptions{}); err != nil {
 			lock.Lock()
 			defer lock.Unlock()
-			createError = fmt.Errorf("error updating PVC status: %s", err)
+			createError = fmt.Errorf("error updating PVC status: %w", err)
 			return
 		}
 
 		if err := CreatePersistentVolumeWithRetries(client, pv); err != nil {
 			lock.Lock()
 			defer lock.Unlock()
-			createError = fmt.Errorf("error creating PV: %s", err)
+			createError = fmt.Errorf("error creating PV: %w", err)
 			return
 		}
 		// We need to update statuses separately, as creating pv/pvc resets status to the default one.
 		if _, err := client.CoreV1().PersistentVolumes().UpdateStatus(ctx, pv, metav1.UpdateOptions{}); err != nil {
 			lock.Lock()
 			defer lock.Unlock()
-			createError = fmt.Errorf("error updating PV status: %s", err)
+			createError = fmt.Errorf("error updating PV status: %w", err)
 			return
 		}
 
@@ -1255,7 +1255,7 @@ func CreatePodWithPersistentVolume(ctx context.Context, client clientset.Interfa
 		if err != nil {
 			lock.Lock()
 			defer lock.Unlock()
-			createError = fmt.Errorf("error getting pod template: %s", err)
+			createError = fmt.Errorf("error getting pod template: %w", err)
 			return
 		}
 		pod = pod.DeepCopy()

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -56,7 +56,7 @@ func ScaleResourceWithRetries(scalesGetter scaleclient.ScalesGetter, namespace, 
 		err = scale.WaitForScaleHasDesiredReplicas(scalesGetter, gvr.GroupResource(), name, namespace, size, waitForReplicas)
 	}
 	if err != nil {
-		return fmt.Errorf("error while scaling %s to %d replicas: %v", name, size, err)
+		return fmt.Errorf("error while scaling %s to %d replicas: %w", name, size, err)
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is legacy that has not yet been handled. I do not think that it would be a constructive PR to fix everything at once under different segments of the code base, but rather to do it in iterations. GoLang 1.26 will introduce a safer way to deal with type casting for errors.
https://pkg.go.dev/errors

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

Most of the instances were fixed with a single regular expression, and then a few random matches from having enabled `errorlint` on the entire code-base. 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
