### PR TITLE
api: enable optionalorrequired linter for storage API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -22537,9 +22537,6 @@
           "description": "spec represents the specification of the CSI Driver."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -22667,9 +22664,6 @@
           "description": "status contains health and status information for the node's storage."
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -22761,9 +22755,6 @@
           "x-kubernetes-patch-strategy": "merge"
         }
       },
-      "required": [
-        "drivers"
-      ],
       "type": "object"
     },
     "io.k8s.api.storage.v1.CSINodeStatus": {
@@ -23034,9 +23025,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "audience"
-      ],
       "type": "object"
     },
     "io.k8s.api.storage.v1.VolumeAttachment": {
@@ -23170,9 +23158,6 @@
           "description": "detachError represents the last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher."
         }
       },
-      "required": [
-        "attached"
-      ],
       "type": "object"
     },
     "io.k8s.api.storage.v1.VolumeAttributesClass": {
@@ -23203,7 +23188,8 @@
         }
       },
       "required": [
-        "driverName"
+        "driverName",
+        "parameters"
       ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
@@ -23303,6 +23289,9 @@
           "description": "Status of the migration."
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -23407,6 +23396,9 @@
           "description": "Status of the migration."
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {

--- a/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
@@ -1195,9 +1195,6 @@
             "description": "spec represents the specification of the CSI Driver."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1345,9 +1342,6 @@
             "description": "status contains health and status information for the node's storage."
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -1450,9 +1444,6 @@
             "x-kubernetes-patch-strategy": "merge"
           }
         },
-        "required": [
-          "drivers"
-        ],
         "type": "object"
       },
       "io.k8s.api.storage.v1.CSINodeStatus": {
@@ -1765,9 +1756,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "audience"
-        ],
         "type": "object"
       },
       "io.k8s.api.storage.v1.VolumeAttachment": {
@@ -1941,9 +1929,6 @@
             "description": "detachError represents the last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher."
           }
         },
