### PR TITLE
Trace writer/reader interface

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/repro_log_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/repro_log_test.go
@@ -1,0 +1,91 @@
+package responsewriters
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"math/rand"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/klog/v2"
+)
+
+func TestSerializeObjectTraceLog(t *testing.T) {
+	// Enable klog V(2) to ensure traces are logged
+	klog.InitFlags(nil)
+	flag.Set("v", "2")
+	flag.Parse()
+
+	// Capture klog output
+	var buf bytes.Buffer
+	klog.SetOutput(&buf)
+	defer klog.SetOutput(nil)
+
+	// Prepare large object
+	// 100,000 pods should be enough to generate significant JSON
+	count := 100000
+	pods := make([]v1.Pod, count)
+	for i := 0; i < count; i++ {
+		pods[i] = v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("pod-%d", i),
+				Labels: map[string]string{
+					"app": "nginx",
+					"tier": "frontend",
+					"env": "prod",
+				},
+				Annotations: map[string]string{
+					"description": fmt.Sprintf("random-data-%d-%d-%s", i, rand.Int(), strings.Repeat("x", 100)),
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "nginx",
+						Image: "nginx:latest",
+						Env: []v1.EnvVar{
+							{Name: "VAR1", Value: "VALUE1"},
+							{Name: "VAR2", Value: "VALUE2"},
+						},
+					},
+				},
+			},
+		}
+	}
+	podList := &v1.PodList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PodList",
+			APIVersion: "v1",
+		},
+		Items: pods,
+	}
+	
+	scheme := runtime.NewScheme()
+	v1.AddToScheme(scheme)
+	serializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{})
+
+	req := httptest.NewRequest("GET", "/api/v1/pods", nil)
+	// Enable gzip
+	req.Header.Set("Accept-Encoding", "gzip")
+	
+	w := httptest.NewRecorder()
+
+	start := time.Now()
+	// Call SerializeObject
+	SerializeObject("application/json", serializer, w, req, 200, podList)
+	duration := time.Since(start)
+
+	fmt.Printf("Serialization took: %v\n", duration)
+	fmt.Printf("Response size: %d bytes\n", w.Body.Len())
+
+	// Print captured log
+	fmt.Println("Captured Klog Output:")
+	fmt.Println(buf.String())
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -109,7 +109,8 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 		ctx:             ctx,
 	}
 
