### PR TITLE
Fix N+1 event queries in kubectl describe prefix search

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
@@ -130,6 +130,7 @@ func (flags *DescribeFlags) ToOptions(parent string, args []string) (*DescribeOp
 		Namespace:         namespace,
 		Describer:         describer,
 		NewBuilder:        flags.Factory.NewBuilder,
+		Factory:           flags.Factory,
 		BuilderArgs:       builderArgs,
 		EnforceNamespace:  enforceNamespace,
 		AllNamespaces:     flags.AllNamespaces,
@@ -235,7 +236,24 @@ func (o *DescribeOptions) Run() error {
 	return utilerrors.NewAggregate(allErrs)
 }
 
+const (
+	// minPrefixLength is the minimum number of characters required for
+	// prefix-based resource matching. Short prefixes can accidentally match
+	// a very large number of resources, causing excessive API calls.
+	minPrefixLength = 3
+
+	// maxPrefixResourcesForEvents is the maximum number of prefix-matched
+	// resources for which events will be fetched. Beyond this threshold,
+	// resources are described without events and a warning is printed.
+	maxPrefixResourcesForEvents = 10
+)
+
 func (o *DescribeOptions) DescribeMatchingResources(originalError error, resource, prefix string) error {
+	// Reject very short prefixes that could match thousands of resources.
+	if len(prefix) < minPrefixLength {
+		return originalError
+	}
+
 	r := o.NewBuilder().
 		Unstructured().
 		NamespaceParam(o.Namespace).DefaultNamespace().
@@ -256,20 +274,81 @@ func (o *DescribeOptions) DescribeMatchingResources(originalError error, resourc
 	if err != nil {
 		return err
 	}
-	isFound := false
+
+	// Collect indices of prefix-matching resources.
+	// Note: the parameter name "resource" shadows the imported package,
+	// so we use index-based access rather than a typed slice.
+	var matchIdx []int
 	for ix := range infos {
-		info := infos[ix]
-		if strings.HasPrefix(info.Name, prefix) {
-			isFound = true
-			s, err := describer.Describe(info.Namespace, info.Name, *o.DescriberSettings)
+		if strings.HasPrefix(infos[ix].Name, prefix) {
+			matchIdx = append(matchIdx, ix)
+		}
+	}
+	if len(matchIdx) == 0 {
+		return originalError
+	}
+
+	// If too many resources match, skip events entirely to avoid overloading
+	// the API server. Describe each resource without events and warn the user.
+	if len(matchIdx) > maxPrefixResourcesForEvents && o.DescriberSettings.ShowEvents {
+		fmt.Fprintf(o.ErrOut, "warning: %d resources matched prefix %q; skipping event queries (threshold is %d)\n",
+			len(matchIdx), prefix, maxPrefixResourcesForEvents)
+		settings := *o.DescriberSettings
+		settings.ShowEvents = false
+		for _, ix := range matchIdx {
+			info := infos[ix]
+			s, err := describer.Describe(info.Namespace, info.Name, settings)
 			if err != nil {
 				return err
 			}
 			fmt.Fprintf(o.Out, "%s\n", s)
 		}
+		return nil
 	}
-	if !isFound {
-		return originalError
+
+	// When describing multiple namespaced resources, batch-fetch all events
+	// in the namespace with a single API call to avoid the N+1 query problem.
+	// Each Describe() call would otherwise issue its own ListEvents request.
+	// See https://github.com/kubernetes/kubectl/issues/1769
+	if len(matchIdx) > 1 && o.DescriberSettings.ShowEvents && o.Factory != nil &&
+		mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		if clientset, csErr := o.Factory.KubernetesClientSet(); csErr == nil {
+			if allEvents, evErr := describe.FetchNamespaceEvents(
+				clientset.CoreV1(), o.Namespace, o.DescriberSettings.ChunkSize,
+			); evErr == nil {
+				// Disable per-resource event fetching; we append events ourselves.
+				settings := *o.DescriberSettings
+				settings.ShowEvents = false
+				for _, ix := range matchIdx {
+					info := infos[ix]
+					s, err := describer.Describe(info.Namespace, info.Name, settings)
+					if err != nil {
+						return err
+					}
+					// Filter without Kind constraint: some describers (e.g. PodDescriber)
+					// deliberately clear Kind before searching events to be more permissive.
+					// Using name+namespace matching is consistent with that behavior.
+					filtered := describe.FilterEventsForObject(allEvents, info.Name, info.Namespace, "")
+					if len(filtered.Items) > 0 {
+						s += describe.FormatEvents(filtered)
+					}
+					fmt.Fprintf(o.Out, "%s\n", s)
+				}
+				return nil
+			}
+		}
+	}
+
+	// Fallback: describe each resource with its own event query (original behavior).
+	// This path is used for single matches, cluster-scoped resources, or when
+	// the batch event fetch fails.
+	for _, ix := range matchIdx {
+		info := infos[ix]
+		s, err := describer.Describe(info.Namespace, info.Name, *o.DescriberSettings)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(o.Out, "%s\n", s)
 	}
 	return nil
 }
@@ -281,6 +360,7 @@ type DescribeOptions struct {
 
 	Describer  func(*meta.RESTMapping) (describe.ResourceDescriber, error)
 	NewBuilder func() *resource.Builder
+	Factory    cmdutil.Factory
 
 	BuilderArgs []string
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
@@ -22,12 +22,15 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/describe"
 	"k8s.io/kubectl/pkg/scheme"
 )
@@ -322,6 +325,716 @@ func TestDescribeNoResourcesFound(t *testing.T) {
 				t.Errorf("Unexpected error:\nExpected:\n%v\nActual:\n%v", e, a)
 			}
 		})
+	}
+}
+
+// TestDescribeMatchingResourcesMultipleMatches verifies that when multiple resources
+// match a prefix, all matching resources are described in the output.
+func TestDescribeMatchingResourcesMultipleMatches(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "15"},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-abc", Namespace: "test", ResourceVersion: "10"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-def", Namespace: "test", ResourceVersion: "11"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "bar-xyz", Namespace: "test", ResourceVersion: "12"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	httpClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch p, m := req.URL.Path, req.Method; {
+		case p == "/namespaces/test/pods/foo" && m == "GET":
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		case p == "/namespaces/test/pods" && m == "GET":
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+		default:
+			// Typed client requests (e.g., batch event fetch via KubernetesClientSet)
+			// hit /api/v1/ paths. Return empty event list so the batch path works
+			// or falls back gracefully to per-resource describing.
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.EventList{})}, nil
+		}
+	})
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "foo"})
+
+	// Both foo-abc and foo-def should be described, but not bar-xyz.
+	if !strings.Contains(buf.String(), d.Output) {
+		t.Errorf("expected output to contain %q, got: %q", d.Output, buf.String())
+	}
+	// Output should contain two copies of the describer output (one per matching pod).
+	count := strings.Count(buf.String(), d.Output)
+	if count != 2 {
+		t.Errorf("expected 2 describe outputs for prefix match, got %d", count)
+	}
+}
+
+// TestDescribeMatchingResourcesSingleMatch verifies that a single prefix match
+// uses the normal per-resource event path (no batching needed).
+func TestDescribeMatchingResourcesSingleMatch(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "15"},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-abc", Namespace: "test", ResourceVersion: "10"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "bar-xyz", Namespace: "test", ResourceVersion: "11"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	httpClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch p, m := req.URL.Path, req.Method; {
+		case p == "/namespaces/test/pods/foo" && m == "GET":
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		case p == "/namespaces/test/pods" && m == "GET":
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+		default:
+			// Return 404 for any unexpected paths (API discovery, namespace checks, etc.)
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		}
+	})
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "foo"})
+
+	// Single match uses the fallback path (no batching for 1 match).
+	// ShowEvents should be true since batching is not triggered.
+	if d.Settings.ShowEvents != true {
+		t.Errorf("expected ShowEvents=true for single match, got %v", d.Settings.ShowEvents)
+	}
+	if buf.String() != fmt.Sprintf("%s\n", d.Output) {
+		t.Errorf("unexpected output: %q", buf.String())
+	}
+}
+
+// TestDescribeMatchingResourcesShortPrefix verifies that a prefix shorter than
+// minPrefixLength is rejected and returns the original NotFound error.
+func TestDescribeMatchingResourcesShortPrefix(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			// The exact name lookup returns 404, triggering the prefix-match path.
+			// But since the prefix is too short, no pod list request should be made.
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		}),
+	}
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	// Capture fatal errors without failing the test — the short prefix
+	// should cause the original NotFound error to propagate via CheckErr.
+	var fatalMsg string
+	cmdutil.BehaviorOnFatal(func(msg string, code int) {
+		fatalMsg = msg
+	})
+	defer cmdutil.DefaultBehaviorOnFatal()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "fo"}) // "fo" is 2 chars, below minPrefixLength
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for short prefix, got: %q", buf.String())
+	}
+	if fatalMsg == "" {
+		t.Error("expected fatal error for short prefix, got none")
+	}
+}
+
+// TestDescribeMatchingResourcesEventCap verifies that when more than
+// maxPrefixResourcesForEvents match, events are skipped and a warning is printed.
+func TestDescribeMatchingResourcesEventCap(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	// Create 12 pods all matching prefix "nginx-" to exceed the cap of 10.
+	var podItems []corev1.Pod
+	for i := 0; i < 12; i++ {
+		podItems = append(podItems, corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("nginx-%03d", i),
+				Namespace:       "test",
+				ResourceVersion: fmt.Sprintf("%d", 10+i),
+			},
+			Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+		})
+	}
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "100"},
+		Items:    podItems,
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	httpClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch p, m := req.URL.Path, req.Method; {
+		case p == "/namespaces/test/pods/nginx" && m == "GET":
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		case p == "/namespaces/test/pods" && m == "GET":
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+		default:
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		}
+	})
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+
+	streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "nginx"})
+
+	// All 12 pods should be described.
+	count := strings.Count(buf.String(), d.Output)
+	if count != 12 {
+		t.Errorf("expected 12 describe outputs, got %d", count)
+	}
+
+	// Events should be skipped (ShowEvents=false passed to describer).
+	if d.Settings.ShowEvents != false {
+		t.Errorf("expected ShowEvents=false when over cap, got %v", d.Settings.ShowEvents)
+	}
+
+	// Warning should be printed to stderr.
+	if !strings.Contains(errbuf.String(), "skipping event queries") {
+		t.Errorf("expected event cap warning in stderr, got: %q", errbuf.String())
+	}
+}
+
+// TestDescribeMatchingResourcesBoundaryPrefix verifies that a prefix of exactly
+// minPrefixLength (3) characters is accepted and triggers the prefix-match path.
+func TestDescribeMatchingResourcesBoundaryPrefix(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "15"},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-abc", Namespace: "test", ResourceVersion: "10"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test/pods/foo" && m == "GET":
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			case p == "/namespaces/test/pods" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+			default:
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			}
+		}),
+	}
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "foo"}) // "foo" is exactly 3 chars = minPrefixLength
+
+	// The prefix-match path should fire and describe the matching pod.
+	if !strings.Contains(buf.String(), d.Output) {
+		t.Errorf("expected output for 3-char prefix, got: %q", buf.String())
+	}
+}
+
+// TestDescribeMatchingResourcesExactlyCap verifies that exactly maxPrefixResourcesForEvents
+// (10) matches does NOT trigger the event cap warning.
+func TestDescribeMatchingResourcesExactlyCap(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	// Create exactly 10 pods matching prefix "nginx-".
+	var podItems []corev1.Pod
+	for i := 0; i < 10; i++ {
+		podItems = append(podItems, corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("nginx-%03d", i),
+				Namespace:       "test",
+				ResourceVersion: fmt.Sprintf("%d", 10+i),
+			},
+			Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+		})
+	}
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "100"},
+		Items:    podItems,
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	httpClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch p, m := req.URL.Path, req.Method; {
+		case p == "/namespaces/test/pods/nginx" && m == "GET":
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		case p == "/namespaces/test/pods" && m == "GET":
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+		default:
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.EventList{})}, nil
+		}
+	})
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+
+	streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "nginx"})
+
+	// All 10 pods should be described.
+	count := strings.Count(buf.String(), d.Output)
+	if count != 10 {
+		t.Errorf("expected 10 describe outputs, got %d", count)
+	}
+
+	// No warning should be printed — 10 is exactly the cap, not over it.
+	if strings.Contains(errbuf.String(), "skipping event queries") {
+		t.Errorf("unexpected event cap warning for exactly %d matches: %q", 10, errbuf.String())
+	}
+}
+
+// TestDescribeMatchingResourcesNoMatch verifies that when no resources match
+// the prefix, the original NotFound error is returned.
+func TestDescribeMatchingResourcesNoMatch(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "15"},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "bar-abc", Namespace: "test", ResourceVersion: "10"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test/pods/foo" && m == "GET":
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			case p == "/namespaces/test/pods" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+			default:
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			}
+		}),
+	}
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	var fatalMsg string
+	cmdutil.BehaviorOnFatal(func(msg string, code int) {
+		fatalMsg = msg
+	})
+	defer cmdutil.DefaultBehaviorOnFatal()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "foo"}) // "foo" prefix doesn't match "bar-abc"
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output when no resources match prefix, got: %q", buf.String())
+	}
+	if fatalMsg == "" {
+		t.Error("expected fatal error for no matching prefix, got none")
+	}
+}
+
+// TestDescribeMatchingResourcesBatchWithEvents verifies that when the batch path
+// fetches namespace events, matching events appear in the output for each resource.
+func TestDescribeMatchingResourcesBatchWithEvents(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "15"},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-abc", Namespace: "test", ResourceVersion: "10"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-def", Namespace: "test", ResourceVersion: "11"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+		},
+	}
+
+	events := &corev1.EventList{
+		Items: []corev1.Event{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ev-1", Namespace: "test"},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "foo-abc",
+					Namespace: "test",
+					Kind:      "Pod",
+				},
+				Source:  corev1.EventSource{Component: "kubelet"},
+				Message: "Successfully pulled image",
+				Type:    corev1.EventTypeNormal,
+				Reason:  "Pulled",
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ev-2", Namespace: "test"},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "foo-def",
+					Namespace: "test",
+					Kind:      "Pod",
+				},
+				Source:  corev1.EventSource{Component: "kubelet"},
+				Message: "Started container",
+				Type:    corev1.EventTypeNormal,
+				Reason:  "Started",
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	httpClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch p, m := req.URL.Path, req.Method; {
+		case p == "/namespaces/test/pods/foo" && m == "GET":
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		case p == "/namespaces/test/pods" && m == "GET":
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+		case p == "/api/v1/namespaces/test/events" && m == "GET":
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, events)}, nil
+		default:
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.EventList{})}, nil
+		}
+	})
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "foo"})
+
+	output := buf.String()
+	// Both pods should be described.
+	if count := strings.Count(output, d.Output); count != 2 {
+		t.Errorf("expected 2 describe outputs, got %d", count)
+	}
+	// Events should be appended from the batch fetch.
+	if !strings.Contains(output, "Successfully pulled image") {
+		t.Errorf("expected foo-abc's event in output, got: %q", output)
+	}
+	if !strings.Contains(output, "Started container") {
+		t.Errorf("expected foo-def's event in output, got: %q", output)
+	}
+	// ShowEvents should be false (disabled for describer, events appended externally).
+	if d.Settings.ShowEvents != false {
+		t.Errorf("expected ShowEvents=false in batch path, got %v", d.Settings.ShowEvents)
+	}
+}
+
+// TestDescribeMatchingResourcesBatchNoEvents verifies that when the batch path
+// finds no events for a resource, no "Events: <none>" section is appended.
+// This is intentional to avoid adding events to resource types that never show them
+// (e.g. SecretDescriber ignores ShowEvents entirely).
+func TestDescribeMatchingResourcesBatchNoEvents(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "15"},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-abc", Namespace: "test", ResourceVersion: "10"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-def", Namespace: "test", ResourceVersion: "11"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	httpClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch p, m := req.URL.Path, req.Method; {
+		case p == "/namespaces/test/pods/foo" && m == "GET":
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		case p == "/namespaces/test/pods" && m == "GET":
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+		default:
+			// Return empty event list — no events in namespace.
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.EventList{})}, nil
+		}
+	})
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "foo"})
+
+	output := buf.String()
+	// Both pods described.
+	if count := strings.Count(output, d.Output); count != 2 {
+		t.Errorf("expected 2 describe outputs, got %d", count)
+	}
+	// No events section should be appended (no events exist).
+	if strings.Contains(output, "Events:") {
+		t.Errorf("expected no Events section when batch has no matching events, got: %q", output)
+	}
+}
+
+// TestDescribeMatchingResourcesBatchFallbackOnEventError verifies that when the
+// batch event fetch fails (e.g., RBAC denied), we gracefully fall back to the
+// per-resource describe path.
+func TestDescribeMatchingResourcesBatchFallbackOnEventError(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "15"},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-abc", Namespace: "test", ResourceVersion: "10"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-def", Namespace: "test", ResourceVersion: "11"},
+				Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	httpClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch p, m := req.URL.Path, req.Method; {
+		case p == "/namespaces/test/pods/foo" && m == "GET":
+			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+		case p == "/namespaces/test/pods" && m == "GET":
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+		case strings.Contains(p, "events"):
+			// Simulate RBAC denied for event listing.
+			return &http.Response{StatusCode: http.StatusForbidden, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody(`{"kind":"Status","apiVersion":"v1","status":"Failure","message":"forbidden"}`)}, nil
+		default:
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.EventList{})}, nil
+		}
+	})
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client:               httpClient,
+	}
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Run(cmd, []string{"pods", "foo"})
+
+	output := buf.String()
+	// Despite event fetch failure, both pods should still be described
+	// via the fallback path (per-resource with ShowEvents=true).
+	if count := strings.Count(output, d.Output); count != 2 {
+		t.Errorf("expected 2 describe outputs after fallback, got %d", count)
+	}
+	// Fallback path uses ShowEvents=true (the describer handles its own events).
+	if d.Settings.ShowEvents != true {
+		t.Errorf("expected ShowEvents=true in fallback path, got %v", d.Settings.ShowEvents)
+	}
+}
+
+// TestDescribeMatchingResourcesEventCapNoWarningWhenEventsDisabled verifies that
+// when >10 resources match but ShowEvents is already false, no warning is printed.
+func TestDescribeMatchingResourcesEventCapNoWarningWhenEventsDisabled(t *testing.T) {
+	d := &testDescriber{Output: "test output"}
+	oldFn := describe.DescriberFn
+	defer func() {
+		describe.DescriberFn = oldFn
+	}()
+	describe.DescriberFn = d.describerFor
+
+	var podItems []corev1.Pod
+	for i := 0; i < 12; i++ {
+		podItems = append(podItems, corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("nginx-%03d", i),
+				Namespace:       "test",
+				ResourceVersion: fmt.Sprintf("%d", 10+i),
+			},
+			Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyAlways},
+		})
+	}
+	pods := &corev1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "100"},
+		Items:    podItems,
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test/pods/nginx" && m == "GET":
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			case p == "/namespaces/test/pods" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+			default:
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			}
+		}),
+	}
+
+	streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdDescribe("kubectl", tf, streams)
+	cmd.Flags().Set("show-events", "false")
+	cmd.Run(cmd, []string{"pods", "nginx"})
+
+	// All 12 pods described.
+	count := strings.Count(buf.String(), d.Output)
+	if count != 12 {
+		t.Errorf("expected 12 describe outputs, got %d", count)
+	}
+
+	// No warning when ShowEvents is already false — nothing to skip.
+	if strings.Contains(errbuf.String(), "skipping event queries") {
+		t.Errorf("unexpected warning when ShowEvents=false: %q", errbuf.String())
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -5359,3 +5359,51 @@ func searchEvents(client corev1client.EventsGetter, objOrRef runtime.Object, lim
 		})
 	return eventList, err
 }
