### PR TITLE
Refactor client-go metrics to use explicit Register() instead of init()

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -48,7 +48,10 @@ import (
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
-	_ "k8s.io/component-base/metrics/prometheus/workqueue"
+	"k8s.io/component-base/metrics/prometheus/clientgo/fifo"
+	"k8s.io/component-base/metrics/prometheus/clientgo/leaderelection"
+	"k8s.io/component-base/metrics/prometheus/restclient"
+	"k8s.io/component-base/metrics/prometheus/workqueue"
 	"k8s.io/component-base/term"
 	utilversion "k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
@@ -146,6 +149,11 @@ cluster's shared state through which all other components interact.`,
 
 // Run runs the specified APIServer.  This should never exit.
 func Run(ctx context.Context, opts options.CompletedOptions) error {
+	restclient.Register()
+	workqueue.Register()
+	fifo.Register()
+	leaderelection.Register()
+
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", utilversion.Get())
 

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -63,8 +63,12 @@ import (
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	metricsfeatures "k8s.io/component-base/metrics/features"
+	"k8s.io/component-base/metrics/prometheus/clientgo/fifo"
+	leaderelectionmetrics "k8s.io/component-base/metrics/prometheus/clientgo/leaderelection"
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
+	restclientmetrics "k8s.io/component-base/metrics/prometheus/restclient"
 	"k8s.io/component-base/metrics/prometheus/slis"
+	"k8s.io/component-base/metrics/prometheus/workqueue"
 	"k8s.io/component-base/term"
 	utilversion "k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
@@ -554,6 +558,10 @@ func CreateControllerContext(ctx context.Context, s *config.CompletedConfig, roo
 	}
 
 	controllersmetrics.Register()
+	restclientmetrics.Register()
+	workqueue.Register()
+	fifo.Register()
+	leaderelectionmetrics.Register()
 	return controllerContext, nil
 }
 

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -59,7 +59,11 @@ import (
 	"k8s.io/component-base/metrics"
 	metricsfeatures "k8s.io/component-base/metrics/features"
 	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/prometheus/clientgo/fifo"
+	"k8s.io/component-base/metrics/prometheus/clientgo/leaderelection"
+	"k8s.io/component-base/metrics/prometheus/restclient"
 	"k8s.io/component-base/metrics/prometheus/slis"
+	"k8s.io/component-base/metrics/prometheus/workqueue"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	zpagesfeatures "k8s.io/component-base/zpages/features"
@@ -531,6 +535,10 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	logger.Info("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
 
 	proxymetrics.RegisterMetrics(s.Config.Mode)
+	restclient.Register()
+	workqueue.Register()
+	fifo.Register()
+	leaderelection.Register()
 
 	// TODO(vmarmol): Use container config for this.
 	var oomAdjuster *oom.OOMAdjuster

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -57,7 +57,11 @@ import (
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/component-base/metrics/features"
 	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/prometheus/clientgo/fifo"
+	leaderelectionmetrics "k8s.io/component-base/metrics/prometheus/clientgo/leaderelection"
+	"k8s.io/component-base/metrics/prometheus/restclient"
 	"k8s.io/component-base/metrics/prometheus/slis"
+	"k8s.io/component-base/metrics/prometheus/workqueue"
 	"k8s.io/component-base/term"
 	utilversion "k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
@@ -169,6 +173,11 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
 
 // Run executes the scheduler based on the given configuration. It only returns on error or when context is done.
 func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *scheduler.Scheduler) error {
+	restclient.Register()
+	workqueue.Register()
+	fifo.Register()
+	leaderelectionmetrics.Register()
+
 	logger := klog.FromContext(ctx)
 
 	// To help debugging, immediately log version

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -84,6 +84,10 @@ import (
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/prometheus/clientgo/fifo"
+	leaderelectionmetrics "k8s.io/component-base/metrics/prometheus/clientgo/leaderelection"
+	restclientmetrics "k8s.io/component-base/metrics/prometheus/restclient"
+	workqueuemetrics "k8s.io/component-base/metrics/prometheus/workqueue"
 	"k8s.io/component-base/tracing"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
@@ -537,6 +541,11 @@ func UnsecuredDependencies(ctx context.Context, s *options.KubeletServer, featur
 // Otherwise, the caller is assumed to have set up the Dependencies object and a default one will
 // not be generated.
 func Run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Dependencies, featureGate featuregate.FeatureGate) error {
+	restclientmetrics.Register()
+	workqueuemetrics.Register()
+	fifo.Register()
+	leaderelectionmetrics.Register()
+
 	logger := klog.FromContext(ctx)
 	// To help debugging, immediately log version
 	logger.Info("Kubelet version", "kubeletVersion", version.Get())

--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -49,8 +49,12 @@ import (
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/component-base/metrics/features"
+	"k8s.io/component-base/metrics/prometheus/clientgo/fifo"
+	leaderelectionmetrics "k8s.io/component-base/metrics/prometheus/clientgo/leaderelection"
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
+	"k8s.io/component-base/metrics/prometheus/restclient"
 	"k8s.io/component-base/metrics/prometheus/slis"
+	"k8s.io/component-base/metrics/prometheus/workqueue"
 	"k8s.io/component-base/term"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
@@ -495,6 +499,10 @@ func CreateControllerContext(s *cloudcontrollerconfig.CompletedConfig, clientBui
 		ControllerManagerMetrics:        controllersmetrics.NewControllerManagerMetrics("cloud-controller-manager"),
 	}
 	controllersmetrics.Register()
+	restclient.Register()
+	workqueue.Register()
+	fifo.Register()
+	leaderelectionmetrics.Register()
 	return ctx, nil
 }
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/fifo/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/fifo/metrics.go
@@ -37,11 +37,9 @@ var (
 	registerOnce sync.Once
 )
 
-func init() {
-	Register()
-}
-
 // Register registers FIFO metrics and sets the metrics provider.
+// This should be called after feature gates have been parsed to support
+// native histogram options.
 func Register() {
 	registerOnce.Do(func() {
 		legacyregistry.MustRegister(fifoQueuedItems)

--- a/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/leaderelection/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/leaderelection/metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package leaderelection
 
 import (
+	"sync"
+
 	"k8s.io/client-go/tools/leaderelection"
 	k8smetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -38,10 +40,17 @@ var (
 	}, []string{"name"})
 )
 
-func init() {
-	legacyregistry.MustRegister(leaderGauge)
-	legacyregistry.MustRegister(leaderSlowpathCounter)
-	leaderelection.SetProvider(prometheusMetricsProvider{})
+var registerOnce sync.Once
+
+// Register registers leaderelection metrics to the legacy registry.
+// This is typically called from component Run() functions after feature gates are parsed,
+// to support native histogram options.
+func Register() {
+	registerOnce.Do(func() {
+		legacyregistry.MustRegister(leaderGauge)
+		legacyregistry.MustRegister(leaderSlowpathCounter)
+		leaderelection.SetProvider(prometheusMetricsProvider{})
+	})
 }
 
 type prometheusMetricsProvider struct{}

--- a/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/metrics.go
@@ -14,11 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package clientgo provides client-go metrics registration.
+// All metrics packages (fifo, leaderelection, restclient, workqueue) now require
+// explicit Register() calls after feature gates are parsed to support native histogram options.
 package clientgo
-
-import (
-	_ "k8s.io/component-base/metrics/prometheus/clientgo/fifo"           // load fifo metrics
-	_ "k8s.io/component-base/metrics/prometheus/clientgo/leaderelection" // load leaderelection metrics
-	_ "k8s.io/component-base/metrics/prometheus/restclient"              // load restclient metrics
-	_ "k8s.io/component-base/metrics/prometheus/workqueue"               // load the workqueue metrics
-)

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"sync"
 	"time"
 
 	"k8s.io/client-go/tools/metrics"
@@ -195,33 +196,39 @@ var (
 	)
 )
 
-func init() {
+var registerOnce sync.Once
 
-	legacyregistry.MustRegister(requestLatency)
-	legacyregistry.MustRegister(requestSize)
-	legacyregistry.MustRegister(responseSize)
-	legacyregistry.MustRegister(rateLimiterLatency)
-	legacyregistry.MustRegister(requestResult)
-	legacyregistry.MustRegister(requestRetry)
-	legacyregistry.RawMustRegister(execPluginCertTTL)
-	legacyregistry.MustRegister(execPluginCertRotation)
-	legacyregistry.MustRegister(execPluginCalls)
-	legacyregistry.MustRegister(transportCacheEntries)
-	legacyregistry.MustRegister(transportCacheCalls)
-	metrics.Register(metrics.RegisterOpts{
-		ClientCertExpiry:      execPluginCertTTLAdapter,
-		ClientCertRotationAge: &rotationAdapter{m: execPluginCertRotation},
-		RequestLatency:        &latencyAdapter{m: requestLatency},
-		ResolverLatency:       &resolverLatencyAdapter{m: resolverLatency},
-		RequestSize:           &sizeAdapter{m: requestSize},
-		ResponseSize:          &sizeAdapter{m: responseSize},
-		RateLimiterLatency:    &latencyAdapter{m: rateLimiterLatency},
-		RequestResult:         &resultAdapter{requestResult},
-		RequestRetry:          &retryAdapter{requestRetry},
-		ExecPluginCalls:       &callsAdapter{m: execPluginCalls},
-		ExecPluginPolicyCalls: &policyAdapter{m: execPluginPolicyCalls},
-		TransportCacheEntries: &transportCacheAdapter{m: transportCacheEntries},
-		TransportCreateCalls:  &transportCacheCallsAdapter{m: transportCacheCalls},
+// Register registers restclient metrics to the legacy registry.
+// This is typically called from component Run() functions after feature gates are parsed,
+// to support native histogram options.
+func Register() {
+	registerOnce.Do(func() {
+		legacyregistry.MustRegister(requestLatency)
+		legacyregistry.MustRegister(requestSize)
+		legacyregistry.MustRegister(responseSize)
+		legacyregistry.MustRegister(rateLimiterLatency)
+		legacyregistry.MustRegister(requestResult)
+		legacyregistry.MustRegister(requestRetry)
+		legacyregistry.RawMustRegister(execPluginCertTTL)
+		legacyregistry.MustRegister(execPluginCertRotation)
+		legacyregistry.MustRegister(execPluginCalls)
+		legacyregistry.MustRegister(transportCacheEntries)
+		legacyregistry.MustRegister(transportCacheCalls)
+		metrics.Register(metrics.RegisterOpts{
+			ClientCertExpiry:      execPluginCertTTLAdapter,
+			ClientCertRotationAge: &rotationAdapter{m: execPluginCertRotation},
+			RequestLatency:        &latencyAdapter{m: requestLatency},
+			ResolverLatency:       &resolverLatencyAdapter{m: resolverLatency},
+			RequestSize:           &sizeAdapter{m: requestSize},
+			ResponseSize:          &sizeAdapter{m: responseSize},
+			RateLimiterLatency:    &latencyAdapter{m: rateLimiterLatency},
+			RequestResult:         &resultAdapter{requestResult},
+			RequestRetry:          &retryAdapter{requestRetry},
+			ExecPluginCalls:       &callsAdapter{m: execPluginCalls},
+			ExecPluginPolicyCalls: &policyAdapter{m: execPluginPolicyCalls},
+			TransportCacheEntries: &transportCacheAdapter{m: transportCacheEntries},
+			TransportCreateCalls:  &transportCacheCallsAdapter{m: transportCacheCalls},
+		})
 	})
 }
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package workqueue
 
 import (
+	"sync"
+
 	"k8s.io/client-go/util/workqueue"
 	k8smetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -101,11 +103,16 @@ var (
 type prometheusMetricsProvider struct {
 }
 
-func init() {
-	for _, m := range metrics {
-		legacyregistry.MustRegister(m)
-	}
-	workqueue.SetProvider(prometheusMetricsProvider{})
+var registerOnce sync.Once
+
+// Register registers workqueue metrics to the legacy registry.
+func Register() {
+	registerOnce.Do(func() {
+		for _, m := range metrics {
+			legacyregistry.MustRegister(m)
+		}
+		workqueue.SetProvider(prometheusMetricsProvider{})
+	})
 }
 
 func (prometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -46,6 +46,9 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/prometheus/clientgo/fifo"
+	"k8s.io/component-base/metrics/prometheus/clientgo/leaderelection"
+	"k8s.io/component-base/metrics/prometheus/restclient"
+	"k8s.io/component-base/metrics/prometheus/workqueue"
 	"k8s.io/component-base/metrics/testutil"
 	zpagesfeatures "k8s.io/component-base/zpages/features"
 	"k8s.io/klog/v2/ktesting"
@@ -690,7 +693,10 @@ users:
 
 	legacyregistry.Reset()
 	cache.ResetInformerNamesForTesting()
+	restclient.Register()
+	workqueue.Register()
 	fifo.Register()
+	leaderelection.Register()
 	_, ctx := ktesting.NewTestContext(t)
 	flags := []string{
 		"--authentication-skip-lookup",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Move metrics registration from init() to explicit Register() functions for fifo, restclient, workqueue, and leaderelection packages. This allows metrics to be registered after feature gates are parsed, enabling support for native histogram options.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Issue: https://github.com/kubernetes/enhancements/issues/5808

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
