### PR TITLE
[WIP] Graduate scheduling/v1alpha1 declarative validations to stable (KEP-5073)

### DIFF
--- a/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
@@ -88,14 +88,14 @@ func Validate_PodGroup(ctx context.Context, op operation.Operation, fldPath *fie
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *schedulingv1alpha1.PodGroup) *string { return &oldObj.Name }), oldObj != nil)...)
 

--- a/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
@@ -62,14 +62,14 @@ func Validate_GangSchedulingPolicy(ctx context.Context, op operation.Operation, 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha()...)
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)...)
 			return
 		}(fldPath.Child("minCount"), &obj.MinCount, safe.Field(oldObj, func(oldObj *schedulingv1alpha1.GangSchedulingPolicy) *int32 { return &oldObj.MinCount }), oldObj != nil)...)
 

--- a/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
@@ -188,13 +188,13 @@ func Validate_TypedLocalObjectReference(ctx context.Context, op operation.Operat
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.LongName(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("apiGroup"), &obj.APIGroup, safe.Field(oldObj, func(oldObj *schedulingv1alpha1.TypedLocalObjectReference) *string { return &oldObj.APIGroup }), oldObj != nil)...)
 
@@ -207,14 +207,14 @@ func Validate_TypedLocalObjectReference(ctx context.Context, op operation.Operat
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.PathSegmentName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.PathSegmentName(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("kind"), &obj.Kind, safe.Field(oldObj, func(oldObj *schedulingv1alpha1.TypedLocalObjectReference) *string { return &oldObj.Kind }), oldObj != nil)...)
 
@@ -227,14 +227,14 @@ func Validate_TypedLocalObjectReference(ctx context.Context, op operation.Operat
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.PathSegmentName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.PathSegmentName(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *schedulingv1alpha1.TypedLocalObjectReference) *string { return &oldObj.Name }), oldObj != nil)...)
 

--- a/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
@@ -129,7 +129,7 @@ func Validate_PodGroupPolicy(ctx context.Context, op operation.Operation, fldPat
 			return false
 		}
 		return obj.Gang != nil
