### PR TITLE
client-go cache: declare that Controller can be modified

### DIFF
--- a/staging/src/k8s.io/client-go/CHANGELOG.md
+++ b/staging/src/k8s.io/client-go/CHANGELOG.md
@@ -4,6 +4,24 @@ Go API changes are typically not included in the Kubernetes release notes, so
 noteworthy Go API changes *may* be documented here. This is currently not
 *required*, so consult the git history to see all changes.
 
+### cache.Controller: mark as private interface
+
+The cache.Controller interface does not need to be implemented outside of
+Kubernetes because there are no Kubernetes APIs which accept a parameter of
+that type. If some downstream consumer is using it for that purpose, then they
+can define their own interface for that parameter.
+
+Adding the private method documents that this interface can be
+changed at any time time without breaking someone. This is a one-time Go API
+break, future changes to it then will be no API breaks.
+
+```
+- ./tools/cache.Controller.private: added unexported method
+- ./tools/cache.SharedIndexInformer: no longer implements ./tools/cache.Controller
+- ./tools/cache.SharedInformer: no longer implements ./tools/cache.Controller
+- ./tools/cache.TypedSharedIndexInformer: no longer implements ./tools/cache.Controller
+```
+
 ### Type-safe informers
 
 All code using the result of the generated client-go Informer() methods (a

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -121,6 +121,10 @@ type controller struct {
 
 // Controller is a low-level controller that is parameterized by a
 // Config and used in sharedIndexInformer.
+//
+// This is an interface which is implemented only by this package itself;
+// it may get extended in the future without causing an API break.
+// Consumers who need a similar one should define their own variant.
 type Controller interface {
 	// RunWithContext does two things.  One is to construct and run a Reflector
 	// to pump objects/notifications from the Config's ListerWatcher
@@ -150,6 +154,11 @@ type Controller interface {
 	// LastSyncResourceVersion delegates to the Reflector when there
 	// is one, otherwise returns the empty string
 	LastSyncResourceVersion() string
+
+	// A private method to prevent users implementing the
+	// interface and so future additions to it will not
+	// cause apidiff warnings.
+	private()
 }
 
 // New makes a new Controller from the given Config.
@@ -160,6 +169,8 @@ func New(c *Config) Controller {
 	}
 	return ctlr
 }
+
+func (c *controller) private() {}
 
 // Run implements [Controller.Run].
 func (c *controller) Run(stopCh <-chan struct{}) {

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -123,6 +123,10 @@ type controller struct {
 
 // Controller is a low-level controller that is parameterized by a
 // Config and used in sharedIndexInformer.
+//
+// This is an interface which is implemented only by this package itself;
+// it may get extended in the future without causing an API break.
+// Consumers who need a similar one should define their own variant.
 type Controller interface {
 	// RunWithContext does two things.  One is to construct and run a Reflector
 	// to pump objects/notifications from the Config's ListerWatcher
@@ -152,6 +156,11 @@ type Controller interface {
 	// LastSyncResourceVersion delegates to the Reflector when there
 	// is one, otherwise returns the empty string
 	LastSyncResourceVersion() string
+
+	// A private method to prevent users implementing the
+	// interface and so future additions to it will not
+	// cause apidiff warnings.
+	private()
 }
 
 // New makes a new Controller from the given Config.
@@ -162,6 +171,8 @@ func New(c *Config) Controller {
 	}
 	return ctlr
 }
+
+func (c *controller) private() {}
 
 // Run implements [Controller.Run].
 func (c *controller) Run(stopCh <-chan struct{}) {

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -667,6 +667,9 @@ func (v *dummyController) LastSyncResourceVersion() string {
 	return ""
 }
 
+func (v *dummyController) private() {
+}
+
 type updateNotification struct {
 	oldObj interface{}
 	newObj interface{}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -790,6 +790,9 @@ func (v *dummyController) LastSyncResourceVersion() string {
 	return ""
 }
 
+func (v *dummyController) private() {
+}
+
 type updateNotification struct {
 	oldObj interface{}
 	newObj interface{}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Normally interfaces cannot be extended without breaking the Go API. The Controller interface is not meant to be implemented by consumers of the cache package and has been extended before (adding RunWithContext, then HasSyncedChecker). Adding the "private" method makes it visible to apidiff that such changes are compatible.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

This is a simpler alternative to removing the interface entirely in https://github.com/kubernetes/kubernetes/pull/136941

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 