-        "required": [
-          "attached"
-        ],
         "type": "object"
       },
       "io.k8s.api.storage.v1.VolumeAttributesClass": {
@@ -1980,7 +1965,8 @@
           }
         },
         "required": [
-          "driverName"
+          "driverName",
+          "parameters"
         ],
         "type": "object",
         "x-kubernetes-group-version-kind": [

--- a/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1_openapi.json
@@ -40,6 +40,9 @@
             "description": "Status of the migration."
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1beta1_openapi.json
@@ -40,6 +40,9 @@
             "description": "Status of the migration."
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -232,7 +232,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -275,6 +275,10 @@ linters:
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
       - text: "optionalfields: field Eviction.Status should be a pointer."
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
+      # VolumeAttachmentSpec.Source is a union type. Validation requires one of its child fields to be set,
+      # but nonpointerstructs does not understand that invariant.
+      - text: "nonpointerstructs: field VolumeAttachmentSpec.Source is a non-pointer struct with no required fields."
+        path: "staging/src/k8s.io/api/storage/(v1|v1alpha1|v1beta1)/types.go"
 
       - linters:
         - forbidigo

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -241,7 +241,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -289,6 +289,10 @@ linters:
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
       - text: "optionalfields: field Eviction.Status should be a pointer."
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
+      # VolumeAttachmentSpec.Source is a union type. Validation requires one of its child fields to be set,
+      # but nonpointerstructs does not understand that invariant.
+      - text: "nonpointerstructs: field VolumeAttachmentSpec.Source is a non-pointer struct with no required fields."
+        path: "staging/src/k8s.io/api/storage/(v1|v1alpha1|v1beta1)/types.go"
 
       - linters:
         - forbidigo

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -247,7 +247,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -290,6 +290,10 @@ linters:
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
       - text: "optionalfields: field Eviction.Status should be a pointer."
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
+      # VolumeAttachmentSpec.Source is a union type. Validation requires one of its child fields to be set,
+      # but nonpointerstructs does not understand that invariant.
+      - text: "nonpointerstructs: field VolumeAttachmentSpec.Source is a non-pointer struct with no required fields."
+        path: "staging/src/k8s.io/api/storage/(v1|v1alpha1|v1beta1)/types.go"
 
       - linters:
         - forbidigo

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -256,7 +256,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -304,6 +304,10 @@ linters:
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
       - text: "optionalfields: field Eviction.Status should be a pointer."
         path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
+      # VolumeAttachmentSpec.Source is a union type. Validation requires one of its child fields to be set,
+      # but nonpointerstructs does not understand that invariant.
+      - text: "nonpointerstructs: field VolumeAttachmentSpec.Source is a non-pointer struct with no required fields."
+        path: "staging/src/k8s.io/api/storage/(v1|v1alpha1|v1beta1)/types.go"
 
       - linters:
         - forbidigo

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -108,7 +108,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -151,3 +151,7 @@
   path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
 - text: "optionalfields: field Eviction.Status should be a pointer."
   path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
+# VolumeAttachmentSpec.Source is a union type. Validation requires one of its child fields to be set,
+# but nonpointerstructs does not understand that invariant.
+- text: "nonpointerstructs: field VolumeAttachmentSpec.Source is a non-pointer struct with no required fields."
+  path: "staging/src/k8s.io/api/storage/(v1|v1alpha1|v1beta1)/types.go"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -117,7 +117,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -165,3 +165,7 @@
   path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
 - text: "optionalfields: field Eviction.Status should be a pointer."
   path: "staging/src/k8s.io/api/lifecycle/v1alpha1/types.go"
+# VolumeAttachmentSpec.Source is a union type. Validation requires one of its child fields to be set,
+# but nonpointerstructs does not understand that invariant.
+- text: "nonpointerstructs: field VolumeAttachmentSpec.Source is a non-pointer struct with no required fields."
+  path: "staging/src/k8s.io/api/storage/(v1|v1alpha1|v1beta1)/types.go"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -59153,7 +59153,6 @@ func schema_k8sio_api_storage_v1_CSIDriver(ref common.ReferenceCallback) common.
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -59369,7 +59368,6 @@ func schema_k8sio_api_storage_v1_CSINode(ref common.ReferenceCallback) common.Op
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -59515,7 +59513,6 @@ func schema_k8sio_api_storage_v1_CSINodeSpec(ref common.ReferenceCallback) commo
 						},
 					},
 				},
-				Required: []string{"drivers"},
 			},
 		},
 		Dependencies: []string{
@@ -59971,7 +59968,6 @@ func schema_k8sio_api_storage_v1_TokenRequest(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"audience"},
 			},
 		},
 	}
@@ -60188,7 +60184,6 @@ func schema_k8sio_api_storage_v1_VolumeAttachmentStatus(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"attached"},
 			},
 		},
 		Dependencies: []string{
@@ -60248,7 +60243,7 @@ func schema_k8sio_api_storage_v1_VolumeAttributesClass(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"driverName"},
+				Required: []string{"driverName", "parameters"},
 			},
 		},
 		Dependencies: []string{
@@ -60685,7 +60680,6 @@ func schema_k8sio_api_storage_v1alpha1_VolumeAttachmentStatus(ref common.Referen
 						},
 					},
 				},
-				Required: []string{"attached"},
 			},
 		},
 		Dependencies: []string{
@@ -60745,7 +60739,7 @@ func schema_k8sio_api_storage_v1alpha1_VolumeAttributesClass(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"driverName"},
+				Required: []string{"driverName", "parameters"},
 			},
 		},
 		Dependencies: []string{
@@ -60874,7 +60868,6 @@ func schema_k8sio_api_storage_v1beta1_CSIDriver(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -61090,7 +61083,6 @@ func schema_k8sio_api_storage_v1beta1_CSINode(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -61236,7 +61228,6 @@ func schema_k8sio_api_storage_v1beta1_CSINodeSpec(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				Required: []string{"drivers"},
 			},
 		},
 		Dependencies: []string{
@@ -61691,7 +61682,6 @@ func schema_k8sio_api_storage_v1beta1_TokenRequest(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"audience"},
 			},
 		},
 	}
