### PR TITLE
Migrate ClusterTrustBundle.Spec.SignerName to +k8s:immutable declarative validation

### DIFF
--- a/pkg/apis/certificates/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1alpha1/zz_generated.validations.go
@@ -22,7 +22,15 @@ limitations under the License.
 package v1alpha1
 
 import (
+	context "context"
+	fmt "fmt"
+
+	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	operation "k8s.io/apimachinery/pkg/api/operation"
+	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	field "k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
@@ -30,5 +38,96 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type ClusterTrustBundle
+	scheme.AddValidationFunc(
+		(*certificatesv1alpha1.ClusterTrustBundle)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/":
+				return Validate_ClusterTrustBundle(
+					ctx, op, nil, /* fldPath */
+					obj.(*certificatesv1alpha1.ClusterTrustBundle),
+					safe.Cast[*certificatesv1alpha1.ClusterTrustBundle](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
 	return nil
+}
+
+// Validate_ClusterTrustBundle validates an instance of ClusterTrustBundle according
+// to declarative validation rules in the API schema.
+func Validate_ClusterTrustBundle(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *certificatesv1alpha1.ClusterTrustBundle) (errs field.ErrorList) {
+
+	// field certificatesv1alpha1.ClusterTrustBundle.TypeMeta has no validation
+	// field certificatesv1alpha1.ClusterTrustBundle.ObjectMeta has no validation
+
+	{ // field certificatesv1alpha1.ClusterTrustBundle.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *certificatesv1alpha1.ClusterTrustBundleSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ClusterTrustBundleSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *certificatesv1alpha1.ClusterTrustBundle) *certificatesv1alpha1.ClusterTrustBundleSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_ClusterTrustBundleSpec validates an instance of ClusterTrustBundleSpec according
+// to declarative validation rules in the API schema.
+func Validate_ClusterTrustBundleSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *certificatesv1alpha1.ClusterTrustBundleSpec) (errs field.ErrorList) {
+
+	{ // field certificatesv1alpha1.ClusterTrustBundleSpec.SignerName
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *certificatesv1alpha1.ClusterTrustBundleSpec) *string {
+				return &oldObj.SignerName
+			})
+		errs = append(errs, fn(fldPath.Child("signerName"), &obj.SignerName, oldVal, oldObj != nil)...)
+	}
+
+	// field certificatesv1alpha1.ClusterTrustBundleSpec.TrustBundle has no validation
+	return errs
 }

--- a/pkg/apis/certificates/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.validations.go
@@ -54,6 +54,21 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
 			}
 		})
+	// type ClusterTrustBundle
+	scheme.AddValidationFunc(
+		(*certificatesv1beta1.ClusterTrustBundle)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/":
+				return Validate_ClusterTrustBundle(
+					ctx, op, nil, /* fldPath */
+					obj.(*certificatesv1beta1.ClusterTrustBundle),
+					safe.Cast[*certificatesv1beta1.ClusterTrustBundle](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
 	return nil
 }
 
@@ -149,5 +164,81 @@ func Validate_CertificateSigningRequestStatus(
 	}
 
 	// field certificatesv1beta1.CertificateSigningRequestStatus.Certificate has no validation
+	return errs
+}
+
+// Validate_ClusterTrustBundle validates an instance of ClusterTrustBundle according
+// to declarative validation rules in the API schema.
+func Validate_ClusterTrustBundle(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *certificatesv1beta1.ClusterTrustBundle) (errs field.ErrorList) {
+
+	// field certificatesv1beta1.ClusterTrustBundle.TypeMeta has no validation
+	// field certificatesv1beta1.ClusterTrustBundle.ObjectMeta has no validation
+
+	{ // field certificatesv1beta1.ClusterTrustBundle.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *certificatesv1beta1.ClusterTrustBundleSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ClusterTrustBundleSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *certificatesv1beta1.ClusterTrustBundle) *certificatesv1beta1.ClusterTrustBundleSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_ClusterTrustBundleSpec validates an instance of ClusterTrustBundleSpec according
+// to declarative validation rules in the API schema.
+func Validate_ClusterTrustBundleSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *certificatesv1beta1.ClusterTrustBundleSpec) (errs field.ErrorList) {
+
+	{ // field certificatesv1beta1.ClusterTrustBundleSpec.SignerName
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *certificatesv1beta1.ClusterTrustBundleSpec) *string {
+				return &oldObj.SignerName
+			})
+		errs = append(errs, fn(fldPath.Child("signerName"), &obj.SignerName, oldVal, oldObj != nil)...)
+	}
+
+	// field certificatesv1beta1.ClusterTrustBundleSpec.TrustBundle has no validation
 	return errs
 }

