### PR TITLE
cloud-provider: clear lastSyncedNodes on Service delete

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -382,7 +382,7 @@ func (c *Controller) syncLoadBalancerIfNeeded(ctx context.Context, service *v1.S
 		if exists {
 			klog.V(2).Infof("Deleting existing load balancer for service %s", key)
 			c.eventRecorder.Event(service, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
-			if err := c.balancer.EnsureLoadBalancerDeleted(ctx, c.clusterName, service); err != nil {
+			if err := c.ensureLoadBalancerDeleted(ctx, service); err != nil {
 				if err == cloudprovider.ImplementedElsewhere {
 					klog.V(4).Infof("LoadBalancer for service %s implemented by a different controller %s, Ignoring error on deletion", key, c.cloud.ProviderName())
 				} else {
@@ -457,6 +457,11 @@ func (c *Controller) ensureLoadBalancer(ctx context.Context, service *v1.Service
 	return status, nil
 }
 
+func (c *Controller) ensureLoadBalancerDeleted(ctx context.Context, service *v1.Service) error {
+	c.removeLastSyncedNodes(service)
+	return c.balancer.EnsureLoadBalancerDeleted(ctx, c.clusterName, service)
+}
+
 func (c *Controller) storeLastSyncedNodes(svc *v1.Service, nodes []*v1.Node) {
 	c.lastSyncedNodesLock.Lock()
 	defer c.lastSyncedNodesLock.Unlock()
@@ -469,6 +474,13 @@ func (c *Controller) getLastSyncedNodes(svc *v1.Service) []*v1.Node {
 	defer c.lastSyncedNodesLock.Unlock()
 	key, _ := cache.MetaNamespaceKeyFunc(svc)
 	return c.lastSyncedNodes[key]
+}
+
+func (c *Controller) removeLastSyncedNodes(svc *v1.Service) {
+	c.lastSyncedNodesLock.Lock()
+	defer c.lastSyncedNodesLock.Unlock()
+	key, _ := cache.MetaNamespaceKeyFunc(svc)
+	delete(c.lastSyncedNodes, key)
 }
 
 // ListKeys implements the interface required by DeltaFIFO to list the keys we
@@ -923,7 +935,7 @@ func (c *Controller) processLoadBalancerDelete(ctx context.Context, service *v1.
 		return nil
 	}
 	c.eventRecorder.Event(service, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer")
-	if err := c.balancer.EnsureLoadBalancerDeleted(ctx, c.clusterName, service); err != nil {
+	if err := c.ensureLoadBalancerDeleted(ctx, service); err != nil {
 		c.eventRecorder.Eventf(service, v1.EventTypeWarning, "DeleteLoadBalancerFailed", "Error deleting load balancer: %v", err)
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a memory leak in the cloud-provider Service load balancer controller by clearing `lastSyncedNodes` entries when a Service is deleted.

The controller stores a per-Service slice of `*v1.Node` pointers in `lastSyncedNodes` (sourced from the node informer lister). When Services are created and deleted repeatedly (especially with continuously new/unique names), the map can grow without bound if entries are not removed on deletion, retaining historical node slices and causing steady memory growth.

This change introduces `ensureLoadBalancerDeleted()` which deletes the `lastSyncedNodes` entry prior to calling `balancer.EnsureLoadBalancerDeleted(...)`, and routes both deletion call sites through that helper.

#### Which issue(s) this PR is related to:

Fixes #137151 

#### Special notes for your reviewer:

- This PR is intentionally small and only affects the Service deletion path.
- Behavior change: after Service deletion, the controller no longer retains the last-synced node list for that Service key (expected).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```