### PR TITLE
fix ContainerRestartRules error message

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3694,7 +3694,7 @@ func validateContainerRestartPolicy(policy *core.ContainerRestartPolicy, rules [
 	}
 
 	if len(rules) > 20 {
-		allErrs = append(allErrs, field.TooLong(fldPath.Child("restartPolicyRules"), rules, 20))
+		allErrs = append(allErrs, field.TooMany(fldPath.Child("restartPolicyRules"), len(rules), 20))
 	}
 	for i, rule := range rules {
 		policyRulesFld := fldPath.Child("restartPolicyRules").Index(i)
@@ -3713,7 +3713,7 @@ func validateContainerRestartPolicy(policy *core.ContainerRestartPolicy, rules [
 			}
 
 			if len(rule.ExitCodes.Values) > 255 {
-				allErrs = append(allErrs, field.TooLong(exitCodesFld.Child("values"), rule.ExitCodes.Values, 255))
+				allErrs = append(allErrs, field.TooMany(exitCodesFld.Child("values"), len(rule.ExitCodes.Values), 255))
 			}
 		} else {
 			allErrs = append(allErrs, field.Required(policyRulesFld.Child("exitCodes"), "must be specified"))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`restartPolicyRules[].exitCodes.values` validation uses `field.TooLong` (designed for byte length) instead of `field.TooMany` (designed for slice length), producing an incorrect error message:

```
containers[0].restartPolicyRules[0].exitCodes.values: Too long: may not be more than 255 bytes
```

This PR replaces it with `field.TooMany` to correctly report:

```
containers[0].restartPolicyRules[0].exitCodes.values: Too many: 256: must have at most 255 items
```

#### Which issue(s) this PR is related to:

Fixes #137135

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fixed validation error messages for restartPolicyRules and exitCodes.values to report "items" instead of "bytes"
```