### PR TITLE
chore(test/autoscaling): update HPA e2e DynamicResourceConsumer to use current APIs

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -91,16 +91,16 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (scale resource: CP
 	})
 
 	// These tests take ~20 minutes each.
-	f.Describe("ReplicationController", func() {
+	f.Describe("ReplicaSet", func() {
 		ginkgo.It(titleUp+" and verify decision stability", func(ctx context.Context) {
-			scaleUp(ctx, "rc", e2eautoscaling.KindRC, cpuResource, utilizationMetricType, true, f)
+			scaleUp(ctx, "rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, true, f)
 		})
 		ginkgo.It(titleDown+" and verify decision stability", func(ctx context.Context) {
-			scaleDown(ctx, "rc", e2eautoscaling.KindRC, cpuResource, utilizationMetricType, true, f)
+			scaleDown(ctx, "rs", e2eautoscaling.KindReplicaSet, cpuResource, utilizationMetricType, true, f)
 		})
 	})
 
-	f.Describe("ReplicationController light", func() {
+	f.Describe("ReplicaSet light", func() {
 		ginkgo.It("Should scale from 1 pod to 2 pods", func(ctx context.Context) {
 			st := &HPAScaleTest{
 				initPods:         1,
@@ -113,7 +113,7 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (scale resource: CP
 				resourceType:     cpuResource,
 				metricTargetType: utilizationMetricType,
 			}
-			st.run(ctx, "rc-light", e2eautoscaling.KindRC, f)
+			st.run(ctx, "rs-light", e2eautoscaling.KindReplicaSet, f)
 		})
 		f.It("Should scale from 2 pods to 1 pod", func(ctx context.Context) {
 			st := &HPAScaleTest{
@@ -127,7 +127,7 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (scale resource: CP
 				resourceType:     cpuResource,
 				metricTargetType: utilizationMetricType,
 			}
-			st.run(ctx, "rc-light", e2eautoscaling.KindRC, f)
+			st.run(ctx, "rs-light", e2eautoscaling.KindReplicaSet, f)
 		})
 	})
 

--- a/test/e2e/upgrades/autoscaling/horizontal_pod_autoscalers.go
+++ b/test/e2e/upgrades/autoscaling/horizontal_pod_autoscalers.go
@@ -42,7 +42,7 @@ func (t *HPAUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	t.rc = e2eautoscaling.NewDynamicResourceConsumer(ctx,
 		"res-cons-upgrade",
 		f.Namespace.Name,
-		e2eautoscaling.KindRC,
+		e2eautoscaling.KindReplicaSet,
 		1,   /* replicas */
 		250, /* initCPUTotal */
 		0,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Updates the HPA e2e `DynamicResourceConsumer` test utilities to stop using deprecated Kubernetes API versions and the legacy `ReplicationController` workload type. `KindDeployment` and `KindReplicaSet` group-version-kinds are corrected from `apps/v1beta2` to the current `apps/v1`, and all remaining uses of `KindRC` (ReplicationController) are replaced with `KindReplicaSet`

#### Which issue(s) this PR is related to:
Fixes #137074

#### Special notes for your reviewer:
**Test name changes**: Ginkgo test names that previously contained `"ReplicationController"`, `"rc"`, or `"rc-light"` now contain `"ReplicaSet"`, `"rs"`, or `"rs-light"` respectively. Any external tooling, dashboards, or flake-tracking systems that reference the old test names by exact string will need to be updated.
