### PR TITLE
[kube-api-linter] Enable optionalorrequired linter for flowcontrol API group

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13282,6 +13282,9 @@
           "description": "`status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -13307,7 +13310,7 @@
           "type": "string"
         },
         "status": {
-          "description": "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+          "description": "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
           "type": "string"
         },
         "type": {
@@ -13315,6 +13318,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "type"
+      ],
       "type": "object"
     },
     "io.k8s.api.flowcontrol.v1.FlowSchemaList": {
@@ -13462,6 +13468,9 @@
           "type": "integer"
         }
       },
+      "required": [
+        "limitResponse"
+      ],
       "type": "object"
     },
     "io.k8s.api.flowcontrol.v1.NonResourcePolicyRule": {
@@ -13547,6 +13556,9 @@
           "description": "`status` is the current status of a \"request-priority\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -13572,7 +13584,7 @@
           "type": "string"
         },
         "status": {
-          "description": "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+          "description": "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
           "type": "string"
         },
         "type": {
@@ -13580,6 +13592,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "type"
+      ],
       "type": "object"
     },
     "io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationList": {

--- a/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1_openapi.json
@@ -70,6 +70,9 @@
             "description": "`status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -99,7 +102,7 @@
             "type": "string"
           },
           "status": {
-            "description": "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+            "description": "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
             "type": "string"
           },
           "type": {
@@ -107,6 +110,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "io.k8s.api.flowcontrol.v1.FlowSchemaList": {
@@ -280,6 +286,9 @@
             "type": "integer"
           }
         },
+        "required": [
+          "limitResponse"
+        ],
         "type": "object"
       },
       "io.k8s.api.flowcontrol.v1.NonResourcePolicyRule": {
@@ -380,6 +389,9 @@
             "description": "`status` is the current status of a \"request-priority\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -409,7 +421,7 @@
             "type": "string"
           },
           "status": {
-            "description": "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+            "description": "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
             "type": "string"
           },
           "type": {
@@ -417,6 +429,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationList": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -231,7 +231,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -246,7 +246,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -107,7 +107,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -36510,6 +36510,7 @@ func schema_k8sio_api_flowcontrol_v1_FlowSchema(ref common.ReferenceCallback) co
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -36533,7 +36534,7 @@ func schema_k8sio_api_flowcontrol_v1_FlowSchemaCondition(ref common.ReferenceCal
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+							Description: "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -36559,6 +36560,7 @@ func schema_k8sio_api_flowcontrol_v1_FlowSchemaCondition(ref common.ReferenceCal
 						},
 					},
 				},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -36809,6 +36811,7 @@ func schema_k8sio_api_flowcontrol_v1_LimitedPriorityLevelConfiguration(ref commo
 						},
 					},
 				},
+				Required: []string{"limitResponse"},
 			},
 		},
 		Dependencies: []string{
@@ -36981,6 +36984,7 @@ func schema_k8sio_api_flowcontrol_v1_PriorityLevelConfiguration(ref common.Refer
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -37004,7 +37008,7 @@ func schema_k8sio_api_flowcontrol_v1_PriorityLevelConfigurationCondition(ref com
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+							Description: "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -37030,6 +37034,7 @@ func schema_k8sio_api_flowcontrol_v1_PriorityLevelConfigurationCondition(ref com
 						},
 					},
 				},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -37530,6 +37535,7 @@ func schema_k8sio_api_flowcontrol_v1beta1_FlowSchema(ref common.ReferenceCallbac
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -37553,7 +37559,7 @@ func schema_k8sio_api_flowcontrol_v1beta1_FlowSchemaCondition(ref common.Referen
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+							Description: "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -37579,6 +37585,7 @@ func schema_k8sio_api_flowcontrol_v1beta1_FlowSchemaCondition(ref common.Referen
 						},
 					},
 				},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -37828,6 +37835,7 @@ func schema_k8sio_api_flowcontrol_v1beta1_LimitedPriorityLevelConfiguration(ref 
 						},
 					},
 				},
+				Required: []string{"limitResponse"},
 			},
 		},
 		Dependencies: []string{
@@ -38000,6 +38008,7 @@ func schema_k8sio_api_flowcontrol_v1beta1_PriorityLevelConfiguration(ref common.
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -38023,7 +38032,7 @@ func schema_k8sio_api_flowcontrol_v1beta1_PriorityLevelConfigurationCondition(re
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+							Description: "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -38049,6 +38058,7 @@ func schema_k8sio_api_flowcontrol_v1beta1_PriorityLevelConfigurationCondition(re
 						},
 					},
 				},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -38547,6 +38557,7 @@ func schema_k8sio_api_flowcontrol_v1beta2_FlowSchema(ref common.ReferenceCallbac
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -38570,7 +38581,7 @@ func schema_k8sio_api_flowcontrol_v1beta2_FlowSchemaCondition(ref common.Referen
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+							Description: "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -38596,6 +38607,7 @@ func schema_k8sio_api_flowcontrol_v1beta2_FlowSchemaCondition(ref common.Referen
 						},
 					},
 				},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -38845,6 +38857,7 @@ func schema_k8sio_api_flowcontrol_v1beta2_LimitedPriorityLevelConfiguration(ref 
 						},
 					},
 				},
+				Required: []string{"limitResponse"},
 			},
 		},
 		Dependencies: []string{
@@ -39017,6 +39030,7 @@ func schema_k8sio_api_flowcontrol_v1beta2_PriorityLevelConfiguration(ref common.
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -39040,7 +39054,7 @@ func schema_k8sio_api_flowcontrol_v1beta2_PriorityLevelConfigurationCondition(re
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+							Description: "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -39066,6 +39080,7 @@ func schema_k8sio_api_flowcontrol_v1beta2_PriorityLevelConfigurationCondition(re
 						},
 					},
 				},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -39564,6 +39579,7 @@ func schema_k8sio_api_flowcontrol_v1beta3_FlowSchema(ref common.ReferenceCallbac
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -39587,7 +39603,7 @@ func schema_k8sio_api_flowcontrol_v1beta3_FlowSchemaCondition(ref common.Referen
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+							Description: "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -39613,6 +39629,7 @@ func schema_k8sio_api_flowcontrol_v1beta3_FlowSchemaCondition(ref common.Referen
 						},
 					},
 				},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -39864,6 +39881,7 @@ func schema_k8sio_api_flowcontrol_v1beta3_LimitedPriorityLevelConfiguration(ref 
 						},
 					},
 				},
+				Required: []string{"limitResponse"},
 			},
 		},
 		Dependencies: []string{
@@ -40036,6 +40054,7 @@ func schema_k8sio_api_flowcontrol_v1beta3_PriorityLevelConfiguration(ref common.
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -40059,7 +40078,7 @@ func schema_k8sio_api_flowcontrol_v1beta3_PriorityLevelConfigurationCondition(re
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+							Description: "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -40085,6 +40104,7 @@ func schema_k8sio_api_flowcontrol_v1beta3_PriorityLevelConfigurationCondition(re
 						},
 					},
 				},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
@@ -67,6 +67,7 @@ message FlowDistinguisherMethod {
   // `type` is the type of flow distinguisher method
   // The supported types are "ByUser" and "ByNamespace".
   // Required.
+  // +required
   optional string type = 1;
 }
 
