### PR TITLE
Make admission quota evaluator initialization conditional on resource serving

### DIFF
--- a/pkg/controlplane/apiserver/admission/config.go
+++ b/pkg/controlplane/apiserver/admission/config.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	webhookinit "k8s.io/apiserver/pkg/admission/plugin/webhook/initializer"
 	egressselector "k8s.io/apiserver/pkg/server/egressselector"
+	"k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/apiserver/pkg/util/webhook"
 	externalinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
@@ -35,6 +36,7 @@ import (
 type Config struct {
 	LoopbackClientConfig *rest.Config
 	ExternalInformers    externalinformers.SharedInformerFactory
+	APIResourceConfig    storage.APIResourceConfigSource
 }
 
 // New sets up the plugins and admission start hooks needed for admission
@@ -42,7 +44,7 @@ func (c *Config) New(proxyTransport *http.Transport, egressSelector *egressselec
 	webhookAuthResolverWrapper := webhook.NewDefaultAuthenticationInfoResolverWrapper(proxyTransport, egressSelector, c.LoopbackClientConfig, tp)
 	webhookPluginInitializer := webhookinit.NewPluginInitializer(webhookAuthResolverWrapper, serviceResolver)
 
-	quotaConfiguration, err := quotainstall.NewQuotaConfigurationForAdmission(c.ExternalInformers)
+	quotaConfiguration, err := quotainstall.NewQuotaConfigurationForAdmission(c.ExternalInformers, c.APIResourceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -362,6 +362,7 @@ func CreateConfig(
 	genericAdmissionConfig := controlplaneadmission.Config{
 		ExternalInformers:    versionedInformers,
 		LoopbackClientConfig: genericConfig.LoopbackClientConfig,
+		APIResourceConfig:    storageFactory.APIResourceConfigSource,
 	}
 	genericInitializers, err := genericAdmissionConfig.New(proxyTransport, genericConfig.EgressSelector, serviceResolver, genericConfig.TracerProvider)
 	if err != nil {

--- a/pkg/controlplane/apiserver/samples/generic/server/config.go
+++ b/pkg/controlplane/apiserver/samples/generic/server/config.go
@@ -80,7 +80,7 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 	genericConfig, versionedInformers, storageFactory, err := controlplaneapiserver.BuildGenericConfig(
 		opts,
 		[]*runtime.Scheme{legacyscheme.Scheme, apiextensionsapiserver.Scheme, aggregatorscheme.Scheme},
-		controlplane.DefaultAPIResourceConfigSource(),
+		controlplane.DefaultGenericAPIResourceConfigSource(),
 		generatedopenapi.GetOpenAPIDefinitions,
 	)
 	if err != nil {

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -107,7 +107,7 @@ func createHandlerWithConfig(kubeClient kubernetes.Interface, informerFactory in
 	if config == nil {
 		config = &resourcequotaapi.Configuration{}
 	}
-	quotaConfiguration, err := install.NewQuotaConfigurationForAdmission(nil)
+	quotaConfiguration, err := install.NewQuotaConfigurationForAdmission(nil, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

kube-apiserver and generic API server can be started with specific API groups disabled from being served.

When this is done, quota evaluators set up for admission are unused, but may start informers on the unserved resources which would never sync, and would block API server healthz.

xref https://github.com/kubernetes/kubernetes/pull/135048#discussion_r2759312785

This PR does two things:
1. Splits the API resource configuration into generic / non-generic API groups, and makes the sample generic API server only explicitly register the API groups it can serve
2. Makes admission quota evaluators conditional on the resource it is protecting actually being served

```release-note
NONE
```

/sig api-machinery
/cc @deads2k @yliaog 