### PR TITLE
Fix RepairIPAddress controller startup failure when namespace informer is not yet synced

### DIFF
--- a/test/integration/servicecidr/startup_race_test.go
+++ b/test/integration/servicecidr/startup_race_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecidr
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+// populateEtcdForRepairTest populates etcd with namespaces, services, and ServiceCIDR
+// to simulate an existing v1.32 cluster that needs repair during upgrade to v1.33.
+func populateEtcdForRepairTest(t *testing.T, etcdOptions *storagebackend.Config, apiServerOptions *kubeapiservertesting.TestServerInstanceOptions, numNamespaces int) string {
+	t.Logf("Populating etcd with %d namespaces and services (simulating v1.32 cluster)", numNamespaces)
+
+	// We need a temporary server just to get the etcd client
+	tempServer := kubeapiservertesting.StartTestServerOrDie(t,
+		apiServerOptions,
+		[]string{
+			"--service-cluster-ip-range=10.0.0.0/24",
+			"--advertise-address=10.1.1.1",
+		},
+		etcdOptions)
+
+	// Create test namespace directly in etcd
+	namespace := "test-repair-race"
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              namespace,
+			CreationTimestamp: metav1.Now(),
+			UID:               types.UID("test-namespace-uid"),
+		},
+	}
+	nsJSON, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), ns)
+	if err != nil {
+		t.Fatalf("Failed to encode namespace: %v", err)
+	}
+	nsKey := "/" + etcdOptions.Prefix + "/namespaces/" + namespace
+	if _, err := tempServer.EtcdClient.Put(context.Background(), nsKey, string(nsJSON)); err != nil {
+		t.Fatalf("Failed to store namespace in etcd: %v", err)
+	}
+	t.Logf("Created namespace %s in etcd", namespace)
+
+	// Create many namespaces directly in etcd to simulate a large cluster
+	// This causes the namespace informer to take significant time to sync on startup
+	for i := 0; i < numNamespaces; i++ {
+		ns := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("bulk-ns-%d", i),
+				CreationTimestamp: metav1.Now(),
+				UID:               types.UID(fmt.Sprintf("bulk-ns-uid-%d", i)),
+			},
+		}
+		nsJSON, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), ns)
+		if err != nil {
+			t.Fatalf("Failed to encode namespace: %v", err)
+		}
+		nsKey := "/" + etcdOptions.Prefix + "/namespaces/" + ns.Name
+		if _, err := tempServer.EtcdClient.Put(context.Background(), nsKey, string(nsJSON)); err != nil {
+			t.Fatalf("Failed to store namespace in etcd: %v", err)
+		}
+		if numNamespaces > 1000 && i%1000 == 0 && i > 0 {
+			t.Logf("Created %d/%d bulk namespaces in etcd", i, numNamespaces)
+		}
+	}
+	t.Logf("Created %d additional namespaces in etcd to simulate large cluster", numNamespaces)
+
+	// Create services directly in etcd (simulating existing services from v1.32)
+	// These services will need IPAddress objects created by the repair controller
+	numServices := 5
+	for i := 1; i <= numServices; i++ {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("test-service-%d", i),
+				Namespace:         namespace,
+				CreationTimestamp: metav1.Now(),
+				UID:               types.UID(fmt.Sprintf("test-svc-uid-%d", i)),
+			},
+			Spec: v1.ServiceSpec{
+				Type:      v1.ServiceTypeClusterIP,
+				ClusterIP: fmt.Sprintf("10.0.0.%d", i+10),
+				Ports: []v1.ServicePort{
+					{
+						Name:     "http",
+						Port:     80,
+						Protocol: v1.ProtocolTCP,
+					},
+				},
+			},
+		}
+		svcJSON, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), svc)
+		if err != nil {
+			t.Fatalf("Failed to encode service: %v", err)
+		}
+		svcKey := "/" + etcdOptions.Prefix + "/services/specs/" + namespace + "/" + svc.Name
+		if _, err := tempServer.EtcdClient.Put(context.Background(), svcKey, string(svcJSON)); err != nil {
+			t.Fatalf("Failed to store service in etcd: %v", err)
+		}
+		t.Logf("Created service %s with ClusterIP %s in etcd", svc.Name, svc.Spec.ClusterIP)
+	}
+
+	// Create ServiceCIDR in etcd - this is required for the repair controller to run
+	serviceCIDR := &networkingv1.ServiceCIDR{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubernetes",
+		},
+		Spec: networkingv1.ServiceCIDRSpec{
+			CIDRs: []string{"10.0.0.0/24"},
+		},
+	}
+	serviceCIDRJSON, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(networkingv1.SchemeGroupVersion), serviceCIDR)
+	if err != nil {
+		t.Fatalf("Failed to encode ServiceCIDR: %v", err)
+	}
+	serviceCIDRKey := "/" + etcdOptions.Prefix + "/servicecidrs/" + serviceCIDR.Name
+	if _, err := tempServer.EtcdClient.Put(context.Background(), serviceCIDRKey, string(serviceCIDRJSON)); err != nil {
+		t.Fatalf("Failed to store ServiceCIDR in etcd: %v", err)
+	}
+	t.Logf("Created ServiceCIDR in etcd")
+
+	// Tear down the temporary server
+	tempServer.TearDownFn()
+	t.Logf("Etcd population complete: %d namespaces, %d services, and ServiceCIDR", numNamespaces+1, numServices)
+
+	return namespace
+}
+
+// TestServiceIPRepairRaceCondition tests the race condition with real namespace load.
+//
+// This test reproduces the race condition described in https://github.com/kubernetes/kubernetes/issues/136288
+// using a real large number of namespaces (330000) without artificial delays.
+//
+// This test simulates the exact scenario where:
+//  1. A cluster is upgraded from v1.32 to v1.33 with MultiCIDRServiceAllocator enabled
+//  2. Services exist in etcd that need IPAddress objects to be created (repair scenario)
+//  3. Many namespaces (330000) exist in etcd, causing the namespace informer to take time to sync naturally
+//  4. During apiserver startup, the repair controller (in PostStartHook) tries to create IPAddress objects
+//  5. Built-in admission plugins (like NamespaceLifecycle) reject these requests with "not yet ready"
+//     because the namespace informer hasn't synced yet
+//  6. The PostStartHook fails, preventing the apiserver from becoming ready
+//
+// This test takes a long time to run (~30 minutes to populate etcd) but reproduces the issue with realistic load.
+func TestServiceIPRepairRaceCondition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping: takes 30+ minutes to load 330000 testing namespace data into etcd")
+	}
+
+	// Setup etcd
+	etcdOptions := framework.SharedEtcd()
+	apiServerOptions := kubeapiservertesting.NewDefaultTestServerOptions()
+
+	// Phase 1: Populate etcd directly to simulate an existing v1.32 cluster
+	// We write directly to etcd to avoid starting an apiserver, making the test faster
+	// Use 330000 namespaces to reproduce the issue with real load (no artificial delay)
+	t.Logf("Phase 1: Populating etcd with namespaces and services (simulating v1.32 cluster)")
+	populateEtcdForRepairTest(t, etcdOptions, apiServerOptions, 330000)
+
+	// Phase 2: Restart apiserver with MultiCIDRServiceAllocator enabled
+	// This simulates the v1.32 -> v1.33 upgrade scenario
+	t.Logf("Phase 2: Starting apiserver with MultiCIDRServiceAllocator enabled (simulating v1.33 upgrade)")
+
+	// Start the apiserver with MultiCIDRServiceAllocator enabled
+	// The repair controller will run in the PostStartHook and attempt to create IPAddress objects
+	// Due to the many namespaces, the namespace informer will take time to sync
+	// Admission plugins that depend on the namespace informer will reject requests with "not yet ready"
+	testServer := kubeapiservertesting.StartTestServerOrDie(t,
+		apiServerOptions,
+		[]string{
+			"--runtime-config=networking.k8s.io/v1beta1=true",
+			"--service-cluster-ip-range=10.0.0.0/24",
+			"--advertise-address=10.1.1.1",
+			"--disable-admission-plugins=ServiceAccount",
+			// Enable verbose logging to see repair controller logs
+			"-v=5",
+		},
+		etcdOptions)
+	defer testServer.TearDownFn()
+}

--- a/test/integration/servicecidr/startup_race_test.go
+++ b/test/integration/servicecidr/startup_race_test.go
@@ -165,9 +165,7 @@ func populateEtcdForRepairTest(t *testing.T, etcdOptions *storagebackend.Config,
 //
 // This test takes a long time to run (~30 minutes to populate etcd) but reproduces the issue with realistic load.
 func TestServiceIPRepairRaceCondition(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping: takes 30+ minutes to load 330000 testing namespace data into etcd")
-	}
+	t.Skip("reproducer for https://issues.k8s.io/136288")
 
 	// Setup etcd
 	etcdOptions := framework.SharedEtcd()

--- a/test/integration/servicecidr/startup_race_test.go
+++ b/test/integration/servicecidr/startup_race_test.go
@@ -67,7 +67,7 @@ func populateEtcdForRepairTest(t *testing.T, etcdOptions *storagebackend.Config,
 
 	// Create many namespaces directly in etcd to simulate a large cluster
 	// This causes the namespace informer to take significant time to sync on startup
-	for i := 0; i < numNamespaces; i++ {
+	for i := range numNamespaces {
 		ns := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              fmt.Sprintf("bulk-ns-%d", i),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

During apiserver startup on clusters upgrading from v1.32 to v1.33 with `MultiCIDRServiceAllocator` enabled, the IP address repair controller (`RepairIPAddress`) runs in a PostStartHook and attempts to create `IPAddress` objects for existing services. On clusters with many namespaces (330k+), the namespace informer takes a long time to sync. During this window, the admission plugin webhook rejects requests with `Forbidden` errors because it considers itself "not yet ready".

Previously, `runOnce()` only retried on `Conflict` errors. This PR changes it to also retry on `Forbidden` errors, allowing the repair controller to succeed once the namespace informer finishes syncing, instead of failing the PostStartHook and preventing the apiserver from becoming ready.

Changes:
- In `RepairIPAddress.runOnce()`, switch from `retry.RetryOnConflict` to `retry.OnError` with a custom predicate that retries on both `Conflict` and `Forbidden` errors
- Add an integration test that reproduces the issue with 330k namespaces (skipped in short mode due to ~30 min runtime)


#### Which issue(s) this PR is related to:
Fixes #136288
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The integration test `TestServiceIPRepairRaceCondition` is skipped in short mode (`testing.Short()`) because it takes ~30 minutes to populate etcd with 330k namespaces. To run it manually:
```
go test -v -short=false ./test/integration/servicecidr/ -run TestServiceIPRepairRaceCondition -timeout 0
```



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix apiserver startup failure during upgrade when MultiCIDRServiceAllocator is enabled and the cluster has a large number of namespaces. The IP address repair controller now retries on Forbidden errors from admission plugins that are not yet ready.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