-	}).MarkAlpha()...)
+	})...)
 
 	// field schedulingv1alpha1.PodGroupPolicy.Basic
 	errs = append(errs,
@@ -140,7 +140,7 @@ func Validate_PodGroupPolicy(ctx context.Context, op operation.Operation, fldPat
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -160,7 +160,7 @@ func Validate_PodGroupPolicy(ctx context.Context, op operation.Operation, fldPat
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
@@ -274,7 +274,7 @@ func Validate_WorkloadSpec(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha(); len(e) != 0 {

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -125,16 +125,7 @@ func validateControllerRef(ref *scheduling.TypedLocalObjectReference, fldPath *f
 
 func validatePodGroup(podGroup *scheduling.PodGroup, fldPath *field.Path, existingPodGroups sets.Set[string]) field.ErrorList {
 	var allErrs field.ErrorList
-	// To match the declarative validation behavior, we return Required for empty string.
-	// Declarative validation treats "" as "missing" via validate.RequiredValue()
-	// and returns early before checking the format constraint.
-	if podGroup.Name == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "").MarkCoveredByDeclarative())
-	} else {
-		for _, detail := range apivalidation.ValidatePodGroupName(podGroup.Name, false) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), podGroup.Name, detail).WithOrigin("format=k8s-short-name").MarkCoveredByDeclarative())
-		}
-	}
+	// PodGroup.Name required and format validation is handled by declarative validation.
 	if existingPodGroups.Has(podGroup.Name) {
 		// MarkCoveredByDeclarative is not needed here because the duplicate check is done.
 		allErrs = append(allErrs, field.Duplicate(fldPath, podGroup).MarkCoveredByDeclarative())

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -132,39 +132,8 @@ func validatePodGroup(podGroup *scheduling.PodGroup, fldPath *field.Path, existi
 	} else {
 		existingPodGroups.Insert(podGroup.Name)
 	}
-	allErrs = append(allErrs, validatePodGroupPolicy(&podGroup.Policy, fldPath.Child("policy"))...)
+	// PodGroupPolicy union validation is handled by declarative validation.
 	return allErrs
-}
-
-func validatePodGroupPolicy(policy *scheduling.PodGroupPolicy, fldPath *field.Path) field.ErrorList {
-	var allErrs field.ErrorList
-	var setFields []string
-
-	if policy.Basic != nil {
-		setFields = append(setFields, "`basic`")
-	}
-	if policy.Gang != nil {
-		setFields = append(setFields, "`gang`")
-	}
-
-	switch {
-	case len(setFields) == 0:
-		allErrs = append(allErrs, field.Invalid(fldPath, "", "must specify one of: `basic`, `gang`").WithOrigin("union").MarkCoveredByDeclarative())
-	case len(setFields) > 1:
-		allErrs = append(allErrs, field.Invalid(fldPath, fmt.Sprintf("{%s}", strings.Join(setFields, ", ")),
-			"exactly one of `basic`, `gang` is required, but multiple fields are set").WithOrigin("union").MarkCoveredByDeclarative())
-	case policy.Basic != nil:
-		allErrs = append(allErrs, validatBasicSchedulingPolicy(policy.Basic, fldPath.Child("basic"))...)
-	case policy.Gang != nil:
-		// Gang scheduling policy validation is handled by declarative validation.
-	}
-
-	return allErrs
-}
-
-func validatBasicSchedulingPolicy(policy *scheduling.BasicSchedulingPolicy, fldPath *field.Path) field.ErrorList {
-	// BasicSchedulingPolicy has no fields.
-	return nil
 }
 
 // ValidateWorkloadUpdate tests if an update to Workload is valid.

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -119,8 +119,6 @@ func validateWorkloadSpecUpdate(spec, oldSpec *scheduling.WorkloadSpec, fldPath 
 	var allErrs field.ErrorList
 	if oldSpec.ControllerRef != nil {
 		allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(spec.ControllerRef, oldSpec.ControllerRef, fldPath.Child("controllerRef")).WithOrigin("update").MarkCoveredByDeclarative()...)
-	} else if spec.ControllerRef != nil {
-		// ControllerRef field validation on new values is handled by declarative validation.
 	}
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.PodGroups, oldSpec.PodGroups, fldPath.Child("podGroups")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	allErrs = append(allErrs, validatePodGroups(fldPath, spec, operation.Update)...)

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -165,7 +165,7 @@ func validatePodGroupPolicy(policy *scheduling.PodGroupPolicy, fldPath *field.Pa
 	case policy.Basic != nil:
 		allErrs = append(allErrs, validatBasicSchedulingPolicy(policy.Basic, fldPath.Child("basic"))...)
 	case policy.Gang != nil:
-		allErrs = append(allErrs, validateGangSchedulingPolicy(policy.Gang, fldPath.Child("gang"))...)
+		// Gang scheduling policy validation is handled by declarative validation.
 	}
 
 	return allErrs
@@ -174,21 +174,6 @@ func validatePodGroupPolicy(policy *scheduling.PodGroupPolicy, fldPath *field.Pa
 func validatBasicSchedulingPolicy(policy *scheduling.BasicSchedulingPolicy, fldPath *field.Path) field.ErrorList {
 	// BasicSchedulingPolicy has no fields.
 	return nil
-}
-
-func validateGangSchedulingPolicy(policy *scheduling.GangSchedulingPolicy, fldPath *field.Path) field.ErrorList {
-	// To match the declarative validation behavior, we return Required for 0.
-	// Declarative validation treats 0 as "missing" via validate.RequiredValue()
-	// and returns early before checking the minimum constraint.
-	// For non-zero values, declarative validation returns early without any validation,
-	// so we don't mark them as covered.
-	var allErrs field.ErrorList
-	if policy.MinCount == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("minCount"), "").MarkCoveredByDeclarative())
-	} else if policy.MinCount < 0 {
-		allErrs = append(allErrs, apivalidation.ValidatePositiveField(int64(policy.MinCount), fldPath.Child("minCount")).WithOrigin("minimum").MarkCoveredByDeclarative()...)
-	}
-	return allErrs
 }
 
 // ValidateWorkloadUpdate tests if an update to Workload is valid.

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -21,10 +21,8 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/operation"
-	"k8s.io/apimachinery/pkg/api/validate/content"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
@@ -75,9 +73,7 @@ func ValidateWorkload(workload *scheduling.Workload) field.ErrorList {
 
 func validateWorkloadSpec(spec *scheduling.WorkloadSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	if spec.ControllerRef != nil {
-		allErrs = append(allErrs, validateControllerRef(spec.ControllerRef, fldPath.Child("controllerRef"))...)
-	}
+	// ControllerRef field validation is handled by declarative validation.
 	allErrs = append(allErrs, validatePodGroups(fldPath, spec, operation.Create)...)
 	return allErrs
 }
@@ -94,30 +90,6 @@ func validatePodGroups(fldPath *field.Path, spec *scheduling.WorkloadSpec, op op
 		// spec.PodGroups is immutable after create.
 		for i := range spec.PodGroups {
 			allErrs = append(allErrs, validatePodGroup(&spec.PodGroups[i], podGroupsPath.Index(i), existingPodGroups)...)
-		}
-	}
-	return allErrs
-}
-
-func validateControllerRef(ref *scheduling.TypedLocalObjectReference, fldPath *field.Path) field.ErrorList {
-	var allErrs = field.ErrorList{}
-	if ref.APIGroup != "" {
-		for _, msg := range validation.IsDNS1123Subdomain(ref.APIGroup) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("apiGroup"), ref.APIGroup, msg).WithOrigin("format=k8s-long-name").MarkCoveredByDeclarative())
-		}
-	}
-	if ref.Kind == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("kind"), "").MarkCoveredByDeclarative())
-	} else {
-		for _, msg := range content.IsPathSegmentName(ref.Kind) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), ref.Kind, msg).WithOrigin("format=k8s-path-segment-name").MarkCoveredByDeclarative())
-		}
-	}
-	if ref.Name == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "").MarkCoveredByDeclarative())
-	} else {
-		for _, msg := range content.IsPathSegmentName(ref.Name) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ref.Name, msg).WithOrigin("format=k8s-path-segment-name").MarkCoveredByDeclarative())
 		}
 	}
 	return allErrs
