### PR TITLE
Clean up code to consolidate similar types

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -529,14 +529,6 @@ type containerToKillInfo struct {
 	reason containerKillReason
 }
 
-// containerResources holds the set of resources applicable to the running container
-type containerResources struct {
-	memoryLimit   int64
-	memoryRequest int64
-	cpuLimit      int64
-	cpuRequest    int64
-}
-
 // containerToUpdateInfo contains necessary information to update a container's resources.
 type containerToUpdateInfo struct {
 	// The spec of the container.
@@ -544,9 +536,9 @@ type containerToUpdateInfo struct {
 	// ID of the runtime container that needs resource update
 	kubeContainerID kubecontainer.ContainerID
 	// Desired resources for the running container
-	desiredContainerResources containerResources
+	desiredContainerResources resourceRequirements
 	// Most recently configured resources on the running container
-	currentContainerResources *containerResources
+	currentContainerResources *resourceRequirements
 }
 
 // containerToRemoveInfo contains necessary information to update a container's resources.
@@ -599,8 +591,9 @@ type podActions struct {
 	UpdatePodLevelResources bool
 }
 
-// podLevelResources holds the set of resources applicable to the running pod
-type podLevelResources struct {
+// resourceRequirements summarizes the set of resources applicable to the
+// running pod or container in kuberuntime context.
+type resourceRequirements struct {
 	memoryLimit   int64
 	memoryRequest int64
 	cpuLimit      int64
@@ -634,8 +627,8 @@ func containerSucceeded(c *v1.Container, podStatus *kubecontainer.PodStatus) boo
 	return cStatus.State == kubecontainer.ContainerStateExited && cStatus.ExitCode == 0
 }
 
-func containerResourcesFromRequirements(podRequirements, containerRequirements *v1.ResourceRequirements) containerResources {
-	resources := containerResources{
+func containerResourcesFromRequirements(podRequirements, containerRequirements *v1.ResourceRequirements) resourceRequirements {
+	resources := resourceRequirements{
 		memoryLimit:   containerRequirements.Limits.Memory().Value(),
 		memoryRequest: containerRequirements.Requests.Memory().Value(),
 		cpuLimit:      containerRequirements.Limits.Cpu().MilliValue(),
@@ -652,12 +645,12 @@ func containerResourcesFromRequirements(podRequirements, containerRequirements *
 	return resources
 }
 
-func podResourcesFromRequirements(requirements *v1.ResourceRequirements) podLevelResources {
+func podResourcesFromRequirements(requirements *v1.ResourceRequirements) resourceRequirements {
 	if requirements == nil {
-		return podLevelResources{}
+		return resourceRequirements{}
 	}
 
-	return podLevelResources{
+	return resourceRequirements{
 		memoryLimit:   requirements.Limits.Memory().Value(),
 		memoryRequest: requirements.Requests.Memory().Value(),
 		cpuLimit:      requirements.Limits.Cpu().MilliValue(),

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2912,11 +2912,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem200M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
@@ -2926,11 +2926,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem200M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
@@ -2984,11 +2984,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem200M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
@@ -2998,11 +2998,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem200M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
@@ -3060,11 +3060,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem600M.Value(),
 									cpuLimit:    cpu600m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem300M.Value(),
 									cpuLimit:    cpu300m.MilliValue(),
 								},
@@ -3074,11 +3074,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem600M.Value(),
 									cpuLimit:    cpu600m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem300M.Value(),
 									cpuLimit:    cpu300m.MilliValue(),
 								},
@@ -3172,11 +3172,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem200M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
@@ -3186,11 +3186,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem200M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
@@ -3225,11 +3225,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
@@ -3264,11 +3264,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[2],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem200M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
@@ -3404,11 +3404,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[1],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem200M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
@@ -3444,11 +3444,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[2],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu200m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit: mem100M.Value(),
 									cpuLimit:    cpu100m.MilliValue(),
 								},
@@ -3530,13 +3530,13 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							{
 								container:       &pod.Spec.Containers[2],
 								kubeContainerID: kcs.ID,
-								desiredContainerResources: containerResources{
+								desiredContainerResources: resourceRequirements{
 									memoryLimit:   mem200M.Value(),
 									memoryRequest: mem100M.Value(),
 									cpuLimit:      cpu200m.MilliValue(),
 									cpuRequest:    cpu100m.MilliValue(),
 								},
-								currentContainerResources: &containerResources{
+								currentContainerResources: &resourceRequirements{
 									memoryLimit:   mem200M.Value(),
 									memoryRequest: mem200M.Value(),
 									cpuLimit:      cpu200m.MilliValue(),
@@ -3664,13 +3664,13 @@ func TestUpdatePodContainerResources(t *testing.T) {
 				return containerToUpdateInfo{
 					container:       container,
 					kubeContainerID: kubecontainer.ContainerID{},
-					desiredContainerResources: containerResources{
+					desiredContainerResources: resourceRequirements{
 						memoryLimit:   tc.apiSpecResources[idx].Limits.Memory().Value(),
 						memoryRequest: tc.apiSpecResources[idx].Requests.Memory().Value(),
 						cpuLimit:      tc.apiSpecResources[idx].Limits.Cpu().MilliValue(),
 						cpuRequest:    tc.apiSpecResources[idx].Requests.Cpu().MilliValue(),
 					},
-					currentContainerResources: &containerResources{
+					currentContainerResources: &resourceRequirements{
 						memoryLimit:   tc.apiStatusResources[idx].Limits.Memory().Value(),
 						memoryRequest: tc.apiStatusResources[idx].Requests.Memory().Value(),
 						cpuLimit:      tc.apiStatusResources[idx].Limits.Cpu().MilliValue(),
@@ -3864,8 +3864,8 @@ func TestDoPodResizeAction(t *testing.T) {
 
 	for i, tc := range []struct {
 		testName                  string
-		currentResources          containerResources
-		desiredResources          containerResources
+		currentResources          resourceRequirements
+		desiredResources          resourceRequirements
 		updatedResources          []v1.ResourceName
 		otherContainersHaveLimits bool
 		runtimeErrors             map[string][]error
@@ -3875,11 +3875,11 @@ func TestDoPodResizeAction(t *testing.T) {
 	}{
 		{
 			testName: "Increase cpu and memory requests and limits, with computed pod limits",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				cpuRequest: 100, cpuLimit: 100,
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				cpuRequest: 200, cpuLimit: 200,
 				memoryRequest: 200, memoryLimit: 200,
 			},
@@ -3889,11 +3889,11 @@ func TestDoPodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Increase cpu and memory requests and limits, with computed pod limits and set a runtime error",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				cpuRequest: 100, cpuLimit: 100,
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				cpuRequest: 200, cpuLimit: 200,
 				memoryRequest: 200, memoryLimit: 200,
 			},
@@ -3906,11 +3906,11 @@ func TestDoPodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Increase cpu and memory requests and limits, without computed pod limits",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				cpuRequest: 100, cpuLimit: 100,
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				cpuRequest: 200, cpuLimit: 200,
 				memoryRequest: 200, memoryLimit: 200,
 			},
@@ -3921,11 +3921,11 @@ func TestDoPodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Increase cpu and memory requests only",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				cpuRequest: 100, cpuLimit: 200,
 				memoryRequest: 100, memoryLimit: 200,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				cpuRequest: 150, cpuLimit: 200,
 				memoryRequest: 150, memoryLimit: 200,
 			},
@@ -3934,11 +3934,11 @@ func TestDoPodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Resize memory request no limits",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				cpuRequest:    100,
 				memoryRequest: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				cpuRequest:    100,
 				memoryRequest: 200,
 			},
@@ -3947,11 +3947,11 @@ func TestDoPodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Resize cpu request no limits",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				cpuRequest:    100,
 				memoryRequest: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				cpuRequest:    200,
 				memoryRequest: 100,
 			},
@@ -3960,11 +3960,11 @@ func TestDoPodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Add limits",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				cpuRequest:    100,
 				memoryRequest: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				cpuRequest: 100, cpuLimit: 100,
 				memoryRequest: 100, memoryLimit: 100,
 			},
@@ -3973,11 +3973,11 @@ func TestDoPodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Add limits and pod limits",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				cpuRequest:    100,
 				memoryRequest: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				cpuRequest: 100, cpuLimit: 100,
 				memoryRequest: 100, memoryLimit: 100,
 			},
@@ -4103,18 +4103,18 @@ func TestValidatePodResizeAction(t *testing.T) {
 
 	for _, tc := range []struct {
 		testName                               string
-		currentResources, desiredResources     containerResources
+		currentResources, desiredResources     resourceRequirements
 		currentPodMemLimit, desiredPodMemLimit *int64
 		containerMemoryUsage, podMemoryUsage   *uint64
 		expectedError                          bool
 	}{
 		{
 			testName: "Resize memory request no limits",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				cpuRequest:    100,
 				memoryRequest: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				cpuRequest:    100,
 				memoryRequest: 200,
 			},
@@ -4122,10 +4122,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Add container limits, low usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			containerMemoryUsage: ptr.To[uint64](10),
@@ -4134,10 +4134,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Add container limits, high usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			containerMemoryUsage: ptr.To[uint64](200),
@@ -4146,10 +4146,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Add container limits, missing container usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			podMemoryUsage: ptr.To[uint64](10),
@@ -4157,10 +4157,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Add container limits, missing pod usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			containerMemoryUsage: ptr.To[uint64](10),
@@ -4168,20 +4168,20 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Increase container limits",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 200,
 			},
 			expectedError: false,
 		},
 		{
 			testName: "Decrease container limits, low usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 200,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			containerMemoryUsage: ptr.To[uint64](20),
@@ -4190,10 +4190,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Decrease container limits, high usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 200,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			containerMemoryUsage: ptr.To[uint64](150),
@@ -4202,10 +4202,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Add pod limit, low usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			desiredPodMemLimit:   ptr.To[int64](100),
@@ -4215,10 +4215,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Add pod limit, high usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			desiredPodMemLimit:   ptr.To[int64](100),
@@ -4228,10 +4228,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Increase pod limits",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			currentPodMemLimit:   ptr.To[int64](100),
@@ -4242,10 +4242,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Decrease pod limits, low usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			currentPodMemLimit:   ptr.To[int64](200),
@@ -4256,10 +4256,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Decrease pod limits, high usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			currentPodMemLimit:   ptr.To[int64](200),
@@ -4270,10 +4270,10 @@ func TestValidatePodResizeAction(t *testing.T) {
 		},
 		{
 			testName: "Decrease pod limits, missing usage",
-			currentResources: containerResources{
+			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			desiredResources: containerResources{
+			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			currentPodMemLimit:   ptr.To[int64](200),

--- a/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/inplacepodresize/pod_level_resource_resize.go
+++ b/staging/src/k8s.io/component-helpers/nodedeclaredfeatures/features/inplacepodresize/pod_level_resource_resize.go
@@ -17,8 +17,7 @@ limitations under the License.
 package inplacepodresize
 
 import (
-	"reflect"
-
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-helpers/nodedeclaredfeatures"
 )
@@ -51,7 +50,7 @@ func (f *podLevelResourcesResizeFeature) InferForUpdate(oldPodInfo, newPodInfo *
 	if oldPodInfo.Spec.Resources == nil && newPodInfo.Spec.Resources == nil {
 		return false
 	}
-	return !reflect.DeepEqual(oldPodInfo.Spec.Resources, newPodInfo.Spec.Resources)
+	return !apiequality.Semantic.DeepEqual(oldPodInfo.Spec.Resources, newPodInfo.Spec.Resources)
 }
 
 func (f *podLevelResourcesResizeFeature) MaxVersion() *version.Version {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:

/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Minor clean up :
- replacing the usage of reflect.DeepEqual with apiequality.Semantic.DeepEqual
- Consolidating containerResources and podResources into a single common type: resourceRequirements
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

