### PR TITLE
Decrease likelihood of HPA flake in Configurable Tolerance

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -499,7 +499,7 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (non-default behavi
 	})
 })
 
-var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithFeatureGate(features.HPAConfigurableTolerance),
+var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithSlow(), framework.WithFeatureGate(features.HPAConfigurableTolerance),
 	"Horizontal pod autoscaling (configurable tolerance)", func() {
 		f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
@@ -547,10 +547,10 @@ var _ = SIGDescribe(feature.HPA, framework.WithSerial(), framework.WithFeatureGa
 		})
 
 		ginkgo.Describe("with small scale-up, large scale-down tolerances", func() {
-			ginkgo.It("should not scale", func(ctx context.Context) {
+			ginkgo.It("should scale up but should not scale down", func(ctx context.Context) {
 				ginkgo.By("setting up resource consumer and HPA")
 				initPods := 10
-				podCPURequest := 200
+				podCPURequest := 500
 				targetCPUUtilizationPercent := 60
 				initCPUUsageTotal := usageForReplicasWithRequest(initPods, podCPURequest, targetCPUUtilizationPercent)
 				waitDeadline := maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake

#### What this PR does / why we need it:

This change is a temporary fix until we can make these tests more robust.

What happens is that 10 pods spin up, each with 200m CPU requests and limits.
The e2e does some calculation to figure out what will bring each pod up to just over 60% utilisation, however, when it does this is does it by dividing up the entire target CPU utilisation, divides that by 100m core chunks ([set here](https://github.com/kubernetes/kubernetes/blob/9c607c36573d90140b878bb63789c7ed965ca585/test/e2e/framework/autoscaling/autoscaling_utils.go#L67)) and makes various API calls to the consumer pods asking them to consume 100m cores, via a Service.

The problem with this is that the Service won't guarantee that API calls are done in a round-robin fashion. It seems that it's quite possible for some pods to get 3 calls, and others get none.
This causes the overall utilisation to be lower than the target value, since if a single pod got asked to use 100m cores 3 times, it would get throttled at 200m cores (the limit).

I tried various workaround to get this fixed, but the one here seems to be the simplest option with the least amount of work. Increasing requests of each pod will increase the target value, which in turn causes more API calls, meaning they are more likely to be evenly spread.

I think the long term solution will be to use a Headless Service, and modify the [resource-consumer-controller](https://github.com/kubernetes/kubernetes/blob/9c607c36573d90140b878bb63789c7ed965ca585/test/images/agnhost/resource-consumer-controller/controller.go) to do the round-robining across each endpoint of that Service, giving us more predicable control of the CPU usage of each pod.

This solution isn't perfect, but it passed more times than it failed on my local 🤞 

I didn't try that since it's a larger task, and I don't know how other tests will interact with that change. I'll file an issue with these details so we fix it in the future.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes flakes like this: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-autoscaling-hpa-cpu-alpha-beta/2024725913366695936

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
