### PR TITLE
Add group, version, resource labels to alpha metric apiserver_rerouted_request_total

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/metrics/metrics.go
@@ -27,6 +27,9 @@ import (
 const (
 	subsystem  = "apiserver"
 	statuscode = "code"
+	group      = "group"
+	version    = "version"
+	resource   = "resource"
 )
 
 var registerMetricsOnce sync.Once
@@ -37,10 +40,10 @@ var (
 		&metrics.CounterOpts{
 			Subsystem:      subsystem,
 			Name:           "rerouted_request_total",
-			Help:           "Total number of requests that were proxied to a peer kube apiserver because the local apiserver was not capable of serving it",
+			Help:           `Total number of requests that were proxied to a peer kube-apiserver because the local apiserver was not capable of serving it, broken down by 'group', 'version', and 'resource' indicating the GVR of the request. If all three are empty (""), the request is a discovery request.`,
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{statuscode},
+		[]string{statuscode, group, version, resource},
 	)
 )
 
@@ -56,6 +59,6 @@ func Reset() {
 }
 
 // IncPeerProxiedRequest increments the # of proxied requests to peer kube-apiserver
-func IncPeerProxiedRequest(ctx context.Context, status string) {
-	peerProxiedRequestsTotal.WithContext(ctx).WithLabelValues(status).Add(1)
+func IncPeerProxiedRequest(ctx context.Context, status, g, v, r string) {
+	peerProxiedRequestsTotal.WithContext(ctx).WithLabelValues(status, g, v, r).Add(1)
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peer_discovery.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peer_discovery.go
@@ -196,7 +196,7 @@ func (h *peerProxyHandler) aggregateDiscovery(ctx context.Context, path string, 
 	req.Header.Add("Accept", discovery.AcceptV2NoPeer+","+discovery.AcceptV2+","+discovery.AcceptV1)
 
 	writer := responsewriterutil.NewInMemoryResponseWriter()
-	h.proxyRequestToDestinationAPIServer(req, writer, hostport)
+	h.proxyRequestToDestinationAPIServer(req, writer, hostport, schema.GroupVersionResource{})
 	if writer.RespCode() != http.StatusOK {
 		return nil, fmt.Errorf("discovery request failed with status: %d", writer.RespCode())
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peerproxy_handler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peerproxy_handler_test.go
@@ -148,10 +148,10 @@ func TestPeerProxy(t *testing.T) {
 			},
 			wantStatus: http.StatusServiceUnavailable,
 			wantMetricsData: `
-				# HELP apiserver_rerouted_request_total [ALPHA] Total number of requests that were proxied to a peer kube apiserver because the local apiserver was not capable of serving it
-				# TYPE apiserver_rerouted_request_total counter
-				apiserver_rerouted_request_total{code="503"} 1
-				`,
+					   # HELP apiserver_rerouted_request_total [ALPHA] Total number of requests that were proxied to a peer kube-apiserver because the local apiserver was not capable of serving it, broken down by 'group', 'version', and 'resource' indicating the GVR of the request. If all three are empty (""), the request is a discovery request.
+					   # TYPE apiserver_rerouted_request_total counter
+					   apiserver_rerouted_request_total{code="503",group="",resource="bar",version="foo"} 1
+					   `,
 		},
 		{
 			desc:                 "503 if one apiserver's endpoint lease wasnt found but another valid (unreachable) apiserver was found",
@@ -180,10 +180,10 @@ func TestPeerProxy(t *testing.T) {
 			},
 			wantStatus: http.StatusServiceUnavailable,
 			wantMetricsData: `
-				# HELP apiserver_rerouted_request_total [ALPHA] Total number of requests that were proxied to a peer kube apiserver because the local apiserver was not capable of serving it
-				# TYPE apiserver_rerouted_request_total counter
-				apiserver_rerouted_request_total{code="503"} 1
-				`,
+					   # HELP apiserver_rerouted_request_total [ALPHA] Total number of requests that were proxied to a peer kube-apiserver because the local apiserver was not capable of serving it, broken down by 'group', 'version', and 'resource' indicating the GVR of the request. If all three are empty (""), the request is a discovery request.
+					   # TYPE apiserver_rerouted_request_total counter
+					   apiserver_rerouted_request_total{code="503",group="",resource="bar",version="foo"} 1
+					   `,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Adds new labels for group, version, resource to existing ALPHA apiserver metric `apiserver_rerouted_request_total`

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Issue: https://github.com/kubernetes/enhancements/issues/4020

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
apiserver_rerouted_request_total metric will expose labels for group, version and resource.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