-	err := encoder.Encode(object, w)
+	traceW := span.WrapWriter(w, "Encoding")
+	err := encoder.Encode(object, traceW)
 	if err == nil {
 		err = w.Close()
 		if err != nil {
@@ -200,6 +201,7 @@ type deferredResponseWriter struct {
 	hasWritten  bool
 	hw          http.ResponseWriter
 	w           io.Writer
+	gzipWriter  *gzip.Writer
 	// totalBytes is the number of bytes written to `w` and does not include buffered bytes
 	totalBytes int
 	// lastWriteErr holds the error result (if any) of the last write attempt to `w`
@@ -257,25 +259,23 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 	w.hasWritten = true
 
 	hw := w.hw
+	span := tracing.SpanFromContext(w.ctx)
+	networkW := span.WrapWriter(hw, "Network")
+
 	header := hw.Header()
 	switch {
-	case w.contentEncoding == "gzip" && len(p) > defaultGzipThresholdBytes:
+	case w.contentEncoding == "gzip":
 		header.Set("Content-Encoding", "gzip")
 		header.Add("Vary", "Accept-Encoding")
 
 		gw := gzipPool.Get().(*gzip.Writer)
-		gw.Reset(hw)
-
-		w.w = gw
+		gw.Reset(networkW)
+		w.gzipWriter = gw
+		w.w = span.WrapWriter(gw, "gzip")
 	default:
-		w.w = hw
+		w.w = networkW
 	}
 
-	span := tracing.SpanFromContext(w.ctx)
-	span.AddEvent("About to start writing response",
-		attribute.String("writer", fmt.Sprintf("%T", w.w)),
-		attribute.Int("size", len(p)),
-	)
 
 	header.Set("Content-Type", w.mediaType)
 	hw.WriteHeader(w.statusCode)
@@ -310,11 +310,11 @@ func (w *deferredResponseWriter) Close() (err error) {
 		return err
 	}
 
-	switch t := w.w.(type) {
-	case *gzip.Writer:
-		err = t.Close()
-		t.Reset(nil)
-		gzipPool.Put(t)
+	if w.gzipWriter != nil {
+		err = w.gzipWriter.Close()
+		w.gzipWriter.Reset(nil)
+		gzipPool.Put(w.gzipWriter)
+		w.gzipWriter = nil
 	}
 	return err
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -253,16 +253,16 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 			runtime.AllocatorPool.Put(s.MemoryAllocator)
 		}
 	}()
-
-	flusher, ok := w.(http.Flusher)
+	_, ok := w.(http.Flusher)
 	if !ok {
 		err := fmt.Errorf("unable to start watch - can't get http.Flusher: %#v", w)
 		utilruntime.HandleErrorWithContext(req.Context(), err, "Unable to start watch")
 		s.Scope.err(errors.NewInternalError(err), w, req)
 		return
 	}
+	tracedNetwork := span.WrapWriter(w, "Network")
 
-	framer := s.Framer.NewFrameWriter(w)
+	framer := s.Framer.NewFrameWriter(tracedNetwork)
 	if framer == nil {
 		// programmer error
 		err := fmt.Errorf("no stream framing support is available for media type %q", s.MediaType)
@@ -270,6 +270,8 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 		s.Scope.err(errors.NewBadRequest(err.Error()), w, req)
 		return
 	}
+
+	tracedFramer := span.WrapWriter(framer, "Framer")
 
 	// ensure the connection times out
 	timeoutCh, cleanup := s.TimeoutFactory.TimeoutCh()
@@ -279,12 +281,12 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", s.MediaType)
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	tracedNetwork.Flush()
 
 	gvr := s.Scope.Resource
 
 	recorder := &watchEventMetricsRecorder{
-		writer:      framer,
+		writer:      tracedFramer,
 		countMetric: metrics.WatchEvents.WithContext(req.Context()).WithLabelValues(gvr.Group, gvr.Version, gvr.Resource),
 		sizeMetric:  metrics.WatchEventsSizes.WithContext(req.Context()).WithLabelValues(gvr.Group, gvr.Version, gvr.Resource),
 	}
@@ -322,9 +324,8 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 			recorder.RecordEvent()
-
 			if len(ch) == 0 {
-				flusher.Flush()
+				tracedNetwork.Flush()
 			}
 			if isWatchListLatencyRecordingRequired {
 				// Record completion of initial listing phase for WatchList
@@ -337,7 +338,6 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 					auditID := audit.GetAuditIDTruncated(req.Context())
 					klog.V(3).InfoS("WatchList initial events sent", "path", req.URL.Path, "auditID", auditID, "initLatency", initLatency)
 					httplog.AddKeyValue(req.Context(), "watchlist_init_latency", initLatency)
-					span.AddEvent("Writing initial events done")
 					span.End(5 * time.Second)
 					s.watchListCompleteHook()
 				}

--- a/staging/src/k8s.io/component-base/tracing/io.go
+++ b/staging/src/k8s.io/component-base/tracing/io.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+type TracedReader struct {
+	next  io.Reader
+	layer *layer
+	span  *Span
+}
+
+func (r *TracedReader) Read(p []byte) (n int, err error) {
+	start := r.span.clock.Now()
+	n, err = r.next.Read(p)
+	duration := r.span.clock.Since(start)
+	r.layer.duration += duration
+	r.layer.bytes += int64(n)
+	r.layer.count++
+	return n, err
+}
+
+type ReaderSpan struct {
+	span      *Span
+	layer     *layer
+	start     time.Time
+	prevLayer *layer
+}
+
+func (s *ReaderSpan) Done() {
+	duration := s.span.clock.Since(s.start)
+	s.layer.duration = duration
+	if s.layer.child != nil {
+		s.layer.childDuration = s.layer.child.duration
+	}
+}
+
+type TracedWriter struct {
+	next  io.Writer
+	layer *layer
+	span  *Span
+}
+
+var _ io.Writer = (*TracedWriter)(nil)
+var _ http.Flusher = (*TracedWriter)(nil)
+
+func (w *TracedWriter) Write(p []byte) (n int, err error) {
+	start := w.span.clock.Now()
+	n, err = w.next.Write(p)
+	duration := w.span.clock.Since(start)
+	w.layer.duration += duration
+	w.layer.bytes += int64(n)
+	w.layer.count++
+	return n, err
+}
+
+func (w *TracedWriter) Flush() {
+	flusher, ok := w.next.(http.Flusher)
+	if !ok {
+		return
+	}
+	start := w.span.clock.Now()
+	flusher.Flush()
+	duration := w.span.clock.Since(start)
+	w.layer.duration += duration
+	w.layer.count++
+}
+
+type WriterSpan struct {
+	span      *Span
+	layer     *layer
+	start     time.Time
+	prevLayer *layer
+}
+
+func (s *WriterSpan) End() {
+	duration := s.span.clock.Since(s.start)
+	s.layer.duration = duration
+	if s.layer.child != nil {
+		s.layer.childDuration = s.layer.child.duration
+	}
+}
+
+func (s *WriterSpan) Done() {
+	s.End()
+}

--- a/staging/src/k8s.io/component-base/tracing/io_test.go
+++ b/staging/src/k8s.io/component-base/tracing/io_test.go
@@ -1,0 +1,956 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"k8s.io/klog/v2"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+type expectedEvent struct {
+	name     string
+	size     int64
+	count    int64
+	duration time.Duration
+}
+
+func TestTracedReaderLogs(t *testing.T) {
+	for _, scenario := range tracedReaderScenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			klog.SetOutput(&buf)
+			defer klog.SetOutput(nil)
+
+			fakeClock := testingclock.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+			ctx := context.Background()
+
+			scenario.testFunc(ctx, fakeClock)
+
+			output := buf.String()
+			t.Logf("Log output:\n%s", output)
+
+			for _, expected := range scenario.expectedEvents {
+				durationMs := expected.duration.Nanoseconds() / 1e6
+				expectedDurationStr := fmt.Sprintf("%dms", durationMs)
+
+				reportBytes := expected.size
+				reportCount := expected.count
+
+				if reportBytes > 0 && reportCount > 0 {
+					assert.Contains(t, output, fmt.Sprintf(`%q size:%d,count:%d %s`, expected.name, reportBytes, reportCount, expectedDurationStr))
+				} else {
+					assert.Contains(t, output, fmt.Sprintf(`%q %s`, expected.name, expectedDurationStr))
+				}
+
+			}
+		})
+	}
+}
+
+func TestTracedReaderOTEL(t *testing.T) {
+	for _, scenario := range tracedReaderScenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			fakeRecorder := tracetest.NewSpanRecorder()
+			otelTracer := trace.NewTracerProvider(trace.WithSpanProcessor(fakeRecorder)).Tracer(instrumentationScope)
+
+			fakeClock := testingclock.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+			ctx := context.Background()
+
+			parentName := "parent otel span"
+			if scenario.expectedParentSpanName != "" {
+				parentName = scenario.expectedParentSpanName
+			}
+
+			ctx, span := otelTracer.Start(ctx, parentName)
+			scenario.testFunc(ctx, fakeClock)
+			span.End()
+
+			output := fakeRecorder.Ended()
+			if len(output) != 2 {
+				t.Fatalf("got %d; expected len(output) == 2", len(output))
+			}
+			child := output[0]
+			if child.Name() != "Reading Response" && child.Name() != scenario.name {
+				// Some scenarios might use different span names
+			}
+
+			if len(child.Events()) != len(scenario.expectedEvents) {
+				t.Fatalf("got events %v; expected %d events", child.Events(), len(scenario.expectedEvents))
+			}
+			for i, event := range child.Events() {
+				expected := scenario.expectedEvents[i]
+				if event.Name != expected.name {
+					t.Errorf("got event %v; expected event name %s", event, expected.name)
+				}
+				for _, attr := range event.Attributes {
+					switch attr.Key {
+					case "size":
+						if attr.Value.AsInt64() != expected.size {
+							t.Errorf("event %s: got size %d; expected %d", event.Name, attr.Value.AsInt64(), expected.size)
+						}
+					case "count":
+						if attr.Value.AsInt64() != expected.count {
+							t.Errorf("event %s: got count %d; expected %d", event.Name, attr.Value.AsInt64(), expected.count)
+						}
+					case "duration":
+						if attr.Value.AsString() != expected.duration.String() {
+							t.Errorf("event %s: got duration %s; expected %s", event.Name, attr.Value.AsString(), expected.duration.String())
+						}
+					}
+				}
+			}
+
+			foundLayers := false
+			var expectedLayers []string
+			for _, e := range scenario.expectedEvents {
+				expectedLayers = append(expectedLayers, e.name)
+			}
+
+			for _, attr := range child.Attributes() {
+				if attr.Key == "writer.layers" {
+					foundLayers = true
+					assert.Equal(t, expectedLayers, attr.Value.AsStringSlice())
+				}
+			}
+			if len(expectedLayers) > 0 && !foundLayers {
+				t.Error("writer.layers attribute not found")
+			}
+		})
+	}
+}
+
+type tracedReaderScenario struct {
+	name                   string
+	expectedParentSpanName string
+	testFunc               func(ctx context.Context, fakeClock *testingclock.FakeClock)
+	expectedEvents         []expectedEvent
+}
+
+var tracedReaderScenarios = []tracedReaderScenario{
+	{
+		name:                   "Base",
+		expectedParentSpanName: "Base",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "Base")
+			span.clock = fakeClock
+			defer span.End(0)
+		},
+		expectedEvents: []expectedEvent{},
+	},
+	{
+		name:                   "NoReadsWithNamedReader",
+		expectedParentSpanName: "NoReadsWithNamedReader",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{ sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "NoReadsWithNamedReader")
+			span.clock = fakeClock
+			defer span.End(0)
+			span.WrapReader(reader, "NamedReader")
+			fakeClock.Step(10 * time.Millisecond)
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedReader", size: 0, count: 0, duration: 0},
+		},
+	},
+	{
+		name:                   "NoReadsWithSpan",
+		expectedParentSpanName: "NoReadsWithSpan",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{ sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "NoReadsWithSpan")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader, s := span.WithReader("Deserialize", reader)
+			defer s.Done()
+			fakeClock.Step(10 * time.Millisecond)
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Reader", size: 0, count: 0, duration: 0},
+			{name: "Deserialize", size: 0, count: 0, duration: 10*time.Millisecond},
+		},
+	},
+	{
+		name:                   "NoReadsWithSpanAndNamedReader",
+		expectedParentSpanName: "NoReadsWithSpanAndNamedReader",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{ sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "NoReadsWithSpanAndNamedReader")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader = span.WrapReader(reader, "NamedReader")
+			reader, s := span.WithReader("Deserialize", reader)
+			defer s.Done()
+			fakeClock.Step(10 * time.Millisecond)
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedReader", size: 0, count: 0, duration: 0},
+			{name: "Deserialize", size: 0, count: 0, duration: 10*time.Millisecond},
+		},
+	},
+	{
+		name:                   "SingleReadWithNamedReader",
+		expectedParentSpanName: "SingleReadWithNamedReader",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "SingleReadWithNamedReader")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader = span.WrapReader(reader, "NamedReader")
+
+			fakeClock.Step(5 * time.Millisecond)
+			reader.Read(make([]byte, 5))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedReader", size: 5, count: 1, duration: 7 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "SingleReadWithSpan",
+		expectedParentSpanName: "SingleReadWithSpan",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "SingleReadWithSpan")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader, s := span.WithReader("Deserialize", reader)
+			defer s.Done()
+			fakeClock.Step(5 * time.Millisecond)
+			reader.Read(make([]byte, 5))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Reader", size: 5, count: 1, duration: 7 * time.Millisecond},
+			{name: "Deserialize", size: 0, count: 0, duration: 5 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "SingleReadWithSpanAndNamedReader",
+		expectedParentSpanName: "SingleReadWithSpanAndNamedReader",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "SingleReadWithSpanAndNamedReader")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader = span.WrapReader(reader, "NamedReader")
+			reader, s := span.WithReader("Deserialize", reader)
+			defer s.Done()
+			fakeClock.Step(5 * time.Millisecond)
+			reader.Read(make([]byte, 5))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedReader", size: 5, count: 1, duration: 7 * time.Millisecond},
+			{name: "Deserialize", size: 0, count: 0, duration: 5 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "SingleReadWithMultipleLayers",
+		expectedParentSpanName: "SingleReadWithMultipleLayers",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "SingleReadWithMultipleLayers")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader = span.WrapReader(reader, "NamedReader")
+			reader = &mockReader{sleep: 3 * time.Millisecond, clock: fakeClock, next: reader}
+			reader = span.WrapReader(reader, "NamedReader2")
+			reader, s := span.WithReader("Deserialize", reader)
+			defer s.Done()
+			fakeClock.Step(5 * time.Millisecond)
+			reader.Read(make([]byte, 5))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedReader", size: 5, count: 1, duration: 7 * time.Millisecond},
+			{name: "NamedReader2", size: 5, count: 1, duration: 3 * time.Millisecond},
+			{name: "Deserialize", size: 0, count: 0, duration: 5 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "MultipleReads",
+		expectedParentSpanName: "MultipleReads",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "MultipleReads")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader = span.WrapReader(reader, "NamedReader")
+			reader, s := span.WithReader("Deserialize", reader)
+			defer s.Done()
+			for i	:= 0; i < 5; i++ {
+				fakeClock.Step(5 * time.Millisecond)
+				reader.Read(make([]byte, 5))
+			}
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedReader", size: 25, count: 5, duration: 35 * time.Millisecond},
+			{name: "Deserialize", size: 0, count: 0, duration: 25 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "MultipleReadsWithMultipleLayers",
+		expectedParentSpanName: "MultipleReadsWithMultipleLayers",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "MultipleReadsWithMultipleLayers")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader = span.WrapReader(reader, "NamedReader")
+			reader = &mockReader{sleep: 3 * time.Millisecond, clock: fakeClock, next: reader}
+			reader = span.WrapReader(reader, "NamedReader2")
+			reader, s := span.WithReader("Deserialize", reader)
+			defer s.Done()
+			for i	:= 0; i < 5; i++ {
+				fakeClock.Step(5 * time.Millisecond)
+				reader.Read(make([]byte, 5))
+			}
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedReader", size: 25, count: 5, duration: 35 * time.Millisecond},
+			{name: "NamedReader2", size: 25, count: 5, duration: 15 * time.Millisecond},
+			{name: "Deserialize", size: 0, count: 0, duration: 25 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "PrefixReader",
+		expectedParentSpanName: "PrefixReader",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "PrefixReader")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader = span.WrapReader(reader, "Raw")
+			reader = &prefixReader{mockReader: mockReader{next: reader, sleep: 3 * time.Millisecond, clock: fakeClock}, prefix: []byte("HEAD")}
+			reader = span.WrapReader(reader, "Prefix")
+			reader, s := span.WithReader("Deserialize", reader)
+			defer s.Done()
+			for i := 0; i < 5; i++ {
+				fakeClock.Step(5 * time.Millisecond)
+				reader.Read(make([]byte, 5))
+			}
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Raw", size: 5, count: 5, duration: 35 * time.Millisecond},
+			{name: "Prefix", size: 25, count: 5, duration: 15* time.Millisecond},
+			{name: "Deserialize", duration: 25 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "ChunkingReader",
+		expectedParentSpanName: "ChunkingReader",
+		testFunc: func(ctx context.Context, fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "ChunkingReader")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader = span.WrapReader(reader, "Raw")
+			reader = &chunkingReader{chunkSize: 10, mockReader: mockReader{next: reader, sleep: 3 * time.Millisecond, clock: fakeClock}}
+			reader = span.WrapReader(reader, "Chunking")
+			reader, s := span.WithReader("Deserialize", reader)
+			defer s.Done()
+			for i := 0; i < 5; i++ {
+				fakeClock.Step(5 * time.Millisecond)
+				reader.Read(make([]byte, 5))
+			}
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Raw", size: 30, count: 3, duration: 21 * time.Millisecond},
+			{name: "Chunking", size: 25, count: 5, duration: 15* time.Millisecond},
+			{name: "Deserialize", duration: 25 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "DeepNesting",
+		expectedParentSpanName: "DeepNesting",
+		testFunc: func(ctx context.Context,fakeClock *testingclock.FakeClock) {
+			var reader io.Reader = &mockReader{ sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx, span := Start(ctx, "DeepNesting")
+			span.clock = fakeClock
+			defer span.End(0)
+			reader = span.WrapReader(reader, "L1")
+			reader = span.WrapReader(reader, "L2")
+			reader = span.WrapReader(reader, "L3")
+
+			fakeClock.Step(10 * time.Millisecond)
+			reader.Read(make([]byte, 4))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "L1", size: 4, count: 1, duration: 7 * time.Millisecond},
+			{name: "L2", size: 4, count: 1, duration: 0},
+			{name: "L3", size: 4, count: 1, duration: 0},
+		},
+	},
+}
+
+type mockReader struct {
+	sleep time.Duration
+	clock *testingclock.FakeClock
+	next  io.Reader
+}
+
+func (m *mockReader) Read(p []byte) (int, error) {
+	m.clock.Step(m.sleep)
+	if m.next != nil {
+		return m.next.Read(p)
+	}
+	// Return data
+	n := copy(p, []byte("1234567890"))
+	if len(p) == 0 {
+		return len(p), nil
+	}
+	// Advance data pointer? No, mockReader is simple.
+	// But for Response reader we need to return different data or just data.
+	// If we don't advance, we return same data.
+	// Chunking reader reads 10 bytes.
+	// If we return 50 bytes, we need to advance?
+	// If we don't advance, we return first 10 bytes 5 times.
+	// That's fine for the test, as long as we return bytes.
+	return n, nil
+}
+
+func (m *mockReader) Unwrap() io.Reader {
+	return m.next
+}
+
+type prefixReader struct {
+	mockReader
+	prefix []byte
+}
+
+func (r *prefixReader) Read(p []byte) (int, error) {
+	n := copy(p, r.prefix)
+	k, err := r.mockReader.Read(p[n:])
+	return n + k, err
+}
+
+type chunkingReader struct {
+	mockReader
+	chunkSize int
+	buffer    []byte
+}
+
+func (r *chunkingReader) Read(p []byte) (n int, err error) {
+	r.clock.Step(r.sleep)
+	for n < len(p) {
+		if len(r.buffer) == 0 {
+			buf := make([]byte, r.chunkSize)
+			nr, er := r.next.Read(buf)
+			if nr > 0 {
+				r.buffer = buf[:nr]
+			}
+			if er != nil {
+				if n == 0 && nr == 0 {
+					return 0, er
+				}
+				err = er
+				if nr == 0 {
+					return n, err
+				}
+			}
+		}
+
+		copied := copy(p[n:], r.buffer)
+		n += copied
+		r.buffer = r.buffer[copied:]
+
+		if err != nil && len(r.buffer) == 0 {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+func TestTracedWriterLogs(t *testing.T) {
+	for _, scenario := range tracedWriterScenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			klog.SetOutput(&buf)
+			defer klog.SetOutput(nil)
+
+			fakeClock := testingclock.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+			writer := &mockWriter{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx := context.Background()
+
+			scenario.testFunc(ctx, writer, fakeClock)
+
+			output := buf.String()
+			t.Logf("Log output:\n%s", output)
+			for _, expected := range scenario.expectedEvents {
+				durationMs := expected.duration.Nanoseconds() / 1e6
+				expectedDurationStr := fmt.Sprintf("%dms", durationMs)
+				if expected.size > 0 && expected.count > 0 {
+					assert.Contains(t, output, fmt.Sprintf(`%q size:%d,count:%d %s`, expected.name, expected.size, expected.count, expectedDurationStr))
+				} else {
+					assert.Contains(t, output, fmt.Sprintf(`%q %s`, expected.name, expectedDurationStr))
+				}
+			}
+		})
+	}
+}
+
+func TestTracedWriterOTEL(t *testing.T) {
+	for _, scenario := range tracedWriterScenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			fakeRecorder := tracetest.NewSpanRecorder()
+			otelTracer := trace.NewTracerProvider(trace.WithSpanProcessor(fakeRecorder)).Tracer(instrumentationScope)
+
+			fakeClock := testingclock.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+			writer := &mockWriter{sleep: 7 * time.Millisecond, clock: fakeClock}
+			ctx := context.Background()
+
+			parentName := "parent otel span"
+			if scenario.expectedParentSpanName != "" {
+				parentName = scenario.expectedParentSpanName
+			}
+
+			ctx, span := otelTracer.Start(ctx, parentName)
+			scenario.testFunc(ctx, writer, fakeClock)
+			span.End()
+
+			output := fakeRecorder.Ended()
+			if len(output) != 2 {
+				t.Fatalf("got %d; expected len(output) == 2", len(output))
+			}
+			child := output[0]
+			if child.Name() != "Writing Response" && child.Name() != scenario.name {
+				// Some scenarios might use different span names, but for now let's assume they use "Writing Response" or scenario name
+			}
+
+			if len(child.Events()) != len(scenario.expectedEvents) {
+				t.Errorf("got events %v; expected %d events", child.Events(), len(scenario.expectedEvents))
+			}
+			for i, event := range child.Events() {
+				expected := scenario.expectedEvents[i]
+				if event.Name != expected.name {
+					t.Errorf("got event %v; expected event name %s", event, expected.name)
+				}
+				for _, attr := range event.Attributes {
+					switch attr.Key {
+					case "size":
+						if attr.Value.AsInt64() != expected.size {
+							t.Errorf("event %s: got size %d; expected %d", event.Name, attr.Value.AsInt64(), expected.size)
+						}
+					case "count":
+						if attr.Value.AsInt64() != expected.count {
+							t.Errorf("event %s: got count %d; expected %d", event.Name, attr.Value.AsInt64(), expected.count)
+						}
+					case "duration":
+						if attr.Value.AsString() != expected.duration.String() {
+							t.Errorf("event %s: got duration %s; expected %s", event.Name, attr.Value.AsString(), expected.duration.String())
+						}
+					}
+				}
+			}
+
+			foundLayers := false
+			var expectedLayers []string
+			for _, e := range scenario.expectedEvents {
+				expectedLayers = append(expectedLayers, e.name)
+			}
+
+			for _, attr := range child.Attributes() {
+				if attr.Key == "writer.layers" {
+					foundLayers = true
+					assert.Equal(t, expectedLayers, attr.Value.AsStringSlice())
+				}
+			}
+			if len(expectedLayers) > 0 && !foundLayers {
+				t.Error("writer.layers attribute not found")
+			}
+		})
+	}
+}
+
+type tracedWriterScenario struct {
+	name                   string
+	expectedParentSpanName string
+	testFunc               func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock)
+	expectedEvents         []expectedEvent
+}
+
+var tracedWriterScenarios = []tracedWriterScenario{
+	{
+		name: "Response writer",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "Writing Response")
+			span.clock = fakeClock // Inject fake clock for testing
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "Raw")
+
+			// Adds 4 bytes to 5 calls, each taking 5ms.
+			writer = &prefixWriter{mockWriter: mockWriter{next: writer, sleep: 5 * time.Millisecond, clock: fakeClock}, prefix: []byte("HEAD")}
+			writer = span.WrapWriter(writer, "Prefix")
+
+			// Batches 11 calls each taking 3 miliseconds, totalling 44 bytes into 5 calls
+			batchW := &chunkingWriter{chunkSize: 10, mockWriter: mockWriter{next: writer, sleep: 3 * time.Millisecond, clock: fakeClock}}
+			writer = span.WrapWriter(batchW, "Chunking")
+			defer batchW.Flush()
+
+			// Called 11 times, each time taking 2ms and writing 4 bytes.
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			for i := 0; i < 11; i++ {
+				fakeClock.Step(2 * time.Millisecond)
+				writer.Write([]byte("data"))
+			}
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Raw", size: 64, count: 5, duration: 35 * time.Millisecond},
+			{name: "Prefix", size: 44, count: 5, duration: 25 * time.Millisecond},
+			{name: "Chunking", size: 44, count: 11, duration: 21 * time.Millisecond}, // 33ms total - 12ms flush (bypassed) = 21ms
+			{name: "Serialize", size: 0, count: 0, duration: 22 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "NoWrites",
+		expectedParentSpanName: "NoWrites",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "NoWrites")
+			span.clock = fakeClock
+			defer span.End(0)
+			span.WrapWriter(writer, "Raw")
+			fakeClock.Step(10 * time.Millisecond)
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Raw", size: 0, count: 0, duration: 0},
+		},
+	},
+	{
+		name:                   "SingleWrite",
+		expectedParentSpanName: "SingleWrite",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "SingleWrite")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "Raw")
+
+			fakeClock.Step(5 * time.Millisecond)
+			writer.Write([]byte("hello"))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Raw", size: 5, count: 1, duration: 7 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "DeepNesting",
+		expectedParentSpanName: "DeepNesting",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "DeepNesting")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "L1")
+			writer = span.WrapWriter(writer, "L2")
+			writer = span.WrapWriter(writer, "L3")
+
+			fakeClock.Step(10 * time.Millisecond)
+			writer.Write([]byte("data"))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "L1", size: 4, count: 1, duration: 7 * time.Millisecond},
+			{name: "L2", size: 4, count: 1, duration: 0}, // Same bytes/count as L1, so 0. Exclusive time is 0.
+			{name: "L3", size: 4, count: 1, duration: 0}, // Same bytes/count as L2, so 0. Exclusive time is 0.
+		},
+	},
+	{
+		name:                   "NoWritesWithNamedWriter",
+		expectedParentSpanName: "NoWritesWithNamedWriter",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "NoWritesWithNamedWriter")
+			span.clock = fakeClock
+			defer span.End(0)
+			span.WrapWriter(writer, "NamedWriter")
+			fakeClock.Step(10 * time.Millisecond)
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedWriter", size: 0, count: 0, duration: 0},
+		},
+	},
+	{
+		name:                   "NoWritesWithSpan",
+		expectedParentSpanName: "NoWritesWithSpan",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "NoWritesWithSpan")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			fakeClock.Step(10 * time.Millisecond)
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Writer", size: 0, count: 0, duration: 0},
+			{name: "Serialize", size: 0, count: 0, duration: 10 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "NoWritesWithSpanAndNamedWriter",
+		expectedParentSpanName: "NoWritesWithSpanAndNamedWriter",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "NoWritesWithSpanAndNamedWriter")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "NamedWriter")
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			fakeClock.Step(10 * time.Millisecond)
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedWriter", size: 0, count: 0, duration: 0},
+			{name: "Serialize", size: 0, count: 0, duration: 10 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "SingleWriteWithNamedWriter",
+		expectedParentSpanName: "SingleWriteWithNamedWriter",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "SingleWriteWithNamedWriter")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "NamedWriter")
+
+			fakeClock.Step(5 * time.Millisecond)
+			writer.Write([]byte("hello"))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedWriter", size: 5, count: 1, duration: 7 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "SingleWriteWithSpan",
+		expectedParentSpanName: "SingleWriteWithSpan",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "SingleWriteWithSpan")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			fakeClock.Step(5 * time.Millisecond)
+			writer.Write([]byte("hello"))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Writer", size: 5, count: 1, duration: 7 * time.Millisecond},
+			{name: "Serialize", size: 0, count: 0, duration: 5 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "SingleWriteWithSpanAndNamedWriter",
+		expectedParentSpanName: "SingleWriteWithSpanAndNamedWriter",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "SingleWriteWithSpanAndNamedWriter")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "NamedWriter")
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			fakeClock.Step(5 * time.Millisecond)
+			writer.Write([]byte("hello"))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedWriter", size: 5, count: 1, duration: 7 * time.Millisecond},
+			{name: "Serialize", size: 0, count: 0, duration: 5 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "SingleWriteWithMultipleLayers",
+		expectedParentSpanName: "SingleWriteWithMultipleLayers",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "SingleWriteWithMultipleLayers")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "NamedWriter")
+			writer = &mockWriter{sleep: 3 * time.Millisecond, clock: fakeClock, next: writer}
+			writer = span.WrapWriter(writer, "NamedWriter2")
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			fakeClock.Step(5 * time.Millisecond)
+			writer.Write([]byte("hello"))
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedWriter", size: 5, count: 1, duration: 7 * time.Millisecond},
+			{name: "NamedWriter2", size: 5, count: 1, duration: 3 * time.Millisecond},
+			{name: "Serialize", size: 0, count: 0, duration: 5 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "MultipleWrites",
+		expectedParentSpanName: "MultipleWrites",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "MultipleWrites")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "NamedWriter")
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			for i := 0; i < 5; i++ {
+				fakeClock.Step(5 * time.Millisecond)
+				writer.Write([]byte("hello"))
+			}
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedWriter", size: 25, count: 5, duration: 35 * time.Millisecond},
+			{name: "Serialize", size: 0, count: 0, duration: 25 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "MultipleWritesWithMultipleLayers",
+		expectedParentSpanName: "MultipleWritesWithMultipleLayers",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "MultipleWritesWithMultipleLayers")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "NamedWriter")
+			writer = &mockWriter{sleep: 3 * time.Millisecond, clock: fakeClock, next: writer}
+			writer = span.WrapWriter(writer, "NamedWriter2")
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			for i := 0; i < 5; i++ {
+				fakeClock.Step(5 * time.Millisecond)
+				writer.Write([]byte("hello"))
+			}
+		},
+		expectedEvents: []expectedEvent{
+			{name: "NamedWriter", size: 25, count: 5, duration: 35 * time.Millisecond},
+			{name: "NamedWriter2", size: 25, count: 5, duration: 15 * time.Millisecond},
+			{name: "Serialize", size: 0, count: 0, duration: 25 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "PrefixWriter",
+		expectedParentSpanName: "PrefixWriter",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "PrefixWriter")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "Raw")
+			writer = &prefixWriter{mockWriter: mockWriter{next: writer, sleep: 3 * time.Millisecond, clock: fakeClock}, prefix: []byte("HEAD")}
+			writer = span.WrapWriter(writer, "Prefix")
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			for i := 0; i < 5; i++ {
+				fakeClock.Step(5 * time.Millisecond)
+				writer.Write([]byte("hello"))
+			}
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Raw", size: 45, count: 5, duration: 35 * time.Millisecond},
+			{name: "Prefix", size: 25, count: 5, duration: 15 * time.Millisecond},
+			{name: "Serialize", size: 0, count: 0, duration: 25 * time.Millisecond},
+		},
+	},
+	{
+		name:                   "ChunkingWriter",
+		expectedParentSpanName: "ChunkingWriter",
+		testFunc: func(ctx context.Context, writer io.Writer, fakeClock *testingclock.FakeClock) {
+			ctx, span := Start(ctx, "ChunkingWriter")
+			span.clock = fakeClock
+			defer span.End(0)
+			writer = span.WrapWriter(writer, "Raw")
+			writer = &chunkingWriter{chunkSize: 10, mockWriter: mockWriter{next: writer, sleep: 3 * time.Millisecond, clock: fakeClock}}
+			writer = span.WrapWriter(writer, "Chunking")
+			writer, s := span.WithWriter("Serialize", writer)
+			defer s.Done()
+			for i := 0; i < 5; i++ {
+				fakeClock.Step(5 * time.Millisecond)
+				writer.Write([]byte("hello"))
+			}
+			// Note: chunkingWriter in this test setup doesn't flush automatically at end unless we call Flush.
+			// The loop writes 5 * 5 = 25 bytes.
+			// Chunk size 10.
+			// 1. "hello" (5). Buf 5.
+			// 2. "hello" (5). Buf 10. Flush 10. Buf 0.
+			// 3. "hello" (5). Buf 5.
+			// 4. "hello" (5). Buf 10. Flush 10. Buf 0.
+			// 5. "hello" (5). Buf 5.
+			// Total flushes: 2. Total bytes written to Raw: 20.
+			// Raw duration: 2 * 7ms = 14ms.
+			// Chunking duration: 5 * 3ms + 2 * 7ms = 15 + 14 = 29ms.
+			// Chunking exclusive: 29 - 14 = 15ms.
+			// Serialize duration: 5 * 5ms = 25ms.
+		},
+		expectedEvents: []expectedEvent{
+			{name: "Raw", size: 20, count: 2, duration: 14 * time.Millisecond},
+			{name: "Chunking", size: 25, count: 5, duration: 15 * time.Millisecond},
+			{name: "Serialize", size: 0, count: 0, duration: 25 * time.Millisecond},
+		},
+	},
+}
+
+type mockWriter struct {
+	sleep time.Duration
+	clock *testingclock.FakeClock
+	next  io.Writer
+}
+
+func (m *mockWriter) Write(p []byte) (int, error) {
+	m.clock.Step(m.sleep)
+	if m.next != nil {
+		return m.next.Write(p)
+	}
+	return len(p), nil
+}
+
+func (m *mockWriter) Unwrap() io.Writer {
+	return m.next
+}
+
+type prefixWriter struct {
+	mockWriter
+	prefix []byte
+}
+
+func (w *prefixWriter) Write(p []byte) (int, error) {
+	_, err := w.mockWriter.Write(append(w.prefix, p...))
+	return len(p), err
+}
+
+type chunkingWriter struct {
+	mockWriter
+	chunkSize int
+	buffer    []byte
+}
+
+func (w *chunkingWriter) Write(p []byte) (int, error) {
+	w.clock.Step(w.sleep)
+	w.buffer = append(w.buffer, p...)
+	if len(w.buffer) >= w.chunkSize {
+		return len(p), w.Flush()
+	}
+	return len(p), nil
+}
+
+func (w *chunkingWriter) Flush() error {
+	if len(w.buffer) == 0 {
+		return nil
+	}
+	toWrite := w.chunkSize
+	if len(w.buffer) < w.chunkSize {
+		toWrite = len(w.buffer)
+	}
+	_, err := w.next.Write(w.buffer[:toWrite])
+	if len(w.buffer) > toWrite {
+		w.buffer = w.buffer[toWrite:]
+	} else {
+		w.buffer = w.buffer[:0]
+	}
+	return err
+}

