### PR TITLE
Enable validation-gen lint rule

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -452,24 +452,6 @@ function codegen::validation() {
         time
     )
 
-    local lint_tag_pkgs=()
-    for pkg in "${tag_pkgs[@]}"; do
-        if [[ "${pkg}" != *"staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests"* ]]; then
-            lint_tag_pkgs+=("${pkg}")
-        fi
-    done
-
-    kube::log::status "Linting validation code for ${#lint_tag_pkgs[@]} targets"
-    validation-gen \
-        -v "${KUBE_VERBOSE}" \
-        --go-header-file "${BOILERPLATE_FILENAME}" \
-        --output-file "${output_file}" \
-        $(printf -- " --readonly-pkg %s" "${readonly_pkgs[@]}") \
-        --lint \
-        --dv-enforced-root k8s.io/api/scheduling/v1alpha1.Workload \
-        "${lint_tag_pkgs[@]}" \
-        "$@"
-
     kube::log::status "Generating validation code for ${#tag_pkgs[@]} targets"
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: running validation-gen for:"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -452,6 +452,25 @@ function codegen::validation() {
         time
     )
 
+
+    local lint_tag_pkgs=()
+    for pkg in "${tag_pkgs[@]}"; do
+        if [[ "${pkg}" != *"staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests"* ]]; then
+            lint_tag_pkgs+=("${pkg}")
+        fi
+    done
+
+    kube::log::status "Linting validation code for ${#lint_tag_pkgs[@]} targets"
+    validation-gen \
+        -v "${KUBE_VERBOSE}" \
+        --go-header-file "${BOILERPLATE_FILENAME}" \
+        --output-file "${output_file}" \
+        $(printf -- " --readonly-pkg %s" "${readonly_pkgs[@]}") \
+        --lint \
+        --dv-enforced-roots k8s.io/api/scheduling/v1alpha1.Workload \
+        "${lint_tag_pkgs[@]}" \
+        "$@"
+
     kube::log::status "Generating validation code for ${#tag_pkgs[@]} targets"
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: running validation-gen for:"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -452,7 +452,6 @@ function codegen::validation() {
         time
     )
 
-
     local lint_tag_pkgs=()
     for pkg in "${tag_pkgs[@]}"; do
         if [[ "${pkg}" != *"staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests"* ]]; then
@@ -467,7 +466,7 @@ function codegen::validation() {
         --output-file "${output_file}" \
         $(printf -- " --readonly-pkg %s" "${readonly_pkgs[@]}") \
         --lint \
-        --dv-enforced-roots k8s.io/api/scheduling/v1alpha1.Workload \
+        --dv-enforced-root k8s.io/api/scheduling/v1alpha1.Workload \
         "${lint_tag_pkgs[@]}" \
         "$@"
 

--- a/pkg/apis/admissionregistration/v1/zz_generated.validations.go
+++ b/pkg/apis/admissionregistration/v1/zz_generated.validations.go
@@ -85,7 +85,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(ctx context.Context, op opera
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -109,7 +109,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(ctx context.Context, op opera
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/admissionregistration/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/admissionregistration/v1alpha1/zz_generated.validations.go
@@ -85,7 +85,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(ctx context.Context, op opera
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -109,7 +109,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(ctx context.Context, op opera
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/admissionregistration/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/admissionregistration/v1beta1/zz_generated.validations.go
@@ -85,7 +85,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(ctx context.Context, op opera
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -109,7 +109,7 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(ctx context.Context, op opera
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/apps/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.validations.go
@@ -77,13 +77,12 @@ func Validate_ScaleSpec(ctx context.Context, op operation.Operation, fldPath *fi
 	// field appsv1beta1.ScaleSpec.Replicas
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
-			// optional value-type fields with zero-value defaults are purely documentation
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)...)
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha()...)
 			return
 		}(fldPath.Child("replicas"), &obj.Replicas, safe.Field(oldObj, func(oldObj *appsv1beta1.ScaleSpec) *int32 { return &oldObj.Replicas }), oldObj != nil)...)
 

--- a/pkg/apis/apps/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.validations.go
@@ -77,13 +77,12 @@ func Validate_ScaleSpec(ctx context.Context, op operation.Operation, fldPath *fi
 	// field appsv1beta2.ScaleSpec.Replicas
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
-			// optional value-type fields with zero-value defaults are purely documentation
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)...)
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha()...)
 			return
 		}(fldPath.Child("replicas"), &obj.Replicas, safe.Field(oldObj, func(oldObj *appsv1beta2.ScaleSpec) *int32 { return &oldObj.Replicas }), oldObj != nil)...)
 

--- a/pkg/apis/autoscaling/v1/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.validations.go
@@ -96,18 +96,18 @@ func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Oper
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
-			})...)
 			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
 				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
-			})...)
+			}).MarkAlpha()...)
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
+			}).MarkAlpha()...)
 			return
 		}(fldPath.Child("minReplicas"), obj.MinReplicas, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 { return oldObj.MinReplicas }), oldObj != nil)...)
 
@@ -120,14 +120,14 @@ func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Oper
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)...)
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha()...)
 			return
 		}(fldPath.Child("maxReplicas"), &obj.MaxReplicas, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 { return &oldObj.MaxReplicas }), oldObj != nil)...)
 
@@ -163,13 +163,12 @@ func Validate_ScaleSpec(ctx context.Context, op operation.Operation, fldPath *fi
 	// field autoscalingv1.ScaleSpec.Replicas
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
-			// optional value-type fields with zero-value defaults are purely documentation
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)...)
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha()...)
 			return
 		}(fldPath.Child("replicas"), &obj.Replicas, safe.Field(oldObj, func(oldObj *autoscalingv1.ScaleSpec) *int32 { return &oldObj.Replicas }), oldObj != nil)...)
 

--- a/pkg/apis/autoscaling/v2/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v2/zz_generated.validations.go
@@ -88,18 +88,18 @@ func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Oper
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
-			})...)
 			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
 				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
-			})...)
+			}).MarkAlpha()...)
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
+			}).MarkAlpha()...)
 			return
 		}(fldPath.Child("minReplicas"), obj.MinReplicas, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 { return oldObj.MinReplicas }), oldObj != nil)...)
 
@@ -112,14 +112,14 @@ func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Oper
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)...)
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha()...)
 			return
 		}(fldPath.Child("maxReplicas"), &obj.MaxReplicas, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 { return &oldObj.MaxReplicas }), oldObj != nil)...)
 

--- a/pkg/apis/autoscaling/validation/declarative_validation_test.go
+++ b/pkg/apis/autoscaling/validation/declarative_validation_test.go
@@ -52,7 +52,7 @@ func TestScaleDeclarativeValidation(t *testing.T) {
 		"spec.replicas: negative replicas": {
 			input: mkScale(setScaleSpecReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 	}

--- a/pkg/apis/batch/v1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1/zz_generated.validations.go
@@ -84,7 +84,7 @@ func Validate_CronJobSpec(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/batch/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.validations.go
@@ -84,7 +84,7 @@ func Validate_CronJobSpec(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/certificates/v1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1/zz_generated.validations.go
@@ -89,7 +89,7 @@ func Validate_CertificateSigningRequestStatus(ctx context.Context, op operation.
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/certificates/v1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1/zz_generated.validations.go
@@ -109,7 +109,7 @@ func Validate_CertificateSigningRequestStatus(ctx context.Context, op operation.
 					}
 				}
 				return false
-			})...)
+			}).MarkAlpha()...)
 			return
 		}(fldPath.Child("conditions"), obj.Conditions, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestStatus) []certificatesv1.CertificateSigningRequestCondition {
 			return oldObj.Conditions

--- a/pkg/apis/certificates/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.validations.go
@@ -89,7 +89,7 @@ func Validate_CertificateSigningRequestStatus(ctx context.Context, op operation.
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/certificates/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.validations.go
@@ -109,7 +109,7 @@ func Validate_CertificateSigningRequestStatus(ctx context.Context, op operation.
 					}
 				}
 				return false
-			})...)
+			}).MarkAlpha()...)
 			return
 		}(fldPath.Child("conditions"), obj.Conditions, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequestStatus) []certificatesv1beta1.CertificateSigningRequestCondition {
 			return oldObj.Conditions

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -66,13 +66,13 @@ func Validate_ReplicationController(ctx context.Context, op operation.Operation,
 			// call field-attached validations
 			func() { // cohort name
 				earlyReturn := false
-				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue); len(e) != 0 {
+				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha(); len(e) != 0 {
 					earlyReturn = true
 				}
 				if earlyReturn {
 					return // do not proceed
 				}
-				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName)...)
+				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkAlpha()...)
 			}()
 			return
 		}(fldPath.Child("metadata"), &obj.ObjectMeta, safe.Field(oldObj, func(oldObj *corev1.ReplicationController) *metav1.ObjectMeta { return &oldObj.ObjectMeta }), oldObj != nil)...)
@@ -106,27 +106,26 @@ func Validate_ReplicationControllerSpec(ctx context.Context, op operation.Operat
 			// call field-attached validations
 			earlyReturn := false
 			// optional fields with default values are effectively required
-			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)...)
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha()...)
 			return
 		}(fldPath.Child("replicas"), obj.Replicas, safe.Field(oldObj, func(oldObj *corev1.ReplicationControllerSpec) *int32 { return oldObj.Replicas }), oldObj != nil)...)
 
 	// field corev1.ReplicationControllerSpec.MinReadySeconds
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
-			// optional value-type fields with zero-value defaults are purely documentation
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)...)
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha()...)
 			return
 		}(fldPath.Child("minReadySeconds"), &obj.MinReadySeconds, safe.Field(oldObj, func(oldObj *corev1.ReplicationControllerSpec) *int32 { return &oldObj.MinReadySeconds }), oldObj != nil)...)
 

--- a/pkg/apis/discovery/v1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1/zz_generated.validations.go
@@ -56,7 +56,7 @@ var symbolsForAddressType = sets.New(discoveryv1.AddressTypeFQDN, discoveryv1.Ad
 // Validate_AddressType validates an instance of AddressType according
 // to declarative validation rules in the API schema.
 func Validate_AddressType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *discoveryv1.AddressType) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -73,11 +73,11 @@ func Validate_Endpoint(ctx context.Context, op operation.Operation, fldPath *fie
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -112,11 +112,11 @@ func Validate_EndpointSlice(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -137,7 +137,7 @@ func Validate_EndpointSlice(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/discovery/v1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1/zz_generated.validations.go
@@ -135,6 +135,14 @@ func Validate_EndpointSlice(ctx context.Context, op operation.Operation, fldPath
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Endpoint)...)
 			return

--- a/pkg/apis/discovery/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1beta1/zz_generated.validations.go
@@ -134,6 +134,14 @@ func Validate_EndpointSlice(ctx context.Context, op operation.Operation, fldPath
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Endpoint)...)
 			return

--- a/pkg/apis/discovery/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1beta1/zz_generated.validations.go
@@ -56,7 +56,7 @@ var symbolsForAddressType = sets.New(discoveryv1beta1.AddressTypeFQDN, discovery
 // Validate_AddressType validates an instance of AddressType according
 // to declarative validation rules in the API schema.
 func Validate_AddressType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *discoveryv1beta1.AddressType) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -73,11 +73,11 @@ func Validate_Endpoint(ctx context.Context, op operation.Operation, fldPath *fie
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -111,11 +111,11 @@ func Validate_EndpointSlice(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -136,7 +136,7 @@ func Validate_EndpointSlice(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/networking/v1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1/zz_generated.validations.go
@@ -99,11 +99,11 @@ func Validate_IPAddressSpec(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -130,7 +130,7 @@ func Validate_IPBlock(ctx context.Context, op operation.Operation, fldPath *fiel
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -179,7 +179,7 @@ func Validate_IngressClassParametersReference(ctx context.Context, op operation.
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -198,7 +198,7 @@ func Validate_IngressClassParametersReference(ctx context.Context, op operation.
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -227,7 +227,7 @@ func Validate_IngressClassSpec(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -278,7 +278,7 @@ func Validate_NetworkPolicyEgressRule(ctx context.Context, op operation.Operatio
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -306,7 +306,7 @@ func Validate_NetworkPolicyIngressRule(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -337,7 +337,7 @@ func Validate_NetworkPolicyPeer(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -365,7 +365,7 @@ func Validate_NetworkPolicySpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -387,7 +387,7 @@ func Validate_NetworkPolicySpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -418,7 +418,7 @@ func Validate_ParentReference(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -439,7 +439,7 @@ func Validate_ParentReference(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/networking/v1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1/zz_generated.validations.go
@@ -276,6 +276,14 @@ func Validate_NetworkPolicyEgressRule(ctx context.Context, op operation.Operatio
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyPeer)...)
 			return
@@ -295,6 +303,14 @@ func Validate_NetworkPolicyIngressRule(ctx context.Context, op operation.Operati
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyPeer)...)
@@ -347,6 +363,14 @@ func Validate_NetworkPolicySpec(ctx context.Context, op operation.Operation, fld
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyIngressRule)...)
 			return
@@ -360,6 +384,14 @@ func Validate_NetworkPolicySpec(ctx context.Context, op operation.Operation, fld
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyEgressRule)...)

--- a/pkg/apis/networking/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1beta1/zz_generated.validations.go
@@ -91,11 +91,11 @@ func Validate_IPAddressSpec(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -147,7 +147,7 @@ func Validate_IngressClassParametersReference(ctx context.Context, op operation.
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -166,7 +166,7 @@ func Validate_IngressClassParametersReference(ctx context.Context, op operation.
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -195,7 +195,7 @@ func Validate_IngressClassSpec(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -225,7 +225,7 @@ func Validate_ParentReference(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -246,7 +246,7 @@ func Validate_ParentReference(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/node/v1/zz_generated.validations.go
+++ b/pkg/apis/node/v1/zz_generated.validations.go
@@ -64,18 +64,18 @@ func Validate_RuntimeClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("handler"), &obj.Handler, safe.Field(oldObj, func(oldObj *nodev1.RuntimeClass) *string { return &oldObj.Handler }), oldObj != nil)...)
 

--- a/pkg/apis/node/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/node/v1alpha1/zz_generated.validations.go
@@ -83,18 +83,18 @@ func Validate_RuntimeClassSpec(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("runtimeHandler"), &obj.RuntimeHandler, safe.Field(oldObj, func(oldObj *nodev1alpha1.RuntimeClassSpec) *string { return &oldObj.RuntimeHandler }), oldObj != nil)...)
 

--- a/pkg/apis/node/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/node/v1beta1/zz_generated.validations.go
@@ -64,18 +64,18 @@ func Validate_RuntimeClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("handler"), &obj.Handler, safe.Field(oldObj, func(oldObj *nodev1beta1.RuntimeClass) *string { return &oldObj.Handler }), oldObj != nil)...)
 

--- a/pkg/apis/rbac/v1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1/zz_generated.validations.go
@@ -89,7 +89,7 @@ func Validate_ClusterRole(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -119,7 +119,7 @@ func Validate_ClusterRoleBinding(ctx context.Context, op operation.Operation, fl
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -157,7 +157,7 @@ func Validate_PolicyRule(ctx context.Context, op operation.Operation, fldPath *f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -189,7 +189,7 @@ func Validate_Role(ctx context.Context, op operation.Operation, fldPath *field.P
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -218,7 +218,7 @@ func Validate_RoleBinding(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -259,7 +259,7 @@ func Validate_RoleRef(ctx context.Context, op operation.Operation, fldPath *fiel
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -287,7 +287,7 @@ func Validate_Subject(ctx context.Context, op operation.Operation, fldPath *fiel
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/rbac/v1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1/zz_generated.validations.go
@@ -87,6 +87,14 @@ func Validate_ClusterRole(ctx context.Context, op operation.Operation, fldPath *
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
 			return
@@ -108,6 +116,14 @@ func Validate_ClusterRoleBinding(ctx context.Context, op operation.Operation, fl
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Subject)...)
@@ -171,6 +187,14 @@ func Validate_Role(ctx context.Context, op operation.Operation, fldPath *field.P
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
 			return
@@ -191,6 +215,14 @@ func Validate_RoleBinding(ctx context.Context, op operation.Operation, fldPath *
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Subject)...)

--- a/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
@@ -89,7 +89,7 @@ func Validate_ClusterRole(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -119,7 +119,7 @@ func Validate_ClusterRoleBinding(ctx context.Context, op operation.Operation, fl
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -157,7 +157,7 @@ func Validate_PolicyRule(ctx context.Context, op operation.Operation, fldPath *f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -189,7 +189,7 @@ func Validate_Role(ctx context.Context, op operation.Operation, fldPath *field.P
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -218,7 +218,7 @@ func Validate_RoleBinding(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -259,7 +259,7 @@ func Validate_RoleRef(ctx context.Context, op operation.Operation, fldPath *fiel
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -287,7 +287,7 @@ func Validate_Subject(ctx context.Context, op operation.Operation, fldPath *fiel
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
@@ -87,6 +87,14 @@ func Validate_ClusterRole(ctx context.Context, op operation.Operation, fldPath *
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
 			return
@@ -108,6 +116,14 @@ func Validate_ClusterRoleBinding(ctx context.Context, op operation.Operation, fl
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Subject)...)
@@ -171,6 +187,14 @@ func Validate_Role(ctx context.Context, op operation.Operation, fldPath *field.P
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
 			return
@@ -191,6 +215,14 @@ func Validate_RoleBinding(ctx context.Context, op operation.Operation, fldPath *
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Subject)...)

--- a/pkg/apis/rbac/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.validations.go
@@ -89,7 +89,7 @@ func Validate_ClusterRole(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -119,7 +119,7 @@ func Validate_ClusterRoleBinding(ctx context.Context, op operation.Operation, fl
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -157,7 +157,7 @@ func Validate_PolicyRule(ctx context.Context, op operation.Operation, fldPath *f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -189,7 +189,7 @@ func Validate_Role(ctx context.Context, op operation.Operation, fldPath *field.P
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -218,7 +218,7 @@ func Validate_RoleBinding(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -259,7 +259,7 @@ func Validate_RoleRef(ctx context.Context, op operation.Operation, fldPath *fiel
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -287,7 +287,7 @@ func Validate_Subject(ctx context.Context, op operation.Operation, fldPath *fiel
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/rbac/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.validations.go
@@ -87,6 +87,14 @@ func Validate_ClusterRole(ctx context.Context, op operation.Operation, fldPath *
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
 			return
@@ -108,6 +116,14 @@ func Validate_ClusterRoleBinding(ctx context.Context, op operation.Operation, fl
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Subject)...)
@@ -171,6 +187,14 @@ func Validate_Role(ctx context.Context, op operation.Operation, fldPath *field.P
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
 			return
@@ -191,6 +215,14 @@ func Validate_RoleBinding(ctx context.Context, op operation.Operation, fldPath *
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Subject)...)

--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -219,6 +219,14 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the map and call the value type's validation function
 			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual, Validate_DeviceAttribute)...)
 			return
@@ -268,6 +276,14 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceTaint)...)
@@ -1053,6 +1069,14 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
 			return
@@ -1183,6 +1207,14 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceAllocationMode(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -1198,6 +1230,14 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
@@ -1278,6 +1318,16 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			// optional fields with default values are effectively required
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTolerationOperator(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -1293,6 +1343,14 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
@@ -1371,6 +1429,14 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)

--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -93,13 +93,13 @@ func Validate_AllocatedDeviceStatus(ctx context.Context, op operation.Operation,
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("shareID"), obj.ShareID, safe.Field(oldObj, func(oldObj *resourcev1.AllocatedDeviceStatus) *string { return oldObj.ShareID }), oldObj != nil)...)
 
@@ -115,7 +115,7 @@ func Validate_AllocatedDeviceStatus(ctx context.Context, op operation.Operation,
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -136,7 +136,7 @@ var symbolsForAllocationConfigSource = sets.New(resourcev1.AllocationConfigSourc
 // Validate_AllocationConfigSource validates an instance of AllocationConfigSource according
 // to declarative validation rules in the API schema.
 func Validate_AllocationConfigSource(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.AllocationConfigSource) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -173,14 +173,14 @@ func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *resourcev1.CounterSet) *string { return &oldObj.Name }), oldObj != nil)...)
 
@@ -193,14 +193,14 @@ func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha()...)
 			return
 		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1.CounterSet) map[string]resourcev1.Counter { return oldObj.Counters }), oldObj != nil)...)
 
@@ -221,7 +221,7 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -245,11 +245,11 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -258,7 +258,7 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceCounterConsumption, b resourcev1.DeviceCounterConsumption) bool {
 				return a.CounterSet == b.CounterSet
-			})...)
+			}).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceCounterConsumption, b resourcev1.DeviceCounterConsumption) bool {
 				return a.CounterSet == b.CounterSet
@@ -279,7 +279,7 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -301,11 +301,11 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -323,11 +323,11 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -352,7 +352,7 @@ func Validate_DeviceAllocationConfiguration(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -375,18 +375,18 @@ func Validate_DeviceAllocationConfiguration(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("requests"), obj.Requests, safe.Field(oldObj, func(oldObj *resourcev1.DeviceAllocationConfiguration) []string { return oldObj.Requests }), oldObj != nil)...)
 
@@ -412,7 +412,7 @@ var symbolsForDeviceAllocationMode = sets.New(resourcev1.DeviceAllocationModeAll
 // Validate_DeviceAllocationMode validates an instance of DeviceAllocationMode according
 // to declarative validation rules in the API schema.
 func Validate_DeviceAllocationMode(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceAllocationMode) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -429,11 +429,11 @@ func Validate_DeviceAllocationResult(ctx context.Context, op operation.Operation
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -455,11 +455,11 @@ func Validate_DeviceAllocationResult(ctx context.Context, op operation.Operation
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -500,7 +500,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			return false
 		}
 		return obj.VersionValue != nil
-	})...)
+	}).MarkAlpha()...)
 
 	// field resourcev1.DeviceAttribute.IntValue
 	errs = append(errs,
@@ -511,7 +511,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -529,7 +529,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -547,7 +547,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -565,7 +565,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -589,18 +589,18 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with map semantics require unique keys
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceRequest, b resourcev1.DeviceRequest) bool { return a.Name == b.Name })...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceRequest, b resourcev1.DeviceRequest) bool { return a.Name == b.Name }).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceRequest, b resourcev1.DeviceRequest) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_DeviceRequest)...)
 			return
@@ -615,11 +615,11 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -639,11 +639,11 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -669,18 +669,18 @@ func Validate_DeviceClaimConfiguration(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("requests"), obj.Requests, safe.Field(oldObj, func(oldObj *resourcev1.DeviceClaimConfiguration) []string { return oldObj.Requests }), oldObj != nil)...)
 
@@ -716,13 +716,13 @@ func Validate_DeviceClass(ctx context.Context, op operation.Operation, fldPath *
 			// call field-attached validations
 			func() { // cohort name
 				earlyReturn := false
-				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue); len(e) != 0 {
+				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha(); len(e) != 0 {
 					earlyReturn = true
 				}
 				if earlyReturn {
 					return // do not proceed
 				}
-				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName)...)
+				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkAlpha()...)
 			}()
 			return
 		}(fldPath.Child("metadata"), &obj.ObjectMeta, safe.Field(oldObj, func(oldObj *resourcev1.DeviceClass) *metav1.ObjectMeta { return &oldObj.ObjectMeta }), oldObj != nil)...)
@@ -774,11 +774,11 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -796,11 +796,11 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -820,13 +820,13 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("extendedResourceName"), obj.ExtendedResourceName, safe.Field(oldObj, func(oldObj *resourcev1.DeviceClassSpec) *string { return oldObj.ExtendedResourceName }), oldObj != nil)...)
 
@@ -845,7 +845,7 @@ func Validate_DeviceConfiguration(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -873,18 +873,18 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("requests"), obj.Requests, safe.Field(oldObj, func(oldObj *resourcev1.DeviceConstraint) []string { return oldObj.Requests }), oldObj != nil)...)
 
@@ -897,13 +897,13 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("matchAttribute"), obj.MatchAttribute, safe.Field(oldObj, func(oldObj *resourcev1.DeviceConstraint) *resourcev1.FullyQualifiedName { return oldObj.MatchAttribute }), oldObj != nil)...)
 
@@ -923,14 +923,14 @@ func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("counterSet"), &obj.CounterSet, safe.Field(oldObj, func(oldObj *resourcev1.DeviceCounterConsumption) *string { return &oldObj.CounterSet }), oldObj != nil)...)
 
@@ -943,14 +943,14 @@ func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha()...)
 			return
 		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1.DeviceCounterConsumption) map[string]resourcev1.Counter {
 			return oldObj.Counters
@@ -973,7 +973,7 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -993,18 +993,18 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with map semantics require unique keys
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceSubRequest, b resourcev1.DeviceSubRequest) bool { return a.Name == b.Name })...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceSubRequest, b resourcev1.DeviceSubRequest) bool { return a.Name == b.Name }).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceSubRequest, b resourcev1.DeviceSubRequest) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_DeviceSubRequest)...)
 			return
@@ -1027,15 +1027,15 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha()...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1.DeviceRequestAllocationResult) *string { return &oldObj.Driver }), oldObj != nil)...)
 
@@ -1048,14 +1048,14 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("pool"), &obj.Pool, safe.Field(oldObj, func(oldObj *resourcev1.DeviceRequestAllocationResult) *string { return &oldObj.Pool }), oldObj != nil)...)
 
@@ -1071,7 +1071,7 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1093,11 +1093,11 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1115,11 +1115,11 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1139,13 +1139,13 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("shareID"), obj.ShareID, safe.Field(oldObj, func(oldObj *resourcev1.DeviceRequestAllocationResult) *types.UID { return oldObj.ShareID }), oldObj != nil)...)
 
@@ -1167,14 +1167,14 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("deviceClassName"), &obj.DeviceClassName, safe.Field(oldObj, func(oldObj *resourcev1.DeviceSubRequest) *string { return &oldObj.DeviceClassName }), oldObj != nil)...)
 
@@ -1187,11 +1187,11 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1209,7 +1209,7 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1233,7 +1233,7 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1263,7 +1263,7 @@ func Validate_DeviceTaint(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1284,7 +1284,7 @@ var symbolsForDeviceTaintEffect = sets.New(resourcev1.DeviceTaintEffectNoExecute
 // Validate_DeviceTaintEffect validates an instance of DeviceTaintEffect according
 // to declarative validation rules in the API schema.
 func Validate_DeviceTaintEffect(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceTaintEffect) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -1301,13 +1301,13 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LabelKey(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("key"), &obj.Key, safe.Field(oldObj, func(oldObj *resourcev1.DeviceToleration) *string { return &oldObj.Key }), oldObj != nil)...)
 
@@ -1321,7 +1321,7 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			// call field-attached validations
 			earlyReturn := false
 			// optional fields with default values are effectively required
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1346,7 +1346,7 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1366,7 +1366,7 @@ var symbolsForDeviceTolerationOperator = sets.New(resourcev1.DeviceTolerationOpE
 // Validate_DeviceTolerationOperator validates an instance of DeviceTolerationOperator according
 // to declarative validation rules in the API schema.
 func Validate_DeviceTolerationOperator(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceTolerationOperator) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -1385,11 +1385,11 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1407,7 +1407,7 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1432,7 +1432,7 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1459,13 +1459,13 @@ func Validate_NetworkDeviceData(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 256)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha()...)
 			return
 		}(fldPath.Child("interfaceName"), &obj.InterfaceName, safe.Field(oldObj, func(oldObj *resourcev1.NetworkDeviceData) *string { return &oldObj.InterfaceName }), oldObj != nil)...)
 
@@ -1478,18 +1478,18 @@ func Validate_NetworkDeviceData(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("ips"), obj.IPs, safe.Field(oldObj, func(oldObj *resourcev1.NetworkDeviceData) []string { return oldObj.IPs }), oldObj != nil)...)
 
@@ -1502,13 +1502,13 @@ func Validate_NetworkDeviceData(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 128)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha()...)
 			return
 		}(fldPath.Child("hardwareAddress"), &obj.HardwareAddress, safe.Field(oldObj, func(oldObj *resourcev1.NetworkDeviceData) *string { return &oldObj.HardwareAddress }), oldObj != nil)...)
 
@@ -1527,15 +1527,15 @@ func Validate_OpaqueDeviceConfiguration(ctx context.Context, op operation.Operat
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha()...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1.OpaqueDeviceConfiguration) *string { return &oldObj.Driver }), oldObj != nil)...)
 
@@ -1558,7 +1558,7 @@ func Validate_ResourceClaim(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1615,10 +1615,10 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify); len(e) != 0 {
+			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1639,11 +1639,11 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1652,7 +1652,7 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.ResourceClaimConsumerReference, b resourcev1.ResourceClaimConsumerReference) bool {
 				return a.UID == b.UID
-			})...)
+			}).MarkAlpha()...)
 			return
 		}(fldPath.Child("reservedFor"), obj.ReservedFor, safe.Field(oldObj, func(oldObj *resourcev1.ResourceClaimStatus) []resourcev1.ResourceClaimConsumerReference {
 			return oldObj.ReservedFor
@@ -1667,7 +1667,7 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1676,7 +1676,7 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.AllocatedDeviceStatus, b resourcev1.AllocatedDeviceStatus) bool {
 				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
-			})...)
+			}).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1.AllocatedDeviceStatus, b resourcev1.AllocatedDeviceStatus) bool {
 				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
@@ -1769,7 +1769,7 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1791,18 +1791,18 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with map semantics require unique keys
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.CounterSet, b resourcev1.CounterSet) bool { return a.Name == b.Name })...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.CounterSet, b resourcev1.CounterSet) bool { return a.Name == b.Name }).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1.CounterSet, b resourcev1.CounterSet) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_CounterSet)...)
 			return

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -173,6 +173,14 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the map and call the value type's validation function
 			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual, Validate_DeviceAttribute)...)
 			return
@@ -224,6 +232,14 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceTaint)...)
@@ -1075,6 +1091,14 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
 			return
@@ -1268,6 +1292,9 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -1282,6 +1309,14 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceAllocationMode(ctx, op, fldPath, obj, oldObj)...)
@@ -1298,6 +1333,14 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
@@ -1380,6 +1423,16 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			// optional fields with default values are effectively required
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTolerationOperator(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -1395,6 +1448,14 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -93,13 +93,13 @@ func Validate_AllocatedDeviceStatus(ctx context.Context, op operation.Operation,
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("shareID"), obj.ShareID, safe.Field(oldObj, func(oldObj *resourcev1beta1.AllocatedDeviceStatus) *string { return oldObj.ShareID }), oldObj != nil)...)
 
@@ -115,7 +115,7 @@ func Validate_AllocatedDeviceStatus(ctx context.Context, op operation.Operation,
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -136,7 +136,7 @@ var symbolsForAllocationConfigSource = sets.New(resourcev1beta1.AllocationConfig
 // Validate_AllocationConfigSource validates an instance of AllocationConfigSource according
 // to declarative validation rules in the API schema.
 func Validate_AllocationConfigSource(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.AllocationConfigSource) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -175,7 +175,7 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -199,11 +199,11 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -212,7 +212,7 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.DeviceCounterConsumption, b resourcev1beta1.DeviceCounterConsumption) bool {
 				return a.CounterSet == b.CounterSet
-			})...)
+			}).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.DeviceCounterConsumption, b resourcev1beta1.DeviceCounterConsumption) bool {
 				return a.CounterSet == b.CounterSet
@@ -235,7 +235,7 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -257,11 +257,11 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -279,11 +279,11 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -308,14 +308,14 @@ func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *resourcev1beta1.CounterSet) *string { return &oldObj.Name }), oldObj != nil)...)
 
@@ -328,14 +328,14 @@ func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha()...)
 			return
 		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1beta1.CounterSet) map[string]resourcev1beta1.Counter { return oldObj.Counters }), oldObj != nil)...)
 
@@ -356,7 +356,7 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -382,7 +382,7 @@ func Validate_DeviceAllocationConfiguration(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -405,18 +405,18 @@ func Validate_DeviceAllocationConfiguration(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("requests"), obj.Requests, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceAllocationConfiguration) []string { return oldObj.Requests }), oldObj != nil)...)
 
@@ -442,7 +442,7 @@ var symbolsForDeviceAllocationMode = sets.New(resourcev1beta1.DeviceAllocationMo
 // Validate_DeviceAllocationMode validates an instance of DeviceAllocationMode according
 // to declarative validation rules in the API schema.
 func Validate_DeviceAllocationMode(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceAllocationMode) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -459,11 +459,11 @@ func Validate_DeviceAllocationResult(ctx context.Context, op operation.Operation
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -485,11 +485,11 @@ func Validate_DeviceAllocationResult(ctx context.Context, op operation.Operation
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -530,7 +530,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			return false
 		}
 		return obj.VersionValue != nil
-	})...)
+	}).MarkAlpha()...)
 
 	// field resourcev1beta1.DeviceAttribute.IntValue
 	errs = append(errs,
@@ -541,7 +541,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -559,7 +559,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -577,7 +577,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -595,7 +595,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -619,18 +619,18 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with map semantics require unique keys
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.DeviceRequest, b resourcev1beta1.DeviceRequest) bool { return a.Name == b.Name })...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.DeviceRequest, b resourcev1beta1.DeviceRequest) bool { return a.Name == b.Name }).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.DeviceRequest, b resourcev1beta1.DeviceRequest) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_DeviceRequest)...)
 			return
@@ -645,11 +645,11 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -671,11 +671,11 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -703,18 +703,18 @@ func Validate_DeviceClaimConfiguration(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("requests"), obj.Requests, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceClaimConfiguration) []string { return oldObj.Requests }), oldObj != nil)...)
 
@@ -750,13 +750,13 @@ func Validate_DeviceClass(ctx context.Context, op operation.Operation, fldPath *
 			// call field-attached validations
 			func() { // cohort name
 				earlyReturn := false
-				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue); len(e) != 0 {
+				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha(); len(e) != 0 {
 					earlyReturn = true
 				}
 				if earlyReturn {
 					return // do not proceed
 				}
-				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName)...)
+				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkAlpha()...)
 			}()
 			return
 		}(fldPath.Child("metadata"), &obj.ObjectMeta, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceClass) *v1.ObjectMeta { return &oldObj.ObjectMeta }), oldObj != nil)...)
@@ -808,11 +808,11 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -832,11 +832,11 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -858,13 +858,13 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("extendedResourceName"), obj.ExtendedResourceName, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceClassSpec) *string { return oldObj.ExtendedResourceName }), oldObj != nil)...)
 
@@ -883,7 +883,7 @@ func Validate_DeviceConfiguration(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -911,18 +911,18 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("requests"), obj.Requests, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceConstraint) []string { return oldObj.Requests }), oldObj != nil)...)
 
@@ -935,13 +935,13 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("matchAttribute"), obj.MatchAttribute, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceConstraint) *resourcev1beta1.FullyQualifiedName {
 			return oldObj.MatchAttribute
@@ -963,14 +963,14 @@ func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("counterSet"), &obj.CounterSet, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceCounterConsumption) *string { return &oldObj.CounterSet }), oldObj != nil)...)
 
@@ -983,14 +983,14 @@ func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha()...)
 			return
 		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceCounterConsumption) map[string]resourcev1beta1.Counter {
 			return oldObj.Counters
@@ -1014,11 +1014,11 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1036,7 +1036,7 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1061,11 +1061,11 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1074,7 +1074,7 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.DeviceSubRequest, b resourcev1beta1.DeviceSubRequest) bool {
 				return a.Name == b.Name
-			})...)
+			}).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.DeviceSubRequest, b resourcev1beta1.DeviceSubRequest) bool {
 				return a.Name == b.Name
@@ -1093,7 +1093,7 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1124,15 +1124,15 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha()...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceRequestAllocationResult) *string { return &oldObj.Driver }), oldObj != nil)...)
 
