### PR TITLE
Enable the optionalorrequired linter for the apidiscovery API group

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -163,7 +163,7 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
       
       # optionalfields - Ignore existing issues for apiserverinternal API group
       - text: "optionalfields: field StorageVersionCondition.(ObservedGeneration|LastTransitionTime) should be a pointer."

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -231,7 +231,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -246,7 +246,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -178,7 +178,7 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
       
       # optionalfields - Ignore existing issues for apiserverinternal API group
       - text: "optionalfields: field StorageVersionCondition.(ObservedGeneration|LastTransitionTime) should be a pointer."

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -39,7 +39,7 @@
 # optionalfields - Ignore optionalfields issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-  path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
 
 # optionalfields - Ignore existing issues for apiserverinternal API group
 - text: "optionalfields: field StorageVersionCondition.(ObservedGeneration|LastTransitionTime) should be a pointer."

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -107,7 +107,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -6797,7 +6797,6 @@ func schema_k8sio_api_apidiscovery_v2_APIGroupDiscoveryList(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"items"},
 			},
 		},
 		Dependencies: []string{
@@ -6921,7 +6920,6 @@ func schema_k8sio_api_apidiscovery_v2_APIResourceDiscovery(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"resource", "scope", "singularResource", "verbs"},
 			},
 		},
 		Dependencies: []string{
@@ -6993,7 +6991,6 @@ func schema_k8sio_api_apidiscovery_v2_APISubresourceDiscovery(ref common.Referen
 						},
 					},
 				},
-				Required: []string{"subresource", "verbs"},
 			},
 		},
 		Dependencies: []string{
@@ -7045,7 +7042,6 @@ func schema_k8sio_api_apidiscovery_v2_APIVersionDiscovery(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"version"},
 			},
 		},
 		Dependencies: []string{
@@ -7152,7 +7148,6 @@ func schema_k8sio_api_apidiscovery_v2beta1_APIGroupDiscoveryList(ref common.Refe
 						},
 					},
 				},
-				Required: []string{"items"},
 			},
 		},
 		Dependencies: []string{
@@ -7276,7 +7271,6 @@ func schema_k8sio_api_apidiscovery_v2beta1_APIResourceDiscovery(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"resource", "scope", "singularResource", "verbs"},
 			},
 		},
 		Dependencies: []string{
@@ -7348,7 +7342,6 @@ func schema_k8sio_api_apidiscovery_v2beta1_APISubresourceDiscovery(ref common.Re
 						},
 					},
 				},
-				Required: []string{"subresource", "verbs"},
 			},
 		},
 		Dependencies: []string{
@@ -7400,7 +7393,6 @@ func schema_k8sio_api_apidiscovery_v2beta1_APIVersionDiscovery(ref common.Refere
 						},
 					},
 				},
