### PR TITLE
api: enable optionalorrequired linter for authorization API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3145,9 +3145,6 @@
           "description": "status is filled in by the server and indicates whether the request is allowed or not"
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -3191,9 +3188,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "verbs"
-      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.ResourceAttributes": {
@@ -3274,9 +3268,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "verbs"
-      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
@@ -3303,9 +3294,6 @@
           "description": "status is filled in by the server and indicates whether the request is allowed or not"
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -3373,6 +3361,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "namespace"
+      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.SubjectAccessReview": {
@@ -3399,9 +3390,6 @@
           "description": "status is filled in by the server and indicates whether the request is allowed or not"
         }
       },
-      "required": [
-        "spec"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -3471,9 +3459,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "allowed"
-      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
@@ -3504,11 +3489,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "resourceRules",
-        "nonResourceRules",
-        "incomplete"
-      ],
       "type": "object"
     },
     "io.k8s.api.autoscaling.v1.CrossVersionObjectReference": {

--- a/api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json
@@ -86,9 +86,6 @@
             "description": "status is filled in by the server and indicates whether the request is allowed or not"
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -134,9 +131,6 @@
             "x-kubernetes-list-type": "atomic"
           }
         },
-        "required": [
-          "verbs"
-        ],
         "type": "object"
       },
       "io.k8s.api.authorization.v1.ResourceAttributes": {
@@ -229,9 +223,6 @@
             "x-kubernetes-list-type": "atomic"
           }
         },
-        "required": [
-          "verbs"
-        ],
         "type": "object"
       },
       "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
@@ -273,9 +264,6 @@
             "description": "status is filled in by the server and indicates whether the request is allowed or not"
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -366,6 +354,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "namespace"
+        ],
         "type": "object"
       },
       "io.k8s.api.authorization.v1.SubjectAccessReview": {
@@ -407,9 +398,6 @@
             "description": "status is filled in by the server and indicates whether the request is allowed or not"
           }
         },
-        "required": [
-          "spec"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -490,9 +478,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "allowed"
-        ],
         "type": "object"
       },
       "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
@@ -534,11 +519,6 @@
             "x-kubernetes-list-type": "atomic"
           }
         },
-        "required": [
-          "resourceRules",
-          "nonResourceRules",
-          "incomplete"
-        ],
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -215,7 +215,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -230,7 +230,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -91,7 +91,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -12771,7 +12771,6 @@ func schema_k8sio_api_authorization_v1_LocalSubjectAccessReview(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -12854,7 +12853,6 @@ func schema_k8sio_api_authorization_v1_NonResourceRule(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -13024,7 +13022,6 @@ func schema_k8sio_api_authorization_v1_ResourceRule(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -13073,7 +13070,6 @@ func schema_k8sio_api_authorization_v1_SelfSubjectAccessReview(ref common.Refere
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -13174,6 +13170,7 @@ func schema_k8sio_api_authorization_v1_SelfSubjectRulesReviewSpec(ref common.Ref
 						},
 					},
 				},
+				Required: []string{"namespace"},
 			},
 		},
 	}
@@ -13222,7 +13219,6 @@ func schema_k8sio_api_authorization_v1_SubjectAccessReview(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -13351,7 +13347,6 @@ func schema_k8sio_api_authorization_v1_SubjectAccessReviewStatus(ref common.Refe
 						},
 					},
 				},
-				Required: []string{"allowed"},
 			},
 		},
 	}
@@ -13418,7 +13413,6 @@ func schema_k8sio_api_authorization_v1_SubjectRulesReviewStatus(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"resourceRules", "nonResourceRules", "incomplete"},
 			},
 		},
 		Dependencies: []string{
@@ -13469,7 +13463,6 @@ func schema_k8sio_api_authorization_v1beta1_LocalSubjectAccessReview(ref common.
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -13552,7 +13545,6 @@ func schema_k8sio_api_authorization_v1beta1_NonResourceRule(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -13722,7 +13714,6 @@ func schema_k8sio_api_authorization_v1beta1_ResourceRule(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -13771,7 +13762,6 @@ func schema_k8sio_api_authorization_v1beta1_SelfSubjectAccessReview(ref common.R
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -13872,6 +13862,7 @@ func schema_k8sio_api_authorization_v1beta1_SelfSubjectRulesReviewSpec(ref commo
 						},
 					},
 				},
+				Required: []string{"namespace"},
 			},
 		},
 	}
