### PR TITLE
Add placement generator plugin interfaces and logic for running them

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -68787,6 +68787,13 @@ func schema_k8sio_kube_scheduler_config_v1_Plugins(ref common.ReferenceCallback)
 							Ref:         ref(configv1.PluginSet{}.OpenAPIModelName()),
 						},
 					},
+					"placementGenerate": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PlacementGenerate is a list of plugins that should be invoked during pod group scheduling cycle when determining placements for a pod group.",
+							Default:     map[string]interface{}{},
+							Ref:         ref(configv1.PluginSet{}.OpenAPIModelName()),
+						},
+					},
 					"placementScore": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PlacementScore is a list of plugins that should be invoked during workload scheduling cycle when ranking pod group assignments.",

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -177,6 +177,9 @@ type Plugins struct {
 	// MultiPoint is a simplified config field for enabling plugins for all valid extension points
 	MultiPoint PluginSet
 
+	// PlacementGenerate is a list of plugins that should be invoked during pod group scheduling cycle when determining placements for a pod group.
+	PlacementGenerate PluginSet
+
 	// PlacementScore is a list of plugins that should be invoked during workload scheduling cycle when ranking pod group assignments.
 	PlacementScore PluginSet
 }
@@ -247,6 +250,7 @@ func (p *Plugins) Names() []string {
 		p.PostBind,
 		p.Permit,
 		p.QueueSort,
+		p.PlacementGenerate,
 		p.PlacementScore,
 	}
 	n := sets.New[string]()

--- a/pkg/scheduler/apis/config/v1/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins.go
@@ -110,6 +110,7 @@ func mergePlugins(logger klog.Logger, defaultPlugins, customPlugins *v1.Plugins)
 	defaultPlugins.PreBind = mergePluginSet(logger, defaultPlugins.PreBind, customPlugins.PreBind)
 	defaultPlugins.Bind = mergePluginSet(logger, defaultPlugins.Bind, customPlugins.Bind)
 	defaultPlugins.PostBind = mergePluginSet(logger, defaultPlugins.PostBind, customPlugins.PostBind)
