### PR TITLE
scheduler: optimistic locking in assume() to prevent multi-replica pod over-assignment

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -366,6 +366,17 @@ func (cache *cacheImpl) PodCount() (int, error) {
 	return count, nil
 }
 
+// GetNodeGeneration returns the current generation of the node in the cache.
+func (cache *cacheImpl) GetNodeGeneration(nodeName string) (int64, error) {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+	ni, ok := cache.nodes[nodeName]
+	if !ok {
+		return 0, fmt.Errorf("node %q not found in cache", nodeName)
+	}
+	return ni.info.Generation, nil
+}
+
 func (cache *cacheImpl) AssumePod(logger klog.Logger, pod *v1.Pod) error {
 	key, err := framework.GetPodKey(pod)
 	if err != nil {

--- a/pkg/scheduler/backend/cache/fake/fake_cache.go
+++ b/pkg/scheduler/backend/cache/fake/fake_cache.go
@@ -17,6 +17,9 @@ limitations under the License.
 package fake
 
 import (
+	"errors"
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
@@ -72,4 +75,12 @@ func (c *Cache) UpdateSnapshot(logger klog.Logger, nodeSnapshot *internalcache.S
 		return c.UpdateSnapshotFunc(nodeSnapshot)
 	}
 	return c.Cache.UpdateSnapshot(logger, nodeSnapshot)
+}
+
+// GetNodeGeneration delegates to the embedded cache; returns error if cache is nil.
+func (c *Cache) GetNodeGeneration(nodeName string) (int64, error) {
+	if c.Cache == nil {
+		return 0, fmt.Errorf("fake.Cache: GetNodeGeneration(%q) called with nil embedded cache: %w", nodeName, errors.New("nil cache"))
+	}
+	return c.Cache.GetNodeGeneration(nodeName)
 }

--- a/pkg/scheduler/backend/cache/interface.go
+++ b/pkg/scheduler/backend/cache/interface.go
@@ -94,6 +94,11 @@ type Cache interface {
 	// RemoveNode removes overall information about node.
 	RemoveNode(logger klog.Logger, node *v1.Node) error
 
+	// GetNodeGeneration returns the current generation of the node in the cache.
+	// Used for optimistic locking: assume() verifies it matches the generation at schedule time.
+	// Returns an error if the node is not found in the cache.
+	GetNodeGeneration(nodeName string) (int64, error)
+
 	// UpdateSnapshot updates the passed infoSnapshot to the current contents of Cache.
 	// The node info contains aggregated information of pods scheduled (including assumed to be)
 	// on this node.

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -322,7 +322,7 @@ func (sched *Scheduler) assumeAndReserve(
 	assumedPodInfo := podInfo.DeepCopy()
 	assumedPod := assumedPodInfo.Pod
 	// assume modifies `assumedPod` by setting NodeName=scheduleResult.SuggestedHost
-	err := sched.assume(logger, assumedPodInfo, scheduleResult.SuggestedHost)
+	err := sched.assume(logger, assumedPodInfo, scheduleResult.SuggestedHost, scheduleResult.SuggestedNodeGeneration)
 	if err != nil {
 		// This is most probably result of a BUG in retrying logic.
 		// We report an error here so that pod scheduling can be retried.
@@ -590,14 +590,16 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 
 	// When only one node after predicate, just use it.
 	if len(feasibleNodes) == 1 {
-		node := feasibleNodes[0].Node().Name
+		selectedNode := feasibleNodes[0]
+		node := selectedNode.Node().Name
 		if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
 			fwk.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, nil, sched.CurrentCycle())
 		}
 		return ScheduleResult{
-			SuggestedHost:  node,
-			EvaluatedNodes: 1 + diagnosis.NodeToStatus.Len(),
-			FeasibleNodes:  1,
+			SuggestedHost:           node,
+			SuggestedNodeGeneration: selectedNode.GetGeneration(),
+			EvaluatedNodes:          1 + diagnosis.NodeToStatus.Len(),
+			FeasibleNodes:           1,
 		}, nil
 	}
 
@@ -610,14 +612,24 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 	node := sortedPrioritizedNodes.Pop()
 	trace.Step("Prioritizing done")
 
+	// Capture generation of the selected node from snapshot (for optimistic locking in assume()).
+	var selectedNodeGeneration int64
+	for _, ni := range feasibleNodes {
+		if ni.Node().Name == node {
+			selectedNodeGeneration = ni.GetGeneration()
+			break
+		}
+	}
+
 	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
 		fwk.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, sortedPrioritizedNodes, sched.CurrentCycle())
 	}
 
 	return ScheduleResult{
-		SuggestedHost:  node,
-		EvaluatedNodes: len(feasibleNodes) + diagnosis.NodeToStatus.Len(),
-		FeasibleNodes:  len(feasibleNodes),
+		SuggestedHost:           node,
+		SuggestedNodeGeneration: selectedNodeGeneration,
+		EvaluatedNodes:          len(feasibleNodes) + diagnosis.NodeToStatus.Len(),
+		FeasibleNodes:           len(feasibleNodes),
 	}, err
 }
 