@@ -148,7 +120,7 @@ func validateWorkloadSpecUpdate(spec, oldSpec *scheduling.WorkloadSpec, fldPath 
 	if oldSpec.ControllerRef != nil {
 		allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(spec.ControllerRef, oldSpec.ControllerRef, fldPath.Child("controllerRef")).WithOrigin("update").MarkCoveredByDeclarative()...)
 	} else if spec.ControllerRef != nil {
-		allErrs = append(allErrs, validateControllerRef(spec.ControllerRef, fldPath.Child("controllerRef"))...)
+		// ControllerRef field validation on new values is handled by declarative validation.
 	}
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.PodGroups, oldSpec.PodGroups, fldPath.Child("podGroups")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	allErrs = append(allErrs, validatePodGroups(fldPath, spec, operation.Update)...)

--- a/pkg/apis/scheduling/validation/validation_test.go
+++ b/pkg/apis/scheduling/validation/validation_test.go
@@ -260,14 +260,6 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "controllerRef", "apiGroup"), strings.Repeat("n", 64), "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')").MarkCoveredByDeclarative(),
 			},
 		},
-		"no pod group name": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups[0].Name = ""
-			}),
-			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "podGroups").Index(0).Child("name"), "").MarkCoveredByDeclarative(),
-			},
-		},
 		"two policies": {
 			workload: mkWorkload(func(w *scheduling.Workload) {
 				w.Spec.PodGroups[0].Policy.Gang = &scheduling.GangSchedulingPolicy{

--- a/pkg/apis/scheduling/validation/validation_test.go
+++ b/pkg/apis/scheduling/validation/validation_test.go
@@ -252,60 +252,12 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(field.NewPath("metadata", "namespace"), strings.Repeat("n", 64), "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
 			},
 		},
-		"too long controllerRef apiGroup": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.ControllerRef.APIGroup = strings.Repeat("g", 254)
-			}),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "controllerRef", "apiGroup"), strings.Repeat("n", 64), "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')").MarkCoveredByDeclarative(),
-			},
-		},
 		"two pod groups with the same name": {
 			workload: mkWorkload(func(w *scheduling.Workload) {
 				w.Spec.PodGroups[1].Name = w.Spec.PodGroups[0].Name
 			}),
 			expectedErrs: field.ErrorList{
 				field.Duplicate(field.NewPath("spec", "podGroups").Index(1), scheduling.PodGroup{Name: "group1", Policy: scheduling.PodGroupPolicy{Gang: &scheduling.GangSchedulingPolicy{MinCount: 1}}}).MarkCoveredByDeclarative(),
-			},
-		},
-		"invalid controllerRef apiGroup": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.ControllerRef.APIGroup = ".group"
-			}),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "controllerRef", "apiGroup"), ".group", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')").MarkCoveredByDeclarative(),
-			},
-		},
-		"no controllerRef kind": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.ControllerRef.Kind = ""
-			}),
-			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "controllerRef", "kind"), "").MarkCoveredByDeclarative(),
-			},
-		},
-		"invalid controllerRef kind": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.ControllerRef.Kind = "/foo"
-			}),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "controllerRef", "kind"), "/foo", "must not contain '/'").MarkCoveredByDeclarative(),
-			},
-		},
-		"no controllerRef name": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.ControllerRef.Name = ""
-			}),
-			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "controllerRef", "name"), "").MarkCoveredByDeclarative(),
-			},
-		},
-		"invalid controllerRef name": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.ControllerRef.Name = "/baz"
-			}),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "controllerRef", "name"), "/baz", "must not contain '/'").WithOrigin("format=k8s-short-name").MarkCoveredByDeclarative(),
 			},
 		},
 		"no pod groups": {

--- a/pkg/apis/scheduling/validation/validation_test.go
+++ b/pkg/apis/scheduling/validation/validation_test.go
@@ -260,16 +260,6 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "controllerRef", "apiGroup"), strings.Repeat("n", 64), "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')").MarkCoveredByDeclarative(),
 			},
 		},
