### PR TITLE
pkg/volume/csi, wait: Remove deprecated NewExponentialBackoffManager

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -45,12 +45,27 @@ import (
 
 const globalMountInGlobalPath = "globalmount"
 
+var (
+	// Backoff parameters for waiting for volume attach/detach.
+	// This is approximately the duration between consecutive ticks after two minutes (CSI timeout).
+	defaultAttachDetachBackoffInit   = 500 * time.Millisecond
+	defaultAttachDetachBackoffMax    = 7 * time.Second
+	defaultAttachDetachBackoffReset  = time.Minute
+	defaultAttachDetachBackoffFactor = 1.05
+	defaultAttachDetachBackoffJitter = 0.1
+)
+
 type csiAttacher struct {
 	plugin       *csiPlugin
 	k8s          kubernetes.Interface
 	watchTimeout time.Duration
 
 	csiClient csiClient
+
+	// backoff is the backoff configuration for waiting on volume attach/detach.
+	backoff *wait.Backoff
+	// clock is used for backoff timing.
+	clock clock.Clock
 }
 
 // volume.Attacher methods
@@ -483,16 +498,7 @@ func (c *csiAttacher) waitForVolumeDetachmentWithLister(volumeHandle, attachID s
 }
 
 func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spec, volumeHandle, attachID string, timeout time.Duration, verifyStatus func() (bool, error), operation string) error {
-	var (
-		initBackoff = 500 * time.Millisecond
-		// This is approximately the duration between consecutive ticks after two minutes (CSI timeout).
-		maxBackoff    = 7 * time.Second
-		resetDuration = time.Minute
-		backoffFactor = 1.05
-		jitter        = 0.1
-		clock         = &clock.RealClock{}
-	)
-	backoffMgr := wait.NewExponentialBackoffManager(initBackoff, maxBackoff, resetDuration, backoffFactor, jitter, clock)
+	delayFunc := c.backoff.DelayWithReset(c.clock, defaultAttachDetachBackoffReset)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -505,9 +511,8 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 	}
 
 	for {
-		t := backoffMgr.Backoff()
 		select {
-		case <-t.C():
+		case <-c.clock.After(delayFunc()):
 			successful, err := verifyStatus()
 			if err != nil {
 				return err
@@ -516,7 +521,6 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 				return nil
 			}
 		case <-ctx.Done():
-			t.Stop()
 			klog.Error(log("%s timeout after %v [volume=%v; attachment.ID=%v]", operation, timeout, volumeHandle, attachID))
 			return fmt.Errorf("timed out waiting for external-attacher of %v CSI driver to %v volume %v", csiDriverName, strings.ToLower(operation), volumeHandle)
 		}

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"math"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -35,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
@@ -123,6 +125,7 @@ func TestAttacherAttach(t *testing.T) {
 		injectAttacherError bool
 		shouldFail          bool
 		watchTimeout        time.Duration
+		backoff             *wait.Backoff
 	}{
 		{
 			name:       "test ok 1",
@@ -131,6 +134,21 @@ func TestAttacherAttach(t *testing.T) {
 			volumeName: "testvol-01",
 			attachID:   getAttachmentName("testvol-01", "testdriver-01", "testnode-01"),
 			spec:       volume.NewSpecFromPersistentVolume(makeTestPV("pv01", 10, "testdriver-01", "testvol-01"), false),
+		},
+		{
+			name:       "test ok with custom backoff",
+			nodeName:   "testnode-01",
+			driverName: "testdriver-01",
+			volumeName: "testvol-01",
+			attachID:   getAttachmentName("testvol-01", "testdriver-01", "testnode-01"),
+			spec:       volume.NewSpecFromPersistentVolume(makeTestPV("pv01", 10, "testdriver-01", "testvol-01"), false),
+			backoff: &wait.Backoff{
+				Duration: 10 * time.Millisecond,
+				Factor:   2.0,
+				Jitter:   0,
+				Steps:    math.MaxInt32,
+				Cap:      100 * time.Millisecond,
+			},
 		},
 		{
 			name:       "test ok 2",
@@ -213,6 +231,9 @@ func TestAttacherAttach(t *testing.T) {
 			}
 
 			csiAttacher := getCsiAttacherFromVolumeAttacher(attacher, tc.watchTimeout)
+			if tc.backoff != nil {
+				csiAttacher.backoff = tc.backoff
+			}
 
 			var wg sync.WaitGroup
 			wg.Add(1)

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +28,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	api "k8s.io/api/core/v1"
@@ -937,6 +939,14 @@ func (p *csiPlugin) newAttacherDetacher() (*csiAttacher, error) {
 		plugin:       p,
 		k8s:          k8s,
 		watchTimeout: csiTimeout,
+		backoff: &wait.Backoff{
+			Duration: defaultAttachDetachBackoffInit,
+			Cap:      defaultAttachDetachBackoffMax,
+			Steps:    math.MaxInt32,
+			Factor:   defaultAttachDetachBackoffFactor,
+			Jitter:   defaultAttachDetachBackoffJitter,
+		},
+		clock: &clock.RealClock{},
 	}, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the last usage of the deprecated `wait.NewExponentialBackoffManager` from `csi_attacher.go` and removes the function itself from the wait package.

This replaces it with `wait.Backoff{}.DelayWithReset()`, following the same pattern used in #136824 for the client-go reflector.

#### Which issue(s) this PR is related to:

Fixes #137068

#### Special notes for your reviewer:

Changes:
- `pkg/volume/csi/csi_attacher.go`: Add `backoff` and `clock` fields to `csiAttacher` struct, use `wait.Backoff{}.DelayWithReset()` instead of `NewExponentialBackoffManager`
- `pkg/volume/csi/csi_plugin.go`: Initialize `backoff` and `clock` fields in `newAttacherDetacher()`
- `pkg/volume/csi/csi_attacher_test.go`: Add test case with custom backoff to verify the new fields work correctly
- `staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go`: Remove `NewExponentialBackoffManager`, `exponentialBackoffManagerImpl` struct, and related methods
- `staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go`: Remove tests for the removed function

This follows the migration pattern documented in the deprecation notice and demonstrated in #136824.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```

/sig storage