+
+// FetchNamespaceEvents fetches all events in the given namespace.
+// This is used to batch-fetch events when describing multiple resources,
+// avoiding the N+1 query problem where each resource triggers a separate
+// event list API call.
+func FetchNamespaceEvents(client corev1client.EventsGetter, namespace string, limit int64) (*corev1.EventList, error) {
+	initialOpts := metav1.ListOptions{Limit: limit}
+	eventList := &corev1.EventList{}
+	err := runtimeresource.FollowContinue(&initialOpts,
+		func(options metav1.ListOptions) (runtime.Object, error) {
+			newEvents, err := client.Events(namespace).List(context.TODO(), options)
+			if err != nil {
+				return nil, runtimeresource.EnhanceListError(err, options, "events")
+			}
+			eventList.Items = append(eventList.Items, newEvents.Items...)
+			return newEvents, nil
+		})
+	return eventList, err
+}
+
+// FilterEventsForObject filters a pre-fetched event list to only include
+// events whose InvolvedObject matches the given name, namespace, and kind.
+// Pass kind="" to match all kinds (useful when the describer is permissive,
+// e.g. PodDescriber clears Kind before searching events).
+func FilterEventsForObject(allEvents *corev1.EventList, name, namespace, kind string) *corev1.EventList {
+	if allEvents == nil {
+		return &corev1.EventList{}
+	}
+	filtered := &corev1.EventList{}
+	for i := range allEvents.Items {
+		e := &allEvents.Items[i]
+		if e.InvolvedObject.Name == name && e.InvolvedObject.Namespace == namespace &&
+			(kind == "" || e.InvolvedObject.Kind == kind) {
+			filtered.Items = append(filtered.Items, *e)
+		}
+	}
+	return filtered
+}
+
+// FormatEvents formats an EventList as a describe-style events section string.
+func FormatEvents(events *corev1.EventList) string {
+	s, _ := tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		DescribeEvents(events, w)
+		return nil
+	})
+	return s
+}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -7939,3 +7939,273 @@ IY5vBsBP6cycvKRL1XZ43uF9e2zE2GiHBw==
 		})
 	}
 }
