### PR TITLE
Graduate apiserver metrics to beta

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -198,7 +198,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 			Subsystem:      subsystem,
 			Name:           "webhook_rejection_count",
 			Help:           "Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"name", "type", "operation", "error_type", "rejection_code"})
 
@@ -218,7 +218,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 			Subsystem:      subsystem,
 			Name:           "webhook_request_total",
 			Help:           "Admission webhook request total, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify whether the request was rejected or not and an HTTP status code. Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"name", "type", "operation", "code", "rejected"})
 

--- a/staging/src/k8s.io/apiserver/pkg/audit/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/metrics.go
@@ -44,7 +44,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "event_total",
 			Help:           "Counter of audit events generated and sent to the audit backend.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		})
 	errorCounter = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -52,7 +52,7 @@ var (
 			Name:      "error_total",
 			Help: "Counter of audit events that failed to be audited properly. " +
 				"Plugin identifies the plugin affected by the error.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"plugin"},
 	)
@@ -61,7 +61,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "level_total",
 			Help:           "Counter of policy levels for audit events (1 per request).",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"level"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -68,7 +68,7 @@ var clientCertificateExpirationHistogram = metrics.NewHistogram(
 			15552000, // 6 months
 			31104000, // 1 year
 		},
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -130,7 +130,7 @@ var (
 			// dependant on user configuration.
 			Buckets: []float64{0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
 				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
 	)
@@ -172,7 +172,7 @@ var (
 			Subsystem:      APIServerComponent,
 			Name:           "watch_events_total",
 			Help:           "Number of events sent in watch clients",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "version", "resource"},
 	)
@@ -182,7 +182,7 @@ var (
 			Name:           "watch_events_sizes",
 			Help:           "Watch event size distribution in bytes",
 			Buckets:        compbasemetrics.ExponentialBuckets(1024, 2.0, 8), // 1K, 2K, 4K, 8K, ..., 128K.
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "version", "resource"},
 	)
@@ -233,7 +233,7 @@ var (
 			Name:           "request_filter_duration_seconds",
 			Help:           "Request filter latency distribution in seconds, for each filter type",
 			Buckets:        []float64{0.0001, 0.0003, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 5.0, 10.0, 15.0, 30.0},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"filter"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/metrics/metrics.go
@@ -66,7 +66,7 @@ func newDialMetrics() *DialMetrics {
 			Subsystem:      subsystem,
 			Name:           "dial_start_total",
 			Help:           "Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"protocol", "transport"},
 	)
@@ -78,7 +78,7 @@ func newDialMetrics() *DialMetrics {
 			Name:           "dial_duration_seconds",
 			Help:           "Dial latency histogram in seconds, labeled by the protocol (http-connect or grpc), transport (tcp or uds)",
 			Buckets:        latencyBuckets,
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"protocol", "transport"},
 	)
@@ -89,7 +89,7 @@ func newDialMetrics() *DialMetrics {
 			Subsystem:      subsystem,
 			Name:           "dial_failure_count",
 			Help:           "Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"protocol", "transport", "stage"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -92,7 +92,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "events_dispatched_total",
 			Help:           "Counter of events dispatched in watch cache broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -102,7 +102,7 @@ var (
 			Namespace:      namespace,
 			Name:           "terminated_watchers_total",
 			Help:           "Counter of watchers closed due to unresponsiveness broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -113,7 +113,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "resource_version",
 			Help:           "Current resource version of watch cache broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -143,7 +143,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "capacity",
 			Help:           "Total capacity of watch cache broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -154,7 +154,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "initializations_total",
 			Help:           "Counter of watch cache initializations broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -165,7 +165,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "read_wait_seconds",
 			Help:           "Histogram of time spent waiting for a watch cache to become fresh.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 			Buckets:        []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3},
 		}, []string{"group", "resource"})
 
