### PR TITLE
DRA device taints: automatically bump TimeAdded when changing effect

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16240,7 +16240,7 @@
         },
         "timeAdded": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
-          "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+          "description": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule)."
         },
         "value": {
           "description": "The taint value corresponding to the taint key. Must be a label value.",
@@ -16750,7 +16750,7 @@
         },
         "timeAdded": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
-          "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+          "description": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule)."
         },
         "value": {
           "description": "The taint value corresponding to the taint key. Must be a label value.",
@@ -17620,7 +17620,7 @@
         },
         "timeAdded": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
-          "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+          "description": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule)."
         },
         "value": {
           "description": "The taint value corresponding to the taint key. Must be a label value.",
@@ -18760,7 +18760,7 @@
         },
         "timeAdded": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
-          "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+          "description": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule)."
         },
         "value": {
           "description": "The taint value corresponding to the taint key. Must be a label value.",

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
@@ -994,7 +994,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
               }
             ],
-            "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+            "description": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule)."
           },
           "value": {
             "description": "The taint value corresponding to the taint key. Must be a label value.",

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json
@@ -20,7 +20,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
               }
             ],
-            "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+            "description": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule)."
           },
           "value": {
             "description": "The taint value corresponding to the taint key. Must be a label value.",

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
@@ -1052,7 +1052,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
               }
             ],
-            "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+            "description": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule)."
           },
           "value": {
             "description": "The taint value corresponding to the taint key. Must be a label value.",

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
@@ -994,7 +994,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
               }
             ],
-            "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+            "description": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule)."
           },
           "value": {
             "description": "The taint value corresponding to the taint key. Must be a label value.",

--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -652,8 +652,12 @@ type DeviceTaint struct {
 	// which will enable adding new enums within a single release without
 	// ratcheting.
 
-	// TimeAdded represents the time at which the taint was added.
+	// TimeAdded represents the time at which the taint was added or
+	// (only in a DeviceTaintRule) the effect was modified.
 	// Added automatically during create or update if not set.
+	// In addition, in a DeviceTaintRule a value provided during
+	// an update gets replaced with the current time if the provided
+	// value is the same as the old one and the new effect is different.
 	//
 	// +optional
 	TimeAdded *metav1.Time

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -48074,7 +48074,7 @@ func schema_k8sio_api_resource_v1_DeviceTaint(ref common.ReferenceCallback) comm
 					},
 					"timeAdded": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set.",
+							Description: "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule).",
 							Ref:         ref(metav1.Time{}.OpenAPIModelName()),
 						},
 					},
@@ -48974,7 +48974,7 @@ func schema_k8sio_api_resource_v1alpha3_DeviceTaint(ref common.ReferenceCallback
 					},
 					"timeAdded": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set.",
+							Description: "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule).",
 							Ref:         ref(metav1.Time{}.OpenAPIModelName()),
 						},
 					},
@@ -50650,7 +50650,7 @@ func schema_k8sio_api_resource_v1beta1_DeviceTaint(ref common.ReferenceCallback)
 					},
 					"timeAdded": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set.",
+							Description: "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule).",
 							Ref:         ref(metav1.Time{}.OpenAPIModelName()),
 						},
 					},
@@ -52754,7 +52754,7 @@ func schema_k8sio_api_resource_v1beta2_DeviceTaint(ref common.ReferenceCallback)
 					},
 					"timeAdded": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set.",
+							Description: "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule).",
 							Ref:         ref(metav1.Time{}.OpenAPIModelName()),
 						},
 					},

