### PR TITLE
Enable norefernece rule for Kube API Linter

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -392,6 +392,7 @@ linters:
               - "duplicatemarkers" #Prevent identical markers from being present on types and fields
               - "dependenttags" # Ensure markers dependent on other markers are present.
               - "nodurations" # Ensure duration types are not used.
+              - "noreferences" # Ensure field names use Ref/Refs suffixes instead of Reference/References.
           lintersConfig:
             conditions:
               isFirstField: Ignore

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -247,6 +247,11 @@ linters:
       # Validation makes this require at least one of the fields within to be set.
       - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate).SchedulingPolicy is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/scheduling/v1alpha3/types.go"
+      
+      # NoReferences - Existing fields that use Reference/References suffixes instead of Ref/Refs.
+      # These fields use the Reference suffix, but renaming them would be a breaking change, so they are allowlisted.
+      - text: 'noreferences: naming convention "reference-to-ref": field (SerializedReference|ImageVolumeSource)\.Reference:'
+        path: "staging/src/k8s.io/api/core/v1/types.go"
 
       - linters:
         - forbidigo

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -405,6 +405,7 @@ linters:
               - "duplicatemarkers" #Prevent identical markers from being present on types and fields
               - "dependenttags" # Ensure markers dependent on other markers are present.
               - "nodurations" # Ensure duration types are not used.
+              - "noreferences" # Ensure field names use Ref/Refs suffixes instead of Reference/References.
           lintersConfig:
             conditions:
               isFirstField: Ignore

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -262,6 +262,11 @@ linters:
       # Validation makes this require at least one of the fields within to be set.
       - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate).SchedulingPolicy is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/scheduling/v1alpha3/types.go"
+      
+      # NoReferences - Existing fields that use Reference/References suffixes instead of Ref/Refs.
+      # These fields use the Reference suffix, but renaming them would be a breaking change, so they are allowlisted.
+      - text: 'noreferences: naming convention "reference-to-ref": field (SerializedReference|ImageVolumeSource)\.Reference:'
+        path: "staging/src/k8s.io/api/core/v1/types.go"
 
       - linters:
         - forbidigo

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -123,3 +123,8 @@
 # Validation makes this require at least one of the fields within to be set.
 - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate).SchedulingPolicy is a non-pointer struct with no required fields."
   path: "staging/src/k8s.io/api/scheduling/v1alpha3/types.go"
+
+# NoReferences - Existing fields that use Reference/References suffixes instead of Ref/Refs.
+# These fields use the Reference suffix, but renaming them would be a breaking change, so they are allowlisted.
+- text: 'noreferences: naming convention "reference-to-ref": field (SerializedReference|ImageVolumeSource)\.Reference:'
+  path: "staging/src/k8s.io/api/core/v1/types.go"

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -24,6 +24,7 @@ linters:
     - "duplicatemarkers" #Prevent identical markers from being present on types and fields
     - "dependenttags" # Ensure markers dependent on other markers are present.
     - "nodurations" # Ensure duration types are not used.
+    - "noreferences" # Ensure field names use Ref/Refs suffixes instead of Reference/References.
 lintersConfig:
   conditions:
     isFirstField: Ignore


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change
/label api-review

#### What this PR does / why we need it:

Enables the `norefernece` rule from KAL:

- Fields should use Ref/Refs and not Reference/References

#### Which issue(s) this PR is related to:

Fixed #136883

#### Special notes for your reviewer:

Maybe there are some fields still using `reference/references` naming:

```
ERROR: staging/src/k8s.io/api/core/v1/types.go:7504:2: noreferences: naming convention "reference-to-ref": field SerializedReference.Reference: field names should use 'Ref' instead of 'Reference' (kubeapilinter)
ERROR: 	Reference ObjectReference `json:"reference,omitempty" protobuf:"bytes,1,opt,name=reference"`
ERROR: 	^
ERROR: staging/src/k8s.io/api/core/v1/types.go:8463:2: noreferences: naming convention "reference-to-ref": field ImageVolumeSource.Reference: field names should use 'Ref' instead of 'Reference' (kubeapilinter)
ERROR: 	Reference string `json:"reference,omitempty" protobuf:"bytes,1,opt,name=reference"`
ERROR: 	^
```

Should we skip these for now and then unskip them after the follow-up PR renames them?

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