@@ -1145,14 +1145,14 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("pool"), &obj.Pool, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceRequestAllocationResult) *string { return &oldObj.Pool }), oldObj != nil)...)
 
@@ -1168,11 +1168,11 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1194,11 +1194,11 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1216,11 +1216,11 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1240,13 +1240,13 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("shareID"), obj.ShareID, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceRequestAllocationResult) *types.UID { return oldObj.ShareID }), oldObj != nil)...)
 
@@ -1268,14 +1268,14 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("deviceClassName"), &obj.DeviceClassName, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceSubRequest) *string { return &oldObj.DeviceClassName }), oldObj != nil)...)
 
@@ -1288,11 +1288,11 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1312,7 +1312,7 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1336,7 +1336,7 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1368,7 +1368,7 @@ func Validate_DeviceTaint(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1389,7 +1389,7 @@ var symbolsForDeviceTaintEffect = sets.New(resourcev1beta1.DeviceTaintEffectNoEx
 // Validate_DeviceTaintEffect validates an instance of DeviceTaintEffect according
 // to declarative validation rules in the API schema.
 func Validate_DeviceTaintEffect(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceTaintEffect) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -1406,13 +1406,13 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LabelKey(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("key"), &obj.Key, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceToleration) *string { return &oldObj.Key }), oldObj != nil)...)
 
@@ -1426,7 +1426,7 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			// call field-attached validations
 			earlyReturn := false
 			// optional fields with default values are effectively required
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1451,7 +1451,7 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1473,7 +1473,7 @@ var symbolsForDeviceTolerationOperator = sets.New(resourcev1beta1.DeviceTolerati
 // Validate_DeviceTolerationOperator validates an instance of DeviceTolerationOperator according
 // to declarative validation rules in the API schema.
 func Validate_DeviceTolerationOperator(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceTolerationOperator) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -1490,13 +1490,13 @@ func Validate_NetworkDeviceData(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 256)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha()...)
 			return
 		}(fldPath.Child("interfaceName"), &obj.InterfaceName, safe.Field(oldObj, func(oldObj *resourcev1beta1.NetworkDeviceData) *string { return &oldObj.InterfaceName }), oldObj != nil)...)
 
@@ -1509,18 +1509,18 @@ func Validate_NetworkDeviceData(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("ips"), obj.IPs, safe.Field(oldObj, func(oldObj *resourcev1beta1.NetworkDeviceData) []string { return oldObj.IPs }), oldObj != nil)...)
 
@@ -1533,13 +1533,13 @@ func Validate_NetworkDeviceData(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 128)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha()...)
 			return
 		}(fldPath.Child("hardwareAddress"), &obj.HardwareAddress, safe.Field(oldObj, func(oldObj *resourcev1beta1.NetworkDeviceData) *string { return &oldObj.HardwareAddress }), oldObj != nil)...)
 
@@ -1558,15 +1558,15 @@ func Validate_OpaqueDeviceConfiguration(ctx context.Context, op operation.Operat
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha()...)
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1beta1.OpaqueDeviceConfiguration) *string { return &oldObj.Driver }), oldObj != nil)...)
 
@@ -1589,7 +1589,7 @@ func Validate_ResourceClaim(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1648,10 +1648,10 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify); len(e) != 0 {
+			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1674,11 +1674,11 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1687,7 +1687,7 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.ResourceClaimConsumerReference, b resourcev1beta1.ResourceClaimConsumerReference) bool {
 				return a.UID == b.UID
-			})...)
+			}).MarkAlpha()...)
 			return
 		}(fldPath.Child("reservedFor"), obj.ReservedFor, safe.Field(oldObj, func(oldObj *resourcev1beta1.ResourceClaimStatus) []resourcev1beta1.ResourceClaimConsumerReference {
 			return oldObj.ReservedFor
@@ -1702,7 +1702,7 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1711,7 +1711,7 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.AllocatedDeviceStatus, b resourcev1beta1.AllocatedDeviceStatus) bool {
 				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
-			})...)
+			}).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.AllocatedDeviceStatus, b resourcev1beta1.AllocatedDeviceStatus) bool {
 				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
@@ -1808,7 +1808,7 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1830,18 +1830,18 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with map semantics require unique keys
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.CounterSet, b resourcev1beta1.CounterSet) bool { return a.Name == b.Name })...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.CounterSet, b resourcev1beta1.CounterSet) bool { return a.Name == b.Name }).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.CounterSet, b resourcev1beta1.CounterSet) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_CounterSet)...)
 			return

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -93,13 +93,13 @@ func Validate_AllocatedDeviceStatus(ctx context.Context, op operation.Operation,
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("shareID"), obj.ShareID, safe.Field(oldObj, func(oldObj *resourcev1beta2.AllocatedDeviceStatus) *string { return oldObj.ShareID }), oldObj != nil)...)
 
@@ -115,7 +115,7 @@ func Validate_AllocatedDeviceStatus(ctx context.Context, op operation.Operation,
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -136,7 +136,7 @@ var symbolsForAllocationConfigSource = sets.New(resourcev1beta2.AllocationConfig
 // Validate_AllocationConfigSource validates an instance of AllocationConfigSource according
 // to declarative validation rules in the API schema.
 func Validate_AllocationConfigSource(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.AllocationConfigSource) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAllocationConfigSource, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -175,14 +175,14 @@ func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *resourcev1beta2.CounterSet) *string { return &oldObj.Name }), oldObj != nil)...)
 
@@ -195,14 +195,14 @@ func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha()...)
 			return
 		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1beta2.CounterSet) map[string]resourcev1beta2.Counter { return oldObj.Counters }), oldObj != nil)...)
 
@@ -223,7 +223,7 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -247,11 +247,11 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -260,7 +260,7 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.DeviceCounterConsumption, b resourcev1beta2.DeviceCounterConsumption) bool {
 				return a.CounterSet == b.CounterSet
-			})...)
+			}).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.DeviceCounterConsumption, b resourcev1beta2.DeviceCounterConsumption) bool {
 				return a.CounterSet == b.CounterSet
@@ -283,7 +283,7 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -305,11 +305,11 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -327,11 +327,11 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -356,7 +356,7 @@ func Validate_DeviceAllocationConfiguration(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -379,18 +379,18 @@ func Validate_DeviceAllocationConfiguration(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("requests"), obj.Requests, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceAllocationConfiguration) []string { return oldObj.Requests }), oldObj != nil)...)
 
@@ -416,7 +416,7 @@ var symbolsForDeviceAllocationMode = sets.New(resourcev1beta2.DeviceAllocationMo
 // Validate_DeviceAllocationMode validates an instance of DeviceAllocationMode according
 // to declarative validation rules in the API schema.
 func Validate_DeviceAllocationMode(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceAllocationMode) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -433,11 +433,11 @@ func Validate_DeviceAllocationResult(ctx context.Context, op operation.Operation
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -459,11 +459,11 @@ func Validate_DeviceAllocationResult(ctx context.Context, op operation.Operation
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -504,7 +504,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			return false
 		}
 		return obj.VersionValue != nil
-	})...)
+	}).MarkAlpha()...)
 
 	// field resourcev1beta2.DeviceAttribute.IntValue
 	errs = append(errs,
@@ -515,7 +515,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -533,7 +533,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -551,7 +551,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -569,7 +569,7 @@ func Validate_DeviceAttribute(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -593,18 +593,18 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with map semantics require unique keys
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.DeviceRequest, b resourcev1beta2.DeviceRequest) bool { return a.Name == b.Name })...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.DeviceRequest, b resourcev1beta2.DeviceRequest) bool { return a.Name == b.Name }).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.DeviceRequest, b resourcev1beta2.DeviceRequest) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_DeviceRequest)...)
 			return
@@ -619,11 +619,11 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -645,11 +645,11 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -677,18 +677,18 @@ func Validate_DeviceClaimConfiguration(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("requests"), obj.Requests, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceClaimConfiguration) []string { return oldObj.Requests }), oldObj != nil)...)
 
@@ -724,13 +724,13 @@ func Validate_DeviceClass(ctx context.Context, op operation.Operation, fldPath *
 			// call field-attached validations
 			func() { // cohort name
 				earlyReturn := false
-				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue); len(e) != 0 {
+				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha(); len(e) != 0 {
 					earlyReturn = true
 				}
 				if earlyReturn {
 					return // do not proceed
 				}
-				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName)...)
+				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName).MarkAlpha()...)
 			}()
 			return
 		}(fldPath.Child("metadata"), &obj.ObjectMeta, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceClass) *v1.ObjectMeta { return &oldObj.ObjectMeta }), oldObj != nil)...)
@@ -782,11 +782,11 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -806,11 +806,11 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -832,13 +832,13 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("extendedResourceName"), obj.ExtendedResourceName, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceClassSpec) *string { return oldObj.ExtendedResourceName }), oldObj != nil)...)
 
@@ -857,7 +857,7 @@ func Validate_DeviceConfiguration(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -885,18 +885,18 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("requests"), obj.Requests, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceConstraint) []string { return oldObj.Requests }), oldObj != nil)...)
 
@@ -909,13 +909,13 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("matchAttribute"), obj.MatchAttribute, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceConstraint) *resourcev1beta2.FullyQualifiedName {
 			return oldObj.MatchAttribute
@@ -937,14 +937,14 @@ func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("counterSet"), &obj.CounterSet, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceCounterConsumption) *string { return &oldObj.CounterSet }), oldObj != nil)...)
 
@@ -957,14 +957,14 @@ func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha()...)
 			return
 		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceCounterConsumption) map[string]resourcev1beta2.Counter {
 			return oldObj.Counters
@@ -987,7 +987,7 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1007,11 +1007,11 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1020,7 +1020,7 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.DeviceSubRequest, b resourcev1beta2.DeviceSubRequest) bool {
 				return a.Name == b.Name
-			})...)
+			}).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.DeviceSubRequest, b resourcev1beta2.DeviceSubRequest) bool {
 				return a.Name == b.Name
@@ -1047,15 +1047,15 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha()...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceRequestAllocationResult) *string { return &oldObj.Driver }), oldObj != nil)...)
 
@@ -1068,14 +1068,14 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("pool"), &obj.Pool, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceRequestAllocationResult) *string { return &oldObj.Pool }), oldObj != nil)...)
 
@@ -1091,7 +1091,7 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1113,11 +1113,11 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1135,11 +1135,11 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1159,13 +1159,13 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("shareID"), obj.ShareID, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceRequestAllocationResult) *types.UID { return oldObj.ShareID }), oldObj != nil)...)
 
@@ -1187,14 +1187,14 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongName(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("deviceClassName"), &obj.DeviceClassName, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceSubRequest) *string { return &oldObj.DeviceClassName }), oldObj != nil)...)
 
@@ -1207,11 +1207,11 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1231,7 +1231,7 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1255,7 +1255,7 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1287,7 +1287,7 @@ func Validate_DeviceTaint(ctx context.Context, op operation.Operation, fldPath *
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1308,7 +1308,7 @@ var symbolsForDeviceTaintEffect = sets.New(resourcev1beta2.DeviceTaintEffectNoEx
 // Validate_DeviceTaintEffect validates an instance of DeviceTaintEffect according
 // to declarative validation rules in the API schema.
 func Validate_DeviceTaintEffect(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceTaintEffect) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -1325,13 +1325,13 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LabelKey(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("key"), &obj.Key, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceToleration) *string { return &oldObj.Key }), oldObj != nil)...)
 
@@ -1345,7 +1345,7 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			// call field-attached validations
 			earlyReturn := false
 			// optional fields with default values are effectively required
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1370,7 +1370,7 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1392,7 +1392,7 @@ var symbolsForDeviceTolerationOperator = sets.New(resourcev1beta2.DeviceTolerati
 // Validate_DeviceTolerationOperator validates an instance of DeviceTolerationOperator according
 // to declarative validation rules in the API schema.
 func Validate_DeviceTolerationOperator(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceTolerationOperator) (errs field.ErrorList) {
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil).MarkAlpha()...)
 
 	return errs
 }
@@ -1411,11 +1411,11 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1435,7 +1435,7 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1460,7 +1460,7 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1489,13 +1489,13 @@ func Validate_NetworkDeviceData(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 256)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha()...)
 			return
 		}(fldPath.Child("interfaceName"), &obj.InterfaceName, safe.Field(oldObj, func(oldObj *resourcev1beta2.NetworkDeviceData) *string { return &oldObj.InterfaceName }), oldObj != nil)...)
 
@@ -1508,18 +1508,18 @@ func Validate_NetworkDeviceData(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with set semantics require unique values
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual)...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha()...)
 			return
 		}(fldPath.Child("ips"), obj.IPs, safe.Field(oldObj, func(oldObj *resourcev1beta2.NetworkDeviceData) []string { return oldObj.IPs }), oldObj != nil)...)
 
@@ -1532,13 +1532,13 @@ func Validate_NetworkDeviceData(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 128)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha()...)
 			return
 		}(fldPath.Child("hardwareAddress"), &obj.HardwareAddress, safe.Field(oldObj, func(oldObj *resourcev1beta2.NetworkDeviceData) *string { return &oldObj.HardwareAddress }), oldObj != nil)...)
 
@@ -1557,15 +1557,15 @@ func Validate_OpaqueDeviceConfiguration(ctx context.Context, op operation.Operat
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha()...)
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
 			return
 		}(fldPath.Child("driver"), &obj.Driver, safe.Field(oldObj, func(oldObj *resourcev1beta2.OpaqueDeviceConfiguration) *string { return &oldObj.Driver }), oldObj != nil)...)
 
@@ -1588,7 +1588,7 @@ func Validate_ResourceClaim(ctx context.Context, op operation.Operation, fldPath
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1647,10 +1647,10 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify); len(e) != 0 {
+			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1673,11 +1673,11 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1686,7 +1686,7 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.ResourceClaimConsumerReference, b resourcev1beta2.ResourceClaimConsumerReference) bool {
 				return a.UID == b.UID
-			})...)
+			}).MarkAlpha()...)
 			return
 		}(fldPath.Child("reservedFor"), obj.ReservedFor, safe.Field(oldObj, func(oldObj *resourcev1beta2.ResourceClaimStatus) []resourcev1beta2.ResourceClaimConsumerReference {
 			return oldObj.ReservedFor
@@ -1701,7 +1701,7 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1710,7 +1710,7 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.AllocatedDeviceStatus, b resourcev1beta2.AllocatedDeviceStatus) bool {
 				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
-			})...)
+			}).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.AllocatedDeviceStatus, b resourcev1beta2.AllocatedDeviceStatus) bool {
 				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
@@ -1807,7 +1807,7 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -1829,18 +1829,18 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8); len(e) != 0 {
-				errs = append(errs, e...)
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// lists with map semantics require unique keys
-			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.CounterSet, b resourcev1beta2.CounterSet) bool { return a.Name == b.Name })...)
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.CounterSet, b resourcev1beta2.CounterSet) bool { return a.Name == b.Name }).MarkAlpha()...)
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.CounterSet, b resourcev1beta2.CounterSet) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_CounterSet)...)
 			return

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -221,6 +221,14 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the map and call the value type's validation function
 			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual, Validate_DeviceAttribute)...)
 			return
@@ -272,6 +280,14 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceTaint)...)
@@ -1073,6 +1089,14 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
 			return
@@ -1205,6 +1229,14 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceAllocationMode(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -1220,6 +1252,14 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
@@ -1302,6 +1342,16 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			// optional fields with default values are effectively required
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTolerationOperator(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -1317,6 +1367,14 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
@@ -1399,6 +1457,14 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1428,7 +1428,7 @@ func validateDeviceToleration(toleration resource.DeviceToleration, fldPath *fie
 	case resource.DeviceTolerationOpEqual:
 		allErrs = append(allErrs, validateLabelValue(toleration.Value, fldPath.Child("value"))...)
 	case "":
-		allErrs = append(allErrs, field.Required(fldPath.Child("operator"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("operator"), "").MarkCoveredByDeclarative())
 	default:
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("operator"), toleration.Operator, validDeviceTolerationOperators).MarkCoveredByDeclarative())
 	}

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -814,11 +814,11 @@ func TestValidateClaim(t *testing.T) {
 				var allErrs field.ErrorList
 				fldPath := field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations")
 				allErrs = append(allErrs,
-					field.Required(fldPath.Index(0).Child("operator"), ""),
+					field.Required(fldPath.Index(0).Child("operator"), "").MarkCoveredByDeclarative(),
 				)
 				fldPath = field.NewPath("spec", "devices", "requests").Index(1).Child("exactly", "tolerations")
 				allErrs = append(allErrs,
-					field.Required(fldPath.Index(3).Child("operator"), ""),
+					field.Required(fldPath.Index(3).Child("operator"), "").MarkCoveredByDeclarative(),
 
 					field.NotSupported(fldPath.Index(4).Child("operator"), resource.DeviceTolerationOperator("some-other-op"), []resource.DeviceTolerationOperator{resource.DeviceTolerationOpEqual, resource.DeviceTolerationOpExists}).MarkCoveredByDeclarative(),
 

--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -74,11 +74,11 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -97,11 +97,11 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -119,11 +119,11 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -146,11 +146,11 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -178,7 +178,7 @@ func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -206,15 +206,15 @@ func Validate_VolumeAttachmentSpec(ctx context.Context, op operation.Operation, 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha()...)
 			return
 		}(fldPath.Child("attacher"), &obj.Attacher, safe.Field(oldObj, func(oldObj *storagev1.VolumeAttachmentSpec) *string { return &oldObj.Attacher }), oldObj != nil)...)
 

--- a/pkg/apis/storage/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1alpha1/zz_generated.validations.go
@@ -65,7 +65,7 @@ func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -95,15 +95,15 @@ func Validate_VolumeAttachmentSpec(ctx context.Context, op operation.Operation, 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha()...)
 			return
 		}(fldPath.Child("attacher"), &obj.Attacher, safe.Field(oldObj, func(oldObj *storagev1alpha1.VolumeAttachmentSpec) *string { return &oldObj.Attacher }), oldObj != nil)...)
 

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -74,11 +74,11 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -97,11 +97,11 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -119,11 +119,11 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -146,11 +146,11 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -180,7 +180,7 @@ func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldP
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -210,15 +210,15 @@ func Validate_VolumeAttachmentSpec(ctx context.Context, op operation.Operation, 
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha()...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha()...)
 			return
 		}(fldPath.Child("attacher"), &obj.Attacher, safe.Field(oldObj, func(oldObj *storagev1beta1.VolumeAttachmentSpec) *string { return &oldObj.Attacher }), oldObj != nil)...)
 

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
@@ -54,13 +54,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"spec.policyName is required": {
 			input: mkValidBinding(tweakPolicyName("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "policyName"), ""),
+				field.Required(field.NewPath("spec", "policyName"), "").MarkAlpha(),
 			},
 		},
 		"spec.validationActions is required": {
 			input: mkValidBinding(tweakValidateActions([]admissionregistration.ValidationAction{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "validationActions"), ""),
+				field.Required(field.NewPath("spec", "validationActions"), "").MarkAlpha(),
 			},
 		},
 		// TODO: Add more test cases
@@ -94,14 +94,14 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidBinding(func(obj *admissionregistration.ValidatingAdmissionPolicyBinding) { obj.ResourceVersion = "1" }),
 			updateObj: mkValidBinding(tweakPolicyName("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "policyName"), ""),
+				field.Required(field.NewPath("spec", "policyName"), "").MarkAlpha(),
 			},
 		},
 		"update with empty spec.validationActions": {
 			oldObj:    mkValidBinding(),
 			updateObj: mkValidBinding(tweakValidateActions([]admissionregistration.ValidationAction{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "validationActions"), ""),
+				field.Required(field.NewPath("spec", "validationActions"), "").MarkAlpha(),
 			},
 		},
 		// TODO: Add more test cases

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
@@ -63,19 +63,19 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid: maxReplicas = 0 (required)": {
 			input: makeValidHPA(tweakMaxReplicas(0)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "maxReplicas"), ""),
+				field.Required(field.NewPath("spec", "maxReplicas"), "").MarkAlpha(),
 			},
 		},
 		"invalid: maxReplicas negative": {
 			input: makeValidHPA(tweakMaxReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "maxReplicas"), int32(-1), "must be greater than or equal to 1").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec", "maxReplicas"), int32(-1), "must be greater than or equal to 1").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 		"invalid: minReplicas = 0 (gate disabled)": {
 			input: makeValidHPA(tweakMinReplicas(0), tweakMetrics(validScaleToZeroMetrics...)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "minReplicas"), int32(0), "must be greater than or equal to 1").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec", "minReplicas"), int32(0), "must be greater than or equal to 1").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 	}
@@ -119,21 +119,21 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    makeValidHPA(),
 			updateObj: makeValidHPA(tweakMaxReplicas(0)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "maxReplicas"), ""),
+				field.Required(field.NewPath("spec", "maxReplicas"), "").MarkAlpha(),
 			},
 		},
 		"invalid update: maxReplicas negative": {
 			oldObj:    makeValidHPA(),
 			updateObj: makeValidHPA(tweakMaxReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "maxReplicas"), int32(-1), "must be greater than or equal to 1").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec", "maxReplicas"), int32(-1), "must be greater than or equal to 1").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 		"invalid update: minReplicas 1 -> 0 (gate disabled)": {
 			oldObj:    makeValidHPA(tweakMinReplicas(1), tweakMetrics(validScaleToZeroMetrics...)),
 			updateObj: makeValidHPA(tweakMinReplicas(0), tweakMetrics(validScaleToZeroMetrics...)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "minReplicas"), int32(0), "must be greater than or equal to 1").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec", "minReplicas"), int32(0), "must be greater than or equal to 1").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 		"valid update: ratcheting minReplicas=0 when gate disabled": {

--- a/pkg/registry/batch/cronjob/declarative_validation_test.go
+++ b/pkg/registry/batch/cronjob/declarative_validation_test.go
@@ -49,7 +49,7 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 		"schedule: empty": {
 			input: mkCronJob(tweakSchedule("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "schedule"), ""),
+				field.Required(field.NewPath("spec", "schedule"), "").MarkAlpha(),
 			},
 		},
 	}
@@ -85,7 +85,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 			old:    mkCronJob(),
 			update: mkCronJob(tweakSchedule("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "schedule"), ""),
+				field.Required(field.NewPath("spec", "schedule"), "").MarkAlpha(),
 			},
 		},
 	}

--- a/pkg/registry/certificates/certificates/declarative_validation_test.go
+++ b/pkg/registry/certificates/certificates/declarative_validation_test.go
@@ -78,13 +78,13 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 		"status.conditions: Approved+Denied = invalid": {
 			input: makeValidCSR(withApprovedCondition(), withDeniedCondition()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf"),
+				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf").MarkAlpha(),
 			},
 		},
 		"status.conditions: Denied+Approved = invalid": {
 			input: makeValidCSR(withDeniedCondition(), withApprovedCondition()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf"),
+				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf").MarkAlpha(),
 			},
 		},
 	}
@@ -154,7 +154,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 			old:    makeValidCSR(),
 			update: makeValidCSR(withApprovedCondition(), withDeniedCondition()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf"),
+				field.Invalid(field.NewPath("status", "conditions"), nil, "").WithOrigin("zeroOrOneOf").MarkAlpha(),
 			},
 			subresources: []string{"/approval"}, // Can only add Approved and Denied conditions on /approval subresource
 		},

--- a/pkg/registry/core/replicationcontroller/declarative_validation_test.go
+++ b/pkg/registry/core/replicationcontroller/declarative_validation_test.go
@@ -67,7 +67,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				rc.Name = "-this-is-not-a-label"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 			},
 		},
 		"name: invalid subdomain format": {
@@ -75,7 +75,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				rc.Name = ".this.is.not.a.subdomain"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 			},
 		},
 		"name: label format with trailing dash": {
@@ -83,7 +83,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				rc.Name = "this-is-a-label-"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 			},
 		},
 		"name: subdomain format with trailing dash": {
@@ -91,7 +91,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				rc.Name = "this.is.a.subdomain-"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 			},
 		},
 		"name: long label format": {
@@ -109,7 +109,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				rc.Name = strings.Repeat("x", 254)
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 			},
 		},
 		"name: too long subdomain format": {
@@ -117,7 +117,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				rc.Name = strings.Repeat("x.", 126) + "xx"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 			},
 		},
 		// metadata.generateName (note: it's is not really validated)
@@ -158,7 +158,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				rc.Spec.Replicas = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec.replicas"), ""),
+				field.Required(field.NewPath("spec.replicas"), "").MarkAlpha(),
 			},
 		},
 		"replicas: 0": {
@@ -170,7 +170,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 		"replicas: negative": {
 			input: mkValidReplicationController(setSpecReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 		// spec.minReadySeconds
@@ -183,7 +183,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 		"minReadySeconds: negative": {
 			input: mkValidReplicationController(setSpecMinReadySeconds(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 	}
@@ -235,7 +235,7 @@ func TestValidateUpdateForDeclarative(t *testing.T) {
 				rc.Spec.Replicas = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec.replicas"), ""),
+				field.Required(field.NewPath("spec.replicas"), "").MarkAlpha(),
 			},
 		},
 		"replicas: 0": {
@@ -250,7 +250,7 @@ func TestValidateUpdateForDeclarative(t *testing.T) {
 			old:    mkValidReplicationController(),
 			update: mkValidReplicationController(setSpecReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 		// spec.minReadySeconds
@@ -266,7 +266,7 @@ func TestValidateUpdateForDeclarative(t *testing.T) {
 			old:    mkValidReplicationController(),
 			update: mkValidReplicationController(setSpecMinReadySeconds(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 	}

--- a/pkg/registry/core/replicationcontroller/storage/scale_declarative_validation_test.go
+++ b/pkg/registry/core/replicationcontroller/storage/scale_declarative_validation_test.go
@@ -49,7 +49,7 @@ func TestValidateScaleForDeclarative(t *testing.T) {
 		"spec.replicas: negative replicas": {
 			input: mkScale(setScaleSpecReplicas(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec.replicas"), nil, "").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 	}

--- a/pkg/registry/discovery/endpointslice/declarative_validation_test.go
+++ b/pkg/registry/discovery/endpointslice/declarative_validation_test.go
@@ -61,25 +61,25 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				obj.Endpoints[0].Addresses = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), ""),
+				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), "").MarkAlpha(),
 			},
 		},
 		"invalid too many endpoint addresses": {
 			input: mkValidEndpointSlice(tweakAddresses(101)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid missing addressType": {
 			input: mkValidEndpointSlice(tweakAddressType("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("addressType"), ""),
+				field.Required(field.NewPath("addressType"), "").MarkAlpha(),
 			},
 		},
 		"invalid addressType not supported": {
 			input: mkValidEndpointSlice(tweakAddressType("invalid")),
 			expectedErrs: field.ErrorList{
-				field.NotSupported(field.NewPath("addressType"), discovery.AddressType("invalid"), []string{string(discovery.AddressTypeIPv4), string(discovery.AddressTypeIPv6), string(discovery.AddressTypeFQDN)}),
+				field.NotSupported(field.NewPath("addressType"), discovery.AddressType("invalid"), []string{string(discovery.AddressTypeIPv4), string(discovery.AddressTypeIPv6), string(discovery.AddressTypeFQDN)}).MarkAlpha(),
 			},
 		},
 	}
@@ -118,21 +118,21 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				obj.Endpoints[0].Addresses = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), ""),
+				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), "").MarkAlpha(),
 			},
 		},
 		"invalid update too many addresses": {
 			oldObj:    mkValidEndpointSlice(),
 			updateObj: mkValidEndpointSlice(tweakAddresses(101)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid update addressType immutable": {
 			oldObj:    mkValidEndpointSlice(),
 			updateObj: mkValidEndpointSlice(tweakAddressType(discovery.AddressTypeIPv6)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("addressType"), discovery.AddressTypeIPv6, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("addressType"), discovery.AddressTypeIPv6, "field is immutable").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 	}

--- a/pkg/registry/networking/ingressclass/declarative_validation_test.go
+++ b/pkg/registry/networking/ingressclass/declarative_validation_test.go
@@ -59,14 +59,14 @@ func TestDeclarativeValidateParameter(t *testing.T) {
 						obj.Spec.Parameters.Name = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parameters", "name"), "")},
+						field.Required(field.NewPath("spec", "parameters", "name"), "").MarkAlpha()},
 				},
 				"missing parameter kind": {
 					input: mkValidIngressClass(func(obj *networking.IngressClass) {
 						obj.Spec.Parameters.Kind = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parameters", "kind"), ""),
+						field.Required(field.NewPath("spec", "parameters", "kind"), "").MarkAlpha(),
 					},
 				},
 			}
@@ -119,7 +119,7 @@ func TestDeclarativeValidateUpdateParameters(t *testing.T) {
 						obj.Spec.Parameters.Name = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parameters", "name"), ""),
+						field.Required(field.NewPath("spec", "parameters", "name"), "").MarkAlpha(),
 					},
 				},
 				"update fails when parameters kind is cleared": {
@@ -131,7 +131,7 @@ func TestDeclarativeValidateUpdateParameters(t *testing.T) {
 						obj.Spec.Parameters.Kind = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parameters", "kind"), ""),
+						field.Required(field.NewPath("spec", "parameters", "kind"), "").MarkAlpha(),
 					},
 				},
 			}

--- a/pkg/registry/networking/ipaddress/declarative_validation_test.go
+++ b/pkg/registry/networking/ipaddress/declarative_validation_test.go
@@ -52,19 +52,19 @@ func TestDeclarativeValidateIPAddress(t *testing.T) {
 				"missing parentRef": {
 					input: mkValidIPAddress(withNilParentRef),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parentRef"), ""),
+						field.Required(field.NewPath("spec", "parentRef"), "").MarkAlpha(),
 					},
 				},
 				"missing parentRef resource": {
 					input: mkValidIPAddress(withEmptyParentRefResource),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parentRef", "resource"), ""),
+						field.Required(field.NewPath("spec", "parentRef", "resource"), "").MarkAlpha(),
 					},
 				},
 				"missing parentRef name": {
 					input: mkValidIPAddress(withEmptyParentRefName),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parentRef", "name"), ""),
+						field.Required(field.NewPath("spec", "parentRef", "name"), "").MarkAlpha(),
 					},
 				},
 			}
@@ -110,7 +110,7 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 							}, "field is immutable")
 							e.Origin = "immutable"
 							return e
-						}(),
+						}().MarkAlpha(),
 					},
 				},
 				"set parentRef": {
@@ -128,7 +128,7 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 							}, "field is immutable")
 							e.Origin = "immutable"
 							return e
-						}(),
+						}().MarkAlpha(),
 					},
 				},
 				"unset parentRef": {
@@ -138,12 +138,12 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 						withNilParentRef,
 					),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parentRef"), ""),
+						field.Required(field.NewPath("spec", "parentRef"), "").MarkAlpha(),
 						func() *field.Error {
 							e := field.Invalid(field.NewPath("spec", "parentRef"), nil, "field is immutable")
 							e.Origin = "immutable"
 							return e
-						}(),
+						}().MarkAlpha(),
 					},
 				},
 			}

--- a/pkg/registry/networking/networkpolicy/declarative_validation_test.go
+++ b/pkg/registry/networking/networkpolicy/declarative_validation_test.go
@@ -59,7 +59,7 @@ func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
 						field.Required(
 							field.NewPath("spec", "ingress").Index(0).Child("from").Index(0).Child("ipBlock", "cidr"),
 							"",
-						),
+						).MarkAlpha(),
 					},
 				},
 				"egress rule rejects empty CIDR in ipBlock": {
@@ -68,7 +68,7 @@ func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
 						field.Required(
 							field.NewPath("spec", "egress").Index(0).Child("to").Index(0).Child("ipBlock", "cidr"),
 							"",
-						),
+						).MarkAlpha(),
 					},
 				},
 			}
@@ -111,7 +111,7 @@ func TestDeclarativeValidateIPBlockCIDRUpdate(t *testing.T) {
 						field.Required(
 							field.NewPath("spec", "ingress").Index(0).Child("from").Index(0).Child("ipBlock", "cidr"),
 							"",
-						),
+						).MarkAlpha(),
 					},
 				},
 
@@ -122,7 +122,7 @@ func TestDeclarativeValidateIPBlockCIDRUpdate(t *testing.T) {
 						field.Required(
 							field.NewPath("spec", "egress").Index(0).Child("to").Index(0).Child("ipBlock", "cidr"),
 							"",
-						),
+						).MarkAlpha(),
 					},
 				},
 			}

--- a/pkg/registry/node/runtimeclass/declarative_validation_test.go
+++ b/pkg/registry/node/runtimeclass/declarative_validation_test.go
@@ -68,7 +68,7 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 						rc.Handler = ""
 					}),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("handler"), "must be a valid DNS label"),
+						field.Required(field.NewPath("handler"), "must be a valid DNS label").MarkAlpha(),
 					},
 				},
 				"handler with special characters": {
@@ -77,7 +77,7 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("handler"),
-							"", "").WithOrigin("format=k8s-short-name"),
+							"", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				"handler with uppercase and special characters": {
@@ -86,7 +86,7 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("handler"),
-							"", "").WithOrigin("format=k8s-short-name"),
+							"", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				"handler exceeds length with invalid characters": {
@@ -95,7 +95,7 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("handler"),
-							"", "").WithOrigin("format=k8s-short-name"),
+							"", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 			}
@@ -139,7 +139,7 @@ func TestRuntimeClass_DeclarativeValidate_Update(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("handler"), "",
-							"").WithOrigin("immutable"),
+							"").WithOrigin("immutable").MarkAlpha(),
 					},
 				},
 			}

--- a/pkg/registry/rbac/clusterrole/declarative_validation_test.go
+++ b/pkg/registry/rbac/clusterrole/declarative_validation_test.go
@@ -49,13 +49,13 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 		"invalid ClusterRole missing verbs": {
 			input: mkValidClusterRole(tweakVerbs(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
 			},
 		},
 		"invalid ClusterRole empty verbs": {
 			input: mkValidClusterRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
 			},
 		},
 		// TODO: Add more test cases
@@ -91,7 +91,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 			old:    mkValidClusterRole(),
 			update: mkValidClusterRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
 			},
 		},
 		// TODO: Add more test cases

--- a/pkg/registry/rbac/role/declarative_validation_test.go
+++ b/pkg/registry/rbac/role/declarative_validation_test.go
@@ -55,13 +55,13 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 		"invalid Role missing verbs": {
 			input: mkValidRole(tweakVerbs(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
 			},
 		},
 		"invalid Role empty verbs": {
 			input: mkValidRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
 			},
 		},
 		// TODO: Add more test cases
@@ -103,7 +103,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 			old:    mkValidRole(),
 			update: mkValidRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkAlpha(),
 			},
 		},
 		// TODO: Add more test cases

--- a/pkg/registry/rbac/rolebinding/declarative_validation_test.go
+++ b/pkg/registry/rbac/rolebinding/declarative_validation_test.go
@@ -59,7 +59,7 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 				},
 			},
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("roleRef", "name"), "name is required"),
+				field.Required(field.NewPath("roleRef", "name"), "name is required").MarkAlpha(),
 			},
 		},
 
@@ -76,7 +76,7 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 				},
 			},
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("subjects").Index(0).Child("name"), "name is required"),
+				field.Required(field.NewPath("subjects").Index(0).Child("name"), "name is required").MarkAlpha(),
 			},
 		},
 

