### PR TITLE
Bump logs e2e timeout to 3s to match log generator

### DIFF
--- a/test/e2e/kubectl/logs.go
+++ b/test/e2e/kubectl/logs.go
@@ -296,8 +296,8 @@ var _ = SIGDescribe("Kubectl logs", func() {
 				podOne := pods.Items[0].GetName()
 				podTwo := pods.Items[1].GetName()
 
-				ginkgo.By("sleep 1s to wait for log generator produce data after pods get ready")
-				time.Sleep(time.Second)
+				ginkgo.By("sleep 3s to wait for log generator produce data after pods get ready")
+				time.Sleep(3 * time.Second)
 
 				ginkgo.By("expecting logs from the default container from both pods in a deployment")
 				out := e2ekubectl.RunKubectlOrDie(ns, "logs", fmt.Sprintf("deploy/%s", deployName), "--all-pods")
@@ -318,8 +318,8 @@ var _ = SIGDescribe("Kubectl logs", func() {
 				podOne := pods.Items[0].GetName()
 				podTwo := pods.Items[1].GetName()
 
-				ginkgo.By("sleep 1s to wait for log generator produce data after pods get ready")
-				time.Sleep(time.Second)
+				ginkgo.By("sleep 3s to wait for log generator produce data after pods get ready")
+				time.Sleep(3 * time.Second)
 
 				ginkgo.By("expecting logs from all containers from both pods in a deployment")
 				out := e2ekubectl.RunKubectlOrDie(ns, "logs", fmt.Sprintf("deploy/%s", deployName), "--all-pods", "--all-containers")


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
In https://github.com/kubernetes/kubernetes/pull/136981#discussion_r2798980792 we discussed bumping the timeout to 3s to hopefully resolve problems from https://github.com/kubernetes/kubernetes/issues/136948 given that initial 1s isn't sufficient this PR bumps the timeout to 3s to match the log-generator process.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/136948

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
