### PR TITLE
DO NOT MERGE - testing e2e tests

### DIFF
--- a/pkg/apis/autoscaling/types.go
+++ b/pkg/apis/autoscaling/types.go
@@ -433,6 +433,8 @@ const (
 	// ScalingLimited indicates that the calculated scale based on metrics would be above or
 	// below the range for the HPA, and has thus been capped.
 	ScalingLimited HorizontalPodAutoscalerConditionType = "ScalingLimited"
+	// ScaledToZero indicates that the HPA controller scaled the workload to zero.
+	ScaledToZero HorizontalPodAutoscalerConditionType = "ScaledToZero"
 )
 
 // HorizontalPodAutoscalerCondition describes the state of

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -756,6 +756,36 @@ func (a *HorizontalController) recordInitialRecommendation(currentReplicas int32
 	}
 }
 
+// shouldComputeMetricsForZeroReplicas determines the scaling behavior when current replicas is zero.
+// Returns:
+//   - needsMetricComputation: true if metrics should be computed to determine desired replicas
+//   - shouldDisable: true if scaling should be disabled (workload was manually scaled to zero)
+func (a *HorizontalController) shouldComputeMetricsForZeroReplicas(
+	minReplicas int32,
+	scaledToZeroCondition, canScaleFromZero bool,
+) (needsMetricComputation bool, shouldDisable bool) {
+	if minReplicas != 0 {
+		// minReplicas requires scaling up from zero
+		if scaledToZeroCondition {
+			// HPA previously scaled this to zero - compute metrics to determine scale-up
+			return true, false
+		}
+		// Workload was manually scaled to zero - disable autoscaling
+		return false, true
+	}
+
+	// minReplicas is 0
+	if canScaleFromZero {
+		// Feature enabled with appropriate metrics - compute metrics for potential scale-up
+		return true, false
+	}
+	// canScaleFromZero is true when all prerequisites for scaling back up from zero are met:
+	// - The HPAScaleToZero feature gate is enabled
+	// - The HPA was responsible for scaling the workload to zero (not a manual scale-down)
+	// - Object or external metrics are configured (pod metrics cannot be evaluated at 0 replicas)
+	return false, true
+}
+
 func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShared *autoscalingv2.HorizontalPodAutoscaler, key string) (retErr error) {
 	// actionLabel is used to report which actions this reconciliation has taken.
 	actionLabel := monitor.ActionLabelNone
@@ -838,11 +868,23 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 	rescale := true
 	logger := klog.FromContext(ctx)
 
-	if currentReplicas == 0 && minReplicas != 0 {
-		// Autoscaling is disabled for this resource
-		desiredReplicas = 0
-		rescale = false
-		setCondition(hpa, autoscalingv2.ScalingActive, v1.ConditionFalse, "ScalingDisabled", "scaling is disabled since the replica count of the target is zero")
+	// Pre-compute scale-to-zero related conditions
+	scaleToZeroFeatureEnabled := utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero)
+	hasObjectOrExtMetrics := hasObjectOrExternalMetrics(hpa)
+	scaledToZeroCondition := scaleToZeroFeatureEnabled && getScaledToZeroConditionStatus(hpa)
+	canScaleFromZero := scaledToZeroCondition && hasObjectOrExtMetrics
+
+	// Track whether we need to compute metrics based on replicas/desired state
+	needsMetricComputation := false
+
+	if currentReplicas == 0 {
+		var shouldDisable bool
+		needsMetricComputation, shouldDisable = a.shouldComputeMetricsForZeroReplicas(minReplicas, scaledToZeroCondition, canScaleFromZero)
+		if shouldDisable {
+			desiredReplicas = 0
+			rescale = false
+			setCondition(hpa, autoscalingv2.ScalingActive, v1.ConditionFalse, "ScalingDisabled", "scaling is disabled since the replica count of the target is zero")
+		}
 	} else if currentReplicas > hpa.Spec.MaxReplicas {
 		rescaleReason = "Current number of replicas above Spec.MaxReplicas"
 		desiredReplicas = hpa.Spec.MaxReplicas
@@ -850,6 +892,12 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 		rescaleReason = "Current number of replicas below Spec.MinReplicas"
 		desiredReplicas = minReplicas
 	} else {
+		// Normal case: currentReplicas is within bounds, need to compute metrics
+		needsMetricComputation = true
+	}
+
+	// Compute metrics and normalize desired replicas for cases that require metric-based scaling
+	if needsMetricComputation {
 		var metricTimestamp time.Time
 		metricDesiredReplicas, metricName, metricStatuses, metricTimestamp, err = a.computeReplicasForMetrics(ctx, hpa, scale, hpa.Spec.Metrics)
 		// computeReplicasForMetrics may return both non-zero metricDesiredReplicas and an error.
@@ -867,7 +915,11 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 			retErr = err
 		}
 
-		logger.V(4).Info("Proposing desired replicas",
+		logMessage := "Proposing desired replicas"
+		if currentReplicas == 0 {
+			logMessage = "Proposing desired replicas from zero"
+		}
+		logger.V(4).Info(logMessage,
 			"desiredReplicas", metricDesiredReplicas,
 			"metric", metricName,
 			"tolerances", a.tolerancesForHpa(hpa),
@@ -889,6 +941,13 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 			desiredReplicas = a.normalizeDesiredReplicas(hpa, key, currentReplicas, desiredReplicas, minReplicas)
 		} else {
 			desiredReplicas = a.normalizeDesiredReplicasWithBehaviors(hpa, key, currentReplicas, desiredReplicas, minReplicas)
+		}
+		// Ensure we scale to at least minReplicas when scaling from zero with increased minReplicas
+		if currentReplicas == 0 && minReplicas != 0 && scaledToZeroCondition && desiredReplicas < minReplicas {
+			desiredReplicas = minReplicas
+			if rescaleReason == "" {
+				rescaleReason = "Current number of replicas below Spec.MinReplicas"
+			}
 		}
 		rescale = desiredReplicas != currentReplicas
 	}
@@ -939,6 +998,15 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 			"currentReplicas", currentReplicas,
 			"desiredReplicas", desiredReplicas,
 			"reason", rescaleReason)
