### PR TITLE
dual stack test fixups

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -47,7 +47,6 @@ import (
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -838,14 +837,10 @@ func (config *NetworkingTestConfig) setup(ctx context.Context, selector map[stri
 		config.SecondaryClusterIP = config.NodePortService.Spec.ClusterIPs[1]
 	}
 
-	// Obtain the primary IP family of the Cluster based on the first ClusterIP
-	// TODO: Eventually we should just be getting these from Spec.IPFamilies
-	// but for now that would only if the feature gate is enabled.
-	family := v1.IPv4Protocol
-	secondaryFamily := v1.IPv6Protocol
-	if netutils.IsIPv6String(config.ClusterIP) {
-		family = v1.IPv6Protocol
-		secondaryFamily = v1.IPv4Protocol
+	var family, secondaryFamily v1.IPFamily
+	family = config.NodePortService.Spec.IPFamilies[0]
+	if len(config.NodePortService.Spec.IPFamilies) == 2 {
+		secondaryFamily = config.NodePortService.Spec.IPFamilies[1]
 	}
 	if config.PreferExternalAddresses {
 		// Get Node IPs from the cluster, ExternalIPs take precedence

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -54,7 +54,6 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	cloudprovider "k8s.io/cloud-provider"
-	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -4210,10 +4209,7 @@ func execAffinityTestForSessionAffinityTimeout(ctx context.Context, f *framework
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 		framework.ExpectNoError(err)
 		// The node addresses must have the same IP family as the ClusterIP
-		family := v1.IPv4Protocol
-		if netutils.IsIPv6String(svc.Spec.ClusterIP) {
-			family = v1.IPv6Protocol
-		}
+		family := svc.Spec.IPFamilies[0]
 		svcIP = e2enode.FirstAddressByTypeAndFamily(nodes, v1.NodeInternalIP, family)
 		if svcIP == "" {
 			svcIP = e2enode.FirstAddressByTypeAndFamily(nodes, v1.NodeExternalIP, family)
@@ -4296,10 +4292,7 @@ func execAffinityTestForNonLBServiceWithOptionalTransition(ctx context.Context, 
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 		framework.ExpectNoError(err)
 		// The node addresses must have the same IP family as the ClusterIP
-		family := v1.IPv4Protocol
-		if netutils.IsIPv6String(svc.Spec.ClusterIP) {
-			family = v1.IPv6Protocol
-		}
+		family := svc.Spec.IPFamilies[0]
 		svcIP = e2enode.FirstAddressByTypeAndFamily(nodes, v1.NodeInternalIP, family)
 		if svcIP == "" {
 			svcIP = e2enode.FirstAddressByTypeAndFamily(nodes, v1.NodeExternalIP, family)


### PR DESCRIPTION
#### What this PR does / why we need it:
drive-by cleanup of some dual-stack e2e tests

We may want to argue a bit about exactly what we guarantee in the "dual-stack nodes" test... without this PR, it checks

1. every node has exactly one IPv4 InternalIP and exactly one IPv6 InternalIP

which is totally wrong. At a minimum it needs to be

2. every node has at least one IPv4 IP (of any type) and at least one IPv6 IP (of any type)

but we've talked about "IPv6-mostly" clusters where only some nodes are dual-stack, so if we were going to support that, the rule would be

3. at least one node has at least one IPv4 IP (of any type) and at least one IPv6 IP (of any type)

but what I actually implemented was

4. at least one node has at least one IPv4 IP (of any type) and at least one node has at least one IPv6 IP (of any type)

which would consider a cluster containing a mix of single-stack IPv4 nodes and single-stack IPv6 nodes with no actual dual-stack nodes to be "dual-stack". Maybe that's too far?

(EDIT: we went with 3)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/assign @aojea 