### PR TITLE
Promote `apiserver_watch_events_total` and `apiserver_watch_events_sizes` to BETA

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -2279,39 +2279,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: watch_events_sizes
-  subsystem: apiserver
-  help: Watch event size distribution in bytes
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  - version
-  buckets:
-  - 1024
-  - 2048
-  - 4096
-  - 8192
-  - 16384
-  - 32768
-  - 65536
-  - 131072
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: watch_events_total
-  subsystem: apiserver
-  help: Number of events sent in watch clients
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - group
-  - resource
-  - version
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: watch_filtered_events_total
   namespace: apiserver
   help: Counter of events filtered out by shard selector during watch dispatch, broken
@@ -7277,6 +7244,39 @@
   help: Number of times declarative validation has panicked during validation.
   type: Counter
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: watch_events_sizes
+  subsystem: apiserver
+  help: Watch event size distribution in bytes
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  - version
+  buckets:
+  - 1024
+  - 2048
+  - 4096
+  - 8192
+  - 16384
+  - 32768
+  - 65536
+  - 131072
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: watch_events_total
+  subsystem: apiserver
+  help: Number of events sent in watch clients
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  - version
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -183,6 +183,33 @@
   help: Number of times declarative validation has panicked during validation.
   type: Counter
   stabilityLevel: BETA
+- name: watch_events_sizes
+  subsystem: apiserver
+  help: Watch event size distribution in bytes
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  - version
+  buckets:
+  - 1024
+  - 2048
+  - 4096
+  - 8192
+  - 16384
+  - 32768
+  - 65536
+  - 131072
+- name: watch_events_total
+  subsystem: apiserver
+  help: Number of events sent in watch clients
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  - version
 - name: watch_list_duration_seconds
   subsystem: apiserver
   help: Response latency distribution in seconds for watch list requests broken by

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch_test.go
@@ -463,7 +463,7 @@ func TestWatchEventSizes(t *testing.T) {
 			close(timeoutCh)
 			<-doneCh
 
-			expected := fmt.Sprintf(`# HELP apiserver_watch_events_sizes [ALPHA] Watch event size distribution in bytes
+			expected := fmt.Sprintf(`# HELP apiserver_watch_events_sizes [BETA] Watch event size distribution in bytes
 # TYPE apiserver_watch_events_sizes histogram
 apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="1024"} 2
 apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="2048"} 2
@@ -477,7 +477,7 @@ apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="v
 apiserver_watch_events_sizes_sum{group="group",resource="resource",version="version"} %d
 apiserver_watch_events_sizes_count{group="group",resource="resource",version="version"} 2
 
-# HELP apiserver_watch_events_total [ALPHA] Number of events sent in watch clients
+# HELP apiserver_watch_events_total [BETA] Number of events sent in watch clients
 # TYPE apiserver_watch_events_total counter
 apiserver_watch_events_total{group="group",resource="resource",version="version"} 2
 `, tc.wantSize)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -172,7 +172,7 @@ var (
 			Subsystem:      APIServerComponent,
 			Name:           "watch_events_total",
 			Help:           "Number of events sent in watch clients",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "version", "resource"},
 	)
@@ -182,7 +182,7 @@ var (
 			Name:           "watch_events_sizes",
 			Help:           "Watch event size distribution in bytes",
 			Buckets:        compbasemetrics.ExponentialBuckets(1024, 2.0, 8), // 1K, 2K, 4K, 8K, ..., 128K.
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "version", "resource"},
 	)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Promote remain metrics to BETA:
- `apiserver_watch_events_total`
- `apiserver_watch_events_sizes`

#### Which issue(s) this PR is related to:

Related #136304

#### Special notes for your reviewer:

This PR add the tests for metrics.

#### Does this PR introduce a user-facing change?

```release-note
Promote `apiserver_watch_events_total` and `apiserver_watch_events_sizes` to BETA
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