+	defaultPlugins.PlacementGenerate = mergePluginSet(logger, defaultPlugins.PlacementGenerate, customPlugins.PlacementGenerate)
 	defaultPlugins.PlacementScore = mergePluginSet(logger, defaultPlugins.PlacementScore, customPlugins.PlacementScore)
 	return defaultPlugins
 }

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -57,6 +57,7 @@ func pluginsNames(p *configv1.Plugins) []string {
 		p.Permit,
 		p.PreEnqueue,
 		p.QueueSort,
+		p.PlacementGenerate,
 		p.PlacementScore,
 	}
 	n := sets.New[string]()

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -785,6 +785,9 @@ func autoConvert_v1_Plugins_To_config_Plugins(in *configv1.Plugins, out *config.
 	if err := Convert_v1_PluginSet_To_config_PluginSet(&in.MultiPoint, &out.MultiPoint, s); err != nil {
 		return err
 	}
+	if err := Convert_v1_PluginSet_To_config_PluginSet(&in.PlacementGenerate, &out.PlacementGenerate, s); err != nil {
+		return err
+	}
 	if err := Convert_v1_PluginSet_To_config_PluginSet(&in.PlacementScore, &out.PlacementScore, s); err != nil {
 		return err
 	}
@@ -834,6 +837,9 @@ func autoConvert_config_Plugins_To_v1_Plugins(in *config.Plugins, out *configv1.
 		return err
 	}
 	if err := Convert_config_PluginSet_To_v1_PluginSet(&in.MultiPoint, &out.MultiPoint, s); err != nil {
+		return err
+	}
+	if err := Convert_config_PluginSet_To_v1_PluginSet(&in.PlacementGenerate, &out.PlacementGenerate, s); err != nil {
 		return err
 	}
 	if err := Convert_config_PluginSet_To_v1_PluginSet(&in.PlacementScore, &out.PlacementScore, s); err != nil {

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -443,6 +443,7 @@ func (in *Plugins) DeepCopyInto(out *Plugins) {
 	in.Bind.DeepCopyInto(&out.Bind)
 	in.PostBind.DeepCopyInto(&out.PostBind)
 	in.MultiPoint.DeepCopyInto(&out.MultiPoint)
+	in.PlacementGenerate.DeepCopyInto(&out.PlacementGenerate)
 	in.PlacementScore.DeepCopyInto(&out.PlacementScore)
 	return
 }

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -207,6 +207,10 @@ type Framework interface {
 	// StoreScheduleResults stores the results after we have sorted and filtered nodes.
 	StoreScheduleResults(ctx context.Context, signature fwk.PodSignature, hintedNode, chosenNode string, otherNodes SortedScoredNodes, cycleCount int64)
 
+	// RunPlacementGeneratePlugins runs the set of configured PlacementGenerate plugins.
+	// It returns the combined list of generated Placements.
+	RunPlacementGeneratePlugins(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, nodes []fwk.NodeInfo) ([]*fwk.Placement, *fwk.Status)
+
 	// RunPreBindPlugins runs the set of configured PreBind plugins. It returns
 	// *fwk.Status and its code is set to non-success if any of the plugins returns
 	// anything but Success. If the Status code is "Unschedulable", it is

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -75,6 +75,7 @@ type frameworkImpl struct {
 	permitPlugins        []fwk.PermitPlugin
 	batchablePlugins     []fwk.SignPlugin
 
+	placementGeneratePlugins   []fwk.PlacementGeneratePlugin
 	placementScorePlugins      []fwk.PlacementScorePlugin
 	placementScorePluginWeight map[string]int
 
@@ -133,6 +134,7 @@ func (f *frameworkImpl) getExtensionPoints(plugins *config.Plugins) []extensionP
 		{&plugins.Permit, &f.permitPlugins},
 		{&plugins.PreEnqueue, &f.preEnqueuePlugins},
 		{&plugins.QueueSort, &f.queueSortPlugins},
+		{&plugins.PlacementGenerate, &f.placementGeneratePlugins},
 		{&plugins.PlacementScore, &f.placementScorePlugins},
 	}
 }
@@ -433,6 +435,9 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 	}
 	if len(f.bindPlugins) == 0 {
 		return nil, fmt.Errorf("at least one bind plugin is needed for profile with scheduler name %q", profile.SchedulerName)
+	}
+	if len(f.placementGeneratePlugins) > 1 {
+		return nil, fmt.Errorf("at most one placement generate plugin is allowed for profile with scheduler name %q", profile.SchedulerName)
 	}
 
 	podScoreWeights, err := getValidScoreWeights(f, reflect.TypeFor[fwk.ScorePlugin](), append(profile.Plugins.Score.Enabled, profile.Plugins.MultiPoint.Enabled...))
@@ -1981,6 +1986,46 @@ func (f *frameworkImpl) runPermitPlugin(ctx context.Context, pl fwk.PermitPlugin
 func (f *frameworkImpl) AddWaitingPod(pod *v1.Pod, pluginsWaitTime map[string]time.Duration) {
 	waitingPod := newWaitingPod(pod, pluginsWaitTime)
 	f.waitingPods.add(waitingPod)
+}
+
+// RunPlacementGeneratePlugins runs the set of configured PlacementGeneratePlugins and returns the generated placements.
+// If no plugins are defined, the input placement is returned instead.
+func (f *frameworkImpl) RunPlacementGeneratePlugins(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, nodes []fwk.NodeInfo) (placements []*fwk.Placement, status *fwk.Status) {
+	startTime := time.Now()
+	defer func() {
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementGenerate, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+	}()
+
+	placement := &fwk.Placement{
+		Nodes: nodes,
+	}
+
+	if len(f.placementGeneratePlugins) == 0 {
+		return []*fwk.Placement{placement}, nil
+	}
+
+	plugin := f.placementGeneratePlugins[0]
+
+	result, status := f.runPlacementGeneratePlugin(ctx, plugin, state, podGroup, placement)
+	if !status.IsSuccess() {
+		return nil, status.WithPlugin(plugin.Name())
+	}
+
+	if len(result.Placements) == 0 {
+		return nil, fwk.NewStatus(fwk.Unschedulable, "no feasible placements found").WithPlugin(plugin.Name())
+	}
+
+	return result.Placements, nil
+}
+
+func (f *frameworkImpl) runPlacementGeneratePlugin(ctx context.Context, pl fwk.PlacementGeneratePlugin, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, parentPlacement *fwk.Placement) (*fwk.GeneratePlacementsResult, *fwk.Status) {
+	if !state.ShouldRecordPluginMetrics() {
+		return pl.GeneratePlacements(ctx, state, podGroup, parentPlacement)
+	}
+	startTime := time.Now()
+	placements, status := pl.GeneratePlacements(ctx, state, podGroup, parentPlacement)
+	f.metricsRecorder.ObservePluginDurationAsync(metrics.PlacementGenerate, pl.Name(), status.Code().String(), metrics.SinceInSeconds(startTime))
+	return placements, status
 }
 
 func (f *frameworkImpl) WillWaitOnPermit(ctx context.Context, pod *v1.Pod) bool {

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -42,6 +42,7 @@ import (
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -61,6 +62,7 @@ const (
 	permitPlugin                      = "permit-plugin"
 	bindPlugin                        = "bind-plugin"
 	testCloseErrorPlugin              = "test-close-error-plugin"
+	placementGeneratePlugin           = "placement-generate-plugin"
 
 	testProfileName              = "test-profile"
 	testPercentageOfNodesToScore = 35
@@ -262,6 +264,10 @@ func (pl *TestPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod,
 	return fwk.NewStatus(fwk.Code(pl.inj.BindStatus), injectReason)
 }
 
+func (pl *TestPlugin) GeneratePlacements(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, parentPlacement *fwk.Placement) (*fwk.GeneratePlacementsResult, *fwk.Status) {
+	return &fwk.GeneratePlacementsResult{Placements: pl.inj.GeneratePlacementsResult}, fwk.NewStatus(fwk.Code(pl.inj.GeneratePlacementsStatus), injectReason)
+}
+
 func (pl *TestPlugin) ScorePlacement(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, placement *fwk.PodGroupAssignments) (int64, *fwk.Status) {
 	return 0, fwk.NewStatus(fwk.Code(pl.inj.PlacementScoreStatus), injectReason)
 }
@@ -418,6 +424,28 @@ func (t TestBindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Po
 	return nil
 }
 
+// TestPlacementGeneratePlugin only implements GeneratePlacements extension point.
+type TestPlacementGeneratePlugin struct {
+	name string
+	inj  injectedResult
+}
+
+func (pl *TestPlacementGeneratePlugin) Name() string {
+	return pl.name
+}
+
+func (pl *TestPlacementGeneratePlugin) GeneratePlacements(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, parentPlacement *fwk.Placement) (*fwk.GeneratePlacementsResult, *fwk.Status) {
+	return &fwk.GeneratePlacementsResult{Placements: pl.inj.GeneratePlacementsResult}, fwk.NewStatus(fwk.Code(pl.inj.GeneratePlacementsStatus), injectReason)
+}
+
+func newTestPlacementGeneratePlugin(_ context.Context, injArgs runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+	var inj injectedResult
+	if err := DecodeInto(injArgs, &inj); err != nil {
+		return nil, err
+	}
+	return &TestPlacementGeneratePlugin{placementGeneratePlugin, inj}, nil
+}
+
 // nolint:errcheck   // Ignore the error returned by Register as before
 var registry = func() Registry {
 	r := make(Registry)
@@ -431,6 +459,7 @@ var registry = func() Registry {
 	r.Register(queueSortPlugin, newQueueSortPlugin)
 	r.Register(bindPlugin, newBindPlugin)
 	r.Register(testCloseErrorPlugin, newTestCloseErrorPlugin)
+	r.Register(placementGeneratePlugin, newTestPlacementGeneratePlugin)
 	r.Register(placementScorePlugin1, newPlacementScorePluginFactory(placementScorePlugin1))
 	return r
 }()
@@ -575,6 +604,34 @@ func TestNewFrameworkErrors(t *testing.T) {
 			},
 			wantErr: "repeated config for plugin",
 		},
+		{
+			name: "more than one PlacementGeneratePlugin",
+			plugins: &config.Plugins{
+				QueueSort: config.PluginSet{
+					Enabled: []config.Plugin{
+						{Name: queueSortPlugin},
+					},
+				},
+				Bind: config.PluginSet{
+					Enabled: []config.Plugin{
+						{Name: bindPlugin},
+					},
+				},
+				PlacementGenerate: config.PluginSet{
+					Enabled: []config.Plugin{
+						{Name: testPlugin},
+						{Name: placementGeneratePlugin},
+					},
+				},
+			},
+			pluginCfg: []config.PluginConfig{
+				{Name: queueSortPlugin},
+				{Name: bindPlugin},
+				{Name: testPlugin},
+				{Name: placementGeneratePlugin},
+			},
+			wantErr: "at most one placement generate plugin is allowed",
+		},
 	}
 
 	for _, tc := range tests {
@@ -611,18 +668,19 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 				},
 			},
 			wantPlugins: &config.Plugins{
-				QueueSort:      config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreFilter:      config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Filter:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostFilter:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreScore:       config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Score:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 5}}},
-				Reserve:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Permit:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreBind:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Bind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostBind:       config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PlacementScore: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 5}}},
+				QueueSort:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreFilter:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Filter:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostFilter:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreScore:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Score:             config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 5}}},
+				Reserve:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Permit:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Bind:              config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostBind:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementGenerate: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementScore:    config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 5}}},
 			},
 		},
 		{
@@ -650,15 +708,16 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 				},
 			},
 			wantPlugins: &config.Plugins{
-				QueueSort:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreFilter:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Filter:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Reserve:    config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Permit:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreBind:    config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Bind:       config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostBind:   config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				QueueSort:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreFilter:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Filter:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostFilter:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Reserve:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Permit:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Bind:              config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostBind:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementGenerate: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 			},
 		},
 		{
@@ -685,11 +744,12 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 					{Name: testPlugin, Weight: 1},
 					{Name: scorePlugin1, Weight: 1},
 				}},