+
+		// Set ScaledToZero condition on every rescale so the condition is never stale.
+		if scaleToZeroFeatureEnabled {
+			if currentReplicas > 0 && desiredReplicas == 0 && minReplicas == 0 && hasObjectOrExtMetrics {
+				setCondition(hpa, autoscalingv2.ScaledToZero, v1.ConditionTrue, "ScaledToZero", "the HPA controller scaled the workload to zero")
+			} else {
+				setCondition(hpa, autoscalingv2.ScaledToZero, v1.ConditionFalse, "NotScaledToZero", "the HPA controller did not scale the workload to zero")
+			}
+		}
 
 		if desiredReplicas > currentReplicas {
 			actionLabel = monitor.ActionLabelScaleUp
@@ -1477,6 +1545,26 @@ func (a *HorizontalController) tolerancesForHpa(hpa *autoscalingv2.HorizontalPod
 // not present.
 func setCondition(hpa *autoscalingv2.HorizontalPodAutoscaler, conditionType autoscalingv2.HorizontalPodAutoscalerConditionType, status v1.ConditionStatus, reason, message string, args ...interface{}) {
 	hpa.Status.Conditions = setConditionInList(hpa.Status.Conditions, conditionType, status, reason, message, args...)
+}
+
+// hasObjectOrExternalMetrics checks if the HPA has at least one object or external metric.
+func hasObjectOrExternalMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
+	for _, metric := range hpa.Spec.Metrics {
+		if metric.Type == autoscalingv2.ObjectMetricSourceType || metric.Type == autoscalingv2.ExternalMetricSourceType {
+			return true
+		}
+	}
+	return false
+}
+
+// getScaledToZeroConditionStatus returns true if the ScaledToZero condition exists and is True.
+func getScaledToZeroConditionStatus(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
+	for _, condition := range hpa.Status.Conditions {
+		if condition.Type == autoscalingv2.ScaledToZero {
+			return condition.Status == v1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // setConditionInList sets the specific condition type on the given HPA to the specified value with the given

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -161,8 +161,9 @@ type testCase struct {
 	testEMClient      *emfake.FakeExternalMetricsClient
 	testScaleClient   *scalefake.FakeScaleClient
 
-	recommendations []timestampedRecommendation
-	hpaSelectors    *selectors.BiMultimap
+	recommendations   []timestampedRecommendation
+	hpaSelectors      *selectors.BiMultimap
+	initialConditions []autoscalingv2.HorizontalPodAutoscalerCondition
 }
 
 // Needs to be called under a lock.
@@ -243,6 +244,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 				CurrentReplicas: tc.specReplicas,
 				DesiredReplicas: tc.specReplicas,
 				LastScaleTime:   tc.lastScaleTime,
+				Conditions:      tc.initialConditions,
 			},
 		}
 		// Initialize default values
@@ -1449,6 +1451,7 @@ func TestScaleUpCMObject(t *testing.T) {
 }
 
 func TestScaleUpFromZeroCMObject(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, true)
 	targetValue := resource.MustParse("15.0")
 	tc := testCase{
 		minReplicas:             0,
@@ -1477,6 +1480,20 @@ func TestScaleUpFromZeroCMObject(t *testing.T) {
 			},
 		},
 		reportedLevels: []uint64{20000},
+		initialConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{
+				Type:   autoscalingv2.ScaledToZero,
+				Status: v1.ConditionTrue,
+				Reason: "ScaledToZero",
+			},
+		},
+		// Conditions are ordered as they appear in the actual result (ScaledToZero first, then statusOk conditions)
+		expectedConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{Type: autoscalingv2.ScaledToZero, Status: v1.ConditionFalse, Reason: "NotScaledToZero"},
+			{Type: autoscalingv2.AbleToScale, Status: v1.ConditionTrue, Reason: "SucceededRescale"},
+			{Type: autoscalingv2.ScalingActive, Status: v1.ConditionTrue, Reason: "ValidMetricFound"},
+			{Type: autoscalingv2.ScalingLimited, Status: v1.ConditionFalse, Reason: "DesiredWithinRange"},
+		},
 		expectedReportedReconciliationActionLabel: monitor.ActionLabelScaleUp,
 		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelNone,
 		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
