### PR TITLE
WIP: client-go cache: restore SharedInformer interface from <= 1.35

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -194,7 +194,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -194,7 +194,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/internal/generic/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/internal/generic/controller.go
@@ -161,7 +161,7 @@ func (c *controller[T]) Run(ctx context.Context) error {
 
 	// Wait for initial cache list to complete before beginning to reconcile
 	// objects.
-	if !cache.WaitFor(ctx, "caches", c.informer.HasSyncedChecker(), registration.HasSyncedChecker()) {
+	if !cache.WaitFor(ctx, "caches", cache.DoneCheckerForInformer(ctx, c.informer), registration.HasSyncedChecker()) {
 		// TODO: should cache.WaitFor return an error?
 		// ctx.Err() or context.Cause(ctx)?
 		// Either of them would make dead code like the "if err == nil"

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -213,7 +213,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -304,6 +304,7 @@ var (
 	_ = Queue(&DeltaFIFO{})             // DeltaFIFO is a Queue
 	_ = TransformingStore(&DeltaFIFO{}) // DeltaFIFO implements TransformingStore to allow memory optimizations
 	_ = DoneChecker(&DeltaFIFO{})       // DeltaFIFO implements DoneChecker.
+	_ = HasSyncedChecker(&DeltaFIFO{})  // DeltaFIFO implements HasSyncedChecker, returning itself as the DoneChecker.
 )
 
 var (

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -197,14 +197,6 @@ type SharedInformer interface {
 	// For that, please call HasSynced on the handle returned by
 	// AddEventHandler.
 	HasSynced() bool
-	// HasSyncedChecker completes if the shared informer's store has been
-	// informed by at least one full LIST of the authoritative state
-	// of the informer's object collection.  This is unrelated to "resync".
-	//
-	// Note that this doesn't tell you if an individual handler is synced!!
-	// For that, please use HasSyncedChecker on the handle returned by
-	// AddEventHandler.
-	HasSyncedChecker() DoneChecker
 	// LastSyncResourceVersion is the resource version observed when last synced with the underlying
 	// store. The value returned is not synchronized with access to the underlying store and is not
 	// thread-safe.
@@ -247,6 +239,74 @@ type SharedInformer interface {
 	// An informer already stopped will never be started again.
 	IsStopped() bool
 }
+
+// ^^^
+// SharedInformer *is* implemented widely out-of-tree and therefore has to
+// be considered frozen for practical reasons. Consider using an approach as with
+// HasSyncedChecker below instead of adding methods.
+
+// HasSyncedChecker defines an additional method that SharedInformer implementations
+// may provide to support waiting for cache sync without polling. All SharedInformer
+// instances created by client-go itself implement this interface.
+//
+// It is not a required method in SharedInformer to avoid breaking downstream consumers
+// of client-go. DoneCheckerForInformer can be used to get a DoneChecker for
+// any SharedInformer implementation.
+type HasSyncedChecker interface {
+	// HasSyncedChecker completes if the shared informer's store has been
+	// informed by at least one full LIST of the authoritative state
+	// of the informer's object collection.  This is unrelated to "resync".
+	//
+	// Note that this doesn't tell you if an individual handler is synced!!
+	// For that, please use HasSyncedChecker on the handle returned by
+	// AddEventHandler.
+	HasSyncedChecker() DoneChecker
+}
+
+// DoneCheckerForInformer returns a DoneChecker for the given
+// SharedInformer. If the SharedInformer implements HasSyncedChecker,
+// then the DoneChecker provided via that interface is returned. If not,
+// then a DoneChecker gets created which polls HasSynced. That polling
+// stops when the given context is canceled (DoneChecker remains in
+// the "not done" state) or when HasSynced returns true (DoneChecker is done).
+func DoneCheckerForInformer(ctx context.Context, informer SharedInformer) DoneChecker {
+	if hasSyncedChecker, ok := informer.(HasSyncedChecker); ok {
+		// This is the common case because sharedIndexInformer implements HasSyncedChecker.
+		return hasSyncedChecker.HasSyncedChecker()
+	}
+
+	// This is the fallback for out-of-tree SharedInformer implementations.
+	// There's no way for unit tests to wait for completion of the additional
+	// goroutine. If that's a problem then the code under test should
+	// be enhanced to support HasSyncedChecker.
+	done := make(chan struct{})
+	d := &doneCheckerForHasSynced{
+		name: fmt.Sprintf("%T SharedInformer implementation", informer),
+		done: done,
+	}
+	go func() {
+		err := wait.PollUntilContextCancel(ctx, syncedPollPeriod, true /* immediate */, func(ctx context.Context) (bool, error) {
+			if informer.HasSynced() {
+				return true, nil
+			}
+			return false, nil
+		})
+		if err == nil {
+			close(done)
+		}
+	}()
+	return d
+}
+
+type doneCheckerForHasSynced struct {
+	name string
+	done <-chan struct{}
+}
+
+var _ DoneChecker = &doneCheckerForHasSynced{}
+
+func (d *doneCheckerForHasSynced) Name() string          { return d.name }
+func (d *doneCheckerForHasSynced) Done() <-chan struct{} { return d.done }
 
 // Opaque interface representing the registration of ResourceEventHandler for
 // a SharedInformer. Must be supplied back to the same SharedInformer's
@@ -571,7 +631,7 @@ func (c SyncResult) AsError() error {
 	return fmt.Errorf("failed to sync all caches: %s: %w", strings.Join(unsynced, ", "), c.Err)
 }
 
-// `*sharedIndexInformer` implements SharedIndexInformer and has three
+// `*sharedIndexInformer` implements SharedIndexInformer and HasSyncedChecker and has three
 // main components.  One is an indexed local cache, `indexer Indexer`.
 // The second main component is a Controller that pulls
 // objects/notifications using the ListerWatcher and pushes them into
@@ -635,6 +695,11 @@ type sharedIndexInformer struct {
 	// keyFunc is called when processing deltas by the underlying process function.
 	keyFunc KeyFunc
 }
+
+var (
+	_ SharedIndexInformer = &sharedIndexInformer{}
+	_ HasSyncedChecker    = &sharedIndexInformer{}
+)
 
 // dummyController hides the fact that a SharedInformer is different from a dedicated one
 // where a caller can `Run`.  The run method is disconnected in this case, because higher

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
@@ -181,7 +181,8 @@ type SyncAllInfo struct{}
 var (
 	_ = Queue(&RealFIFO{})             // RealFIFO is a Queue
 	_ = TransformingStore(&RealFIFO{}) // RealFIFO implements TransformingStore to allow memory optimizations
-	_ = DoneChecker(&RealFIFO{})       // RealFIFO and implements DoneChecker.
+	_ = DoneChecker(&RealFIFO{})       // RealFIFO implements DoneChecker.
+	_ = HasSyncedChecker(&RealFIFO{})  // RealFIFO implements HasSyncedChecker, returning itself as the DoneChecker.
 )
 
 // Close the queue.

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -75,6 +75,7 @@ func (g *factoryGenerator) GenerateType(c *generator.Context, t *types.Type, w i
 	}
 	m := map[string]interface{}{
 		"cacheDoneChecker":               c.Universe.Type(cacheDoneChecker),
+		"cacheDoneCheckerForInformer":    c.Universe.Type(cacheDoneCheckerForInformer),
 		"cacheInformerName":              c.Universe.Type(cacheInformerName),
 		"cacheSharedIndexInformer":       c.Universe.Type(cacheSharedIndexInformer),
 		"cacheSyncResult":                c.Universe.Type(cacheSyncResult),
@@ -270,7 +271,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]{{.cacheDoneChecker|raw}}, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, {{.cacheDoneCheckerForInformer|raw}}(ctx, informer))
 	}
 	{{.cacheWaitFor|raw}}(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
@@ -21,6 +21,7 @@ import "k8s.io/gengo/v2/types"
 var (
 	apiScheme                                    = types.Name{Package: "k8s.io/kubernetes/pkg/api/legacyscheme", Name: "Scheme"}
 	cacheDoneChecker                             = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "DoneChecker"}
+	cacheDoneCheckerForInformer                  = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "DoneCheckerForInformer"}
 	cacheGenericLister                           = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "GenericLister"}
 	cacheIndexers                                = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "Indexers"}
 	cacheInformerName                            = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "InformerName"}

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -194,7 +194,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -194,7 +194,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -197,7 +197,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
@@ -197,7 +197,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
@@ -194,7 +194,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -256,7 +256,9 @@ func (t *Tracker) HasSynced() bool {
 
 func (t *Tracker) HasSyncedChecker() cache.DoneChecker {
 	if !t.enableDeviceTaintRules {
-		return t.resourceSlices.HasSyncedChecker()
+		// t.resourceSlices is a SharedInformer created by client-go,
+		// so we can do an unchecked type cast.
+		return t.resourceSlices.(cache.HasSyncedChecker).HasSyncedChecker()
 	}
 
 	return trackerHasSynced{t}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -194,7 +194,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -194,7 +194,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -194,7 +194,7 @@ func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context)
 	// Wait for informers to sync, without polling.
 	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
 	for _, informer := range informers {
-		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
+		cacheSyncs = append(cacheSyncs, cache.DoneCheckerForInformer(ctx, informer))
 	}
 	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Introducing DoneChecker changed the SharedInformer interface to keep the client-go code simpler, assuming that the impact on the ecosystem would be low because sharedIndexInformer look like the main implementation of this interface.

It was later called out that there this is a bigger breaking change than expected because there are other SharedInformer implementations. Therefore this change reverts to the original interface definition and instead uses type assertion to get access to sharedIndexInformer.HasSyncedChecker.

#### Which issue(s) this PR is related to:

Follow-up to https://github.com/kubernetes/kubernetes/pull/135395

/cc @sbueringer @aojea @alvaroaleman @michaelasp @jpbetz 

#### Special notes for your reviewer:

Out-of-tree SharedInformer implementations are supported by the SharedInformerFactory implementations by polling their mandatory HasSynced method, using some wrapper provided by client-go.

This approach keeps WaitFor and SharedInformerFactory type-safe. The alternative would have been a `WaitFor(..., checker any)` where the informer or DoneChecker instances get passed and then `WaitFor` figures out how to check. This seems worse than the current solution with DoneCheckerForInformer.

WIP because I want to get feedback on the proposal before adding unit tests.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
