### PR TITLE
Add --tls-curve-preferences flag for configuring TLS key exchange mechanism (curves)

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -23,6 +23,7 @@ API rule violation: list_type_missing,k8s.io/kubelet/config/v1beta1,KubeletConfi
 API rule violation: list_type_missing,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,ReservedMemory
 API rule violation: list_type_missing,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,ShutdownGracePeriodByPodPriority
 API rule violation: list_type_missing,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,TLSCipherSuites
+API rule violation: list_type_missing,k8s.io/kubelet/config/v1beta1,KubeletConfiguration,TLSCurvePreferences
 API rule violation: names_match,k8s.io/api/authorization/v1beta1,SubjectAccessReviewSpec,Groups
 API rule violation: names_match,k8s.io/api/core/v1,AzureDiskVolumeSource,DataDiskURI
 API rule violation: names_match,k8s.io/api/core/v1,ContainerStatus,LastTerminationState

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1175,12 +1175,18 @@ func InitializeTLS(ctx context.Context, kf *options.KubeletFlags, kc *kubeletcon
 		}
 	}
 
+	curvePreferences, err := cliflag.TLSCurvePreferences(kc.TLSCurvePreferences)
+	if err != nil {
+		return nil, err
+	}
+
 	tlsOptions := &server.TLSOptions{
-		MinVersion:   minTLSVersion,
-		CipherSuites: tlsCipherSuites,
-		CertFile:     kc.TLSCertFile,
-		KeyFile:      kc.TLSPrivateKeyFile,
-		ClientCAFile: kc.Authentication.X509.ClientCAFile,
+		MinVersion:       minTLSVersion,
+		CipherSuites:     tlsCipherSuites,
+		CurvePreferences: curvePreferences,
+		CertFile:         kc.TLSCertFile,
+		KeyFile:          kc.TLSPrivateKeyFile,
+		ClientCAFile:     kc.Authentication.X509.ClientCAFile,
 	}
 
 	return tlsOptions, nil

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -70825,6 +70825,21 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 							},
 						},
 					},
