### PR TITLE
Fix ExpiringCache race condition by using `sync.Map`

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring.go
@@ -34,7 +34,6 @@ func NewExpiring() *Expiring {
 func NewExpiringWithClock(clock clock.Clock) *Expiring {
 	return &Expiring{
 		clock: clock,
-		cache: make(map[interface{}]entry),
 	}
 }
 
@@ -52,7 +51,7 @@ type Expiring struct {
 	// mu protects the below fields
 	mu sync.RWMutex
 	// cache is the internal map that backs the cache.
-	cache map[interface{}]entry
+	cache sync.Map
 	// generation is used as a cheap resource version for cache entries. Cleanups
 	// are scheduled with a key and generation. When the cleanup runs, it first
 	// compares its generation with the current generation of the entry. It
@@ -73,13 +72,12 @@ type entry struct {
 }
 
 // Get looks up an entry in the cache.
-func (c *Expiring) Get(key interface{}) (val interface{}, ok bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	e, ok := c.cache[key]
+func (c *Expiring) Get(key interface{}) (interface{}, bool) {
+	val, ok := c.cache.Load(key)
 	if !ok {
 		return nil, false
 	}
+	e := val.(entry)
 	if !c.AllowExpiredGet && !c.clock.Now().Before(e.expiry) {
 		return nil, false
 	}
@@ -101,11 +99,11 @@ func (c *Expiring) Set(key interface{}, val interface{}, ttl time.Duration) {
 
 	c.generation++
 
-	c.cache[key] = entry{
+	c.cache.Store(key, entry{
 		val:        val,
 		expiry:     expiry,
 		generation: c.generation,
-	}
+	})
 
 	// Run GC inline before pushing the new entry.
 	c.gc(now)
@@ -132,21 +130,25 @@ func (c *Expiring) Delete(key interface{}) {
 //
 // del must be called under the write lock.
 func (c *Expiring) del(key interface{}, generation uint64) {
-	e, ok := c.cache[key]
+	val, ok := c.cache.Load(key)
 	if !ok {
 		return
 	}
+	e := val.(entry)
 	if generation != 0 && generation != e.generation {
 		return
 	}
-	delete(c.cache, key)
+	c.cache.Delete(key)
 }
 
 // Len returns the number of items in the cache.
 func (c *Expiring) Len() int {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return len(c.cache)
+	count := 0
+	c.cache.Range(func(key, value interface{}) bool {
+		count++
+		return true
+	})
+	return count
 }
 
 func (c *Expiring) gc(now time.Time) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring_test.go
@@ -92,10 +92,16 @@ func TestExpiration(t *testing.T) {
 	// remove the key.
 	c.Set("a", "a", time.Second)
 
-	e := c.cache["a"]
+	val, ok := c.cache.Load("a")
+	if !ok {
+		t.Fatalf("key 'a' not found in cache")
+	}
+	e := val.(entry)
+
 	e.generation++
 	e.expiry = e.expiry.Add(1 * time.Second)
-	c.cache["a"] = e
+
+	c.cache.Store("a", e)
 
 	fc.Step(1 * time.Second)
 	if _, ok := c.Get("a"); !ok {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test

/kind regression
-->

#### What this PR does / why we need it:
This PR migrates `TestStressExpiringCache` by using the internal cache implementation from `map[interface{}]entry]` + `sync.RWMutex` to [`sync.Map`](https://pkg.go.dev/sync#Map) as it is designed to handle these specific concurrency patterns safely as documented. This ensures that updates are fully visible across cores before they can be read and eliminating the race condition for architectures that follow a weak memory model.

Steps to reproduce the flake:

#### Which issue(s) this PR is related to: #137044
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".



#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None.
```