-		"two policies": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups[0].Policy.Gang = &scheduling.GangSchedulingPolicy{
-					MinCount: 2,
-				}
-			}),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy"), "{`basic`, `gang`}", "exactly one of `basic`, `gang` is required, but multiple fields are set").MarkCoveredByDeclarative(),
-			},
-		},
 		"two pod groups with the same name": {
 			workload: mkWorkload(func(w *scheduling.Workload) {
 				w.Spec.PodGroups[1].Name = w.Spec.PodGroups[0].Name
@@ -348,24 +338,6 @@ func TestValidateWorkload(t *testing.T) {
 			}),
 			expectedErrs: field.ErrorList{
 				field.Duplicate(field.NewPath("spec", "podGroups").Index(1), scheduling.PodGroup{Name: "group1", Policy: scheduling.PodGroupPolicy{Gang: &scheduling.GangSchedulingPolicy{MinCount: 1}}}).MarkCoveredByDeclarative(),
-			},
-		},
-		"no policy set": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups[0].Policy = scheduling.PodGroupPolicy{}
-			}),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy"), "", "must specify one of: `basic`, `gang`").MarkCoveredByDeclarative(),
-			},
-		},
-		"multiple policies set": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups[0].Policy.Gang = &scheduling.GangSchedulingPolicy{
-					MinCount: 2,
-				}
-			}),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy"), "{`basic`, `gang`}", "exactly one of `basic`, `gang` is required, but multiple fields are set").MarkCoveredByDeclarative(),
 			},
 		},
 	}

--- a/pkg/apis/scheduling/validation/validation_test.go
+++ b/pkg/apis/scheduling/validation/validation_test.go
@@ -278,22 +278,6 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy"), "{`basic`, `gang`}", "exactly one of `basic`, `gang` is required, but multiple fields are set").MarkCoveredByDeclarative(),
 			},
 		},
-		"zero min count in gang": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups[1].Policy.Gang.MinCount = 0
-			}),
-			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "podGroups").Index(1).Child("policy", "gang", "minCount"), "").MarkCoveredByDeclarative(),
-			},
-		},
-		"negative min count in gang": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups[1].Policy.Gang.MinCount = -1
-			}),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "podGroups").Index(1).Child("policy", "gang", "minCount"), int64(-1), "must be greater than zero").WithOrigin("minimum").MarkCoveredByDeclarative(),
-			},
-		},
 		"two pod groups with the same name": {
 			workload: mkWorkload(func(w *scheduling.Workload) {
 				w.Spec.PodGroups[1].Name = w.Spec.PodGroups[0].Name
@@ -390,14 +374,6 @@ func TestValidateWorkload(t *testing.T) {
 			}),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy"), "{`basic`, `gang`}", "exactly one of `basic`, `gang` is required, but multiple fields are set").MarkCoveredByDeclarative(),
-			},
-		},
-		"negative minCount in gang": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups[1].Policy.Gang.MinCount = -1
-			}),
-			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "podGroups").Index(1).Child("policy", "gang", "minCount"), int64(-1), "must be greater than zero").WithOrigin("minimum").MarkCoveredByDeclarative(),
 			},
 		},
 	}

