### PR TITLE
Pass pod from cache to updatePod in handleSchedulingFailure

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1241,6 +1241,7 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 			// ignore this err since apiserver doesn't properly validate affinity terms
 			// and we can't fix the validation for backwards compatibility.
 			podInfo.PodInfo, _ = framework.NewPodInfo(cachedPod.DeepCopy())
+			pod = podInfo.Pod
 			if err := sched.SchedulingQueue.AddUnschedulableIfNotPresent(logger, podInfo, sched.SchedulingQueue.SchedulingCycle()); err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred")
 			}


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
/kind bug
/kind flake

#### What this PR does / why we need it:

Currently handleSchedulingFailure extracts the current version of pod from the informer but it passes the old version of the object to updatePod. It means that the pod can be stale, specially the previous call to set NominatedNodeName can be not reflected in the pod status.

#### Which issue(s) this PR is related to:

#137125 

#### Special notes for your reviewer:

This PR introduces changes that are enough to remove flakiness from the TestSchedulerScheduleOne but it's not the final solution. The exact problem is described here https://github.com/kubernetes/kubernetes/issues/137125#issuecomment-3927212907 and possible definitive solutions are described here: https://github.com/kubernetes/kubernetes/issues/137125#issuecomment-3927529284

#### Does this PR introduce a user-facing change?

```
NONE 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