@@ -1103,7 +1115,16 @@ func (h *nodeScoreHeap) Pop() interface{} {
 
 // assume signals to the cache that a pod is already in the cache, so that binding can be asynchronous.
 // When called during pod group scheduling cycle, pod is assumed in the snapshot instead.
-func (sched *Scheduler) assume(logger klog.Logger, assumedPodInfo *framework.QueuedPodInfo, host string) error {
+// expectedNodeGeneration is the generation of the node when we selected it (from snapshot); used for optimistic locking.
+func (sched *Scheduler) assume(logger klog.Logger, assumedPodInfo *framework.QueuedPodInfo, host string, expectedNodeGeneration int64) error {
+	// Optimistic locking: verify node generation hasn't changed (e.g. another scheduler replica assumed a pod).
+	currentGen, err := sched.Cache.GetNodeGeneration(host)
+	if err != nil {
+		return fmt.Errorf("node %s get generation: %w", host, err)
+	}
+	if currentGen != expectedNodeGeneration {
+		return fmt.Errorf("node %s generation mismatch: expected %d, got %d (retry needed)", host, expectedNodeGeneration, currentGen)
+	}
 	// Optimistically assume that the binding will succeed and send it to apiserver
 	// in the background.
 	// If the binding fails, scheduler will release resources allocated to assumed pod

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -4833,3 +4833,86 @@ func TestEvaluateNominatedNode(t *testing.T) {
 		})
 	}
 }