@@ -1490,6 +1507,7 @@ func TestScaleUpFromZeroCMObject(t *testing.T) {
 }
 
 func TestScaleUpFromZeroIgnoresToleranceCMObject(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, true)
 	targetValue := resource.MustParse("1.0")
 	tc := testCase{
 		minReplicas:             0,
@@ -1518,6 +1536,20 @@ func TestScaleUpFromZeroIgnoresToleranceCMObject(t *testing.T) {
 			},
 		},
 		reportedLevels: []uint64{1000},
+		initialConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{
+				Type:   autoscalingv2.ScaledToZero,
+				Status: v1.ConditionTrue,
+				Reason: "ScaledToZero",
+			},
+		},
+		// Conditions are ordered as they appear in the actual result (ScaledToZero first, then statusOk conditions)
+		expectedConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{Type: autoscalingv2.ScaledToZero, Status: v1.ConditionFalse, Reason: "NotScaledToZero"},
+			{Type: autoscalingv2.AbleToScale, Status: v1.ConditionTrue, Reason: "SucceededRescale"},
+			{Type: autoscalingv2.ScalingActive, Status: v1.ConditionTrue, Reason: "ValidMetricFound"},
+			{Type: autoscalingv2.ScalingLimited, Status: v1.ConditionFalse, Reason: "DesiredWithinRange"},
+		},
 		expectedReportedReconciliationActionLabel: monitor.ActionLabelScaleUp,
 		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelNone,
 		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