@@ -81,7 +82,7 @@ message FlowSchema {
 
   // `spec` is the specification of the desired behavior of a FlowSchema.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional FlowSchemaSpec spec = 2;
 
   // `status` is the current status of a FlowSchema.
@@ -94,20 +95,24 @@ message FlowSchema {
 message FlowSchemaCondition {
   // `type` is the type of the condition.
   // Required.
+  // +required
   optional string type = 1;
 
   // `status` is the status of the condition.
-  // Can be True, False, Unknown.
-  // Required.
+  // Should be specified and set to one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+  // +optional
   optional string reason = 4;
 
   // `message` is a human-readable message indicating details about last transition.
+  // +optional
   optional string message = 5;
 }
 
@@ -127,6 +132,7 @@ message FlowSchemaSpec {
   // `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
   // be resolved, the FlowSchema will be ignored and marked as invalid in its status.
   // Required.
+  // +required
   optional PriorityLevelConfigurationReference priorityLevelConfiguration = 1;
 
   // `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
@@ -166,6 +172,7 @@ message GroupSubject {
   // See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some
   // well-known group names.
   // Required.
+  // +required
   optional string name = 1;
 }
 
@@ -179,6 +186,7 @@ message LimitResponse {
   // "Reject" means that requests that can not be executed upon arrival
   // are rejected.
   // Required.
+  // +required
   // +unionDiscriminator
   // +k8s:beta(since: "1.37")=+k8s:required
   // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -221,6 +229,7 @@ message LimitedPriorityLevelConfiguration {
   optional int32 nominalConcurrencyShares = 1;
 
   // `limitResponse` indicates what to do with requests that can not be executed right now
+  // +required
   optional LimitResponse limitResponse = 2;
 
   // `lendablePercent` prescribes the fraction of the level's NominalCL that
@@ -261,6 +270,7 @@ message NonResourcePolicyRule {
   // "*" matches all verbs. If it is present, it must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string verbs = 1;
 
   // `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
@@ -273,6 +283,7 @@ message NonResourcePolicyRule {
   // "*" matches all non-resource urls. if it is present, it must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string nonResourceURLs = 6;
 }
 
@@ -286,6 +297,7 @@ message PolicyRulesWithSubjects {
   // A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request.
   // +listType=atomic
   // Required.
+  // +required
   repeated Subject subjects = 1;
 
   // `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the
@@ -312,7 +324,7 @@ message PriorityLevelConfiguration {
 
   // `spec` is the specification of the desired behavior of a "request-priority".
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional PriorityLevelConfigurationSpec spec = 2;
 
   // `status` is the current status of a "request-priority".
@@ -325,20 +337,24 @@ message PriorityLevelConfiguration {
 message PriorityLevelConfigurationCondition {
   // `type` is the type of the condition.
   // Required.
+  // +required
   optional string type = 1;
 
   // `status` is the status of the condition.
-  // Can be True, False, Unknown.
-  // Required.
+  // Should be specified and set to one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+  // +optional
   optional string reason = 4;
 
   // `message` is a human-readable message indicating details about last transition.
+  // +optional
   optional string message = 5;
 }
 
@@ -357,6 +373,7 @@ message PriorityLevelConfigurationList {
 message PriorityLevelConfigurationReference {
   // `name` is the name of the priority level configuration being referenced
   // Required.
+  // +required
   optional string name = 1;
 }
 
@@ -372,6 +389,7 @@ message PriorityLevelConfigurationSpec {
   // _are_ subject to limits and (b) some of the server's limited
   // capacity is made available exclusively to this priority level.
   // Required.
+  // +required
   // +unionDiscriminator
   // +k8s:beta(since: "1.37")=+k8s:required
   // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -453,12 +471,14 @@ message ResourcePolicyRule {
   // "*" matches all verbs and, if present, must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string verbs = 1;
 
   // `apiGroups` is a list of matching API groups and may not be empty.
   // "*" matches all API groups and, if present, must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string apiGroups = 2;
 
   // `resources` is a list of matching resources (i.e., lowercase
@@ -467,6 +487,7 @@ message ResourcePolicyRule {
   // "*" matches all resources and, if present, must be the only entry.
   // Required.
   // +listType=set
+  // +required
   repeated string resources = 3;
 
   // `clusterScope` indicates whether to match requests that do not
@@ -494,10 +515,12 @@ message ResourcePolicyRule {
 message ServiceAccountSubject {
   // `namespace` is the namespace of matching ServiceAccount objects.
   // Required.
+  // +required
   optional string namespace = 1;
 
   // `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name.
   // Required.
+  // +required
   optional string name = 2;
 }
 
@@ -507,6 +530,7 @@ message ServiceAccountSubject {
 message Subject {
   // `kind` indicates which one of the other fields is non-empty.
   // Required
+  // +required
   // +unionDiscriminator
   optional string kind = 1;
 
@@ -527,6 +551,7 @@ message Subject {
 message UserSubject {
   // `name` is the username that matches, or "*" to match all usernames.
   // Required.
+  // +required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1/types.go
@@ -119,7 +119,7 @@ type FlowSchema struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a FlowSchema.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec FlowSchemaSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a FlowSchema.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -147,6 +147,7 @@ type FlowSchemaSpec struct {
 	// `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
 	// be resolved, the FlowSchema will be ignored and marked as invalid in its status.
 	// Required.
+	// +required
 	PriorityLevelConfiguration PriorityLevelConfigurationReference `json:"priorityLevelConfiguration" protobuf:"bytes,1,opt,name=priorityLevelConfiguration"`
 	// `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
 	// FlowSchema is among those with the numerically lowest (which we take to be logically highest)
@@ -188,6 +189,7 @@ type FlowDistinguisherMethod struct {
 	// `type` is the type of flow distinguisher method
 	// The supported types are "ByUser" and "ByNamespace".
 	// Required.
+	// +required
 	Type FlowDistinguisherMethodType `json:"type" protobuf:"bytes,1,opt,name=type"`
 }
 
@@ -195,6 +197,7 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -208,6 +211,7 @@ type PolicyRulesWithSubjects struct {
 	// A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request.
 	// +listType=atomic
 	// Required.
+	// +required
 	Subjects []Subject `json:"subjects" protobuf:"bytes,1,rep,name=subjects"`
 	// `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the
 	// target resource.
@@ -228,6 +232,7 @@ type PolicyRulesWithSubjects struct {
 type Subject struct {
 	// `kind` indicates which one of the other fields is non-empty.
 	// Required
+	// +required
 	// +unionDiscriminator
 	Kind SubjectKind `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 	// `user` matches based on username.
@@ -255,6 +260,7 @@ const (
 type UserSubject struct {
 	// `name` is the username that matches, or "*" to match all usernames.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -264,6 +270,7 @@ type GroupSubject struct {
 	// See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some
 	// well-known group names.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -271,9 +278,11 @@ type GroupSubject struct {
 type ServiceAccountSubject struct {
 	// `namespace` is the namespace of matching ServiceAccount objects.
 	// Required.
+	// +required
 	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
 	// `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 }
 
@@ -291,12 +300,14 @@ type ResourcePolicyRule struct {
 	// "*" matches all verbs and, if present, must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// `apiGroups` is a list of matching API groups and may not be empty.
 	// "*" matches all API groups and, if present, must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	APIGroups []string `json:"apiGroups" protobuf:"bytes,2,rep,name=apiGroups"`
 
 	// `resources` is a list of matching resources (i.e., lowercase
@@ -305,6 +316,7 @@ type ResourcePolicyRule struct {
 	// "*" matches all resources and, if present, must be the only entry.
 	// Required.
 	// +listType=set
+	// +required
 	Resources []string `json:"resources" protobuf:"bytes,3,rep,name=resources"`
 
 	// `clusterScope` indicates whether to match requests that do not
@@ -336,6 +348,7 @@ type NonResourcePolicyRule struct {
 	// "*" matches all verbs. If it is present, it must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 	// `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
 	// For example:
@@ -347,6 +360,7 @@ type NonResourcePolicyRule struct {
 	// "*" matches all non-resource urls. if it is present, it must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	NonResourceURLs []string `json:"nonResourceURLs" protobuf:"bytes,6,rep,name=nonResourceURLs"`
 }
 
@@ -365,16 +379,20 @@ type FlowSchemaStatus struct {
 type FlowSchemaCondition struct {
 	// `type` is the type of the condition.
 	// Required.
+	// +required
 	Type FlowSchemaConditionType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
+	// +optional
 	Status ConditionStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 	// `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
 	// `message` is a human-readable message indicating details about last transition.
+	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 
@@ -396,7 +414,7 @@ type PriorityLevelConfiguration struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a "request-priority".
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec PriorityLevelConfigurationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a "request-priority".
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -430,6 +448,7 @@ type PriorityLevelConfigurationSpec struct {
 	// _are_ subject to limits and (b) some of the server's limited
 	// capacity is made available exclusively to this priority level.
 	// Required.
+	// +required
 	// +unionDiscriminator
 	// +k8s:beta(since: "1.37")=+k8s:required
 	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -494,6 +513,7 @@ type LimitedPriorityLevelConfiguration struct {
 	NominalConcurrencyShares *int32 `json:"nominalConcurrencyShares" protobuf:"varint,1,opt,name=nominalConcurrencyShares"`
 
 	// `limitResponse` indicates what to do with requests that can not be executed right now
+	// +required
 	LimitResponse LimitResponse `json:"limitResponse,omitempty" protobuf:"bytes,2,opt,name=limitResponse"`
 
 	// `lendablePercent` prescribes the fraction of the level's NominalCL that
@@ -573,6 +593,7 @@ type LimitResponse struct {
 	// "Reject" means that requests that can not be executed upon arrival
 	// are rejected.
 	// Required.
+	// +required
 	// +unionDiscriminator
 	// +k8s:beta(since: "1.37")=+k8s:required
 	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -649,16 +670,20 @@ type PriorityLevelConfigurationStatus struct {
 type PriorityLevelConfigurationCondition struct {
 	// `type` is the type of the condition.
 	// Required.
+	// +required
 	Type PriorityLevelConfigurationConditionType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
+	// +optional
 	Status ConditionStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 	// `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
 	// `message` is a human-readable message indicating details about last transition.
+	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1/types_swagger_doc_generated.go
@@ -60,7 +60,7 @@ func (FlowSchema) SwaggerDoc() map[string]string {
 var map_FlowSchemaCondition = map[string]string{
 	"":                   "FlowSchemaCondition describes conditions for a FlowSchema.",
 	"type":               "`type` is the type of the condition. Required.",
-	"status":             "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+	"status":             "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 	"lastTransitionTime": "`lastTransitionTime` is the last time the condition transitioned from one status to another.",
 	"reason":             "`reason` is a unique, one-word, CamelCase reason for the condition's last transition.",
 	"message":            "`message` is a human-readable message indicating details about last transition.",
@@ -167,7 +167,7 @@ func (PriorityLevelConfiguration) SwaggerDoc() map[string]string {
 var map_PriorityLevelConfigurationCondition = map[string]string{
 	"":                   "PriorityLevelConfigurationCondition defines the condition of priority level.",
 	"type":               "`type` is the type of the condition. Required.",
-	"status":             "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+	"status":             "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 	"lastTransitionTime": "`lastTransitionTime` is the last time the condition transitioned from one status to another.",
 	"reason":             "`reason` is a unique, one-word, CamelCase reason for the condition's last transition.",
 	"message":            "`message` is a human-readable message indicating details about last transition.",

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
@@ -67,6 +67,7 @@ message FlowDistinguisherMethod {
   // `type` is the type of flow distinguisher method
   // The supported types are "ByUser" and "ByNamespace".
   // Required.
+  // +required
   optional string type = 1;
 }
 
@@ -81,7 +82,7 @@ message FlowSchema {
 
   // `spec` is the specification of the desired behavior of a FlowSchema.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional FlowSchemaSpec spec = 2;
 
   // `status` is the current status of a FlowSchema.
@@ -94,20 +95,24 @@ message FlowSchema {
 message FlowSchemaCondition {
   // `type` is the type of the condition.
   // Required.
+  // +required
   optional string type = 1;
 
   // `status` is the status of the condition.
-  // Can be True, False, Unknown.
-  // Required.
+  // Should be specified and set to one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+  // +optional
   optional string reason = 4;
 
   // `message` is a human-readable message indicating details about last transition.
+  // +optional
   optional string message = 5;
 }
 
@@ -127,6 +132,7 @@ message FlowSchemaSpec {
   // `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
   // be resolved, the FlowSchema will be ignored and marked as invalid in its status.
   // Required.
+  // +required
   optional PriorityLevelConfigurationReference priorityLevelConfiguration = 1;
 
   // `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
@@ -164,6 +170,7 @@ message GroupSubject {
   // See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some
   // well-known group names.
   // Required.
+  // +required
   optional string name = 1;
 }
 
@@ -177,6 +184,7 @@ message LimitResponse {
   // "Reject" means that requests that can not be executed upon arrival
   // are rejected.
   // Required.
+  // +required
   // +unionDiscriminator
   // +k8s:beta(since: "1.37")=+k8s:required
   // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -214,6 +222,7 @@ message LimitedPriorityLevelConfiguration {
   optional int32 assuredConcurrencyShares = 1;
 
   // `limitResponse` indicates what to do with requests that can not be executed right now
+  // +required
   optional LimitResponse limitResponse = 2;
 
   // `lendablePercent` prescribes the fraction of the level's NominalCL that
@@ -254,6 +263,7 @@ message NonResourcePolicyRule {
   // "*" matches all verbs. If it is present, it must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string verbs = 1;
 
   // `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
@@ -266,6 +276,7 @@ message NonResourcePolicyRule {
   // "*" matches all non-resource urls. if it is present, it must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string nonResourceURLs = 6;
 }
 
@@ -279,6 +290,7 @@ message PolicyRulesWithSubjects {
   // A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request.
   // +listType=atomic
   // Required.
+  // +required
   repeated Subject subjects = 1;
 
   // `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the
@@ -305,7 +317,7 @@ message PriorityLevelConfiguration {
 
   // `spec` is the specification of the desired behavior of a "request-priority".
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional PriorityLevelConfigurationSpec spec = 2;
 
   // `status` is the current status of a "request-priority".
@@ -318,20 +330,24 @@ message PriorityLevelConfiguration {
 message PriorityLevelConfigurationCondition {
   // `type` is the type of the condition.
   // Required.
+  // +required
   optional string type = 1;
 
   // `status` is the status of the condition.
-  // Can be True, False, Unknown.
-  // Required.
+  // Should be specified and set to one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+  // +optional
   optional string reason = 4;
 
   // `message` is a human-readable message indicating details about last transition.
+  // +optional
   optional string message = 5;
 }
 
@@ -350,6 +366,7 @@ message PriorityLevelConfigurationList {
 message PriorityLevelConfigurationReference {
   // `name` is the name of the priority level configuration being referenced
   // Required.
+  // +required
   optional string name = 1;
 }
 
@@ -365,6 +382,7 @@ message PriorityLevelConfigurationSpec {
   // _are_ subject to limits and (b) some of the server's limited
   // capacity is made available exclusively to this priority level.
   // Required.
+  // +required
   // +unionDiscriminator
   // +k8s:beta(since: "1.37")=+k8s:required
   // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -444,12 +462,14 @@ message ResourcePolicyRule {
   // "*" matches all verbs and, if present, must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string verbs = 1;
 
   // `apiGroups` is a list of matching API groups and may not be empty.
   // "*" matches all API groups and, if present, must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string apiGroups = 2;
 
   // `resources` is a list of matching resources (i.e., lowercase
@@ -458,6 +478,7 @@ message ResourcePolicyRule {
   // "*" matches all resources and, if present, must be the only entry.
   // Required.
   // +listType=set
+  // +required
   repeated string resources = 3;
 
   // `clusterScope` indicates whether to match requests that do not
@@ -485,10 +506,12 @@ message ResourcePolicyRule {
 message ServiceAccountSubject {
   // `namespace` is the namespace of matching ServiceAccount objects.
   // Required.
+  // +required
   optional string namespace = 1;
 
   // `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name.
   // Required.
+  // +required
   optional string name = 2;
 }
 
@@ -498,6 +521,7 @@ message ServiceAccountSubject {
 message Subject {
   // `kind` indicates which one of the other fields is non-empty.
   // Required
+  // +required
   // +unionDiscriminator
   optional string kind = 1;
 
@@ -518,6 +542,7 @@ message Subject {
 message UserSubject {
   // `name` is the username that matches, or "*" to match all usernames.
   // Required.
+  // +required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
@@ -120,7 +120,7 @@ type FlowSchema struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a FlowSchema.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec FlowSchemaSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a FlowSchema.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -149,6 +149,7 @@ type FlowSchemaSpec struct {
 	// `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
 	// be resolved, the FlowSchema will be ignored and marked as invalid in its status.
 	// Required.
+	// +required
 	PriorityLevelConfiguration PriorityLevelConfigurationReference `json:"priorityLevelConfiguration" protobuf:"bytes,1,opt,name=priorityLevelConfiguration"`
 	// `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
 	// FlowSchema is among those with the numerically lowest (which we take to be logically highest)
@@ -190,6 +191,7 @@ type FlowDistinguisherMethod struct {
 	// `type` is the type of flow distinguisher method
 	// The supported types are "ByUser" and "ByNamespace".
 	// Required.
+	// +required
 	Type FlowDistinguisherMethodType `json:"type" protobuf:"bytes,1,opt,name=type"`
 }
 
@@ -197,6 +199,7 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -210,6 +213,7 @@ type PolicyRulesWithSubjects struct {
 	// A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request.
 	// +listType=atomic
 	// Required.
+	// +required
 	Subjects []Subject `json:"subjects" protobuf:"bytes,1,rep,name=subjects"`
 	// `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the
 	// target resource.
@@ -230,6 +234,7 @@ type PolicyRulesWithSubjects struct {
 type Subject struct {
 	// `kind` indicates which one of the other fields is non-empty.
 	// Required
+	// +required
 	// +unionDiscriminator
 	Kind SubjectKind `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 	// `user` matches based on username.
@@ -257,6 +262,7 @@ const (
 type UserSubject struct {
 	// `name` is the username that matches, or "*" to match all usernames.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -266,6 +272,7 @@ type GroupSubject struct {
 	// See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some
 	// well-known group names.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -273,9 +280,11 @@ type GroupSubject struct {
 type ServiceAccountSubject struct {
 	// `namespace` is the namespace of matching ServiceAccount objects.
 	// Required.
+	// +required
 	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
 	// `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 }
 
@@ -293,12 +302,14 @@ type ResourcePolicyRule struct {
 	// "*" matches all verbs and, if present, must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// `apiGroups` is a list of matching API groups and may not be empty.
 	// "*" matches all API groups and, if present, must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	APIGroups []string `json:"apiGroups" protobuf:"bytes,2,rep,name=apiGroups"`
 
 	// `resources` is a list of matching resources (i.e., lowercase
@@ -307,6 +318,7 @@ type ResourcePolicyRule struct {
 	// "*" matches all resources and, if present, must be the only entry.
 	// Required.
 	// +listType=set
+	// +required
 	Resources []string `json:"resources" protobuf:"bytes,3,rep,name=resources"`
 
 	// `clusterScope` indicates whether to match requests that do not
@@ -338,6 +350,7 @@ type NonResourcePolicyRule struct {
 	// "*" matches all verbs. If it is present, it must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 	// `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
 	// For example:
@@ -349,6 +362,7 @@ type NonResourcePolicyRule struct {
 	// "*" matches all non-resource urls. if it is present, it must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	NonResourceURLs []string `json:"nonResourceURLs" protobuf:"bytes,6,rep,name=nonResourceURLs"`
 }
 
@@ -365,16 +379,20 @@ type FlowSchemaStatus struct {
 type FlowSchemaCondition struct {
 	// `type` is the type of the condition.
 	// Required.
+	// +required
 	Type FlowSchemaConditionType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
+	// +optional
 	Status ConditionStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 	// `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
 	// `message` is a human-readable message indicating details about last transition.
+	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 
@@ -397,7 +415,7 @@ type PriorityLevelConfiguration struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a "request-priority".
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec PriorityLevelConfigurationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a "request-priority".
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -432,6 +450,7 @@ type PriorityLevelConfigurationSpec struct {
 	// _are_ subject to limits and (b) some of the server's limited
 	// capacity is made available exclusively to this priority level.
 	// Required.
+	// +required
 	// +unionDiscriminator
 	// +k8s:beta(since: "1.37")=+k8s:required
 	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -491,6 +510,7 @@ type LimitedPriorityLevelConfiguration struct {
 	AssuredConcurrencyShares int32 `json:"assuredConcurrencyShares" protobuf:"varint,1,opt,name=assuredConcurrencyShares"`
 
 	// `limitResponse` indicates what to do with requests that can not be executed right now
+	// +required
 	LimitResponse LimitResponse `json:"limitResponse,omitempty" protobuf:"bytes,2,opt,name=limitResponse"`
 
 	// `lendablePercent` prescribes the fraction of the level's NominalCL that
@@ -570,6 +590,7 @@ type LimitResponse struct {
 	// "Reject" means that requests that can not be executed upon arrival
 	// are rejected.
 	// Required.
+	// +required
 	// +unionDiscriminator
 	// +k8s:beta(since: "1.37")=+k8s:required
 	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -644,16 +665,20 @@ type PriorityLevelConfigurationStatus struct {
 type PriorityLevelConfigurationCondition struct {
 	// `type` is the type of the condition.
 	// Required.
+	// +required
 	Type PriorityLevelConfigurationConditionType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
+	// +optional
 	Status ConditionStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 	// `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
 	// `message` is a human-readable message indicating details about last transition.
+	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/types_swagger_doc_generated.go
@@ -60,7 +60,7 @@ func (FlowSchema) SwaggerDoc() map[string]string {
 var map_FlowSchemaCondition = map[string]string{
 	"":                   "FlowSchemaCondition describes conditions for a FlowSchema.",
 	"type":               "`type` is the type of the condition. Required.",
-	"status":             "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+	"status":             "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 	"lastTransitionTime": "`lastTransitionTime` is the last time the condition transitioned from one status to another.",
 	"reason":             "`reason` is a unique, one-word, CamelCase reason for the condition's last transition.",
 	"message":            "`message` is a human-readable message indicating details about last transition.",
@@ -167,7 +167,7 @@ func (PriorityLevelConfiguration) SwaggerDoc() map[string]string {
 var map_PriorityLevelConfigurationCondition = map[string]string{
 	"":                   "PriorityLevelConfigurationCondition defines the condition of priority level.",
 	"type":               "`type` is the type of the condition. Required.",
-	"status":             "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+	"status":             "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 	"lastTransitionTime": "`lastTransitionTime` is the last time the condition transitioned from one status to another.",
 	"reason":             "`reason` is a unique, one-word, CamelCase reason for the condition's last transition.",
 	"message":            "`message` is a human-readable message indicating details about last transition.",

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
@@ -67,6 +67,7 @@ message FlowDistinguisherMethod {
   // `type` is the type of flow distinguisher method
   // The supported types are "ByUser" and "ByNamespace".
   // Required.
+  // +required
   optional string type = 1;
 }
 
@@ -81,7 +82,7 @@ message FlowSchema {
 
   // `spec` is the specification of the desired behavior of a FlowSchema.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional FlowSchemaSpec spec = 2;
 
   // `status` is the current status of a FlowSchema.
@@ -94,20 +95,24 @@ message FlowSchema {
 message FlowSchemaCondition {
   // `type` is the type of the condition.
   // Required.
+  // +required
   optional string type = 1;
 
   // `status` is the status of the condition.
-  // Can be True, False, Unknown.
-  // Required.
+  // Should be specified and set to one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+  // +optional
   optional string reason = 4;
 
   // `message` is a human-readable message indicating details about last transition.
+  // +optional
   optional string message = 5;
 }
 
@@ -127,6 +132,7 @@ message FlowSchemaSpec {
   // `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
   // be resolved, the FlowSchema will be ignored and marked as invalid in its status.
   // Required.
+  // +required
   optional PriorityLevelConfigurationReference priorityLevelConfiguration = 1;
 
   // `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
@@ -164,6 +170,7 @@ message GroupSubject {
   // See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some
   // well-known group names.
   // Required.
+  // +required
   optional string name = 1;
 }
 
@@ -177,6 +184,7 @@ message LimitResponse {
   // "Reject" means that requests that can not be executed upon arrival
   // are rejected.
   // Required.
+  // +required
   // +unionDiscriminator
   // +k8s:beta(since: "1.37")=+k8s:required
   // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -214,6 +222,7 @@ message LimitedPriorityLevelConfiguration {
   optional int32 assuredConcurrencyShares = 1;
 
   // `limitResponse` indicates what to do with requests that can not be executed right now
+  // +required
   optional LimitResponse limitResponse = 2;
 
   // `lendablePercent` prescribes the fraction of the level's NominalCL that
@@ -254,6 +263,7 @@ message NonResourcePolicyRule {
   // "*" matches all verbs. If it is present, it must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string verbs = 1;
 
   // `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
@@ -266,6 +276,7 @@ message NonResourcePolicyRule {
   // "*" matches all non-resource urls. if it is present, it must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string nonResourceURLs = 6;
 }
 
@@ -279,6 +290,7 @@ message PolicyRulesWithSubjects {
   // A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request.
   // +listType=atomic
   // Required.
+  // +required
   repeated Subject subjects = 1;
 
   // `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the
@@ -305,7 +317,7 @@ message PriorityLevelConfiguration {
 
   // `spec` is the specification of the desired behavior of a "request-priority".
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional PriorityLevelConfigurationSpec spec = 2;
 
   // `status` is the current status of a "request-priority".
@@ -318,20 +330,24 @@ message PriorityLevelConfiguration {
 message PriorityLevelConfigurationCondition {
   // `type` is the type of the condition.
   // Required.
+  // +required
   optional string type = 1;
 
   // `status` is the status of the condition.
-  // Can be True, False, Unknown.
-  // Required.
+  // Should be specified and set to one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+  // +optional
   optional string reason = 4;
 
   // `message` is a human-readable message indicating details about last transition.
+  // +optional
   optional string message = 5;
 }
 
@@ -350,6 +366,7 @@ message PriorityLevelConfigurationList {
 message PriorityLevelConfigurationReference {
   // `name` is the name of the priority level configuration being referenced
   // Required.
+  // +required
   optional string name = 1;
 }
 
@@ -365,6 +382,7 @@ message PriorityLevelConfigurationSpec {
   // _are_ subject to limits and (b) some of the server's limited
   // capacity is made available exclusively to this priority level.
   // Required.
+  // +required
   // +unionDiscriminator
   // +k8s:beta(since: "1.37")=+k8s:required
   // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -444,12 +462,14 @@ message ResourcePolicyRule {
   // "*" matches all verbs and, if present, must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string verbs = 1;
 
   // `apiGroups` is a list of matching API groups and may not be empty.
   // "*" matches all API groups and, if present, must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string apiGroups = 2;
 
   // `resources` is a list of matching resources (i.e., lowercase
@@ -458,6 +478,7 @@ message ResourcePolicyRule {
   // "*" matches all resources and, if present, must be the only entry.
   // Required.
   // +listType=set
+  // +required
   repeated string resources = 3;
 
   // `clusterScope` indicates whether to match requests that do not
@@ -485,10 +506,12 @@ message ResourcePolicyRule {
 message ServiceAccountSubject {
   // `namespace` is the namespace of matching ServiceAccount objects.
   // Required.
+  // +required
   optional string namespace = 1;
 
   // `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name.
   // Required.
+  // +required
   optional string name = 2;
 }
 
@@ -498,6 +521,7 @@ message ServiceAccountSubject {
 message Subject {
   // `kind` indicates which one of the other fields is non-empty.
   // Required
+  // +required
   // +unionDiscriminator
   optional string kind = 1;
 
@@ -518,6 +542,7 @@ message Subject {
 message UserSubject {
   // `name` is the username that matches, or "*" to match all usernames.
   // Required.
+  // +required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
@@ -120,7 +120,7 @@ type FlowSchema struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a FlowSchema.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec FlowSchemaSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a FlowSchema.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -149,6 +149,7 @@ type FlowSchemaSpec struct {
 	// `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
 	// be resolved, the FlowSchema will be ignored and marked as invalid in its status.
 	// Required.
+	// +required
 	PriorityLevelConfiguration PriorityLevelConfigurationReference `json:"priorityLevelConfiguration" protobuf:"bytes,1,opt,name=priorityLevelConfiguration"`
 	// `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
 	// FlowSchema is among those with the numerically lowest (which we take to be logically highest)
@@ -190,6 +191,7 @@ type FlowDistinguisherMethod struct {
 	// `type` is the type of flow distinguisher method
 	// The supported types are "ByUser" and "ByNamespace".
 	// Required.
+	// +required
 	Type FlowDistinguisherMethodType `json:"type" protobuf:"bytes,1,opt,name=type"`
 }
 
@@ -197,6 +199,7 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -210,6 +213,7 @@ type PolicyRulesWithSubjects struct {
 	// A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request.
 	// +listType=atomic
 	// Required.
+	// +required
 	Subjects []Subject `json:"subjects" protobuf:"bytes,1,rep,name=subjects"`
 	// `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the
 	// target resource.
@@ -230,6 +234,7 @@ type PolicyRulesWithSubjects struct {
 type Subject struct {
 	// `kind` indicates which one of the other fields is non-empty.
 	// Required
+	// +required
 	// +unionDiscriminator
 	Kind SubjectKind `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 	// `user` matches based on username.
@@ -257,6 +262,7 @@ const (
 type UserSubject struct {
 	// `name` is the username that matches, or "*" to match all usernames.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -266,6 +272,7 @@ type GroupSubject struct {
 	// See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some
 	// well-known group names.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -273,9 +280,11 @@ type GroupSubject struct {
 type ServiceAccountSubject struct {
 	// `namespace` is the namespace of matching ServiceAccount objects.
 	// Required.
+	// +required
 	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
 	// `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 }
 
@@ -293,12 +302,14 @@ type ResourcePolicyRule struct {
 	// "*" matches all verbs and, if present, must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// `apiGroups` is a list of matching API groups and may not be empty.
 	// "*" matches all API groups and, if present, must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	APIGroups []string `json:"apiGroups" protobuf:"bytes,2,rep,name=apiGroups"`
 
 	// `resources` is a list of matching resources (i.e., lowercase
@@ -307,6 +318,7 @@ type ResourcePolicyRule struct {
 	// "*" matches all resources and, if present, must be the only entry.
 	// Required.
 	// +listType=set
+	// +required
 	Resources []string `json:"resources" protobuf:"bytes,3,rep,name=resources"`
 
 	// `clusterScope` indicates whether to match requests that do not
@@ -338,6 +350,7 @@ type NonResourcePolicyRule struct {
 	// "*" matches all verbs. If it is present, it must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 	// `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
 	// For example:
@@ -349,6 +362,7 @@ type NonResourcePolicyRule struct {
 	// "*" matches all non-resource urls. if it is present, it must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	NonResourceURLs []string `json:"nonResourceURLs" protobuf:"bytes,6,rep,name=nonResourceURLs"`
 }
 
@@ -365,16 +379,20 @@ type FlowSchemaStatus struct {
 type FlowSchemaCondition struct {
 	// `type` is the type of the condition.
 	// Required.
+	// +required
 	Type FlowSchemaConditionType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
+	// +optional
 	Status ConditionStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 	// `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
 	// `message` is a human-readable message indicating details about last transition.
+	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 
@@ -397,7 +415,7 @@ type PriorityLevelConfiguration struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a "request-priority".
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec PriorityLevelConfigurationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a "request-priority".
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -432,6 +450,7 @@ type PriorityLevelConfigurationSpec struct {
 	// _are_ subject to limits and (b) some of the server's limited
 	// capacity is made available exclusively to this priority level.
 	// Required.
+	// +required
 	// +unionDiscriminator
 	// +k8s:beta(since: "1.37")=+k8s:required
 	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -491,6 +510,7 @@ type LimitedPriorityLevelConfiguration struct {
 	AssuredConcurrencyShares int32 `json:"assuredConcurrencyShares" protobuf:"varint,1,opt,name=assuredConcurrencyShares"`
 
 	// `limitResponse` indicates what to do with requests that can not be executed right now
+	// +required
 	LimitResponse LimitResponse `json:"limitResponse,omitempty" protobuf:"bytes,2,opt,name=limitResponse"`
 
 	// `lendablePercent` prescribes the fraction of the level's NominalCL that
@@ -570,6 +590,7 @@ type LimitResponse struct {
 	// "Reject" means that requests that can not be executed upon arrival
 	// are rejected.
 	// Required.
+	// +required
 	// +unionDiscriminator
 	// +k8s:beta(since: "1.37")=+k8s:required
 	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -644,16 +665,20 @@ type PriorityLevelConfigurationStatus struct {
 type PriorityLevelConfigurationCondition struct {
 	// `type` is the type of the condition.
 	// Required.
+	// +required
 	Type PriorityLevelConfigurationConditionType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
+	// +optional
 	Status ConditionStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 	// `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
 	// `message` is a human-readable message indicating details about last transition.
+	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/types_swagger_doc_generated.go
@@ -60,7 +60,7 @@ func (FlowSchema) SwaggerDoc() map[string]string {
 var map_FlowSchemaCondition = map[string]string{
 	"":                   "FlowSchemaCondition describes conditions for a FlowSchema.",
 	"type":               "`type` is the type of the condition. Required.",
-	"status":             "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+	"status":             "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 	"lastTransitionTime": "`lastTransitionTime` is the last time the condition transitioned from one status to another.",
 	"reason":             "`reason` is a unique, one-word, CamelCase reason for the condition's last transition.",
 	"message":            "`message` is a human-readable message indicating details about last transition.",
@@ -167,7 +167,7 @@ func (PriorityLevelConfiguration) SwaggerDoc() map[string]string {
 var map_PriorityLevelConfigurationCondition = map[string]string{
 	"":                   "PriorityLevelConfigurationCondition defines the condition of priority level.",
 	"type":               "`type` is the type of the condition. Required.",
-	"status":             "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+	"status":             "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 	"lastTransitionTime": "`lastTransitionTime` is the last time the condition transitioned from one status to another.",
 	"reason":             "`reason` is a unique, one-word, CamelCase reason for the condition's last transition.",
 	"message":            "`message` is a human-readable message indicating details about last transition.",

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
@@ -67,6 +67,7 @@ message FlowDistinguisherMethod {
   // `type` is the type of flow distinguisher method
   // The supported types are "ByUser" and "ByNamespace".
   // Required.
+  // +required
   optional string type = 1;
 }
 
@@ -81,7 +82,7 @@ message FlowSchema {
 
   // `spec` is the specification of the desired behavior of a FlowSchema.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional FlowSchemaSpec spec = 2;
 
   // `status` is the current status of a FlowSchema.
@@ -94,20 +95,24 @@ message FlowSchema {
 message FlowSchemaCondition {
   // `type` is the type of the condition.
   // Required.
+  // +required
   optional string type = 1;
 
   // `status` is the status of the condition.
-  // Can be True, False, Unknown.
-  // Required.
+  // Should be specified and set to one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+  // +optional
   optional string reason = 4;
 
   // `message` is a human-readable message indicating details about last transition.
+  // +optional
   optional string message = 5;
 }
 
@@ -127,6 +132,7 @@ message FlowSchemaSpec {
   // `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
   // be resolved, the FlowSchema will be ignored and marked as invalid in its status.
   // Required.
+  // +required
   optional PriorityLevelConfigurationReference priorityLevelConfiguration = 1;
 
   // `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
@@ -166,6 +172,7 @@ message GroupSubject {
   // See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some
   // well-known group names.
   // Required.
+  // +required
   optional string name = 1;
 }
 
@@ -179,6 +186,7 @@ message LimitResponse {
   // "Reject" means that requests that can not be executed upon arrival
   // are rejected.
   // Required.
+  // +required
   // +unionDiscriminator
   // +k8s:beta(since: "1.37")=+k8s:required
   // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -216,6 +224,7 @@ message LimitedPriorityLevelConfiguration {
   optional int32 nominalConcurrencyShares = 1;
 
   // `limitResponse` indicates what to do with requests that can not be executed right now
+  // +required
   optional LimitResponse limitResponse = 2;
 
   // `lendablePercent` prescribes the fraction of the level's NominalCL that
@@ -256,6 +265,7 @@ message NonResourcePolicyRule {
   // "*" matches all verbs. If it is present, it must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string verbs = 1;
 
   // `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
@@ -268,6 +278,7 @@ message NonResourcePolicyRule {
   // "*" matches all non-resource urls. if it is present, it must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string nonResourceURLs = 6;
 }
 
@@ -281,6 +292,7 @@ message PolicyRulesWithSubjects {
   // A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request.
   // +listType=atomic
   // Required.
+  // +required
   repeated Subject subjects = 1;
 
   // `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the
@@ -307,7 +319,7 @@ message PriorityLevelConfiguration {
 
   // `spec` is the specification of the desired behavior of a "request-priority".
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional PriorityLevelConfigurationSpec spec = 2;
 
   // `status` is the current status of a "request-priority".
@@ -320,20 +332,24 @@ message PriorityLevelConfiguration {
 message PriorityLevelConfigurationCondition {
   // `type` is the type of the condition.
   // Required.
+  // +required
   optional string type = 1;
 
   // `status` is the status of the condition.
-  // Can be True, False, Unknown.
-  // Required.
+  // Should be specified and set to one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+  // +optional
   optional string reason = 4;
 
   // `message` is a human-readable message indicating details about last transition.
+  // +optional
   optional string message = 5;
 }
 
@@ -352,6 +368,7 @@ message PriorityLevelConfigurationList {
 message PriorityLevelConfigurationReference {
   // `name` is the name of the priority level configuration being referenced
   // Required.
+  // +required
   optional string name = 1;
 }
 
@@ -367,6 +384,7 @@ message PriorityLevelConfigurationSpec {
   // _are_ subject to limits and (b) some of the server's limited
   // capacity is made available exclusively to this priority level.
   // Required.
+  // +required
   // +unionDiscriminator
   // +k8s:beta(since: "1.37")=+k8s:required
   // +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -448,12 +466,14 @@ message ResourcePolicyRule {
   // "*" matches all verbs and, if present, must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string verbs = 1;
 
   // `apiGroups` is a list of matching API groups and may not be empty.
   // "*" matches all API groups and, if present, must be the only entry.
   // +listType=set
   // Required.
+  // +required
   repeated string apiGroups = 2;
 
   // `resources` is a list of matching resources (i.e., lowercase
@@ -462,6 +482,7 @@ message ResourcePolicyRule {
   // "*" matches all resources and, if present, must be the only entry.
   // Required.
   // +listType=set
+  // +required
   repeated string resources = 3;
 
   // `clusterScope` indicates whether to match requests that do not
@@ -489,10 +510,12 @@ message ResourcePolicyRule {
 message ServiceAccountSubject {
   // `namespace` is the namespace of matching ServiceAccount objects.
   // Required.
+  // +required
   optional string namespace = 1;
 
   // `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name.
   // Required.
+  // +required
   optional string name = 2;
 }
 
@@ -502,6 +525,7 @@ message ServiceAccountSubject {
 message Subject {
   // `kind` indicates which one of the other fields is non-empty.
   // Required
+  // +required
   // +unionDiscriminator
   optional string kind = 1;
 
@@ -522,6 +546,7 @@ message Subject {
 message UserSubject {
   // `name` is the username that matches, or "*" to match all usernames.
   // Required.
+  // +required
   optional string name = 1;
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
@@ -134,7 +134,7 @@ type FlowSchema struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a FlowSchema.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec FlowSchemaSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a FlowSchema.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -163,6 +163,7 @@ type FlowSchemaSpec struct {
 	// `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot
 	// be resolved, the FlowSchema will be ignored and marked as invalid in its status.
 	// Required.
+	// +required
 	PriorityLevelConfiguration PriorityLevelConfigurationReference `json:"priorityLevelConfiguration" protobuf:"bytes,1,opt,name=priorityLevelConfiguration"`
 	// `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen
 	// FlowSchema is among those with the numerically lowest (which we take to be logically highest)
@@ -204,6 +205,7 @@ type FlowDistinguisherMethod struct {
 	// `type` is the type of flow distinguisher method
 	// The supported types are "ByUser" and "ByNamespace".
 	// Required.
+	// +required
 	Type FlowDistinguisherMethodType `json:"type" protobuf:"bytes,1,opt,name=type"`
 }
 
@@ -211,6 +213,7 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -224,6 +227,7 @@ type PolicyRulesWithSubjects struct {
 	// A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request.
 	// +listType=atomic
 	// Required.
+	// +required
 	Subjects []Subject `json:"subjects" protobuf:"bytes,1,rep,name=subjects"`
 	// `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the
 	// target resource.
@@ -244,6 +248,7 @@ type PolicyRulesWithSubjects struct {
 type Subject struct {
 	// `kind` indicates which one of the other fields is non-empty.
 	// Required
+	// +required
 	// +unionDiscriminator
 	Kind SubjectKind `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 	// `user` matches based on username.
@@ -271,6 +276,7 @@ const (
 type UserSubject struct {
 	// `name` is the username that matches, or "*" to match all usernames.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -280,6 +286,7 @@ type GroupSubject struct {
 	// See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some
 	// well-known group names.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -287,9 +294,11 @@ type GroupSubject struct {
 type ServiceAccountSubject struct {
 	// `namespace` is the namespace of matching ServiceAccount objects.
 	// Required.
+	// +required
 	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
 	// `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 }
 
@@ -307,12 +316,14 @@ type ResourcePolicyRule struct {
 	// "*" matches all verbs and, if present, must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// `apiGroups` is a list of matching API groups and may not be empty.
 	// "*" matches all API groups and, if present, must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	APIGroups []string `json:"apiGroups" protobuf:"bytes,2,rep,name=apiGroups"`
 
 	// `resources` is a list of matching resources (i.e., lowercase
@@ -321,6 +332,7 @@ type ResourcePolicyRule struct {
 	// "*" matches all resources and, if present, must be the only entry.
 	// Required.
 	// +listType=set
+	// +required
 	Resources []string `json:"resources" protobuf:"bytes,3,rep,name=resources"`
 
 	// `clusterScope` indicates whether to match requests that do not
@@ -352,6 +364,7 @@ type NonResourcePolicyRule struct {
 	// "*" matches all verbs. If it is present, it must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 	// `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
 	// For example:
@@ -363,6 +376,7 @@ type NonResourcePolicyRule struct {
 	// "*" matches all non-resource urls. if it is present, it must be the only entry.
 	// +listType=set
 	// Required.
+	// +required
 	NonResourceURLs []string `json:"nonResourceURLs" protobuf:"bytes,6,rep,name=nonResourceURLs"`
 }
 
@@ -381,16 +395,20 @@ type FlowSchemaStatus struct {
 type FlowSchemaCondition struct {
 	// `type` is the type of the condition.
 	// Required.
+	// +required
 	Type FlowSchemaConditionType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
+	// +optional
 	Status ConditionStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 	// `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
 	// `message` is a human-readable message indicating details about last transition.
+	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 
@@ -413,7 +431,7 @@ type PriorityLevelConfiguration struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a "request-priority".
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec PriorityLevelConfigurationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a "request-priority".
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -448,6 +466,7 @@ type PriorityLevelConfigurationSpec struct {
 	// _are_ subject to limits and (b) some of the server's limited
 	// capacity is made available exclusively to this priority level.
 	// Required.
+	// +required
 	// +unionDiscriminator
 	// +k8s:beta(since: "1.37")=+k8s:required
 	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -507,6 +526,7 @@ type LimitedPriorityLevelConfiguration struct {
 	NominalConcurrencyShares int32 `json:"nominalConcurrencyShares" protobuf:"varint,1,opt,name=nominalConcurrencyShares"`
 
 	// `limitResponse` indicates what to do with requests that can not be executed right now
+	// +required
 	LimitResponse LimitResponse `json:"limitResponse,omitempty" protobuf:"bytes,2,opt,name=limitResponse"`
 
 	// `lendablePercent` prescribes the fraction of the level's NominalCL that
@@ -586,6 +606,7 @@ type LimitResponse struct {
 	// "Reject" means that requests that can not be executed upon arrival
 	// are rejected.
 	// Required.
+	// +required
 	// +unionDiscriminator
 	// +k8s:beta(since: "1.37")=+k8s:required
 	// +k8s:beta(since: "1.37")=+k8s:modeDiscriminator
@@ -662,16 +683,20 @@ type PriorityLevelConfigurationStatus struct {
 type PriorityLevelConfigurationCondition struct {
 	// `type` is the type of the condition.
 	// Required.
+	// +required
 	Type PriorityLevelConfigurationConditionType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
+	// +optional
 	Status ConditionStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
 	// `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
 	// `message` is a human-readable message indicating details about last transition.
+	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/types_swagger_doc_generated.go
@@ -60,7 +60,7 @@ func (FlowSchema) SwaggerDoc() map[string]string {
 var map_FlowSchemaCondition = map[string]string{
 	"":                   "FlowSchemaCondition describes conditions for a FlowSchema.",
 	"type":               "`type` is the type of the condition. Required.",
-	"status":             "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+	"status":             "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 	"lastTransitionTime": "`lastTransitionTime` is the last time the condition transitioned from one status to another.",
 	"reason":             "`reason` is a unique, one-word, CamelCase reason for the condition's last transition.",
 	"message":            "`message` is a human-readable message indicating details about last transition.",
@@ -167,7 +167,7 @@ func (PriorityLevelConfiguration) SwaggerDoc() map[string]string {
 var map_PriorityLevelConfigurationCondition = map[string]string{
 	"":                   "PriorityLevelConfigurationCondition defines the condition of priority level.",
 	"type":               "`type` is the type of the condition. Required.",
-	"status":             "`status` is the status of the condition. Can be True, False, Unknown. Required.",
+	"status":             "`status` is the status of the condition. Should be specified and set to one of True, False, Unknown.",
 	"lastTransitionTime": "`lastTransitionTime` is the last time the condition transitioned from one status to another.",
 	"reason":             "`reason` is a unique, one-word, CamelCase reason for the condition's last transition.",
 	"message":            "`message` is a human-readable message indicating details about last transition.",

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschemacondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschemacondition.go
@@ -32,8 +32,7 @@ type FlowSchemaConditionApplyConfiguration struct {
 	// Required.
 	Type *flowcontrolv1.FlowSchemaConditionType `json:"type,omitempty"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
 	Status *flowcontrolv1.ConditionStatus `json:"status,omitempty"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationcondition.go
@@ -32,8 +32,7 @@ type PriorityLevelConfigurationConditionApplyConfiguration struct {
 	// Required.
 	Type *flowcontrolv1.PriorityLevelConfigurationConditionType `json:"type,omitempty"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
 	Status *flowcontrolv1.ConditionStatus `json:"status,omitempty"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemacondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemacondition.go
@@ -32,8 +32,7 @@ type FlowSchemaConditionApplyConfiguration struct {
 	// Required.
 	Type *flowcontrolv1beta1.FlowSchemaConditionType `json:"type,omitempty"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
 	Status *flowcontrolv1beta1.ConditionStatus `json:"status,omitempty"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
 	LastTransitionTime *v1.Time `json:"lastTransitionTime,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationcondition.go
@@ -32,8 +32,7 @@ type PriorityLevelConfigurationConditionApplyConfiguration struct {
 	// Required.
 	Type *flowcontrolv1beta1.PriorityLevelConfigurationConditionType `json:"type,omitempty"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
 	Status *flowcontrolv1beta1.ConditionStatus `json:"status,omitempty"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
 	LastTransitionTime *v1.Time `json:"lastTransitionTime,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemacondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemacondition.go
@@ -32,8 +32,7 @@ type FlowSchemaConditionApplyConfiguration struct {
 	// Required.
 	Type *flowcontrolv1beta2.FlowSchemaConditionType `json:"type,omitempty"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
 	Status *flowcontrolv1beta2.ConditionStatus `json:"status,omitempty"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
 	LastTransitionTime *v1.Time `json:"lastTransitionTime,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationcondition.go
@@ -32,8 +32,7 @@ type PriorityLevelConfigurationConditionApplyConfiguration struct {
 	// Required.
 	Type *flowcontrolv1beta2.PriorityLevelConfigurationConditionType `json:"type,omitempty"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
 	Status *flowcontrolv1beta2.ConditionStatus `json:"status,omitempty"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
 	LastTransitionTime *v1.Time `json:"lastTransitionTime,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemacondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemacondition.go
@@ -32,8 +32,7 @@ type FlowSchemaConditionApplyConfiguration struct {
 	// Required.
 	Type *flowcontrolv1beta3.FlowSchemaConditionType `json:"type,omitempty"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
 	Status *flowcontrolv1beta3.ConditionStatus `json:"status,omitempty"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
 	LastTransitionTime *v1.Time `json:"lastTransitionTime,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationcondition.go
@@ -32,8 +32,7 @@ type PriorityLevelConfigurationConditionApplyConfiguration struct {
 	// Required.
 	Type *flowcontrolv1beta3.PriorityLevelConfigurationConditionType `json:"type,omitempty"`
 	// `status` is the status of the condition.
-	// Can be True, False, Unknown.
-	// Required.
+	// Should be specified and set to one of True, False, Unknown.
 	Status *flowcontrolv1beta3.ConditionStatus `json:"status,omitempty"`
 	// `lastTransitionTime` is the last time the condition transitioned from one status to another.
 	LastTransitionTime *v1.Time `json:"lastTransitionTime,omitempty"`


### PR DESCRIPTION
Enable the optionalorrequired linter for the flowcontrol API group as part of 
kubernetes/kubernetes#134671.
https://github.com/kubernetes/kubernetes/issues/136870

This PR addresses 108 existing violations by adding +required and +optional tags to all fields in the flowcontrol API across all versions (v1, v1beta1, v1beta2, v1beta3).

**Changes:**
- Added `// +required` tags to all required fields in flowcontrol types
- Added `// +optional` tags to optional condition fields
- Updated generated protobuf files to reflect these changes
- Removed flowcontrol from the optionalorrequired linter exceptions in 
  `hack/kube-api-linter/exceptions.yaml`

**Testing:**
- All flowcontrol API packages build successfully
- kube-apiserver and kubelet compile without errors
- Code generation and protobuf files are synchronized
- All existing tests pass
- ✓ Build verification: All flowcontrol API packages compile
- ✓ Unit tests: All API packages pass testing
- ✓ Static analysis: go vet validation passed
- ✓ Core components: kube-apiserver and kubelet build successfully
- ✓ Generated code: Protobuf files synchronized with source changes

**Related:**
- Fixes #136870
- Follows pattern of #134675

/sig architecture
/sig api-machinery

```release-note
NONE
```