### PR TITLE
Fix typo: User Case Studies -> Use Case Studies in README

### DIFF
--- a/CHANGELOG/CHANGELOG-1.27.md
+++ b/CHANGELOG/CHANGELOG-1.27.md
@@ -2789,7 +2789,7 @@ The cause PR is [reverted](https://github.com/kubernetes/kubernetes/pull/117194)
 
 ### Other (Cleanup or Flake)
 
-- Added basic Denial Of Service prevention for the the node-local kubelet `podresource` API ([#116459](https://github.com/kubernetes/kubernetes/pull/116459), [@ffromani](https://github.com/ffromani)) [SIG Node and Testing]
+- Added basic Denial Of Service prevention for the node-local kubelet `podresource` API ([#116459](https://github.com/kubernetes/kubernetes/pull/116459), [@ffromani](https://github.com/ffromani)) [SIG Node and Testing]
 - Callers of `wait.ExponentialBackoffWithContext` now must pass a `ConditionWithContextFunc` to be consistent with the signature and avoid creating a duplicate context. If your condition does not need a context you can use the `ConditionFunc.WithContext()` helper to ignore the context, or use `ExponentialBackoff` directly. ([#115113](https://github.com/kubernetes/kubernetes/pull/115113), [@smarterclayton](https://github.com/smarterclayton))
 - Changed docs for `--contention-profiling` flag to reflect it performed block profiling ([#114490](https://github.com/kubernetes/kubernetes/pull/114490), [@MadhavJivrajani](https://github.com/MadhavJivrajani))
 - E2e framework: added `--report-complete-ginkgo` and `--report-complete-junit` parameters. They work like `ginkgo --json-report <report dir>/ginkgo/report.json --junit-report <report dir>/ginkgo/report.xml`. ([#115678](https://github.com/kubernetes/kubernetes/pull/115678), [@pohly](https://github.com/pohly)) [SIG Testing]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The [Calendar](https://www.kubernetes.dev/resources/calendar/) has the list of a
 
 ## Adopters
 
-The [User Case Studies](https://kubernetes.io/case-studies/) website has real-world use cases of organizations across industries that are deploying/migrating to Kubernetes.
+The [Use Case Studies](https://kubernetes.io/case-studies/) website has real-world use cases of organizations across industries that are deploying/migrating to Kubernetes.
 
 ## Governance 
 


### PR DESCRIPTION
Simple typo fix: Changed "User Case Studies" to "Use Case Studies" in the README.md file. The link points to use case studies, not user studies.