@@ -175,7 +175,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "consistent_read_total",
 			Help:           "Counter for consistent reads from cache.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		}, []string{"group", "resource", "success", "fallback"})
 
 	StorageConsistencyCheckTotal = compbasemetrics.NewCounterVec(

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics/metrics.go
@@ -74,7 +74,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "dek_cache_fill_percent",
 			Help:           "Percent of the cache slots currently occupied by cached DEKs.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 	)
 
@@ -85,7 +85,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "dek_cache_inter_arrival_time_seconds",
 			Help:           "Time (in seconds) of inter arrival of transformation requests.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 			Buckets:        metrics.ExponentialBuckets(60, 2, 10),
 		},
 		[]string{"transformation_type"},

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -51,7 +51,7 @@ var (
 			// In-process transformations (ex. AES CBC) complete on the order of 20 microseconds. However, when
 			// external KMS is involved latencies may climb into hundreds of milliseconds.
 			Buckets:        metrics.ExponentialBuckets(5e-6, 2, 25),
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"transformation_type", "transformer_prefix"},
 	)
@@ -62,7 +62,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "transformation_operations_total",
 			Help:           "Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"resource", "transformation_type", "transformer_prefix", "status"},
 	)
@@ -73,7 +73,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "envelope_transformation_cache_misses_total",
 			Help:           "Total number of cache misses while accessing key decryption key(KEK).",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 	)
 
@@ -84,7 +84,7 @@ var (
 			Name:           "data_key_generation_duration_seconds",
 			Help:           "Latencies in seconds of data encryption key(DEK) generation operations.",
 			Buckets:        metrics.ExponentialBuckets(5e-6, 2, 14),
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 	)
 