@@ -13920,7 +13911,6 @@ func schema_k8sio_api_authorization_v1beta1_SubjectAccessReview(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -14049,7 +14039,6 @@ func schema_k8sio_api_authorization_v1beta1_SubjectAccessReviewStatus(ref common
 						},
 					},
 				},
-				Required: []string{"allowed"},
 			},
 		},
 	}
@@ -14116,7 +14105,6 @@ func schema_k8sio_api_authorization_v1beta1_SubjectRulesReviewStatus(ref common.
 						},
 					},
 				},
-				Required: []string{"resourceRules", "nonResourceRules", "incomplete"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/authorization/v1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1/generated.proto
@@ -102,6 +102,7 @@ message LocalSubjectAccessReview {
 
   // spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
   // you made the request against.  If empty, it is defaulted.
+  // +optional
   optional SubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -123,6 +124,7 @@ message NonResourceAttributes {
 // NonResourceRule holds information that describes a rule for the non-resource
 message NonResourceRule {
   // verbs is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+  // +optional
   // +listType=atomic
   repeated string verbs = 1;
 
@@ -179,6 +181,7 @@ message ResourceAttributes {
 // may contain duplicates, and possibly be incomplete.
 message ResourceRule {
   // verbs is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+  // +optional
   // +listType=atomic
   repeated string verbs = 1;
 
@@ -210,6 +213,7 @@ message SelfSubjectAccessReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated.  user and groups must be empty
+  // +optional
   optional SelfSubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -242,6 +246,7 @@ message SelfSubjectRulesReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated.
+  // +required
   optional SelfSubjectRulesReviewSpec spec = 2;
 
   // status is filled in by the server and indicates the set of actions a user can perform.
@@ -252,6 +257,7 @@ message SelfSubjectRulesReview {
 // SelfSubjectRulesReviewSpec defines the specification for SelfSubjectRulesReview.
 message SelfSubjectRulesReviewSpec {
   // namespace to evaluate rules for. Required.
+  // +required
   optional string namespace = 1;
 }
 
@@ -263,6 +269,7 @@ message SubjectAccessReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated
+  // +optional
   optional SubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -304,6 +311,7 @@ message SubjectAccessReviewSpec {
 // SubjectAccessReviewStatus
 message SubjectAccessReviewStatus {
   // allowed is required. True if the action would be allowed, false otherwise.
+  // +optional
   optional bool allowed = 1;
 
   // denied is optional. True if the action would be denied, otherwise
@@ -331,16 +339,19 @@ message SubjectAccessReviewStatus {
 message SubjectRulesReviewStatus {
   // resourceRules is the list of actions the subject is allowed to perform on resources.
   // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  // +optional
   // +listType=atomic
   repeated ResourceRule resourceRules = 1;
 
   // nonResourceRules is the list of actions the subject is allowed to perform on non-resources.
   // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  // +optional
   // +listType=atomic
   repeated NonResourceRule nonResourceRules = 2;
 
   // incomplete is true when the rules returned by this call are incomplete. This is most commonly
   // encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+  // +optional
   optional bool incomplete = 3;
 
   // evaluationError can appear in combination with Rules. It indicates an error occurred during

--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -37,6 +37,7 @@ type SubjectAccessReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated
+	// +optional
 	Spec SubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -61,6 +62,7 @@ type SelfSubjectAccessReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated.  user and groups must be empty
+	// +optional
 	Spec SelfSubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -85,6 +87,7 @@ type LocalSubjectAccessReview struct {
 
 	// spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
 	// you made the request against.  If empty, it is defaulted.
+	// +optional
 	Spec SubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -240,6 +243,7 @@ type SelfSubjectAccessReviewSpec struct {
 // SubjectAccessReviewStatus
 type SubjectAccessReviewStatus struct {
 	// allowed is required. True if the action would be allowed, false otherwise.
+	// +optional
 	Allowed bool `json:"allowed" protobuf:"varint,1,opt,name=allowed"`
 	// denied is optional. True if the action would be denied, otherwise
 	// false. If both allowed is false and denied is false, then the
@@ -277,6 +281,7 @@ type SelfSubjectRulesReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated.
+	// +required
 	Spec SelfSubjectRulesReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates the set of actions a user can perform.
@@ -287,6 +292,7 @@ type SelfSubjectRulesReview struct {
 // SelfSubjectRulesReviewSpec defines the specification for SelfSubjectRulesReview.
 type SelfSubjectRulesReviewSpec struct {
 	// namespace to evaluate rules for. Required.
+	// +required
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
 }
 
@@ -297,14 +303,17 @@ type SelfSubjectRulesReviewSpec struct {
 type SubjectRulesReviewStatus struct {
 	// resourceRules is the list of actions the subject is allowed to perform on resources.
 	// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+	// +optional
 	// +listType=atomic
 	ResourceRules []ResourceRule `json:"resourceRules" protobuf:"bytes,1,rep,name=resourceRules"`
 	// nonResourceRules is the list of actions the subject is allowed to perform on non-resources.
 	// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+	// +optional
 	// +listType=atomic
 	NonResourceRules []NonResourceRule `json:"nonResourceRules" protobuf:"bytes,2,rep,name=nonResourceRules"`
 	// incomplete is true when the rules returned by this call are incomplete. This is most commonly
 	// encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+	// +optional
 	Incomplete bool `json:"incomplete" protobuf:"bytes,3,rep,name=incomplete"`
 	// evaluationError can appear in combination with Rules. It indicates an error occurred during
 	// rule evaluation, such as an authorizer that doesn't support rule evaluation, and that
@@ -317,6 +326,7 @@ type SubjectRulesReviewStatus struct {
 // may contain duplicates, and possibly be incomplete.
 type ResourceRule struct {
 	// verbs is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+	// +optional
 	// +listType=atomic
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
@@ -339,6 +349,7 @@ type ResourceRule struct {
 // NonResourceRule holds information that describes a rule for the non-resource
 type NonResourceRule struct {
 	// verbs is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+	// +optional
 	// +listType=atomic
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 

--- a/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
@@ -49,6 +49,7 @@ message LocalSubjectAccessReview {
 
   // spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
   // you made the request against.  If empty, it is defaulted.
+  // +optional
   optional SubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -70,6 +71,7 @@ message NonResourceAttributes {
 // NonResourceRule holds information that describes a rule for the non-resource
 message NonResourceRule {
   // verbs is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+  // +optional
   // +listType=atomic
   repeated string verbs = 1;
 
@@ -126,6 +128,7 @@ message ResourceAttributes {
 // may contain duplicates, and possibly be incomplete.
 message ResourceRule {
   // verbs is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+  // +optional
   // +listType=atomic
   repeated string verbs = 1;
 
@@ -157,6 +160,7 @@ message SelfSubjectAccessReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated.  user and groups must be empty
+  // +optional
   optional SelfSubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -189,6 +193,7 @@ message SelfSubjectRulesReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated.
+  // +required
   optional SelfSubjectRulesReviewSpec spec = 2;
 
   // status is filled in by the server and indicates the set of actions a user can perform.
@@ -199,6 +204,7 @@ message SelfSubjectRulesReview {
 // SelfSubjectRulesReviewSpec defines the specification for SelfSubjectRulesReview.
 message SelfSubjectRulesReviewSpec {
   // namespace to evaluate rules for. Required.
+  // +required
   optional string namespace = 1;
 }
 
@@ -210,6 +216,7 @@ message SubjectAccessReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated
+  // +optional
   optional SubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -251,6 +258,7 @@ message SubjectAccessReviewSpec {
 // SubjectAccessReviewStatus
 message SubjectAccessReviewStatus {
   // allowed is required. True if the action would be allowed, false otherwise.
+  // +optional
   optional bool allowed = 1;
 
   // denied is optional. True if the action would be denied, otherwise
@@ -278,16 +286,19 @@ message SubjectAccessReviewStatus {
 message SubjectRulesReviewStatus {
   // resourceRules is the list of actions the subject is allowed to perform on resources.
   // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  // +optional
   // +listType=atomic
   repeated ResourceRule resourceRules = 1;
 
   // nonResourceRules is the list of actions the subject is allowed to perform on non-resources.
   // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  // +optional
   // +listType=atomic
   repeated NonResourceRule nonResourceRules = 2;
 
   // incomplete is true when the rules returned by this call are incomplete. This is most commonly
   // encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+  // +optional
   optional bool incomplete = 3;
 
   // evaluationError can appear in combination with Rules. It indicates an error occurred during

--- a/staging/src/k8s.io/api/authorization/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/types.go
@@ -40,6 +40,7 @@ type SubjectAccessReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated
+	// +optional
 	Spec SubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -66,6 +67,7 @@ type SelfSubjectAccessReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated.  user and groups must be empty
+	// +optional
 	Spec SelfSubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -92,6 +94,7 @@ type LocalSubjectAccessReview struct {
 
 	// spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
 	// you made the request against.  If empty, it is defaulted.
+	// +optional
 	Spec SubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -193,6 +196,7 @@ type SelfSubjectAccessReviewSpec struct {
 // SubjectAccessReviewStatus
 type SubjectAccessReviewStatus struct {
 	// allowed is required. True if the action would be allowed, false otherwise.
+	// +optional
 	Allowed bool `json:"allowed" protobuf:"varint,1,opt,name=allowed"`
 	// denied is optional. True if the action would be denied, otherwise
 	// false. If both allowed is false and denied is false, then the
@@ -232,6 +236,7 @@ type SelfSubjectRulesReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated.
+	// +required
 	Spec SelfSubjectRulesReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates the set of actions a user can perform.
@@ -242,6 +247,7 @@ type SelfSubjectRulesReview struct {
 // SelfSubjectRulesReviewSpec defines the specification for SelfSubjectRulesReview.
 type SelfSubjectRulesReviewSpec struct {
 	// namespace to evaluate rules for. Required.
+	// +required
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
 }
 
@@ -252,14 +258,17 @@ type SelfSubjectRulesReviewSpec struct {
 type SubjectRulesReviewStatus struct {
 	// resourceRules is the list of actions the subject is allowed to perform on resources.
 	// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+	// +optional
 	// +listType=atomic
 	ResourceRules []ResourceRule `json:"resourceRules" protobuf:"bytes,1,rep,name=resourceRules"`
 	// nonResourceRules is the list of actions the subject is allowed to perform on non-resources.
 	// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+	// +optional
 	// +listType=atomic
 	NonResourceRules []NonResourceRule `json:"nonResourceRules" protobuf:"bytes,2,rep,name=nonResourceRules"`
 	// incomplete is true when the rules returned by this call are incomplete. This is most commonly
 	// encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+	// +optional
 	Incomplete bool `json:"incomplete" protobuf:"bytes,3,rep,name=incomplete"`
 	// evaluationError can appear in combination with Rules. It indicates an error occurred during
 	// rule evaluation, such as an authorizer that doesn't support rule evaluation, and that
@@ -272,6 +281,7 @@ type SubjectRulesReviewStatus struct {
 // may contain duplicates, and possibly be incomplete.
 type ResourceRule struct {
 	// verbs is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+	// +optional
 	// +listType=atomic
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
@@ -294,6 +304,7 @@ type ResourceRule struct {
 // NonResourceRule holds information that describes a rule for the non-resource
 type NonResourceRule struct {
 	// verbs is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+	// +optional
 	// +listType=atomic
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add missing `+optional` and `+required` markers to the `authorization` API group (`v1` and `v1beta1`) and enable the `optionalorrequired` linter for it.

#### Which issue(s) this PR fixes:

Part of #134671
Fixes #136861

#### Special notes for your reviewer:

This adds `// +required` markers to:
- `SelfSubjectRulesReview.Spec` — non-pointer struct containing at least one `+required` inner field (`Namespace`)
- `SelfSubjectRulesReviewSpec.Namespace` — REST handler in `selfsubjectrulesreview/rest.go` explicitly rejects empty namespace with `NewBadRequest("no namespace on request")`

This adds `// +optional` markers to:
- `SubjectAccessReview.Spec`, `SelfSubjectAccessReview.Spec`, `LocalSubjectAccessReview.Spec` — non-pointer structs where all inner fields are `+optional`
- `SubjectAccessReviewStatus.Allowed` — status response field set by the server, no validation on create
- `SubjectRulesReviewStatus.ResourceRules`, `.NonResourceRules`, `.Incomplete` — status response fields set by the server
- `ResourceRule.Verbs`, `NonResourceRule.Verbs` — no server-side validation requiring non-empty

#### Does this PR introduce a user-facing change?

```release-note
NONE
```