--- a/pkg/registry/scheduling/workload/declarative_validation_test.go
+++ b/pkg/registry/scheduling/workload/declarative_validation_test.go
@@ -79,11 +79,11 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		// instead of checking minimum constraint and returning Invalid error.
 		"gang minCount zero": {
 			input:        mkValidWorkload(setPodGroupMinCount(0, 0)),
-			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec", "podGroups").Index(0).Child("policy", "gang", "minCount"), "").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec", "podGroups").Index(0).Child("policy", "gang", "minCount"), "")},
 		},
 		"gang minCount negative": {
 			input:        mkValidWorkload(setPodGroupMinCount(0, -1)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy", "gang", "minCount"), nil, "").WithOrigin("minimum").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy", "gang", "minCount"), nil, "").WithOrigin("minimum")},
 		},
 		"valid with controllerRef": {
 			input: mkValidWorkload(setControllerRef("apps", "Deployment", "my-deployment")),

--- a/pkg/registry/scheduling/workload/declarative_validation_test.go
+++ b/pkg/registry/scheduling/workload/declarative_validation_test.go
@@ -65,11 +65,11 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		},
 		"empty podGroup name": {
 			input:        mkValidWorkload(setPodGroupName(0, "")),
-			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec", "podGroups").Index(0).Child("name"), "").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec", "podGroups").Index(0).Child("name"), "")},
 		},
 		"invalid podGroup name": {
 			input:        mkValidWorkload(setPodGroupName(0, "Invalid_Name")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("name"), nil, "").WithOrigin("format=k8s-short-name").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("name"), nil, "").WithOrigin("format=k8s-short-name")},
 		},
 		"duplicate podGroup names": {
 			input:        mkValidWorkload(addPodGroup("main")),

--- a/pkg/registry/scheduling/workload/declarative_validation_test.go
+++ b/pkg/registry/scheduling/workload/declarative_validation_test.go
@@ -93,31 +93,31 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		},
 		"controllerRef invalid APIGroup": {
 			input:        mkValidWorkload(setControllerRef("invalid_api_group", "Deployment", "my-deployment")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "apiGroup"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "apiGroup"), nil, "").WithOrigin("format=k8s-long-name")},
 		},
 		"controllerRef missing kind": {
 			input:        mkValidWorkload(setControllerRef("apps", "", "my-deployment")),
-			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec", "controllerRef", "kind"), "").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec", "controllerRef", "kind"), "")},
 		},
 		"controllerRef invalid kind with slash": {
 			input:        mkValidWorkload(setControllerRef("apps", "Deploy/ment", "my-deployment")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "kind"), nil, "").WithOrigin("format=k8s-path-segment-name").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "kind"), nil, "").WithOrigin("format=k8s-path-segment-name")},
 		},
 		"controllerRef missing name": {
 			input:        mkValidWorkload(setControllerRef("apps", "Deployment", "")),
-			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec", "controllerRef", "name"), "").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec", "controllerRef", "name"), "")},
 		},
 		"controllerRef invalid name": {
 			input:        mkValidWorkload(setControllerRef("apps", "Deployment", "/invalid-name")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "name"), nil, "").WithOrigin("format=k8s-path-segment-name").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "name"), nil, "").WithOrigin("format=k8s-path-segment-name")},
 		},
 		"controllerRef invalid kind with percent": {
 			input:        mkValidWorkload(setControllerRef("apps", "Deploy%ment", "my-deployment")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "kind"), nil, "").WithOrigin("format=k8s-path-segment-name").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "kind"), nil, "").WithOrigin("format=k8s-path-segment-name")},
 		},
 		"controllerRef invalid name with percent": {
 			input:        mkValidWorkload(setControllerRef("apps", "Deployment", "my%deployment")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "name"), nil, "").WithOrigin("format=k8s-path-segment-name").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "controllerRef", "name"), nil, "").WithOrigin("format=k8s-path-segment-name")},
 		},
 		"policy with neither basic nor gang": {
 			input:        mkValidWorkload(clearPodGroupPolicy(0)),

--- a/pkg/registry/scheduling/workload/declarative_validation_test.go
+++ b/pkg/registry/scheduling/workload/declarative_validation_test.go
@@ -121,11 +121,11 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		},
 		"policy with neither basic nor gang": {
 			input:        mkValidWorkload(clearPodGroupPolicy(0)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy"), nil, "").WithOrigin("union").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy"), nil, "").WithOrigin("union")},
 		},
 		"policy with both basic and gang": {
 			input:        mkValidWorkload(setBothPolicies(0)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy"), nil, "").WithOrigin("union").MarkAlpha()},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroups").Index(0).Child("policy"), nil, "").WithOrigin("union")},
 		},
 		"valid with basic policy": {
 			input: mkValidWorkload(setBasicPolicy(0)),

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -137,24 +137,24 @@ message TypedLocalObjectReference {
   // It must be a DNS subdomain.
   //
   // +optional
-  // +k8s:alpha(since:"1.35")=+k8s:optional
-  // +k8s:alpha(since:"1.35")=+k8s:format=k8s-long-name
+  // +k8s:optional
+  // +k8s:format=k8s-long-name
   optional string apiGroup = 1;
 
   // Kind is the type of resource being referenced.
   // It must be a path segment name.
   //
   // +required
-  // +k8s:alpha(since:"1.35")=+k8s:required
-  // +k8s:alpha(since:"1.35")=+k8s:format=k8s-path-segment-name
+  // +k8s:required
+  // +k8s:format=k8s-path-segment-name
   optional string kind = 2;
 
   // Name is the name of resource being referenced.
   // It must be a path segment name.
   //
   // +required
-  // +k8s:alpha(since:"1.35")=+k8s:required
-  // +k8s:alpha(since:"1.35")=+k8s:format=k8s-path-segment-name
+  // +k8s:required
+  // +k8s:format=k8s-path-segment-name
   optional string name = 3;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -193,7 +193,7 @@ message WorkloadSpec {
   // When set, it cannot be changed.
   //
   // +optional
-  // +k8s:alpha(since:"1.35")=+k8s:optional
+  // +k8s:optional
   // +k8s:alpha(since:"1.35")=+k8s:update=NoModify
   optional TypedLocalObjectReference controllerRef = 1;
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -41,8 +41,8 @@ message GangSchedulingPolicy {
   // It must be a positive integer.
   //
   // +required
-  // +k8s:alpha(since:"1.35")=+k8s:required
-  // +k8s:alpha(since:"1.35")=+k8s:minimum=0
+  // +k8s:required
+  // +k8s:minimum=0
   optional int32 minCount = 1;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -52,8 +52,8 @@ message PodGroup {
   // It must be a DNS label. This field is immutable.
   //
   // +required
-  // +k8s:alpha(since:"1.35")=+k8s:required
-  // +k8s:alpha(since:"1.35")=+k8s:format=k8s-short-name
+  // +k8s:required
+  // +k8s:format=k8s-short-name
   optional string name = 1;
 
   // Policy defines the scheduling policy for this PodGroup.

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -69,18 +69,18 @@ message PodGroupPolicy {
   // standard Kubernetes scheduling behavior.
   //
   // +optional
-  // +k8s:alpha(since:"1.35")=+k8s:optional
+  // +k8s:optional
   // +oneOf=PolicySelection
-  // +k8s:alpha(since:"1.35")=+k8s:unionMember
+  // +k8s:unionMember
   optional BasicSchedulingPolicy basic = 2;
 
   // Gang specifies that the pods in this group should be scheduled using
   // all-or-nothing semantics.
   //
   // +optional
-  // +k8s:alpha(since:"1.35")=+k8s:optional
+  // +k8s:optional
   // +oneOf=PolicySelection
-  // +k8s:alpha(since:"1.35")=+k8s:unionMember
+  // +k8s:unionMember
   optional GangSchedulingPolicy gang = 3;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -145,22 +145,22 @@ type TypedLocalObjectReference struct {
 	// It must be a DNS subdomain.
 	//
 	// +optional
-	// +k8s:alpha(since:"1.35")=+k8s:optional
-	// +k8s:alpha(since:"1.35")=+k8s:format=k8s-long-name
+	// +k8s:optional
+	// +k8s:format=k8s-long-name
 	APIGroup string `json:"apiGroup,omitempty" protobuf:"bytes,1,opt,name=apiGroup"`
 	// Kind is the type of resource being referenced.
 	// It must be a path segment name.
 	//
 	// +required
-	// +k8s:alpha(since:"1.35")=+k8s:required
-	// +k8s:alpha(since:"1.35")=+k8s:format=k8s-path-segment-name
+	// +k8s:required
+	// +k8s:format=k8s-path-segment-name
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced.
 	// It must be a path segment name.
 	//
 	// +required
-	// +k8s:alpha(since:"1.35")=+k8s:required
-	// +k8s:alpha(since:"1.35")=+k8s:format=k8s-path-segment-name
+	// +k8s:required
+	// +k8s:format=k8s-path-segment-name
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -187,18 +187,18 @@ type PodGroupPolicy struct {
 	// standard Kubernetes scheduling behavior.
 	//
 	// +optional
-	// +k8s:alpha(since:"1.35")=+k8s:optional
+	// +k8s:optional
 	// +oneOf=PolicySelection
-	// +k8s:alpha(since:"1.35")=+k8s:unionMember
+	// +k8s:unionMember
 	Basic *BasicSchedulingPolicy `json:"basic,omitempty" protobuf:"bytes,2,opt,name=basic"`
 
 	// Gang specifies that the pods in this group should be scheduled using
 	// all-or-nothing semantics.
 	//
 	// +optional
-	// +k8s:alpha(since:"1.35")=+k8s:optional
+	// +k8s:optional
 	// +oneOf=PolicySelection
-	// +k8s:alpha(since:"1.35")=+k8s:unionMember
+	// +k8s:unionMember
 	Gang *GangSchedulingPolicy `json:"gang,omitempty" protobuf:"bytes,3,opt,name=gang"`
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -218,7 +218,7 @@ type GangSchedulingPolicy struct {
 	// It must be a positive integer.
 	//
 	// +required
-	// +k8s:alpha(since:"1.35")=+k8s:required
-	// +k8s:alpha(since:"1.35")=+k8s:minimum=0
+	// +k8s:required
+	// +k8s:minimum=0
 	MinCount int32 `json:"minCount" protobuf:"varint,1,opt,name=minCount"`
 }

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -119,7 +119,7 @@ type WorkloadSpec struct {
 	// When set, it cannot be changed.
 	//
 	// +optional
-	// +k8s:alpha(since:"1.35")=+k8s:optional
+	// +k8s:optional
 	// +k8s:alpha(since:"1.35")=+k8s:update=NoModify
 	ControllerRef *TypedLocalObjectReference `json:"controllerRef,omitempty" protobuf:"bytes,1,opt,name=controllerRef"`
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -170,8 +170,8 @@ type PodGroup struct {
 	// It must be a DNS label. This field is immutable.
 	//
 	// +required
-	// +k8s:alpha(since:"1.35")=+k8s:required
-	// +k8s:alpha(since:"1.35")=+k8s:format=k8s-short-name
+	// +k8s:required
+	// +k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// Policy defines the scheduling policy for this PodGroup.


### PR DESCRIPTION
### PR Description

#### What type of PR is this?
/kind api-change

#### What this PR does / why we need it:
This PR graduates several declarative validation rules for the `scheduling.x-k8s.io/v1alpha1` API group from Alpha to Stable status. Specifically, it promotes validation tags for the following fields and types:
*   **`GangSchedulingPolicy.MinCount`**: Graduates `+k8s:required` and `+k8s:minimum=0`.
*   **`PodGroup.Name`**: Graduates `+k8s:required` and `+k8s:format=k8s-short-name`.
*   **`PodGroupPolicy`**: Graduates union member validations (`+k8s:unionMember`) for the `Basic` and `Gang` fields.
*   **`TypedLocalObjectReference`**: Graduates format and requirement tags for `APIGroup`, `Kind`, and `Name`.

Following the migration strategy outlined in **KEP-5073**, this PR also removes the legacy handwritten validation functions in `pkg/apis/scheduling/validation/validation.go` (such as `validateControllerRef`, `validatePodGroupPolicy`, and `validateGangSchedulingPolicy`) and their corresponding unit tests, as these are now fully covered by the generated declarative validation logic.

#### Which issue(s) this PR is related to:
Related to KEP-5073: Declarative Validation of Kubernetes Native Types.

#### Special notes for your reviewer:
The graduation involves removing the `+k8s:alpha(since:"1.35")` prefix from the validation tags in `types.go`. Equivalence has been verified through existing integration and fuzz tests which ensure that the generated validation matches the previous handwritten behavior.

#### Does this PR introduce a user-facing change?
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
[KEP-5073]: [https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md)