--- a/pkg/registry/resource/devicetaintrule/strategy.go
+++ b/pkg/registry/resource/devicetaintrule/strategy.go
@@ -18,6 +18,7 @@ package devicetaintrule
 
 import (
 	"context"
+	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,6 +86,23 @@ func (*deviceTaintRuleStrategy) PrepareForUpdate(ctx context.Context, obj, old r
 	rule := obj.(*resource.DeviceTaintRule)
 	oldRule := old.(*resource.DeviceTaintRule)
 	rule.Status = oldRule.Status
+
+	// Automatically bump the TimeAdded when the effect changes and the
+	// client hasn't already changed it. This makes the TimeAdded track
+	// "when was this *effect* added" instead of "when was this
+	// *DeviceTaintRule* added". This is relevant for computing the
+	// toleration duration of affected claims.
+	//
+	// The downside is that clients cannot keep the old time even if that
+	// is what they want - this seems extremely unlikely compared to "I
+	// want TimeAdded to work automatically".
+	if rule.Spec.Taint.Effect != oldRule.Spec.Taint.Effect &&
+		rule.Spec.Taint.TimeAdded.Equal(oldRule.Spec.Taint.TimeAdded) {
+		// Encoding only has seconds as resolution, so don't even
+		// generate something which does not survive encode/decode (can cause
+		// random unit test failures).
+		rule.Spec.Taint.TimeAdded = &metav1.Time{Time: time.Now().Truncate(time.Second)}
+	}
 
 	// Any changes to the spec increment the generation number.
 	if !apiequality.Semantic.DeepEqual(oldRule.Spec, rule.Spec) {

--- a/pkg/registry/resource/devicetaintrule/strategy_test.go
+++ b/pkg/registry/resource/devicetaintrule/strategy_test.go
@@ -18,13 +18,21 @@ package devicetaintrule
 
 import (
 	"testing"
+	"testing/synctest"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/kubernetes/pkg/apis/resource"
 )
+
+// synctestEpoch is when the clock inside a synctest bubble starts (part of the
+// package API, but not defined there in Go).
+var synctestEpoch = &metav1.Time{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}
 
 var obj = &resource.DeviceTaintRule{
 	ObjectMeta: metav1.ObjectMeta{
@@ -33,8 +41,9 @@ var obj = &resource.DeviceTaintRule{
 	},
 	Spec: resource.DeviceTaintRuleSpec{
 		Taint: resource.DeviceTaint{
-			Key:    "example.com/tainted",
-			Effect: resource.DeviceTaintEffectNoExecute,
+			Key:       "example.com/tainted",
+			Effect:    resource.DeviceTaintEffectNoExecute,
+			TimeAdded: synctestEpoch,
 		},
 	},
 }
@@ -46,8 +55,9 @@ var objWithStatus = &resource.DeviceTaintRule{
 	},
 	Spec: resource.DeviceTaintRuleSpec{
 		Taint: resource.DeviceTaint{
-			Key:    "example.com/tainted",
-			Effect: resource.DeviceTaintEffectNoExecute,
+			Key:       "example.com/tainted",
+			Effect:    resource.DeviceTaintEffectNoExecute,
+			TimeAdded: synctestEpoch,
 		},
 	},
 	Status: resource.DeviceTaintRuleStatus{
@@ -132,6 +142,11 @@ func TestDeviceTaintRuleStrategyCreate(t *testing.T) {
 func TestDeviceTaintRuleStrategyUpdate(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 
+	// The update happens some time after the epoch.
+	updateDelay := 10 * time.Second
+	updateTime := &metav1.Time{Time: synctestEpoch.Add(updateDelay)}
+	oldTime := &metav1.Time{Time: synctestEpoch.Add(updateDelay / 2)}
+
 	testcases := map[string]struct {
 		oldObj                *resource.DeviceTaintRule
 		newObj                *resource.DeviceTaintRule
@@ -157,7 +172,7 @@ func TestDeviceTaintRuleStrategyUpdate(t *testing.T) {
 			newObj:    objWithStatus,
 			expectObj: obj,
 		},
-		"bump-generation": {
+		"change-effect": {
 			oldObj: obj,
 			newObj: func() *resource.DeviceTaintRule {
 				obj := obj.DeepCopy()
@@ -167,6 +182,51 @@ func TestDeviceTaintRuleStrategyUpdate(t *testing.T) {
 			expectObj: func() *resource.DeviceTaintRule {
 				obj := obj.DeepCopy()
 				obj.Spec.Taint.Effect = resource.DeviceTaintEffectNone
+				// Automatically bumped.
+				obj.Spec.Taint.TimeAdded = updateTime
+				obj.Generation++
+				return obj
+			}(),
+		},
+		"change-key": {
+			oldObj: obj,
+			newObj: func() *resource.DeviceTaintRule {
+				obj := obj.DeepCopy()
+				obj.Spec.Taint.Key += "-other"
+				return obj
+			}(),
+			expectObj: func() *resource.DeviceTaintRule {
+				obj := obj.DeepCopy()
+				obj.Spec.Taint.Key += "-other"
+				obj.Generation++
+				return obj
+			}(),
+		},
+		"change-value": {
+			oldObj: obj,
+			newObj: func() *resource.DeviceTaintRule {
+				obj := obj.DeepCopy()
+				obj.Spec.Taint.Value = "value"
+				return obj
+			}(),
+			expectObj: func() *resource.DeviceTaintRule {
+				obj := obj.DeepCopy()
+				obj.Spec.Taint.Value = "value"
+				obj.Generation++
+				return obj
+			}(),
+		},
+		"change-time-added": {
+			oldObj: obj,
+			newObj: func() *resource.DeviceTaintRule {
+				obj := obj.DeepCopy()
+				obj.Spec.Taint.TimeAdded = oldTime
+				return obj
+			}(),
+			expectObj: func() *resource.DeviceTaintRule {
+				obj := obj.DeepCopy()
+				// Stored as requested.
+				obj.Spec.Taint.TimeAdded = oldTime
 				obj.Generation++
 				return obj
 			}(),
@@ -175,28 +235,34 @@ func TestDeviceTaintRuleStrategyUpdate(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			oldObj := tc.oldObj.DeepCopy()
-			newObj := tc.newObj.DeepCopy()
-			newObj.ResourceVersion = "4"
+			synctest.Test(t, func(t *testing.T) {
+				oldObj := tc.oldObj.DeepCopy()
+				newObj := tc.newObj.DeepCopy()
+				newObj.ResourceVersion = "4"
 
-			Strategy.PrepareForUpdate(ctx, newObj, oldObj)
-			if errs := Strategy.ValidateUpdate(ctx, newObj, oldObj); len(errs) != 0 {
-				if tc.expectValidationError == "" {
-					t.Fatalf("unexpected error(s): %v", errs)
+				time.Sleep(updateDelay)
+
+				Strategy.PrepareForUpdate(ctx, newObj, oldObj)
+				if errs := Strategy.ValidateUpdate(ctx, newObj, oldObj); len(errs) != 0 {
+					if tc.expectValidationError == "" {
+						t.Fatalf("unexpected error(s): %v", errs)
+					}
+					assert.ErrorContains(t, errs[0], tc.expectValidationError, "the error message should have contained the expected error message")
+					return
 				}
-				assert.ErrorContains(t, errs[0], tc.expectValidationError, "the error message should have contained the expected error message")
-				return
-			}
-			if tc.expectValidationError != "" {
-				t.Fatal("expected validation error(s), got none")
-			}
-			if warnings := Strategy.WarningsOnUpdate(ctx, newObj, oldObj); len(warnings) != 0 {
-				t.Fatalf("unexpected warnings: %q", warnings)
-			}
-			Strategy.Canonicalize(newObj)
-			expectObj := tc.expectObj.DeepCopy()
-			expectObj.ResourceVersion = "4"
-			assert.Equal(t, expectObj, newObj)
+				if tc.expectValidationError != "" {
+					t.Fatal("expected validation error(s), got none")
+				}
+				if warnings := Strategy.WarningsOnUpdate(ctx, newObj, oldObj); len(warnings) != 0 {
+					t.Fatalf("unexpected warnings: %q", warnings)
+				}
+				Strategy.Canonicalize(newObj)
+				expectObj := tc.expectObj.DeepCopy()
+				expectObj.ResourceVersion = "4"
+				if !apiequality.Semantic.DeepEqual(expectObj, newObj) {
+					t.Error(cmp.Diff(expectObj, newObj))
+				}
+			})
 		})
 	}
 }

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -1128,8 +1128,17 @@ message DeviceTaint {
   // +k8s:required
   optional string effect = 3;
 
-  // TimeAdded represents the time at which the taint was added.
+  // TimeAdded represents the time at which the taint was added or
+  // (only in a DeviceTaintRule) the effect was modified.
   // Added automatically during create or update if not set.
+  //
+  // In addition, in a DeviceTaintRule a value provided during
+  // an update gets replaced with the current time if the provided
+  // value is the same as the old one and the new effect is different.
+  // Changing the key and/or value while keeping the effect unchanged
+  // is possible and does not update the time stamp because the eviction
+  // which uses it is either already started (NoExecute) or
+  // not started yet (NoEffect, NoSchedule).
   //
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timeAdded = 4;

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -684,8 +684,17 @@ type DeviceTaint struct {
 	// which will enable adding new enums within a single release without
 	// ratcheting.
 
-	// TimeAdded represents the time at which the taint was added.
+	// TimeAdded represents the time at which the taint was added or
+	// (only in a DeviceTaintRule) the effect was modified.
 	// Added automatically during create or update if not set.
+	//
+	// In addition, in a DeviceTaintRule a value provided during
+	// an update gets replaced with the current time if the provided
+	// value is the same as the old one and the new effect is different.
+	// Changing the key and/or value while keeping the effect unchanged
+	// is possible and does not update the time stamp because the eviction
+	// which uses it is either already started (NoExecute) or
+	// not started yet (NoEffect, NoSchedule).
 	//
 	// +optional
 	TimeAdded *metav1.Time `json:"timeAdded,omitempty" protobuf:"bytes,4,opt,name=timeAdded"`

--- a/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
@@ -321,7 +321,7 @@ var map_DeviceTaint = map[string]string{
 	"key":       "The taint key to be applied to a device. Must be a label name.",
 	"value":     "The taint value corresponding to the taint key. Must be a label value.",
 	"effect":    "The effect of the taint on claims that do not tolerate the taint and through such claims on the pods using them.\n\nValid effects are None, NoSchedule and NoExecute. PreferNoSchedule as used for nodes is not valid here. More effects may get added in the future. Consumers must treat unknown effects like None.",
-	"timeAdded": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set.",
+	"timeAdded": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule).",
 }
 
 func (DeviceTaint) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
@@ -122,8 +122,17 @@ message DeviceTaint {
   // +required
   optional string effect = 3;
 
-  // TimeAdded represents the time at which the taint was added.
+  // TimeAdded represents the time at which the taint was added or
+  // (only in a DeviceTaintRule) the effect was modified.
   // Added automatically during create or update if not set.
+  //
+  // In addition, in a DeviceTaintRule a value provided during
+  // an update gets replaced with the current time if the provided
+  // value is the same as the old one and the new effect is different.
+  // Changing the key and/or value while keeping the effect unchanged
+  // is possible and does not update the time stamp because the eviction
+  // which uses it is either already started (NoExecute) or
+  // not started yet (NoEffect, NoSchedule).
   //
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timeAdded = 4;

--- a/staging/src/k8s.io/api/resource/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types.go
@@ -155,8 +155,17 @@ type DeviceTaint struct {
 	// which will enable adding new enums within a single release without
 	// ratcheting.
 
-	// TimeAdded represents the time at which the taint was added.
+	// TimeAdded represents the time at which the taint was added or
+	// (only in a DeviceTaintRule) the effect was modified.
 	// Added automatically during create or update if not set.
+	//
+	// In addition, in a DeviceTaintRule a value provided during
+	// an update gets replaced with the current time if the provided
+	// value is the same as the old one and the new effect is different.
+	// Changing the key and/or value while keeping the effect unchanged
+	// is possible and does not update the time stamp because the eviction
+	// which uses it is either already started (NoExecute) or
+	// not started yet (NoEffect, NoSchedule).
 	//
 	// +optional
 	TimeAdded *metav1.Time `json:"timeAdded,omitempty" protobuf:"bytes,4,opt,name=timeAdded"`

--- a/staging/src/k8s.io/api/resource/v1alpha3/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types_swagger_doc_generated.go
@@ -50,7 +50,7 @@ var map_DeviceTaint = map[string]string{
 	"key":       "The taint key to be applied to a device. Must be a label name.",
 	"value":     "The taint value corresponding to the taint key. Must be a label value.",
 	"effect":    "The effect of the taint on claims that do not tolerate the taint and through such claims on the pods using them.\n\nValid effects are None, NoSchedule and NoExecute. PreferNoSchedule as used for nodes is not valid here. More effects may get added in the future. Consumers must treat unknown effects like None.",
-	"timeAdded": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set.",
+	"timeAdded": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule).",
 }
 
 func (DeviceTaint) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -1257,8 +1257,17 @@ message DeviceTaint {
   // +k8s:required
   optional string effect = 3;
 
-  // TimeAdded represents the time at which the taint was added.
+  // TimeAdded represents the time at which the taint was added or
+  // (only in a DeviceTaintRule) the effect was modified.
   // Added automatically during create or update if not set.
+  //
+  // In addition, in a DeviceTaintRule a value provided during
+  // an update gets replaced with the current time if the provided
+  // value is the same as the old one and the new effect is different.
+  // Changing the key and/or value while keeping the effect unchanged
+  // is possible and does not update the time stamp because the eviction
+  // which uses it is either already started (NoExecute) or
+  // not started yet (NoEffect, NoSchedule).
   //
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timeAdded = 4;

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -696,8 +696,17 @@ type DeviceTaint struct {
 	// which will enable adding new enums within a single release without
 	// ratcheting.
 
-	// TimeAdded represents the time at which the taint was added.
+	// TimeAdded represents the time at which the taint was added or
+	// (only in a DeviceTaintRule) the effect was modified.
 	// Added automatically during create or update if not set.
+	//
+	// In addition, in a DeviceTaintRule a value provided during
+	// an update gets replaced with the current time if the provided
+	// value is the same as the old one and the new effect is different.
+	// Changing the key and/or value while keeping the effect unchanged
+	// is possible and does not update the time stamp because the eviction
+	// which uses it is either already started (NoExecute) or
+	// not started yet (NoEffect, NoSchedule).
 	//
 	// +optional
 	TimeAdded *metav1.Time `json:"timeAdded,omitempty" protobuf:"bytes,4,opt,name=timeAdded"`

--- a/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
@@ -336,7 +336,7 @@ var map_DeviceTaint = map[string]string{
 	"key":       "The taint key to be applied to a device. Must be a label name.",
 	"value":     "The taint value corresponding to the taint key. Must be a label value.",
 	"effect":    "The effect of the taint on claims that do not tolerate the taint and through such claims on the pods using them.\n\nValid effects are None, NoSchedule and NoExecute. PreferNoSchedule as used for nodes is not valid here. More effects may get added in the future. Consumers must treat unknown effects like None.",
-	"timeAdded": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set.",
+	"timeAdded": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule).",
 }
 
 func (DeviceTaint) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -1131,8 +1131,17 @@ message DeviceTaint {
   // +k8s:required
   optional string effect = 3;
 
-  // TimeAdded represents the time at which the taint was added.
+  // TimeAdded represents the time at which the taint was added or
+  // (only in a DeviceTaintRule) the effect was modified.
   // Added automatically during create or update if not set.
+  //
+  // In addition, in a DeviceTaintRule a value provided during
+  // an update gets replaced with the current time if the provided
+  // value is the same as the old one and the new effect is different.
+  // Changing the key and/or value while keeping the effect unchanged
+  // is possible and does not update the time stamp because the eviction
+  // which uses it is either already started (NoExecute) or
+  // not started yet (NoEffect, NoSchedule).
   //
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timeAdded = 4;

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -687,8 +687,17 @@ type DeviceTaint struct {
 	// which will enable adding new enums within a single release without
 	// ratcheting.
 
-	// TimeAdded represents the time at which the taint was added.
+	// TimeAdded represents the time at which the taint was added or
+	// (only in a DeviceTaintRule) the effect was modified.
 	// Added automatically during create or update if not set.
+	//
+	// In addition, in a DeviceTaintRule a value provided during
+	// an update gets replaced with the current time if the provided
+	// value is the same as the old one and the new effect is different.
+	// Changing the key and/or value while keeping the effect unchanged
+	// is possible and does not update the time stamp because the eviction
+	// which uses it is either already started (NoExecute) or
+	// not started yet (NoEffect, NoSchedule).
 	//
 	// +optional
 	TimeAdded *metav1.Time `json:"timeAdded,omitempty" protobuf:"bytes,4,opt,name=timeAdded"`

--- a/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
@@ -321,7 +321,7 @@ var map_DeviceTaint = map[string]string{
 	"key":       "The taint key to be applied to a device. Must be a label name.",
 	"value":     "The taint value corresponding to the taint key. Must be a label value.",
 	"effect":    "The effect of the taint on claims that do not tolerate the taint and through such claims on the pods using them.\n\nValid effects are None, NoSchedule and NoExecute. PreferNoSchedule as used for nodes is not valid here. More effects may get added in the future. Consumers must treat unknown effects like None.",
-	"timeAdded": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set.",
+	"timeAdded": "TimeAdded represents the time at which the taint was added or (only in a DeviceTaintRule) the effect was modified. Added automatically during create or update if not set.\n\nIn addition, in a DeviceTaintRule a value provided during an update gets replaced with the current time if the provided value is the same as the old one and the new effect is different. Changing the key and/or value while keeping the effect unchanged is possible and does not update the time stamp because the eviction which uses it is either already started (NoExecute) or not started yet (NoEffect, NoSchedule).",
 }
 
 func (DeviceTaint) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/devicetaint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/devicetaint.go
@@ -43,8 +43,17 @@ type DeviceTaintApplyConfiguration struct {
 	// nodes is not valid here. More effects may get added in the future.
 	// Consumers must treat unknown effects like None.
 	Effect *resourcev1.DeviceTaintEffect `json:"effect,omitempty"`
-	// TimeAdded represents the time at which the taint was added.
+	// TimeAdded represents the time at which the taint was added or
+	// (only in a DeviceTaintRule) the effect was modified.
 	// Added automatically during create or update if not set.
+	//
+	// In addition, in a DeviceTaintRule a value provided during
+	// an update gets replaced with the current time if the provided
+	// value is the same as the old one and the new effect is different.
+	// Changing the key and/or value while keeping the effect unchanged
+	// is possible and does not update the time stamp because the eviction
+	// which uses it is either already started (NoExecute) or
+	// not started yet (NoEffect, NoSchedule).
 	TimeAdded *metav1.Time `json:"timeAdded,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaint.go
@@ -43,8 +43,17 @@ type DeviceTaintApplyConfiguration struct {
 	// nodes is not valid here. More effects may get added in the future.
 	// Consumers must treat unknown effects like None.
 	Effect *resourcev1alpha3.DeviceTaintEffect `json:"effect,omitempty"`
-	// TimeAdded represents the time at which the taint was added.
+	// TimeAdded represents the time at which the taint was added or
+	// (only in a DeviceTaintRule) the effect was modified.
 	// Added automatically during create or update if not set.
+	//
+	// In addition, in a DeviceTaintRule a value provided during
+	// an update gets replaced with the current time if the provided
+	// value is the same as the old one and the new effect is different.
+	// Changing the key and/or value while keeping the effect unchanged
+	// is possible and does not update the time stamp because the eviction
+	// which uses it is either already started (NoExecute) or
+	// not started yet (NoEffect, NoSchedule).
 	TimeAdded *v1.Time `json:"timeAdded,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicetaint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicetaint.go
@@ -43,8 +43,17 @@ type DeviceTaintApplyConfiguration struct {
 	// nodes is not valid here. More effects may get added in the future.
 	// Consumers must treat unknown effects like None.
 	Effect *resourcev1beta1.DeviceTaintEffect `json:"effect,omitempty"`
-	// TimeAdded represents the time at which the taint was added.
+	// TimeAdded represents the time at which the taint was added or
+	// (only in a DeviceTaintRule) the effect was modified.
 	// Added automatically during create or update if not set.
+	//
+	// In addition, in a DeviceTaintRule a value provided during
+	// an update gets replaced with the current time if the provided
+	// value is the same as the old one and the new effect is different.
+	// Changing the key and/or value while keeping the effect unchanged
+	// is possible and does not update the time stamp because the eviction
+	// which uses it is either already started (NoExecute) or
+	// not started yet (NoEffect, NoSchedule).
 	TimeAdded *v1.Time `json:"timeAdded,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicetaint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicetaint.go
@@ -43,8 +43,17 @@ type DeviceTaintApplyConfiguration struct {
 	// nodes is not valid here. More effects may get added in the future.
 	// Consumers must treat unknown effects like None.
 	Effect *resourcev1beta2.DeviceTaintEffect `json:"effect,omitempty"`
-	// TimeAdded represents the time at which the taint was added.
+	// TimeAdded represents the time at which the taint was added or
+	// (only in a DeviceTaintRule) the effect was modified.
 	// Added automatically during create or update if not set.
+	//
+	// In addition, in a DeviceTaintRule a value provided during
+	// an update gets replaced with the current time if the provided
+	// value is the same as the old one and the new effect is different.
+	// Changing the key and/or value while keeping the effect unchanged
+	// is possible and does not update the time stamp because the eviction
+	// which uses it is either already started (NoExecute) or
+	// not started yet (NoEffect, NoSchedule).
 	TimeAdded *v1.Time `json:"timeAdded,omitempty"`
 }
 

--- a/test/integration/dra/device_taints_test.go
+++ b/test/integration/dra/device_taints_test.go
@@ -181,23 +181,30 @@ func testEvictCluster(tCtx ktesting.TContext, useRule bool) {
 	})
 
 	ruleName := "rule-" + namespace
-	rule := &resourcealpha.DeviceTaintRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ruleName,
-		},
-		Spec: resourcealpha.DeviceTaintRuleSpec{
-			DeviceSelector: &resourcealpha.DeviceTaintSelector{
-				Driver: &driverName,
-			},
-			Taint: resourcealpha.DeviceTaint{
-				Key:    "testing",
-				Effect: resourcealpha.DeviceTaintEffectNoExecute,
-			},
-		},
+	getRule := func(tCtx ktesting.TContext) *resourcealpha.DeviceTaintRule {
+		return must(tCtx, tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Get, ruleName, metav1.GetOptions{})
 	}
 
 	if useRule {
 		// Evict through DeviceTaintRule.
+		//
+		// Let's also test some of the semantics around DeviceTaintRule.
+		// We start with NoEffect, check the report, change TimeAdded manually,
+		// then turn on eviction.
+		rule := &resourcealpha.DeviceTaintRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ruleName,
+			},
+			Spec: resourcealpha.DeviceTaintRuleSpec{
+				DeviceSelector: &resourcealpha.DeviceTaintSelector{
+					Driver: &driverName,
+				},
+				Taint: resourcealpha.DeviceTaint{
+					Key:    "testing",
+					Effect: resourcealpha.DeviceTaintEffectNone,
+				},
+			},
+		}
 		must(tCtx, tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Create, rule, metav1.CreateOptions{})
 		tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
 			err := tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Delete(tCtx, ruleName, metav1.DeleteOptions{})
@@ -206,6 +213,49 @@ func testEvictCluster(tCtx ktesting.TContext, useRule bool) {
 			}
 			tCtx.ExpectNoError(err)
 		})
+
+		tCtx.Eventually(getRule).
+			WithPolling(10 * time.Second).
+			Should(gomega.HaveField("Status.Conditions", gomega.ConsistOf(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Type":    gomega.Equal(resourcealpha.DeviceTaintConditionEvictionInProgress),
+				"Status":  gomega.Equal(metav1.ConditionFalse),
+				"Message": gomega.Equal(fmt.Sprintf("%[1]d published devices selected. %[1]d allocated devices selected. %[1]d pods would be evicted in 1 namespace if the effect was NoExecute. This information will not be updated again. Recreate the DeviceTaintRule to trigger an update.", numPods)),
+			}))))
+		rule = getRule(tCtx)
+
+		var newTime *metav1.Time
+		for {
+			newTime = &metav1.Time{Time: time.Now().Truncate(time.Second)}
+			if !newTime.Equal(rule.Spec.Taint.TimeAdded) {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		rule.Spec.Taint.TimeAdded = newTime
+		rule = must(tCtx, tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Update, rule, metav1.UpdateOptions{})
+		if !newTime.Equal(rule.Spec.Taint.TimeAdded) {
+			tCtx.Error("our TimeAdded should have been stored")
+		}
+		tCtx.Expect(rule).To(gomega.HaveField("ObjectMeta.Generation", gomega.Equal(int64(2))))
+		tCtx.Eventually(getRule).
+			WithPolling(10 * time.Second).
+			Should(gomega.HaveField("Status.Conditions", gomega.ConsistOf(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"ObservedGeneration": gomega.Equal(rule.Generation),
+				"Type":               gomega.Equal(resourcealpha.DeviceTaintConditionEvictionInProgress),
+				"Status":             gomega.Equal(metav1.ConditionFalse),
+				"Message":            gomega.Equal(fmt.Sprintf("%[1]d published devices selected. %[1]d allocated devices selected. %[1]d pods would be evicted in 1 namespace if the effect was NoExecute. This information will not be updated again. Recreate the DeviceTaintRule to trigger an update.", numPods)),
+			}))))
+		rule = getRule(tCtx)
+
+		rule.Spec.Taint.Effect = resourcealpha.DeviceTaintEffectNoExecute
+		// Must roll over to next second, that's the resolution of TimeAdded.
+		// We could rely on the delay for updating the status, but that
+		// could change.
+		time.Sleep(time.Second)
+		rule = must(tCtx, tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Update, rule, metav1.UpdateOptions{})
+		if newTime.Equal(rule.Spec.Taint.TimeAdded) {
+			tCtx.Error("TimeAdded should have been updated automatically")
+		}
 	} else {
 		// Evict by tainting each device.
 		for i, slice := range slices {
@@ -219,11 +269,6 @@ func testEvictCluster(tCtx ktesting.TContext, useRule bool) {
 			}
 			slices[i] = must(tCtx, tCtx.Client().ResourceV1().ResourceSlices().Update, slice, metav1.UpdateOptions{})
 		}
-	}
-
-	getRule := func(tCtx ktesting.TContext) *resourcealpha.DeviceTaintRule {
-		rule = must(tCtx, tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Get, ruleName, metav1.GetOptions{})
-		return rule
 	}
 
 	// Evict and wait for pods to be gone.
@@ -241,10 +286,12 @@ func testEvictCluster(tCtx ktesting.TContext, useRule bool) {
 
 	if useRule {
 		// Check condition.
-		tCtx.Eventually(getRule).WithPolling(10 * time.Second).Should(gomega.HaveField("Status.Conditions", gomega.ConsistOf(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"Type":    gomega.Equal(resourcealpha.DeviceTaintConditionEvictionInProgress),
-			"Status":  gomega.Equal(metav1.ConditionFalse),
-			"Message": gomega.Equal(fmt.Sprintf("%d pods evicted since starting the controller.", numPods)),
-		}))))
+		tCtx.Eventually(getRule).
+			WithPolling(10 * time.Second).
+			Should(gomega.HaveField("Status.Conditions", gomega.ConsistOf(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Type":    gomega.Equal(resourcealpha.DeviceTaintConditionEvictionInProgress),
+				"Status":  gomega.Equal(metav1.ConditionFalse),
+				"Message": gomega.Equal(fmt.Sprintf("%d pods evicted since starting the controller.", numPods)),
+			}))))
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In practice, TimeAdded is managed by the API server. When admins use DeviceTaintRule to simulate eviction, then change the effect to really evict, it is useful to calculate tolerations based on the time when that second update happened. Therefore the TimeAdded field gets bumped automatically when changing the effect.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5055

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
DRA DeviceTaintRules: the TimeAdded of the taint is not only added automatically, it now also gets updated automatically when changing the effect.
```
