### PR TITLE
Cleanup: Replace manual port-forward implementation with kubectl Port

### DIFF
--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -274,7 +274,15 @@ func (emc *ExternalMetricsController) doRequestWithPortForward(ctx context.Conte
 
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- pfOptions.RunPortForwardContext(ctx)
+		// RunPortForwardContext may return nil on success. Only send
+		// non-nil errors into errChan to avoid sending a nil error
+		// which can be mis-handled by the select below.
+		if err := pfOptions.RunPortForwardContext(ctx); err != nil {
+			select {
+			case errChan <- err:
+			default:
+			}
+		}
 	}()
 
 	select {

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -165,8 +165,8 @@ func (cpf *customPortForwarder) ForwardPorts(method string, url *url.URL, opts k
 		return err
 	}
 	cpf.forwarder = forwarder
-	go forwarder.ForwardPorts() //nolint:errcheck
-	return nil
+	// ForwardPorts is expected to block until StopChannel is closed.
+	return forwarder.ForwardPorts()
 }
 
 func (cpf *customPortForwarder) GetPorts() ([]string, error) {
@@ -285,14 +285,55 @@ func (emc *ExternalMetricsController) doRequestWithPortForward(ctx context.Conte
 		}
 	}()
 
+	// Wait for port-forward to be ready with timeout
+	const readyTimeout = 20 * time.Second
 	select {
 	case <-readyChan:
+		framework.Logf("port-forward: ready channel signaled")
 	case err := <-errChan:
 		return fmt.Errorf("port-forward failed: %w", err)
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-time.After(readyTimeout):
+		return fmt.Errorf("timeout waiting for port-forward ready")
 	}
 	defer close(stopChan)
