### PR TITLE
Configure memorymanager policy in local-up-cluster

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -95,6 +95,7 @@ KUBELET_PROVIDER_ID=${KUBELET_PROVIDER_ID:-"$(hostname)"}
 FEATURE_GATES=${FEATURE_GATES:-"AllAlpha=false"}
 EMULATED_VERSION=${EMULATED_VERSION:+kube=$EMULATED_VERSION}
 TOPOLOGY_MANAGER_POLICY=${TOPOLOGY_MANAGER_POLICY:-""}
+MEMORY_MANAGER_POLICY=${MEMORY_MANAGER_POLICY:-""}
 CPUMANAGER_POLICY=${CPUMANAGER_POLICY:-""}
 CPUMANAGER_RECONCILE_PERIOD=${CPUMANAGER_RECONCILE_PERIOD:-""}
 CPUMANAGER_POLICY_OPTIONS=${CPUMANAGER_POLICY_OPTIONS:-""}
@@ -181,6 +182,15 @@ function usage {
             echo "           CPUMANAGER_RECONCILE_PERIOD=\"5s\" \\"
             echo "           KUBELET_FLAGS=\"--kube-reserved=cpu=1,memory=2Gi,ephemeral-storage=1Gi --system-reserved=cpu=1,memory=2Gi,ephemeral-storage=1Gi\" \\"
             echo "           hack/local-up-cluster.sh (build a local copy of the source with full-pcpus-only CPU Management policy)"
+            echo "Example 5: PATH=\"\${PATH}:/usr/local/go/src/k8s.io/kubernetes/third_party/etcd\" \\"
+            echo "           FEATURE_GATES=CPUManagerPolicyOptions=true,MemoryManager=true,InPlacePodVerticalScalingExclusiveCPUs=true \\"
+            echo "           TOPOLOGY_MANAGER_POLICY=\"single-numa-node\" \\"
+            echo "           MEMORY_MANAGER_POLICY=\"Static\" \\"
+            echo "           CPUMANAGER_POLICY=\"static\" \\"
+            echo "           CPUMANAGER_POLICY_OPTIONS=full-pcpus-only=\"true\" \\"
+            echo "           CPUMANAGER_RECONCILE_PERIOD=\"5s\" \\"
+            echo "           KUBELET_FLAGS=\"--kube-reserved=cpu=1,memory=4Gi --system-reserved=cpu=1,memory=1Gi --reserved-memory 0:memory=3Gi;1:memory=2148Mi --resolv-conf=/run/systemd/resolve/resolv.conf\" \\"
+            echo "           hack/local-up-cluster.sh ( run with Topology, CPU, Memory Management policies alongside InPlacePodVerticalScaling, extra flags for etcd and coredns)"
             echo ""
             echo "-d         dry-run: prepare for running commands, then show their command lines instead of running them"
 }
@@ -1000,6 +1010,11 @@ EOF
       # topology maanager policy
       if [[ -n ${TOPOLOGY_MANAGER_POLICY} ]]; then
         echo "topologyManagerPolicy: \"${TOPOLOGY_MANAGER_POLICY}\""
+      fi
+
+      # memorymanager policy
+      if [[ -n ${MEMORY_MANAGER_POLICY} ]]; then
+        echo "memoryManagerPolicy: \"${MEMORY_MANAGER_POLICY}\""
       fi
 
       # cpumanager policy


### PR DESCRIPTION
#### What type of PR is this?

kind/cleanup

#### What this PR does / why we need it:

Memory manager policy cannot be configured with KUBELET_FLAGS. It need to
be included in kubelet configuration instead. This commit allows this, with the introduction of 'MEMORY_MANAGER_POLICY` environment variable, using same implementation as done for enabling CPU Manager policy in local-up-cluster.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```