### PR TITLE
Using component helpers library to get  pod resources instead of recalculating in kubectl libraries

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
@@ -39,156 +39,19 @@ func PodRequestsAndLimits(pod *corev1.Pod) (reqs, limits corev1.ResourceList) {
 // podRequests is a simplified form of PodRequests from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
 // feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
 func podRequests(pod *corev1.Pod) corev1.ResourceList {
-	// attempt to reuse the maps if passed, or allocate otherwise
-	reqs := corev1.ResourceList{}
-
-	containerStatuses := map[string]*corev1.ContainerStatus{}
-	for i := range pod.Status.ContainerStatuses {
-		containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
-	}
-	for i := range pod.Status.InitContainerStatuses {
-		containerStatuses[pod.Status.InitContainerStatuses[i].Name] = &pod.Status.InitContainerStatuses[i]
-	}
-
-	for _, container := range pod.Spec.Containers {
-		containerReqs := container.Resources.Requests
-		cs, found := containerStatuses[container.Name]
-		if found && cs.Resources != nil {
-			containerReqs = determineContainerReqs(pod, &container, cs)
-		}
-		addResourceList(reqs, containerReqs)
-	}
-
-	restartableInitContainerReqs := corev1.ResourceList{}
-	initContainerReqs := corev1.ResourceList{}
-
-	for _, container := range pod.Spec.InitContainers {
-		containerReqs := container.Resources.Requests
-
-		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
-			cs, found := containerStatuses[container.Name]
-			if found && cs.Resources != nil {
-				containerReqs = determineContainerReqs(pod, &container, cs)
-			}
-			// and add them to the resulting cumulative container requests
-			addResourceList(reqs, containerReqs)
-
-			// track our cumulative restartable init container resources
-			addResourceList(restartableInitContainerReqs, containerReqs)
-			containerReqs = restartableInitContainerReqs
-		} else {
-			tmp := corev1.ResourceList{}
-			addResourceList(tmp, containerReqs)
-			addResourceList(tmp, restartableInitContainerReqs)
-			containerReqs = tmp
-		}
-		maxResourceList(initContainerReqs, containerReqs)
-	}
-
-	maxResourceList(reqs, initContainerReqs)
-
-	// Add overhead for running a pod to the sum of requests if requested:
-	if pod.Spec.Overhead != nil {
-		addResourceList(reqs, pod.Spec.Overhead)
-	}
-
-	return reqs
+	return helpers.PodRequests(pod, helpers.PodResourcesOptions{
+		UseStatusResources: true,
+		InPlacePodLevelResourcesVerticalScalingEnabled: true,
+	})
 }
 
 // podLimits is a simplified form of PodLimits from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
 // feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
 func podLimits(pod *corev1.Pod) corev1.ResourceList {
-	limits := corev1.ResourceList{}
-
-	for _, container := range pod.Spec.Containers {
-		addResourceList(limits, container.Resources.Limits)
-	}
-
-	restartableInitContainerLimits := corev1.ResourceList{}
-	initContainerLimits := corev1.ResourceList{}
-
-	for _, container := range pod.Spec.InitContainers {
-		containerLimits := container.Resources.Limits
-		// Is the init container marked as a restartable init container?
-		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
-			addResourceList(limits, containerLimits)
-
-			// track our cumulative restartable init container resources
-			addResourceList(restartableInitContainerLimits, containerLimits)
-			containerLimits = restartableInitContainerLimits
-		} else {
-			tmp := corev1.ResourceList{}
-			addResourceList(tmp, containerLimits)
-			addResourceList(tmp, restartableInitContainerLimits)
-			containerLimits = tmp
-		}
-
-		maxResourceList(initContainerLimits, containerLimits)
-	}
-
-	maxResourceList(limits, initContainerLimits)
-
-	// Add overhead to non-zero limits if requested:
-	if pod.Spec.Overhead != nil {
-		for name, quantity := range pod.Spec.Overhead {
-			if value, ok := limits[name]; ok && !value.IsZero() {
-				value.Add(quantity)
-				limits[name] = value
-			}
-		}
-	}
-
-	return limits
-}
-
-// determineContainerReqs will return a copy of the container requests based on if resizing is feasible or not.
-func determineContainerReqs(pod *corev1.Pod, container *corev1.Container, cs *corev1.ContainerStatus) corev1.ResourceList {
-	if helpers.IsPodResizeInfeasible(pod) {
-		return max(cs.Resources.Requests, cs.AllocatedResources)
-	}
-	return max(container.Resources.Requests, cs.Resources.Requests, cs.AllocatedResources)
-}
-
-// max returns the result of max(a, b...) for each named resource and is only used if we can't
-// accumulate into an existing resource list
-func max(a corev1.ResourceList, b ...corev1.ResourceList) corev1.ResourceList {
-	var result corev1.ResourceList
-	if a != nil {
-		result = a.DeepCopy()
-	} else {
-		result = corev1.ResourceList{}
-	}
-	for _, other := range b {
-		maxResourceList(result, other)
-	}
-	return result
-}
-
-// addResourceList adds the resources in newList to list
-func addResourceList(list, new corev1.ResourceList) {
-	for name, quantity := range new {
-		if value, ok := list[name]; !ok {
-			list[name] = quantity.DeepCopy()
-		} else {
-			value.Add(quantity)
-			list[name] = value
-		}
-	}
-}
-
-// maxResourceList sets list to the greater of list/newList for every resource
-// either list
-func maxResourceList(list, new corev1.ResourceList) {
-	for name, quantity := range new {
-		if value, ok := list[name]; !ok {
-			list[name] = quantity.DeepCopy()
-			continue
-		} else {
-			if quantity.Cmp(value) > 0 {
-				list[name] = quantity.DeepCopy()
-			}
-		}
-	}
+	return helpers.PodLimits(pod, helpers.PodResourcesOptions{
+		UseStatusResources: true,
+		InPlacePodLevelResourcesVerticalScalingEnabled: true,
+	})
 }
 
 // ExtractContainerResourceValue extracts the value of a resource