--- a/pkg/apis/certificates/validation/validation.go
+++ b/pkg/apis/certificates/validation/validation.go
@@ -512,7 +512,7 @@ func ValidateClusterTrustBundleUpdate(newBundle, oldBundle *certificates.Cluster
 	var allErrors field.ErrorList
 	allErrors = append(allErrors, ValidateClusterTrustBundle(newBundle, opts)...)
 	allErrors = append(allErrors, apivalidation.ValidateObjectMetaUpdate(&newBundle.ObjectMeta, &oldBundle.ObjectMeta, field.NewPath("metadata"))...)
-	allErrors = append(allErrors, apivalidation.ValidateImmutableField(newBundle.Spec.SignerName, oldBundle.Spec.SignerName, field.NewPath("spec", "signerName"))...)
+	allErrors = append(allErrors, apivalidation.ValidateImmutableField(newBundle.Spec.SignerName, oldBundle.Spec.SignerName, field.NewPath("spec", "signerName")).WithOrigin("immutable").MarkAlpha().MarkCoveredByDeclarative()...)
 	return allErrors
 }
 

--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -1526,7 +1526,7 @@ func TestValidateClusterTrustBundleUpdate(t *testing.T) {
 		},
 		wantErrors: field.ErrorList{
 			field.Invalid(field.NewPath("metadata", "name"), "k8s.io:foo:bar", "ClusterTrustBundle for signerName k8s.io/bar must be named with prefix k8s.io:bar:"),
-			field.Invalid(field.NewPath("spec", "signerName"), "k8s.io/bar", "field is immutable"),
+			field.Invalid(field.NewPath("spec", "signerName"), "k8s.io/bar", "field is immutable").WithOrigin("immutable").MarkAlpha().MarkCoveredByDeclarative(),
 		},
 	}, {
 		description: "adding certificate allowed",

--- a/pkg/registry/certificates/clustertrustbundle/declarative_validation_test.go
+++ b/pkg/registry/certificates/clustertrustbundle/declarative_validation_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustertrustbundle
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	mathrand "math/rand"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/certificates"
+)
+
+var apiVersions = []string{"v1alpha1", "v1beta1"}
+
+func mustMakeTestCert(t *testing.T) string {
+	t.Helper()
+	gen := mathrand.New(mathrand.NewSource(12345))
+
+	pub, priv, err := ed25519.GenerateKey(gen)
+	if err != nil {
+		t.Fatalf("Error while generating key: %v", err)
+	}
+
+	cert, err := x509.CreateCertificate(gen, &x509.Certificate{
+		SerialNumber:          big.NewInt(0),
+		Subject:               pkix.Name{CommonName: "root1"},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}, &x509.Certificate{
+		SerialNumber:          big.NewInt(0),
+		Subject:               pkix.Name{CommonName: "root1"},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}, pub, priv)
+	if err != nil {
+		t.Fatalf("Error while making certificate: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	}))
+}
+
+func mkValidBundle(t *testing.T, tweaks ...func(*certificates.ClusterTrustBundle)) certificates.ClusterTrustBundle {
+	t.Helper()
+	bundle := certificates.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "example.com:foo:bar"},
+		Spec: certificates.ClusterTrustBundleSpec{
+			SignerName:  "example.com/foo",
+			TrustBundle: mustMakeTestCert(t),
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&bundle)
+	}
+	return bundle
+}
+
+func tweakSignerName(signerName string) func(*certificates.ClusterTrustBundle) {
+	return func(bundle *certificates.ClusterTrustBundle) {
+		bundle.Spec.SignerName = signerName
+	}
+}
+
+func tweakName(name string) func(*certificates.ClusterTrustBundle) {
+	return func(bundle *certificates.ClusterTrustBundle) {
+		bundle.ObjectMeta.Name = name
+	}
+}
+
+func TestDeclarativeValidateForDeclarative(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateForDeclarative(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "certificates.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "clustertrustbundles",
+		Name:              "test-bundle",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	testCases := map[string]struct {
+		input        certificates.ClusterTrustBundle
+		expectedErrs field.ErrorList
+	}{
+		"valid bundle without signer": {
+			input:        mkValidBundle(t, tweakName("test-bundle"), tweakSignerName("")),
+			expectedErrs: field.ErrorList{},
+		},
+		"valid bundle with signer": {
+			input:        mkValidBundle(t),
+			expectedErrs: field.ErrorList{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdateForDeclarative(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdateForDeclarative(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
+	testCases := map[string]struct {
+		oldObj       certificates.ClusterTrustBundle
+		updateObj    certificates.ClusterTrustBundle
+		expectedErrs field.ErrorList
+	}{
+		"signerName unchanged - valid": {
+			oldObj:    mkValidBundle(t),
+			updateObj: mkValidBundle(t),
+		},
+		"signerName changed - invalid": {
+			oldObj:    mkValidBundle(t),
+			updateObj: mkValidBundle(t, tweakSignerName("example.com/bar")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "name"), "example.com:foo:bar", "ClusterTrustBundle for signerName example.com/bar must be named with prefix example.com:bar:").MarkFromImperative(),
+				field.Invalid(field.NewPath("spec", "signerName"), "example.com/bar", "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"signerName set from unset - invalid": {
+			oldObj:    mkValidBundle(t, tweakName("no-signer-bundle"), tweakSignerName("")),
+			updateObj: mkValidBundle(t, tweakName("no-signer-bundle")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "name"), "no-signer-bundle", "ClusterTrustBundle for signerName example.com/foo must be named with prefix example.com:foo:").MarkFromImperative(),
+				field.Invalid(field.NewPath("spec", "signerName"), "example.com/foo", "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"signerName unset from set - invalid": {
+			oldObj:    mkValidBundle(t),
+			updateObj: mkValidBundle(t, tweakSignerName("")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "name"), "example.com:foo:bar", `ClusterTrustBundle without signer name must not have ":" in its name`).MarkFromImperative(),
+				field.Invalid(field.NewPath("spec", "signerName"), "", "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIPrefix:         "apis",
+				APIGroup:          "certificates.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "clustertrustbundles",
+				Name:              tc.oldObj.Name,
+				IsResourceRequest: true,
+				Verb:              "update",
+			})
+			tc.oldObj.ResourceVersion = "1"
+			tc.updateObj.ResourceVersion = "2"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy, tc.expectedErrs)
+		})
+	}
+}

--- a/staging/src/k8s.io/api/certificates/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1alpha1/generated.proto
@@ -85,6 +85,8 @@ message ClusterTrustBundleSpec {
   // using a `spec.signerName=NAME` field selector.
   //
   // +optional
+  // +k8s:alpha(since:"1.37")=+k8s:optional
+  // +k8s:alpha(since:"1.37")=+k8s:immutable
   optional string signerName = 1;
 
   // trustBundle contains the individual X.509 trust anchors for this

--- a/staging/src/k8s.io/api/certificates/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1alpha1/types.go
@@ -74,6 +74,8 @@ type ClusterTrustBundleSpec struct {
 	// using a `spec.signerName=NAME` field selector.
 	//
 	// +optional
+	// +k8s:alpha(since:"1.37")=+k8s:optional
+	// +k8s:alpha(since:"1.37")=+k8s:immutable
 	SignerName string `json:"signerName,omitempty" protobuf:"bytes,1,opt,name=signerName"`
 
 	// trustBundle contains the individual X.509 trust anchors for this

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -253,6 +253,8 @@ message ClusterTrustBundleSpec {
   // using a `spec.signerName=NAME` field selector.
   //
   // +optional
+  // +k8s:alpha(since:"1.37")=+k8s:optional
+  // +k8s:alpha(since:"1.37")=+k8s:immutable
   optional string signerName = 1;
 
   // trustBundle contains the individual X.509 trust anchors for this

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -324,6 +324,8 @@ type ClusterTrustBundleSpec struct {
 	// using a `spec.signerName=NAME` field selector.
 	//
 	// +optional
+	// +k8s:alpha(since:"1.37")=+k8s:optional
+	// +k8s:alpha(since:"1.37")=+k8s:immutable
 	SignerName string `json:"signerName,omitempty" protobuf:"bytes,1,opt,name=signerName"`
 
 	// trustBundle contains the individual X.509 trust anchors for this


### PR DESCRIPTION
## Summary
- Wire declarative validation in `ClusterTrustBundle` strategy (`Validate` and `ValidateUpdate`)
- Add `+k8s:immutable` tag to `ClusterTrustBundleSpec.SignerName` across certificates v1alpha1 and v1beta1
- Mark existing `ValidateImmutableField` call as covered by declarative validation
- Add create and update equivalence tests in new `declarative_validation_test.go`

Part of KEP-5073 declarative validation migration tracking issue #136785.

## Test plan
- [x] `hack/update-codegen.sh validation` regenerated `zz_generated.validations.go` for certificates v1alpha1/v1beta1
- [x] `go test ./pkg/registry/certificates/clustertrustbundle/...` passes (new DV equivalence tests)
- [x] `go test ./pkg/apis/certificates/validation/...` passes (updated expected error in `TestValidateClusterTrustBundleUpdate`)
- [x] DV equivalence verified under all 4 feature gate scenarios (Beta enabled, Beta disabled, hand-written only, all rules enforced)

```release-note
NONE
```