-				Reserve:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Permit:   config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreBind:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Bind:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostBind: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Reserve:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Permit:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Bind:              config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostBind:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementGenerate: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementScore: config.PluginSet{Enabled: []config.Plugin{
 					{Name: testPlugin, Weight: 1},
 					{Name: placementScorePlugin1, Weight: 1},
@@ -720,12 +780,13 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 					{Name: testPlugin, Weight: 1},
 					{Name: scorePlugin1, Weight: 1},
 				}},
-				Reserve:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Permit:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreBind:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Bind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostBind:       config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PlacementScore: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}},
+				Reserve:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Permit:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Bind:              config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostBind:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementGenerate: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementScore:    config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}},
 			},
 		},
 		{
@@ -759,12 +820,13 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 					{Name: testPlugin, Weight: 1},
 					{Name: scoreWithNormalizePlugin1, Weight: 1},
 				}},
-				Reserve:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Permit:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreBind:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Bind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostBind:       config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PlacementScore: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}},
+				Reserve:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Permit:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Bind:              config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostBind:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementGenerate: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementScore:    config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}},
 			},
 		},
 		{
@@ -798,12 +860,13 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 					{Name: testPlugin, Weight: 1},
 					{Name: scoreWithNormalizePlugin1, Weight: 1},
 				}},