@@ -94,7 +94,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "data_key_generation_failures_total",
 			Help:           "Total number of failed data encryption key(DEK) generation operations.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 	)
 )

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics_test.go
@@ -58,7 +58,7 @@ func TestTotals(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-				# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+				# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
 				# TYPE apiserver_storage_transformation_operations_total counter
 				apiserver_storage_transformation_operations_total{resource="test",status="unknown-non-grpc",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
 				apiserver_storage_transformation_operations_total{resource="test",status="unknown-non-grpc",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
@@ -72,7 +72,7 @@ func TestTotals(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-				# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+				# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
 				# TYPE apiserver_storage_transformation_operations_total counter
 				apiserver_storage_transformation_operations_total{resource="test",status="OK",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
 				apiserver_storage_transformation_operations_total{resource="test",status="OK",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
@@ -86,7 +86,7 @@ func TestTotals(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-				# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+				# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
 				# TYPE apiserver_storage_transformation_operations_total counter
 				apiserver_storage_transformation_operations_total{resource="test",status="FailedPrecondition",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
 				apiserver_storage_transformation_operations_total{resource="test",status="FailedPrecondition",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
@@ -100,7 +100,7 @@ func TestTotals(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-				# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+				# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
 				# TYPE apiserver_storage_transformation_operations_total counter
 				apiserver_storage_transformation_operations_total{resource="test",status="Internal",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
 				apiserver_storage_transformation_operations_total{resource="test",status="Internal",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
@@ -114,7 +114,7 @@ func TestTotals(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-			# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+			# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
 			# TYPE apiserver_storage_transformation_operations_total counter
 			apiserver_storage_transformation_operations_total{resource="test",status="NotFound",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
 			apiserver_storage_transformation_operations_total{resource="test",status="NotFound",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
@@ -163,7 +163,7 @@ func TestLatency(t *testing.T) {
 				"apiserver_storage_transformation_duration_seconds",
 			},
 			want: `
-			# HELP apiserver_storage_transformation_duration_seconds [ALPHA] Latencies in seconds of value transformation operations.
+			# HELP apiserver_storage_transformation_duration_seconds [BETA] Latencies in seconds of value transformation operations.
 			# TYPE apiserver_storage_transformation_duration_seconds histogram
 			apiserver_storage_transformation_duration_seconds_bucket{transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:",le="5e-06"} 0
 			apiserver_storage_transformation_duration_seconds_bucket{transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:",le="1e-05"} 0
@@ -204,7 +204,7 @@ func TestLatency(t *testing.T) {
 				"apiserver_storage_transformation_duration_seconds",
 			},
 			want: `
-			# HELP apiserver_storage_transformation_duration_seconds [ALPHA] Latencies in seconds of value transformation operations.
+			# HELP apiserver_storage_transformation_duration_seconds [BETA] Latencies in seconds of value transformation operations.
 			# TYPE apiserver_storage_transformation_duration_seconds histogram
 			apiserver_storage_transformation_duration_seconds_bucket{transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v2:",le="5e-06"} 0
 			apiserver_storage_transformation_duration_seconds_bucket{transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v2:",le="1e-05"} 0

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/transformer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/transformer_test.go
@@ -136,7 +136,7 @@ func TestPrefixFromMetrics(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+	# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
   # TYPE apiserver_storage_transformation_operations_total counter
   apiserver_storage_transformation_operations_total{resource="test",status="OK",transformation_type="from_storage",transformer_prefix="identity"} 1
   `,
@@ -150,7 +150,7 @@ func TestPrefixFromMetrics(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+	# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
   # TYPE apiserver_storage_transformation_operations_total counter
   apiserver_storage_transformation_operations_total{resource="test",status="OK",transformation_type="from_storage",transformer_prefix="other:"} 1
   `,
@@ -164,7 +164,7 @@ func TestPrefixFromMetrics(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+	# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
   # TYPE apiserver_storage_transformation_operations_total counter
   apiserver_storage_transformation_operations_total{resource="test",status="unknown-non-grpc",transformation_type="from_storage",transformer_prefix="other:"} 1
   `,
@@ -178,7 +178,7 @@ func TestPrefixFromMetrics(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+	# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
   # TYPE apiserver_storage_transformation_operations_total counter
   apiserver_storage_transformation_operations_total{resource="test",status="unknown-non-grpc",transformation_type="from_storage",transformer_prefix="unknown"} 1
   `,
@@ -226,7 +226,7 @@ func TestPrefixToMetrics(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+	# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
   # TYPE apiserver_storage_transformation_operations_total counter
   apiserver_storage_transformation_operations_total{resource="test",status="OK",transformation_type="to_storage",transformer_prefix="other:"} 1
   `,
@@ -241,7 +241,7 @@ func TestPrefixToMetrics(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+	# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
   # TYPE apiserver_storage_transformation_operations_total counter
   apiserver_storage_transformation_operations_total{resource="",status="OK",transformation_type="to_storage",transformer_prefix="other:"} 1
   `,
@@ -256,7 +256,7 @@ func TestPrefixToMetrics(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+	# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
   # TYPE apiserver_storage_transformation_operations_total counter
   apiserver_storage_transformation_operations_total{resource="test.testGroup",status="OK",transformation_type="to_storage",transformer_prefix="other:"} 1
   `,
@@ -271,7 +271,7 @@ func TestPrefixToMetrics(t *testing.T) {
 				"apiserver_storage_transformation_operations_total",
 			},
 			want: `
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
+	# HELP apiserver_storage_transformation_operations_total [BETA] Total number of transformations. Successful transformation will have a status 'OK' and a varied status string when the transformation fails. The status, resource, and transformation_type fields can be used for alerting purposes. For example, you can monitor for encryption/decryption failures using the transformation_type (e.g., from_storage for decryption and to_storage for encryption). Additionally, these fields can be used to ensure that the correct transformers are applied to each resource.
   # TYPE apiserver_storage_transformation_operations_total counter
   apiserver_storage_transformation_operations_total{resource="test",status="unknown-non-grpc",transformation_type="to_storage",transformer_prefix="other:"} 1
   `,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
@@ -118,7 +118,7 @@ var (
 			// Buckets for both 0.99 and 1.0 mean PromQL's histogram_quantile will reveal saturation
 			Buckets:        []float64{0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1},
 			ConstLabels:    map[string]string{phase: "executing"},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		priorityLevel,
 	)
@@ -132,7 +132,7 @@ var (
 			// For executing: the denominator will be seats, so this metric will skew low.
 			// For waiting: total queue capacity is generally quite generous, so this metric will skew low.
 			Buckets:        []float64{0, 0.001, 0.003, 0.01, 0.03, 0.1, 0.25, 0.5, 0.75, 1},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		LabelNamePhase, priorityLevel,
 	)
@@ -239,7 +239,7 @@ var (
 			Help:      "Nominal number of execution seats configured for each priority level",
 			// Remove this metric once all suppported releases have the equal nominal_limit_seats metric
 			DeprecatedVersion: "1.30.0",
-			StabilityLevel:    compbasemetrics.ALPHA,
+			StabilityLevel:    compbasemetrics.BETA,
 		},
 		[]string{priorityLevel},
 	)
@@ -271,7 +271,7 @@ var (
 			Help:      "Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem",
 			// Remove this metric once all suppported releases have the equal current_executing_seats metric
 			DeprecatedVersion: "1.31.0",
-			StabilityLevel:    compbasemetrics.ALPHA,
+			StabilityLevel:    compbasemetrics.BETA,
 		},
 		[]string{priorityLevel, flowSchema},
 	)
@@ -293,7 +293,7 @@ var (
 			Name:           "request_execution_seconds",
 			Help:           "Duration of initial stage (for a WATCH) or any (for a non-WATCH) stage of request execution in the API Priority and Fairness subsystem",
 			Buckets:        requestDurationSecondsBuckets,
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{priorityLevel, flowSchema, "type"},
 	)
@@ -327,7 +327,7 @@ var (
 			// the upper bound comes from the maximum number of seats a request
 			// can occupy which is currently set at 10.
 			Buckets:        []float64{1, 2, 4, 8, 16, 32, 64, 100},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{priorityLevel, flowSchema},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/metrics.go
@@ -30,7 +30,7 @@ var x509MissingSANCounter = metrics.NewCounter(
 			"in their serving certificate OR the number of connection failures " +
 			"due to the lack of x509 certificate SAN extension missing " +
 			"(either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 
@@ -42,7 +42,7 @@ var x509InsecureSHA1Counter = metrics.NewCounter(
 		Help: "Counts the number of requests to servers with insecure SHA1 signatures " +
 			"in their serving certificate OR the number of connection failures " +
 			"due to the insecure SHA1 signatures (either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics.go
@@ -113,7 +113,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "webhook_evaluations_total",
 			Help:           "Round-trips to authorization webhooks.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"name", "result"},
 	)
@@ -125,7 +125,7 @@ var (
 			Name:           "webhook_duration_seconds",
 			Help:           "Request latency in seconds.",
 			Buckets:        compbasemetrics.DefBuckets,
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"name", "result"},
 	)
@@ -136,7 +136,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "webhook_evaluations_fail_open_total",
 			Help:           "NoOpinion results due to webhook timeout or error.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"name", "result"},
 	)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics_test.go
@@ -45,7 +45,7 @@ func TestRecordWebhookMetrics(t *testing.T) {
 			result:   "timeout",
 			duration: 1.5,
 			want: `
-			# HELP apiserver_authorization_webhook_duration_seconds [ALPHA] Request latency in seconds.
+			# HELP apiserver_authorization_webhook_duration_seconds [BETA] Request latency in seconds.
 			# TYPE apiserver_authorization_webhook_duration_seconds histogram
             apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.005"} 0
             apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.01"} 0
@@ -61,10 +61,10 @@ func TestRecordWebhookMetrics(t *testing.T) {
             apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="+Inf"} 1
             apiserver_authorization_webhook_duration_seconds_sum{name="wh1.example.com",result="timeout"} 1.5
             apiserver_authorization_webhook_duration_seconds_count{name="wh1.example.com",result="timeout"} 1
-            # HELP apiserver_authorization_webhook_evaluations_fail_open_total [ALPHA] NoOpinion results due to webhook timeout or error.
+            # HELP apiserver_authorization_webhook_evaluations_fail_open_total [BETA] NoOpinion results due to webhook timeout or error.
             # TYPE apiserver_authorization_webhook_evaluations_fail_open_total counter
             apiserver_authorization_webhook_evaluations_fail_open_total{name="wh1.example.com",result="timeout"} 1
-            # HELP apiserver_authorization_webhook_evaluations_total [ALPHA] Round-trips to authorization webhooks.
+            # HELP apiserver_authorization_webhook_evaluations_total [BETA] Round-trips to authorization webhooks.
             # TYPE apiserver_authorization_webhook_evaluations_total counter
             apiserver_authorization_webhook_evaluations_total{name="wh1.example.com",result="timeout"} 1
             `,

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
@@ -30,7 +30,7 @@ var x509MissingSANCounter = metrics.NewCounter(
 			"in their serving certificate OR the number of connection failures " +
 			"due to the lack of x509 certificate SAN extension missing " +
 			"(either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 
@@ -42,7 +42,7 @@ var x509InsecureSHA1Counter = metrics.NewCounter(
 		Help: "Counts the number of requests to servers with insecure SHA1 signatures " +
 			"in their serving certificate OR the number of connection failures " +
 			"due to the insecure SHA1 signatures (either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -1,3 +1,56 @@
+- name: webhook_rejection_count
+  subsystem: admission
+  namespace: apiserver
+  help: Admission webhook rejection count, identified by name and broken out for each
+    admission type (validating or admit) and operation. Additional labels specify
+    an error type (calling_webhook_error or apiserver_internal_error if an error occurred;
+    no_error otherwise) and optionally a non-zero rejection code if the webhook rejects
+    the request with an HTTP status code (honored by the apiserver when the code is
+    greater or equal to 400). Codes greater than 600 are truncated to 600, to keep
+    the metrics cardinality bounded.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - error_type
+  - name
+  - operation
+  - rejection_code
+  - type
+- name: webhook_request_total
+  subsystem: admission
+  namespace: apiserver
+  help: Admission webhook request total, identified by name and broken out for each
+    admission type (validating or admit) and operation. Additional labels specify
+    whether the request was rejected or not and an HTTP status code. Codes greater
+    than 600 are truncated to 600, to keep the metrics cardinality bounded.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - code
+  - name
+  - operation
+  - rejected
+  - type
+- name: error_total
+  subsystem: apiserver_audit
+  help: Counter of audit events that failed to be audited properly. Plugin identifies
+    the plugin affected by the error.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - plugin
+- name: event_total
+  subsystem: apiserver_audit
+  help: Counter of audit events generated and sent to the audit backend.
+  type: Counter
+  stabilityLevel: BETA
+- name: level_total
+  subsystem: apiserver_audit
+  help: Counter of policy levels for audit events (1 per request).
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - level
 - name: automatic_reload_last_timestamp_seconds
   subsystem: authentication_config_controller
   namespace: apiserver
@@ -38,6 +91,45 @@
   labels:
   - apiserver_id_hash
   - status
+- name: webhook_duration_seconds
+  subsystem: authorization
+  namespace: apiserver
+  help: Request latency in seconds.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
+  buckets:
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+- name: webhook_evaluations_fail_open_total
+  subsystem: authorization
+  namespace: apiserver
+  help: NoOpinion results due to webhook timeout or error.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
+- name: webhook_evaluations_total
+  subsystem: authorization
+  namespace: apiserver
+  help: Round-trips to authorization webhooks.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
 - name: compilation_duration_seconds
   subsystem: cel
   namespace: apiserver
@@ -50,6 +142,92 @@
   help: CEL evaluation time in seconds.
   type: Histogram
   stabilityLevel: BETA
+- name: certificate_expiration_seconds
+  subsystem: client
+  namespace: apiserver
+  help: Distribution of the remaining lifetime on the certificate used to authenticate
+    a request.
+  type: Histogram
+  stabilityLevel: BETA
+  buckets:
+  - 0
+  - 1800
+  - 3600
+  - 7200
+  - 21600
+  - 43200
+  - 86400
+  - 172800
+  - 345600
+  - 604800
+  - 2.592e+06
+  - 7.776e+06
+  - 1.5552e+07
+  - 3.1104e+07
+- name: dial_duration_seconds
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial latency histogram in seconds, labeled by the protocol (http-connect or
+    grpc), transport (tcp or uds)
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - transport
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.5
+  - 2.5
+  - 12.5
+- name: dial_failure_count
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial failure count, labeled by the protocol (http-connect or grpc), transport
+    (tcp or uds), and stage (connect or proxy). The stage indicates at which stage
+    the dial failed
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - stage
+  - transport
+- name: dial_start_total
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial starts, labeled by the protocol (http-connect or grpc) and transport
+    (tcp or uds).
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - transport
+- name: dek_cache_fill_percent
+  subsystem: envelope_encryption
+  namespace: apiserver
+  help: Percent of the cache slots currently occupied by cached DEKs.
+  type: Gauge
+  stabilityLevel: BETA
+- name: dek_cache_inter_arrival_time_seconds
+  subsystem: envelope_encryption
+  namespace: apiserver
+  help: Time (in seconds) of inter arrival of transformation requests.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - transformation_type
+  buckets:
+  - 60
+  - 120
+  - 240
+  - 480
+  - 960
+  - 1920
+  - 3840
+  - 7680
+  - 15360
+  - 30720
 - name: current_executing_requests
   subsystem: flowcontrol
   namespace: apiserver
@@ -98,6 +276,53 @@
   stabilityLevel: BETA
   labels:
   - priority_level
+- name: priority_level_request_utilization
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Observations, at the end of every nanosecond, of number of requests (as a
+    fraction of the relevant limit) waiting or in any stage of execution (but only
+    initial stage for WATCHes)
+  type: TimingRatioHistogram
+  stabilityLevel: BETA
+  labels:
+  - phase
+  - priority_level
+  buckets:
+  - 0
+  - 0.001
+  - 0.003
+  - 0.01
+  - 0.03
+  - 0.1
+  - 0.25
+  - 0.5
+  - 0.75
+  - 1
+- name: priority_level_seat_utilization
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Observations, at the end of every nanosecond, of utilization of seats for
+    any stage of execution (but only initial stage for WATCHes)
+  type: TimingRatioHistogram
+  stabilityLevel: BETA
+  labels:
+  - priority_level
+  buckets:
+  - 0
+  - 0.1
+  - 0.2
+  - 0.3
+  - 0.4
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - 0.95
+  - 0.99
+  - 1
+  constLabels:
+    phase: executing
 - name: rejected_requests_total
   subsystem: flowcontrol
   namespace: apiserver
@@ -108,6 +333,52 @@
   - flow_schema
   - priority_level
   - reason
+- name: request_concurrency_in_use
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Concurrency (number of seats) occupied by the currently executing (initial
+    stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness
+    subsystem
+  type: Gauge
+  deprecatedVersion: 1.31.0
+  stabilityLevel: BETA
+  labels:
+  - flow_schema
+  - priority_level
+- name: request_concurrency_limit
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Nominal number of execution seats configured for each priority level
+  type: Gauge
+  deprecatedVersion: 1.30.0
+  stabilityLevel: BETA
+  labels:
+  - priority_level
+- name: request_execution_seconds
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Duration of initial stage (for a WATCH) or any (for a non-WATCH) stage of
+    request execution in the API Priority and Fairness subsystem
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - flow_schema
+  - priority_level
+  - type
+  buckets:
+  - 0
+  - 0.005
+  - 0.02
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.5
+  - 1
+  - 2
+  - 5
+  - 10
+  - 15
+  - 30
 - name: request_wait_duration_seconds
   subsystem: flowcontrol
   namespace: apiserver
@@ -132,6 +403,192 @@
   - 10
   - 15
   - 30
+- name: work_estimated_seats
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Number of estimated seats (maximum of initial and final seats) associated
+    with requests in API Priority and Fairness
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - flow_schema
+  - priority_level
+  buckets:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 100
+- name: x509_insecure_sha1_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers with insecure SHA1 signatures in
+    their serving certificate OR the number of connection failures due to the insecure
+    SHA1 signatures (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
+- name: x509_missing_san_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers missing SAN extension in their serving
+    certificate OR the number of connection failures due to the lack of x509 certificate
+    SAN extension missing (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
+- name: request_filter_duration_seconds
+  subsystem: apiserver
+  help: Request filter latency distribution in seconds, for each filter type
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - filter
+  buckets:
+  - 0.0001
+  - 0.0003
+  - 0.001
+  - 0.003
+  - 0.01
+  - 0.03
+  - 0.1
+  - 0.3
+  - 1
+  - 5
+  - 10
+  - 15
+  - 30
+- name: request_sli_duration_seconds
+  subsystem: apiserver
+  help: Response latency distribution (not counting webhook duration and priority
+    & fairness queue wait times) in seconds for each verb, group, version, resource,
+    subresource, scope and component.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - component
+  - group
+  - resource
+  - scope
+  - subresource
+  - verb
+  - version
+  buckets:
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.4
+  - 0.6
+  - 0.8
+  - 1
+  - 1.25
+  - 1.5
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 8
+  - 10
+  - 15
+  - 20
+  - 30
+  - 45
+  - 60
+- name: data_key_generation_duration_seconds
+  subsystem: storage
+  namespace: apiserver
+  help: Latencies in seconds of data encryption key(DEK) generation operations.
+  type: Histogram
+  stabilityLevel: BETA
+  buckets:
+  - 5e-06
+  - 1e-05
+  - 2e-05
+  - 4e-05
+  - 8e-05
+  - 0.00016
+  - 0.00032
+  - 0.00064
+  - 0.00128
+  - 0.00256
+  - 0.00512
+  - 0.01024
+  - 0.02048
+  - 0.04096
+- name: data_key_generation_failures_total
+  subsystem: storage
+  namespace: apiserver
+  help: Total number of failed data encryption key(DEK) generation operations.
+  type: Counter
+  stabilityLevel: BETA
+- name: envelope_transformation_cache_misses_total
+  subsystem: storage
+  namespace: apiserver
+  help: Total number of cache misses while accessing key decryption key(KEK).
+  type: Counter
+  stabilityLevel: BETA
+- name: transformation_duration_seconds
+  subsystem: storage
+  namespace: apiserver
+  help: Latencies in seconds of value transformation operations.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - transformation_type
+  - transformer_prefix
+  buckets:
+  - 5e-06
+  - 1e-05
+  - 2e-05
+  - 4e-05
+  - 8e-05
+  - 0.00016
+  - 0.00032
+  - 0.00064
+  - 0.00128
+  - 0.00256
+  - 0.00512
+  - 0.01024
+  - 0.02048
+  - 0.04096
+  - 0.08192
+  - 0.16384
+  - 0.32768
+  - 0.65536
+  - 1.31072
+  - 2.62144
+  - 5.24288
+  - 10.48576
+  - 20.97152
+  - 41.94304
+  - 83.88608
+- name: transformation_operations_total
+  subsystem: storage
+  namespace: apiserver
+  help: Total number of transformations. Successful transformation will have a status
+    'OK' and a varied status string when the transformation fails. The status, resource,
+    and transformation_type fields can be used for alerting purposes. For example,
+    you can monitor for encryption/decryption failures using the transformation_type
+    (e.g., from_storage for decryption and to_storage for encryption). Additionally,
+    these fields can be used to ensure that the correct transformers are applied to
+    each resource.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - resource
+  - status
+  - transformation_type
+  - transformer_prefix
+- name: terminated_watchers_total
+  namespace: apiserver
+  help: Counter of watchers closed due to unresponsiveness broken by resource type.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
 - name: check_duration_seconds
   subsystem: validating_admission_policy
   namespace: apiserver
@@ -175,6 +632,94 @@
   help: Number of times declarative validation has panicked during validation.
   type: Counter
   stabilityLevel: BETA
+- name: consistent_read_total
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Counter for consistent reads from cache.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - fallback
+  - group
+  - resource
+  - success
+- name: events_dispatched_total
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Counter of events dispatched in watch cache broken by resource type.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+- name: initializations_total
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Counter of watch cache initializations broken by resource type.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+- name: read_wait_seconds
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Histogram of time spent waiting for a watch cache to become fresh.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.4
+  - 0.6
+  - 0.8
+  - 1
+  - 1.25
+  - 1.5
+  - 2
+  - 3
+- name: resource_version
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Current resource version of watch cache broken by resource type.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+- name: watch_events_sizes
+  subsystem: apiserver
+  help: Watch event size distribution in bytes
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  - version
+  buckets:
+  - 1024
+  - 2048
+  - 4096
+  - 8192
+  - 16384
+  - 32768
+  - 65536
+  - 131072
+- name: watch_events_total
+  subsystem: apiserver
+  help: Number of events sent in watch clients
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  - version
 - name: watch_list_duration_seconds
   subsystem: apiserver
   help: Response latency distribution in seconds for watch list requests broken by
@@ -204,6 +749,22 @@
   - 30
   - 45
   - 60
+- name: x509_insecure_sha1_total
+  subsystem: webhooks
+  namespace: apiserver
+  help: Counts the number of requests to servers with insecure SHA1 signatures in
+    their serving certificate OR the number of connection failures due to the insecure
+    SHA1 signatures (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
+- name: x509_missing_san_total
+  subsystem: webhooks
+  namespace: apiserver
+  help: Counts the number of requests to servers missing SAN extension in their serving
+    certificate OR the number of connection failures due to the lack of x509 certificate
+    SAN extension missing (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
 - name: disabled_metrics_total
   help: The count of disabled metrics.
   type: Counter
@@ -285,6 +846,14 @@
   - 1310.72
   - 2621.44
   - 5242.88
+- name: capacity
+  subsystem: watch_cache
+  help: Total capacity of watch cache broken by resource type.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
 - name: adds_total
   subsystem: workqueue
   help: Total number of adds handled by workqueue


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes a set of kube-apiserver and kube-aggregator metrics from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304 .

Graduating these metrics to Beta provides stronger compatibility guarantees for metric consumers (dashboards/alerts/monitoring), specifically that existing metric names and label sets will not be removed while the metrics remain in Beta.


#### Which issue(s) this PR is related to:
Fixes : #136304 

### Split PR tracking (from this umbrella PR)

Per reviewer request, this PR is being split into smaller, focused PRs for easier review/approval across SIGs.

- [x] Admission webhook metrics: #137502 
- [ ] Audit metrics: #137505 
- [ ] Authn x509 expiration metric: #137506 
- [ ] Endpoints metrics: #137508 : Duplicate
- [ ] Egress selector dial metrics: #137509
- [x] Storage cacher metrics: #137510 : Duplicate
- [x] Storage value metrics: #137511
- [ ] Flowcontrol metrics: #137512
- [ ] Util + kube-aggregator webhook x509 metrics: #137514 : Duplicate
- [ ] Authz webhook metrics: #137515

#### Special notes for your reviewer:

- Promotions are limited to the metrics explicitly listed in #136304

- updated focused unit tests validating expected labels and values

- No functional behavior changes.

- make verify pass locally.

#### Does this PR introduce a user-facing change?
Yes. The affected apiserver and aggregator metrics are now Beta, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted apiserver metrics from Alpha to Beta stability. These metrics now provide stronger compatibility guarantees, including stability of existing label sets while in Beta.
```