--- a/pkg/registry/resource/deviceclass/declarative_validation_test.go
+++ b/pkg/registry/resource/deviceclass/declarative_validation_test.go
@@ -64,13 +64,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				"name: invalid (uppercase)": {
 					input: mkDeviceClass(tweakName("Invalid-Name")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("metadata", "name"), "Invalid-Name", "").WithOrigin("format=k8s-long-name"),
+						field.Invalid(field.NewPath("metadata", "name"), "Invalid-Name", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 					},
 				},
 				"name: invalid (start with dash)": {
 					input: mkDeviceClass(tweakName("-invalid")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("metadata", "name"), "-invalid", "").WithOrigin("format=k8s-long-name"),
+						field.Invalid(field.NewPath("metadata", "name"), "-invalid", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 					},
 				},
 				"name: max length": {
@@ -79,7 +79,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"name: too long": {
 					input: mkDeviceClass(tweakName(strings.Repeat("a", 254))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("metadata", "name"), strings.Repeat("a", 254), "").WithOrigin("format=k8s-long-name"),
+						field.Invalid(field.NewPath("metadata", "name"), strings.Repeat("a", 254), "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 					},
 				},
 				// spec.selectors.
@@ -89,14 +89,14 @@ func TestDeclarativeValidate(t *testing.T) {
 				"too many selectors": {
 					input: mkDeviceClass(tweakSelectors(33)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				// spec.config
 				"too many configs": {
 					input: mkDeviceClass(tweakConfig(33)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				"valid: at limit configs": {
@@ -110,31 +110,31 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid extended resource name": {
 					input: mkDeviceClass(tweakExtendedResourceName("invalid_name")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "invalid_name", "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "invalid_name", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				"invalid extended resource name, no slash": {
 					input: mkDeviceClass(tweakExtendedResourceName("noslash")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "noslash", "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "noslash", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				"invalid extended resource name, kubernetes.io domain": {
 					input: mkDeviceClass(tweakExtendedResourceName("kubernetes.io/foo")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "kubernetes.io/foo", "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "kubernetes.io/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				"invalid extended resource name, requests. prefix": {
 					input: mkDeviceClass(tweakExtendedResourceName("requests.example.com/foo")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "requests.example.com/foo", "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "requests.example.com/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				"invalid extended resource name, too long": {
 					input: mkDeviceClass(tweakExtendedResourceName("example.com/" + strings.Repeat("a", 64))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "example.com/"+strings.Repeat("a", 64), "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "example.com/"+strings.Repeat("a", 64), "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				// TODO: Add more test cases
@@ -185,7 +185,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakSelectors(33)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				"valid update: at limit configs": {
@@ -196,7 +196,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakConfig(33)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 
@@ -209,35 +209,35 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("invalid_name")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "invalid_name", "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "invalid_name", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				"invalid extended resource name update, no slash": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("noslash")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "noslash", "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "noslash", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				"invalid extended resource name update, kubernetes.io domain": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("kubernetes.io/foo")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "kubernetes.io/foo", "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "kubernetes.io/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				"invalid extended resource name update, requests. prefix": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("requests.example.com/foo")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "requests.example.com/foo", "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "requests.example.com/foo", "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				"invalid extended resource name update, too long": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakExtendedResourceName("example.com/" + strings.Repeat("a", 64))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "extendedResourceName"), "example.com/"+strings.Repeat("a", 64), "").WithOrigin("format=k8s-extended-resource-name"),
+						field.Invalid(field.NewPath("spec", "extendedResourceName"), "example.com/"+strings.Repeat("a", 64), "").WithOrigin("format=k8s-extended-resource-name").MarkAlpha(),
 					},
 				},
 				// TODO: Add more test cases

--- a/pkg/registry/resource/resourceclaim/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaim/declarative_validation_test.go
@@ -328,6 +328,14 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				},
 			})),
 		},
+		"invalid DeviceTolerationOperator empty - Exactly": {
+			input: mkValidResourceClaim(
+				tweakExactlyTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
+			),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"), ""),
+			},
+		},
 		"invalid DeviceTolerationOperator - Exactly": {
 			input: mkValidResourceClaim(tweakExactlyTolerations([]resource.DeviceToleration{
 				{
@@ -371,6 +379,15 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					Effect:   resource.DeviceTaintEffectNoSchedule,
 				},
 			})),
+		},
+		"invalid DeviceTolerationOperator empty - FirstAvailable": {
+			input: mkValidResourceClaim(
+				tweakFirstAvailable(1),
+				tweakFirstAvailableTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
+			),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"), ""),
+			},
 		},
 		"invalid DeviceTolerationOperator - FirstAvailable": {
 			input: mkValidResourceClaim(tweakFirstAvailable(1), tweakFirstAvailableTolerations([]resource.DeviceToleration{

--- a/pkg/registry/resource/resourceclaim/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaim/declarative_validation_test.go
@@ -82,82 +82,82 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid requests, too many": {
 			input: mkValidResourceClaim(tweakDevicesRequests(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid requests, duplicate name": {
 			input: mkValidResourceClaim(tweakAddDeviceRequest(mkDeviceRequest("req-0"))),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(1), "req-0"),
+				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(1), "req-0").MarkAlpha(),
 			},
 		},
 		"invalid requests, too many AND duplicate name (short-circuit check)": {
 			input: mkValidResourceClaim(tweakDevicesRequests(33), tweakAddDeviceRequest(mkDeviceRequest("req-0"))),
 			expectedErrs: field.ErrorList{
 				// We expect ONLY TooMany, suppressing the Duplicate error because of short-circuiting
-				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid constraints, too many": {
 			input: mkValidResourceClaim(tweakDevicesConstraints(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "constraints"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "devices", "constraints"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid config, too many": {
 			input: mkValidResourceClaim(tweakDevicesConfigs(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "config"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "devices", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid firstAvailable, too many": {
 			input: mkValidResourceClaim(tweakFirstAvailable(9)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable"), 9, 8).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable"), 9, 8).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid firstAvailable, duplicate name": {
 			input: mkValidResourceClaim(tweakDuplicateFirstAvailableName("sub-0")),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(1), "sub-0"),
+				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(1), "sub-0").MarkAlpha(),
 			},
 		},
 		"invalid selectors, too many": {
 			input: mkValidResourceClaim(tweakExactlySelectors(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "selectors"), 33, 32).WithOrigin("maxItems").MarkCoveredByDeclarative(),
+				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "selectors"), 33, 32).WithOrigin("maxItems").MarkCoveredByDeclarative().MarkAlpha(),
 			},
 		},
 		"invalid subrequest selectors, too many": {
 			input: mkValidResourceClaim(tweakSubRequestSelectors(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("selectors"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("selectors"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid constraint requests, too many": {
 			input: mkValidResourceClaim(tweakConstraintRequests(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems"),
-				field.TooMany(field.NewPath("spec", "devices", "constraints").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "constraints").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid config requests, too many": {
 			input: mkValidResourceClaim(tweakConfigRequests(33)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems"),
-				field.TooMany(field.NewPath("spec", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid constraint requests, duplicate name": {
 			input: mkValidResourceClaim(tweakDuplicateConstraintRequest("req-0")),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "devices", "constraints").Index(0).Child("requests").Index(1), "req-0"),
+				field.Duplicate(field.NewPath("spec", "devices", "constraints").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
 			},
 		},
 		"invalid config requests, duplicate name": {
 			input: mkValidResourceClaim(tweakDuplicateConfigRequest("req-0")),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "devices", "config").Index(0).Child("requests").Index(1), "req-0"),
+				field.Duplicate(field.NewPath("spec", "devices", "config").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
 			},
 		},
 		"valid firstAvailable, max allowed": {
@@ -187,32 +187,32 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid opaque driver, empty": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver("")),
 			expectedErrs: field.ErrorList{
-				field.Required(opaqueDriverPath, ""),
+				field.Required(opaqueDriverPath, "").MarkAlpha(),
 			},
 		},
 		"invalid opaque driver, too long - 64 characters": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength"),
+				field.TooLong(opaqueDriverPath, "", 63).MarkAlpha().WithOrigin("maxLength").MarkAlpha(),
 			},
 		},
 		"invalid opaque driver, too long - 255 characters": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver(strings.Repeat("a", 255))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength"),
-				field.Invalid(opaqueDriverPath, "", "").WithOrigin("format=k8s-long-name-caseless"),
+				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength").MarkAlpha(),
+				field.Invalid(opaqueDriverPath, "", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
 			},
 		},
 		"invalid opaque driver, invalid character": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver("dra_example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(opaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless"),
+				field.Invalid(opaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
 			},
 		},
 		"invalid opaque driver, invalid DNS name (leading dot)": {
 			input: mkValidResourceClaim(tweakDeviceConfigWithDriver(".example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(opaqueDriverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless"),
+				field.Invalid(opaqueDriverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
 			},
 		},
 		// spec.Devices.Requests[%d].Exactly.Tolerations.Key
@@ -231,7 +231,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key"),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 			},
 		},
 		"invalid  Exactly.Tolerations.Key - multiple slashes": {
@@ -239,7 +239,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "a/b/c", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key"),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 			},
 		},
 		// spec.Devices.Requests[%d].FirsAvailable[%d].Tolerations.Key
@@ -258,7 +258,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key"),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 			},
 		},
 		"invalid FirstAvailable.Tolerations.Key - multiple slashes": {
@@ -266,7 +266,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				{Key: "a/b/c", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key"),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 			},
 		},
 		"valid DeviceAllocationMode - All": {
@@ -279,7 +279,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "allocationMode"),
 					resource.DeviceAllocationMode("InvalidMode"),
 					[]string{"All", "ExactCount"},
-				),
+				).MarkAlpha(),
 			},
 		},
 		"valid DeviceAllocationMode - FirstAvailable": {
@@ -292,7 +292,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("allocationMode"),
 					resource.DeviceAllocationMode("InvalidMode"),
 					[]string{"All", "ExactCount"},
-				),
+				).MarkAlpha(),
 			},
 		},
 		// spec.devices.requests[%d].firstAvailable[%d].deviceClassName
@@ -303,19 +303,19 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid firstAvailable class name - invalid characters": {
 			input: mkValidResourceClaim(tweakFirstAvailableDeviceClassName("Class&")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name"),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 			},
 		},
 		"invalid firstAvailable class name - long name": {
 			input: mkValidResourceClaim(tweakFirstAvailableDeviceClassName(strings.Repeat("a", 254))),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name"),
+				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
 			},
 		},
 		"invalid firstAvailable class name - empty": {
 			input: mkValidResourceClaim(tweakFirstAvailableDeviceClassName("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), ""),
+				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "").MarkAlpha(),
 			},
 		},
 		"valid DeviceTolerationOperator/Effect - Exactly": {
@@ -333,7 +333,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakExactlyTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
 			),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"), ""),
+				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"), "").MarkAlpha(),
 			},
 		},
 		"invalid DeviceTolerationOperator - Exactly": {
@@ -350,7 +350,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"),
 					resource.DeviceTolerationOperator("InvalidOp"),
 					[]string{"Equal", "Exists"},
-				),
+				).MarkAlpha(),
 			},
 		},
 		"invalid DeviceTaintEffect - Exactly": {
@@ -367,7 +367,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("effect"),
 					resource.DeviceTaintEffect("InvalidEffect"),
 					[]string{"NoExecute", "NoSchedule"},
-				),
+				).MarkAlpha(),
 			},
 		},
 		"valid DeviceTolerationOperator/Effect - FirstAvailable": {
@@ -386,7 +386,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakFirstAvailableTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
 			),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"), ""),
+				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"), "").MarkAlpha(),
 			},
 		},
 		"invalid DeviceTolerationOperator - FirstAvailable": {
@@ -403,7 +403,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"),
 					resource.DeviceTolerationOperator("InvalidOp"),
 					[]string{"Equal", "Exists"},
-				),
+				).MarkAlpha(),
 			},
 		},
 		"invalid DeviceTaintEffect - FirstAvailable": {
@@ -420,7 +420,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("effect"),
 					resource.DeviceTaintEffect("InvalidEffect"),
 					[]string{"NoExecute", "NoSchedule"},
-				),
+				).MarkAlpha(),
 			},
 		},
 		// Spec.Devices.Constraints[%d].MatchAttribute
@@ -429,7 +429,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("invalid!"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid!", "").WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid!", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
 			},
 		},
 		"match attribute without domain": {
@@ -437,7 +437,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("nodomain"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "nodomain", "a fully qualified name must be a domain and a name separated by a slash").WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "nodomain", "a fully qualified name must be a domain and a name separated by a slash").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
 			},
 		},
 		"match attribute empty": {
@@ -445,7 +445,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute(""),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
 			},
 		},
 		"match attribute with empty domain": {
@@ -453,7 +453,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("/foo"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
 			},
 		},
 		"match attribute with empty name": {
@@ -461,7 +461,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("foo/"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
 			},
 		},
 		"match attribute with invalid domain": {
@@ -469,7 +469,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("invalid_domain/foo"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid_domain", "").WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid_domain", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
 			},
 		},
 		"match attribute with invalid name": {
@@ -477,7 +477,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("domain/invalid-name"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid-name", "").WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid-name", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
 			},
 		},
 		"match attribute with long name": {
@@ -485,7 +485,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute("domain/" + strings.Repeat("a", 65)),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 64).WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 64).WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
 			},
 		},
 		"match attribute with long domain": {
@@ -493,8 +493,8 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakMatchAttribute(strings.Repeat("a", 254) + "/name"),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 63).WithOrigin("format=k8s-resource-fully-qualified-name"),
-				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 63).WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
 			},
 		},
 		// TODO: Add more test cases
@@ -734,35 +734,35 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			update: mkValidResourceClaim(tweakSpecChangeClassName("another-class")),
 			old:    validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"spec immutable: add request": {
 			update: mkValidResourceClaim(tweakAddDeviceRequest(mkDeviceRequest("req-1"))),
 			old:    validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"spec immutable: remove request": {
 			update: mkValidResourceClaim(tweakSpecRemoveRequest(0)),
 			old:    validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"spec immutable: add constraint": {
 			update: mkValidResourceClaim(tweakSpecAddConstraint(mkDeviceConstraint())),
 			old:    validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"spec immutable: short-circuits other errors (e.g. TooMany)": {
 			update: mkValidResourceClaim(tweakDevicesRequests(33)),
 			old:    mkValidResourceClaim(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"spec immutable: add Exactly.Tolerations": {
@@ -771,7 +771,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			})),
 			old: validClaim,
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"spec immutable: change Exactly.Tolerations.Key": {
@@ -782,7 +782,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				{Key: "valid-key", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		// spec.Devices.Requests[%d].FirsAvailable[%d].Tolerations.Key
@@ -792,7 +792,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			})),
 			old: mkValidResourceClaim(tweakFirstAvailable(1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"spec immutable: change FirstAvailable.Tolerations.Key": {
@@ -803,14 +803,14 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				{Key: "valid-key", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
 			})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"spec immutable: short-circuits deviceClassName error": {
 			update: mkValidResourceClaim(tweakFirstAvailableDeviceClassName("Class")),
 			old:    mkValidResourceClaim(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), "field is immutable", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		// TODO: Add more test cases
@@ -870,36 +870,28 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver("")),
 			expectedErrs: field.ErrorList{
-				field.Required(driverPath, ""),
+				field.Required(driverPath, "").MarkAlpha(),
 			},
 		},
 		"invalid driver name, too long - 64 characters": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(driverPath, "", 63).WithOrigin("maxLength"),
-			},
-		},
-		"invalid driver name, too long - 255 characters": {
-			old:    mkValidResourceClaim(),
-			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver(strings.Repeat("a", 255))),
-			expectedErrs: field.ErrorList{
-				field.TooLong(driverPath, "", 63).WithOrigin("maxLength"),
-				field.Invalid(driverPath, "", "").WithOrigin("format=k8s-long-name-caseless"),
+				field.TooLong(driverPath, "", 63).MarkAlpha().WithOrigin("maxLength"),
 			},
 		},
 		"invalid driver name, invalid character": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver("dra_example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(driverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless"),
+				field.Invalid(driverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
 			},
 		},
 		"invalid driver name, invalid DNS name (leading dot)": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultDriver(".example.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(driverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless"),
+				field.Invalid(driverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
 			},
 		},
 		// .Status.Allocation.Devices.Results[%d].Pool
@@ -915,42 +907,42 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("")),
 			expectedErrs: field.ErrorList{
-				field.Required(poolPath, ""),
+				field.Required(poolPath, "").MarkAlpha(),
 			},
 		},
 		"invalid pool name, too long": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool(strings.Repeat("a", 253) + "/" + strings.Repeat("a", 253))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(poolPath, "", 253).WithOrigin("format=k8s-resource-pool-name"),
+				field.TooLong(poolPath, "", 253).WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
 			},
 		},
 		"invalid pool name, format": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("a/Not_Valid")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(poolPath, "Not_Valid", "").WithOrigin("format=k8s-resource-pool-name"),
+				field.Invalid(poolPath, "Not_Valid", "").WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
 			},
 		},
 		"invalid pool name, leading slash": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("/a")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name"),
+				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
 			},
 		},
 		"invalid pool name, trailing slash": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("a/")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name"),
+				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
 			},
 		},
 		"invalid pool name, double slash": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultPool("a//b")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name"),
+				field.Invalid(poolPath, "", "").WithOrigin("format=k8s-resource-pool-name").MarkAlpha(),
 			},
 		},
 		// .Status.Allocation.Devices.Results[%d].ShareID
@@ -962,14 +954,14 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultShareID("invalid-uid")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "").WithOrigin("format=k8s-uuid"),
+				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "").WithOrigin("format=k8s-uuid").MarkAlpha(),
 			},
 		},
 		"invalid uppercase status.Allocation.Devices.Results[].ShareID ": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusDeviceRequestAllocationResultShareID("123e4567-E89b-12d3-A456-426614174000")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "").WithOrigin("format=k8s-uuid"),
+				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "").WithOrigin("format=k8s-uuid").MarkAlpha(),
 			},
 		},
 		// .Status.Devices[%d].ShareID
@@ -989,8 +981,8 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakStatusAllocatedDeviceStatusShareID("invalid-uid"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid"),
-				field.Invalid(field.NewPath("status", "devices").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid"),
+				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkAlpha(),
 			},
 		},
 		"invalid upper case status.Devices[].ShareID": {
@@ -1001,8 +993,8 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakStatusAllocatedDeviceStatusShareID("123e4567-E89b-12d3-A456-426614174000"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid"),
-				field.Invalid(field.NewPath("status", "devices").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid"),
+				field.Invalid(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkAlpha(),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("shareID"), "invalid-uid", "must be a lowercase UUID in 8-4-4-4-12 format").WithOrigin("format=k8s-uuid").MarkAlpha(),
 			},
 		},
 		// UID in status.ReservedFor
@@ -1015,7 +1007,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 					resourceClaimReference(validUUID),
 				)),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "reservedFor").Index(2), ""),
+				field.Duplicate(field.NewPath("status", "reservedFor").Index(2), "").MarkAlpha(),
 			},
 		},
 		"multiple- duplicate uid in status.ReservedFor": {
@@ -1029,8 +1021,8 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				resourceClaimReference(uuid.New().String()),
 			)),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "reservedFor").Index(2), ""),
-				field.Duplicate(field.NewPath("status", "reservedFor").Index(4), ""),
+				field.Duplicate(field.NewPath("status", "reservedFor").Index(2), "").MarkAlpha(),
+				field.Duplicate(field.NewPath("status", "reservedFor").Index(4), "").MarkAlpha(),
 			},
 		},
 		"invalid status.ReservedFor, too many": {
@@ -1039,7 +1031,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakStatusReservedFor(generateResourceClaimReferences(257)...),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "reservedFor"), 257, 256).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("status", "reservedFor"), 257, 256).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"valid status.ReservedFor, max items": {
@@ -1070,35 +1062,35 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 			old:    mkResourceClaimWithStatus(),
 			update: tweakStatusAllocationDevice(mkResourceClaimWithStatus(), "device-different"),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update"),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
 			},
 		},
 		"invalid status.allocation changed driver (NoModify)": {
 			old:    mkResourceClaimWithStatus(),
 			update: tweakStatusAllocationDriver(mkResourceClaimWithStatus(), "different.example.com"),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update"),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
 			},
 		},
 		"invalid status.allocation changed pool (NoModify)": {
 			old:    mkResourceClaimWithStatus(),
 			update: tweakStatusAllocationPool(mkResourceClaimWithStatus(), "different-pool"),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update"),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
 			},
 		},
 		"invalid status.allocation added result (NoModify)": {
 			old:    mkResourceClaimWithStatus(),
 			update: addStatusAllocationResult(mkResourceClaimWithStatus()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update"),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
 			},
 		},
 		"invalid status.allocation removed result (NoModify)": {
 			old:    addStatusAllocationResult(mkResourceClaimWithStatus()),
 			update: mkResourceClaimWithStatus(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update"),
+				field.Invalid(field.NewPath("status", "allocation"), nil, "field is immutable").WithOrigin("update").MarkAlpha(),
 			},
 		},
 		"invalid status.allocation.devices.results, too many": {
@@ -1107,7 +1099,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakStatusAllocationDevicesResults(33),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "results"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "results"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"valid status.allocation.devices.config, max items": {
@@ -1122,7 +1114,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakStatusAllocationDevicesConfig(65),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "config"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid status.allocation.devices.config requests, duplicate": {
@@ -1131,7 +1123,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakAddStatusAllocationConfigRequest("req-0"),
 			),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "allocation", "devices", "config").Index(0).Child("requests").Index(1), "req-0"),
+				field.Duplicate(field.NewPath("status", "allocation", "devices", "config").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
 			},
 		},
 		// .Status.Allocation.Devices.Config[%d].Source
@@ -1147,14 +1139,14 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigSource("")),
 			expectedErrs: field.ErrorList{
-				field.Required(configSourcePath, "").MarkCoveredByDeclarative(),
+				field.Required(configSourcePath, "").MarkCoveredByDeclarative().MarkAlpha(),
 			},
 		},
 		"invalid status.allocation.devices.config source invalid": {
 			old:    mkValidResourceClaim(),
 			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigSource("invalid")),
 			expectedErrs: field.ErrorList{
-				field.NotSupported(configSourcePath, resource.AllocationConfigSource("invalid"), []string{string(resource.AllocationConfigSourceClaim), string(resource.AllocationConfigSourceClass)}).MarkCoveredByDeclarative(),
+				field.NotSupported(configSourcePath, resource.AllocationConfigSource("invalid"), []string{string(resource.AllocationConfigSourceClaim), string(resource.AllocationConfigSourceClass)}).MarkCoveredByDeclarative().MarkAlpha(),
 			},
 		},
 		// .Status.Devices
@@ -1196,7 +1188,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "devices").Index(1), "driver1/pool1/device1"),
+				field.Duplicate(field.NewPath("status", "devices").Index(1), "driver1/pool1/device1").MarkAlpha(),
 			},
 		},
 		"invalid devices, duplicate with share ID": {
@@ -1211,7 +1203,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "devices").Index(1), "driver1/pool1/device1"),
+				field.Duplicate(field.NewPath("status", "devices").Index(1), "driver1/pool1/device1").MarkAlpha(),
 			},
 		},
 		// .Status.Allocation.Devices.Results[%d].BindingConditions
@@ -1229,7 +1221,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakStatusBindingFailureConditions(1),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"valid binding failure conditions, max items": {
@@ -1246,7 +1238,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakStatusBindingFailureConditions(resource.BindingFailureConditionsMaxSize+1),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "results").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		// .Status.Devices[%d].NetworkData.InterfaceName
@@ -1280,7 +1272,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "interfaceName"), "", resource.NetworkDeviceDataInterfaceNameMaxLength).MarkCoveredByDeclarative().WithOrigin("maxLength"),
+				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "interfaceName"), "", resource.NetworkDeviceDataInterfaceNameMaxLength).MarkCoveredByDeclarative().WithOrigin("maxLength").MarkAlpha(),
 			},
 		},
 		"valid status.devices.networkData.hardwareAddress": {
@@ -1313,7 +1305,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "hardwareAddress"), "", resource.NetworkDeviceDataHardwareAddressMaxLength).MarkCoveredByDeclarative().WithOrigin("maxLength"),
+				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "hardwareAddress"), "", resource.NetworkDeviceDataHardwareAddressMaxLength).MarkCoveredByDeclarative().WithOrigin("maxLength").MarkAlpha(),
 			},
 		},
 		"invalid status.devices.networkData.ips duplicate": {
@@ -1331,7 +1323,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				),
 			),
 			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(1), "1.2.3.4/32"),
+				field.Duplicate(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(1), "1.2.3.4/32").MarkAlpha(),
 			},
 		},
 		"invalid status.allocation.devices.config.requests too many": {
@@ -1340,7 +1332,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakStatusAllocationConfigRequests(33),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "allocation", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("status", "allocation", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"valid status.allocation.devices.config.requests, max allowed": {
@@ -1355,7 +1347,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 				tweakStatusDevicesTooManyIPs(17),
 			),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("status", "devices").Index(0).Child("networkData", "ips"), 17, 16).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("status", "devices").Index(0).Child("networkData", "ips"), 17, 16).WithOrigin("maxItems").MarkAlpha(),
 			},
 		},
 		"invalid status.devices.networkData.ips, max allowed": {

--- a/pkg/registry/resource/resourceslice/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceslice/declarative_validation_test.go
@@ -60,7 +60,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: too many binding conditions": {
 					input: mkResourceSliceWithDevices(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				// spec.devices[%d].bindingFailureConditions
@@ -73,7 +73,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: too many binding failure conditions": {
 					input: mkResourceSliceWithDevices(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				// spec.Devices[%d].Taints[%d].Effect
@@ -88,13 +88,13 @@ func TestDeclarativeValidate(t *testing.T) {
 					expectedErrs: field.ErrorList{
 						field.NotSupported(
 							field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"),
-							resource.DeviceTaintEffect("Invalid"), []string{}),
+							resource.DeviceTaintEffect("Invalid"), []string{}).MarkAlpha(),
 					},
 				},
 				"invalid: taint empty": {
 					input: mkResourceSliceWithDevices(tweakDeviceTaintEffect("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), ""),
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "").MarkAlpha(),
 					},
 				},
 				// spec.Devices[%].attribute
@@ -113,13 +113,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: device attribute with multiple values": {
 					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union"),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union").MarkAlpha(),
 					},
 				},
 				"invalid: device attribute no value": {
 					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union"),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters
@@ -129,7 +129,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: too many shared counters": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCounters(resource.ResourceSliceMaxCounterSets + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				// spec.devices.consumesCounters
@@ -139,7 +139,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: too many device consumes counters": {
 					input: mkResourceSliceWithDevices(tweakDeviceConsumesCounters(resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters.name
@@ -149,13 +149,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: counter set name": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("InvalidKey")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				"invalid: counter set name not set": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), ""),
+						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "").MarkAlpha(),
 					},
 				},
 				// spec.devices.consumesCounters.counterSet
@@ -165,13 +165,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: device consumes counters counter set name": {
 					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("InvalidKey")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				"invalid: device consumes counters counter set name not set": {
 					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), ""),
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters
@@ -181,7 +181,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: duplicate names for shared counters": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("duplicate-key", "duplicate-key")),
 					expectedErrs: field.ErrorList{
-						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key"),
+						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key").MarkAlpha(),
 					},
 				},
 				// spec.devices.consumesCounters
@@ -191,14 +191,14 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: duplicate names for counter set in device counter consumption": {
 					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("duplicate-key", "duplicate-key")),
 					expectedErrs: field.ErrorList{
-						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key"),
+						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters.counters
 				"invalid: shared counter key with uppercase": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				"valid: shared counter key": {
@@ -208,7 +208,7 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: device counter key with uppercase": {
 					input: mkResourceSliceWithDevices(tweakDeviceCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				"valid: device counter key": {
@@ -255,7 +255,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				// spec.devices[%d].bindingFailureConditions
@@ -267,7 +267,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				// spec.devices.taints.effect
@@ -283,14 +283,14 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceTaintEffect("InvalidEffect")),
 					expectedErrs: field.ErrorList{
-						field.NotSupported(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "InvalidEffect", []string{string(resource.DeviceTaintEffectNoSchedule), string(resource.DeviceTaintEffectNoExecute)}),
+						field.NotSupported(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "InvalidEffect", []string{string(resource.DeviceTaintEffectNoSchedule), string(resource.DeviceTaintEffectNoExecute)}).MarkAlpha(),
 					},
 				},
 				"invalid update: empty taint effect": {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceTaintEffect("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), ""),
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "").MarkAlpha(),
 					},
 				},
 				"valid update: device attribute": {
@@ -301,7 +301,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union"),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters
@@ -313,7 +313,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCounters(resource.ResourceSliceMaxCounterSets + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				// spec.devices.consumesCounters
@@ -325,7 +325,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceConsumesCounters(resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice + 1)),
 					expectedErrs: field.ErrorList{
-						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems"),
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters.name
@@ -337,14 +337,14 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("InvalidKey")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				"invalid update: counter set name not set": {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), ""),
+						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "").MarkAlpha(),
 					},
 				},
 				// spec.devices.consumesCounters.counterSet
@@ -356,14 +356,14 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("InvalidKey")),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				"invalidupdate: device consumes counters counter set name not set": {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("")),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), ""),
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters
@@ -375,7 +375,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("duplicate-key", "duplicate-key")),
 					expectedErrs: field.ErrorList{
-						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key"),
+						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key").MarkAlpha(),
 					},
 				},
 				// spec.devices.consumesCounters
@@ -387,7 +387,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("duplicate-key", "duplicate-key")),
 					expectedErrs: field.ErrorList{
-						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key"),
+						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters.counters
@@ -395,7 +395,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters.counters: nil -> invalid
@@ -403,7 +403,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithSharedCounters(tweakSharedCounter(nil)),
 					update: mkResourceSliceWithSharedCounters(tweakSharedCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				// spec.devices.consumesCounters.counters
@@ -411,7 +411,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 				// spec.devices.consumesCounters.counters: nil -> invalid
@@ -419,7 +419,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(tweakDeviceCounter(nil)),
 					update: mkResourceSliceWithDevices(tweakDeviceCounter(counters("InvalidKey"))),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name").MarkAlpha(),
 					},
 				},
 			}

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -58,7 +58,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				obj.Provisioner = ""
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("provisioner"), ""),
+				field.Required(field.NewPath("provisioner"), "").MarkAlpha(),
 			},
 		},
 		// TODO: Add more test cases
@@ -92,86 +92,86 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakProvisioner("kubernetes.io/aws-ebs")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update provisioner unset to set": {
 			oldObj:    mkValidStorageClass(TweakProvisioner("")),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update provisioner set to unset": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakProvisioner("")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable"),