-				Reserve:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Permit:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreBind:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Bind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostBind:       config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PlacementScore: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}},
+				Reserve:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Permit:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Bind:              config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostBind:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementGenerate: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementScore:    config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}},
 			},
 		},
 		{
@@ -840,12 +903,13 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 					{Name: scorePlugin1, Weight: 5},
 					{Name: testPlugin, Weight: 3},
 				}},
-				Reserve:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Permit:         config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreBind:        config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Bind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostBind:       config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PlacementScore: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 2}}},
+				Reserve:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Permit:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Bind:              config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostBind:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementGenerate: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementScore:    config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 2}}},
 			},
 		},
 		{
@@ -952,11 +1016,12 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 					{Name: testPlugin, Weight: 3},
 					{Name: scorePlugin2, Weight: 5},
 				}},
-				Reserve:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Permit:   config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PreBind:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				Bind:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
-				PostBind: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Reserve:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Permit:            config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PreBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				Bind:              config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PostBind:          config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementGenerate: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementScore: config.PluginSet{Enabled: []config.Plugin{
 					{Name: testPlugin, Weight: 2},
 					{Name: placementScorePlugin1, Weight: 6},
@@ -3326,6 +3391,15 @@ func TestRecordingMetrics(t *testing.T) {
 			wantStatus:         fwk.Success,
 		},
 		{
+			name: "PlacementGenerate - Success",
+			action: func(ctx context.Context, f framework.Framework) {
+				f.RunPlacementGeneratePlugins(ctx, state, nil, []fwk.NodeInfo{framework.NewNodeInfo()})
+			},
+			inject:             injectedResult{GeneratePlacementsResult: []*fwk.Placement{{}}},
+			wantExtensionPoint: "PlacementGenerate",
+			wantStatus:         fwk.Success,
+		},
+		{
 			name: "PlacementScore - Success",
 			action: func(ctx context.Context, f framework.Framework) {
 				f.RunPlacementScorePlugins(ctx, state, nil, []*fwk.PodGroupAssignments{{Placement: &fwk.Placement{}}})
@@ -3393,6 +3467,15 @@ func TestRecordingMetrics(t *testing.T) {
 			wantStatus:         fwk.Wait,
 		},
 		{
+			name: "PlacementGenerate - Error",
+			action: func(ctx context.Context, f framework.Framework) {
+				f.RunPlacementGeneratePlugins(ctx, state, nil, []fwk.NodeInfo{framework.NewNodeInfo()})
+			},
+			inject:             injectedResult{GeneratePlacementsStatus: int(fwk.Error)},
+			wantExtensionPoint: "PlacementGenerate",
+			wantStatus:         fwk.Error,
+		},
+		{
 			name: "PlacementScore - Error",
 			action: func(ctx context.Context, f framework.Framework) {
 				f.RunPlacementScorePlugins(ctx, state, nil, []*fwk.PodGroupAssignments{{Placement: &fwk.Placement{}}})
@@ -3418,16 +3501,17 @@ func TestRecordingMetrics(t *testing.T) {
 				})
 			pluginSet := config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}}
 			plugins := &config.Plugins{
-				Score:          pluginSet,
-				PreFilter:      pluginSet,
-				Filter:         pluginSet,
-				PreScore:       pluginSet,
-				Reserve:        pluginSet,
-				Permit:         pluginSet,
-				PreBind:        pluginSet,
-				Bind:           pluginSet,
-				PostBind:       pluginSet,
-				PlacementScore: pluginSet,
+				Score:             pluginSet,
+				PreFilter:         pluginSet,
+				Filter:            pluginSet,
+				PreScore:          pluginSet,
+				Reserve:           pluginSet,
+				Permit:            pluginSet,
+				PreBind:           pluginSet,
+				Bind:              pluginSet,
+				PostBind:          pluginSet,
+				PlacementGenerate: pluginSet,
+				PlacementScore:    pluginSet,
 			}
 
 			recorder := metrics.NewMetricsAsyncRecorder(100, time.Nanosecond, ctx.Done())
@@ -3837,6 +3921,8 @@ type injectedResult struct {
 	BindStatus               int                  `json:"bindStatus,omitempty"`
 	PermitStatus             int                  `json:"permitStatus,omitempty"`
 	PermitTimeout            time.Duration        `json:"permitTimeout,omitempty"`
+	GeneratePlacementsResult []*fwk.Placement     `json:"generatePlacementsResult,omitempty"`
+	GeneratePlacementsStatus int                  `json:"generatePlacementsStatus,omitempty"`
 	PlacementScoreStatus     int                  `json:"placementScoreStatus,omitempty"`
 }
 
@@ -3931,6 +4017,125 @@ func BuildNodeInfos(nodes []*v1.Node) []fwk.NodeInfo {
 		res[i].SetNode(nodes[i])
 	}
 	return res
+}
+
+func TestRunPlacementGeneratePlugins(t *testing.T) {
+	nodeResources := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+		st.MakeNode().Name("node3").Obj(),
+	}
+	nodesInCluster := make([]fwk.NodeInfo, len(nodeResources))
+	for i, node := range nodeResources {
+		nodesInCluster[i] = framework.NewNodeInfo()
+		nodesInCluster[i].SetNode(node)
+	}
+	tests := map[string]struct {
+		pluginResults  []injectedResult
+		wantPlacements []*fwk.Placement
+		wantStatusCode fwk.Code
+	}{
+		"When no plugins provided, returns a single placement with initial nodes": {
+			pluginResults: []injectedResult{},
+			wantPlacements: []*fwk.Placement{
+				{
+					Name:  "",
+					Nodes: nodesInCluster,
+				},
+			},
+			wantStatusCode: fwk.Success,
+		},
+		"When one plugin provided, returns placements generated by the plugin": {
+			pluginResults: []injectedResult{
+				{
+					GeneratePlacementsResult: []*fwk.Placement{
+						{
+							Name: "foo",
+							Nodes: []fwk.NodeInfo{
+								nodesInCluster[0],
+								nodesInCluster[1],
+							},
+						},
+						{
+							Name: "bar",
+							Nodes: []fwk.NodeInfo{
+								nodesInCluster[1],
+								nodesInCluster[2],
+							},
+						},
+					},
+				},
+			},
+			wantPlacements: []*fwk.Placement{
+				{
+					Name: "foo",
+					Nodes: []fwk.NodeInfo{
+						nodesInCluster[0],
+						nodesInCluster[1],
+					},
+				},
+				{
+					Name: "bar",
+					Nodes: []fwk.NodeInfo{
+						nodesInCluster[1],
+						nodesInCluster[2],
+					},
+				},
+			},
+			wantStatusCode: fwk.Success,
+		},
+		"When plugin fails, returns error status": {
+			pluginResults: []injectedResult{
+				{GeneratePlacementsStatus: int(fwk.Error)},
+			},
+			wantStatusCode: fwk.Error,
+		},
+		"When plugin returns no placements, returns unschedulable": {
+			pluginResults: []injectedResult{
+				{GeneratePlacementsResult: []*fwk.Placement{}},
+			},
+			wantStatusCode: fwk.Unschedulable,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+
+			r := make(Registry)
+			pluginSet := config.PluginSet{}
+			plugins := make([]*TestPlacementGeneratePlugin, len(tt.pluginResults))
+			for i, inj := range tt.pluginResults {
+				pluginName := fmt.Sprintf("plugin[%d]", i)
+				pluginSet.Enabled = append(pluginSet.Enabled, config.Plugin{Name: pluginName})
+				plugins[i] = &TestPlacementGeneratePlugin{
+					name: pluginName,
+					inj:  inj,
+				}
+				err := r.Register(pluginName, func(ctx context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
+					return plugins[i], nil
+				})
+				if err != nil {
+					t.Fatalf("failed to register PlacementGeneratePlugin")
+				}
+			}
+
+			profile := config.KubeSchedulerProfile{Plugins: &config.Plugins{PlacementGenerate: pluginSet}}
+			fw, err := newFrameworkWithQueueSortAndBind(ctx, r, profile, WithSnapshotSharedLister(cache.NewEmptySnapshot()))
+			if err != nil {
+				t.Fatalf("Unexpected error during calling NewFramework, got %v", err)
+			}
+
+			result, status := fw.RunPlacementGeneratePlugins(ctx, framework.NewCycleState(), nil, nodesInCluster)
+
+			if status.Code() != tt.wantStatusCode {
+				t.Errorf("Unexpected status code, want %v, got %v", tt.wantStatusCode, status.Code())
+			}
+			if diff := cmp.Diff(tt.wantPlacements, result, cmp.AllowUnexported(framework.NodeInfo{})); diff != "" {
+				t.Errorf("Unexpected placements (-want,+got):\n%s", diff)
+			}
+		})
+	}
 }
 
 type placementScoreResult struct {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -63,6 +63,7 @@ var ExtensionPoints = []string{
 	Unreserve,
 	Permit,
 	Sign,
+	PlacementGenerate,
 }
 
 const (
@@ -82,6 +83,7 @@ const (
 	Unreserve                        = "Unreserve"
 	Permit                           = "Permit"
 	Sign                             = "Sign"
+	PlacementGenerate                = "PlacementGenerate"
 	PlacementScore                   = "PlacementScore"
 	PlacementScoreExtensionNormalize = "PlacementScoreExtensionNormalize"
 )

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types.go
@@ -233,6 +233,9 @@ type Plugins struct {
 	// plugin through MultiPoint. This follows the same behavior as all other extension point configurations.
 	MultiPoint PluginSet `json:"multiPoint,omitempty"`
 
+	// PlacementGenerate is a list of plugins that should be invoked during pod group scheduling cycle when determining placements for a pod group.
+	PlacementGenerate PluginSet `json:"placementGenerate,omitempty"`
+
 	// PlacementScore is a list of plugins that should be invoked during workload scheduling cycle when ranking pod group assignments.
 	PlacementScore PluginSet `json:"placementScore,omitempty"`
 }

--- a/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
@@ -485,6 +485,7 @@ func (in *Plugins) DeepCopyInto(out *Plugins) {
 	in.Bind.DeepCopyInto(&out.Bind)
 	in.PostBind.DeepCopyInto(&out.PostBind)
 	in.MultiPoint.DeepCopyInto(&out.MultiPoint)
+	in.PlacementGenerate.DeepCopyInto(&out.PlacementGenerate)
 	in.PlacementScore.DeepCopyInto(&out.PlacementScore)
 	return
 }

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -753,6 +753,24 @@ type SignPlugin interface {
 	SignPod(ctx context.Context, pod *v1.Pod) ([]SignFragment, *Status)
 }
 
+// GeneratePlacementsResult represents the result of the PlacementGeneratePlugin.
+type GeneratePlacementsResult struct {
+	// Placements is the set of placements that the plugin wants to partition the resources into.
+	// The partitions can overlap.
+	//
+	// To represent no valid partitions, set the array to nil or empty.
+	Placements []*Placement
+}
+
+// PlacementGeneratePlugin is an interface for plugins that generate candidate Placements.
+type PlacementGeneratePlugin interface {
+	Plugin
+
+	// GeneratePlacements generates a list of potential Placements for the given PodGroup within the parent placement.
+	// Each Placement represents a candidate set of resources, e.g., nodes matching a selector.
+	GeneratePlacements(ctx context.Context, state PodGroupCycleState, podGroup PodGroupInfo, parentPlacement *Placement) (*GeneratePlacementsResult, *Status)
+}
+
 // PlacementScore stores result of a placement score plugin to be later used for normalization.
 type PlacementScore struct {
 	// Placement is the placement for which the score was computed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/feature

#### What this PR does / why we need it:

This adds the necessary interfaces and logic for running placement generator plugins as described in https://github.com/kubernetes/enhancements/blob/ee22fae0f678e184400bcd4fd3281c2743be296b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md#L426.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/5732

#### Special notes for your reviewer:

Majority of this code is boilerplate. The interesting part is in framework.go, where we iterate over plugins to generate the final placements array. This function is not called anywhere yet, but will be used in the workload scheduling cycle.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added PlacementGenerate extension point to the scheduler. It's used to generate placements for placement-based pod group scheduling. Its use is guarded by the TopologyAwareWorkloadScheduling feature gate.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/ee22fae0f678e184400bcd4fd3281c2743be296b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md?plain=1#L426
```