+
+// TestAssumeOptimisticLocking verifies that assume() detects a generation mismatch when
+// another actor (e.g. a second scheduler replica) has assumed a pod on the same node
+// between our SchedulePod and assume(). This prevents the multi-replica race (issue #136782).
+func TestAssumeOptimisticLocking(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	logger := klog.FromContext(ctx)
+
+	// One node with room for multiple pods.
+	node := makeNode("node1", 1000, 10*mb)
+	node.Status.Allocatable[v1.ResourcePods] = resource.MustParse("110")
+	node.Status.Capacity[v1.ResourcePods] = resource.MustParse("110")
+
+	cache := internalcache.New(ctx, nil)
+	cache.AddNode(logger, node)
+	snapshot := internalcache.NewEmptySnapshot()
+	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+		t.Fatalf("UpdateSnapshot: %v", err)
+	}
+
+	cs := clientsetfake.NewClientset()
+	informerFactory := informers.NewSharedInformerFactory(cs, 0)
+	registerPlugins := []tf.RegisterPluginFunc{
+		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		tf.RegisterFilterPlugin(noderesources.Name, frameworkruntime.FactoryAdapter(feature.Features{}, noderesources.NewFit)),
+		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+	}
+	fwk, err := tf.NewFramework(
+		ctx,
+		registerPlugins, "",
+		frameworkruntime.WithSnapshotSharedLister(snapshot),
+		frameworkruntime.WithInformerFactory(informerFactory),
+		frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+	)
+	if err != nil {
+		t.Fatalf("NewFramework: %v", err)
+	}
+
+	sched := &Scheduler{
+		Cache:                    cache,
+		nodeInfoSnapshot:         snapshot,
+		percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+	}
+	sched.applyDefaultHandlers()
+
+	// Pod to be scheduled by "this replica".
+	pod1 := st.MakePod().Name("pod1").UID("pod1").Namespace("default").SchedulerName(testSchedulerName).Obj()
+	podInfo1 := queuedPodInfoForPod(pod1)
+
+	// 1) Run SchedulePod; we get a result with SuggestedHost and SuggestedNodeGeneration.
+	state := framework.NewCycleState()
+	result, err := sched.SchedulePod(ctx, fwk, state, podInfo1)
+	if err != nil {
+		t.Fatalf("SchedulePod: %v", err)
+	}
+	if result.SuggestedHost != node.Name {
+		t.Fatalf("expected SuggestedHost %q, got %q", node.Name, result.SuggestedHost)
+	}
+	expectedGen := result.SuggestedNodeGeneration
+
+	// 2) Simulate another scheduler replica: assume a different pod on the same node.
+	//    This bumps the cache's node generation.
+	pod2 := st.MakePod().Name("pod2").UID("pod2").Namespace("default").SchedulerName(testSchedulerName).Obj()
+	pod2.Spec.NodeName = node.Name
+	if err := cache.AssumePod(logger, pod2); err != nil {
+		t.Fatalf("AssumePod(pod2): %v", err)
+	}
+
+	// 3) Now assume(pod1) with the generation we captured earlier. With optimistic locking,
+	//    the cache's node generation has changed, so assume should fail.
+	err = sched.assume(logger, podInfo1, result.SuggestedHost, expectedGen)
+	if err == nil {
+		t.Fatal("expected assume() to fail with generation mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "generation mismatch") {
+		t.Errorf("expected error to contain %q, got: %v", "generation mismatch", err)
+	}
+	if !strings.Contains(err.Error(), "retry needed") {
+		t.Errorf("expected error to contain %q, got: %v", "retry needed", err)
+	}
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -153,6 +153,9 @@ type Option func(*schedulerOptions)
 type ScheduleResult struct {
 	// Name of the selected node.
 	SuggestedHost string
+	// SuggestedNodeGeneration is the generation of the node when we selected it (from snapshot).
+	// Used for optimistic locking: assume() verifies the cache's node generation still matches.
+	SuggestedNodeGeneration int64
 	// The number of nodes the scheduler evaluated the pod against in the filtering
 	// phase and beyond.
 	EvaluatedNodes int


### PR DESCRIPTION
## Problem

With multiple kube-scheduler replicas (e.g. HA: one per control-plane node), the scheduler can assign far more pods to a single node than the node’s pod limit. In [issue #136782](https://github.com/kubernetes/kubernetes/issues/136782), one node received **168 pods** (limit 110), causing **58 pods** to fail with `OutOfpods` on the kubelet while the scheduler kept assigning more.

## Root cause

- Each replica has its **own in-memory cache**. When replica A runs `AssumePod(pod, nodeX)`, only A’s cache is updated.
- Replicas B and C do **not** see that pod until the binding is written to the API server and their informers sync (order of seconds).
- During that delay, **all replicas** still see the node (from their snapshot) as having capacity. The “Too many pods” check in NodeResourcesFit uses `len(nodeInfo.GetPods())+1 > allowedPodNumber`, and `nodeInfo` comes from each replica’s **snapshot**, which is stale across replicas.
- So multiple replicas can all pass the filter for the same node and call `assume()`; each `AssumePod()` succeeds locally and we over-assign.

## Solution: optimistic locking in `assume()`

We use the existing **per-node generation** on `NodeInfo` (bumped on AddPod/RemovePod) to detect that the node changed between “we chose it” and “we are about to assume”:

1. **Capture:** When we build a successful `ScheduleResult` (in `schedulePod`), we store the selected node’s **generation from the snapshot** in `ScheduleResult.SuggestedNodeGeneration`.
2. **Verify:** In `assume()`, **before** calling `Cache.AssumePod()`, we call `Cache.GetNodeGeneration(host)` and compare it to `expectedNodeGeneration`. If they differ, another replica (or another cycle) has already assumed a pod on that node → we return an error so the pod is retried with a fresh snapshot.
3. **Cache API:** We add `GetNodeGeneration(nodeName string) (int64, error)` to the scheduler cache interface and implement it in the real and fake caches.

So we don’t add cross-replica coordination or new state; we only add a **check** using the existing generation. Single-replica behavior is unchanged.

## Why this over alternatives

- **Reserved capacity buffer (e.g. “treat max pods as 100 when limit is 110”):** Requires tuning (buffer size vs replica count), wastes capacity, and doesn’t fix the underlying race—it only reduces how often we hit the limit. Optimistic locking **detects** the race and forces a retry with an up-to-date view.
- **Leader election / single active scheduler:** Already the recommended HA pattern; this fix helps when multiple replicas are active (misconfiguration, or intentional scale-out) and makes the system safe when caches are temporarily out of sync.
- **Distributed lock per node:** Would add latency and coupling; generation check is local to each replica and one extra read before assume.

## Testing

- **Unit test:** `TestAssumeOptimisticLocking` in `pkg/scheduler/schedule_one_test.go`:
  - One node, real cache, snapshot, framework with NodeResourcesFit.
  - `SchedulePod(pod1)` → get `result` with `SuggestedNodeGeneration`.
  - Simulate “other replica” by calling `cache.AssumePod(pod2)` on the same node (bumps generation).
  - Call `assume(pod1, host, result.SuggestedNodeGeneration)` → test asserts we get a non-nil error whose message contains `"generation mismatch"` and `"retry needed"`.
- Existing scheduler tests remain unchanged; only the new test and the added code paths are covered.

## Impact

- **Single replica:** No behavioral change; generation always matches when no one else updates the cache.
- **Multiple replicas:** Prevents over-assignment: the second (or Nth) replica’s `assume()` fails with generation mismatch and the pod is rescheduled with an updated snapshot, so we no longer drive a node over its pod limit and avoid `OutOfpods` on the kubelet.

## Release note
```release-note
Fixed scheduler race condition where multiple replicas could assign more pods to a node than its capacity, causing OutOfpods errors. Added optimistic locking in assume() using node generation to detect concurrent modifications.
```