-				field.Required(field.NewPath("provisioner"), ""),
+				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkAlpha(),
+				field.Required(field.NewPath("provisioner"), "").MarkAlpha(),
 			},
 		},
 		"invalid update parameters changed": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"new": "value"})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update parameters unset to set": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakParameters(map[string]string{"foo": "bar"})),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update parameters set to unset": {
 			oldObj:    mkValidStorageClass(TweakParameters(map[string]string{"foo": "bar"})),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("parameters"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update reclaimPolicy changed": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakReclaimPolicy(api.PersistentVolumeReclaimRetain)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update reclaimPolicy unset to set": {
 			oldObj:    mkValidStorageClass(TweakReclaimPolicyNil()),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update reclaimPolicy set to unset": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakReclaimPolicyNil()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("reclaimPolicy"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update volumeBindingMode changed": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakVolumeBindingMode(storage.VolumeBindingWaitForFirstConsumer)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update volumeBindingMode unset to set": {
 			oldObj:    mkValidStorageClass(TweakVolumeBindingModeNil()),
 			updateObj: mkValidStorageClass(),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 		"invalid update volumeBindingMode set to unset": {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakVolumeBindingModeNil()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable"),
 				field.Required(field.NewPath("volumeBindingMode"), "").MarkFromImperative(),
+				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 	}

--- a/pkg/registry/storage/volumeattachment/declarative_validation_test.go
+++ b/pkg/registry/storage/volumeattachment/declarative_validation_test.go
@@ -70,19 +70,19 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid attacher (required)": {
 			input: mkValidVolumeAttachment(TweakAttacher("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "attacher"), ""),
+				field.Required(field.NewPath("spec", "attacher"), "").MarkAlpha(),
 			},
 		},
 		"attacher with special characters": {
 			input: mkValidVolumeAttachment(TweakAttacher("asdadasd&@!")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "attacher"), "", "").WithOrigin("format=k8s-long-name-caseless"),
+				field.Invalid(field.NewPath("spec", "attacher"), "", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
 			},
 		},
 		"attacher with number of characters exceeds 63": {
 			input: mkValidVolumeAttachment(TweakAttacher(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("spec", "attacher"), strings.Repeat("a", 64), 63).WithOrigin("maxLength"),
+				field.TooLong(field.NewPath("spec", "attacher"), strings.Repeat("a", 64), 63).WithOrigin("maxLength").MarkAlpha(),
 			},
 		},
 	}
@@ -116,7 +116,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldInput: mkValidVolumeAttachment(),
 			newInput: mkValidVolumeAttachment(TweakAttacher("different.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec"), nil, "field is immutable").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
@@ -926,7 +926,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -985,7 +985,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // Required.
   // +listType=set
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   repeated string validationActions = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -476,7 +476,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -535,7 +535,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// Required.
 	// +listType=set
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	ValidationActions []ValidationAction `json:"validationActions,omitempty" protobuf:"bytes,4,rep,name=validationActions"`
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
@@ -648,7 +648,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -707,7 +707,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // Required.
   // +listType=set
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   repeated string validationActions = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
@@ -416,7 +416,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -475,7 +475,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// Required.
 	// +listType=set
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	ValidationActions []ValidationAction `json:"validationActions,omitempty" protobuf:"bytes,4,rep,name=validationActions"`
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
@@ -874,7 +874,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -933,7 +933,7 @@ message ValidatingAdmissionPolicyBindingSpec {
   // Required.
   // +listType=set
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   repeated string validationActions = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -429,7 +429,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -488,7 +488,7 @@ type ValidatingAdmissionPolicyBindingSpec struct {
 	// Required.
 	// +listType=set
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	ValidationActions []ValidationAction `json:"validationActions,omitempty" protobuf:"bytes,4,rep,name=validationActions"`
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -318,9 +318,9 @@ message Scale {
 message ScaleSpec {
   // replicas is the number of observed instances of the scaled object.
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +default=0
-  // +k8s:minimum=0
+  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
   optional int32 replicas = 1;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -33,9 +33,9 @@ const (
 type ScaleSpec struct {
 	// replicas is the number of observed instances of the scaled object.
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +default=0
-	// +k8s:minimum=0
+	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -616,9 +616,9 @@ message Scale {
 message ScaleSpec {
   // desired number of instances for the scaled object.
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +default=0
-  // +k8s:minimum=0
+  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
   optional int32 replicas = 1;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -35,9 +35,9 @@ const (
 type ScaleSpec struct {
 	// desired number of instances for the scaled object.
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +default=0
-	// +k8s:minimum=0
+	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -202,15 +202,15 @@ message HorizontalPodAutoscalerSpec {
   // metric is configured.  Scaling is active as long as at least one metric value is
   // available.
   // +optional
-  // +k8s:optional
-  // +k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
-  // +k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+  // +k8s:alpha(since: "1.36")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
   optional int32 minReplicas = 2;
 
   // maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
   // +required
-  // +k8s:required
-  // +k8s:minimum=1
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:minimum=1
   optional int32 maxReplicas = 3;
 
   // targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
@@ -478,9 +478,9 @@ message Scale {
 message ScaleSpec {
   // replicas is the desired number of instances for the scaled object.
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +default=0
-  // +k8s:minimum=0
+  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
   optional int32 replicas = 1;
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -47,15 +47,15 @@ type HorizontalPodAutoscalerSpec struct {
 	// metric is configured.  Scaling is active as long as at least one metric value is
 	// available.
 	// +optional
-	// +k8s:optional
-	// +k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
-	// +k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+	// +k8s:alpha(since: "1.36")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
 
 	// maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
 	// +required
-	// +k8s:required
-	// +k8s:minimum=1
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:minimum=1
 	MaxReplicas int32 `json:"maxReplicas" protobuf:"varint,3,opt,name=maxReplicas"`
 
 	// targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
@@ -145,9 +145,9 @@ type Scale struct {
 type ScaleSpec struct {
 	// replicas is the desired number of instances for the scaled object.
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +default=0
-	// +k8s:minimum=0
+	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -248,16 +248,16 @@ message HorizontalPodAutoscalerSpec {
   // metric is configured.  Scaling is active as long as at least one metric value is
   // available.
   // +optional
-  // +k8s:optional
-  // +k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
-  // +k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+  // +k8s:alpha(since: "1.36")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
   optional int32 minReplicas = 2;
 
   // maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
   // It cannot be less that minReplicas.
   // +required
-  // +k8s:required
-  // +k8s:minimum=1
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:minimum=1
   optional int32 maxReplicas = 3;
 
   // metrics contains the specifications for which to use to calculate the

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -59,16 +59,16 @@ type HorizontalPodAutoscalerSpec struct {
 	// metric is configured.  Scaling is active as long as at least one metric value is
 	// available.
 	// +optional
-	// +k8s:optional
-	// +k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
-	// +k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:ifEnabled(HPAScaleToZero)=+k8s:minimum=0
+	// +k8s:alpha(since: "1.36")=+k8s:ifDisabled(HPAScaleToZero)=+k8s:minimum=1
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
 
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
 	// It cannot be less that minReplicas.
 	// +required
-	// +k8s:required
-	// +k8s:minimum=1
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:minimum=1
 	MaxReplicas int32 `json:"maxReplicas" protobuf:"varint,3,opt,name=maxReplicas"`
 
 	// metrics contains the specifications for which to use to calculate the

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -62,7 +62,7 @@ message CronJobList {
 message CronJobSpec {
   // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string schedule = 1;
 
   // The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -716,7 +716,7 @@ type CronJobSpec struct {
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Schedule string `json:"schedule" protobuf:"bytes,1,opt,name=schedule"`
 
 	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/batch/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1beta1/generated.proto
@@ -63,7 +63,7 @@ message CronJobList {
 message CronJobSpec {
   // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string schedule = 1;
 
   // The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/batch/v1beta1/types.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/types.go
@@ -85,7 +85,7 @@ type CronJobSpec struct {
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Schedule string `json:"schedule" protobuf:"bytes,1,opt,name=schedule"`
 
 	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -204,12 +204,12 @@ message CertificateSigningRequestStatus {
   // +listType=map
   // +listMapKey=type
   // +optional
-  // +k8s:listType=map
-  // +k8s:listMapKey=type
-  // +k8s:customUnique
-  // +k8s:optional
-  // +k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
-  // +k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
+  // +k8s:alpha(since: "1.36")=+k8s:listType=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=type
+  // +k8s:alpha(since: "1.36")=+k8s:customUnique
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+  // +k8s:alpha(since: "1.36")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
   repeated CertificateSigningRequestCondition conditions = 1;
 
   // certificate is populated with an issued certificate by the signer after an Approved condition is present.

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -179,12 +179,12 @@ type CertificateSigningRequestStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	// +k8s:listType=map
-	// +k8s:listMapKey=type
-	// +k8s:customUnique
-	// +k8s:optional
-	// +k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
-	// +k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
+	// +k8s:alpha(since: "1.36")=+k8s:listType=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=type
+	// +k8s:alpha(since: "1.36")=+k8s:customUnique
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+	// +k8s:alpha(since: "1.36")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
 	Conditions []CertificateSigningRequestCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 
 	// certificate is populated with an issued certificate by the signer after an Approved condition is present.

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -183,12 +183,12 @@ message CertificateSigningRequestStatus {
   // +listType=map
   // +listMapKey=type
   // +optional
-  // +k8s:listType=map
-  // +k8s:listMapKey=type
-  // +k8s:customUnique
-  // +k8s:optional
-  // +k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
-  // +k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
+  // +k8s:alpha(since: "1.36")=+k8s:listType=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=type
+  // +k8s:alpha(since: "1.36")=+k8s:customUnique
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+  // +k8s:alpha(since: "1.36")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
   repeated CertificateSigningRequestCondition conditions = 1;
 
   // If request was approved, the controller will place the issued certificate here.

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -177,12 +177,12 @@ type CertificateSigningRequestStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	// +k8s:listType=map
-	// +k8s:listMapKey=type
-	// +k8s:customUnique
-	// +k8s:optional
-	// +k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
-	// +k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
+	// +k8s:alpha(since: "1.36")=+k8s:listType=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=type
+	// +k8s:alpha(since: "1.36")=+k8s:customUnique
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+	// +k8s:alpha(since: "1.36")=+k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
 	Conditions []CertificateSigningRequestCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 
 	// If request was approved, the controller will place the issued certificate here.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5305,8 +5305,8 @@ message ReplicationController {
   // be the same as the Pod(s) that the replication controller manages.
   // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  // +k8s:subfield(name)=+k8s:optional
-  // +k8s:subfield(name)=+k8s:format=k8s-long-name
+  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the specification of the desired behavior of the replication controller.
@@ -5363,18 +5363,18 @@ message ReplicationControllerSpec {
   // Defaults to 1.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +default=1
-  // +k8s:minimum=0
+  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
   optional int32 replicas = 1;
 
   // Minimum number of seconds for which a newly created pod should be ready
   // without any of its container crashing, for it to be considered available.
   // Defaults to 0 (pod will be considered available as soon as it is ready)
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +default=0
-  // +k8s:minimum=0
+  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
   optional int32 minReadySeconds = 4;
 
   // Selector is a label query over pods that should match the Replicas count.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5550,18 +5550,18 @@ type ReplicationControllerSpec struct {
 	// Defaults to 1.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +default=1
-	// +k8s:minimum=0
+	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
 	Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing, for it to be considered available.
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +default=0
-	// +k8s:minimum=0
+	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty" protobuf:"varint,4,opt,name=minReadySeconds"`
 
 	// Selector is a label query over pods that should match the Replicas count.
@@ -5661,8 +5661,8 @@ type ReplicationController struct {
 	// be the same as the Pod(s) that the replication controller manages.
 	// Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
-	// +k8s:subfield(name)=+k8s:optional
-	// +k8s:subfield(name)=+k8s:format=k8s-long-name
+	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines the specification of the desired behavior of the replication controller.

--- a/staging/src/k8s.io/api/discovery/v1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1/generated.proto
@@ -39,8 +39,8 @@ message Endpoint {
   // additional addresses beyond the first, and kube-proxy does not look at them.
   // +listType=set
   // +required
-  // +k8s:required
-  // +k8s:maxItems=100
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=100
   repeated string addresses = 1;
 
   // conditions contains information about the current status of the endpoint.
@@ -185,15 +185,15 @@ message EndpointSlice {
   // slices of addressType "IPv4" and "IPv6". No semantics are defined for
   // the "FQDN" type.
   // +required
-  // +k8s:required
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional string addressType = 4;
 
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated Endpoint endpoints = 2;
 
   // ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/discovery/v1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1/generated.proto
@@ -193,6 +193,7 @@ message EndpointSlice {
   // include a maximum of 1000 endpoints.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Endpoint endpoints = 2;
 
   // ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -57,6 +57,7 @@ type EndpointSlice struct {
 	// include a maximum of 1000 endpoints.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
 
 	// ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -49,15 +49,15 @@ type EndpointSlice struct {
 	// slices of addressType "IPv4" and "IPv6". No semantics are defined for
 	// the "FQDN" type.
 	// +required
-	// +k8s:required
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
 
 	// ports specifies the list of network ports exposed by each endpoint in
@@ -73,7 +73,7 @@ type EndpointSlice struct {
 
 // AddressType represents the type of address referred to by an endpoint.
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type AddressType string
 
 const (
@@ -97,8 +97,8 @@ type Endpoint struct {
 	// additional addresses beyond the first, and kube-proxy does not look at them.
 	// +listType=set
 	// +required
-	// +k8s:required
-	// +k8s:maxItems=100
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=100
 	Addresses []string `json:"addresses" protobuf:"bytes,1,rep,name=addresses"`
 
 	// conditions contains information about the current status of the endpoint.

--- a/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
@@ -178,6 +178,7 @@ message EndpointSlice {
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
   // +listType=atomic
+  // +k8s:optional
   repeated Endpoint endpoints = 2;
 
   // ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
@@ -39,8 +39,8 @@ message Endpoint {
   // use the first element. Refer to: https://issue.k8s.io/106267
   // +listType=set
   // +required
-  // +k8s:required
-  // +k8s:maxItems=100
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=100
   repeated string addresses = 1;
 
   // conditions contains information about the current status of the endpoint.
@@ -171,14 +171,14 @@ message EndpointSlice {
   // * IPv6: Represents an IPv6 Address.
   // * FQDN: Represents a Fully Qualified Domain Name.
   // +required
-  // +k8s:required
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional string addressType = 4;
 
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated Endpoint endpoints = 2;
 
   // ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -46,14 +46,14 @@ type EndpointSlice struct {
 	// * IPv6: Represents an IPv6 Address.
 	// * FQDN: Represents a Fully Qualified Domain Name.
 	// +required
-	// +k8s:required
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
 
 	// ports specifies the list of network ports exposed by each endpoint in
@@ -68,7 +68,7 @@ type EndpointSlice struct {
 
 // AddressType represents the type of address referred to by an endpoint.
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type AddressType string
 
 const (
@@ -92,8 +92,8 @@ type Endpoint struct {
 	// use the first element. Refer to: https://issue.k8s.io/106267
 	// +listType=set
 	// +required
-	// +k8s:required
-	// +k8s:maxItems=100
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=100
 	Addresses []string `json:"addresses" protobuf:"bytes,1,rep,name=addresses"`
 
 	// conditions contains information about the current status of the endpoint.

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -53,6 +53,7 @@ type EndpointSlice struct {
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
 	// +listType=atomic
+	// +k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
 
 	// ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -688,6 +688,7 @@ message NetworkPolicyEgressRule {
   // allows traffic only if the traffic matches at least one item in the to list.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated NetworkPolicyPeer to = 2;
 }
 
@@ -710,6 +711,7 @@ message NetworkPolicyIngressRule {
   // traffic matches at least one item in the from list.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated NetworkPolicyPeer from = 2;
 }
 
@@ -792,6 +794,7 @@ message NetworkPolicySpec {
   // (and serves solely to ensure that the pods it selects are isolated by default).
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated NetworkPolicyIngressRule ingress = 2;
 
   // List of egress rules to be applied to the selected pods. Outgoing traffic is
@@ -803,6 +806,7 @@ message NetworkPolicySpec {
   // This field is beta-level in 1.8
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated NetworkPolicyEgressRule egress = 3;
 
   // List of rule types that the NetworkPolicy relates to.

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -429,7 +429,7 @@ message IPBlock {
   // CIDR is a string representing the IP Block
   // Valid examples are "192.168.1.0/24" or "2001:db8::/64"
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string cidr = 1;
 
   // Except is a slice of CIDRs that should not be included within an IP Block
@@ -688,7 +688,7 @@ message NetworkPolicyEgressRule {
   // allows traffic only if the traffic matches at least one item in the to list.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated NetworkPolicyPeer to = 2;
 }
 
@@ -711,7 +711,7 @@ message NetworkPolicyIngressRule {
   // traffic matches at least one item in the from list.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated NetworkPolicyPeer from = 2;
 }
 
@@ -750,7 +750,7 @@ message NetworkPolicyPeer {
   // IPBlock defines policy on a particular IPBlock. If this field is set then
   // neither of the other fields can be.
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional IPBlock ipBlock = 3;
 }
 
@@ -794,7 +794,7 @@ message NetworkPolicySpec {
   // (and serves solely to ensure that the pods it selects are isolated by default).
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated NetworkPolicyIngressRule ingress = 2;
 
   // List of egress rules to be applied to the selected pods. Outgoing traffic is
@@ -806,7 +806,7 @@ message NetworkPolicySpec {
   // This field is beta-level in 1.8
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated NetworkPolicyEgressRule egress = 3;
 
   // List of rule types that the NetworkPolicy relates to.
@@ -1046,9 +1046,9 @@ message Scale {
 message ScaleSpec {
   // desired number of instances for the scaled object.
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +default=0
-  // +k8s:minimum=0
+  // +k8s:alpha(since: "1.36")=+k8s:minimum=0
   optional int32 replicas = 1;
 }
 

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -1106,6 +1106,7 @@ type NetworkPolicySpec struct {
 	// (and serves solely to ensure that the pods it selects are isolated by default).
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Ingress []NetworkPolicyIngressRule `json:"ingress,omitempty" protobuf:"bytes,2,rep,name=ingress"`
 
 	// List of egress rules to be applied to the selected pods. Outgoing traffic is
@@ -1117,6 +1118,7 @@ type NetworkPolicySpec struct {
 	// This field is beta-level in 1.8
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Egress []NetworkPolicyEgressRule `json:"egress,omitempty" protobuf:"bytes,3,rep,name=egress"`
 
 	// List of rule types that the NetworkPolicy relates to.
@@ -1153,6 +1155,7 @@ type NetworkPolicyIngressRule struct {
 	// traffic matches at least one item in the from list.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	From []NetworkPolicyPeer `json:"from,omitempty" protobuf:"bytes,2,rep,name=from"`
 }
 
@@ -1177,6 +1180,7 @@ type NetworkPolicyEgressRule struct {
 	// allows traffic only if the traffic matches at least one item in the to list.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	To []NetworkPolicyPeer `json:"to,omitempty" protobuf:"bytes,2,rep,name=to"`
 }
 

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -27,9 +27,9 @@ import (
 type ScaleSpec struct {
 	// desired number of instances for the scaled object.
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +default=0
-	// +k8s:minimum=0
+	// +k8s:alpha(since: "1.36")=+k8s:minimum=0
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 
@@ -1106,7 +1106,7 @@ type NetworkPolicySpec struct {
 	// (and serves solely to ensure that the pods it selects are isolated by default).
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Ingress []NetworkPolicyIngressRule `json:"ingress,omitempty" protobuf:"bytes,2,rep,name=ingress"`
 
 	// List of egress rules to be applied to the selected pods. Outgoing traffic is
@@ -1118,7 +1118,7 @@ type NetworkPolicySpec struct {
 	// This field is beta-level in 1.8
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Egress []NetworkPolicyEgressRule `json:"egress,omitempty" protobuf:"bytes,3,rep,name=egress"`
 
 	// List of rule types that the NetworkPolicy relates to.
@@ -1155,7 +1155,7 @@ type NetworkPolicyIngressRule struct {
 	// traffic matches at least one item in the from list.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	From []NetworkPolicyPeer `json:"from,omitempty" protobuf:"bytes,2,rep,name=from"`
 }
 
@@ -1180,7 +1180,7 @@ type NetworkPolicyEgressRule struct {
 	// allows traffic only if the traffic matches at least one item in the to list.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	To []NetworkPolicyPeer `json:"to,omitempty" protobuf:"bytes,2,rep,name=to"`
 }
 
@@ -1214,7 +1214,7 @@ type IPBlock struct {
 	// CIDR is a string representing the IP Block
 	// Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	CIDR string `json:"cidr" protobuf:"bytes,1,name=cidr"`
 	// Except is a slice of CIDRs that should not be included within an IP Block
 	// Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -1247,7 +1247,7 @@ type NetworkPolicyPeer struct {
 	// IPBlock defines policy on a particular IPBlock. If this field is set then
 	// neither of the other fields can be.
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	IPBlock *IPBlock `json:"ipBlock,omitempty" protobuf:"bytes,3,rep,name=ipBlock"`
 }
 

--- a/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.validations.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.validations.go
@@ -116,6 +116,14 @@ func Validate_NetworkPolicyEgressRule(ctx context.Context, op operation.Operatio
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyPeer)...)
 			return
@@ -135,6 +143,14 @@ func Validate_NetworkPolicyIngressRule(ctx context.Context, op operation.Operati
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyPeer)...)
@@ -185,6 +201,14 @@ func Validate_NetworkPolicySpec(ctx context.Context, op operation.Operation, fld
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyIngressRule)...)
 			return
@@ -196,6 +220,14 @@ func Validate_NetworkPolicySpec(ctx context.Context, op operation.Operation, fld
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyEgressRule)...)

--- a/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.validations.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.validations.go
@@ -69,7 +69,7 @@ func Validate_IPBlock(ctx context.Context, op operation.Operation, fldPath *fiel
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -118,7 +118,7 @@ func Validate_NetworkPolicyEgressRule(ctx context.Context, op operation.Operatio
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -146,7 +146,7 @@ func Validate_NetworkPolicyIngressRule(ctx context.Context, op operation.Operati
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -175,7 +175,7 @@ func Validate_NetworkPolicyPeer(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -203,7 +203,7 @@ func Validate_NetworkPolicySpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -223,7 +223,7 @@ func Validate_NetworkPolicySpec(ctx context.Context, op operation.Operation, fld
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -266,13 +266,12 @@ func Validate_ScaleSpec(ctx context.Context, op operation.Operation, fldPath *fi
 	// field ScaleSpec.Replicas
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
-			// optional value-type fields with zero-value defaults are purely documentation
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)...)
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha()...)
 			return
 		}(fldPath.Child("replicas"), &obj.Replicas, safe.Field(oldObj, func(oldObj *ScaleSpec) *int32 { return &oldObj.Replicas }), oldObj != nil)...)
 

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -455,6 +455,7 @@ message NetworkPolicyEgressRule {
   // allows traffic only if the traffic matches at least one item in the to list.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated NetworkPolicyPeer to = 2;
 }
 
@@ -477,6 +478,7 @@ message NetworkPolicyIngressRule {
   // allows traffic only if the traffic matches at least one item in the from list.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated NetworkPolicyPeer from = 2;
 }
 
@@ -561,6 +563,7 @@ message NetworkPolicySpec {
   // solely to ensure that the pods it selects are isolated by default)
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated NetworkPolicyIngressRule ingress = 2;
 
   // egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
@@ -572,6 +575,7 @@ message NetworkPolicySpec {
   // This field is beta-level in 1.8
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated NetworkPolicyEgressRule egress = 3;
 
   // policyTypes is a list of rule types that the NetworkPolicy relates to.

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -107,8 +107,8 @@ message IPAddressSpec {
   // ParentRef references the resource that an IPAddress is attached to.
   // An IPAddress must reference a parent object.
   // +required
-  // +k8s:required
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional ParentReference parentRef = 1;
 }
 
@@ -119,7 +119,7 @@ message IPBlock {
   // cidr is a string representing the IPBlock
   // Valid examples are "192.168.1.0/24" or "2001:db8::/64"
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string cidr = 1;
 
   // except is a slice of CIDRs that should not be included within an IPBlock
@@ -204,12 +204,12 @@ message IngressClassParametersReference {
 
   // kind is the type of resource being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string kind = 2;
 
   // name is the name of resource being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 3;
 
   // scope represents if this refers to a cluster or namespace scoped resource.
@@ -238,7 +238,7 @@ message IngressClassSpec {
   // configuration for the controller. This is optional if the controller does
   // not require extra parameters.
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional IngressClassParametersReference parameters = 2;
 }
 
@@ -455,7 +455,7 @@ message NetworkPolicyEgressRule {
   // allows traffic only if the traffic matches at least one item in the to list.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated NetworkPolicyPeer to = 2;
 }
 
@@ -478,7 +478,7 @@ message NetworkPolicyIngressRule {
   // allows traffic only if the traffic matches at least one item in the from list.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated NetworkPolicyPeer from = 2;
 }
 
@@ -517,7 +517,7 @@ message NetworkPolicyPeer {
   // ipBlock defines policy on a particular IPBlock. If this field is set then
   // neither of the other fields can be.
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional IPBlock ipBlock = 3;
 }
 
@@ -563,7 +563,7 @@ message NetworkPolicySpec {
   // solely to ensure that the pods it selects are isolated by default)
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated NetworkPolicyIngressRule ingress = 2;
 
   // egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
@@ -575,7 +575,7 @@ message NetworkPolicySpec {
   // This field is beta-level in 1.8
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated NetworkPolicyEgressRule egress = 3;
 
   // policyTypes is a list of rule types that the NetworkPolicy relates to.
@@ -601,7 +601,7 @@ message ParentReference {
 
   // Resource is the resource of the object being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string resource = 2;
 
   // Namespace is the namespace of the object being referenced.
@@ -610,7 +610,7 @@ message ParentReference {
 
   // Name is the name of the object being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 4;
 }
 

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -77,6 +77,7 @@ type NetworkPolicySpec struct {
 	// solely to ensure that the pods it selects are isolated by default)
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Ingress []NetworkPolicyIngressRule `json:"ingress,omitempty" protobuf:"bytes,2,rep,name=ingress"`
 
 	// egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
@@ -88,6 +89,7 @@ type NetworkPolicySpec struct {
 	// This field is beta-level in 1.8
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Egress []NetworkPolicyEgressRule `json:"egress,omitempty" protobuf:"bytes,3,rep,name=egress"`
 
 	// policyTypes is a list of rule types that the NetworkPolicy relates to.
@@ -124,6 +126,7 @@ type NetworkPolicyIngressRule struct {
 	// allows traffic only if the traffic matches at least one item in the from list.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	From []NetworkPolicyPeer `json:"from,omitempty" protobuf:"bytes,2,rep,name=from"`
 }
 
@@ -147,6 +150,7 @@ type NetworkPolicyEgressRule struct {
 	// allows traffic only if the traffic matches at least one item in the to list.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	To []NetworkPolicyPeer `json:"to,omitempty" protobuf:"bytes,2,rep,name=to"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -77,7 +77,7 @@ type NetworkPolicySpec struct {
 	// solely to ensure that the pods it selects are isolated by default)
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Ingress []NetworkPolicyIngressRule `json:"ingress,omitempty" protobuf:"bytes,2,rep,name=ingress"`
 
 	// egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
@@ -89,7 +89,7 @@ type NetworkPolicySpec struct {
 	// This field is beta-level in 1.8
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Egress []NetworkPolicyEgressRule `json:"egress,omitempty" protobuf:"bytes,3,rep,name=egress"`
 
 	// policyTypes is a list of rule types that the NetworkPolicy relates to.
@@ -126,7 +126,7 @@ type NetworkPolicyIngressRule struct {
 	// allows traffic only if the traffic matches at least one item in the from list.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	From []NetworkPolicyPeer `json:"from,omitempty" protobuf:"bytes,2,rep,name=from"`
 }
 
@@ -150,7 +150,7 @@ type NetworkPolicyEgressRule struct {
 	// allows traffic only if the traffic matches at least one item in the to list.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	To []NetworkPolicyPeer `json:"to,omitempty" protobuf:"bytes,2,rep,name=to"`
 }
 
@@ -183,7 +183,7 @@ type IPBlock struct {
 	// cidr is a string representing the IPBlock
 	// Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	CIDR string `json:"cidr" protobuf:"bytes,1,name=cidr"`
 
 	// except is a slice of CIDRs that should not be included within an IPBlock
@@ -218,7 +218,7 @@ type NetworkPolicyPeer struct {
 	// ipBlock defines policy on a particular IPBlock. If this field is set then
 	// neither of the other fields can be.
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	IPBlock *IPBlock `json:"ipBlock,omitempty" protobuf:"bytes,3,rep,name=ipBlock"`
 }
 
@@ -590,7 +590,7 @@ type IngressClassSpec struct {
 	// configuration for the controller. This is optional if the controller does
 	// not require extra parameters.
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Parameters *IngressClassParametersReference `json:"parameters,omitempty" protobuf:"bytes,2,opt,name=parameters"`
 }
 
@@ -614,12 +614,12 @@ type IngressClassParametersReference struct {
 
 	// kind is the type of resource being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 
 	// name is the name of resource being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 
 	// scope represents if this refers to a cluster or namespace scoped resource.
@@ -678,8 +678,8 @@ type IPAddressSpec struct {
 	// ParentRef references the resource that an IPAddress is attached to.
 	// An IPAddress must reference a parent object.
 	// +required
-	// +k8s:required
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	ParentRef *ParentReference `json:"parentRef,omitempty" protobuf:"bytes,1,opt,name=parentRef"`
 }
 
@@ -690,14 +690,14 @@ type ParentReference struct {
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the resource of the object being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Resource string `json:"resource,omitempty" protobuf:"bytes,2,opt,name=resource"`
 	// Namespace is the namespace of the object being referenced.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
 	// Name is the name of the object being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name,omitempty" protobuf:"bytes,4,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -108,8 +108,8 @@ message IPAddressSpec {
   // ParentRef references the resource that an IPAddress is attached to.
   // An IPAddress must reference a parent object.
   // +required
-  // +k8s:required
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional ParentReference parentRef = 1;
 }
 
@@ -189,12 +189,12 @@ message IngressClassParametersReference {
 
   // kind is the type of resource being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string kind = 2;
 
   // name is the name of resource being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 3;
 
   // scope represents if this refers to a cluster or namespace scoped resource.
@@ -222,7 +222,7 @@ message IngressClassSpec {
   // configuration for the controller. This is optional if the controller does
   // not require extra parameters.
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional IngressClassParametersReference parameters = 2;
 }
 
@@ -404,7 +404,7 @@ message ParentReference {
 
   // Resource is the resource of the object being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string resource = 2;
 
   // Namespace is the namespace of the object being referenced.
@@ -413,7 +413,7 @@ message ParentReference {
 
   // Name is the name of the object being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 4;
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -368,7 +368,7 @@ type IngressClassSpec struct {
 	// configuration for the controller. This is optional if the controller does
 	// not require extra parameters.
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Parameters *IngressClassParametersReference `json:"parameters,omitempty" protobuf:"bytes,2,opt,name=parameters"`
 }
 
@@ -392,12 +392,12 @@ type IngressClassParametersReference struct {
 
 	// kind is the type of resource being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 
 	// name is the name of resource being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 
 	// scope represents if this refers to a cluster or namespace scoped resource.
@@ -456,8 +456,8 @@ type IPAddressSpec struct {
 	// ParentRef references the resource that an IPAddress is attached to.
 	// An IPAddress must reference a parent object.
 	// +required
-	// +k8s:required
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	ParentRef *ParentReference `json:"parentRef,omitempty" protobuf:"bytes,1,opt,name=parentRef"`
 }
 
@@ -468,14 +468,14 @@ type ParentReference struct {
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the resource of the object being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Resource string `json:"resource,omitempty" protobuf:"bytes,2,opt,name=resource"`
 	// Namespace is the namespace of the object being referenced.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
 	// Name is the name of the object being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name,omitempty" protobuf:"bytes,4,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/node/v1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1/generated.proto
@@ -60,9 +60,9 @@ message RuntimeClass {
   // The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements,
   // and is immutable.
   // +required
-  // +k8s:format="k8s-short-name"
-  // +k8s:immutable
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string handler = 2;
 
   // overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1/types.go
+++ b/staging/src/k8s.io/api/node/v1/types.go
@@ -51,9 +51,9 @@ type RuntimeClass struct {
 	// The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements,
 	// and is immutable.
 	// +required
-	// +k8s:format="k8s-short-name"
-	// +k8s:immutable
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Handler string `json:"handler" protobuf:"bytes,2,opt,name=handler"`
 
 	// overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1alpha1/generated.proto
@@ -82,9 +82,9 @@ message RuntimeClassSpec {
   // The runtimeHandler must be lowercase, conform to the DNS Label (RFC 1123)
   // requirements, and is immutable.
   // +required
-  // +k8s:format="k8s-short-name"
-  // +k8s:immutable
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string runtimeHandler = 1;
 
   // overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/node/v1alpha1/types.go
@@ -61,9 +61,9 @@ type RuntimeClassSpec struct {
 	// The runtimeHandler must be lowercase, conform to the DNS Label (RFC 1123)
 	// requirements, and is immutable.
 	// +required
-	// +k8s:format="k8s-short-name"
-	// +k8s:immutable
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	RuntimeHandler string `json:"runtimeHandler" protobuf:"bytes,1,opt,name=runtimeHandler"`
 
 	// overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1beta1/generated.proto
@@ -60,9 +60,9 @@ message RuntimeClass {
   // The handler must be lowercase, conform to the DNS Label (RFC 1123) requirements,
   // and is immutable.
   // +required
-  // +k8s:format="k8s-short-name"
-  // +k8s:immutable
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string handler = 2;
 
   // overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/node/v1beta1/types.go
+++ b/staging/src/k8s.io/api/node/v1beta1/types.go
@@ -52,9 +52,9 @@ type RuntimeClass struct {
 	// The handler must be lowercase, conform to the DNS Label (RFC 1123) requirements,
 	// and is immutable.
 	// +required
-	// +k8s:format="k8s-short-name"
-	// +k8s:immutable
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-short-name"
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Handler string `json:"handler" protobuf:"bytes,2,opt,name=handler"`
 
 	// overhead represents the resource overhead associated with running a pod for a

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -46,7 +46,7 @@ message ClusterRole {
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -66,7 +66,7 @@ message ClusterRoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -102,7 +102,7 @@ message PolicyRule {
   // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -138,7 +138,7 @@ message Role {
   // Rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated PolicyRule rules = 2;
 }
 
@@ -153,7 +153,7 @@ message RoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -196,7 +196,7 @@ message RoleRef {
 
   // Name is the name of resource being referenced
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 3;
 }
 
@@ -217,7 +217,7 @@ message Subject {
 
   // Name of the object being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 3;
 
   // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -46,6 +46,7 @@ message ClusterRole {
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -65,6 +66,7 @@ message ClusterRoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -136,6 +138,7 @@ message Role {
   // Rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 }
 
@@ -150,6 +153,7 @@ message RoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -127,6 +127,7 @@ type Role struct {
 	// Rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -146,6 +147,7 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -198,6 +200,7 @@ type ClusterRole struct {
 	// Rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -232,6 +235,7 @@ type ClusterRoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -50,7 +50,7 @@ type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -90,7 +90,7 @@ type Subject struct {
 	APIGroup string `json:"apiGroup,omitempty" protobuf:"bytes,2,opt,name=apiGroup"`
 	// Name of the object being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
@@ -109,7 +109,7 @@ type RoleRef struct {
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 }
 
@@ -127,7 +127,7 @@ type Role struct {
 	// Rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -147,7 +147,7 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -200,7 +200,7 @@ type ClusterRole struct {
 	// Rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -235,7 +235,7 @@ type ClusterRoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -47,7 +47,7 @@ message ClusterRole {
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -68,7 +68,7 @@ message ClusterRoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -105,7 +105,7 @@ message PolicyRule {
   // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -142,7 +142,7 @@ message Role {
   // Rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated PolicyRule rules = 2;
 }
 
@@ -158,7 +158,7 @@ message RoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -201,7 +201,7 @@ message RoleRef {
 
   // Name is the name of resource being referenced
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 3;
 }
 
@@ -222,7 +222,7 @@ message Subject {
 
   // Name of the object being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 3;
 
   // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -47,6 +47,7 @@ message ClusterRole {
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -67,6 +68,7 @@ message ClusterRoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -140,6 +142,7 @@ message Role {
   // Rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 }
 
@@ -155,6 +158,7 @@ message RoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -126,6 +126,7 @@ type Role struct {
 	// Rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -145,6 +146,7 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -196,6 +198,7 @@ type ClusterRole struct {
 	// Rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -230,6 +233,7 @@ type ClusterRoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -50,7 +50,7 @@ type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -90,7 +90,7 @@ type Subject struct {
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,2,opt,name=apiVersion"`
 	// Name of the object being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
@@ -108,7 +108,7 @@ type RoleRef struct {
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 }
 
@@ -126,7 +126,7 @@ type Role struct {
 	// Rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -146,7 +146,7 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -198,7 +198,7 @@ type ClusterRole struct {
 	// Rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -233,7 +233,7 @@ type ClusterRoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -47,7 +47,7 @@ message ClusterRole {
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -68,7 +68,7 @@ message ClusterRoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -105,7 +105,7 @@ message PolicyRule {
   // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -143,7 +143,7 @@ message Role {
   // Rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated PolicyRule rules = 2;
 }
 
@@ -159,7 +159,7 @@ message RoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -202,7 +202,7 @@ message RoleRef {
 
   // Name is the name of resource being referenced
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 3;
 }
 
@@ -222,7 +222,7 @@ message Subject {
 
   // Name of the object being referenced.
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 3;
 
   // Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -47,6 +47,7 @@ message ClusterRole {
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 
   // AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -67,6 +68,7 @@ message ClusterRoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -141,6 +143,7 @@ message Role {
   // Rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 }
 
@@ -156,6 +159,7 @@ message RoleBinding {
   // Subjects holds references to the objects the role applies to.
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -130,6 +130,7 @@ type Role struct {
 	// Rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -153,6 +154,7 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -216,6 +218,7 @@ type ClusterRole struct {
 	// Rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
@@ -253,6 +256,7 @@ type ClusterRoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -50,7 +50,7 @@ type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -90,7 +90,7 @@ type Subject struct {
 	APIGroup string `json:"apiGroup,omitempty" protobuf:"bytes,2,opt,name=apiGroup"`
 	// Name of the object being referenced.
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
 	// the Authorizer should report an error.
@@ -108,7 +108,7 @@ type RoleRef struct {
 	Kind string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	// Name is the name of resource being referenced
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 }
 
@@ -130,7 +130,7 @@ type Role struct {
 	// Rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -154,7 +154,7 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
@@ -218,7 +218,7 @@ type ClusterRole struct {
 	// Rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 	// AggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be
@@ -256,7 +256,7 @@ type ClusterRoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -65,8 +65,8 @@ message AllocatedDeviceStatus {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:optional
-  // +k8s:format=k8s-uuid
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
   optional string shareID = 7;
 
   // Conditions contains the latest observation of the device's state.
@@ -90,7 +90,7 @@ message AllocatedDeviceStatus {
   // NetworkData contains network-related information specific to the device.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional NetworkDeviceData networkData = 6;
 }
 
@@ -307,8 +307,8 @@ message CounterSet {
   // It must be a DNS label.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
   optional string name = 1;
 
   // Counters defines the set of counters for this CounterSet
@@ -317,8 +317,8 @@ message CounterSet {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -337,7 +337,7 @@ message Device {
   // The maximum number of attributes and capacities combined is 32.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   map<string, DeviceAttribute> attributes = 2;
 
   // Capacity defines the set of capacities for this device.
@@ -358,13 +358,13 @@ message Device {
   // device is 2.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=counterSet
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
   // +featureGate=DRAPartitionableDevices
-  // +k8s:maxItems=2
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=2
   repeated DeviceCounterConsumption consumesCounters = 4;
 
   // NodeName identifies the node where the device is available.
@@ -411,7 +411,7 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceTaint taints = 8;
 
   // BindsToNode indicates if the usage of an allocation involving this device
@@ -441,8 +441,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingConditions = 10;
 
   // BindingFailureConditions defines the conditions for binding failure.
@@ -459,8 +459,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 11;
 
   // AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -480,7 +480,7 @@ message DeviceAllocationConfiguration {
   // or from a claim.
   //
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string source = 1;
 
   // Requests lists the names of requests where the configuration applies.
@@ -492,10 +492,10 @@ message DeviceAllocationConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated string requests = 2;
 
   optional DeviceConfiguration deviceConfiguration = 3;
@@ -507,8 +507,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceRequestAllocationResult results = 1;
 
   // This field is a combination of all the claim and class configuration parameters.
@@ -521,8 +521,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=64
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=64
   repeated DeviceAllocationConfiguration config = 2;
 }
 
@@ -531,30 +531,30 @@ message DeviceAttribute {
   // IntValue is a number.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional int64 int = 2;
 
   // BoolValue is a true/false value.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional bool bool = 3;
 
   // StringValue is a string. Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional string string = 4;
 
   // VersionValue is a semantic version according to semver.org spec 2.0.0.
   // Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional string version = 5;
 }
 
@@ -591,11 +591,11 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=name
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceRequest requests = 1;
 
   // These constraints must be satisfied by the set of devices that get
@@ -603,8 +603,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceConstraint constraints = 2;
 
   // This field holds configuration for multiple potential drivers which
@@ -613,8 +613,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceClaimConfiguration config = 3;
 }
 
@@ -629,10 +629,10 @@ message DeviceClaimConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated string requests = 1;
 
   optional DeviceConfiguration deviceConfiguration = 2;
@@ -645,8 +645,8 @@ message DeviceClaimConfiguration {
 message DeviceClass {
   // Standard object metadata
   // +optional
-  // +k8s:subfield(name)=+k8s:optional
-  // +k8s:subfield(name)=+k8s:format=k8s-long-name
+  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines what can be allocated and how to configure it.
@@ -682,8 +682,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -694,8 +694,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceClassConfiguration config = 2;
 
   // ExtendedResourceName is the extended resource name for the devices of this class.
@@ -710,8 +710,8 @@ message DeviceClassSpec {
   // This is an alpha field.
   // +optional
   // +featureGate=DRAExtendedResource
-  // +k8s:optional
-  // +k8s:format=k8s-extended-resource-name
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
   optional string extendedResourceName = 4;
 }
 
@@ -723,7 +723,7 @@ message DeviceConfiguration {
   //
   // +optional
   // +oneOf=ConfigurationType
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional OpaqueDeviceConfiguration opaque = 1;
 }
 
@@ -741,10 +741,10 @@ message DeviceConstraint {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated string requests = 1;
 
   // MatchAttribute requires that all devices in question have this
@@ -762,8 +762,8 @@ message DeviceConstraint {
   //
   // +optional
   // +oneOf=ConstraintType
-  // +k8s:optional
-  // +k8s:format=k8s-resource-fully-qualified-name
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
   optional string matchAttribute = 2;
 
   // DistinctAttribute requires that all devices in question have this
@@ -790,8 +790,8 @@ message DeviceCounterConsumption {
   // counters defined will be consumed.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
   optional string counterSet = 1;
 
   // Counters defines the counters that will be consumed by the device.
@@ -799,8 +799,8 @@ message DeviceCounterConsumption {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -830,7 +830,7 @@ message DeviceRequest {
   //
   // +optional
   // +oneOf=deviceRequestType
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional ExactDeviceRequest exactly = 2;
 
   // FirstAvailable contains subrequests, of which exactly one will be
@@ -851,11 +851,11 @@ message DeviceRequest {
   // +oneOf=deviceRequestType
   // +listType=atomic
   // +featureGate=DRAPrioritizedList
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=name
-  // +k8s:maxItems=8
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
   repeated DeviceSubRequest firstAvailable = 3;
 }
 
@@ -880,9 +880,9 @@ message DeviceRequestAllocationResult {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:format=k8s-long-name-caseless
-  // +k8s:required
-  // +k8s:maxLength=63
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
   optional string driver = 2;
 
   // This name together with the driver name and the device name field
@@ -892,8 +892,8 @@ message DeviceRequestAllocationResult {
   // DNS sub-domains separated by slashes.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-resource-pool-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
   optional string pool = 3;
 
   // Device references one device instance via its name in the driver's
@@ -925,7 +925,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // BindingConditions contains a copy of the BindingConditions
@@ -937,8 +937,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingConditions = 7;
 
   // BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -950,8 +950,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 8;
 
   // ShareID uniquely identifies an individual allocation share of the device,
@@ -961,8 +961,8 @@ message DeviceRequestAllocationResult {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:optional
-  // +k8s:format=k8s-uuid
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
   optional string shareID = 9;
 
   // ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1019,8 +1019,8 @@ message DeviceSubRequest {
   // to reference.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-long-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
   optional string deviceClassName = 2;
 
   // Selectors define criteria which must be satisfied by a specific
@@ -1030,8 +1030,8 @@ message DeviceSubRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 3;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1053,7 +1053,7 @@ message DeviceSubRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1084,7 +1084,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1131,7 +1131,7 @@ message DeviceTaint {
   // Consumers must treat unknown effects like None.
   //
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added.
@@ -1149,8 +1149,8 @@ message DeviceToleration {
   // Must be a label name.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:format=k8s-label-key
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.
@@ -1160,7 +1160,7 @@ message DeviceToleration {
   //
   // +optional
   // +default="Equal"
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string operator = 2;
 
   // Value is the taint value the toleration matches to.
@@ -1174,7 +1174,7 @@ message DeviceToleration {
   // When specified, allowed values are NoSchedule and NoExecute.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be
@@ -1212,8 +1212,8 @@ message ExactDeviceRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 2;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1236,7 +1236,7 @@ message ExactDeviceRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string allocationMode = 3;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1281,7 +1281,7 @@ message ExactDeviceRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1313,8 +1313,8 @@ message NetworkDeviceData {
   // Must not be longer than 256 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:maxLength=256
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=256
   optional string interfaceName = 1;
 
   // IPs lists the network addresses assigned to the device's network interface.
@@ -1325,10 +1325,10 @@ message NetworkDeviceData {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=16
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=16
   repeated string ips = 2;
 
   // HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -1336,8 +1336,8 @@ message NetworkDeviceData {
   // Must not be longer than 128 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:maxLength=128
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=128
   optional string hardwareAddress = 3;
 }
 
@@ -1354,9 +1354,9 @@ message OpaqueDeviceConfiguration {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-long-name-caseless
-  // +k8s:maxLength=63
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
   optional string driver = 1;
 
   // Parameters can contain arbitrary data. It is the responsibility of
@@ -1382,7 +1382,7 @@ message ResourceClaim {
 
   // Spec describes what is being requested and how to configure it.
   // The spec is immutable.
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional ResourceClaimSpec spec = 2;
 
   // Status describes whether the claim is ready to use and what has been allocated.
@@ -1437,8 +1437,8 @@ message ResourceClaimStatus {
   // Allocation is set once the claim has been allocated successfully.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:update=NoModify
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:update=NoModify
   optional AllocationResult allocation = 1;
 
   // ReservedFor indicates which entities are currently allowed to use
@@ -1466,10 +1466,10 @@ message ResourceClaimStatus {
   // +listMapKey=uid
   // +patchStrategy=merge
   // +patchMergeKey=uid
-  // +k8s:optional
-  // +k8s:listType=map
-  // +k8s:listMapKey=uid
-  // +k8s:maxItems=256
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:listType=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=256
   repeated ResourceClaimConsumerReference reservedFor = 2;
 
   // Devices contains the status of each device allocated for this
@@ -1477,18 +1477,18 @@ message ResourceClaimStatus {
   // information. Entries are owned by their respective drivers.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +listType=map
   // +listMapKey=driver
   // +listMapKey=device
   // +listMapKey=pool
   // +listMapKey=shareID
   // +featureGate=DRAResourceClaimDeviceStatus
-  // +k8s:listType=map
-  // +k8s:listMapKey=driver
-  // +k8s:listMapKey=device
-  // +k8s:listMapKey=pool
-  // +k8s:listMapKey=shareID
+  // +k8s:alpha(since: "1.36")=+k8s:listType=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
   repeated AllocatedDeviceStatus devices = 4;
 }
 
@@ -1671,7 +1671,7 @@ message ResourceSliceSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +zeroOrOneOf=ResourceSliceType
   repeated Device devices = 6;
 
@@ -1697,14 +1697,14 @@ message ResourceSliceSpec {
   // The maximum number of counter sets is 8.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=name
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
   // +featureGate=DRAPartitionableDevices
   // +zeroOrOneOf=ResourceSliceType
-  // +k8s:maxItems=8
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
   repeated CounterSet sharedCounters = 8;
 }
 

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -337,6 +337,7 @@ message Device {
   // The maximum number of attributes and capacities combined is 32.
   //
   // +optional
+  // +k8s:optional
   map<string, DeviceAttribute> attributes = 2;
 
   // Capacity defines the set of capacities for this device.
@@ -410,6 +411,7 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceTaint taints = 8;
 
   // BindsToNode indicates if the usage of an allocation involving this device
@@ -923,6 +925,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // BindingConditions contains a copy of the BindingConditions
@@ -1050,6 +1053,7 @@ message DeviceSubRequest {
   // requests with unknown modes.
   //
   // +optional
+  // +k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1080,6 +1084,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1155,6 +1160,7 @@ message DeviceToleration {
   //
   // +optional
   // +default="Equal"
+  // +k8s:optional
   optional string operator = 2;
 
   // Value is the taint value the toleration matches to.
@@ -1168,6 +1174,7 @@ message DeviceToleration {
   // When specified, allowed values are NoSchedule and NoExecute.
   //
   // +optional
+  // +k8s:optional
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be
@@ -1274,6 +1281,7 @@ message ExactDeviceRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -298,6 +298,7 @@ type Device struct {
 	// The maximum number of attributes and capacities combined is 32.
 	//
 	// +optional
+	// +k8s:optional
 	Attributes map[QualifiedName]DeviceAttribute `json:"attributes,omitempty" protobuf:"bytes,2,rep,name=attributes"`
 
 	// Capacity defines the set of capacities for this device.
@@ -371,6 +372,7 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Taints []DeviceTaint `json:"taints,omitempty" protobuf:"bytes,8,rep,name=taints"`
 
 	// BindsToNode indicates if the usage of an allocation involving this device
@@ -970,6 +972,7 @@ type ExactDeviceRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1055,6 +1058,7 @@ type DeviceSubRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
+	// +k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1085,6 +1089,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1396,6 +1401,7 @@ type DeviceToleration struct {
 	//
 	// +optional
 	// +default="Equal"
+	// +k8s:optional
 	Operator DeviceTolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=DeviceTolerationOperator"`
 
 	// Value is the taint value the toleration matches to.
@@ -1409,6 +1415,7 @@ type DeviceToleration struct {
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
 	// +optional
+	// +k8s:optional
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be
@@ -1647,6 +1654,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// BindingConditions contains a copy of the BindingConditions

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -153,7 +153,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +zeroOrOneOf=ResourceSliceType
 	Devices []Device `json:"devices,omitempty" protobuf:"bytes,6,name=devices"`
 
@@ -179,14 +179,14 @@ type ResourceSliceSpec struct {
 	// The maximum number of counter sets is 8.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=name
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
 	// +featureGate=DRAPartitionableDevices
 	// +zeroOrOneOf=ResourceSliceType
-	// +k8s:maxItems=8
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
 	SharedCounters []CounterSet `json:"sharedCounters,omitempty" protobuf:"bytes,8,name=sharedCounters"`
 }
 
@@ -203,8 +203,8 @@ type CounterSet struct {
 	// It must be a DNS label.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Counters defines the set of counters for this CounterSet
@@ -213,8 +213,8 @@ type CounterSet struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
 }
 
@@ -298,7 +298,7 @@ type Device struct {
 	// The maximum number of attributes and capacities combined is 32.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Attributes map[QualifiedName]DeviceAttribute `json:"attributes,omitempty" protobuf:"bytes,2,rep,name=attributes"`
 
 	// Capacity defines the set of capacities for this device.
@@ -319,13 +319,13 @@ type Device struct {
 	// device is 2.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=counterSet
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
 	// +featureGate=DRAPartitionableDevices
-	// +k8s:maxItems=2
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=2
 	ConsumesCounters []DeviceCounterConsumption `json:"consumesCounters,omitempty" protobuf:"bytes,4,rep,name=consumesCounters"`
 
 	// NodeName identifies the node where the device is available.
@@ -372,7 +372,7 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Taints []DeviceTaint `json:"taints,omitempty" protobuf:"bytes,8,rep,name=taints"`
 
 	// BindsToNode indicates if the usage of an allocation involving this device
@@ -402,8 +402,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,10,rep,name=bindingConditions"`
 
 	// BindingFailureConditions defines the conditions for binding failure.
@@ -420,8 +420,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,11,rep,name=bindingFailureConditions"`
 
 	// AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -441,8 +441,8 @@ type DeviceCounterConsumption struct {
 	// counters defined will be consumed.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
 	CounterSet string `json:"counterSet" protobuf:"bytes,1,opt,name=counterSet"`
 
 	// Counters defines the counters that will be consumed by the device.
@@ -450,8 +450,8 @@ type DeviceCounterConsumption struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
 }
 
@@ -611,30 +611,30 @@ type DeviceAttribute struct {
 	// IntValue is a number.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	IntValue *int64 `json:"int,omitempty" protobuf:"varint,2,opt,name=int"`
 
 	// BoolValue is a true/false value.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	BoolValue *bool `json:"bool,omitempty" protobuf:"varint,3,opt,name=bool"`
 
 	// StringValue is a string. Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	StringValue *string `json:"string,omitempty" protobuf:"bytes,4,opt,name=string"`
 
 	// VersionValue is a semantic version according to semver.org spec 2.0.0.
 	// Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	VersionValue *string `json:"version,omitempty" protobuf:"bytes,5,opt,name=version"`
 }
 
@@ -670,7 +670,7 @@ type DeviceTaint struct {
 	// Consumers must treat unknown effects like None.
 	//
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -700,7 +700,7 @@ type DeviceTaint struct {
 }
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceTaintEffect string
 
 const (
@@ -748,7 +748,7 @@ type ResourceClaim struct {
 
 	// Spec describes what is being requested and how to configure it.
 	// The spec is immutable.
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
 	// Status describes whether the claim is ready to use and what has been allocated.
@@ -776,11 +776,11 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=name
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []DeviceRequest `json:"requests" protobuf:"bytes,1,name=requests"`
 
 	// These constraints must be satisfied by the set of devices that get
@@ -788,8 +788,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Constraints []DeviceConstraint `json:"constraints,omitempty" protobuf:"bytes,2,opt,name=constraints"`
 
 	// This field holds configuration for multiple potential drivers which
@@ -798,8 +798,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Config []DeviceClaimConfiguration `json:"config,omitempty" protobuf:"bytes,3,opt,name=config"`
 
 	// Potential future extension, ignored by older schedulers. This is
@@ -850,7 +850,7 @@ type DeviceRequest struct {
 	//
 	// +optional
 	// +oneOf=deviceRequestType
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Exactly *ExactDeviceRequest `json:"exactly,omitempty" protobuf:"bytes,2,name=exactly"`
 
 	// FirstAvailable contains subrequests, of which exactly one will be
@@ -871,11 +871,11 @@ type DeviceRequest struct {
 	// +oneOf=deviceRequestType
 	// +listType=atomic
 	// +featureGate=DRAPrioritizedList
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=name
-	// +k8s:maxItems=8
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
 	FirstAvailable []DeviceSubRequest `json:"firstAvailable,omitempty" protobuf:"bytes,3,name=firstAvailable"`
 }
 
@@ -903,8 +903,8 @@ type ExactDeviceRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,2,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -927,7 +927,7 @@ type ExactDeviceRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,3,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -972,7 +972,7 @@ type ExactDeviceRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1024,8 +1024,8 @@ type DeviceSubRequest struct {
 	// to reference.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-long-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
 	DeviceClassName string `json:"deviceClassName" protobuf:"bytes,2,name=deviceClassName"`
 
 	// Selectors define criteria which must be satisfied by a specific
@@ -1035,8 +1035,8 @@ type DeviceSubRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,3,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1058,7 +1058,7 @@ type DeviceSubRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1089,7 +1089,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1146,7 +1146,7 @@ const (
 )
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceAllocationMode string
 
 // Valid [DeviceRequest.CountMode] values.
@@ -1265,10 +1265,10 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	// MatchAttribute requires that all devices in question have this
@@ -1286,8 +1286,8 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +oneOf=ConstraintType
-	// +k8s:optional
-	// +k8s:format=k8s-resource-fully-qualified-name
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
 	MatchAttribute *FullyQualifiedName `json:"matchAttribute,omitempty" protobuf:"bytes,2,opt,name=matchAttribute"`
 
 	// Potential future extension, not part of the current design:
@@ -1328,10 +1328,10 @@ type DeviceClaimConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	DeviceConfiguration `json:",inline" protobuf:"bytes,2,name=deviceConfiguration"`
@@ -1345,7 +1345,7 @@ type DeviceConfiguration struct {
 	//
 	// +optional
 	// +oneOf=ConfigurationType
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Opaque *OpaqueDeviceConfiguration `json:"opaque,omitempty" protobuf:"bytes,1,opt,name=opaque"`
 }
 
@@ -1362,9 +1362,9 @@ type OpaqueDeviceConfiguration struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-long-name-caseless
-	// +k8s:maxLength=63
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
 
 	// Parameters can contain arbitrary data. It is the responsibility of
@@ -1390,8 +1390,8 @@ type DeviceToleration struct {
 	// Must be a label name.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:format=k8s-label-key
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
 	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"`
 
 	// Operator represents a key's relationship to the value.
@@ -1401,7 +1401,7 @@ type DeviceToleration struct {
 	//
 	// +optional
 	// +default="Equal"
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Operator DeviceTolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=DeviceTolerationOperator"`
 
 	// Value is the taint value the toleration matches to.
@@ -1415,7 +1415,7 @@ type DeviceToleration struct {
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be
@@ -1432,7 +1432,7 @@ type DeviceToleration struct {
 // A toleration operator is the set of operators that can be used in a toleration.
 //
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceTolerationOperator string
 
 const (
@@ -1446,8 +1446,8 @@ type ResourceClaimStatus struct {
 	// Allocation is set once the claim has been allocated successfully.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:update=NoModify
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:update=NoModify
 	Allocation *AllocationResult `json:"allocation,omitempty" protobuf:"bytes,1,opt,name=allocation"`
 
 	// ReservedFor indicates which entities are currently allowed to use
@@ -1475,10 +1475,10 @@ type ResourceClaimStatus struct {
 	// +listMapKey=uid
 	// +patchStrategy=merge
 	// +patchMergeKey=uid
-	// +k8s:optional
-	// +k8s:listType=map
-	// +k8s:listMapKey=uid
-	// +k8s:maxItems=256
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:listType=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=256
 	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,2,opt,name=reservedFor" patchStrategy:"merge" patchMergeKey:"uid"`
 
 	// DeallocationRequested is tombstoned since Kubernetes 1.32 where
@@ -1491,18 +1491,18 @@ type ResourceClaimStatus struct {
 	// information. Entries are owned by their respective drivers.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +listType=map
 	// +listMapKey=driver
 	// +listMapKey=device
 	// +listMapKey=pool
 	// +listMapKey=shareID
 	// +featureGate=DRAResourceClaimDeviceStatus
-	// +k8s:listType=map
-	// +k8s:listMapKey=driver
-	// +k8s:listMapKey=device
-	// +k8s:listMapKey=pool
-	// +k8s:listMapKey=shareID
+	// +k8s:alpha(since: "1.36")=+k8s:listType=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
 	Devices []AllocatedDeviceStatus `json:"devices,omitempty" protobuf:"bytes,4,opt,name=devices"`
 }
 
@@ -1565,8 +1565,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Results []DeviceRequestAllocationResult `json:"results,omitempty" protobuf:"bytes,1,opt,name=results"`
 
 	// This field is a combination of all the claim and class configuration parameters.
@@ -1579,8 +1579,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=64
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=64
 	Config []DeviceAllocationConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 }
 
@@ -1609,9 +1609,9 @@ type DeviceRequestAllocationResult struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:format=k8s-long-name-caseless
-	// +k8s:required
-	// +k8s:maxLength=63
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
 
 	// This name together with the driver name and the device name field
@@ -1621,8 +1621,8 @@ type DeviceRequestAllocationResult struct {
 	// DNS sub-domains separated by slashes.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-resource-pool-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
 	Pool string `json:"pool" protobuf:"bytes,3,name=pool"`
 
 	// Device references one device instance via its name in the driver's
@@ -1654,7 +1654,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// BindingConditions contains a copy of the BindingConditions
@@ -1666,8 +1666,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,7,rep,name=bindingConditions"`
 
 	// BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1679,8 +1679,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,8,rep,name=bindingFailureConditions"`
 
 	// ShareID uniquely identifies an individual allocation share of the device,
@@ -1690,8 +1690,8 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:optional
-	// +k8s:format=k8s-uuid
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
 	ShareID *types.UID `json:"shareID,omitempty" protobuf:"bytes,9,opt,name=shareID"`
 
 	// ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1715,7 +1715,7 @@ type DeviceAllocationConfiguration struct {
 	// or from a claim.
 	//
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Source AllocationConfigSource `json:"source" protobuf:"bytes,1,name=source"`
 
 	// Requests lists the names of requests where the configuration applies.
@@ -1727,17 +1727,17 @@ type DeviceAllocationConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,2,opt,name=requests"`
 
 	DeviceConfiguration `json:",inline" protobuf:"bytes,3,name=deviceConfiguration"`
 }
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type AllocationConfigSource string
 
 // Valid [DeviceAllocationConfiguration.Source] values.
@@ -1773,8 +1773,8 @@ type DeviceClass struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata
 	// +optional
-	// +k8s:subfield(name)=+k8s:optional
-	// +k8s:subfield(name)=+k8s:format=k8s-long-name
+	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines what can be allocated and how to configure it.
@@ -1795,8 +1795,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -1807,8 +1807,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Config []DeviceClassConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 
 	// SuitableNodes is tombstoned since Kubernetes 1.32 where
@@ -1828,8 +1828,8 @@ type DeviceClassSpec struct {
 	// This is an alpha field.
 	// +optional
 	// +featureGate=DRAExtendedResource
-	// +k8s:optional
-	// +k8s:format=k8s-extended-resource-name
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
 	ExtendedResourceName *string `json:"extendedResourceName,omitempty" protobuf:"bytes,4,opt,name=extendedResourceName"`
 }
 
@@ -1952,8 +1952,8 @@ type AllocatedDeviceStatus struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:optional
-	// +k8s:format=k8s-uuid
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
 	ShareID *string `json:"shareID,omitempty" protobuf:"bytes,7,opt,name=shareID"`
 
 	// Conditions contains the latest observation of the device's state.
@@ -1977,7 +1977,7 @@ type AllocatedDeviceStatus struct {
 	// NetworkData contains network-related information specific to the device.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	NetworkData *NetworkDeviceData `json:"networkData,omitempty" protobuf:"bytes,6,opt,name=networkData"`
 }
 
@@ -1992,8 +1992,8 @@ type NetworkDeviceData struct {
 	// Must not be longer than 256 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:maxLength=256
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=256
 	InterfaceName string `json:"interfaceName,omitempty" protobuf:"bytes,1,opt,name=interfaceName"`
 
 	// IPs lists the network addresses assigned to the device's network interface.
@@ -2004,10 +2004,10 @@ type NetworkDeviceData struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=16
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=16
 	IPs []string `json:"ips,omitempty" protobuf:"bytes,2,opt,name=ips"`
 
 	// HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -2015,7 +2015,7 @@ type NetworkDeviceData struct {
 	// Must not be longer than 128 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:maxLength=128
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=128
 	HardwareAddress string `json:"hardwareAddress,omitempty" protobuf:"bytes,3,opt,name=hardwareAddress"`
 }

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -65,8 +65,8 @@ message AllocatedDeviceStatus {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:optional
-  // +k8s:format=k8s-uuid
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
   optional string shareID = 7;
 
   // Conditions contains the latest observation of the device's state.
@@ -90,7 +90,7 @@ message AllocatedDeviceStatus {
   // NetworkData contains network-related information specific to the device.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional NetworkDeviceData networkData = 6;
 }
 
@@ -126,7 +126,7 @@ message BasicDevice {
   // The maximum number of attributes and capacities combined is 32.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   map<string, DeviceAttribute> attributes = 1;
 
   // Capacity defines the set of capacities for this device.
@@ -147,13 +147,13 @@ message BasicDevice {
   // device is 2.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=counterSet
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
   // +featureGate=DRAPartitionableDevices
-  // +k8s:maxItems=2
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=2
   repeated DeviceCounterConsumption consumesCounters = 3;
 
   // NodeName identifies the node where the device is available.
@@ -199,7 +199,7 @@ message BasicDevice {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceTaint taints = 7;
 
   // BindsToNode indicates if the usage of an allocation involving this device
@@ -229,8 +229,8 @@ message BasicDevice {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingConditions = 9;
 
   // BindingFailureConditions defines the conditions for binding failure.
@@ -247,8 +247,8 @@ message BasicDevice {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 10;
 
   // AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -450,8 +450,8 @@ message CounterSet {
   // It must be a DNS label.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
   optional string name = 1;
 
   // Counters defines the set of counters for this CounterSet
@@ -460,8 +460,8 @@ message CounterSet {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -478,7 +478,7 @@ message Device {
   //
   // +optional
   // +oneOf=deviceType
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional BasicDevice basic = 2;
 }
 
@@ -489,7 +489,7 @@ message DeviceAllocationConfiguration {
   // or from a claim.
   //
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string source = 1;
 
   // Requests lists the names of requests where the configuration applies.
@@ -501,10 +501,10 @@ message DeviceAllocationConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated string requests = 2;
 
   optional DeviceConfiguration deviceConfiguration = 3;
@@ -516,8 +516,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceRequestAllocationResult results = 1;
 
   // This field is a combination of all the claim and class configuration parameters.
@@ -530,8 +530,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=64
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=64
   repeated DeviceAllocationConfiguration config = 2;
 }
 
@@ -540,30 +540,30 @@ message DeviceAttribute {
   // IntValue is a number.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional int64 int = 2;
 
   // BoolValue is a true/false value.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional bool bool = 3;
 
   // StringValue is a string. Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional string string = 4;
 
   // VersionValue is a semantic version according to semver.org spec 2.0.0.
   // Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional string version = 5;
 }
 
@@ -600,11 +600,11 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=name
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceRequest requests = 1;
 
   // These constraints must be satisfied by the set of devices that get
@@ -612,8 +612,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceConstraint constraints = 2;
 
   // This field holds configuration for multiple potential drivers which
@@ -622,8 +622,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceClaimConfiguration config = 3;
 }
 
@@ -638,10 +638,10 @@ message DeviceClaimConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated string requests = 1;
 
   optional DeviceConfiguration deviceConfiguration = 2;
@@ -657,8 +657,8 @@ message DeviceClaimConfiguration {
 message DeviceClass {
   // Standard object metadata
   // +optional
-  // +k8s:subfield(name)=+k8s:optional
-  // +k8s:subfield(name)=+k8s:format=k8s-long-name
+  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines what can be allocated and how to configure it.
@@ -694,8 +694,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -706,8 +706,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceClassConfiguration config = 2;
 
   // ExtendedResourceName is the extended resource name for the devices of this class.
@@ -722,8 +722,8 @@ message DeviceClassSpec {
   // This is an alpha field.
   // +optional
   // +featureGate=DRAExtendedResource
-  // +k8s:optional
-  // +k8s:format=k8s-extended-resource-name
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
   optional string extendedResourceName = 4;
 }
 
@@ -735,7 +735,7 @@ message DeviceConfiguration {
   //
   // +optional
   // +oneOf=ConfigurationType
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional OpaqueDeviceConfiguration opaque = 1;
 }
 
@@ -753,10 +753,10 @@ message DeviceConstraint {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated string requests = 1;
 
   // MatchAttribute requires that all devices in question have this
@@ -774,8 +774,8 @@ message DeviceConstraint {
   //
   // +optional
   // +oneOf=ConstraintType
-  // +k8s:optional
-  // +k8s:format=k8s-resource-fully-qualified-name
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
   optional string matchAttribute = 2;
 
   // DistinctAttribute requires that all devices in question have this
@@ -802,8 +802,8 @@ message DeviceCounterConsumption {
   // counters defined will be consumed.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
   optional string counterSet = 1;
 
   // Counters defines the counters that will be consumed by the device.
@@ -811,8 +811,8 @@ message DeviceCounterConsumption {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -858,8 +858,8 @@ message DeviceRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 3;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -885,7 +885,7 @@ message DeviceRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -935,11 +935,11 @@ message DeviceRequest {
   // +oneOf=deviceRequestType
   // +listType=atomic
   // +featureGate=DRAPrioritizedList
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=name
-  // +k8s:maxItems=8
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
   repeated DeviceSubRequest firstAvailable = 7;
 
   // If specified, the request's tolerations.
@@ -966,7 +966,7 @@ message DeviceRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceToleration tolerations = 8;
 
   // Capacity define resource requirements against each capacity.
@@ -1008,9 +1008,9 @@ message DeviceRequestAllocationResult {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:format=k8s-long-name-caseless
-  // +k8s:required
-  // +k8s:maxLength=63
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
   optional string driver = 2;
 
   // This name together with the driver name and the device name field
@@ -1020,8 +1020,8 @@ message DeviceRequestAllocationResult {
   // DNS sub-domains separated by slashes.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-resource-pool-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
   optional string pool = 3;
 
   // Device references one device instance via its name in the driver's
@@ -1053,8 +1053,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
-  // +k8s:maxItems=16
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=16
   repeated DeviceToleration tolerations = 6;
 
   // BindingConditions contains a copy of the BindingConditions
@@ -1066,8 +1066,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingConditions = 7;
 
   // BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1079,8 +1079,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 8;
 
   // ShareID uniquely identifies an individual allocation share of the device,
@@ -1090,8 +1090,8 @@ message DeviceRequestAllocationResult {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:optional
-  // +k8s:format=k8s-uuid
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
   optional string shareID = 9;
 
   // ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1149,8 +1149,8 @@ message DeviceSubRequest {
   // to reference.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-long-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
   optional string deviceClassName = 2;
 
   // Selectors define criteria which must be satisfied by a specific
@@ -1160,8 +1160,8 @@ message DeviceSubRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:maxItems=32
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceSelector selectors = 3;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1183,7 +1183,7 @@ message DeviceSubRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1214,7 +1214,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceToleration tolerations = 7;
 
   // Capacity define resource requirements against each capacity.
@@ -1261,7 +1261,7 @@ message DeviceTaint {
   // Consumers must treat unknown effects like None.
   //
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added.
@@ -1279,8 +1279,8 @@ message DeviceToleration {
   // Must be a label name.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:format=k8s-label-key
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.
@@ -1290,7 +1290,7 @@ message DeviceToleration {
   //
   // +optional
   // +default="Equal"
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string operator = 2;
 
   // Value is the taint value the toleration matches to.
@@ -1304,7 +1304,7 @@ message DeviceToleration {
   // When specified, allowed values are NoSchedule and NoExecute.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be
@@ -1329,8 +1329,8 @@ message NetworkDeviceData {
   // Must not be longer than 256 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:maxLength=256
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=256
   optional string interfaceName = 1;
 
   // IPs lists the network addresses assigned to the device's network interface.
@@ -1343,10 +1343,10 @@ message NetworkDeviceData {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=16
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=16
   repeated string ips = 2;
 
   // HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -1354,8 +1354,8 @@ message NetworkDeviceData {
   // Must not be longer than 128 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:maxLength=128
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=128
   optional string hardwareAddress = 3;
 }
 
@@ -1372,9 +1372,9 @@ message OpaqueDeviceConfiguration {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:required
-  // +k8s:maxLength=63
-  // +k8s:format=k8s-long-name-caseless
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
   optional string driver = 1;
 
   // Parameters can contain arbitrary data. It is the responsibility of
@@ -1403,7 +1403,7 @@ message ResourceClaim {
 
   // Spec describes what is being requested and how to configure it.
   // The spec is immutable.
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional ResourceClaimSpec spec = 2;
 
   // Status describes whether the claim is ready to use and what has been allocated.
@@ -1458,8 +1458,8 @@ message ResourceClaimStatus {
   // Allocation is set once the claim has been allocated successfully.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:update=NoModify
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:update=NoModify
   optional AllocationResult allocation = 1;
 
   // ReservedFor indicates which entities are currently allowed to use
@@ -1487,10 +1487,10 @@ message ResourceClaimStatus {
   // +listMapKey=uid
   // +patchStrategy=merge
   // +patchMergeKey=uid
-  // +k8s:optional
-  // +k8s:listType=map
-  // +k8s:listMapKey=uid
-  // +k8s:maxItems=256
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:listType=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=256
   repeated ResourceClaimConsumerReference reservedFor = 2;
 
   // Devices contains the status of each device allocated for this
@@ -1498,18 +1498,18 @@ message ResourceClaimStatus {
   // information. Entries are owned by their respective drivers.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +listType=map
   // +listMapKey=driver
   // +listMapKey=device
   // +listMapKey=pool
   // +listMapKey=shareID
   // +featureGate=DRAResourceClaimDeviceStatus
-  // +k8s:listType=map
-  // +k8s:listMapKey=driver
-  // +k8s:listMapKey=device
-  // +k8s:listMapKey=pool
-  // +k8s:listMapKey=shareID
+  // +k8s:alpha(since: "1.36")=+k8s:listType=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
   repeated AllocatedDeviceStatus devices = 4;
 }
 
@@ -1698,7 +1698,7 @@ message ResourceSliceSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +zeroOrOneOf=ResourceSliceType
   repeated Device devices = 6;
 
@@ -1724,14 +1724,14 @@ message ResourceSliceSpec {
   // The maximum number of counter sets is 8.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=name
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
   // +featureGate=DRAPartitionableDevices
   // +zeroOrOneOf=ResourceSliceType
-  // +k8s:maxItems=8
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
   repeated CounterSet sharedCounters = 8;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -126,6 +126,7 @@ message BasicDevice {
   // The maximum number of attributes and capacities combined is 32.
   //
   // +optional
+  // +k8s:optional
   map<string, DeviceAttribute> attributes = 1;
 
   // Capacity defines the set of capacities for this device.
@@ -198,6 +199,7 @@ message BasicDevice {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceTaint taints = 7;
 
   // BindsToNode indicates if the usage of an allocation involving this device
@@ -964,6 +966,7 @@ message DeviceRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceToleration tolerations = 8;
 
   // Capacity define resource requirements against each capacity.
@@ -1158,6 +1161,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +k8s:maxItems=32
+  // +k8s:optional
   repeated DeviceSelector selectors = 3;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1179,6 +1183,7 @@ message DeviceSubRequest {
   // requests with unknown modes.
   //
   // +optional
+  // +k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1209,6 +1214,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceToleration tolerations = 7;
 
   // Capacity define resource requirements against each capacity.
@@ -1284,6 +1290,7 @@ message DeviceToleration {
   //
   // +optional
   // +default="Equal"
+  // +k8s:optional
   optional string operator = 2;
 
   // Value is the taint value the toleration matches to.
@@ -1297,6 +1304,7 @@ message DeviceToleration {
   // When specified, allowed values are NoSchedule and NoExecute.
   //
   // +optional
+  // +k8s:optional
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -319,6 +319,7 @@ type BasicDevice struct {
 	// The maximum number of attributes and capacities combined is 32.
 	//
 	// +optional
+	// +k8s:optional
 	Attributes map[QualifiedName]DeviceAttribute `json:"attributes,omitempty" protobuf:"bytes,1,rep,name=attributes"`
 
 	// Capacity defines the set of capacities for this device.
@@ -391,6 +392,7 @@ type BasicDevice struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Taints []DeviceTaint `json:"taints,omitempty" protobuf:"bytes,7,rep,name=taints"`
 
 	// BindsToNode indicates if the usage of an allocation involving this device
@@ -987,6 +989,7 @@ type DeviceRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,8,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1051,6 +1054,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +k8s:maxItems=32
+	// +k8s:optional
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,3,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1072,6 +1076,7 @@ type DeviceSubRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
+	// +k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1102,6 +1107,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,7,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1413,6 +1419,7 @@ type DeviceToleration struct {
 	//
 	// +optional
 	// +default="Equal"
+	// +k8s:optional
 	Operator DeviceTolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=DeviceTolerationOperator"`
 
 	// Value is the taint value the toleration matches to.
@@ -1426,6 +1433,7 @@ type DeviceToleration struct {
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
 	// +optional
+	// +k8s:optional
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -156,7 +156,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +zeroOrOneOf=ResourceSliceType
 	Devices []Device `json:"devices,omitempty" protobuf:"bytes,6,name=devices"`
 
@@ -182,14 +182,14 @@ type ResourceSliceSpec struct {
 	// The maximum number of counter sets is 8.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=name
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
 	// +featureGate=DRAPartitionableDevices
 	// +zeroOrOneOf=ResourceSliceType
-	// +k8s:maxItems=8
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
 	SharedCounters []CounterSet `json:"sharedCounters,omitempty" protobuf:"bytes,8,name=sharedCounters"`
 }
 
@@ -206,8 +206,8 @@ type CounterSet struct {
 	// It must be a DNS label.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Counters defines the set of counters for this CounterSet
@@ -216,8 +216,8 @@ type CounterSet struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
 }
 
@@ -307,7 +307,7 @@ type Device struct {
 	//
 	// +optional
 	// +oneOf=deviceType
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Basic *BasicDevice `json:"basic,omitempty" protobuf:"bytes,2,opt,name=basic"`
 }
 
@@ -319,7 +319,7 @@ type BasicDevice struct {
 	// The maximum number of attributes and capacities combined is 32.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Attributes map[QualifiedName]DeviceAttribute `json:"attributes,omitempty" protobuf:"bytes,1,rep,name=attributes"`
 
 	// Capacity defines the set of capacities for this device.
@@ -340,13 +340,13 @@ type BasicDevice struct {
 	// device is 2.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=counterSet
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
 	// +featureGate=DRAPartitionableDevices
-	// +k8s:maxItems=2
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=2
 	ConsumesCounters []DeviceCounterConsumption `json:"consumesCounters,omitempty" protobuf:"bytes,3,rep,name=consumesCounters"`
 
 	// NodeName identifies the node where the device is available.
@@ -392,7 +392,7 @@ type BasicDevice struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Taints []DeviceTaint `json:"taints,omitempty" protobuf:"bytes,7,rep,name=taints"`
 
 	// BindsToNode indicates if the usage of an allocation involving this device
@@ -422,8 +422,8 @@ type BasicDevice struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,9,rep,name=bindingConditions"`
 
 	// BindingFailureConditions defines the conditions for binding failure.
@@ -440,8 +440,8 @@ type BasicDevice struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,10,rep,name=bindingFailureConditions"`
 
 	// AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -461,8 +461,8 @@ type DeviceCounterConsumption struct {
 	// counters defined will be consumed.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
 	CounterSet string `json:"counterSet" protobuf:"bytes,1,opt,name=counterSet"`
 
 	// Counters defines the counters that will be consumed by the device.
@@ -470,8 +470,8 @@ type DeviceCounterConsumption struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
 }
 
@@ -623,30 +623,30 @@ type DeviceAttribute struct {
 	// IntValue is a number.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	IntValue *int64 `json:"int,omitempty" protobuf:"varint,2,opt,name=int"`
 
 	// BoolValue is a true/false value.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	BoolValue *bool `json:"bool,omitempty" protobuf:"varint,3,opt,name=bool"`
 
 	// StringValue is a string. Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	StringValue *string `json:"string,omitempty" protobuf:"bytes,4,opt,name=string"`
 
 	// VersionValue is a semantic version according to semver.org spec 2.0.0.
 	// Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	VersionValue *string `json:"version,omitempty" protobuf:"bytes,5,opt,name=version"`
 }
 
@@ -682,7 +682,7 @@ type DeviceTaint struct {
 	// Consumers must treat unknown effects like None.
 	//
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -712,7 +712,7 @@ type DeviceTaint struct {
 }
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceTaintEffect string
 
 const (
@@ -763,7 +763,7 @@ type ResourceClaim struct {
 
 	// Spec describes what is being requested and how to configure it.
 	// The spec is immutable.
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
 	// Status describes whether the claim is ready to use and what has been allocated.
@@ -791,11 +791,11 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=name
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []DeviceRequest `json:"requests" protobuf:"bytes,1,name=requests"`
 
 	// These constraints must be satisfied by the set of devices that get
@@ -803,8 +803,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Constraints []DeviceConstraint `json:"constraints,omitempty" protobuf:"bytes,2,opt,name=constraints"`
 
 	// This field holds configuration for multiple potential drivers which
@@ -813,8 +813,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Config []DeviceClaimConfiguration `json:"config,omitempty" protobuf:"bytes,3,opt,name=config"`
 
 	// Potential future extension, ignored by older schedulers. This is
@@ -881,8 +881,8 @@ type DeviceRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,3,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -908,7 +908,7 @@ type DeviceRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -958,11 +958,11 @@ type DeviceRequest struct {
 	// +oneOf=deviceRequestType
 	// +listType=atomic
 	// +featureGate=DRAPrioritizedList
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=name
-	// +k8s:maxItems=8
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
 	FirstAvailable []DeviceSubRequest `json:"firstAvailable,omitempty" protobuf:"bytes,7,name=firstAvailable"`
 
 	// If specified, the request's tolerations.
@@ -989,7 +989,7 @@ type DeviceRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,8,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1042,8 +1042,8 @@ type DeviceSubRequest struct {
 	// to reference.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-long-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
 	DeviceClassName string `json:"deviceClassName" protobuf:"bytes,2,name=deviceClassName"`
 
 	// Selectors define criteria which must be satisfied by a specific
@@ -1053,8 +1053,8 @@ type DeviceSubRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:maxItems=32
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,3,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1076,7 +1076,7 @@ type DeviceSubRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1107,7 +1107,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,7,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1164,7 +1164,7 @@ const (
 )
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceAllocationMode string
 
 // Valid [DeviceRequest.CountMode] values.
@@ -1283,10 +1283,10 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	// MatchAttribute requires that all devices in question have this
@@ -1304,8 +1304,8 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +oneOf=ConstraintType
-	// +k8s:optional
-	// +k8s:format=k8s-resource-fully-qualified-name
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
 	MatchAttribute *FullyQualifiedName `json:"matchAttribute,omitempty" protobuf:"bytes,2,opt,name=matchAttribute"`
 
 	// Potential future extension, not part of the current design:
@@ -1346,10 +1346,10 @@ type DeviceClaimConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	DeviceConfiguration `json:",inline" protobuf:"bytes,2,name=deviceConfiguration"`
@@ -1363,7 +1363,7 @@ type DeviceConfiguration struct {
 	//
 	// +optional
 	// +oneOf=ConfigurationType
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Opaque *OpaqueDeviceConfiguration `json:"opaque,omitempty" protobuf:"bytes,1,opt,name=opaque"`
 }
 
@@ -1380,9 +1380,9 @@ type OpaqueDeviceConfiguration struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:maxLength=63
-	// +k8s:format=k8s-long-name-caseless
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
 
 	// Parameters can contain arbitrary data. It is the responsibility of
@@ -1408,8 +1408,8 @@ type DeviceToleration struct {
 	// Must be a label name.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:format=k8s-label-key
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
 	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"`
 
 	// Operator represents a key's relationship to the value.
@@ -1419,7 +1419,7 @@ type DeviceToleration struct {
 	//
 	// +optional
 	// +default="Equal"
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Operator DeviceTolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=DeviceTolerationOperator"`
 
 	// Value is the taint value the toleration matches to.
@@ -1433,7 +1433,7 @@ type DeviceToleration struct {
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be
@@ -1450,7 +1450,7 @@ type DeviceToleration struct {
 // A toleration operator is the set of operators that can be used in a toleration.
 //
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceTolerationOperator string
 
 const (
@@ -1464,8 +1464,8 @@ type ResourceClaimStatus struct {
 	// Allocation is set once the claim has been allocated successfully.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:update=NoModify
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:update=NoModify
 	Allocation *AllocationResult `json:"allocation,omitempty" protobuf:"bytes,1,opt,name=allocation"`
 
 	// ReservedFor indicates which entities are currently allowed to use
@@ -1493,10 +1493,10 @@ type ResourceClaimStatus struct {
 	// +listMapKey=uid
 	// +patchStrategy=merge
 	// +patchMergeKey=uid
-	// +k8s:optional
-	// +k8s:listType=map
-	// +k8s:listMapKey=uid
-	// +k8s:maxItems=256
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:listType=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=256
 	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,2,opt,name=reservedFor" patchStrategy:"merge" patchMergeKey:"uid"`
 
 	// DeallocationRequested is tombstoned since Kubernetes 1.32 where
@@ -1509,18 +1509,18 @@ type ResourceClaimStatus struct {
 	// information. Entries are owned by their respective drivers.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +listType=map
 	// +listMapKey=driver
 	// +listMapKey=device
 	// +listMapKey=pool
 	// +listMapKey=shareID
 	// +featureGate=DRAResourceClaimDeviceStatus
-	// +k8s:listType=map
-	// +k8s:listMapKey=driver
-	// +k8s:listMapKey=device
-	// +k8s:listMapKey=pool
-	// +k8s:listMapKey=shareID
+	// +k8s:alpha(since: "1.36")=+k8s:listType=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
 	Devices []AllocatedDeviceStatus `json:"devices,omitempty" protobuf:"bytes,4,opt,name=devices"`
 }
 
@@ -1583,8 +1583,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Results []DeviceRequestAllocationResult `json:"results,omitempty" protobuf:"bytes,1,opt,name=results"`
 
 	// This field is a combination of all the claim and class configuration parameters.
@@ -1597,8 +1597,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=64
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=64
 	Config []DeviceAllocationConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 }
 
@@ -1627,9 +1627,9 @@ type DeviceRequestAllocationResult struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:format=k8s-long-name-caseless
-	// +k8s:required
-	// +k8s:maxLength=63
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
 
 	// This name together with the driver name and the device name field
@@ -1639,8 +1639,8 @@ type DeviceRequestAllocationResult struct {
 	// DNS sub-domains separated by slashes.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-resource-pool-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
 	Pool string `json:"pool" protobuf:"bytes,3,name=pool"`
 
 	// Device references one device instance via its name in the driver's
@@ -1672,8 +1672,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
-	// +k8s:maxItems=16
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=16
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// BindingConditions contains a copy of the BindingConditions
@@ -1685,8 +1685,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,7,rep,name=bindingConditions"`
 
 	// BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1698,8 +1698,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,8,rep,name=bindingFailureConditions"`
 
 	// ShareID uniquely identifies an individual allocation share of the device,
@@ -1709,8 +1709,8 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:optional
-	// +k8s:format=k8s-uuid
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
 	ShareID *types.UID `json:"shareID,omitempty" protobuf:"bytes,9,opt,name=shareID"`
 
 	// ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1734,7 +1734,7 @@ type DeviceAllocationConfiguration struct {
 	// or from a claim.
 	//
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Source AllocationConfigSource `json:"source" protobuf:"bytes,1,name=source"`
 
 	// Requests lists the names of requests where the configuration applies.
@@ -1746,17 +1746,17 @@ type DeviceAllocationConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,2,opt,name=requests"`
 
 	DeviceConfiguration `json:",inline" protobuf:"bytes,3,name=deviceConfiguration"`
 }
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type AllocationConfigSource string
 
 // Valid [DeviceAllocationConfiguration.Source] values.
@@ -1795,8 +1795,8 @@ type DeviceClass struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata
 	// +optional
-	// +k8s:subfield(name)=+k8s:optional
-	// +k8s:subfield(name)=+k8s:format=k8s-long-name
+	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines what can be allocated and how to configure it.
@@ -1817,8 +1817,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -1829,8 +1829,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Config []DeviceClassConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 
 	// SuitableNodes is tombstoned since Kubernetes 1.32 where
@@ -1850,8 +1850,8 @@ type DeviceClassSpec struct {
 	// This is an alpha field.
 	// +optional
 	// +featureGate=DRAExtendedResource
-	// +k8s:optional
-	// +k8s:format=k8s-extended-resource-name
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
 	ExtendedResourceName *string `json:"extendedResourceName,omitempty" protobuf:"bytes,4,opt,name=extendedResourceName"`
 }
 
@@ -1977,8 +1977,8 @@ type AllocatedDeviceStatus struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:optional
-	// +k8s:format=k8s-uuid
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
 	ShareID *string `json:"shareID,omitempty" protobuf:"bytes,7,opt,name=shareID"`
 
 	// Conditions contains the latest observation of the device's state.
@@ -2002,7 +2002,7 @@ type AllocatedDeviceStatus struct {
 	// NetworkData contains network-related information specific to the device.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	NetworkData *NetworkDeviceData `json:"networkData,omitempty" protobuf:"bytes,6,opt,name=networkData"`
 }
 
@@ -2017,8 +2017,8 @@ type NetworkDeviceData struct {
 	// Must not be longer than 256 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:maxLength=256
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=256
 	InterfaceName string `json:"interfaceName,omitempty" protobuf:"bytes,1,opt,name=interfaceName"`
 
 	// IPs lists the network addresses assigned to the device's network interface.
@@ -2031,10 +2031,10 @@ type NetworkDeviceData struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=16
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=16
 	IPs []string `json:"ips,omitempty" protobuf:"bytes,2,opt,name=ips"`
 
 	// HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -2042,7 +2042,7 @@ type NetworkDeviceData struct {
 	// Must not be longer than 128 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:maxLength=128
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=128
 	HardwareAddress string `json:"hardwareAddress,omitempty" protobuf:"bytes,3,opt,name=hardwareAddress"`
 }

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -65,8 +65,8 @@ message AllocatedDeviceStatus {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:optional
-  // +k8s:format=k8s-uuid
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
   optional string shareID = 7;
 
   // Conditions contains the latest observation of the device's state.
@@ -90,7 +90,7 @@ message AllocatedDeviceStatus {
   // NetworkData contains network-related information specific to the device.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional NetworkDeviceData networkData = 6;
 }
 
@@ -307,8 +307,8 @@ message CounterSet {
   // It must be a DNS label.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
   optional string name = 1;
 
   // Counters defines the set of counters for this CounterSet
@@ -317,8 +317,8 @@ message CounterSet {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -337,7 +337,7 @@ message Device {
   // The maximum number of attributes and capacities combined is 32.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   map<string, DeviceAttribute> attributes = 2;
 
   // Capacity defines the set of capacities for this device.
@@ -358,13 +358,13 @@ message Device {
   // device is 2.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=counterSet
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
   // +featureGate=DRAPartitionableDevices
-  // +k8s:maxItems=2
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=2
   repeated DeviceCounterConsumption consumesCounters = 4;
 
   // NodeName identifies the node where the device is available.
@@ -411,7 +411,7 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceTaint taints = 8;
 
   // BindsToNode indicates if the usage of an allocation involving this device
@@ -441,8 +441,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingConditions = 10;
 
   // BindingFailureConditions defines the conditions for binding failure.
@@ -459,8 +459,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 11;
 
   // AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -480,7 +480,7 @@ message DeviceAllocationConfiguration {
   // or from a claim.
   //
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string source = 1;
 
   // Requests lists the names of requests where the configuration applies.
@@ -492,10 +492,10 @@ message DeviceAllocationConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated string requests = 2;
 
   optional DeviceConfiguration deviceConfiguration = 3;
@@ -507,8 +507,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceRequestAllocationResult results = 1;
 
   // This field is a combination of all the claim and class configuration parameters.
@@ -521,8 +521,8 @@ message DeviceAllocationResult {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=64
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=64
   repeated DeviceAllocationConfiguration config = 2;
 }
 
@@ -531,30 +531,30 @@ message DeviceAttribute {
   // IntValue is a number.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional int64 int = 2;
 
   // BoolValue is a true/false value.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional bool bool = 3;
 
   // StringValue is a string. Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional string string = 4;
 
   // VersionValue is a semantic version according to semver.org spec 2.0.0.
   // Must not be longer than 64 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:unionMember
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:unionMember
   optional string version = 5;
 }
 
@@ -591,11 +591,11 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=name
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceRequest requests = 1;
 
   // These constraints must be satisfied by the set of devices that get
@@ -603,8 +603,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceConstraint constraints = 2;
 
   // This field holds configuration for multiple potential drivers which
@@ -613,8 +613,8 @@ message DeviceClaim {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceClaimConfiguration config = 3;
 }
 
@@ -629,10 +629,10 @@ message DeviceClaimConfiguration {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated string requests = 1;
 
   optional DeviceConfiguration deviceConfiguration = 2;
@@ -648,8 +648,8 @@ message DeviceClaimConfiguration {
 message DeviceClass {
   // Standard object metadata
   // +optional
-  // +k8s:subfield(name)=+k8s:optional
-  // +k8s:subfield(name)=+k8s:format=k8s-long-name
+  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines what can be allocated and how to configure it.
@@ -685,8 +685,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -697,8 +697,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceClassConfiguration config = 2;
 
   // ExtendedResourceName is the extended resource name for the devices of this class.
@@ -713,8 +713,8 @@ message DeviceClassSpec {
   // This is an alpha field.
   // +optional
   // +featureGate=DRAExtendedResource
-  // +k8s:optional
-  // +k8s:format=k8s-extended-resource-name
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
   optional string extendedResourceName = 4;
 }
 
@@ -726,7 +726,7 @@ message DeviceConfiguration {
   //
   // +optional
   // +oneOf=ConfigurationType
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional OpaqueDeviceConfiguration opaque = 1;
 }
 
@@ -744,10 +744,10 @@ message DeviceConstraint {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated string requests = 1;
 
   // MatchAttribute requires that all devices in question have this
@@ -765,8 +765,8 @@ message DeviceConstraint {
   //
   // +optional
   // +oneOf=ConstraintType
-  // +k8s:optional
-  // +k8s:format=k8s-resource-fully-qualified-name
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
   optional string matchAttribute = 2;
 
   // DistinctAttribute requires that all devices in question have this
@@ -793,8 +793,8 @@ message DeviceCounterConsumption {
   // counters defined will be consumed.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
   optional string counterSet = 1;
 
   // Counters defines the counters that will be consumed by the device.
@@ -802,8 +802,8 @@ message DeviceCounterConsumption {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -833,7 +833,7 @@ message DeviceRequest {
   //
   // +optional
   // +oneOf=deviceRequestType
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional ExactDeviceRequest exactly = 2;
 
   // FirstAvailable contains subrequests, of which exactly one will be
@@ -854,11 +854,11 @@ message DeviceRequest {
   // +oneOf=deviceRequestType
   // +listType=atomic
   // +featureGate=DRAPrioritizedList
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=name
-  // +k8s:maxItems=8
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
   repeated DeviceSubRequest firstAvailable = 3;
 }
 
@@ -883,9 +883,9 @@ message DeviceRequestAllocationResult {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:format=k8s-long-name-caseless
-  // +k8s:maxLength=63
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string driver = 2;
 
   // This name together with the driver name and the device name field
@@ -895,8 +895,8 @@ message DeviceRequestAllocationResult {
   // DNS sub-domains separated by slashes.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-resource-pool-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
   optional string pool = 3;
 
   // Device references one device instance via its name in the driver's
@@ -928,7 +928,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // BindingConditions contains a copy of the BindingConditions
@@ -940,8 +940,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingConditions = 7;
 
   // BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -953,8 +953,8 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-  // +k8s:optional
-  // +k8s:maxItems=4
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=4
   repeated string bindingFailureConditions = 8;
 
   // ShareID uniquely identifies an individual allocation share of the device,
@@ -964,8 +964,8 @@ message DeviceRequestAllocationResult {
   //
   // +optional
   // +featureGate=DRAConsumableCapacity
-  // +k8s:optional
-  // +k8s:format=k8s-uuid
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
   optional string shareID = 9;
 
   // ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1022,8 +1022,8 @@ message DeviceSubRequest {
   // to reference.
   //
   // +required
-  // +k8s:required
-  // +k8s:format=k8s-long-name
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
   optional string deviceClassName = 2;
 
   // Selectors define criteria which must be satisfied by a specific
@@ -1033,8 +1033,8 @@ message DeviceSubRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 3;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1056,7 +1056,7 @@ message DeviceSubRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1087,7 +1087,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1134,7 +1134,7 @@ message DeviceTaint {
   // Consumers must treat unknown effects like None.
   //
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added.
@@ -1152,8 +1152,8 @@ message DeviceToleration {
   // Must be a label name.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:format=k8s-label-key
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.
@@ -1163,7 +1163,7 @@ message DeviceToleration {
   //
   // +optional
   // +default="Equal"
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string operator = 2;
 
   // Value is the taint value the toleration matches to.
@@ -1177,7 +1177,7 @@ message DeviceToleration {
   // When specified, allowed values are NoSchedule and NoExecute.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be
@@ -1215,8 +1215,8 @@ message ExactDeviceRequest {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
-  // +k8s:maxItems=32
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=32
   repeated DeviceSelector selectors = 2;
 
   // AllocationMode and its related fields define how devices are allocated
@@ -1239,7 +1239,7 @@ message ExactDeviceRequest {
   // requests with unknown modes.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string allocationMode = 3;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1284,7 +1284,7 @@ message ExactDeviceRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1316,8 +1316,8 @@ message NetworkDeviceData {
   // Must not be longer than 256 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:maxLength=256
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=256
   optional string interfaceName = 1;
 
   // IPs lists the network addresses assigned to the device's network interface.
@@ -1328,10 +1328,10 @@ message NetworkDeviceData {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:listType=atomic
-  // +k8s:unique=set
-  // +k8s:maxItems=16
+  // +k8s:alpha(since: "1.36")=+k8s:unique=set
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=16
   repeated string ips = 2;
 
   // HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -1339,8 +1339,8 @@ message NetworkDeviceData {
   // Must not be longer than 128 characters.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:maxLength=128
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=128
   optional string hardwareAddress = 3;
 }
 
@@ -1357,9 +1357,9 @@ message OpaqueDeviceConfiguration {
   // vendor of the driver. It should use only lower case characters.
   //
   // +required
-  // +k8s:required
-  // +k8s:maxLength=63
-  // +k8s:format=k8s-long-name-caseless
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+  // +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
   optional string driver = 1;
 
   // Parameters can contain arbitrary data. It is the responsibility of
@@ -1388,7 +1388,7 @@ message ResourceClaim {
 
   // Spec describes what is being requested and how to configure it.
   // The spec is immutable.
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional ResourceClaimSpec spec = 2;
 
   // Status describes whether the claim is ready to use and what has been allocated.
@@ -1443,8 +1443,8 @@ message ResourceClaimStatus {
   // Allocation is set once the claim has been allocated successfully.
   //
   // +optional
-  // +k8s:optional
-  // +k8s:update=NoModify
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:update=NoModify
   optional AllocationResult allocation = 1;
 
   // ReservedFor indicates which entities are currently allowed to use
@@ -1472,10 +1472,10 @@ message ResourceClaimStatus {
   // +listMapKey=uid
   // +patchStrategy=merge
   // +patchMergeKey=uid
-  // +k8s:optional
-  // +k8s:listType=map
-  // +k8s:listMapKey=uid
-  // +k8s:maxItems=256
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:listType=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=256
   repeated ResourceClaimConsumerReference reservedFor = 2;
 
   // Devices contains the status of each device allocated for this
@@ -1483,18 +1483,18 @@ message ResourceClaimStatus {
   // information. Entries are owned by their respective drivers.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +listType=map
   // +listMapKey=driver
   // +listMapKey=device
   // +listMapKey=pool
   // +listMapKey=shareID
   // +featureGate=DRAResourceClaimDeviceStatus
-  // +k8s:listType=map
-  // +k8s:listMapKey=driver
-  // +k8s:listMapKey=device
-  // +k8s:listMapKey=pool
-  // +k8s:listMapKey=shareID
+  // +k8s:alpha(since: "1.36")=+k8s:listType=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
   repeated AllocatedDeviceStatus devices = 4;
 }
 
@@ -1683,7 +1683,7 @@ message ResourceSliceSpec {
   //
   // +optional
   // +listType=atomic
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +zeroOrOneOf=ResourceSliceType
   repeated Device devices = 6;
 
@@ -1709,14 +1709,14 @@ message ResourceSliceSpec {
   // The maximum number of counter sets is 8.
   //
   // +optional
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   // +listType=atomic
   // +k8s:listType=atomic
-  // +k8s:unique=map
-  // +k8s:listMapKey=name
+  // +k8s:alpha(since: "1.36")=+k8s:unique=map
+  // +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
   // +featureGate=DRAPartitionableDevices
   // +zeroOrOneOf=ResourceSliceType
-  // +k8s:maxItems=8
+  // +k8s:alpha(since: "1.36")=+k8s:maxItems=8
   repeated CounterSet sharedCounters = 8;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -337,6 +337,7 @@ message Device {
   // The maximum number of attributes and capacities combined is 32.
   //
   // +optional
+  // +k8s:optional
   map<string, DeviceAttribute> attributes = 2;
 
   // Capacity defines the set of capacities for this device.
@@ -410,6 +411,7 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceTaint taints = 8;
 
   // BindsToNode indicates if the usage of an allocation involving this device
@@ -926,6 +928,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // BindingConditions contains a copy of the BindingConditions
@@ -1053,6 +1056,7 @@ message DeviceSubRequest {
   // requests with unknown modes.
   //
   // +optional
+  // +k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1083,6 +1087,7 @@ message DeviceSubRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.
@@ -1158,6 +1163,7 @@ message DeviceToleration {
   //
   // +optional
   // +default="Equal"
+  // +k8s:optional
   optional string operator = 2;
 
   // Value is the taint value the toleration matches to.
@@ -1171,6 +1177,7 @@ message DeviceToleration {
   // When specified, allowed values are NoSchedule and NoExecute.
   //
   // +optional
+  // +k8s:optional
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be
@@ -1277,6 +1284,7 @@ message ExactDeviceRequest {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceTaints
+  // +k8s:optional
   repeated DeviceToleration tolerations = 6;
 
   // Capacity define resource requirements against each capacity.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -156,7 +156,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +zeroOrOneOf=ResourceSliceType
 	Devices []Device `json:"devices,omitempty" protobuf:"bytes,6,name=devices"`
 
@@ -182,14 +182,14 @@ type ResourceSliceSpec struct {
 	// The maximum number of counter sets is 8.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=name
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
 	// +featureGate=DRAPartitionableDevices
 	// +zeroOrOneOf=ResourceSliceType
-	// +k8s:maxItems=8
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
 	SharedCounters []CounterSet `json:"sharedCounters,omitempty" protobuf:"bytes,8,name=sharedCounters"`
 }
 
@@ -206,8 +206,8 @@ type CounterSet struct {
 	// It must be a DNS label.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Counters defines the set of counters for this CounterSet
@@ -216,8 +216,8 @@ type CounterSet struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
 }
 
@@ -301,7 +301,7 @@ type Device struct {
 	// The maximum number of attributes and capacities combined is 32.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Attributes map[QualifiedName]DeviceAttribute `json:"attributes,omitempty" protobuf:"bytes,2,rep,name=attributes"`
 
 	// Capacity defines the set of capacities for this device.
@@ -322,13 +322,13 @@ type Device struct {
 	// device is 2.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +listType=atomic
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=counterSet
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=counterSet
 	// +featureGate=DRAPartitionableDevices
-	// +k8s:maxItems=2
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=2
 	ConsumesCounters []DeviceCounterConsumption `json:"consumesCounters,omitempty" protobuf:"bytes,4,rep,name=consumesCounters"`
 
 	// NodeName identifies the node where the device is available.
@@ -375,7 +375,7 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Taints []DeviceTaint `json:"taints,omitempty" protobuf:"bytes,8,rep,name=taints"`
 
 	// BindsToNode indicates if the usage of an allocation involving this device
@@ -405,8 +405,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,10,rep,name=bindingConditions"`
 
 	// BindingFailureConditions defines the conditions for binding failure.
@@ -423,8 +423,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,11,rep,name=bindingFailureConditions"`
 
 	// AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -444,8 +444,8 @@ type DeviceCounterConsumption struct {
 	// counters defined will be consumed.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-short-name
 	CounterSet string `json:"counterSet" protobuf:"bytes,1,opt,name=counterSet"`
 
 	// Counters defines the counters that will be consumed by the device.
@@ -453,8 +453,8 @@ type DeviceCounterConsumption struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
 }
 
@@ -614,30 +614,30 @@ type DeviceAttribute struct {
 	// IntValue is a number.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	IntValue *int64 `json:"int,omitempty" protobuf:"varint,2,opt,name=int"`
 
 	// BoolValue is a true/false value.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	BoolValue *bool `json:"bool,omitempty" protobuf:"varint,3,opt,name=bool"`
 
 	// StringValue is a string. Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	StringValue *string `json:"string,omitempty" protobuf:"bytes,4,opt,name=string"`
 
 	// VersionValue is a semantic version according to semver.org spec 2.0.0.
 	// Must not be longer than 64 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:unionMember
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:unionMember
 	VersionValue *string `json:"version,omitempty" protobuf:"bytes,5,opt,name=version"`
 }
 
@@ -673,7 +673,7 @@ type DeviceTaint struct {
 	// Consumers must treat unknown effects like None.
 	//
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -703,7 +703,7 @@ type DeviceTaint struct {
 }
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceTaintEffect string
 
 const (
@@ -754,7 +754,7 @@ type ResourceClaim struct {
 
 	// Spec describes what is being requested and how to configure it.
 	// The spec is immutable.
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
 	// Status describes whether the claim is ready to use and what has been allocated.
@@ -782,11 +782,11 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=name
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []DeviceRequest `json:"requests" protobuf:"bytes,1,name=requests"`
 
 	// These constraints must be satisfied by the set of devices that get
@@ -794,8 +794,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Constraints []DeviceConstraint `json:"constraints,omitempty" protobuf:"bytes,2,opt,name=constraints"`
 
 	// This field holds configuration for multiple potential drivers which
@@ -804,8 +804,8 @@ type DeviceClaim struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Config []DeviceClaimConfiguration `json:"config,omitempty" protobuf:"bytes,3,opt,name=config"`
 
 	// Potential future extension, ignored by older schedulers. This is
@@ -856,7 +856,7 @@ type DeviceRequest struct {
 	//
 	// +optional
 	// +oneOf=deviceRequestType
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Exactly *ExactDeviceRequest `json:"exactly,omitempty" protobuf:"bytes,2,name=exactly"`
 
 	// FirstAvailable contains subrequests, of which exactly one will be
@@ -877,11 +877,11 @@ type DeviceRequest struct {
 	// +oneOf=deviceRequestType
 	// +listType=atomic
 	// +featureGate=DRAPrioritizedList
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=map
-	// +k8s:listMapKey=name
-	// +k8s:maxItems=8
+	// +k8s:alpha(since: "1.36")=+k8s:unique=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=name
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=8
 	FirstAvailable []DeviceSubRequest `json:"firstAvailable,omitempty" protobuf:"bytes,3,name=firstAvailable"`
 }
 
@@ -909,8 +909,8 @@ type ExactDeviceRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,2,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -933,7 +933,7 @@ type ExactDeviceRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,3,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -978,7 +978,7 @@ type ExactDeviceRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1030,8 +1030,8 @@ type DeviceSubRequest struct {
 	// to reference.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-long-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name
 	DeviceClassName string `json:"deviceClassName" protobuf:"bytes,2,name=deviceClassName"`
 
 	// Selectors define criteria which must be satisfied by a specific
@@ -1041,8 +1041,8 @@ type DeviceSubRequest struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,3,name=selectors"`
 
 	// AllocationMode and its related fields define how devices are allocated
@@ -1064,7 +1064,7 @@ type DeviceSubRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1095,7 +1095,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1152,7 +1152,7 @@ const (
 )
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceAllocationMode string
 
 // Valid [DeviceRequest.CountMode] values.
@@ -1271,10 +1271,10 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	// MatchAttribute requires that all devices in question have this
@@ -1292,8 +1292,8 @@ type DeviceConstraint struct {
 	//
 	// +optional
 	// +oneOf=ConstraintType
-	// +k8s:optional
-	// +k8s:format=k8s-resource-fully-qualified-name
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-fully-qualified-name
 	MatchAttribute *FullyQualifiedName `json:"matchAttribute,omitempty" protobuf:"bytes,2,opt,name=matchAttribute"`
 
 	// Potential future extension, not part of the current design:
@@ -1334,10 +1334,10 @@ type DeviceClaimConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,1,opt,name=requests"`
 
 	DeviceConfiguration `json:",inline" protobuf:"bytes,2,name=deviceConfiguration"`
@@ -1351,7 +1351,7 @@ type DeviceConfiguration struct {
 	//
 	// +optional
 	// +oneOf=ConfigurationType
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Opaque *OpaqueDeviceConfiguration `json:"opaque,omitempty" protobuf:"bytes,1,opt,name=opaque"`
 }
 
@@ -1368,9 +1368,9 @@ type OpaqueDeviceConfiguration struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:maxLength=63
-	// +k8s:format=k8s-long-name-caseless
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
 
 	// Parameters can contain arbitrary data. It is the responsibility of
@@ -1396,8 +1396,8 @@ type DeviceToleration struct {
 	// Must be a label name.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:format=k8s-label-key
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-label-key
 	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"`
 
 	// Operator represents a key's relationship to the value.
@@ -1407,7 +1407,7 @@ type DeviceToleration struct {
 	//
 	// +optional
 	// +default="Equal"
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Operator DeviceTolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=DeviceTolerationOperator"`
 
 	// Value is the taint value the toleration matches to.
@@ -1421,7 +1421,7 @@ type DeviceToleration struct {
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be
@@ -1438,7 +1438,7 @@ type DeviceToleration struct {
 // A toleration operator is the set of operators that can be used in a toleration.
 //
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceTolerationOperator string
 
 const (
@@ -1452,8 +1452,8 @@ type ResourceClaimStatus struct {
 	// Allocation is set once the claim has been allocated successfully.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:update=NoModify
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:update=NoModify
 	Allocation *AllocationResult `json:"allocation,omitempty" protobuf:"bytes,1,opt,name=allocation"`
 
 	// ReservedFor indicates which entities are currently allowed to use
@@ -1481,10 +1481,10 @@ type ResourceClaimStatus struct {
 	// +listMapKey=uid
 	// +patchStrategy=merge
 	// +patchMergeKey=uid
-	// +k8s:optional
-	// +k8s:listType=map
-	// +k8s:listMapKey=uid
-	// +k8s:maxItems=256
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:listType=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=uid
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=256
 	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,2,opt,name=reservedFor" patchStrategy:"merge" patchMergeKey:"uid"`
 
 	// DeallocationRequested is tombstoned since Kubernetes 1.32 where
@@ -1497,18 +1497,18 @@ type ResourceClaimStatus struct {
 	// information. Entries are owned by their respective drivers.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +listType=map
 	// +listMapKey=driver
 	// +listMapKey=device
 	// +listMapKey=pool
 	// +listMapKey=shareID
 	// +featureGate=DRAResourceClaimDeviceStatus
-	// +k8s:listType=map
-	// +k8s:listMapKey=driver
-	// +k8s:listMapKey=device
-	// +k8s:listMapKey=pool
-	// +k8s:listMapKey=shareID
+	// +k8s:alpha(since: "1.36")=+k8s:listType=map
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=driver
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=device
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=pool
+	// +k8s:alpha(since: "1.36")=+k8s:listMapKey=shareID
 	Devices []AllocatedDeviceStatus `json:"devices,omitempty" protobuf:"bytes,4,opt,name=devices"`
 }
 
@@ -1571,8 +1571,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Results []DeviceRequestAllocationResult `json:"results,omitempty" protobuf:"bytes,1,opt,name=results"`
 
 	// This field is a combination of all the claim and class configuration parameters.
@@ -1585,8 +1585,8 @@ type DeviceAllocationResult struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=64
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=64
 	Config []DeviceAllocationConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 }
 
@@ -1615,9 +1615,9 @@ type DeviceRequestAllocationResult struct {
 	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
-	// +k8s:format=k8s-long-name-caseless
-	// +k8s:maxLength=63
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-long-name-caseless
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
 
 	// This name together with the driver name and the device name field
@@ -1627,8 +1627,8 @@ type DeviceRequestAllocationResult struct {
 	// DNS sub-domains separated by slashes.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:format=k8s-resource-pool-name
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-resource-pool-name
 	Pool string `json:"pool" protobuf:"bytes,3,name=pool"`
 
 	// Device references one device instance via its name in the driver's
@@ -1660,7 +1660,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// BindingConditions contains a copy of the BindingConditions
@@ -1672,8 +1672,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,7,rep,name=bindingConditions"`
 
 	// BindingFailureConditions contains a copy of the BindingFailureConditions
@@ -1685,8 +1685,8 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
-	// +k8s:optional
-	// +k8s:maxItems=4
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,8,rep,name=bindingFailureConditions"`
 
 	// ShareID uniquely identifies an individual allocation share of the device,
@@ -1696,8 +1696,8 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:optional
-	// +k8s:format=k8s-uuid
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
 	ShareID *types.UID `json:"shareID,omitempty" protobuf:"bytes,9,opt,name=shareID"`
 
 	// ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request.
@@ -1721,7 +1721,7 @@ type DeviceAllocationConfiguration struct {
 	// or from a claim.
 	//
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Source AllocationConfigSource `json:"source" protobuf:"bytes,1,name=source"`
 
 	// Requests lists the names of requests where the configuration applies.
@@ -1733,17 +1733,17 @@ type DeviceAllocationConfiguration struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Requests []string `json:"requests,omitempty" protobuf:"bytes,2,opt,name=requests"`
 
 	DeviceConfiguration `json:",inline" protobuf:"bytes,3,name=deviceConfiguration"`
 }
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type AllocationConfigSource string
 
 // Valid [DeviceAllocationConfiguration.Source] values.
@@ -1782,8 +1782,8 @@ type DeviceClass struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata
 	// +optional
-	// +k8s:subfield(name)=+k8s:optional
-	// +k8s:subfield(name)=+k8s:format=k8s-long-name
+	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines what can be allocated and how to configure it.
@@ -1804,8 +1804,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
@@ -1816,8 +1816,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
-	// +k8s:maxItems=32
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=32
 	Config []DeviceClassConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 
 	// SuitableNodes is tombstoned since Kubernetes 1.32 where
@@ -1837,8 +1837,8 @@ type DeviceClassSpec struct {
 	// This is an alpha field.
 	// +optional
 	// +featureGate=DRAExtendedResource
-	// +k8s:optional
-	// +k8s:format=k8s-extended-resource-name
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-extended-resource-name
 	ExtendedResourceName *string `json:"extendedResourceName,omitempty" protobuf:"bytes,4,opt,name=extendedResourceName"`
 }
 
@@ -1964,8 +1964,8 @@ type AllocatedDeviceStatus struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	// +k8s:optional
-	// +k8s:format=k8s-uuid
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:format=k8s-uuid
 	ShareID *string `json:"shareID,omitempty" protobuf:"bytes,7,opt,name=shareID"`
 
 	// Conditions contains the latest observation of the device's state.
@@ -1989,7 +1989,7 @@ type AllocatedDeviceStatus struct {
 	// NetworkData contains network-related information specific to the device.
 	//
 	// +optional
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	NetworkData *NetworkDeviceData `json:"networkData,omitempty" protobuf:"bytes,6,opt,name=networkData"`
 }
 
@@ -2004,8 +2004,8 @@ type NetworkDeviceData struct {
 	// Must not be longer than 256 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:maxLength=256
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=256
 	InterfaceName string `json:"interfaceName,omitempty" protobuf:"bytes,1,opt,name=interfaceName"`
 
 	// IPs lists the network addresses assigned to the device's network interface.
@@ -2016,10 +2016,10 @@ type NetworkDeviceData struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:listType=atomic
-	// +k8s:unique=set
-	// +k8s:maxItems=16
+	// +k8s:alpha(since: "1.36")=+k8s:unique=set
+	// +k8s:alpha(since: "1.36")=+k8s:maxItems=16
 	IPs []string `json:"ips,omitempty" protobuf:"bytes,2,opt,name=ips"`
 
 	// HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.
@@ -2027,7 +2027,7 @@ type NetworkDeviceData struct {
 	// Must not be longer than 128 characters.
 	//
 	// +optional
-	// +k8s:optional
-	// +k8s:maxLength=128
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=128
 	HardwareAddress string `json:"hardwareAddress,omitempty" protobuf:"bytes,3,opt,name=hardwareAddress"`
 }

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -301,6 +301,7 @@ type Device struct {
 	// The maximum number of attributes and capacities combined is 32.
 	//
 	// +optional
+	// +k8s:optional
 	Attributes map[QualifiedName]DeviceAttribute `json:"attributes,omitempty" protobuf:"bytes,2,rep,name=attributes"`
 
 	// Capacity defines the set of capacities for this device.
@@ -374,6 +375,7 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Taints []DeviceTaint `json:"taints,omitempty" protobuf:"bytes,8,rep,name=taints"`
 
 	// BindsToNode indicates if the usage of an allocation involving this device
@@ -976,6 +978,7 @@ type ExactDeviceRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1061,6 +1064,7 @@ type DeviceSubRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
+	// +k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1091,6 +1095,7 @@ type DeviceSubRequest struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// Capacity define resource requirements against each capacity.
@@ -1402,6 +1407,7 @@ type DeviceToleration struct {
 	//
 	// +optional
 	// +default="Equal"
+	// +k8s:optional
 	Operator DeviceTolerationOperator `json:"operator,omitempty" protobuf:"bytes,2,opt,name=operator,casttype=DeviceTolerationOperator"`
 
 	// Value is the taint value the toleration matches to.
@@ -1415,6 +1421,7 @@ type DeviceToleration struct {
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
 	// +optional
+	// +k8s:optional
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be
@@ -1653,6 +1660,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
+	// +k8s:optional
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// BindingConditions contains a copy of the BindingConditions

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -434,22 +434,22 @@ message StorageClass {
 
   // provisioner indicates the type of the provisioner.
   // +required
-  // +k8s:required
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional string provisioner = 2;
 
   // parameters holds the parameters for the provisioner that should
   // create volumes of this storage class.
   // +optional
-  // +k8s:immutable
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   map<string, string> parameters = 3;
 
   // reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
   // Defaults to Delete.
   // +optional
-  // +k8s:immutable
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string reclaimPolicy = 4;
 
   // mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -467,8 +467,8 @@ message StorageClass {
   // provisioned and bound.  When unset, VolumeBindingImmediate is used.
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
-  // +k8s:immutable
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string volumeBindingMode = 7;
 
   // allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
@@ -516,7 +516,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   // +required
   optional VolumeAttachmentSpec spec = 2;
 
@@ -562,9 +562,9 @@ message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
   // +required
-  // +k8s:required
-  // +k8s:format="k8s-long-name-caseless"
-  // +k8s:maxLength=63
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -42,22 +42,22 @@ type StorageClass struct {
 
 	// provisioner indicates the type of the provisioner.
 	// +required
-	// +k8s:required
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	Provisioner string `json:"provisioner" protobuf:"bytes,2,opt,name=provisioner"`
 
 	// parameters holds the parameters for the provisioner that should
 	// create volumes of this storage class.
 	// +optional
-	// +k8s:immutable
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
 	// Defaults to Delete.
 	// +optional
-	// +k8s:immutable
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	ReclaimPolicy *v1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy,omitempty" protobuf:"bytes,4,opt,name=reclaimPolicy,casttype=k8s.io/api/core/v1.PersistentVolumeReclaimPolicy"`
 
 	// mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -75,8 +75,8 @@ type StorageClass struct {
 	// provisioned and bound.  When unset, VolumeBindingImmediate is used.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
-	// +k8s:immutable
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	VolumeBindingMode *VolumeBindingMode `json:"volumeBindingMode,omitempty" protobuf:"bytes,7,opt,name=volumeBindingMode"`
 
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
@@ -140,7 +140,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
@@ -172,9 +172,9 @@ type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
 	// +required
-	// +k8s:required
-	// +k8s:format="k8s-long-name-caseless"
-	// +k8s:maxLength=63
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
@@ -134,7 +134,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   // +required
   optional VolumeAttachmentSpec spec = 2;
 
@@ -180,9 +180,9 @@ message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
   // +required
-  // +k8s:required
-  // +k8s:format="k8s-long-name-caseless"
-  // +k8s:maxLength=63
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types.go
@@ -44,7 +44,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
@@ -78,9 +78,9 @@ type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
 	// +required
-	// +k8s:required
-	// +k8s:format="k8s-long-name-caseless"
-	// +k8s:maxLength=63
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -436,22 +436,22 @@ message StorageClass {
 
   // provisioner indicates the type of the provisioner.
   // +required
-  // +k8s:required
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional string provisioner = 2;
 
   // parameters holds the parameters for the provisioner that should
   // create volumes of this storage class.
   // +optional
-  // +k8s:immutable
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   map<string, string> parameters = 3;
 
   // reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
   // Defaults to Delete.
   // +optional
-  // +k8s:immutable
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string reclaimPolicy = 4;
 
   // mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -469,8 +469,8 @@ message StorageClass {
   // provisioned and bound.  When unset, VolumeBindingImmediate is used.
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
-  // +k8s:immutable
-  // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional string volumeBindingMode = 7;
 
   // allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
@@ -518,7 +518,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
-  // +k8s:immutable
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   // +required
   optional VolumeAttachmentSpec spec = 2;
 
@@ -564,9 +564,9 @@ message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
   // +required
-  // +k8s:required
-  // +k8s:format="k8s-long-name-caseless"
-  // +k8s:maxLength=63
+  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
+  // +k8s:alpha(since: "1.36")=+k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -44,22 +44,22 @@ type StorageClass struct {
 
 	// provisioner indicates the type of the provisioner.
 	// +required
-	// +k8s:required
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	Provisioner string `json:"provisioner" protobuf:"bytes,2,opt,name=provisioner"`
 
 	// parameters holds the parameters for the provisioner that should
 	// create volumes of this storage class.
 	// +optional
-	// +k8s:immutable
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
 
 	// reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
 	// Defaults to Delete.
 	// +optional
-	// +k8s:immutable
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	ReclaimPolicy *v1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy,omitempty" protobuf:"bytes,4,opt,name=reclaimPolicy,casttype=k8s.io/api/core/v1.PersistentVolumeReclaimPolicy"`
 
 	// mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class.
@@ -77,8 +77,8 @@ type StorageClass struct {
 	// provisioned and bound.  When unset, VolumeBindingImmediate is used.
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	// +optional
-	// +k8s:immutable
-	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	VolumeBindingMode *VolumeBindingMode `json:"volumeBindingMode,omitempty" protobuf:"bytes,7,opt,name=volumeBindingMode"`
 
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
@@ -145,7 +145,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
-	// +k8s:immutable
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
@@ -179,9 +179,9 @@ type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
 	// +required
-	// +k8s:required
-	// +k8s:format="k8s-long-name-caseless"
-	// +k8s:maxLength=63
+	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:format="k8s-long-name-caseless"
+	// +k8s:alpha(since: "1.36")=+k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint.go
@@ -72,6 +72,10 @@ func (l *linter) lintType(t *types.Type) error {
 	l.linted[t] = true
 
 	if t.CommentLines != nil {
+		extracted := codetags.Extract("+", t.CommentLines)
+		if _, ok := extracted["k8s:validation-gen-nolint"]; ok {
+			return nil
+		}
 		klog.V(5).Infof("linting type %s", t.Name.String())
 		lintErrs, err := l.lintComments(t, t, t.CommentLines)
 		if err != nil {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint.go
@@ -19,8 +19,8 @@ package main
 import (
 	"fmt"
 	"sort"
-	"strings"
 
+	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
 	"k8s.io/klog/v2"
 )
@@ -37,9 +37,12 @@ type linter struct {
 }
 
 // lintRule is a function that validates a slice of comments.
+// container is the type containing the element being linted (e.g. the Struct when linting a Field).
+// It may be nil if the element is top-level (e.g. a Type definition).
+// t is the type of the element being linted (e.g. the Field's type, or the Type itself).
 // It returns a string as an error message if the comments are invalid,
 // and an error there is an error happened during the linting process.
-type lintRule func(comments []string) (string, error)
+type lintRule func(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error)
 
 func (l *linter) AddError(t *types.Type, field, msg string) {
 	var err error
@@ -53,7 +56,7 @@ func (l *linter) AddError(t *types.Type, field, msg string) {
 
 func newLinter(rules ...lintRule) *linter {
 	if len(rules) == 0 {
-		rules = defaultLintRules
+		klog.Errorf("rules are not passed to the linter")
 	}
 	return &linter{
 		linted:     make(map[*types.Type]bool),
@@ -70,7 +73,7 @@ func (l *linter) lintType(t *types.Type) error {
 
 	if t.CommentLines != nil {
 		klog.V(5).Infof("linting type %s", t.Name.String())
-		lintErrs, err := l.lintComments(t.CommentLines)
+		lintErrs, err := l.lintComments(t, t, t.CommentLines)
 		if err != nil {
 			return err
 		}
@@ -88,7 +91,7 @@ func (l *linter) lintType(t *types.Type) error {
 		// Recursively lint each member of the struct.
 		for _, member := range t.Members {
 			klog.V(5).Infof("linting comments for field %s of type %s", member.String(), t.Name.String())
-			lintErrs, err := l.lintComments(member.CommentLines)
+			lintErrs, err := l.lintComments(t, member.Type, member.CommentLines)
 			if err != nil {
 				return err
 			}
@@ -117,10 +120,29 @@ func (l *linter) lintType(t *types.Type) error {
 }
 
 // lintComments runs all registered rules on a slice of comments.
-func (l *linter) lintComments(comments []string) ([]string, error) {
+func (l *linter) lintComments(container *types.Type, t *types.Type, comments []string) ([]string, error) {
 	var lintErrs []string
+	var tags []codetags.Tag
+
+	extracted := codetags.Extract("+", comments)
+	keys := make([]string, 0, len(extracted))
+	for k := range extracted {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, tagName := range keys {
+		lines := extracted[tagName]
+		t, err := codetags.ParseAll(lines)
+		if err != nil {
+			// If parsing fails, it means it is not a valid tag.
+			continue
+		}
+		tags = append(tags, t...)
+	}
+
 	for _, rule := range l.rules {
-		if msg, err := rule(comments); err != nil {
+		if msg, err := rule(container, t, tags); err != nil {
 			return nil, err
 		} else if msg != "" {
 			lintErrs = append(lintErrs, msg)
@@ -128,31 +150,4 @@ func (l *linter) lintComments(comments []string) ([]string, error) {
 	}
 
 	return lintErrs, nil
-}
-
-// conflictingTagsRule creates a lintRule which checks for conflicting tags.
-func conflictingTagsRule(msg string, tags ...string) lintRule {
-	if len(tags) < 2 {
-		panic("conflictingTagsRule: at least 2 tags must be specified")
-	}
-
-	return func(comments []string) (string, error) {
-		found := make(map[string]bool)
-		for _, comment := range comments {
-			for _, tag := range tags {
-				if strings.HasPrefix(comment, tag) {
-					found[tag] = true
-				}
-			}
-		}
-		if len(found) > 1 {
-			keys := make([]string, 0, len(found))
-			for k := range found {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-			return fmt.Sprintf("conflicting tags: {%s}: %s", strings.Join(keys, ", "), msg), nil
-		}
-		return "", nil
-	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
@@ -16,15 +16,266 @@ limitations under the License.
 
 package main
 
-var ruleOptionalAndRequired = conflictingTagsRule(
-	"fields cannot be both optional and required",
-	"+k8s:optional", "+k8s:required")
+import (
+	"fmt"
 
-var ruleRequiredAndDefault = conflictingTagsRule(
-	"fields with default values are always optional",
-	"+k8s:required", "+default")
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/code-generator/cmd/validation-gen/validators"
+	"k8s.io/gengo/v2/codetags"
+	"k8s.io/gengo/v2/types"
+)
 
-var defaultLintRules = []lintRule{
-	ruleOptionalAndRequired,
-	ruleRequiredAndDefault,
+// FilteredRule returns a lintRule that only runs if the type (or its container) is in the enabledTypes set.
+// If enabledTypes is empty or nil, the rule is disabled.
+func FilteredRule(enabledTypes sets.Set[string], rule lintRule) lintRule {
+	if len(enabledTypes) == 0 {
+		return func(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
+			return "", nil
+		}
+	}
+	return func(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
+		checkType := t
+		if container != nil {
+			checkType = container
+		}
+		if checkType != nil && !enabledTypes.Has(checkType.Name.String()) {
+			return "", nil
+		}
+		return rule(container, t, tags)
+	}
+}
+
+func checkAlphaBetaUsage(tag codetags.Tag, isRoot bool) (string, error) {
+	if tag.Name == "k8s:alpha" || tag.Name == "k8s:beta" {
+		if !isRoot {
+			return fmt.Sprintf("tag %q can't be used in between", tag.Name), nil
+		}
+		if tag.ValueTag == nil {
+			return fmt.Sprintf("tag %q requires a validation tag as its value payload", tag.Name), nil
+		}
+	}
+
+	if tag.ValueTag != nil {
+		return checkAlphaBetaUsage(*tag.ValueTag, false)
+	}
+	return "", nil
+}
+
+// alphaBetaPrefix enforces that +k8s:alpha and +k8s:beta tags are always used as prefix to
+func alphaBetaPrefix() lintRule {
+	return func(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
+		for _, tag := range tags {
+			// Only check alpha/beta tags or validation tags.
+			if msg, err := checkAlphaBetaUsage(tag, true); err != nil || msg != "" {
+				return msg, err
+			}
+		}
+		return "", nil
+	}
+}
+
+// checkTagStability recursively checks that a tag and its nested tags
+// satisfy the stability requirements of the context.
+func checkTagStability(tag codetags.Tag, contextLevel validators.TagStabilityLevel) (string, error) {
+	if contextLevel == validators.TagStabilityLevelAlpha {
+		return "", nil
+	}
+
+	stability, err := validators.GetStability(tag.Name)
+	if err == nil {
+		if contextLevel == validators.TagStabilityLevelBeta {
+			if stability != validators.TagStabilityLevelStable && stability != validators.TagStabilityLevelBeta {
+				return fmt.Sprintf("tag %q with stability level %q cannot be used in %s validation", tag.Name, stability, contextLevel), nil
+			}
+		} else if stability != validators.TagStabilityLevelStable {
+			return fmt.Sprintf("tag %q with stability level %q cannot be used in %s validation", tag.Name, stability, contextLevel), nil
+		}
+	}
+
+	if tag.ValueTag != nil {
+		return checkTagStability(*tag.ValueTag, contextLevel)
+	}
+	return "", nil
+}
+
+// validationStability enforces stability level constraints on tags.
+func validationStability(enabledTypes sets.Set[string]) lintRule {
+	return FilteredRule(enabledTypes, func(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
+		for _, tag := range tags {
+			contextLevel := validators.TagStabilityLevelStable
+			switch tag.Name {
+			case "k8s:alpha":
+				contextLevel = validators.TagStabilityLevelAlpha
+			case "k8s:beta":
+				contextLevel = validators.TagStabilityLevelBeta
+			default:
+				// Normal tag (implicit Stable context).
+				// Check the root tag itself.
+				stability, err := validators.GetStability(tag.Name)
+				if err == nil && stability != validators.TagStabilityLevelStable {
+					return fmt.Sprintf("tag %q with stability level %q cannot be used in Stable validation", tag.Name, stability), nil
+				}
+			}
+
+			// Recursively check content.
+			if tag.ValueTag != nil {
+				msg, err := checkTagStability(*tag.ValueTag, contextLevel)
+				if err != nil {
+					return "", err
+				}
+				if msg != "" {
+					return msg, nil
+				}
+			}
+		}
+		return "", nil
+	})
+}
+
+// hasTag recursively checks if a tag with given name exists in the tag tree.
+func hasTag(tags []codetags.Tag, name string) bool {
+	for _, tag := range tags {
+		if tag.Name == name {
+			return true
+		}
+		// Also check conditional tags value
+		if tag.ValueTag != nil && hasTag([]codetags.Tag{*tag.ValueTag}, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasRequirednessTag returns true if tags contain +k8s:optional, +k8s:required, or +k8s:forbidden.
+func hasRequirednessTag(tags []codetags.Tag) bool {
+	return hasTag(tags, "k8s:optional") || hasTag(tags, "k8s:required") || hasTag(tags, "k8s:forbidden")
+}
+
+// hasAnyValidationTag returns true if tags contain any registered validation tag.
+func hasAnyValidationTag(tags []codetags.Tag) bool {
+	for _, tag := range tags {
+		switch tag.Name {
+		case "k8s:optional":
+			continue
+		case "k8s:alpha", "k8s:beta":
+			if tag.ValueTag != nil && hasAnyValidationTag([]codetags.Tag{*tag.ValueTag}) {
+				return true
+			}
+			continue
+		}
+		// Check if it's a known validation tag.
+		if _, err := validators.GetStability(tag.Name); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// requiredAndOptional checks that fields (pointers, slices, maps, arrays) with validation
+// (either direct or transitive) explicitly declare +k8s:optional or +k8s:required.
+func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
+	// Cache for transitive validation check.
+	// Tri-state: key absent = unvisited, value nil = in-progress (cycle), value *bool = computed result.
+	hasValidation := make(map[*types.Type]*bool)
+
+	// checkType recursively checks if a type has any validation (transitively).
+	var checkType func(t *types.Type) (bool, bool)
+	checkType = func(t *types.Type) (bool, bool) {
+		if val, ok := hasValidation[t]; ok {
+			if val == nil {
+				return false, true // Cycle detected, break conservatively
+			}
+			return *val, false
+		}
+		// Mark in-progress
+		hasValidation[t] = nil
+		extractedTags, err := extractor.ExtractTags(validators.Context{}, t.CommentLines)
+		hasVal := err == nil && hasAnyValidationTag(extractedTags)
+		cycleBroken := false
+
+		switch t.Kind {
+		case types.Alias:
+			if hv, cb := checkType(t.Underlying); hv {
+				hasVal = true
+			} else if cb {
+				cycleBroken = true
+			}
+		case types.Struct:
+			for _, member := range t.Members {
+				memberTags, err := extractor.ExtractTags(validators.Context{}, member.CommentLines)
+				memberHasVal := err == nil && hasAnyValidationTag(memberTags)
+				if hv, cb := checkType(member.Type); hv {
+					memberHasVal = true
+				} else if cb {
+					cycleBroken = true
+				}
+				if memberHasVal {
+					hasVal = true
+				}
+			}
+		case types.Slice, types.Array, types.Pointer:
+			if hv, cb := checkType(t.Elem); hv {
+				hasVal = true
+			} else if cb {
+				cycleBroken = true
+			}
+		case types.Map:
+			if hv, cb := checkType(t.Key); hv {
+				hasVal = true
+			} else if cb {
+				cycleBroken = true
+			}
+			if hv, cb := checkType(t.Elem); hv {
+				hasVal = true
+			} else if cb {
+				cycleBroken = true
+			}
+		}
+
+		if hasVal || !cycleBroken {
+			hasValidation[t] = &hasVal
+		} else {
+			delete(hasValidation, t)
+		}
+		return hasVal, cycleBroken
+	}
+
+	return func(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
+		// We only care about fields in a struct. Skip if linting the struct itself.
+		if container == nil || container.Kind != types.Struct || container == t {
+			return "", nil
+		}
+
+		// Skip non-pointer structs (and aliases to them) as they don't support requiredness tags.
+		underlying := t
+		for underlying.Kind == types.Alias {
+			underlying = underlying.Underlying
+		}
+		if underlying.Kind == types.Struct {
+			return "", nil
+		}
+
+		// Check if already has requiredness tag
+		if hasRequirednessTag(tags) {
+			return "", nil
+		}
+
+		// Check if it has validation (direct or transitive)
+		hasDirectVal := hasAnyValidationTag(tags)
+		hasTransitiveVal, _ := checkType(t)
+
+		if hasDirectVal || hasTransitiveVal {
+			return "field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden", nil
+		}
+
+		return "", nil
+	}
+}
+
+func lintRules(dvEnforcedTypes sets.Set[string], extractor validators.ValidationExtractor) []lintRule {
+	return []lintRule{
+		alphaBetaPrefix(),
+		validationStability(dvEnforcedTypes),
+		requiredAndOptional(extractor),
+	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
@@ -18,30 +18,35 @@ package main
 
 import (
 	"errors"
-	"regexp"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/code-generator/cmd/validation-gen/validators"
+	"k8s.io/gengo/v2/codetags"
+	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/types"
 )
 
-func ruleAlwaysPass(comments []string) (string, error) {
+func ruleAlwaysPass(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
 	return "", nil
 }
 
-func ruleAlwaysFail(comments []string) (string, error) {
+func ruleAlwaysFail(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
 	return "lintfail", nil
 }
 
-func ruleAlwaysErr(comments []string) (string, error) {
+func ruleAlwaysErr(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
 	return "", errors.New("linterr")
 }
 
 func mkCountRule(counter *int, realRule lintRule) lintRule {
-	return func(comments []string) (string, error) {
+	return func(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
 		(*counter)++
-		return realRule(comments)
+		return realRule(container, t, tags)
 	}
 }
+
+var validator = validators.InitGlobalValidator(&generator.Context{})
 
 func TestLintCommentsRuleInvocation(t *testing.T) {
 	tests := []struct {
@@ -104,7 +109,7 @@ func TestLintCommentsRuleInvocation(t *testing.T) {
 			}
 			l := newLinter(rules...)
 			for _, commentLines := range tt.commentLineGroups {
-				_, err := l.lintComments(commentLines)
+				_, err := l.lintComments(nil, nil, commentLines)
 				gotErr := err != nil
 				if gotErr != tt.wantErr {
 					t.Errorf("lintComments() error = %v, wantErr %v", err, tt.wantErr)
@@ -117,176 +122,210 @@ func TestLintCommentsRuleInvocation(t *testing.T) {
 	}
 }
 
-func TestRuleOptionalAndRequired(t *testing.T) {
+func TestRuleAlphaBetaPrefix(t *testing.T) {
 	tests := []struct {
 		name     string
 		comments []string
 		wantMsg  string
 	}{
 		{
-			name:     "no comments",
-			comments: []string{},
+			name:     "valid alpha prefix",
+			comments: []string{"+k8s:alpha=+k8s:required"},
 			wantMsg:  "",
 		},
 		{
-			name:     "only optional",
-			comments: []string{"+k8s:optional"},
+			name:     "valid beta prefix",
+			comments: []string{"+k8s:beta=+k8s:required"},
 			wantMsg:  "",
 		},
 		{
-			name:     "only required",
-			comments: []string{"+k8s:required"},
-			wantMsg:  "",
+			name:     "invalid alpha prefix (no value)",
+			comments: []string{"+k8s:alpha"},
+			wantMsg:  `tag "k8s:alpha" requires a validation tag as its value payload`,
 		},
 		{
-			name:     "optional required",
-			comments: []string{"+k8s:optional", "+k8s:required"},
-			wantMsg:  `conflicting tags: {\+k8s:optional, \+k8s:required}`,
+			name:     "invalid beta prefix (no value)",
+			comments: []string{"+k8s:beta"},
+			wantMsg:  `tag "k8s:beta" requires a validation tag as its value payload`,
 		},
 		{
-			name:     "required optional",
-			comments: []string{"+k8s:optional", "+k8s:required"},
-			wantMsg:  `conflicting tags: {\+k8s:optional, \+k8s:required}`,
+			name:     "invalid alpha prefix (value not tag)",
+			comments: []string{"+k8s:alpha=foo"},
+			wantMsg:  `tag "k8s:alpha" requires a validation tag as its value payload`,
 		},
 		{
-			name:     "optional empty required",
-			comments: []string{"+k8s:optional", "", "+k8s:required"},
-			wantMsg:  `conflicting tags: {\+k8s:optional, \+k8s:required}`,
+			name:     "invalid usage of alpha prefix",
+			comments: []string{`+k8s:item(type: "Approved")=+k8s:alpha=+k8s:zeroOrOneOfMember`},
+			wantMsg:  `tag "k8s:alpha" can't be used in between`,
 		},
 		{
-			name:     "empty required empty empty optional empty",
-			comments: []string{"", "+k8s:optional", "", "", "+k8s:required", ""},
-			wantMsg:  `conflicting tags: {\+k8s:optional, \+k8s:required}`,
+			name:     "nested alpha in item",
+			comments: []string{`+k8s:item=+k8s:alpha=+k8s:required`},
+			wantMsg:  `tag "k8s:alpha" can't be used in between`,
+		},
+		{
+			name:     "alpha nested in listType",
+			comments: []string{`+k8s:listType=+k8s:alpha=+k8s:required`},
+			wantMsg:  `tag "k8s:alpha" can't be used in between`,
+		},
+		{
+			name:     "deeply nested alpha",
+			comments: []string{`+k8s:item=+k8s:listType=+k8s:alpha=+k8s:required`},
+			wantMsg:  `tag "k8s:alpha" can't be used in between`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			msg, err := ruleOptionalAndRequired(tt.comments)
+			tags, _ := validator.ExtractTags(validators.Context{}, tt.comments)
+			msg, err := alphaBetaPrefix()(nil, nil, tags)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
-			} else if tt.wantMsg != "" {
-				re := regexp.MustCompile(tt.wantMsg)
-				if !re.MatchString(msg) {
-					t.Errorf("message:\n\t%s\ndoes not match:\n\t%s", msg, re.String())
-				}
+			} else if msg != tt.wantMsg {
+				t.Errorf("got %q, want %q", msg, tt.wantMsg)
 			}
 		})
 	}
 }
 
-func TestRuleRequiredAndDefault(t *testing.T) {
+func TestRuleStability(t *testing.T) {
 	tests := []struct {
 		name     string
 		comments []string
 		wantMsg  string
 	}{
 		{
-			name:     "no comments",
-			comments: []string{},
+			name:     "stable context, stable tag",
+			comments: []string{"+k8s:required"}, // Stable
 			wantMsg:  "",
 		},
 		{
-			name:     "only required",
-			comments: []string{"+k8s:required"},
+			name:     "beta context, stable tag",
+			comments: []string{"+k8s:beta=+k8s:required"}, // Beta context, Stable tag
 			wantMsg:  "",
 		},
 		{
-			name:     "only default",
-			comments: []string{"+default=somevalue"},
+			name:     "alpha context, stable tag",
+			comments: []string{"+k8s:alpha=+k8s:required"}, // Alpha context, Stable tag
 			wantMsg:  "",
 		},
 		{
-			name:     "required default",
-			comments: []string{"+k8s:required", "+default=somevalue"},
-			wantMsg:  `conflicting tags: {\+default, \+k8s:required}`,
+			name:     "alpha context, alpha tag",
+			comments: []string{"+k8s:alpha=+k8s:forbidden"}, // Alpha context, Alpha tag
+			wantMsg:  "",
 		},
 		{
-			name:     "default required",
-			comments: []string{"+default=somevalue", "+k8s:required"},
-			wantMsg:  `conflicting tags: {\+default, \+k8s:required}`,
+			name:     "stable context, alpha tag",
+			comments: []string{"+k8s:forbidden"}, // Stable context, Alpha tag
+			wantMsg:  `tag "k8s:forbidden" with stability level "Alpha" cannot be used in Stable validation`,
 		},
 		{
-			name:     "required empty default",
-			comments: []string{"+k8s:required", "", "+default=somevalue"},
-			wantMsg:  `conflicting tags: {\+default, \+k8s:required}`,
-		},
-		{
-			name:     "empty default empty empty required empty",
-			comments: []string{"", "+default=somevalue", "", "", "+k8s:required", ""},
-			wantMsg:  `conflicting tags: {\+default, \+k8s:required}`,
+			name:     "beta context, alpha tag",
+			comments: []string{"+k8s:beta=+k8s:forbidden"}, // Beta context, Alpha tag
+			wantMsg:  `tag "k8s:forbidden" with stability level "Alpha" cannot be used in Beta validation`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			msg, err := ruleRequiredAndDefault(tt.comments)
+			dummyType := &types.Type{Name: types.Name{Name: "Dummy"}}
+			rule := validationStability(sets.New("Dummy"))
+			tags, _ := validator.ExtractTags(validators.Context{}, tt.comments)
+			msg, err := rule(nil, dummyType, tags)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
-			} else if tt.wantMsg != "" {
-				re := regexp.MustCompile(tt.wantMsg)
-				if !re.MatchString(msg) {
-					t.Errorf("message:\n\t%s\ndoes not match:\n\t%s", msg, re.String())
-				}
+			} else if msg != tt.wantMsg {
+				t.Errorf("got %q, want %q", msg, tt.wantMsg)
 			}
 		})
 	}
 }
 
-func TestConflictingTagsRule(t *testing.T) {
+func TestTransitiveClosure(t *testing.T) {
+	universe := types.Universe{}
+	pkg := &types.Package{
+		Path:  "test/pkg",
+		Name:  "pkg",
+		Types: map[string]*types.Type{},
+	}
+	universe["test/pkg"] = pkg
+
+	recursiveType := &types.Type{
+		Name: types.Name{Package: "test/pkg", Name: "Recursive"},
+		Kind: types.Struct,
+	}
+	// Self-reference via pointer
+	recursiveType.Members = []types.Member{
+		{
+			Name: "Self",
+			Type: &types.Type{
+				Kind: types.Pointer,
+				Elem: recursiveType,
+			},
+		},
+	}
+	pkg.Types["Recursive"] = recursiveType
+
+	rootType := &types.Type{
+		Name: types.Name{Package: "test/pkg", Name: "Root"},
+		Kind: types.Struct,
+		Members: []types.Member{
+			{
+				Name: "Field",
+				Type: recursiveType,
+			},
+		},
+	}
+	pkg.Types["Root"] = rootType
+
+	roots := []string{"test/pkg.Root"}
+	closure := transitiveClosure(universe, roots)
+
+	if !closure.Has("test/pkg.Root") {
+		t.Errorf("closure missing Root")
+	}
+	if !closure.Has("test/pkg.Recursive") {
+		t.Errorf("closure missing Recursive")
+	}
+}
+
+func TestRuleTypeFiltering(t *testing.T) {
+	enabledTypes := sets.New("AllowedType")
+	rule := validationStability(enabledTypes)
+
 	tests := []struct {
 		name     string
+		typeName string
 		comments []string
-		tags     []string
 		wantMsg  string
 	}{
 		{
-			name:     "no comments",
-			comments: []string{},
-			tags:     []string{"+tag1", "+tag2"},
+			name:     "allowed type, invalid tag",
+			typeName: "AllowedType",
+			comments: []string{"+k8s:forbidden"},
+			wantMsg:  `tag "k8s:forbidden" with stability level "Alpha" cannot be used in Stable validation`,
+		},
+		{
+			name:     "ignored type, invalid tag",
+			typeName: "IgnoredType",
+			comments: []string{"+k8s:forbidden"},
 			wantMsg:  "",
-		},
-		{
-			name:     "only tag1",
-			comments: []string{"+tag1"},
-			tags:     []string{"+tag1", "+tag2"},
-			wantMsg:  "",
-		},
-		{
-			name:     "tag1, empty, tag2",
-			comments: []string{"+tag1", "", "+tag2"},
-			tags:     []string{"+tag1", "+tag2"},
-			wantMsg:  `conflicting tags: {\+tag1, \+tag2}`,
-		},
-		{
-			name:     "3 lines 2 tags match",
-			comments: []string{"tag3", "+tag1", "+tag2=value"},
-			tags:     []string{"+tag1", "+tag2", "+tag3"},
-			wantMsg:  `conflicting tags: {\+tag1, \+tag2}`,
-		},
-		{
-			name:     "3 tags all match",
-			comments: []string{"+tag3", "+tag1", "+tag2=value"},
-			tags:     []string{"+tag1", "+tag2", "+tag3"},
-			wantMsg:  `conflicting tags: {\+tag1, \+tag2, \+tag3}`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			msg, err := conflictingTagsRule("test", tt.tags...)(tt.comments)
+			typ := &types.Type{Name: types.Name{Name: tt.typeName}}
+			tags, _ := validator.ExtractTags(validators.Context{}, tt.comments)
+			msg, err := rule(nil, typ, tags)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
-			} else if tt.wantMsg != "" {
-				re := regexp.MustCompile(tt.wantMsg)
-				if !re.MatchString(msg) {
-					t.Errorf("message:\n\t%s\ndoes not match:\n\t%s", msg, re.String())
-				}
+			} else if msg != tt.wantMsg {
+				t.Errorf("got %q, want %q", msg, tt.wantMsg)
 			}
 		})
 	}
 }
-
 func TestLintType(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -435,6 +474,357 @@ func TestLintType(t *testing.T) {
 			}
 			if counter != tt.wantCount {
 				t.Errorf("expected %d rule invocations, got %d", tt.wantCount, counter)
+			}
+		})
+	}
+}
+
+func TestHasAnyValidationTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		comments []string
+		want     bool
+	}{
+		{
+			name:     "empty",
+			comments: []string{},
+			want:     false,
+		},
+		{
+			name:     "no k8s tags",
+			comments: []string{"just a comment"},
+			want:     false,
+		},
+		{
+			name:     "optional only",
+			comments: []string{"+k8s:optional"},
+			want:     false,
+		},
+		{
+			name:     "required only",
+			comments: []string{"+k8s:required"},
+			want:     true,
+		},
+		{
+			name:     "forbidden only",
+			comments: []string{"+k8s:forbidden"},
+			want:     true,
+		},
+		{
+			name:     "unrecognized k8s tag",
+			comments: []string{"+k8s:openapi-gen=true"},
+			want:     false,
+		},
+		{
+			name:     "minimum tag",
+			comments: []string{"+k8s:minimum=0"},
+			want:     true,
+		},
+		{
+			name:     "enum tag",
+			comments: []string{"+k8s:enum"},
+			want:     true,
+		},
+		{
+			name:     "mixed with optional",
+			comments: []string{"+k8s:optional", "+k8s:minimum=0"},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tags, _ := validator.ExtractTags(validators.Context{}, tt.comments)
+			if got := hasAnyValidationTag(tags); got != tt.want {
+				t.Errorf("hasAnyValidationTag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasRequirednessTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		comments []string
+		want     bool
+	}{
+		{
+			name:     "empty",
+			comments: []string{},
+			want:     false,
+		},
+		{
+			name:     "no requireness",
+			comments: []string{"+k8s:minimum=0"},
+			want:     false,
+		},
+		{
+			name:     "optional",
+			comments: []string{"+k8s:optional"},
+			want:     true,
+		},
+		{
+			name:     "required",
+			comments: []string{"+k8s:required"},
+			want:     true,
+		},
+		{
+			name:     "optional with value",
+			comments: []string{"+k8s:optional=true"},
+			want:     true,
+		},
+		{
+			name:     "conditional optional",
+			comments: []string{`+k8s:alpha(since:"1.35")=+k8s:optional`},
+			want:     true,
+		},
+		{
+			name:     "conditional required",
+			comments: []string{`+k8s:alpha(since:"1.35")=+k8s:required`},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tags, _ := validator.ExtractTags(validators.Context{}, tt.comments)
+			if got := hasRequirednessTag(tags); got != tt.want {
+				t.Errorf("hasRequirednessTag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLintRequiredness(t *testing.T) {
+	tests := []struct {
+		name       string
+		typeToLint *types.Type
+		wantError  string
+	}{
+		{
+			name: "pointer field without validation - no error",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "pkg", Name: "T"},
+				Kind: types.Struct,
+				Members: []types.Member{{
+					Name: "Foo",
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "Bar"},
+						Kind: types.Pointer,
+						Elem: &types.Type{Name: types.Name{Package: "", Name: "string"}},
+					},
+				}},
+			},
+			wantError: "",
+		},
+		{
+			name: "pointer field with direct validation, no requireness - error",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "pkg", Name: "T"},
+				Kind: types.Struct,
+				Members: []types.Member{{
+					Name:         "Foo",
+					CommentLines: []string{"+k8s:minimum=0"},
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "Bar"},
+						Kind: types.Pointer,
+						Elem: &types.Type{Name: types.Name{Package: "", Name: "int"}},
+					},
+				}},
+			},
+			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "pointer field with transitive validation, no requireness - error",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "pkg", Name: "T"},
+				Kind: types.Struct,
+				Members: []types.Member{{
+					Name: "Foo",
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "Nested"},
+						Kind: types.Pointer,
+						Elem: &types.Type{
+							Name: types.Name{Package: "pkg", Name: "Inner"},
+							Kind: types.Struct,
+							Members: []types.Member{{
+								Name:         "Bar",
+								CommentLines: []string{"+k8s:minimum=0"},
+								Type:         &types.Type{Name: types.Name{Package: "", Name: "int"}},
+							}},
+						},
+					},
+				}},
+			},
+			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "pointer field with validation and +k8s:optional - no error",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "pkg", Name: "T"},
+				Kind: types.Struct,
+				Members: []types.Member{{
+					Name:         "Foo",
+					CommentLines: []string{"+k8s:optional", "+k8s:minimum=0"},
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "Bar"},
+						Kind: types.Pointer,
+						Elem: &types.Type{Name: types.Name{Package: "", Name: "int"}},
+					},
+				}},
+			},
+			wantError: "",
+		},
+		{
+			name: "slice field with validation, no requireness - error",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "pkg", Name: "T"},
+				Kind: types.Struct,
+				Members: []types.Member{{
+					Name:         "Items",
+					CommentLines: []string{"+k8s:maxItems=10"},
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "List"},
+						Kind: types.Slice,
+						Elem: &types.Type{Name: types.Name{Package: "", Name: "string"}},
+					},
+				}},
+			},
+			wantError: "field Items: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "map field with validation, no requireness - error",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "pkg", Name: "T"},
+				Kind: types.Struct,
+				Members: []types.Member{{
+					Name:         "Data",
+					CommentLines: []string{"+k8s:maxItems=5"},
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "M"},
+						Kind: types.Map,
+						Key:  &types.Type{Name: types.Name{Package: "", Name: "string"}},
+						Elem: &types.Type{Name: types.Name{Package: "", Name: "string"}},
+					},
+				}},
+			},
+			wantError: "field Data: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "non-pointer struct field with validation - no error (exempt)",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "pkg", Name: "T"},
+				Kind: types.Struct,
+				Members: []types.Member{{
+					Name: "Nested",
+					Type: &types.Type{
+						Name:         types.Name{Package: "pkg", Name: "Inner"},
+						Kind:         types.Struct,
+						CommentLines: []string{"+k8s:minimum=0"},
+					},
+				}},
+			},
+			wantError: "",
+		},
+		{
+			name: "recursive type with pointer to self - no infinite loop",
+			typeToLint: func() *types.Type {
+				t := &types.Type{
+					Name: types.Name{Package: "pkg", Name: "Node"},
+					Kind: types.Struct,
+				}
+				t.Members = []types.Member{{
+					Name:         "Next",
+					CommentLines: []string{"+k8s:optional"},
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "NodePtr"},
+						Kind: types.Pointer,
+						Elem: t, // cycle
+					},
+				}}
+				return t
+			}(),
+			wantError: "",
+		},
+		{
+			name: "recursive type with pointer to self - no infinite loop, missing required validation",
+			typeToLint: func() *types.Type {
+				t := &types.Type{
+					Name: types.Name{Package: "pkg", Name: "Node"},
+					Kind: types.Struct,
+				}
+				t.Members = []types.Member{{
+					Name:         "Next",
+					CommentLines: []string{"+k8s:immutable"},
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "NodePtr"},
+						Kind: types.Pointer,
+						Elem: t, // cycle
+					},
+				}}
+				return t
+			}(),
+			wantError: "field Next: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "recursive type with validation - detects validation on first visit",
+			typeToLint: func() *types.Type {
+				t := &types.Type{
+					Name:         types.Name{Package: "pkg", Name: "Node"},
+					Kind:         types.Struct,
+					CommentLines: []string{"+k8s:immutable"},
+				}
+				t.Members = []types.Member{{
+					Name:         "Next",
+					CommentLines: []string{"+k8s:optional"},
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "NodePtr"},
+						Kind: types.Pointer,
+						Elem: t, // cycle
+					},
+				}}
+				return t
+			}(),
+			wantError: "",
+		},
+		{
+			name: "array field with transitive validation, no requiredNess - error",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "pkg", Name: "T"},
+				Kind: types.Struct,
+				Members: []types.Member{{
+					Name: "Arr",
+					Type: &types.Type{
+						Name: types.Name{Package: "pkg", Name: "ArrType"},
+						Kind: types.Array,
+						Elem: &types.Type{
+							Name:         types.Name{Package: "pkg", Name: "Inner"},
+							Kind:         types.Struct,
+							CommentLines: []string{"+k8s:enum"},
+						},
+					},
+				}},
+			},
+			wantError: "field Arr: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newLinter(requiredAndOptional(validator))
+			if err := l.lintType(tt.typeToLint); err != nil {
+				t.Fatalf("lintType() unexpected error: %v", err)
+			}
+			errs := l.lintErrors[tt.typeToLint]
+			if len(errs) > 1 {
+				t.Fatalf("got %d errors, but expected 0 or 1 error: %v", len(errs), errs)
+			}
+			var gotError string
+			if len(errs) == 1 {
+				gotError = errs[0].Error()
+			}
+			if gotError != tt.wantError {
+				t.Errorf("lintRequiredness() error = %q, want %q", gotError, tt.wantError)
 			}
 		})
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
@@ -74,11 +74,12 @@ func main() {
 }
 
 type Args struct {
-	OutputFile   string
-	ReadOnlyPkgs []string // Always consider these as last-ditch possibilities for validations.
-	GoHeaderFile string
-	PrintDocs    bool
-	LintOnly     bool
+	OutputFile      string
+	ReadOnlyPkgs    []string // Always consider these as last-ditch possibilities for validations.
+	GoHeaderFile    string
+	PrintDocs       bool
+	LintOnly        bool
+	DVEnforcedRoots []string
 }
 
 // AddFlags add the generator flags to the flag set.
@@ -93,6 +94,8 @@ func (args *Args) AddFlags(fs *pflag.FlagSet) {
 		"print documentation for supported declarative validations, and then exit")
 	fs.BoolVar(&args.LintOnly, "lint", false,
 		"only run linting checks, do not generate code")
+	fs.StringSliceVar(&args.DVEnforcedRoots, "dv-enforced-roots", args.DVEnforcedRoots,
+		"list of root types (e.g. k8s.io/api/core/v1.Pod) to enforce strict linting rules on")
 }
 
 // Validate checks the given arguments.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
@@ -94,7 +94,7 @@ func (args *Args) AddFlags(fs *pflag.FlagSet) {
 		"print documentation for supported declarative validations, and then exit")
 	fs.BoolVar(&args.LintOnly, "lint", false,
 		"only run linting checks, do not generate code")
-	fs.StringSliceVar(&args.DVEnforcedRoots, "dv-enforced-roots", args.DVEnforcedRoots,
+	fs.StringSliceVar(&args.DVEnforcedRoots, "dv-enforced-root", args.DVEnforcedRoots,
 		"list of root types (e.g. k8s.io/api/core/v1.Pod) to enforce strict linting rules on")
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
@@ -74,12 +74,10 @@ func main() {
 }
 
 type Args struct {
-	OutputFile      string
-	ReadOnlyPkgs    []string // Always consider these as last-ditch possibilities for validations.
-	GoHeaderFile    string
-	PrintDocs       bool
-	LintOnly        bool
-	DVEnforcedRoots []string
+	OutputFile   string
+	ReadOnlyPkgs []string // Always consider these as last-ditch possibilities for validations.
+	GoHeaderFile string
+	PrintDocs    bool
 }
 
 // AddFlags add the generator flags to the flag set.
@@ -92,10 +90,6 @@ func (args *Args) AddFlags(fs *pflag.FlagSet) {
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")
 	fs.BoolVar(&args.PrintDocs, "docs", false,
 		"print documentation for supported declarative validations, and then exit")
-	fs.BoolVar(&args.LintOnly, "lint", false,
-		"only run linting checks, do not generate code")
-	fs.StringSliceVar(&args.DVEnforcedRoots, "dv-enforced-root", args.DVEnforcedRoots,
-		"list of root types (e.g. k8s.io/api/core/v1.Pod) to enforce strict linting rules on")
 }
 
 // Validate checks the given arguments.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/_codegenignore/other/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/_codegenignore/other/doc.go
@@ -20,6 +20,7 @@ limitations under the License.
 // are not part of the gengo args.  Even though this package purports to have
 // validations, it is outside of the args used when generating output_tests,
 // and so the generated could should NOT descend into these.
+// +k8s:validation-gen-nolint
 package other
 
 // +k8s:validateFalse="you should not see this outside of this pkg"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/trivial/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/trivial/doc.go
@@ -20,6 +20,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package trivial
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_field_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_field_validations/doc.go
@@ -20,6 +20,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package withfieldvalidations
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/doc.go
@@ -20,6 +20,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package withtypevalidations
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cohorts/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cohorts/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package cohorts
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/doc.go
@@ -21,6 +21,7 @@ limitations under the License.
 //nolint:unused
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package crosspkg
 
 import (

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package elidenovalidations
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/embedded/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/embedded/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package embedded
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/keys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/keys/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package keys
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_primitive/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package mapofprimitive
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_struct/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package mapofstruct
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package multiplevalidations
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef_to_map/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef_to_map/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package typedeftomap
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/multiple_tags/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/multiple_tags/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package multipletags
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_generation/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_generation/doc.go
@@ -18,6 +18,8 @@ limitations under the License.
 
 // Package nogeneration is a test package.
 //
+// +k8s:validation-gen-nolint
+//
 //nolint:unused
 package nogeneration
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_types_match/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_types_match/doc.go
@@ -20,6 +20,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package notypesmatch
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/trivial/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/trivial/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package trivial
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_field_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_field_validations/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package withfieldvalidations
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_type_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_type_validations/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package withtypevalidations
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package structs
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package typedefs
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/pointers/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/pointers/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package pointers
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/primitives/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/primitives/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package primitives
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/public_private/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/public_private/doc.go
@@ -20,6 +20,8 @@ limitations under the License.
 
 // Package publicprivate is a test package.
 //
+// +k8s:validation-gen-nolint
+//
 //nolint:unused,govet // govet disables structtag check, which checks for use of tags on private fields
 package publicprivate
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/default_behavior/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/default_behavior/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package defaultbehavior
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package list
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/maps/eachkey/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/maps/eachkey/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package eachkey
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/maps/eachval/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/maps/eachval/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package eachval
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/subfield/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/subfield/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package subfield
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/maps/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/maps/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package maps
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/pointers/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/pointers/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package pointers
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/slices/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/slices/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package slices
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package multiplevalidations
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_primitive/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package sliceofprimitive
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_struct/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package sliceofstruct
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef_to_slice/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef_to_slice/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package typedeftoslice
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/discriminator/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/discriminator/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package discriminator
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachkey/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachkey/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package eachkey
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_primitive/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package mapofprimitive
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_struct/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package mapofstruct
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_primitive/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package sliceofprimitive
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_struct/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package sliceofstruct
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_map/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_map/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package typedeftomap
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_slice/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_slice/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package typedeftoslice
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package enum
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/options/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/options/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package options
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-extended-resource-name/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-extended-resource-name/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package k8sextendedresourcename
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-key/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-key/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 
 // Package format is the internal version of the API.
 // +k8s:validation:internal
+// +k8s:validation-gen-nolint
 package format
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-value/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-value/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package format
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-long-name-caseless/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-long-name-caseless/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package format
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-long-name/k8s-long-name/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-long-name/k8s-long-name/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package format
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-resource-fully-qualified-name/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-resource-fully-qualified-name/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package fullyqualifiedname
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-resource-pool-name/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-resource-pool-name/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package format
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-short-name/k8s-short-name/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-short-name/k8s-short-name/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package format
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-uuid/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-uuid/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package k8suuid
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package immutable
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/immutable_transitions/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/immutable_transitions/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package transitions
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package multiplekeys
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package singlekey
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/subfield/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/subfield/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package subfield
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/typedef/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/typedef/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package typedef
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/union/simple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/union/simple/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package unionsimple
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/union/typedef/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/union/typedef/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package uniontypedef
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/zerorooneof/simple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/zerorooneof/simple/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package zeroroneofsimple
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/zerorooneof/typedef/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/zerorooneof/typedef/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package zeroroneooftypedef
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/atomicslice/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/atomicslice/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package atomicslice
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/enums/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/enums/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package enums
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/listkeys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/listkeys/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package listkeys
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/listmapitem/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/listmapitem/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package listmapitem
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/listset/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/listset/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package listset
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/mapvalidation/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/mapvalidation/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package mapvalidation
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/optionalrequired/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/optionalrequired/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package optionalrequired
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/simple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/simple/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package simple
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/structs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/structs/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package structs
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package subfields
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/doc.go
@@ -32,8 +32,17 @@ type Struct struct {
 
 	// +k8s:beta=+k8s:subfield(inner)=+k8s:minimum=5
 	SubfieldBeta SubStruct `json:"subfieldBeta"`
+
+	// +k8s:alpha=+k8s:subfield(z1)=+k8s:zeroOrOneOfMember
+	// +k8s:alpha=+k8s:subfield(z2)=+k8s:zeroOrOneOfMember
+	UnionField SubUnion `json:"unionField"`
 }
 
 type SubStruct struct {
 	Inner int `json:"inner"`
+}
+
+type SubUnion struct {
+	Z1 *int `json:"z1"`
+	Z2 *int `json:"z2"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/doc_test.go
@@ -37,6 +37,20 @@ func TestAlpha(t *testing.T) {
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByValidationStabilityLevel(), field.ErrorList{
 		field.Invalid(field.NewPath("subfield", "inner"), 1, "").WithOrigin("minimum").MarkAlpha(),
 	})
+
+	one := 1
+	st.Value(&Struct{
+		Subfield:     SubStruct{Inner: 5},
+		SubfieldBeta: SubStruct{Inner: 5},
+		UnionField: SubUnion{
+			Z1: &one,
+			Z2: &one,
+		},
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByValidationStabilityLevel(), field.ErrorList{
+		field.Invalid(field.NewPath("unionField"), &SubUnion{
+			Z1: &one, Z2: &one,
+		}, "only one of z1, z2 may be specified").WithOrigin("zeroOrOneOf").MarkAlpha(),
+	})
 }
 
 func TestBeta(t *testing.T) {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/zz_generated.validations.go
@@ -25,6 +25,7 @@ import (
 	context "context"
 	fmt "fmt"
 
+	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
@@ -47,6 +48,8 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 	})
 	return nil
 }
+
+var zeroOrOneOfMembershipFor_k8s_io_code_generator_cmd_validation_gen_output_tests_tags_levels_subfields_Struct_unionField_ = validate.NewUnionMembership(validate.NewUnionMember("z1"), validate.NewUnionMember("z2"))
 
 // Validate_Struct validates an instance of Struct according
 // to declarative validation rules in the API schema.
@@ -84,6 +87,28 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			}()
 			return
 		}(fldPath.Child("subfieldBeta"), &obj.SubfieldBeta, safe.Field(oldObj, func(oldObj *Struct) *SubStruct { return &oldObj.SubfieldBeta }), oldObj != nil)...)
+
+	// field Struct.UnionField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *SubUnion, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			errs = append(errs, validate.ZeroOrOneOfUnion(ctx, op, fldPath, obj, oldObj, zeroOrOneOfMembershipFor_k8s_io_code_generator_cmd_validation_gen_output_tests_tags_levels_subfields_Struct_unionField_, func(obj *SubUnion) bool {
+				if obj == nil {
+					return false
+				}
+				return obj.Z1 != nil
+			}, func(obj *SubUnion) bool {
+				if obj == nil {
+					return false
+				}
+				return obj.Z2 != nil
+			}).MarkAlpha()...)
+			return
+		}(fldPath.Child("unionField"), &obj.UnionField, safe.Field(oldObj, func(oldObj *Struct) *SubUnion { return &oldObj.UnionField }), oldObj != nil)...)
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/doc.go
@@ -103,3 +103,28 @@ type Z2 struct{}
 
 type BetaZ1 struct{}
 type BetaZ2 struct{}
+
+type MyListStruct struct {
+	TypeMeta int
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=name
+	// +k8s:alpha=+k8s:item(name: "succeeded")=+k8s:zeroOrOneOfMember
+	// +k8s:alpha=+k8s:item(name: "failed")=+k8s:zeroOrOneOfMember
+	Tasks []Task `json:"tasks"`
+}
+
+type MyListStructBeta struct {
+	TypeMeta int
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=name
+	// +k8s:beta=+k8s:item(name: "succeeded")=+k8s:zeroOrOneOfMember
+	// +k8s:beta=+k8s:item(name: "failed")=+k8s:zeroOrOneOfMember
+	TasksBeta []Task `json:"tasksBeta"`
+}
+
+type Task struct {
+	Name  string `json:"name"`
+	State string `json:"state"`
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package unions
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/doc_test.go
@@ -45,6 +45,15 @@ func TestAlpha(t *testing.T) {
 			Z1: &Z1{}, Z2: &Z2{},
 		}, "only one of z1, z2 may be specified").WithOrigin("zeroOrOneOf").MarkAlpha(),
 	})
+
+	st.Value(&MyListStruct{
+		Tasks: []Task{
+			{Name: "succeeded", State: "Succeeded"},
+			{Name: "failed", State: "Failed"},
+		},
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByValidationStabilityLevel(), field.ErrorList{
+		field.Invalid(field.NewPath("tasks"), nil, "").WithOrigin("zeroOrOneOf").MarkAlpha(),
+	})
 }
 
 func TestBeta(t *testing.T) {
@@ -69,5 +78,14 @@ func TestBeta(t *testing.T) {
 		field.Invalid(nil, &MyStructBeta{
 			Z1Beta: &BetaZ1{}, Z2Beta: &BetaZ2{},
 		}, "only one of z1Beta, z2Beta may be specified").WithOrigin("zeroOrOneOf").MarkBeta(),
+	})
+
+	st.Value(&MyListStructBeta{
+		TasksBeta: []Task{
+			{Name: "succeeded", State: "Succeeded"},
+			{Name: "failed", State: "Failed"},
+		},
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByValidationStabilityLevel(), field.ErrorList{
+		field.Invalid(field.NewPath("tasksBeta"), nil, "").WithOrigin("zeroOrOneOf").MarkBeta(),
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/zz_generated.validations.go
@@ -25,6 +25,7 @@ import (
 	context "context"
 	fmt "fmt"
 
+	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
@@ -37,6 +38,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
+	// type MyListStruct
+	scheme.AddValidationFunc((*MyListStruct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_MyListStruct(ctx, op, nil /* fldPath */, obj.(*MyListStruct), safe.Cast[*MyListStruct](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type MyListStructBeta
+	scheme.AddValidationFunc((*MyListStructBeta)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_MyListStructBeta(ctx, op, nil /* fldPath */, obj.(*MyListStructBeta), safe.Cast[*MyListStructBeta](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type MyStruct
 	scheme.AddValidationFunc((*MyStruct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -70,6 +87,82 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+var zeroOrOneOfMembershipFor_k8s_io_code_generator_cmd_validation_gen_output_tests_tags_levels_unions_MyListStruct_tasks_ = validate.NewUnionMembership(validate.NewUnionMember("tasks[{\"name\": \"succeeded\"}]"), validate.NewUnionMember("tasks[{\"name\": \"failed\"}]"))
+
+// Validate_MyListStruct validates an instance of MyListStruct according
+// to declarative validation rules in the API schema.
+func Validate_MyListStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *MyListStruct) (errs field.ErrorList) {
+	// field MyListStruct.TypeMeta has no validation
+
+	// field MyListStruct.Tasks
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []Task, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a Task, b Task) bool { return a.Name == b.Name })...)
+			errs = append(errs, validate.ZeroOrOneOfUnion(ctx, op, fldPath, obj, oldObj, zeroOrOneOfMembershipFor_k8s_io_code_generator_cmd_validation_gen_output_tests_tags_levels_unions_MyListStruct_tasks_, func(list []Task) bool {
+				for i := range list {
+					if list[i].Name == "failed" {
+						return true
+					}
+				}
+				return false
+			}, func(list []Task) bool {
+				for i := range list {
+					if list[i].Name == "succeeded" {
+						return true
+					}
+				}
+				return false
+			}).MarkAlpha()...)
+			return
+		}(fldPath.Child("tasks"), obj.Tasks, safe.Field(oldObj, func(oldObj *MyListStruct) []Task { return oldObj.Tasks }), oldObj != nil)...)
+
+	return errs
+}
+
+var zeroOrOneOfMembershipFor_k8s_io_code_generator_cmd_validation_gen_output_tests_tags_levels_unions_MyListStructBeta_tasksBeta_ = validate.NewUnionMembership(validate.NewUnionMember("tasksBeta[{\"name\": \"succeeded\"}]"), validate.NewUnionMember("tasksBeta[{\"name\": \"failed\"}]"))
+
+// Validate_MyListStructBeta validates an instance of MyListStructBeta according
+// to declarative validation rules in the API schema.
+func Validate_MyListStructBeta(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *MyListStructBeta) (errs field.ErrorList) {
+	// field MyListStructBeta.TypeMeta has no validation
+
+	// field MyListStructBeta.TasksBeta
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []Task, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a Task, b Task) bool { return a.Name == b.Name })...)
+			errs = append(errs, validate.ZeroOrOneOfUnion(ctx, op, fldPath, obj, oldObj, zeroOrOneOfMembershipFor_k8s_io_code_generator_cmd_validation_gen_output_tests_tags_levels_unions_MyListStructBeta_tasksBeta_, func(list []Task) bool {
+				for i := range list {
+					if list[i].Name == "failed" {
+						return true
+					}
+				}
+				return false
+			}, func(list []Task) bool {
+				for i := range list {
+					if list[i].Name == "succeeded" {
+						return true
+					}
+				}
+				return false
+			}).MarkBeta()...)
+			return
+		}(fldPath.Child("tasksBeta"), obj.TasksBeta, safe.Field(oldObj, func(oldObj *MyListStructBeta) []Task { return oldObj.TasksBeta }), oldObj != nil)...)
+
+	return errs
 }
 
 var zeroOrOneOfMembershipFor_k8s_io_code_generator_cmd_validation_gen_output_tests_tags_levels_unions_MyStruct_ = validate.NewUnionMembership(validate.NewUnionMember("z1"), validate.NewUnionMember("z2"))

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/uniquetag/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/uniquetag/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
+// +k8s:validation-gen-nolint
 package uniquetag
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package multiplekeys
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package singlekey
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package listset
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package sliceofprimitive
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package sliceofstruct
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package typedeftoslice
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package maxlength
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package minimum
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neq/neqchained/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neq/neqchained/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package for complex neq compositions.
+// +k8s:validation-gen-nolint
 package neqchained
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqbool/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqbool/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package neqbool
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqint/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqint/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package neqint
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqstring/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqstring/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package neqstring
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package opaque
 
 import (

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package optional
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/nonzero_defaults/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/nonzero_defaults/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package nonzerodefaults
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zero_defaults/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zero_defaults/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package zerodefaults
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package options
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/deep/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/deep/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // Package subfield contains test types for testing subfield field validation tags.
+// +k8s:validation-gen-nolint
 package deep
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // Package nonincluded contains test types for testing subfield field validation tags.
+// +k8s:validation-gen-nolint
 package nonincluded
 
 import (

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // Package subfield contains test types for testing subfield field validation tags.
+// +k8s:validation-gen-nolint
 package shallow
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/issubresource/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/issubresource/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package issubresource
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/root/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/root/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package root
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/subresource/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/subresource/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package subresource
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/custom_members/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/custom_members/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package custommembers
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/empty/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/empty/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package empty
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/multiple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/multiple/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package multiple
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/simple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/simple/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package simple
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/sparse/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/sparse/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package sparse
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/custom_members/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/custom_members/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package custommembers
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/multiple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/multiple/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package multiple
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/simple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/simple/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package simple
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/unique/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/unique/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package unique
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package for the +k8s:update tag.
+// +k8s:validation-gen-nolint
 package update
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/validate_false/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/validate_false/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package validatefalse
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/validate_true/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/validate_true/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package validatetrue
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/custom_members/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/custom_members/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package custommembers
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/multiple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/multiple/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package multiple
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/simple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/simple/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package simple
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package typeargs
 
 import (

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/typedefs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/typedefs/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package typedefs
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/lists/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/lists/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package lists
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/maps/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/maps/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:validation-gen-test-fixture=validateFalse
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package maps
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc.go
@@ -19,6 +19,8 @@ limitations under the License.
 
 // Package primitivepointers is a test package.
 //
+// +k8s:validation-gen-nolint
+//
 //nolint:unused
 package primitivepointers
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
+// +k8s:validation-gen-nolint
 package primitives
 
 import "k8s.io/code-generator/cmd/validation-gen/testscheme"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -88,10 +88,11 @@ func (evtv eachValTagValidator) GetValidations(context Context, tag codetags.Tag
 
 	elemContext := Context{
 		// Scope is initialized below.
-		Type:       nt.Elem,
-		Path:       context.Path.Key("(vals)"),
-		Member:     nil, // NA for list/map values
-		ParentPath: context.Path,
+		Type:           nt.Elem,
+		Path:           context.Path.Key("(vals)"),
+		Member:         nil, // NA for list/map values
+		ParentPath:     context.Path,
+		StabilityLevel: context.StabilityLevel,
 	}
 	switch nt.Kind {
 	case types.Slice, types.Array:
@@ -268,11 +269,12 @@ func (ektv eachKeyTagValidator) GetValidations(context Context, tag codetags.Tag
 	}
 
 	elemContext := Context{
-		Scope:      ScopeMapKey,
-		Type:       nt.Key,
-		Path:       context.Path.Key("(keys)"),
-		Member:     nil, // NA for map keys
-		ParentPath: context.Path,
+		Scope:          ScopeMapKey,
+		Type:           nt.Key,
+		Path:           context.Path.Key("(keys)"),
+		Member:         nil, // NA for map keys
+		ParentPath:     context.Path,
+		StabilityLevel: context.StabilityLevel,
 	}
 
 	if validations, err := ektv.validator.ExtractTagValidations(elemContext, *tag.ValueTag); err != nil {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/item.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/item.go
@@ -153,11 +153,12 @@ func (itv *itemTagValidator) GetValidations(context Context, tag codetags.Tag) (
 	itemPath := context.Path.Key(itemKey)
 	itemSelector := generateSelector(criteria)
 	subContext := Context{
-		Scope:        ScopeListVal,
-		Type:         elemT,
-		Path:         itemPath,
-		ListSelector: itemSelector,
-		ParentPath:   context.Path,
+		Scope:          ScopeListVal,
+		Type:           elemT,
+		Path:           itemPath,
+		ListSelector:   itemSelector,
+		ParentPath:     context.Path,
+		StabilityLevel: context.StabilityLevel,
 	}
 
 	validations, err := itv.validator.ExtractTagValidations(subContext, *tag.ValueTag)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/levels.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/levels.go
@@ -98,7 +98,7 @@ func (ltv *levelTagValidator) GetValidations(context Context, tag codetags.Tag) 
 func (ltv *levelTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            ltv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Scopes:         ltv.ValidScopes().UnsortedList(),
 		Description:    fmt.Sprintf("Marks the given payload validation as a %s validation of the handwritten validation code. An optional Kubernetes version can be specified.", ltv.level),
 		Args: []TagArgDoc{{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
@@ -326,6 +326,11 @@ func (reg *registry) Stability(tag string) (TagStabilityLevel, error) {
 	return tv.Docs().StabilityLevel, nil
 }
 
+// GetStability returns the stability level for a given tag from the global registry.
+func GetStability(tag string) (TagStabilityLevel, error) {
+	return globalRegistry.Stability(tag)
+}
+
 // InitGlobalValidator must be called exactly once by the main application to
 // initialize and safely access the global tag registry.  Once this is called,
 // no more validators may be registered.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -71,11 +71,12 @@ func (stv subfieldTagValidator) GetValidations(context Context, tag codetags.Tag
 	}
 	result := Validations{}
 	subContext := Context{
-		Scope:      ScopeField,
-		Type:       submemb.Type,
-		Path:       context.Path.Child(subname),
-		Member:     submemb,
-		ParentPath: context.Path,
+		Scope:          ScopeField,
+		Type:           submemb.Type,
+		Path:           context.Path.Child(subname),
+		Member:         submemb,
+		ParentPath:     context.Path,
+		StabilityLevel: context.StabilityLevel,
 	}
 	if validations, err := stv.validator.ExtractTagValidations(subContext, *tag.ValueTag); err != nil {
 		return Validations{}, err


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR implements advanced linting rules and enforcement mechanisms for **Declarative Validation (KEP 5073)** within the `validation-gen` tool. The primary goal is to ensure that declarative validation markers follow stability and structural requirements before any code is generated.

**Key changes include:**
*   **Enforcement of Stability Rules:** Adds linting for `+k8s:alpha` and `+k8s:beta` prefixes to ensure they are used correctly and that nested tags do not exceed the stability level of their context.
*   **Explicit Requiredness Check:** Enforces that pointer, slice, map, and array fields with validation (direct or transitive) must explicitly declare `+k8s:optional` or `+k8s:required`.
*   **Linting in Codegen Pipeline:** Updates `hack/update-codegen.sh` to execute `validation-gen` in `--lint` mode as a pre-generation gatekeeper.
*   **Removal of Conflicting Tags Rule:** The generic `conflictingTagsRule` has been removed from the `validation-gen` internal linter. As per the enforcement principles of **KEP 5073**, any rule that can be effectively enforced by the **Kubernetes API Linter (KAL)** (such as conflicting markers) is removed from `validation-gen` to maintain a single source of truth and avoid logic duplication.
*   **API Fixes:** Corrects existing lint errors in `discovery` and `resource` API packages by adding missing `+k8s:optional` tags to validated fields.

#### Which issue(s) this PR is related to:
Related to **KEP 5073**: Declarative Validation of Kubernetes Native Types.

#### Special notes for your reviewer:
The `transitiveClosure` logic in `targets.go` now correctly identifies all types reachable from the roots specified via the new `--dv-enforced-roots` flag (e.g., `k8s.io/api/scheduling/v1alpha1.Workload`) to apply strict linting.

Suppressed lint warning for non lint run, as it was printing too many warnings for the output_tests. 

#### Does this PR introduce a user-facing change?
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- **KEP 5073**: `https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation`