### PR TITLE
fix: remove duplicate etcd readiness check

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -356,15 +356,17 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 	if err != nil {
 		return err
 	}
-	c.AddHealthChecks(healthz.NamedGroupedCheck("etcd", "etcd", func(r *http.Request) error {
+	namedHealthCheck := healthz.NamedGroupedCheck("etcd", "etcd", func(r *http.Request) error {
 		return healthCheck()
-	}))
+	})
+	c.AddHealthzChecks(namedHealthCheck)
+	c.AddLivezChecks(namedHealthCheck)
 
 	readyCheck, err := storagefactory.CreateReadyCheck(s.StorageConfig, c.DrainedNotify())
 	if err != nil {
 		return err
 	}
-	c.AddReadyzChecks(healthz.NamedGroupedCheck("etcd-readiness", "etcd-readiness", func(r *http.Request) error {
+	c.AddReadyzChecks(healthz.NamedGroupedCheck("etcd", "etcd", func(r *http.Request) error {
 		return readyCheck()
 	}))
 
@@ -396,15 +398,17 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 			if err != nil {
 				return err
 			}
-			c.AddHealthChecks(healthz.NamedGroupedCheck(fmt.Sprintf("etcd-override-%d", len(serversSets)-1), "etcd", func(r *http.Request) error {
+			namedHealthCheck := healthz.NamedGroupedCheck(fmt.Sprintf("etcd-override-%d", len(serversSets)-1), "etcd", func(r *http.Request) error {
 				return healthCheck()
-			}))
+			})
+			c.AddHealthzChecks(namedHealthCheck)
+			c.AddLivezChecks(namedHealthCheck)
 
 			readyCheck, err := storagefactory.CreateReadyCheck(sc, c.DrainedNotify())
 			if err != nil {
 				return err
 			}
-			c.AddReadyzChecks(healthz.NamedGroupedCheck(fmt.Sprintf("etcd-override-readiness-%d", len(serversSets)-1), "etcd-readiness", func(r *http.Request) error {
+			c.AddReadyzChecks(healthz.NamedGroupedCheck(fmt.Sprintf("etcd-override-%d", len(serversSets)-1), "etcd", func(r *http.Request) error {
 				return readyCheck()
 			}))
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -278,7 +278,7 @@ func TestKMSHealthzEndpoint(t *testing.T) {
 			name:                 "no kms-provider, expect no kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/no-kms-provider.yaml",
 			wantHealthzChecks:    []string{"etcd"},
-			wantReadyzChecks:     []string{"etcd", "etcd-readiness"},
+			wantReadyzChecks:     []string{"etcd"},
 			wantLivezChecks:      []string{"etcd"},
 		},
 		{
@@ -286,21 +286,21 @@ func TestKMSHealthzEndpoint(t *testing.T) {
 			encryptionConfigPath: "testdata/encryption-configs/no-kms-provider.yaml",
 			reload:               true,
 			wantHealthzChecks:    []string{"etcd", "kms-providers"},
-			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantReadyzChecks:     []string{"kms-providers", "etcd"},
 			wantLivezChecks:      []string{"etcd"},
 		},
 		{
 			name:                 "single kms-provider, expect single kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/single-kms-provider.yaml",
 			wantHealthzChecks:    []string{"etcd", "kms-provider-0"},
-			wantReadyzChecks:     []string{"etcd", "kms-provider-0", "etcd-readiness"},
+			wantReadyzChecks:     []string{"kms-provider-0", "etcd"},
 			wantLivezChecks:      []string{"etcd"},
 		},
 		{
 			name:                 "two kms-providers, expect two kms healthz checks, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-providers.yaml",
 			wantHealthzChecks:    []string{"etcd", "kms-provider-0", "kms-provider-1"},
-			wantReadyzChecks:     []string{"etcd", "kms-provider-0", "kms-provider-1", "etcd-readiness"},
+			wantReadyzChecks:     []string{"kms-provider-0", "kms-provider-1", "etcd"},
 			wantLivezChecks:      []string{"etcd"},
 		},
 		{
@@ -308,14 +308,14 @@ func TestKMSHealthzEndpoint(t *testing.T) {
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-providers.yaml",
 			reload:               true,
 			wantHealthzChecks:    []string{"etcd", "kms-providers"},
-			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantReadyzChecks:     []string{"kms-providers", "etcd"},
 			wantLivezChecks:      []string{"etcd"},
 		},
 		{
 			name:                 "kms v1+v2, expect three kms healthz checks, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-providers-with-v2.yaml",
 			wantHealthzChecks:    []string{"etcd", "kms-provider-0", "kms-provider-1", "kms-provider-2"},
-			wantReadyzChecks:     []string{"etcd", "kms-provider-0", "kms-provider-1", "kms-provider-2", "etcd-readiness"},
+			wantReadyzChecks:     []string{"kms-provider-0", "kms-provider-1", "kms-provider-2", "etcd"},
 			wantLivezChecks:      []string{"etcd"},
 		},
 		{
@@ -323,14 +323,14 @@ func TestKMSHealthzEndpoint(t *testing.T) {
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-providers-with-v2.yaml",
 			reload:               true,
 			wantHealthzChecks:    []string{"etcd", "kms-providers"},
-			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantReadyzChecks:     []string{"kms-providers", "etcd"},
 			wantLivezChecks:      []string{"etcd"},
 		},
 		{
 			name:                 "multiple kms v2, expect single kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-v2-providers.yaml",
 			wantHealthzChecks:    []string{"etcd", "kms-providers"},
-			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantReadyzChecks:     []string{"kms-providers", "etcd"},
 			wantLivezChecks:      []string{"etcd"},
 		},
 		{
@@ -338,7 +338,7 @@ func TestKMSHealthzEndpoint(t *testing.T) {
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-v2-providers.yaml",
 			reload:               true,
 			wantHealthzChecks:    []string{"etcd", "kms-providers"},
-			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantReadyzChecks:     []string{"kms-providers", "etcd"},
 			wantLivezChecks:      []string{"etcd"},
 		},
 		{
@@ -384,7 +384,7 @@ func TestReadinessCheck(t *testing.T) {
 	}{
 		{
 			name:              "Readyz should have etcd-readiness check",
-			wantReadyzChecks:  []string{"etcd", "etcd-readiness"},
+			wantReadyzChecks:  []string{"etcd"},
 			wantHealthzChecks: []string{"etcd"},
 			wantLivezChecks:   []string{"etcd"},
 		},
@@ -397,7 +397,7 @@ func TestReadinessCheck(t *testing.T) {
 		},
 		{
 			name:                 "Health checks should not have duplicated servers from etcd-servers-overrides",
-			wantReadyzChecks:     []string{"etcd", "etcd-readiness", "etcd-override-0", "etcd-override-readiness-0"},
+			wantReadyzChecks:     []string{"etcd", "etcd-override-0"},
 			wantHealthzChecks:    []string{"etcd", "etcd-override-0"},
 			wantLivezChecks:      []string{"etcd", "etcd-override-0"},
 			etcdServersOverrides: []string{"/r1#s1.com;s2.com", "/r2#s1.com;s2.com"},
@@ -405,23 +405,21 @@ func TestReadinessCheck(t *testing.T) {
 		{
 			name: "Health checks should not have duplicated servers from etcd-servers-overrides " +
 				"if servers are provided in different orders",
-			wantReadyzChecks:     []string{"etcd", "etcd-readiness", "etcd-override-0", "etcd-override-readiness-0"},
+			wantReadyzChecks:     []string{"etcd", "etcd-override-0"},
 			wantHealthzChecks:    []string{"etcd", "etcd-override-0"},
 			wantLivezChecks:      []string{"etcd", "etcd-override-0"},
 			etcdServersOverrides: []string{"/r1#s1.com;s2.com", "/r2#s2.com;s1.com"},
 		},
 		{
-			name: "Health checks should allow multiple overrides in etcd-servers-overrides",
-			wantReadyzChecks: []string{"etcd", "etcd-readiness", "etcd-override-0", "etcd-override-readiness-0",
-				"etcd-override-1", "etcd-override-readiness-1"},
+			name:                 "Health checks should allow multiple overrides in etcd-servers-overrides",
+			wantReadyzChecks:     []string{"etcd", "etcd-override-0", "etcd-override-1"},
 			wantHealthzChecks:    []string{"etcd", "etcd-override-0", "etcd-override-1"},
 			wantLivezChecks:      []string{"etcd", "etcd-override-0", "etcd-override-1"},
 			etcdServersOverrides: []string{"/r1#s1.com;s2.com", "/r2#s3.com;s4.com"},
 		},
 		{
-			name: "Health checks should allow multiple overrides in etcd-servers-overrides if servers overlap between overrides",
-			wantReadyzChecks: []string{"etcd", "etcd-readiness", "etcd-override-0", "etcd-override-readiness-0",
-				"etcd-override-1", "etcd-override-readiness-1"},
+			name:                 "Health checks should allow multiple overrides in etcd-servers-overrides if servers overlap between overrides",
+			wantReadyzChecks:     []string{"etcd", "etcd-override-0", "etcd-override-1"},
 			wantHealthzChecks:    []string{"etcd", "etcd-override-0", "etcd-override-1"},
 			wantLivezChecks:      []string{"etcd", "etcd-override-0", "etcd-override-1"},
 			etcdServersOverrides: []string{"/r1#s1.com;s2.com", "/r2#s2.com;s3.com"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

There are separate "health" and "ready" checks for etcd (`etcd` and `etcd-readiness`, respectively). The `etcd` check is registered to all of the `healthz`, `livez`, and `readyz` groups. The `etcd-readiness` check is only registered to `readyz`.

Both checks have the same underlying impl: https://github.com/kubernetes/kubernetes/blob/f3c452e8f4832c47a3e15176ee3385947be2c428/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go#L116-L130

Which means that a call to `/readyz` does the same check on etcd twice in a row. This is multiplied when etcd overrides are used.

The `etcd-readiness` check was added in https://github.com/kubernetes/kubernetes/pull/111399 (1.25) and there's no discussion of the duplication there.

The `etcd-readiness` check came with a config option (`etcd-readycheck-timeout`). This PR uses that option to control the timeout of the `etcd` check on the `/readyz` endpoint, keeping the intent of the option the same.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `etcd-readiness` check is removed from the `/readyz` endpoint, in favor of the existing `etcd` check.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