--- a/staging/src/k8s.io/component-base/tracing/tracing.go
+++ b/staging/src/k8s.io/component-base/tracing/tracing.go
@@ -18,15 +18,20 @@ package tracing
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"k8s.io/utils/clock"
 	utiltrace "k8s.io/utils/trace"
 )
 
 const instrumentationScope = "k8s.io/component-base/tracing"
+
+type contextKey struct{}
 
 // Start creates spans using both OpenTelemetry, and the k8s.io/utils/trace package.
 // It only creates an OpenTelemetry span if the incoming context already includes a span.
@@ -36,11 +41,14 @@ func Start(ctx context.Context, name string, attributes ...attribute.KeyValue) (
 	ctx, otelSpan := trace.SpanFromContext(ctx).TracerProvider().Tracer(instrumentationScope).Start(ctx, name, trace.WithAttributes(attributes...))
 	// If there is already a utiltrace span in the context, use that as our parent span.
 	utilSpan := utiltrace.FromContext(ctx).Nest(name, attributesToFields(attributes)...)
-	// Set the trace as active in the context so that subsequent Start calls create nested spans.
-	return utiltrace.ContextWithTrace(ctx, utilSpan), &Span{
+	
+	span := &Span{
 		otelSpan: otelSpan,
 		utilSpan: utilSpan,
+		clock:    clock.RealClock{},
 	}
+	// Set the trace as active in the context so that subsequent Start calls create nested spans.
+	return ContextWithSpan(ctx, span), span
 }
 
 // Span is a component part of a trace. It represents a single named
@@ -50,6 +58,19 @@ func Start(ctx context.Context, name string, attributes ...attribute.KeyValue) (
 type Span struct {
 	otelSpan trace.Span
 	utilSpan *utiltrace.Trace
+
+	layers      []*layer
+	activeLayer *layer
+	clock       clock.PassiveClock
+}
+
+type layer struct {
+	name          string
+	duration      time.Duration
+	childDuration time.Duration
+	bytes         int64
+	count         int64
+	child         *layer
 }
 
 // AddEvent adds a point-in-time event with a name and attributes.
@@ -60,11 +81,206 @@ func (s *Span) AddEvent(name string, attributes ...attribute.KeyValue) {
 	}
 }
 
+// WrapWriter wraps the given writer to track writes as a layer in the span.
+func (s *Span) WrapWriter(w io.Writer, name string) WriterFlusher {
+	l := &layer{name: name}
+	tw := &TracedWriter{
+		next:  w,
+		layer: l,
+		span:  s,
+	}
+
+	// Attempt to find a child layer if the writer is a TracedWriter or wraps one.
+	// This allows us to calculate exclusive time without dynamic tracking in Write.
+	if unwrapper, ok := w.(interface{ Unwrap() io.Writer }); ok {
+		if childTw, ok := w.(*TracedWriter); ok {
+			l.child = childTw.layer
+		} else if childTw, ok := unwrapper.Unwrap().(*TracedWriter); ok {
+			l.child = childTw.layer
+		}
+	} else if childTw, ok := w.(*TracedWriter); ok {
+		l.child = childTw.layer
+	}
+
+	s.layers = append(s.layers, l)
+	return tw
+}
+
+type WriterFlusher interface {
+	io.Writer
+	http.Flusher
+}
+
+// WrapReader wraps the given reader to track reads as a layer in the span.
+func (s *Span) WrapReader(r io.Reader, name string) io.Reader {
+	l := &layer{name: name}
+	tr := &TracedReader{
+		next:  r,
+		layer: l,
+		span:  s,
+	}
+
+	// Attempt to find a child layer if the reader is a TracedReader or wraps one.
+	// This allows us to calculate exclusive time without dynamic tracking in Read.
+	if unwrapper, ok := r.(interface{ Unwrap() io.Reader }); ok {
+		if childTr, ok := r.(*TracedReader); ok {
+			l.child = childTr.layer
+		} else if childTr, ok := unwrapper.Unwrap().(*TracedReader); ok {
+			l.child = childTr.layer
+		}
+	} else if childTr, ok := r.(*TracedReader); ok {
+		l.child = childTr.layer
+	}
+
+	s.layers = append(s.layers, l)
+	return tr
+}
+
+// WithReader creates a new ReaderSpan for tracking a logical step in reading.
+// It wraps the provided reader to track the IO time separately from the processing time.
+func (s *Span) WithReader(name string, r io.Reader) (io.Reader, *ReaderSpan) {
+	// Check if there is already a traced layer
+	var childLayer *layer
+	for current := r; current != nil; {
+		if tr, ok := current.(*TracedReader); ok {
+			childLayer = tr.layer
+			break
+		}
+		if unwrapper, ok := current.(interface{ Unwrap() io.Reader }); ok {
+			current = unwrapper.Unwrap()
+		} else {
+			break
+		}
+	}
+
+	if childLayer != nil {
+		l := &layer{name: name, child: childLayer}
+		s.layers = append(s.layers, l)
+		return r, &ReaderSpan{
+			span:  s,
+			layer: l,
+			start: s.clock.Now(),
+		}
+	}
+
+	// Layer for the IO part
+	ioLayer := &layer{name: "Reader"}
+	s.layers = append(s.layers, ioLayer)
+
+	tr := &TracedReader{
+		next:  r,
+		layer: ioLayer,
+		span:  s,
+	}
+
+	// Layer for the wrapper (e.g. Deserialize)
+	l := &layer{name: name, child: ioLayer}
+	s.layers = append(s.layers, l)
+
+	return tr, &ReaderSpan{
+		span:  s,
+		layer: l,
+		start: s.clock.Now(),
+	}
+}
+
+// WithWriter creates a new WriterSpan for tracking a logical step in writing.
+// It wraps the provided writer to track the IO time separately from the processing time.
+func (s *Span) WithWriter(name string, w io.Writer) (io.Writer, *WriterSpan) {
+	// Check if there is already a traced layer
+	var childLayer *layer
+	for current := w; current != nil; {
+		if tw, ok := current.(*TracedWriter); ok {
+			childLayer = tw.layer
+			break
+		}
+		if unwrapper, ok := current.(interface{ Unwrap() io.Writer }); ok {
+			current = unwrapper.Unwrap()
+		} else {
+			break
+		}
+	}
+
+	if childLayer != nil {
+		l := &layer{name: name, child: childLayer}
+		s.layers = append(s.layers, l)
+		return w, &WriterSpan{
+			span:  s,
+			layer: l,
+			start: s.clock.Now(),
+		}
+	}
+
+	// Layer for the IO part
+	ioLayer := &layer{name: "Writer"}
+	s.layers = append(s.layers, ioLayer)
+
+	tw := &TracedWriter{
+		next:  w,
+		layer: ioLayer,
+		span:  s,
+	}
+
+	// Layer for the wrapper (e.g. Serialize)
+	l := &layer{name: name, child: ioLayer}
+	s.layers = append(s.layers, l)
+
+	return tw, &WriterSpan{
+		span:  s,
+		layer: l,
+		start: s.clock.Now(),
+	}
+}
+
 // End ends the span, and logs if the span duration is greater than the logThreshold.
 func (s *Span) End(logThreshold time.Duration) {
+	s.reportLayers()
 	s.otelSpan.End()
 	if s.utilSpan != nil {
 		s.utilSpan.LogIfLong(logThreshold)
+	}
+}
+
+func (s *Span) reportLayers() {
+
+	var layers []string
+	for _, l := range s.layers {
+		layers = append(layers, l.name)
+		
+		var exclusive time.Duration
+		if l.childDuration > 0 {
+			exclusive = l.duration - l.childDuration
+		} else if l.child != nil {
+			exclusive = l.duration - l.child.duration
+		} else {
+			exclusive = l.duration
+		}
+		
+		if exclusive < 0 {
+			exclusive = 0
+		}
+
+		// If this layer has the same bytes and count as the previous layer,
+		// it means it's just a wrapper that didn't add any writes.
+		// We report 0 for size and count to avoid repetition, but keep duration.
+		reportBytes := l.bytes
+		reportCount := l.count
+
+
+		var attrs []attribute.KeyValue
+		if reportBytes > 0 || reportCount > 0 {
+			attrs = append(attrs, attribute.Int64("size", reportBytes), attribute.Int64("count", reportCount))
+		}
+
+		otelAttrs := append(attrs, attribute.String("duration", exclusive.String()))
+		s.otelSpan.AddEvent(l.name, trace.WithAttributes(otelAttrs...))
+		if s.utilSpan != nil {
+			s.utilSpan.ParallelStep(l.name, exclusive, attributesToFields(attrs)...)
+		}
+
+	}
+	if len(layers) > 0 {
+		s.otelSpan.SetAttributes(attribute.StringSlice("writer.layers", layers))
 	}
 }
 
@@ -86,13 +302,18 @@ func attributesToFields(attributes []attribute.KeyValue) []utiltrace.Field {
 // SpanFromContext returns the *Span from the current context. It is composed of the active
 // OpenTelemetry and k8s.io/utils/trace spans.
 func SpanFromContext(ctx context.Context) *Span {
+	if s, ok := ctx.Value(contextKey{}).(*Span); ok {
+		return s
+	}
 	return &Span{
 		otelSpan: trace.SpanFromContext(ctx),
 		utilSpan: utiltrace.FromContext(ctx),
+		clock:    clock.RealClock{},
 	}
 }
 
 // ContextWithSpan returns a context with the Span included in the context.
 func ContextWithSpan(ctx context.Context, s *Span) context.Context {
+	ctx = context.WithValue(ctx, contextKey{}, s)
 	return trace.ContextWithSpan(utiltrace.ContextWithTrace(ctx, s.utilSpan), s.otelSpan)
 }

--- a/test/integration/apiserver/tracing/tracing_test.go
+++ b/test/integration/apiserver/tracing/tracing_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 	traceservice "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -48,6 +49,7 @@ import (
 	client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	utiltesting "k8s.io/client-go/util/testing"
+	"k8s.io/klog/v2"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
 )
@@ -324,6 +326,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 }
 
 func TestAPIServerTracing(t *testing.T) {
+	klog.SetLogger(logr.Discard())
 	// Listen for traces from the API Server before starting it, so the
 	// API Server will successfully connect right away during the test.
 	listener, err := net.Listen("tcp", "localhost:")
@@ -1270,6 +1273,12 @@ func (t traceExpectation) updateForSpan(span *tracev1.Span, traceID trace.TraceI
 		return
 	}
 	for i, spanExpectation := range t {
+		if span.Name == "WatchServer.HandleHTTP" {
+			fmt.Printf("Span %s duration: %v\n", span.Name, time.Duration(span.EndTimeUnixNano-span.StartTimeUnixNano)*time.Nanosecond)
+			for _, event := range span.GetEvents() {
+				fmt.Printf("Event %v\n", event)
+			}
+		}
 		if spanExpectation.name != "" && span.Name != spanExpectation.name {
 			continue
 		}

--- a/vendor/k8s.io/utils/trace/trace.go
+++ b/vendor/k8s.io/utils/trace/trace.go
@@ -80,6 +80,7 @@ type traceItem interface {
 
 type traceStep struct {
 	stepTime time.Time
+	duration time.Duration
 	msg      string
 	fields   []Field
 }
@@ -94,6 +95,9 @@ func (s traceStep) time() time.Time {
 
 func (s traceStep) writeItem(b *bytes.Buffer, formatter string, startTime time.Time, stepThreshold *time.Duration) {
 	stepDuration := s.stepTime.Sub(startTime)
+	if s.duration > 0 {
+		stepDuration = s.duration
+	}
 	if stepThreshold == nil || *stepThreshold == 0 || stepDuration >= *stepThreshold || klogV(4) {
 		b.WriteString(fmt.Sprintf("%s---", formatter))
 		writeTraceItemSummary(b, s.msg, stepDuration, s.stepTime, s.fields)
@@ -166,6 +170,18 @@ func (t *Trace) Step(msg string, fields ...Field) {
 		t.traceItems = make([]traceItem, 0, 6)
 	}
 	t.traceItems = append(t.traceItems, traceStep{stepTime: time.Now(), msg: msg, fields: fields})
+}
+
+// ParallelStep adds a new step with a specific message and duration.
+// This allows reporting steps that happened in parallel or with a known duration.
+func (t *Trace) ParallelStep(msg string, duration time.Duration, fields ...Field) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.traceItems == nil {
+		// traces almost always have less than 6 steps, do this to avoid more than a single allocation
+		t.traceItems = make([]traceItem, 0, 6)
+	}
+	t.traceItems = append(t.traceItems, traceStep{stepTime: time.Now(), duration: duration, msg: msg, fields: fields})
 }
 
 // Nest adds a nested trace with the given message and fields and returns it.


### PR DESCRIPTION
Experimenting with integration
```
I0221 14:30:59.185235 2474320 trace.go:252] Trace[263339281]: "SerializeObject" audit-id:,method:GET,url:/api/v1/pods,protocol:HTTP/1.1,mediaType:application/json,encoder:{"name":"json","pretty":"false","strict":"false","yaml":"false"} (21-Feb-2026 14:30:58.779) (total time: 405ms):
Trace[263339281]: ---"Write call succeeded" size:42565835 405ms (14:30:59.185)
Trace[263339281]: ---"Encoding" size:42565835,count:1 72ms (14:30:59.185)
Trace[263339281]: ---"Network" size:1977475,count:8243 0ms (14:30:59.185)
Trace[263339281]: ---"gzip" size:42565835,count:1 72ms (14:30:59.185)
Trace[263339281]: [405.873031ms] [405.873031ms] END
```