--- a/staging/src/k8s.io/kubectl/pkg/util/resource/resource_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/resource/resource_test.go
@@ -23,72 +23,116 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func TestMaxWithNilResourceList(t *testing.T) {
+func TestPodRequestsAndLimits(t *testing.T) {
 	tests := []struct {
-		name string
-		a    corev1.ResourceList
-		b    []corev1.ResourceList
-		want corev1.ResourceList
+		name         string
+		pod          *corev1.Pod
+		wantRequests corev1.ResourceList
+		wantLimits   corev1.ResourceList
 	}{
 		{
-			name: "nil first argument with non-nil second",
-			a:    nil,
-			b:    []corev1.ResourceList{{corev1.ResourceCPU: resource.MustParse("100m")}},
-			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			name: "pod with container resources only",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "c1",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("200m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRequests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("100m"),
+			},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("200m"),
+			},
 		},
 		{
-			name: "nil first argument with nil second",
-			a:    nil,
-			b:    []corev1.ResourceList{nil},
-			want: corev1.ResourceList{},
+			name: "pod with pod-level resources",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "c1",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("200m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("300m"),
+						},
+					},
+				},
+			},
+			wantRequests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("200m"),
+			},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("300m"),
+			},
 		},
 		{
-			name: "nil first argument with empty second",
-			a:    nil,
-			b:    []corev1.ResourceList{{}},
-			want: corev1.ResourceList{},
-		},
-		{
-			name: "nil first argument with no second arguments",
-			a:    nil,
-			b:    nil,
-			want: corev1.ResourceList{},
-		},
-		{
-			name: "empty first argument with non-nil second",
-			a:    corev1.ResourceList{},
-			b:    []corev1.ResourceList{{corev1.ResourceCPU: resource.MustParse("100m")}},
-			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
-		},
-		{
-			name: "non-nil first argument takes max",
-			a:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
-			b:    []corev1.ResourceList{{corev1.ResourceCPU: resource.MustParse("100m")}},
-			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
-		},
-		{
-			name: "second argument larger takes max",
-			a:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
-			b:    []corev1.ResourceList{{corev1.ResourceCPU: resource.MustParse("200m")}},
-			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+			name: "pod with only pod-level resources",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "c1",
+						},
+					},
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("200m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("300m"),
+						},
+					},
+				},
+			},
+			wantRequests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("200m"),
+			},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("300m"),
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := max(tt.a, tt.b...)
-			if len(got) != len(tt.want) {
-				t.Errorf("case %q, expected %d resources but got %d", tt.name, len(tt.want), len(got))
-				return
+			reqs, limits := PodRequestsAndLimits(tt.pod)
+			// DeepEqual might fail on nil vs empty map, so we check content
+			if len(reqs) != len(tt.wantRequests) {
+				t.Errorf("%s: Requests length = %d, want %d", tt.name, len(reqs), len(tt.wantRequests))
 			}
-			for name, wantQty := range tt.want {
-				gotQty, ok := got[name]
-				if !ok {
-					t.Errorf("case %q, expected resource %s but it was missing", tt.name, name)
-					continue
+			for k, v := range tt.wantRequests {
+				if q, ok := reqs[k]; !ok || q.Cmp(v) != 0 {
+					t.Errorf("%s: Request %s = %v, want %v", tt.name, k, q, v)
 				}
-				if gotQty.Cmp(wantQty) != 0 {
-					t.Errorf("case %q, expected resource %s to be %s but got %s", tt.name, name, wantQty.String(), gotQty.String())
+			}
+			if len(limits) != len(tt.wantLimits) {
+				t.Errorf("%s: Limits length = %d, want %d", tt.name, len(limits), len(tt.wantLimits))
+			}
+			for k, v := range tt.wantLimits {
+				if q, ok := limits[k]; !ok || q.Cmp(v) != 0 {
+					t.Errorf("%s: Limit %s = %v, want %v", tt.name, k, q, v)
 				}
 			}
 		})


### PR DESCRIPTION
Using component helpers library to get  pod resources instead of recalculating in kubectl libraries
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes the bug because of which kubectl describe node isn't describing the pod-level resources
#### Which issue(s) this PR is related to:
Fixes #137158 
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fixing the kubectl client to describe non terminating pods and allocated resources accurately for pods with pod-level resources
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
