### PR TITLE
Automated cherry pick of #130716: use diff port for TestCreateConfigWithoutWebHooks from TestCreateConfig

### DIFF
--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -481,7 +481,7 @@ func TestCreateConfigWithoutWebHooks(t *testing.T) {
 		"--allocate-node-cidrs=true",
 		"--authorization-always-allow-paths=",
 		"--bind-address=0.0.0.0",
-		"--secure-port=10200",
+		"--secure-port=10400",
 		fmt.Sprintf("--cert-dir=%s/certs", tmpdir),
 		"--cloud-provider=aws",
 		"--cluster-cidr=1.2.3.4/24",


### PR DESCRIPTION
Cherry pick of #130716 on release-1.32.

#130716: use diff port for TestCreateConfigWithoutWebHooks from TestCreateConfig

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```