@@ -1759,14 +1791,20 @@ func TestScaleUpOneMetricInvalid(t *testing.T) {
 }
 
 func TestScaleUpFromZeroOneMetricInvalid(t *testing.T) {
+	// Enable feature gate to verify that even with the feature enabled,
+	// scaling from zero is disabled without object/external metrics
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, true)
+	// This test uses CPU metrics, not object/external, so it can't scale from zero
+	// (only object/external metrics support scale-from-zero per KEP-2021)
+	// When currentReplicas=0 and minReplicas=0 without object/external metrics, scaling is disabled
 	tc := testCase{
 		minReplicas:             0,
 		maxReplicas:             6,
 		specReplicas:            0,
 		statusReplicas:          0,
-		expectedDesiredReplicas: 4,
+		expectedDesiredReplicas: 0,
 		CPUTarget:               30,
-		verifyCPUCurrent:        true,
+		verifyCPUCurrent:        false, // No scaling happens, so no CPU metrics computed
 		metricsTarget: []autoscalingv2.MetricSpec{
 			{
 				Type: "CheddarCheese",
@@ -1775,18 +1813,14 @@ func TestScaleUpFromZeroOneMetricInvalid(t *testing.T) {
 		reportedLevels:      []uint64{300, 400, 500},
 		reportedCPURequests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
 		recommendations:     []timestampedRecommendation{},
-		expectedReportedReconciliationActionLabel: monitor.ActionLabelScaleUp,
-		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelInternal,
-		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
-			autoscalingv2.ResourceMetricSourceType: monitor.ActionLabelScaleUp,
-			// Actually, such an invalid type should be validated in the kube-apiserver and invalid metric type shouldn't be recorded.
-			"CheddarCheese": monitor.ActionLabelNone,
+		expectedConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{Type: autoscalingv2.AbleToScale, Status: v1.ConditionTrue, Reason: "SucceededGetScale"},
+			{Type: autoscalingv2.ScalingActive, Status: v1.ConditionFalse, Reason: "ScalingDisabled"},
 		},
-		expectedReportedMetricComputationErrorLabels: map[autoscalingv2.MetricSourceType]monitor.ErrorLabel{
-			autoscalingv2.ResourceMetricSourceType: monitor.ErrorLabelNone,
-			// Actually, such an invalid type should be validated in the kube-apiserver and invalid metric type shouldn't be recorded.
-			"CheddarCheese": monitor.ErrorLabelSpec,
-		},
+		expectedReportedReconciliationActionLabel:     monitor.ActionLabelNone,
+		expectedReportedReconciliationErrorLabel:      monitor.ErrorLabelNone,
+		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{},
+		expectedReportedMetricComputationErrorLabels:  map[autoscalingv2.MetricSourceType]monitor.ErrorLabel{},
 	}
 	tc.runTest(t)
 }
@@ -1940,6 +1974,7 @@ func TestScaleDownCMObject(t *testing.T) {
 }
 
 func TestScaleDownToZeroCMObject(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, true)
 	targetValue := resource.MustParse("20.0")
 	tc := testCase{
 		minReplicas:             0,
@@ -1970,6 +2005,11 @@ func TestScaleDownToZeroCMObject(t *testing.T) {
 		reportedLevels:      []uint64{0},
 		reportedCPURequests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
 		recommendations:     []timestampedRecommendation{},
+		expectedConditions: statusOkWithOverrides(autoscalingv2.HorizontalPodAutoscalerCondition{
+			Type:   autoscalingv2.ScaledToZero,
+			Status: v1.ConditionTrue,
+			Reason: "ScaledToZero",
+		}),
 		expectedReportedReconciliationActionLabel: monitor.ActionLabelScaleDown,
 		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelNone,
 		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
@@ -2062,6 +2102,7 @@ func TestScaleDownCMExternal(t *testing.T) {
 }
 
 func TestScaleDownToZeroCMExternal(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, true)
 	tc := testCase{
 		minReplicas:             0,
 		maxReplicas:             6,
@@ -2085,6 +2126,11 @@ func TestScaleDownToZeroCMExternal(t *testing.T) {
 		},
 		reportedLevels:  []uint64{0},
 		recommendations: []timestampedRecommendation{},
+		expectedConditions: statusOkWithOverrides(autoscalingv2.HorizontalPodAutoscalerCondition{
+			Type:   autoscalingv2.ScaledToZero,
+			Status: v1.ConditionTrue,
+			Reason: "ScaledToZero",
+		}),
 		expectedReportedReconciliationActionLabel: monitor.ActionLabelScaleDown,
 		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelNone,
 		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
@@ -2092,6 +2138,109 @@ func TestScaleDownToZeroCMExternal(t *testing.T) {
 		},
 		expectedReportedMetricComputationErrorLabels: map[autoscalingv2.MetricSourceType]monitor.ErrorLabel{
 			autoscalingv2.ExternalMetricSourceType: monitor.ErrorLabelNone,
+		},
+	}
+	tc.runTest(t)
+}
+
+func TestScaleUpFromZeroWithoutCondition(t *testing.T) {
+	// Test that scaling from zero doesn't work without ScaledToZero condition
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, true)
+	targetValue := resource.MustParse("15.0")
+	tc := testCase{
+		minReplicas:             0,
+		maxReplicas:             6,
+		specReplicas:            0,
+		statusReplicas:          0,
+		expectedDesiredReplicas: 0,
+		CPUTarget:               0,
+		metricsTarget: []autoscalingv2.MetricSpec{
+			{
+				Type: autoscalingv2.ObjectMetricSourceType,
+				Object: &autoscalingv2.ObjectMetricSource{
+					DescribedObject: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "some-deployment",
+					},
+					Metric: autoscalingv2.MetricIdentifier{
+						Name: "qps",
+					},
+					Target: autoscalingv2.MetricTarget{
+						Type:  autoscalingv2.ValueMetricType,
+						Value: &targetValue,
+					},
+				},
+			},
+		},
+		reportedLevels: []uint64{20000},
+		// No initial ScaledToZero condition - should not scale
+		expectedConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{Type: autoscalingv2.AbleToScale, Status: v1.ConditionTrue, Reason: "SucceededGetScale"},
+			{Type: autoscalingv2.ScalingActive, Status: v1.ConditionFalse, Reason: "ScalingDisabled"},
+		},
+		expectedReportedReconciliationActionLabel:     monitor.ActionLabelNone,
+		expectedReportedReconciliationErrorLabel:      monitor.ErrorLabelNone,
+		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{},
+		expectedReportedMetricComputationErrorLabels:  map[autoscalingv2.MetricSourceType]monitor.ErrorLabel{},
+	}
+	tc.runTest(t)
+}
+
+func TestScaleUpFromZeroWhenMinReplicasIncreased(t *testing.T) {
+	// Test that scaling up from zero works when minReplicas is increased from 0 to non-zero
+	// This covers the case where HPA previously scaled to zero, then minReplicas was updated
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, true)
+	tc := testCase{
+		minReplicas:             2,
+		maxReplicas:             6,
+		specReplicas:            0,
+		statusReplicas:          0,
+		expectedDesiredReplicas: 2,
+		CPUTarget:               0,
+		metricsTarget: []autoscalingv2.MetricSpec{
+			{
+				Type: autoscalingv2.ObjectMetricSourceType,
+				Object: &autoscalingv2.ObjectMetricSource{
+					DescribedObject: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "some-deployment",
+					},
+					Metric: autoscalingv2.MetricIdentifier{
+						Name: "qps",
+					},
+					Target: autoscalingv2.MetricTarget{
+						Type:  autoscalingv2.ValueMetricType,
+						Value: resource.NewMilliQuantity(15000, resource.DecimalSI),
+					},
+				},
+			},
+		},
+		reportedLevels: []uint64{10000},
+		initialConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{
+				Type:   autoscalingv2.ScaledToZero,
+				Status: v1.ConditionTrue,
+				Reason: "ScaledToZero",
+			},
+		},
+		// Should scale up to minReplicas=2 and clear ScaledToZero condition
+		// Since we're scaling to exactly minReplicas, ScalingLimited should be True with "TooFewReplicas"
+		// Note: Conditions are ordered as they appear in the actual result (ScaledToZero first, then statusOk conditions)
+		expectedConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{Type: autoscalingv2.ScaledToZero, Status: v1.ConditionFalse, Reason: "NotScaledToZero"},
+			{Type: autoscalingv2.AbleToScale, Status: v1.ConditionTrue, Reason: "SucceededRescale"},
+			{Type: autoscalingv2.ScalingActive, Status: v1.ConditionTrue, Reason: "ValidMetricFound"},
+			{Type: autoscalingv2.ScalingLimited, Status: v1.ConditionTrue, Reason: "TooFewReplicas"},
+		},
+		expectedReportedReconciliationActionLabel: monitor.ActionLabelScaleUp,
+		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelNone,
+		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
+			autoscalingv2.ObjectMetricSourceType: monitor.ActionLabelScaleUp,
+		},
+		expectedReportedMetricComputationErrorLabels: map[autoscalingv2.MetricSourceType]monitor.ErrorLabel{
+			autoscalingv2.ObjectMetricSourceType: monitor.ErrorLabelNone,
 		},
 	}
 	tc.runTest(t)

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -352,7 +352,8 @@ const (
 	// Enables support of configurable HPA scale-up and scale-down tolerances.
 	HPAConfigurableTolerance featuregate.Feature = "HPAConfigurableTolerance"
 
-	// owner: @dxist
+	// owner: @johanneswuerbach
+	// kep: https://kep.k8s.io/2021
 	//
 	// Enables support of HPA scaling to zero pods when an object or custom metric is configured.
 	HPAScaleToZero featuregate.Feature = "HPAScaleToZero"

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -414,6 +414,8 @@ const (
 	// ScalingLimited indicates that the calculated scale based on metrics would be above or
 	// below the range for the HPA, and has thus been capped.
 	ScalingLimited HorizontalPodAutoscalerConditionType = "ScalingLimited"
+	// ScaledToZero indicates that the HPA controller scaled the workload to zero.
+	ScaledToZero HorizontalPodAutoscalerConditionType = "ScaledToZero"
 )
 
 // HorizontalPodAutoscalerCondition describes the state of

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -450,6 +450,8 @@ const (
 	// ScalingLimited indicates that the calculated scale based on metrics would be above or
 	// below the range for the HPA, and has thus been capped.
 	ScalingLimited HorizontalPodAutoscalerConditionType = "ScalingLimited"
+	// ScaledToZero indicates that the HPA controller scaled the workload to zero.
+	ScaledToZero HorizontalPodAutoscalerConditionType = "ScaledToZero"
 )
 
 // HorizontalPodAutoscalerCondition describes the state of

--- a/test/e2e/autoscaling/horizontal_pod_autosclaing_external_metrics.go
+++ b/test/e2e/autoscaling/horizontal_pod_autosclaing_external_metrics.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	v2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eautoscaling "k8s.io/kubernetes/test/e2e/framework/autoscaling"
@@ -84,3 +85,67 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (external metrics)"
 		ginkgo.DeferCleanup(e2eautoscaling.DeleteHorizontalPodAutoscaler, rc, hpa.Name)
 	})
 })