+					"tlsCurvePreferences": {
+						SchemaProps: spec.SchemaProps{
+							Description: "tlsCurvePreferences is the set of allowed key exchange mechanisms for the server, specified as numeric Go crypto/tls CurveID values. The supported values depend on the Go version used. See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version. The order of the list is ignored, and key exchange mechanisms are chosen by Go from this list using an internal preference order. If empty, the default Go curves will be used. Default: nil",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: 0,
+										Type:    []string{"integer"},
+										Format:  "int32",
+									},
+								},
+							},
+						},
+					},
 					"tlsMinVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "tlsMinVersion is the minimum TLS version supported. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). Default: \"\"",

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -236,6 +236,7 @@ var (
 		"SingleProcessOOMKill",
 		"Logging.Verbosity",
 		"TLSCipherSuites[*]",
+		"TLSCurvePreferences[*]",
 		"TLSMinVersion",
 		"IPTablesDropBit",
 		"IPTablesMasqueradeBit",

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -131,6 +131,14 @@ type KubeletConfiguration struct {
 	// Note that TLS 1.3 ciphersuites are not configurable.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	TLSCipherSuites []string
+	// TLSCurvePreferences is the set of allowed key exchange mechanisms for the server,
+	// specified as numeric Go crypto/tls CurveID values.
+	// The supported values depend on the Go version used.
+	// See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version.
+	// The order of the list is ignored, and key exchange mechanisms are
+	// chosen by Go from this list using an internal preference order.
+	// If empty, the default Go curves will be used.
+	TLSCurvePreferences []int32
 	// TLSMinVersion is the minimum TLS version supported.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	TLSMinVersion string

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -582,6 +582,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TLSCipherSuites = *(*[]string)(unsafe.Pointer(&in.TLSCipherSuites))
+	out.TLSCurvePreferences = *(*[]int32)(unsafe.Pointer(&in.TLSCurvePreferences))
 	out.TLSMinVersion = in.TLSMinVersion
 	out.RotateCertificates = in.RotateCertificates
 	out.ServerTLSBootstrap = in.ServerTLSBootstrap
@@ -790,6 +791,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TLSCipherSuites = *(*[]string)(unsafe.Pointer(&in.TLSCipherSuites))
+	out.TLSCurvePreferences = *(*[]int32)(unsafe.Pointer(&in.TLSCurvePreferences))
 	out.TLSMinVersion = in.TLSMinVersion
 	out.RotateCertificates = in.RotateCertificates
 	out.ServerTLSBootstrap = in.ServerTLSBootstrap

--- a/pkg/kubelet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/config/zz_generated.deepcopy.go
@@ -333,6 +333,11 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.TLSCurvePreferences != nil {
+		in, out := &in.TLSCurvePreferences, &out.TLSCurvePreferences
+		*out = make([]int32, len(*in))
+		copy(*out, *in)
+	}
 	out.Authentication = in.Authentication
 	out.Authorization = in.Authorization
 	if in.PreloadedImagesVerificationAllowlist != nil {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -904,6 +904,7 @@ func NewMainKubelet(ctx context.Context,
 
 		kubeDeps.TLSConfig.MinVersion = kubeDeps.TLSOptions.MinVersion
 		kubeDeps.TLSConfig.CipherSuites = kubeDeps.TLSOptions.CipherSuites
+		kubeDeps.TLSConfig.CurvePreferences = kubeDeps.TLSOptions.CurvePreferences
 
 		getServingCertificate := func() *tls.Certificate { return nil }
 

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -134,11 +134,12 @@ type Server struct {
 
 // TLSOptions holds the TLS options.
 type TLSOptions struct {
-	MinVersion   uint16
-	CipherSuites []uint16
-	CertFile     string
-	KeyFile      string
-	ClientCAFile string
+	MinVersion       uint16
+	CipherSuites     []uint16
+	CurvePreferences []tls.CurveID
+	CertFile         string
+	KeyFile          string
+	ClientCAFile     string
 }
 
 // containerInterface defines the restful.Container functions used on the root container

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/base32"
 	"fmt"
 	"net"
@@ -364,6 +365,13 @@ type SecureServingInfo struct {
 	// CipherSuites optionally overrides the list of allowed cipher suites for the server.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	CipherSuites []uint16
+
+	// CurvePreferences optionally specifies the set of allowed key exchange mechanisms for the server.
+	// The order of the list is ignored, and key exchange mechanisms
+	// are chosen by Go from this list using an internal preference order.
+	// If empty, the default Go curves will be used.
+	// Values are from the Go crypto/tls CurveID constants (https://golang.org/pkg/crypto/tls/#CurveID).
+	CurvePreferences []tls.CurveID
 
 	// HTTP2MaxStreamsPerConnection is the limit that the api server imposes on each client.
 	// A value of zero means to use the default provided by golang's HTTP/2 support.

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -64,6 +64,14 @@ type SecureServingOptions struct {
 	// CipherSuites is the list of allowed cipher suites for the server.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	CipherSuites []string
+	// CurvePreferences is the set of allowed key exchange mechanisms for the server,
+	// specified as numeric Go crypto/tls CurveID values.
+	// The supported values depend on the Go version used.
+	// See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version.
+	// The order of the list is ignored, and key exchange mechanisms are
+	// chosen by Go from this list using an internal preference order.
+	// If empty, the default Go curves will be used.
+	CurvePreferences []int32
 	// MinTLSVersion is the minimum TLS version supported.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	MinTLSVersion string
@@ -188,6 +196,15 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 			"If omitted, the default Go cipher suites will be used. \n"+
 			"Preferred values: "+strings.Join(tlsCipherPreferredValues, ", ")+". \n"+
 			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
+
+	fs.Int32SliceVar(&s.CurvePreferences, "tls-curve-preferences", s.CurvePreferences,
+		"Comma-separated list of numeric Go crypto/tls CurveID values, "+
+			"as the allowed key exchange mechanisms for the server. "+
+			"The supported values depend on the Go version used. "+
+			"See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version. "+
+			"The order of the list is ignored, and key exchange mechanisms are chosen "+
+			"by Go from this list using an internal preference order. "+
+			"If omitted, the default Go curves will be used.")
 
 	tlsPossibleVersions := cliflag.TLSPossibleVersions()
 	fs.StringVar(&s.MinTLSVersion, "tls-min-version", s.MinTLSVersion,
@@ -315,6 +332,14 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 			return err
 		}
 		c.CipherSuites = cipherSuites
+	}
+
+	if len(s.CurvePreferences) != 0 {
+		curvePreferences, err := cliflag.TLSCurvePreferences(s.CurvePreferences)
+		if err != nil {
+			return err
+		}
+		c.CurvePreferences = curvePreferences
 	}
 
 	var err error

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -71,6 +71,9 @@ func (s *SecureServingInfo) tlsConfig(stopCh <-chan struct{}) (*tls.Config, erro
 			}
 		}
 	}
+	if len(s.CurvePreferences) > 0 {
+		tlsConfig.CurvePreferences = s.CurvePreferences
+	}
 
 	if s.ClientCA != nil {
 		// Populate PeerCertificates in requests, but don't reject connections without certificates

--- a/staging/src/k8s.io/cloud-provider/options/webhook.go
+++ b/staging/src/k8s.io/cloud-provider/options/webhook.go
@@ -149,6 +149,15 @@ func (o *WebhookServingOptions) AddFlags(fs *pflag.FlagSet) {
 			"Preferred values: "+strings.Join(tlsCipherPreferredValues, ", ")+". \n"+
 			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
 
+	fs.Int32SliceVar(&o.CurvePreferences, "webhook-tls-curve-preferences", o.CurvePreferences,
+		"Comma-separated list of numeric Go crypto/tls CurveID values, "+
+			"as the allowed key exchange mechanisms for the webhook server. "+
+			"The supported values depend on the Go version used. "+
+			"See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version. "+
+			"The order of the list is ignored, and key exchange mechanisms are chosen "+
+			"by Go from this list using an internal preference order. "+
+			"If omitted, the default Go curves will be used.")
+
 	tlsPossibleVersions := cliflag.TLSPossibleVersions()
 	fs.StringVar(&o.MinTLSVersion, "webhook-tls-min-version", o.MinTLSVersion,
 		"Minimum TLS version supported for the webhook server. "+
@@ -226,6 +235,14 @@ func (o *WebhookServingOptions) ApplyTo(cfg **server.SecureServingInfo, webhookC
 			return fmt.Errorf("failed to parse cipher suites: %w", err)
 		}
 		c.CipherSuites = cipherSuites
+	}
+
+	if len(o.CurvePreferences) != 0 {
+		curvePreferences, err := cliflag.TLSCurvePreferences(o.CurvePreferences)
+		if err != nil {
+			return fmt.Errorf("failed to parse curve preferences: %w", err)
+		}
+		c.CurvePreferences = curvePreferences
 	}
 
 	c.MinTLSVersion, err = cliflag.TLSVersion(o.MinTLSVersion)

--- a/staging/src/k8s.io/component-base/cli/flag/curves_flag.go
+++ b/staging/src/k8s.io/component-base/cli/flag/curves_flag.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"crypto/tls"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// TLSCurvePreferences returns a list of Go's crypto/tls CurveID values from the ids passed.
+// The supported values depend on the Go version used.
+// See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version.
+func TLSCurvePreferences(curveIDs []int32) ([]tls.CurveID, error) {
+	if len(curveIDs) == 0 {
+		return nil, nil
+	}
+	seen := make(map[int32]bool, len(curveIDs))
+	result := make([]tls.CurveID, 0, len(curveIDs))
+	for _, id := range curveIDs {
+		if id <= 0 || id > math.MaxUint16 {
+			return nil, fmt.Errorf("curve preference %d is out of range (must be 1-%d)", id, math.MaxUint16)
+		}
+		if seen[id] {
+			return nil, fmt.Errorf("duplicate curve preference %d", id)
+		}
+		seen[id] = true
+		curve := tls.CurveID(id)
+		if strings.HasPrefix(curve.String(), "CurveID(") {
+			return nil, fmt.Errorf("curve preference %d is not supported by the current Go version", id)
+		}
+		result = append(result, curve)
+	}
+	return result, nil
+}

--- a/staging/src/k8s.io/component-base/cli/flag/curves_flag_test.go
+++ b/staging/src/k8s.io/component-base/cli/flag/curves_flag_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"crypto/tls"
+	"reflect"
+	"testing"
+)
+
+func TestTLSCurvePreferences(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []int32
+		expected    []tls.CurveID
+		expectError bool
+	}{
+		{
+			name:     "multiple curves",
+			input:    []int32{23, 24, 29},
+			expected: []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.X25519},
+		},
+		{
+			name:     "single curve",
+			input:    []int32{29},
+			expected: []tls.CurveID{tls.X25519},
+		},
+		{
+			name:     "empty input",
+			input:    []int32{},
+			expected: nil,
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "all standard curves",
+			input:    []int32{23, 24, 25, 29, 4588},
+			expected: []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.CurveP521, tls.X25519, tls.X25519MLKEM768},
+		},
+		{
+			name:        "duplicate curve",
+			input:       []int32{23, 29, 23},
+			expectError: true,
+		},
+		{
+			name:        "zero value",
+			input:       []int32{0},
+			expectError: true,
+		},
+		{
+			name:        "negative value",
+			input:       []int32{-1},
+			expectError: true,
+		},
+		{
+			name:        "exceeds uint16 range",
+			input:       []int32{70000},
+			expectError: true,
+		},
+		{
+			name:        "unknown curve ID",
+			input:       []int32{9999},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TLSCurvePreferences(tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("TLSCurvePreferences(%v) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("TLSCurvePreferences(%v) unexpected error: %v", tt.input, err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("TLSCurvePreferences(%v) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -180,6 +180,16 @@ type KubeletConfiguration struct {
 	// Default: nil
 	// +optional
 	TLSCipherSuites []string `json:"tlsCipherSuites,omitempty"`
+	// tlsCurvePreferences is the set of allowed key exchange mechanisms for the server,
+	// specified as numeric Go crypto/tls CurveID values.
+	// The supported values depend on the Go version used.
+	// See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version.
+	// The order of the list is ignored, and key exchange mechanisms are
+	// chosen by Go from this list using an internal preference order.
+	// If empty, the default Go curves will be used.
+	// Default: nil
+	// +optional
+	TLSCurvePreferences []int32 `json:"tlsCurvePreferences,omitempty"`
 	// tlsMinVersion is the minimum TLS version supported.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	// Default: ""

--- a/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
@@ -338,6 +338,11 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.TLSCurvePreferences != nil {
+		in, out := &in.TLSCurvePreferences, &out.TLSCurvePreferences
+		*out = make([]int32, len(*in))
+		copy(*out, *in)
+	}
 	in.Authentication.DeepCopyInto(&out.Authentication)
 	out.Authorization = in.Authorization
 	if in.RegistryPullQPS != nil {

--- a/test/integration/tls/curves_test.go
+++ b/test/integration/tls/curves_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func runSecureAPIServerWithCurves(t *testing.T, curves []string) (kubeapiservertesting.TearDownFunc, int) {
+	flags := []string{"--tls-curve-preferences", strings.Join(curves, ",")}
+	testServer := kubeapiservertesting.StartTestServerOrDie(t, nil, flags, framework.SharedEtcd())
+	return testServer.TearDownFn, testServer.ServerOpts.SecureServing.BindPort
+}
+
+func TestAPICurvePreferences(t *testing.T) {
+	serverCurves := []string{"23", "24", "25", "29", "4588"}
+
+	tearDown, port := runSecureAPIServerWithCurves(t, serverCurves)
+	defer tearDown()
+
+	tests := []struct {
+		name          string
+		clientCurves  []tls.CurveID
+		minTLSVersion uint16
+		expectError   bool
+	}{
+		{
+			name:          "supported curve",
+			clientCurves:  []tls.CurveID{tls.CurveP256},
+			minTLSVersion: tls.VersionTLS12,
+			expectError:   false,
+		},
+		{
+			name:          "supported curve",
+			clientCurves:  []tls.CurveID{tls.CurveP384},
+			minTLSVersion: tls.VersionTLS12,
+			expectError:   false,
+		},
+		{
+			name:          "supported curve",
+			clientCurves:  []tls.CurveID{tls.CurveP521},
+			minTLSVersion: tls.VersionTLS12,
+			expectError:   false,
+		},
+		{
+			name:          "supported curve",
+			clientCurves:  []tls.CurveID{tls.X25519MLKEM768},
+			minTLSVersion: tls.VersionTLS13,
+			expectError:   false,
+		},
+		{
+			name:          "supported curve",
+			clientCurves:  []tls.CurveID{tls.X25519},
+			minTLSVersion: tls.VersionTLS13,
+			expectError:   false,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runTestAPICurves(t, i, port, test.clientCurves, test.minTLSVersion, test.expectError)
+		})
+	}
+}
+
+func runTestAPICurves(t *testing.T, testID int, kubePort int, clientCurves []tls.CurveID, minTLSVersion uint16, expectedError bool) {
+	t.Helper()
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion:         minTLSVersion,
+			InsecureSkipVerify: true,
+			CurvePreferences:   clientCurves,
+		},
+	}
+	client := &http.Client{Transport: tr}
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://127.0.0.1:%d", kubePort), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err == nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	if expectedError && err == nil {
+		t.Fatalf("%d: expecting error for curve test, but client curve was accepted and it shouldn't have been", testID)
+	} else if err != nil && !expectedError {
+		t.Fatalf("%d: not expecting error but client with curve failed: %+v", testID, err)
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

It introduces support for specifying allowed TLS key exchange mechanisms (a.k.a. curves) (IANA TLS Supported Groups)
via a new `--tls-curve-preferences` flag, following the same pattern as `--tls-cipher-suites`.

**Changes**:
- Add curves flag in `component-base/cli/flag` as tls.CurveID values
- Add `CurvePreferences` field to `SecureServingOptions` and `SecureServingInfo`, and wire it through to `tls.Config`

The order of the list is ignored; Go selects from the set using an internal preference order. If omitted, Go defaults are used.

All components using SecureServingOptions (kube-apiserver, kube-scheduler, kube-controller-manager, etc.) automatically gain the new flag.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --tls-curve-preferences flag for configuring TLS key exchange mechanism
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