+
+	// Verify forwarded ports are reported by custom port-forwarder (poll briefly)
+	var localPort int
+	for i := 0; i < 10; i++ {
+		ports, err := customPF.GetPorts()
+		if err == nil && len(ports) > 0 {
+			// ports format is "local:remote"
+			parts := strings.Split(ports[0], ":")
+			if len(parts) == 2 {
+				if p, err := strconv.Atoi(parts[0]); err == nil && p != 0 {
+					localPort = p
+					break
+				}
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if localPort == 0 {
+		return fmt.Errorf("port-forward ready but no local port reported")
+	}
+	framework.Logf("port-forward: local port %d verified from GetPorts()", localPort)
+
+	// Probe TCP connect to ensure listener is accepting before HTTP client uses it
+	addr := fmt.Sprintf("127.0.0.1:%d", localPort)
+	for i := 0; i < 10; i++ {
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			framework.Logf("port-forward: TCP probe to %s successful", addr)
+			break
+		}
+		if i == 9 {
+			return fmt.Errorf("failed to verify port-forward TCP probe to %s: %v", addr, err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 
 	ports, err := customPF.GetPorts()
 	if err != nil {

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -165,7 +165,7 @@ func (cpf *customPortForwarder) ForwardPorts(method string, url *url.URL, opts k
 		return err
 	}
 	cpf.forwarder = forwarder
-	go forwarder.ForwardPorts()
+	go forwarder.ForwardPorts() //nolint:errcheck
 	return nil
 }
 

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -165,8 +165,7 @@ func (cpf *customPortForwarder) ForwardPorts(method string, url *url.URL, opts k
 		return err
 	}
 	cpf.forwarder = forwarder
-	go forwarder.ForwardPorts() //nolint:errcheck
-	return nil
+	return forwarder.ForwardPorts()
 }
 
 func (cpf *customPortForwarder) GetPorts() ([]string, error) {

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -165,7 +165,8 @@ func (cpf *customPortForwarder) ForwardPorts(method string, url *url.URL, opts k
 		return err
 	}
 	cpf.forwarder = forwarder
-	return forwarder.ForwardPorts()
+	go forwarder.ForwardPorts() //nolint:errcheck
+	return nil
 }
 
 func (cpf *customPortForwarder) GetPorts() ([]string, error) {

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -335,20 +335,7 @@ func (emc *ExternalMetricsController) doRequestWithPortForward(ctx context.Conte
 		time.Sleep(200 * time.Millisecond)
 	}
 
-	ports, err := customPF.GetPorts()
-	if err != nil {
-		return fmt.Errorf("failed to get forwarded ports: %w", err)
-	}
-	if len(ports) == 0 {
-		return fmt.Errorf("no forwarded ports")
-	}
-
-	_, localPortStr, err := net.SplitHostPort(ports[0])
-	if err != nil {
-		return fmt.Errorf("failed to parse forwarded port: %w", err)
-	}
-
-	requestURL := fmt.Sprintf("https://localhost:%s/%s/%s", localPortStr, action, metricName)
+	requestURL := fmt.Sprintf("https://localhost:%d/%s/%s", localPort, action, metricName)
 	if len(params) > 0 {
 		requestURL += "?" + params.Encode()
 	}

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -283,6 +283,7 @@ func (emc *ExternalMetricsController) doRequestWithPortForward(ctx context.Conte
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+	defer close(stopChan)
 
 	ports, err := customPF.GetPorts()
 	if err != nil {

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -42,11 +43,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	scaleclient "k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+	kubectlportforward "k8s.io/kubectl/pkg/cmd/portforward"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
 	e2eendpointslice "k8s.io/kubernetes/test/e2e/framework/endpointslice"
@@ -147,7 +150,39 @@ type ExternalMetricsController struct {
 	httpClient  *http.Client
 }
 
-// NewExternalMetricsController creates a new controller for the external metrics server
+type customPortForwarder struct {
+	forwarder *portforward.PortForwarder
+}
+
+func (cpf *customPortForwarder) ForwardPorts(method string, url *url.URL, opts kubectlportforward.PortForwardOptions) error {
+	transport, upgrader, err := spdy.RoundTripperFor(opts.Config)
+	if err != nil {
+		return err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, method, url)
+	forwarder, err := portforward.NewOnAddresses(dialer, opts.Address, opts.Ports, opts.StopChannel, opts.ReadyChannel, io.Discard, io.Discard)
+	if err != nil {
+		return err
+	}
+	cpf.forwarder = forwarder
+	return forwarder.ForwardPorts()
+}
+
+func (cpf *customPortForwarder) GetPorts() ([]string, error) {
+	if cpf.forwarder == nil {
+		return nil, fmt.Errorf("port forwarder not initialized")
+	}
+	ports, err := cpf.forwarder.GetPorts()
+	if err != nil {
+		return nil, err
+	}
+	var result []string
+	for _, p := range ports {
+		result = append(result, fmt.Sprintf("%d:%d", p.Local, p.Remote))
+	}
+	return result, nil
+}
+
 func NewExternalMetricsController(clientSet clientset.Interface, serviceName, namespace string) *ExternalMetricsController {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -202,7 +237,6 @@ func (emc *ExternalMetricsController) sendMetricRequest(ctx context.Context, act
 }
 
 func (emc *ExternalMetricsController) doRequestWithPortForward(ctx context.Context, action, metricName string, params url.Values) error {
-	// Find the pod
 	pods, err := emc.clientSet.CoreV1().Pods(emc.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "name=" + emc.serviceName,
 	})
@@ -214,58 +248,56 @@ func (emc *ExternalMetricsController) doRequestWithPortForward(ctx context.Conte
 	}
 	podName := pods.Items[0].Name
 
-	// Set up port-forward
 	config, err := framework.LoadConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	transport, upgrader, err := spdy.RoundTripperFor(config)
-	if err != nil {
-		return fmt.Errorf("failed to create round tripper: %w", err)
-	}
-
-	reqURL := emc.clientSet.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Namespace(emc.namespace).
-		Name(podName).
-		SubResource("portforward").
-		URL()
-
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, reqURL)
-
 	stopChan := make(chan struct{})
 	readyChan := make(chan struct{})
 
-	fw, err := portforward.New(dialer, []string{"0:6443"}, stopChan, readyChan, io.Discard, io.Discard)
-	if err != nil {
-		return fmt.Errorf("failed to create port forwarder: %w", err)
+	customPF := &customPortForwarder{}
+
+	pfOptions := &kubectlportforward.PortForwardOptions{
+		Namespace:     emc.namespace,
+		PodName:       podName,
+		Ports:         []string{"0:6443"},
+		Config:        config,
+		RESTClient:    emc.clientSet.CoreV1().RESTClient(),
+		PodClient:     emc.clientSet.CoreV1().(corev1client.PodsGetter),
+		StopChannel:   stopChan,
+		ReadyChannel:  readyChan,
+		Address:       []string{"localhost"},
+		PortForwarder: customPF,
 	}
 
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- fw.ForwardPorts()
+		errChan <- pfOptions.RunPortForwardContext(ctx)
 	}()
 
 	select {
 	case <-readyChan:
-		// Ready
 	case err := <-errChan:
 		return fmt.Errorf("port-forward failed: %w", err)
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-	defer close(stopChan)
 
-	// Get assigned local port
-	forwardedPorts, err := fw.GetPorts()
+	ports, err := customPF.GetPorts()
 	if err != nil {
 		return fmt.Errorf("failed to get forwarded ports: %w", err)
 	}
-	localPort := forwardedPorts[0].Local
+	if len(ports) == 0 {
+		return fmt.Errorf("no forwarded ports")
+	}
 
-	// Build URL and make request
-	requestURL := fmt.Sprintf("https://localhost:%d/%s/%s", localPort, action, metricName)
+	_, localPortStr, err := net.SplitHostPort(ports[0])
+	if err != nil {
+		return fmt.Errorf("failed to parse forwarded port: %w", err)
+	}
+
+	requestURL := fmt.Sprintf("https://localhost:%s/%s/%s", localPortStr, action, metricName)
 	if len(params) > 0 {
 		requestURL += "?" + params.Encode()
 	}
@@ -282,7 +314,11 @@ func (emc *ExternalMetricsController) doRequestWithPortForward(ctx context.Conte
 		framework.Logf("ExternalMetrics %s failure: %v", action, err)
 		return err
 	}
-	defer resp.Body.Close() //nolint: errcheck
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			framework.Logf("Error closing response body: %v", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -165,7 +165,8 @@ func (cpf *customPortForwarder) ForwardPorts(method string, url *url.URL, opts k
 		return err
 	}
 	cpf.forwarder = forwarder
-	return forwarder.ForwardPorts()
+	go forwarder.ForwardPorts()
+	return nil
 }
 
 func (cpf *customPortForwarder) GetPorts() ([]string, error) {


### PR DESCRIPTION
Summary
This replaces the manual port-forward implementation in `doRequestWithPortForward` with kubectl's `PortForwardOptions.RunPortForward()`.
 Changes
- Created `customPortForwarder` struct that wraps client-go's `PortForwarder`
- `customPortForwarder` implements the `portForwarder` interface from kubectl  
- Added `GetPorts()` method to retrieve actual forwarded ports
- Modified `doRequestWithPortForward` to use `PortForwardOptions` instead of manual SPDY dialer setup
 Benefits
This reduces code duplication by reusing kubectl's port-forward logic instead of manually setting up SPDY transport and dialer. The new implementation is cleaner and more maintainable.
Fixes #137058
/sig autoscaling
/kind cleanup
/release-note-none