@@ -61908,7 +61898,6 @@ func schema_k8sio_api_storage_v1beta1_VolumeAttachmentStatus(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"attached"},
 			},
 		},
 		Dependencies: []string{
@@ -61968,7 +61957,7 @@ func schema_k8sio_api_storage_v1beta1_VolumeAttributesClass(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"driverName"},
+				Required: []string{"driverName", "parameters"},
 			},
 		},
 		Dependencies: []string{
@@ -62124,6 +62113,7 @@ func schema_k8sio_api_storagemigration_v1_StorageVersionMigration(ref common.Ref
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -62292,6 +62282,7 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigration(ref commo
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -59546,7 +59546,6 @@ func schema_k8sio_api_storage_v1_CSIDriver(ref common.ReferenceCallback) common.
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -59762,7 +59761,6 @@ func schema_k8sio_api_storage_v1_CSINode(ref common.ReferenceCallback) common.Op
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -59908,7 +59906,6 @@ func schema_k8sio_api_storage_v1_CSINodeSpec(ref common.ReferenceCallback) commo
 						},
 					},
 				},
-				Required: []string{"drivers"},
 			},
 		},
 		Dependencies: []string{
@@ -60364,7 +60361,6 @@ func schema_k8sio_api_storage_v1_TokenRequest(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"audience"},
 			},
 		},
 	}
@@ -60581,7 +60577,6 @@ func schema_k8sio_api_storage_v1_VolumeAttachmentStatus(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"attached"},
 			},
 		},
 		Dependencies: []string{
@@ -60641,7 +60636,7 @@ func schema_k8sio_api_storage_v1_VolumeAttributesClass(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"driverName"},
+				Required: []string{"driverName", "parameters"},
 			},
 		},
 		Dependencies: []string{
@@ -61078,7 +61073,6 @@ func schema_k8sio_api_storage_v1alpha1_VolumeAttachmentStatus(ref common.Referen
 						},
 					},
 				},
-				Required: []string{"attached"},
 			},
 		},
 		Dependencies: []string{
@@ -61138,7 +61132,7 @@ func schema_k8sio_api_storage_v1alpha1_VolumeAttributesClass(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"driverName"},
+				Required: []string{"driverName", "parameters"},
 			},
 		},
 		Dependencies: []string{
@@ -61267,7 +61261,6 @@ func schema_k8sio_api_storage_v1beta1_CSIDriver(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -61483,7 +61476,6 @@ func schema_k8sio_api_storage_v1beta1_CSINode(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -61629,7 +61621,6 @@ func schema_k8sio_api_storage_v1beta1_CSINodeSpec(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				Required: []string{"drivers"},
 			},
 		},
 		Dependencies: []string{
@@ -62084,7 +62075,6 @@ func schema_k8sio_api_storage_v1beta1_TokenRequest(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"audience"},
 			},
 		},
 	}