+
+func TestFilterEventsForObject(t *testing.T) {
+	allEvents := &corev1.EventList{
+		Items: []corev1.Event{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ev-1"},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "pod-a",
+					Namespace: "default",
+					Kind:      "Pod",
+				},
+				Message: "pulled image",
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ev-2"},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "pod-b",
+					Namespace: "default",
+					Kind:      "Pod",
+				},
+				Message: "started container",
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ev-3"},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "pod-a",
+					Namespace: "other",
+					Kind:      "Pod",
+				},
+				Message: "wrong namespace",
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ev-4"},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "svc-a",
+					Namespace: "default",
+					Kind:      "Service",
+				},
+				Message: "different resource same namespace",
+			},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		objName       string
+		objNamespace  string
+		objKind       string
+		expectedCount int
+		expectedNames []string
+	}{
+		{
+			name:          "matches single pod",
+			objName:       "pod-a",
+			objNamespace:  "default",
+			objKind:       "Pod",
+			expectedCount: 1,
+			expectedNames: []string{"ev-1"},
+		},
+		{
+			name:          "matches different pod",
+			objName:       "pod-b",
+			objNamespace:  "default",
+			objKind:       "Pod",
+			expectedCount: 1,
+			expectedNames: []string{"ev-2"},
+		},
+		{
+			name:          "no match wrong namespace",
+			objName:       "pod-a",
+			objNamespace:  "nonexistent",
+			objKind:       "Pod",
+			expectedCount: 0,
+		},
+		{
+			name:          "no match wrong name",
+			objName:       "pod-c",
+			objNamespace:  "default",
+			objKind:       "Pod",
+			expectedCount: 0,
+		},
+		{
+			name:          "no match wrong kind",
+			objName:       "pod-a",
+			objNamespace:  "default",
+			objKind:       "Service",
+			expectedCount: 0,
+		},
+		{
+			name:          "empty kind matches all kinds",
+			objName:       "pod-a",
+			objNamespace:  "default",
+			objKind:       "",
+			expectedCount: 1,
+			expectedNames: []string{"ev-1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filtered := FilterEventsForObject(allEvents, tc.objName, tc.objNamespace, tc.objKind)
+			if len(filtered.Items) != tc.expectedCount {
+				t.Errorf("expected %d events, got %d", tc.expectedCount, len(filtered.Items))
+			}
+			for i, name := range tc.expectedNames {
+				if filtered.Items[i].Name != name {
+					t.Errorf("expected event %d to be %q, got %q", i, name, filtered.Items[i].Name)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterEventsForObjectNilInput(t *testing.T) {
+	filtered := FilterEventsForObject(nil, "pod-a", "default", "Pod")
+	if filtered == nil {
+		t.Error("expected non-nil EventList for nil input")
+	}
+	if len(filtered.Items) != 0 {
+		t.Errorf("expected 0 events for nil input, got %d", len(filtered.Items))
+	}
+}
+
+func TestFormatEvents(t *testing.T) {
+	testCases := []struct {
+		name             string
+		events           *corev1.EventList
+		expectedContains []string
+	}{
+		{
+			name:             "empty events",
+			events:           &corev1.EventList{},
+			expectedContains: []string{"Events:", "<none>"},
+		},
+		{
+			name: "single event",
+			events: &corev1.EventList{
+				Items: []corev1.Event{
+					{
+						ObjectMeta:     metav1.ObjectMeta{Name: "ev-1"},
+						Source:         corev1.EventSource{Component: "kubelet"},
+						Message:        "Started container",
+						FirstTimestamp: metav1.NewTime(time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC)),
+						LastTimestamp:  metav1.NewTime(time.Date(2024, time.January, 15, 0, 0, 0, 0, time.UTC)),
+						Count:          1,
+						Type:           corev1.EventTypeNormal,
+					},
+				},
+			},
+			expectedContains: []string{"Events:", "Normal", "kubelet", "Started container"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := FormatEvents(tc.events)
+			for _, expected := range tc.expectedContains {
+				if !strings.Contains(out, expected) {
+					t.Errorf("expected output to contain %q, got: %s", expected, out)
+				}
+			}
+		})
+	}
+}
+
+func TestFetchNamespaceEvents(t *testing.T) {
+	events := &corev1.EventList{
+		Items: []corev1.Event{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ev-1",
+					Namespace: "test-ns",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "pod-a",
+					Namespace: "test-ns",
+				},
+				Message: "pulled image",
+				Type:    corev1.EventTypeNormal,
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ev-2",
+					Namespace: "test-ns",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "pod-b",
+					Namespace: "test-ns",
+				},
+				Message: "started container",
+				Type:    corev1.EventTypeNormal,
+			},
+		},
+	}
+
+	clientset := fake.NewClientset(events)
+	fetched, err := FetchNamespaceEvents(clientset.CoreV1(), "test-ns", 500)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fetched.Items) != 2 {
+		t.Errorf("expected 2 events, got %d", len(fetched.Items))
+	}
+}
+
+// TestFilterEventsForObjectKindWildcard verifies that passing kind="" to
+// FilterEventsForObject matches events of any Kind for the same name+namespace.
+// This is important because PodDescriber clears Kind before searching events,
+// and our batch path must reproduce that permissive behavior.
+func TestFilterEventsForObjectKindWildcard(t *testing.T) {
+	allEvents := &corev1.EventList{
+		Items: []corev1.Event{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ev-pod"},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "myapp",
+					Namespace: "default",
+					Kind:      "Pod",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ev-svc"},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "myapp",
+					Namespace: "default",
+					Kind:      "Service",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ev-other-ns"},
+				InvolvedObject: corev1.ObjectReference{
+					Name:      "myapp",
+					Namespace: "other",
+					Kind:      "Pod",
+				},
+			},
+		},
+	}
+
+	// kind="" should match both Pod and Service events with same name+namespace.
+	filtered := FilterEventsForObject(allEvents, "myapp", "default", "")
+	if len(filtered.Items) != 2 {
+		t.Errorf("expected 2 events with kind wildcard, got %d", len(filtered.Items))
+	}
+
+	// kind="Pod" should match only the Pod event.
+	filtered = FilterEventsForObject(allEvents, "myapp", "default", "Pod")
+	if len(filtered.Items) != 1 {
+		t.Errorf("expected 1 event with kind=Pod, got %d", len(filtered.Items))
+	}
+	if filtered.Items[0].Name != "ev-pod" {
+		t.Errorf("expected ev-pod, got %s", filtered.Items[0].Name)
+	}
+}
+
+// TestFetchNamespaceEventsEmpty verifies that FetchNamespaceEvents returns
+// an empty list (not nil) when no events exist in the namespace.
+func TestFetchNamespaceEventsEmpty(t *testing.T) {
+	clientset := fake.NewClientset()
+	fetched, err := FetchNamespaceEvents(clientset.CoreV1(), "empty-ns", 500)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fetched == nil {
+		t.Fatal("expected non-nil EventList, got nil")
+	}
+	if len(fetched.Items) != 0 {
+		t.Errorf("expected 0 events, got %d", len(fetched.Items))
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `kubectl describe pod <name>` gets a 404 it falls back to prefix
matching — lists all pods, filters by prefix, then calls ListEvents
per matched pod. On a namespace with thousands of pods this hammers
the API server.

Three changes to `DescribeMatchingResources`:

* Batch event fetch — single ListEvents for the namespace, filter
  client-side. Only kicks in for 2-10 namespaced prefix matches.
  Falls back to per-resource queries for single matches, cluster-scoped
  resources, or if the batch call fails.
* Minimum prefix length of 3 chars — rejects single/double char
  prefixes that would match everything.
* Event cap at 10 — if >10 resources match, describe them without
  events and print a warning. No point fetching 10k event lists for
  a typo.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1769

#### Special notes for your reviewer:

Follows the approach agreed by @soltysh, @liggitt, and @ardaguclu in
the issue thread (flatten queries + prefix minimum + event threshold).

The getter interface refactor (@liggitt comment 12) and the `.Latest()`
fix for `-f` (#136232) are separate concerns — keeping this scoped to
the event N+1 in the prefix path.

Known trade-offs:

* Filters by name+namespace only, not Kind or UID. Some describers
  (PodDescriber) deliberately clear Kind before searching events, so
  filtering by Kind would be MORE restrictive than original behaviour.
  Name+namespace is good enough — cross-resource name collisions in
  the same namespace are vanishingly rare.
* When the batch path finds zero events for a resource it doesn't
  append "Events: <none>". Doing so would add an events section to
  resource types that never showed one (SecretDescriber ignores
  ShowEvents entirely). Acceptable trade-off for the prefix-match
  path.

#### Does this PR introduce a user-facing change?

```release-note
Fix N+1 event queries in kubectl describe prefix search by batch-fetching namespace events, adding minimum prefix length (3 chars), and capping event queries at 10 matched resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```