+
+var _ = SIGDescribe(feature.HPA, framework.WithFeatureGate(features.HPAScaleToZero),
+	"Horizontal pod autoscaling (scale to zero)", func() {
+		var (
+			rc                *e2eautoscaling.ResourceConsumer
+			metricsController *e2eautoscaling.ExternalMetricsController
+		)
+
+		waitBuffer := 1 * time.Minute
+
+		f := framework.NewDefaultFramework("horizontal-pod-autoscaling-scale-to-zero")
+		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			ginkgo.By("Setting up the external metrics server")
+			metricsController = e2eautoscaling.RunExternalMetricsServer(ctx, f.ClientSet, f.Namespace.Name, "external-metrics-server", nil)
+		})
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if metricsController != nil {
+				e2eautoscaling.CleanupExternalMetricsServer(ctx, f.ClientSet, f.Namespace.Name, "external-metrics-server")
+			}
+		})
+
+		ginkgo.It("should scale down to zero and back up based on external metric value", func(ctx context.Context) {
+			ginkgo.By("Creating the resource consumer deployment")
+			initPods := 1
+			rc = e2eautoscaling.NewDynamicResourceConsumer(ctx,
+				hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+				0, 0, 0,
+				int64(podCPURequest), 200,
+				f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
+				nil)
+			ginkgo.DeferCleanup(rc.CleanUp)
+			rc.WaitForReplicas(ctx, initPods, maxResourceConsumerDelay+waitBuffer)
+
+			metricName := "queue_messages_ready"
+
+			ginkgo.By(fmt.Sprintf("Creating an HPA with minReplicas=0 based on external metric %s", metricName))
+			stabilizationWindowZero := int32(0)
+			behavior := &v2.HorizontalPodAutoscalerBehavior{
+				ScaleDown: &v2.HPAScalingRules{
+					StabilizationWindowSeconds: &stabilizationWindowZero,
+				},
+			}
+			hpa := e2eautoscaling.CreateExternalHorizontalPodAutoscalerWithBehavior(ctx,
+				rc, metricName, nil, v2.ValueMetricType, 50,
+				0, 3, behavior)
+			ginkgo.DeferCleanup(e2eautoscaling.DeleteHPAWithBehavior, rc, hpa.Name)
+
+			ginkgo.By(fmt.Sprintf("Setting %s metric value to 0 to trigger scale to zero", metricName))
+			err := metricsController.SetMetricValue(ctx, metricName, 0, nil)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for HPA to scale down to zero replicas")
+			rc.WaitForReplicas(ctx, 0, maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
+
+			ginkgo.By(fmt.Sprintf("Setting %s metric value to 200 to trigger scale from zero", metricName))
+			err = metricsController.SetMetricValue(ctx, metricName, 200, nil)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for HPA to scale back up from zero")
+			rc.WaitForReplicas(ctx, int(hpa.Spec.MaxReplicas), maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
+		})
+	})


### PR DESCRIPTION
I'm testing the changes made in https://github.com/kubernetes/test-infra/pull/36497, do not merge.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