-				Required: []string{"version"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/apidiscovery/v2/generated.proto
+++ b/staging/src/k8s.io/api/apidiscovery/v2/generated.proto
@@ -44,6 +44,7 @@ message APIGroupDiscovery {
   // with the preferred version being the first entry.
   // +listType=map
   // +listMapKey=version
+  // +optional
   repeated APIVersionDiscovery versions = 2;
 }
 
@@ -67,40 +68,48 @@ message APIResourceDiscovery {
   // for this resource across all versions in the API group.
   // Resources with non-empty groups are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>
   // Resources with empty groups are located at /api/v1/<APIResourceDiscovery.Resource>
+  // +required
   optional string resource = 1;
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
   // APIs may return other objects types at their discretion, such as error conditions, requests for alternate representations, or other operation specific behavior.
   // This value will be null or empty if an APIService reports subresources but supports no operations on the parent resource
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // scope indicates the scope of a resource, either Cluster or Namespaced
+  // +required
   optional string scope = 3;
 
   // singularResource is the singular name of the resource.  This allows clients to handle plural and singular opaquely.
   // For many clients the singular form of the resource will be more understandable to users reading messages and should be used when integrating the name of the resource into a sentence.
   // The command line tool kubectl, for example, allows use of the singular resource name in place of plurals.
   // The singular form of a resource should always be an optional element - when in doubt use the canonical resource name.
+  // +required
   optional string singularResource = 4;
 
   // verbs is a list of supported API operation types (this includes
   // but is not limited to get, list, watch, create, update, patch,
   // delete, deletecollection, and proxy).
   // +listType=set
+  // +required
   repeated string verbs = 5;
 
   // shortNames is a list of suggested short names of the resource.
   // +listType=set
+  // +optional
   repeated string shortNames = 6;
 
   // categories is a list of the grouped resources this resource belongs to (e.g. 'all').
   // Clients may use this to simplify acting on multiple resource types at once.
   // +listType=set
+  // +optional
   repeated string categories = 7;
 
   // subresources is a list of subresources provided by this resource. Subresources are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>/name-of-instance/<APIResourceDiscovery.subresources[i].subresource>
   // +listType=map
   // +listMapKey=subresource
+  // +optional
   repeated APISubresourceDiscovery subresources = 8;
 }
 
@@ -108,10 +117,12 @@ message APIResourceDiscovery {
 message APISubresourceDiscovery {
   // subresource is the name of the subresource.  This is used in the URL path and is the unique identifier
   // for this resource across all versions.
+  // +required
   optional string subresource = 1;
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
   // Some subresources do not return normal resources, these will have null or empty return types.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // acceptedTypes describes the kinds that this endpoint accepts.
@@ -122,6 +133,7 @@ message APISubresourceDiscovery {
   // +listMapKey=group
   // +listMapKey=version
   // +listMapKey=kind
+  // +optional
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind acceptedTypes = 3;
 
   // verbs is a list of supported API operation types (this includes
@@ -131,17 +143,20 @@ message APISubresourceDiscovery {
   // should expect the behavior of standard verbs to align with
   // Kubernetes interaction conventions.
   // +listType=set
+  // +required
   repeated string verbs = 4;
 }
 
 // APIVersionDiscovery holds a list of APIResourceDiscovery types that are served for a particular version within an API Group.
 message APIVersionDiscovery {
   // version is the name of the version within a group version.
+  // +required
   optional string version = 1;
 
   // resources is a list of APIResourceDiscovery objects for the corresponding group version.
   // +listType=map
   // +listMapKey=resource
+  // +optional
   repeated APIResourceDiscovery resources = 2;
 
   // freshness marks whether a group version's discovery document is up to date.
@@ -151,6 +166,7 @@ message APIVersionDiscovery {
   // significantly out of date. Clients that require the latest
   // version of the discovery information be retrieved before
   // performing an operation should not use the aggregated document
+  // +optional
   optional string freshness = 3;
 }
 

--- a/staging/src/k8s.io/api/apidiscovery/v2/generated.proto
+++ b/staging/src/k8s.io/api/apidiscovery/v2/generated.proto
@@ -59,6 +59,7 @@ message APIGroupDiscoveryList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of groups for discovery. The groups are listed in priority order.
+  // +optional
   repeated APIGroupDiscovery items = 2;
 }
 
@@ -68,7 +69,7 @@ message APIResourceDiscovery {
   // for this resource across all versions in the API group.
   // Resources with non-empty groups are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>
   // Resources with empty groups are located at /api/v1/<APIResourceDiscovery.Resource>
-  // +required
+  // +optional
   optional string resource = 1;
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
@@ -78,21 +79,21 @@ message APIResourceDiscovery {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // scope indicates the scope of a resource, either Cluster or Namespaced
-  // +required
+  // +optional
   optional string scope = 3;
 
   // singularResource is the singular name of the resource.  This allows clients to handle plural and singular opaquely.
   // For many clients the singular form of the resource will be more understandable to users reading messages and should be used when integrating the name of the resource into a sentence.
   // The command line tool kubectl, for example, allows use of the singular resource name in place of plurals.
   // The singular form of a resource should always be an optional element - when in doubt use the canonical resource name.
-  // +required
+  // +optional
   optional string singularResource = 4;
 
   // verbs is a list of supported API operation types (this includes
   // but is not limited to get, list, watch, create, update, patch,
   // delete, deletecollection, and proxy).
   // +listType=set
-  // +required
+  // +optional
   repeated string verbs = 5;
 
   // shortNames is a list of suggested short names of the resource.
@@ -117,7 +118,7 @@ message APIResourceDiscovery {
 message APISubresourceDiscovery {
   // subresource is the name of the subresource.  This is used in the URL path and is the unique identifier
   // for this resource across all versions.
-  // +required
+  // +optional
   optional string subresource = 1;
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
@@ -143,14 +144,14 @@ message APISubresourceDiscovery {
   // should expect the behavior of standard verbs to align with
   // Kubernetes interaction conventions.
   // +listType=set
-  // +required
+  // +optional
   repeated string verbs = 4;
 }
 
 // APIVersionDiscovery holds a list of APIResourceDiscovery types that are served for a particular version within an API Group.
 message APIVersionDiscovery {
   // version is the name of the version within a group version.
-  // +required
+  // +optional
   optional string version = 1;
 
   // resources is a list of APIResourceDiscovery objects for the corresponding group version.

--- a/staging/src/k8s.io/api/apidiscovery/v2/types.go
+++ b/staging/src/k8s.io/api/apidiscovery/v2/types.go
@@ -34,6 +34,7 @@ type APIGroupDiscoveryList struct {
 	// +optional
 	v1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// items is the list of groups for discovery. The groups are listed in priority order.
+	// +optional
 	Items []APIGroupDiscovery `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -63,7 +64,7 @@ type APIGroupDiscovery struct {
 // APIVersionDiscovery holds a list of APIResourceDiscovery types that are served for a particular version within an API Group.
 type APIVersionDiscovery struct {
 	// version is the name of the version within a group version.
-	// +required
+	// +optional
 	Version string `json:"version" protobuf:"bytes,1,opt,name=version"`
 	// resources is a list of APIResourceDiscovery objects for the corresponding group version.
 	// +listType=map
@@ -87,7 +88,7 @@ type APIResourceDiscovery struct {
 	// for this resource across all versions in the API group.
 	// Resources with non-empty groups are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>
 	// Resources with empty groups are located at /api/v1/<APIResourceDiscovery.Resource>
-	// +required
+	// +optional
 	Resource string `json:"resource" protobuf:"bytes,1,opt,name=resource"`
 	// responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
 	// APIs may return other objects types at their discretion, such as error conditions, requests for alternate representations, or other operation specific behavior.
@@ -95,19 +96,19 @@ type APIResourceDiscovery struct {
 	// +optional
 	ResponseKind *v1.GroupVersionKind `json:"responseKind,omitempty" protobuf:"bytes,2,opt,name=responseKind"`
 	// scope indicates the scope of a resource, either Cluster or Namespaced
-	// +required
+	// +optional
 	Scope ResourceScope `json:"scope" protobuf:"bytes,3,opt,name=scope"`
 	// singularResource is the singular name of the resource.  This allows clients to handle plural and singular opaquely.
 	// For many clients the singular form of the resource will be more understandable to users reading messages and should be used when integrating the name of the resource into a sentence.
 	// The command line tool kubectl, for example, allows use of the singular resource name in place of plurals.
 	// The singular form of a resource should always be an optional element - when in doubt use the canonical resource name.
-	// +required
+	// +optional
 	SingularResource string `json:"singularResource" protobuf:"bytes,4,opt,name=singularResource"`
 	// verbs is a list of supported API operation types (this includes
 	// but is not limited to get, list, watch, create, update, patch,
 	// delete, deletecollection, and proxy).
 	// +listType=set
-	// +required
+	// +optional
 	Verbs []string `json:"verbs" protobuf:"bytes,5,opt,name=verbs"`
 	// shortNames is a list of suggested short names of the resource.
 	// +listType=set
@@ -145,7 +146,7 @@ const (
 type APISubresourceDiscovery struct {
 	// subresource is the name of the subresource.  This is used in the URL path and is the unique identifier
 	// for this resource across all versions.
-	// +required
+	// +optional
 	Subresource string `json:"subresource" protobuf:"bytes,1,opt,name=subresource"`
 	// responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
 	// Some subresources do not return normal resources, these will have null or empty return types.
@@ -168,6 +169,6 @@ type APISubresourceDiscovery struct {
 	// should expect the behavior of standard verbs to align with
 	// Kubernetes interaction conventions.
 	// +listType=set
-	// +required
+	// +optional
 	Verbs []string `json:"verbs" protobuf:"bytes,4,opt,name=verbs"`
 }

--- a/staging/src/k8s.io/api/apidiscovery/v2/types.go
+++ b/staging/src/k8s.io/api/apidiscovery/v2/types.go
@@ -56,16 +56,19 @@ type APIGroupDiscovery struct {
 	// with the preferred version being the first entry.
 	// +listType=map
 	// +listMapKey=version
+	// +optional
 	Versions []APIVersionDiscovery `json:"versions,omitempty" protobuf:"bytes,2,rep,name=versions"`
 }
 
 // APIVersionDiscovery holds a list of APIResourceDiscovery types that are served for a particular version within an API Group.
 type APIVersionDiscovery struct {
 	// version is the name of the version within a group version.
+	// +required
 	Version string `json:"version" protobuf:"bytes,1,opt,name=version"`
 	// resources is a list of APIResourceDiscovery objects for the corresponding group version.
 	// +listType=map
 	// +listMapKey=resource
+	// +optional
 	Resources []APIResourceDiscovery `json:"resources,omitempty" protobuf:"bytes,2,rep,name=resources"`
 	// freshness marks whether a group version's discovery document is up to date.
 	// "Current" indicates the discovery document was recently
@@ -74,6 +77,7 @@ type APIVersionDiscovery struct {
 	// significantly out of date. Clients that require the latest
 	// version of the discovery information be retrieved before
 	// performing an operation should not use the aggregated document
+	// +optional
 	Freshness DiscoveryFreshness `json:"freshness,omitempty" protobuf:"bytes,3,opt,name=freshness"`
 }
 
@@ -83,33 +87,41 @@ type APIResourceDiscovery struct {
 	// for this resource across all versions in the API group.
 	// Resources with non-empty groups are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>
 	// Resources with empty groups are located at /api/v1/<APIResourceDiscovery.Resource>
+	// +required
 	Resource string `json:"resource" protobuf:"bytes,1,opt,name=resource"`
 	// responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
 	// APIs may return other objects types at their discretion, such as error conditions, requests for alternate representations, or other operation specific behavior.
 	// This value will be null or empty if an APIService reports subresources but supports no operations on the parent resource
+	// +optional
 	ResponseKind *v1.GroupVersionKind `json:"responseKind,omitempty" protobuf:"bytes,2,opt,name=responseKind"`
 	// scope indicates the scope of a resource, either Cluster or Namespaced
+	// +required
 	Scope ResourceScope `json:"scope" protobuf:"bytes,3,opt,name=scope"`
 	// singularResource is the singular name of the resource.  This allows clients to handle plural and singular opaquely.
 	// For many clients the singular form of the resource will be more understandable to users reading messages and should be used when integrating the name of the resource into a sentence.
 	// The command line tool kubectl, for example, allows use of the singular resource name in place of plurals.
 	// The singular form of a resource should always be an optional element - when in doubt use the canonical resource name.
+	// +required
 	SingularResource string `json:"singularResource" protobuf:"bytes,4,opt,name=singularResource"`
 	// verbs is a list of supported API operation types (this includes
 	// but is not limited to get, list, watch, create, update, patch,
 	// delete, deletecollection, and proxy).
 	// +listType=set
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,5,opt,name=verbs"`
 	// shortNames is a list of suggested short names of the resource.
 	// +listType=set
+	// +optional
 	ShortNames []string `json:"shortNames,omitempty" protobuf:"bytes,6,rep,name=shortNames"`
 	// categories is a list of the grouped resources this resource belongs to (e.g. 'all').
 	// Clients may use this to simplify acting on multiple resource types at once.
 	// +listType=set
+	// +optional
 	Categories []string `json:"categories,omitempty" protobuf:"bytes,7,rep,name=categories"`
 	// subresources is a list of subresources provided by this resource. Subresources are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>/name-of-instance/<APIResourceDiscovery.subresources[i].subresource>
 	// +listType=map
 	// +listMapKey=subresource
+	// +optional
 	Subresources []APISubresourceDiscovery `json:"subresources,omitempty" protobuf:"bytes,8,rep,name=subresources"`
 }
 
@@ -133,9 +145,11 @@ const (
 type APISubresourceDiscovery struct {
 	// subresource is the name of the subresource.  This is used in the URL path and is the unique identifier
 	// for this resource across all versions.
+	// +required
 	Subresource string `json:"subresource" protobuf:"bytes,1,opt,name=subresource"`
 	// responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
 	// Some subresources do not return normal resources, these will have null or empty return types.
+	// +optional
 	ResponseKind *v1.GroupVersionKind `json:"responseKind,omitempty" protobuf:"bytes,2,opt,name=responseKind"`
 	// acceptedTypes describes the kinds that this endpoint accepts.
 	// Subresources may accept the standard content types or define
@@ -145,6 +159,7 @@ type APISubresourceDiscovery struct {
 	// +listMapKey=group
 	// +listMapKey=version
 	// +listMapKey=kind
+	// +optional
 	AcceptedTypes []v1.GroupVersionKind `json:"acceptedTypes,omitempty" protobuf:"bytes,3,rep,name=acceptedTypes"`
 	// verbs is a list of supported API operation types (this includes
 	// but is not limited to get, list, watch, create, update, patch,
@@ -153,5 +168,6 @@ type APISubresourceDiscovery struct {
 	// should expect the behavior of standard verbs to align with
 	// Kubernetes interaction conventions.
 	// +listType=set
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,4,opt,name=verbs"`
 }

--- a/staging/src/k8s.io/api/apidiscovery/v2beta1/generated.proto
+++ b/staging/src/k8s.io/api/apidiscovery/v2beta1/generated.proto
@@ -44,6 +44,7 @@ message APIGroupDiscovery {
   // with the preferred version being the first entry.
   // +listType=map
   // +listMapKey=version
+  // +optional
   repeated APIVersionDiscovery versions = 2;
 }
 
@@ -67,40 +68,48 @@ message APIResourceDiscovery {
   // for this resource across all versions in the API group.
   // Resources with non-empty groups are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>
   // Resources with empty groups are located at /api/v1/<APIResourceDiscovery.Resource>
+  // +required
   optional string resource = 1;
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
   // APIs may return other objects types at their discretion, such as error conditions, requests for alternate representations, or other operation specific behavior.
   // This value will be null or empty if an APIService reports subresources but supports no operations on the parent resource
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // scope indicates the scope of a resource, either Cluster or Namespaced
+  // +required
   optional string scope = 3;
 
   // singularResource is the singular name of the resource.  This allows clients to handle plural and singular opaquely.
   // For many clients the singular form of the resource will be more understandable to users reading messages and should be used when integrating the name of the resource into a sentence.
   // The command line tool kubectl, for example, allows use of the singular resource name in place of plurals.
   // The singular form of a resource should always be an optional element - when in doubt use the canonical resource name.
+  // +required
   optional string singularResource = 4;
 
   // verbs is a list of supported API operation types (this includes
   // but is not limited to get, list, watch, create, update, patch,
   // delete, deletecollection, and proxy).
   // +listType=set
+  // +required
   repeated string verbs = 5;
 
   // shortNames is a list of suggested short names of the resource.
   // +listType=set
+  // +optional
   repeated string shortNames = 6;
 
   // categories is a list of the grouped resources this resource belongs to (e.g. 'all').
   // Clients may use this to simplify acting on multiple resource types at once.
   // +listType=set
+  // +optional
   repeated string categories = 7;
 
   // subresources is a list of subresources provided by this resource. Subresources are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>/name-of-instance/<APIResourceDiscovery.subresources[i].subresource>
   // +listType=map
   // +listMapKey=subresource
+  // +optional
   repeated APISubresourceDiscovery subresources = 8;
 }
 
@@ -108,10 +117,12 @@ message APIResourceDiscovery {
 message APISubresourceDiscovery {
   // subresource is the name of the subresource.  This is used in the URL path and is the unique identifier
   // for this resource across all versions.
+  // +required
   optional string subresource = 1;
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
   // Some subresources do not return normal resources, these will have null or empty return types.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // acceptedTypes describes the kinds that this endpoint accepts.
@@ -122,6 +133,7 @@ message APISubresourceDiscovery {
   // +listMapKey=group
   // +listMapKey=version
   // +listMapKey=kind
+  // +optional
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind acceptedTypes = 3;
 
   // verbs is a list of supported API operation types (this includes
@@ -131,17 +143,20 @@ message APISubresourceDiscovery {
   // should expect the behavior of standard verbs to align with
   // Kubernetes interaction conventions.
   // +listType=set
+  // +required
   repeated string verbs = 4;
 }
 
 // APIVersionDiscovery holds a list of APIResourceDiscovery types that are served for a particular version within an API Group.
 message APIVersionDiscovery {
   // version is the name of the version within a group version.
+  // +required
   optional string version = 1;
 
   // resources is a list of APIResourceDiscovery objects for the corresponding group version.
   // +listType=map
   // +listMapKey=resource
+  // +optional
   repeated APIResourceDiscovery resources = 2;
 
   // freshness marks whether a group version's discovery document is up to date.
@@ -151,6 +166,7 @@ message APIVersionDiscovery {
   // significantly out of date. Clients that require the latest
   // version of the discovery information be retrieved before
   // performing an operation should not use the aggregated document
+  // +optional
   optional string freshness = 3;
 }
 

--- a/staging/src/k8s.io/api/apidiscovery/v2beta1/generated.proto
+++ b/staging/src/k8s.io/api/apidiscovery/v2beta1/generated.proto
@@ -59,6 +59,7 @@ message APIGroupDiscoveryList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of groups for discovery. The groups are listed in priority order.
+  // +optional
   repeated APIGroupDiscovery items = 2;
 }
 
@@ -68,7 +69,7 @@ message APIResourceDiscovery {
   // for this resource across all versions in the API group.
   // Resources with non-empty groups are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>
   // Resources with empty groups are located at /api/v1/<APIResourceDiscovery.Resource>
-  // +required
+  // +optional
   optional string resource = 1;
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
@@ -78,21 +79,21 @@ message APIResourceDiscovery {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // scope indicates the scope of a resource, either Cluster or Namespaced
-  // +required
+  // +optional
   optional string scope = 3;
 
   // singularResource is the singular name of the resource.  This allows clients to handle plural and singular opaquely.
   // For many clients the singular form of the resource will be more understandable to users reading messages and should be used when integrating the name of the resource into a sentence.
   // The command line tool kubectl, for example, allows use of the singular resource name in place of plurals.
   // The singular form of a resource should always be an optional element - when in doubt use the canonical resource name.
-  // +required
+  // +optional
   optional string singularResource = 4;
 
   // verbs is a list of supported API operation types (this includes
   // but is not limited to get, list, watch, create, update, patch,
   // delete, deletecollection, and proxy).
   // +listType=set
-  // +required
+  // +optional
   repeated string verbs = 5;
 
   // shortNames is a list of suggested short names of the resource.
@@ -117,7 +118,7 @@ message APIResourceDiscovery {
 message APISubresourceDiscovery {
   // subresource is the name of the subresource.  This is used in the URL path and is the unique identifier
   // for this resource across all versions.
-  // +required
+  // +optional
   optional string subresource = 1;
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
@@ -143,14 +144,14 @@ message APISubresourceDiscovery {
   // should expect the behavior of standard verbs to align with
   // Kubernetes interaction conventions.
   // +listType=set
-  // +required
+  // +optional
   repeated string verbs = 4;
 }
 
 // APIVersionDiscovery holds a list of APIResourceDiscovery types that are served for a particular version within an API Group.
 message APIVersionDiscovery {
   // version is the name of the version within a group version.
-  // +required
+  // +optional
   optional string version = 1;
 
   // resources is a list of APIResourceDiscovery objects for the corresponding group version.

--- a/staging/src/k8s.io/api/apidiscovery/v2beta1/types.go
+++ b/staging/src/k8s.io/api/apidiscovery/v2beta1/types.go
@@ -37,6 +37,7 @@ type APIGroupDiscoveryList struct {
 	// +optional
 	v1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// items is the list of groups for discovery. The groups are listed in priority order.
+	// +optional
 	Items []APIGroupDiscovery `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -69,7 +70,7 @@ type APIGroupDiscovery struct {
 // APIVersionDiscovery holds a list of APIResourceDiscovery types that are served for a particular version within an API Group.
 type APIVersionDiscovery struct {
 	// version is the name of the version within a group version.
-	// +required
+	// +optional
 	Version string `json:"version" protobuf:"bytes,1,opt,name=version"`
 	// resources is a list of APIResourceDiscovery objects for the corresponding group version.
 	// +listType=map
@@ -93,7 +94,7 @@ type APIResourceDiscovery struct {
 	// for this resource across all versions in the API group.
 	// Resources with non-empty groups are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>
 	// Resources with empty groups are located at /api/v1/<APIResourceDiscovery.Resource>
-	// +required
+	// +optional
 	Resource string `json:"resource" protobuf:"bytes,1,opt,name=resource"`
 	// responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
 	// APIs may return other objects types at their discretion, such as error conditions, requests for alternate representations, or other operation specific behavior.
@@ -101,19 +102,19 @@ type APIResourceDiscovery struct {
 	// +optional
 	ResponseKind *v1.GroupVersionKind `json:"responseKind,omitempty" protobuf:"bytes,2,opt,name=responseKind"`
 	// scope indicates the scope of a resource, either Cluster or Namespaced
-	// +required
+	// +optional
 	Scope ResourceScope `json:"scope" protobuf:"bytes,3,opt,name=scope"`
 	// singularResource is the singular name of the resource.  This allows clients to handle plural and singular opaquely.
 	// For many clients the singular form of the resource will be more understandable to users reading messages and should be used when integrating the name of the resource into a sentence.
 	// The command line tool kubectl, for example, allows use of the singular resource name in place of plurals.
 	// The singular form of a resource should always be an optional element - when in doubt use the canonical resource name.
-	// +required
+	// +optional
 	SingularResource string `json:"singularResource" protobuf:"bytes,4,opt,name=singularResource"`
 	// verbs is a list of supported API operation types (this includes
 	// but is not limited to get, list, watch, create, update, patch,
 	// delete, deletecollection, and proxy).
 	// +listType=set
-	// +required
+	// +optional
 	Verbs []string `json:"verbs" protobuf:"bytes,5,opt,name=verbs"`
 	// shortNames is a list of suggested short names of the resource.
 	// +listType=set
@@ -151,7 +152,7 @@ const (
 type APISubresourceDiscovery struct {
 	// subresource is the name of the subresource.  This is used in the URL path and is the unique identifier
 	// for this resource across all versions.
-	// +required
+	// +optional
 	Subresource string `json:"subresource" protobuf:"bytes,1,opt,name=subresource"`
 	// responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
 	// Some subresources do not return normal resources, these will have null or empty return types.
@@ -174,6 +175,6 @@ type APISubresourceDiscovery struct {
 	// should expect the behavior of standard verbs to align with
 	// Kubernetes interaction conventions.
 	// +listType=set
-	// +required
+	// +optional
 	Verbs []string `json:"verbs" protobuf:"bytes,4,opt,name=verbs"`
 }

--- a/staging/src/k8s.io/api/apidiscovery/v2beta1/types.go
+++ b/staging/src/k8s.io/api/apidiscovery/v2beta1/types.go
@@ -62,16 +62,19 @@ type APIGroupDiscovery struct {
 	// with the preferred version being the first entry.
 	// +listType=map
 	// +listMapKey=version
+	// +optional
 	Versions []APIVersionDiscovery `json:"versions,omitempty" protobuf:"bytes,2,rep,name=versions"`
 }
 
 // APIVersionDiscovery holds a list of APIResourceDiscovery types that are served for a particular version within an API Group.
 type APIVersionDiscovery struct {
 	// version is the name of the version within a group version.
+	// +required
 	Version string `json:"version" protobuf:"bytes,1,opt,name=version"`
 	// resources is a list of APIResourceDiscovery objects for the corresponding group version.
 	// +listType=map
 	// +listMapKey=resource
+	// +optional
 	Resources []APIResourceDiscovery `json:"resources,omitempty" protobuf:"bytes,2,rep,name=resources"`
 	// freshness marks whether a group version's discovery document is up to date.
 	// "Current" indicates the discovery document was recently
@@ -80,6 +83,7 @@ type APIVersionDiscovery struct {
 	// significantly out of date. Clients that require the latest
 	// version of the discovery information be retrieved before
 	// performing an operation should not use the aggregated document
+	// +optional
 	Freshness DiscoveryFreshness `json:"freshness,omitempty" protobuf:"bytes,3,opt,name=freshness"`
 }
 
@@ -89,33 +93,41 @@ type APIResourceDiscovery struct {
 	// for this resource across all versions in the API group.
 	// Resources with non-empty groups are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>
 	// Resources with empty groups are located at /api/v1/<APIResourceDiscovery.Resource>
+	// +required
 	Resource string `json:"resource" protobuf:"bytes,1,opt,name=resource"`
 	// responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
 	// APIs may return other objects types at their discretion, such as error conditions, requests for alternate representations, or other operation specific behavior.
 	// This value will be null or empty if an APIService reports subresources but supports no operations on the parent resource
+	// +optional
 	ResponseKind *v1.GroupVersionKind `json:"responseKind,omitempty" protobuf:"bytes,2,opt,name=responseKind"`
 	// scope indicates the scope of a resource, either Cluster or Namespaced
+	// +required
 	Scope ResourceScope `json:"scope" protobuf:"bytes,3,opt,name=scope"`
 	// singularResource is the singular name of the resource.  This allows clients to handle plural and singular opaquely.
 	// For many clients the singular form of the resource will be more understandable to users reading messages and should be used when integrating the name of the resource into a sentence.
 	// The command line tool kubectl, for example, allows use of the singular resource name in place of plurals.
 	// The singular form of a resource should always be an optional element - when in doubt use the canonical resource name.
+	// +required
 	SingularResource string `json:"singularResource" protobuf:"bytes,4,opt,name=singularResource"`
 	// verbs is a list of supported API operation types (this includes
 	// but is not limited to get, list, watch, create, update, patch,
 	// delete, deletecollection, and proxy).
 	// +listType=set
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,5,opt,name=verbs"`
 	// shortNames is a list of suggested short names of the resource.
 	// +listType=set
+	// +optional
 	ShortNames []string `json:"shortNames,omitempty" protobuf:"bytes,6,rep,name=shortNames"`
 	// categories is a list of the grouped resources this resource belongs to (e.g. 'all').
 	// Clients may use this to simplify acting on multiple resource types at once.
 	// +listType=set
+	// +optional
 	Categories []string `json:"categories,omitempty" protobuf:"bytes,7,rep,name=categories"`
 	// subresources is a list of subresources provided by this resource. Subresources are located at /apis/<APIGroupDiscovery.objectMeta.name>/<APIVersionDiscovery.version>/<APIResourceDiscovery.Resource>/name-of-instance/<APIResourceDiscovery.subresources[i].subresource>
 	// +listType=map
 	// +listMapKey=subresource
+	// +optional
 	Subresources []APISubresourceDiscovery `json:"subresources,omitempty" protobuf:"bytes,8,rep,name=subresources"`
 }
 
@@ -139,9 +151,11 @@ const (
 type APISubresourceDiscovery struct {
 	// subresource is the name of the subresource.  This is used in the URL path and is the unique identifier
 	// for this resource across all versions.
+	// +required
 	Subresource string `json:"subresource" protobuf:"bytes,1,opt,name=subresource"`
 	// responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
 	// Some subresources do not return normal resources, these will have null or empty return types.
+	// +optional
 	ResponseKind *v1.GroupVersionKind `json:"responseKind,omitempty" protobuf:"bytes,2,opt,name=responseKind"`
 	// acceptedTypes describes the kinds that this endpoint accepts.
 	// Subresources may accept the standard content types or define
@@ -151,6 +165,7 @@ type APISubresourceDiscovery struct {
 	// +listMapKey=group
 	// +listMapKey=version
 	// +listMapKey=kind
+	// +optional
 	AcceptedTypes []v1.GroupVersionKind `json:"acceptedTypes,omitempty" protobuf:"bytes,3,rep,name=acceptedTypes"`
 	// verbs is a list of supported API operation types (this includes
 	// but is not limited to get, list, watch, create, update, patch,
@@ -159,5 +174,6 @@ type APISubresourceDiscovery struct {
 	// should expect the behavior of standard verbs to align with
 	// Kubernetes interaction conventions.
 	// +listType=set
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,4,opt,name=verbs"`
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind api-change
/kind feature

#### What this PR does / why we need it:

- Enable the optionalorrequired linter for the admission API group.

#### Which issue(s) this PR is related to:
Fixes : #136859

#### Special notes for your reviewer:

- This PR enables the optionalorrequired kube-api-linter rule for the apidiscovery API group as tracked in [#136859](https://github.com/kubernetes/kubernetes/issues/136859)

- To support this change, all fields in the apidiscovery API types have been annotated with explicit markers (+required or +optional) in accordance with Kubernetes API conventions.

- The adjustments do not alter API semantics, behavior, or compatibility; they only satisfy static analysis requirements enforced by the linter.

- The optionalorrequired rule ensures that every API field is explicitly marked as either optional or required, improving API clarity and future maintainability.

#### Does this PR introduce a user-facing change?
No.

```release-note
NONE
```
