### PR TITLE
Enable the uniquemarkers linter

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -421,7 +421,7 @@ linters:
               - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.
-              # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
+              - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
               - "duplicatemarkers" #Prevent identical markers from being present on types and fields
               - "dependenttags" # Ensure markers dependent on other markers are present.
               - "nodurations" # Ensure duration types are not used.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -434,7 +434,7 @@ linters:
               - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.
-              # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
+              - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
               - "duplicatemarkers" #Prevent identical markers from being present on types and fields
               - "dependenttags" # Ensure markers dependent on other markers are present.
               - "nodurations" # Ensure duration types are not used.

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -20,7 +20,7 @@ linters:
     - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
     # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
     - "ssatags" # Ensure lists have a listType tag.
-    # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
+    - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
     - "duplicatemarkers" #Prevent identical markers from being present on types and fields
     - "dependenttags" # Ensure markers dependent on other markers are present.
     - "nodurations" # Ensure duration types are not used.


### PR DESCRIPTION
What type of PR is this?
/kind api-change
/kind feature

What this PR does / why we need it:
Enable the uniquemarkers linter

Which issue(s) this PR is related to:
Fixes : #136878

Special notes for your reviewer:

- This PR enable the uniquemarkers linter as tracked in #136878

- The adjustments do not alter API semantics, behavior, or compatibility; they only satisfy static analysis requirements enforced by the linter.

- make verify : passed

Does this PR introduce a user-facing change?
No.

```release-note
NONE
```