@@ -62301,7 +62291,6 @@ func schema_k8sio_api_storage_v1beta1_VolumeAttachmentStatus(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"attached"},
 			},
 		},
 		Dependencies: []string{
@@ -62361,7 +62350,7 @@ func schema_k8sio_api_storage_v1beta1_VolumeAttributesClass(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"driverName"},
+				Required: []string{"driverName", "parameters"},
 			},
 		},
 		Dependencies: []string{
@@ -62517,6 +62506,7 @@ func schema_k8sio_api_storagemigration_v1_StorageVersionMigration(ref common.Ref
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -62685,6 +62675,7 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigration(ref commo
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -44,9 +44,11 @@ message CSIDriver {
   // an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and
   // alphanumerics between.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec represents the specification of the CSI Driver.
+  // +optional
   optional CSIDriverSpec spec = 2;
 }
 
@@ -286,9 +288,11 @@ message CSIDriverSpec {
 message CSINode {
   // metadata is the standard object metadata.
   // metadata.name must be the Kubernetes node name.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the specification of CSINode
+  // +optional
   optional CSINodeSpec spec = 2;
 
   // status contains health and status information for the node's storage.
@@ -301,6 +305,7 @@ message CSINodeDriver {
   // name represents the name of the CSI driver that this object refers to.
   // This MUST be the same name returned by the CSI GetPluginName() call for
   // that driver.
+  // +required
   optional string name = 1;
 
   // nodeID of the node from the driver point of view.
@@ -311,6 +316,7 @@ message CSINodeDriver {
   // system to attach a volume to a specific node, it can use this field to
   // refer to the node name using the ID that the storage system will
   // understand, e.g. "nodeA" instead of "node1". This field is required.
+  // +required
   optional string nodeID = 2;
 
   // topologyKeys is the list of keys supported by the driver.
@@ -353,6 +359,7 @@ message CSINodeSpec {
   // +patchStrategy=merge
   // +listType=map
   // +listMapKey=name
+  // +optional
   repeated CSINodeDriver drivers = 1;
 }
 
@@ -420,6 +427,7 @@ message CSIStorageCapacity {
   // the CSIStorageCapacity object is obsolete and should be removed by its
   // creator.
   // This field is immutable.
+  // +required
   optional string storageClassName = 3;
 
   // capacity is the value reported by the CSI driver in its GetCapacityResponse
@@ -578,6 +586,7 @@ message StorageHealthCondition {
 message TokenRequest {
   // audience is the intended audience of the token in "TokenRequestSpec".
   // It will default to the audiences of kube apiserver.
+  // +optional
   optional string audience = 1;
 
   // expirationSeconds is the duration of validity of the token in "TokenRequestSpec".
@@ -651,9 +660,11 @@ message VolumeAttachmentSpec {
   optional string attacher = 1;
 
   // source represents the volume that should be attached.
+  // +required
   optional VolumeAttachmentSource source = 2;
 
   // nodeName represents the node that the volume should be attached to.
+  // +required
   optional string nodeName = 3;
 }
 
@@ -662,6 +673,7 @@ message VolumeAttachmentStatus {
   // attached indicates the volume is successfully attached.
   // This field must only be set by the entity completing the attach
   // operation, i.e. the external-attacher.
+  // +optional
   optional bool attached = 1;
 
   // attachmentMetadata is populated with any
@@ -696,6 +708,7 @@ message VolumeAttributesClass {
 
   // driverName is the name of the CSI driver
   // This field is immutable.
+  // +required
   optional string driverName = 2;
 
   // parameters hold volume attributes defined by the CSI driver. These values
@@ -711,6 +724,7 @@ message VolumeAttributesClass {
   // a cumulative max size of 256K. If the CSI driver rejects invalid parameters,
   // the target PersistentVolumeClaim will be set to an "Infeasible" state in the
   // modifyVolumeStatus field.
+  // +required
   map<string, string> parameters = 3;
 }
 

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -178,9 +178,11 @@ type VolumeAttachmentSpec struct {
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.
+	// +required
 	Source VolumeAttachmentSource `json:"source" protobuf:"bytes,2,opt,name=source"`
 
 	// nodeName represents the node that the volume should be attached to.
+	// +required
 	NodeName string `json:"nodeName" protobuf:"bytes,3,opt,name=nodeName"`
 }
 
@@ -208,6 +210,7 @@ type VolumeAttachmentStatus struct {
 	// attached indicates the volume is successfully attached.
 	// This field must only be set by the entity completing the attach
 	// operation, i.e. the external-attacher.
+	// +optional
 	Attached bool `json:"attached" protobuf:"varint,1,opt,name=attached"`
 
 	// attachmentMetadata is populated with any
@@ -273,9 +276,11 @@ type CSIDriver struct {
 	// an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and
 	// alphanumerics between.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec represents the specification of the CSI Driver.
+	// +optional
 	Spec CSIDriverSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -548,6 +553,7 @@ type VolumeLifecycleMode string
 type TokenRequest struct {
 	// audience is the intended audience of the token in "TokenRequestSpec".
 	// It will default to the audiences of kube apiserver.
+	// +optional
 	Audience string `json:"audience" protobuf:"bytes,1,opt,name=audience"`
 
 	// expirationSeconds is the duration of validity of the token in "TokenRequestSpec".
@@ -598,9 +604,11 @@ type CSINode struct {
 
 	// metadata is the standard object metadata.
 	// metadata.name must be the Kubernetes node name.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec is the specification of CSINode
+	// +optional
 	Spec CSINodeSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status contains health and status information for the node's storage.
@@ -616,6 +624,7 @@ type CSINodeSpec struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=name
+	// +optional
 	Drivers []CSINodeDriver `json:"drivers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,1,rep,name=drivers"`
 }
 
@@ -624,6 +633,7 @@ type CSINodeDriver struct {
 	// name represents the name of the CSI driver that this object refers to.
 	// This MUST be the same name returned by the CSI GetPluginName() call for
 	// that driver.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// nodeID of the node from the driver point of view.
@@ -634,6 +644,7 @@ type CSINodeDriver struct {
 	// system to attach a volume to a specific node, it can use this field to
 	// refer to the node name using the ID that the storage system will
 	// understand, e.g. "nodeA" instead of "node1". This field is required.
+	// +required
 	NodeID string `json:"nodeID" protobuf:"bytes,2,opt,name=nodeID"`
 
 	// topologyKeys is the list of keys supported by the driver.
@@ -802,6 +813,7 @@ type CSIStorageCapacity struct {
 	// the CSIStorageCapacity object is obsolete and should be removed by its
 	// creator.
 	// This field is immutable.
+	// +required
 	StorageClassName string `json:"storageClassName" protobuf:"bytes,3,name=storageClassName"`
 
 	// capacity is the value reported by the CSI driver in its GetCapacityResponse
@@ -865,6 +877,7 @@ type VolumeAttributesClass struct {
 
 	// driverName is the name of the CSI driver
 	// This field is immutable.
+	// +required
 	DriverName string `json:"driverName" protobuf:"bytes,2,opt,name=driverName"`
 
 	// parameters hold volume attributes defined by the CSI driver. These values
@@ -880,6 +893,7 @@ type VolumeAttributesClass struct {
 	// a cumulative max size of 256K. If the CSI driver rejects invalid parameters,
 	// the target PersistentVolumeClaim will be set to an "Infeasible" state in the
 	// modifyVolumeStatus field.
+	// +required
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 }
 

--- a/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
@@ -82,6 +82,7 @@ message CSIStorageCapacity {
   // the CSIStorageCapacity object is obsolete and should be removed by its
   // creator.
   // This field is immutable.
+  // +required
   optional string storageClassName = 3;
 
   // capacity is the value reported by the CSI driver in its GetCapacityResponse
@@ -186,9 +187,11 @@ message VolumeAttachmentSpec {
   optional string attacher = 1;
 
   // source represents the volume that should be attached.
+  // +required
   optional VolumeAttachmentSource source = 2;
 
   // nodeName represents the node that the volume should be attached to.
+  // +required
   optional string nodeName = 3;
 }
 
@@ -197,6 +200,7 @@ message VolumeAttachmentStatus {
   // attached indicates the volume is successfully attached.
   // This field must only be set by the entity completing the attach
   // operation, i.e. the external-attacher.
+  // +optional
   optional bool attached = 1;
 
   // attachmentMetadata is populated with any
@@ -231,6 +235,7 @@ message VolumeAttributesClass {
 
   // driverName is the name of the CSI driver
   // This field is immutable.
+  // +required
   optional string driverName = 2;
 
   // parameters hold volume attributes defined by the CSI driver. These values
@@ -246,6 +251,7 @@ message VolumeAttributesClass {
   // a cumulative max size of 256K. If the CSI driver rejects invalid parameters,
   // the target PersistentVolumeClaim will be set to an "Infeasible" state in the
   // modifyVolumeStatus field.
+  // +required
   map<string, string> parameters = 3;
 }
 

--- a/staging/src/k8s.io/api/storage/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types.go
@@ -84,9 +84,11 @@ type VolumeAttachmentSpec struct {
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.
+	// +required
 	Source VolumeAttachmentSource `json:"source" protobuf:"bytes,2,opt,name=source"`
 
 	// nodeName represents the node that the volume should be attached to.
+	// +required
 	NodeName string `json:"nodeName" protobuf:"bytes,3,opt,name=nodeName"`
 }
 
@@ -114,6 +116,7 @@ type VolumeAttachmentStatus struct {
 	// attached indicates the volume is successfully attached.
 	// This field must only be set by the entity completing the attach
 	// operation, i.e. the external-attacher.
+	// +optional
 	Attached bool `json:"attached" protobuf:"varint,1,opt,name=attached"`
 
 	// attachmentMetadata is populated with any
@@ -218,6 +221,7 @@ type CSIStorageCapacity struct {
 	// the CSIStorageCapacity object is obsolete and should be removed by its
 	// creator.
 	// This field is immutable.
+	// +required
 	StorageClassName string `json:"storageClassName" protobuf:"bytes,3,name=storageClassName"`
 
 	// capacity is the value reported by the CSI driver in its GetCapacityResponse
@@ -285,6 +289,7 @@ type VolumeAttributesClass struct {
 
 	// driverName is the name of the CSI driver
 	// This field is immutable.
+	// +required
 	DriverName string `json:"driverName" protobuf:"bytes,2,opt,name=driverName"`
 
 	// parameters hold volume attributes defined by the CSI driver. These values
@@ -300,6 +305,7 @@ type VolumeAttributesClass struct {
 	// a cumulative max size of 256K. If the CSI driver rejects invalid parameters,
 	// the target PersistentVolumeClaim will be set to an "Infeasible" state in the
 	// modifyVolumeStatus field.
+	// +required
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 }
 

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -47,9 +47,11 @@ message CSIDriver {
   // an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and
   // alphanumerics between.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec represents the specification of the CSI Driver.
+  // +optional
   optional CSIDriverSpec spec = 2;
 }
 
@@ -290,9 +292,11 @@ message CSIDriverSpec {
 message CSINode {
   // metadata is the standard object metadata.
   // metadata.name must be the Kubernetes node name.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the specification of CSINode
+  // +optional
   optional CSINodeSpec spec = 2;
 
   // status contains health and status information for the node's storage.
@@ -305,6 +309,7 @@ message CSINodeDriver {
   // name represents the name of the CSI driver that this object refers to.
   // This MUST be the same name returned by the CSI GetPluginName() call for
   // that driver.
+  // +required
   optional string name = 1;
 
   // nodeID of the node from the driver point of view.
@@ -315,6 +320,7 @@ message CSINodeDriver {
   // system to attach a volume to a specific node, it can use this field to
   // refer to the node name using the ID that the storage system will
   // understand, e.g. "nodeA" instead of "node1". This field is required.
+  // +required
   optional string nodeID = 2;
 
   // topologyKeys is the list of keys supported by the driver.
@@ -356,6 +362,7 @@ message CSINodeSpec {
   // +patchStrategy=merge
   // +listType=map
   // +listMapKey=name
+  // +optional
   repeated CSINodeDriver drivers = 1;
 }
 
@@ -423,6 +430,7 @@ message CSIStorageCapacity {
   // the CSIStorageCapacity object is obsolete and should be removed by its
   // creator.
   // This field is immutable.
+  // +required
   optional string storageClassName = 3;
 
   // capacity is the value reported by the CSI driver in its GetCapacityResponse
@@ -581,6 +589,7 @@ message StorageHealthCondition {
 message TokenRequest {
   // audience is the intended audience of the token in "TokenRequestSpec".
   // It will default to the audiences of kube apiserver.
+  // +optional
   optional string audience = 1;
 
   // expirationSeconds is the duration of validity of the token in "TokenRequestSpec".
@@ -654,9 +663,11 @@ message VolumeAttachmentSpec {
   optional string attacher = 1;
 
   // source represents the volume that should be attached.
+  // +required
   optional VolumeAttachmentSource source = 2;
 
   // nodeName represents the node that the volume should be attached to.
+  // +required
   optional string nodeName = 3;
 }
 
@@ -665,6 +676,7 @@ message VolumeAttachmentStatus {
   // attached indicates the volume is successfully attached.
   // This field must only be set by the entity completing the attach
   // operation, i.e. the external-attacher.
+  // +optional
   optional bool attached = 1;
 
   // attachmentMetadata is populated with any
@@ -699,6 +711,7 @@ message VolumeAttributesClass {
 
   // driverName is the name of the CSI driver
   // This field is immutable.
+  // +required
   optional string driverName = 2;
 
   // parameters hold volume attributes defined by the CSI driver. These values
@@ -714,6 +727,7 @@ message VolumeAttributesClass {
   // a cumulative max size of 256K. If the CSI driver rejects invalid parameters,
   // the target PersistentVolumeClaim will be set to an "Infeasible" state in the
   // modifyVolumeStatus field.
+  // +required
   map<string, string> parameters = 3;
 }
 

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -185,9 +185,11 @@ type VolumeAttachmentSpec struct {
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.
+	// +required
 	Source VolumeAttachmentSource `json:"source" protobuf:"bytes,2,opt,name=source"`
 
 	// nodeName represents the node that the volume should be attached to.
+	// +required
 	NodeName string `json:"nodeName" protobuf:"bytes,3,opt,name=nodeName"`
 }
 
@@ -215,6 +217,7 @@ type VolumeAttachmentStatus struct {
 	// attached indicates the volume is successfully attached.
 	// This field must only be set by the entity completing the attach
 	// operation, i.e. the external-attacher.
+	// +optional
 	Attached bool `json:"attached" protobuf:"varint,1,opt,name=attached"`
 
 	// attachmentMetadata is populated with any
@@ -285,9 +288,11 @@ type CSIDriver struct {
 	// an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and
 	// alphanumerics between.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec represents the specification of the CSI Driver.
+	// +optional
 	Spec CSIDriverSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -556,6 +561,7 @@ type VolumeLifecycleMode string
 type TokenRequest struct {
 	// audience is the intended audience of the token in "TokenRequestSpec".
 	// It will default to the audiences of kube apiserver.
+	// +optional
 	Audience string `json:"audience" protobuf:"bytes,1,opt,name=audience"`
 
 	// expirationSeconds is the duration of validity of the token in "TokenRequestSpec".
@@ -611,9 +617,11 @@ type CSINode struct {
 
 	// metadata is the standard object metadata.
 	// metadata.name must be the Kubernetes node name.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec is the specification of CSINode
+	// +optional
 	Spec CSINodeSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status contains health and status information for the node's storage.
@@ -629,6 +637,7 @@ type CSINodeSpec struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=name
+	// +optional
 	Drivers []CSINodeDriver `json:"drivers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,1,rep,name=drivers"`
 }
 
@@ -637,6 +646,7 @@ type CSINodeDriver struct {
 	// name represents the name of the CSI driver that this object refers to.
 	// This MUST be the same name returned by the CSI GetPluginName() call for
 	// that driver.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// nodeID of the node from the driver point of view.
@@ -647,6 +657,7 @@ type CSINodeDriver struct {
 	// system to attach a volume to a specific node, it can use this field to
 	// refer to the node name using the ID that the storage system will
 	// understand, e.g. "nodeA" instead of "node1". This field is required.
+	// +required
 	NodeID string `json:"nodeID" protobuf:"bytes,2,opt,name=nodeID"`
 
 	// topologyKeys is the list of keys supported by the driver.
@@ -819,6 +830,7 @@ type CSIStorageCapacity struct {
 	// the CSIStorageCapacity object is obsolete and should be removed by its
 	// creator.
 	// This field is immutable.
+	// +required
 	StorageClassName string `json:"storageClassName" protobuf:"bytes,3,name=storageClassName"`
 
 	// capacity is the value reported by the CSI driver in its GetCapacityResponse
@@ -886,6 +898,7 @@ type VolumeAttributesClass struct {
 
 	// driverName is the name of the CSI driver
 	// This field is immutable.
+	// +required
 	DriverName string `json:"driverName" protobuf:"bytes,2,opt,name=driverName"`
 
 	// parameters hold volume attributes defined by the CSI driver. These values
@@ -901,6 +914,7 @@ type VolumeAttributesClass struct {
 	// a cumulative max size of 256K. If the CSI driver rejects invalid parameters,
 	// the target PersistentVolumeClaim will be set to an "Infeasible" state in the
 	// modifyVolumeStatus field.
+	// +required
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 }
 

--- a/staging/src/k8s.io/api/storagemigration/v1/generated.proto
+++ b/staging/src/k8s.io/api/storagemigration/v1/generated.proto
@@ -38,7 +38,7 @@ message StorageVersionMigration {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the migration.
-  // +optional
+  // +required
   optional StorageVersionMigrationSpec spec = 2;
 
   // Status of the migration.
@@ -62,6 +62,7 @@ message StorageVersionMigrationSpec {
   // The resource that is being migrated. The migrator sends requests to
   // the endpoint serving the resource.
   // Immutable.
+  // +required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupResource resource = 1;
 }
 
@@ -81,6 +82,7 @@ message StorageVersionMigrationStatus {
   // ResourceVersion to compare with the GC cache for performing the migration.
   // This is the current resource version of given group, version and resource when
   // kube-controller-manager first observes this StorageVersionMigration resource.
+  // +optional
   optional string resourceVersion = 2;
 }
 

--- a/staging/src/k8s.io/api/storagemigration/v1/types.go
+++ b/staging/src/k8s.io/api/storagemigration/v1/types.go
@@ -35,7 +35,7 @@ type StorageVersionMigration struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Specification of the migration.
-	// +optional
+	// +required
 	Spec StorageVersionMigrationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// Status of the migration.
 	// +optional
@@ -47,6 +47,7 @@ type StorageVersionMigrationSpec struct {
 	// The resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
+	// +required
 	Resource metav1.GroupResource `json:"resource" protobuf:"bytes,1,opt,name=resource"`
 }
 
@@ -76,6 +77,7 @@ type StorageVersionMigrationStatus struct {
 	// ResourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
+	// +optional
 	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,2,opt,name=resourceVersion"`
 }
 

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
@@ -38,7 +38,7 @@ message StorageVersionMigration {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the migration.
-  // +optional
+  // +required
   optional StorageVersionMigrationSpec spec = 2;
 
   // Status of the migration.
@@ -62,6 +62,7 @@ message StorageVersionMigrationSpec {
   // The resource that is being migrated. The migrator sends requests to
   // the endpoint serving the resource.
   // Immutable.
+  // +required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupResource resource = 1;
 }
 
@@ -81,6 +82,7 @@ message StorageVersionMigrationStatus {
   // ResourceVersion to compare with the GC cache for performing the migration.
   // This is the current resource version of given group, version and resource when
   // kube-controller-manager first observes this StorageVersionMigration resource.
+  // +optional
   optional string resourceVersion = 2;
 }
 

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
@@ -37,7 +37,7 @@ type StorageVersionMigration struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Specification of the migration.
-	// +optional
+	// +required
 	Spec StorageVersionMigrationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// Status of the migration.
 	// +optional
@@ -49,6 +49,7 @@ type StorageVersionMigrationSpec struct {
 	// The resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
+	// +required
 	Resource metav1.GroupResource `json:"resource" protobuf:"bytes,1,opt,name=resource"`
 }
 
@@ -78,6 +79,7 @@ type StorageVersionMigrationStatus struct {
 	// ResourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
+	// +optional
 	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,2,opt,name=resourceVersion"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds missing +optional / +required tags in storage API types (v1, v1beta1, v1alpha1).
#### Which issue(s) this PR is related to:

Part of #134671

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```