### PR TITLE
scheduler: fix nil pointer dereference in submitPodGroupAlgorithmResult

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -439,7 +439,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		} else {
 			// TBD: Add a message to status if the pod used features for which finding a placement cannot be guaranteed,
 			// such as heterogeneous pod group or using inter-pod dependencies.
-			if podResult.scheduleResult.nominatingInfo.NominatedNodeName != "" && result.status == podGroupUnschedulable {
+			if podResult.scheduleResult.nominatingInfo != nil && podResult.scheduleResult.nominatingInfo.NominatedNodeName != "" && result.status == podGroupUnschedulable {
 				// Pod group is unschedulable, so the pod has to be marked as unschedulable, even if it just required preemption.
 				// Its rejection status is set to its permit status message, as the preemption message is no longer relevant.
 				status := fwk.NewStatus(fwk.Unschedulable, podResult.permitStatus.Message()).WithError(errPodGroupUnschedulable)


### PR DESCRIPTION
## What this fixes

When a pod in a gang group is plain-unschedulable (no preemption candidate), `schedulingAlgorithm` returns a `ScheduleResult` with `nominatingInfo == nil`.

The `else`-branch in `submitPodGroupAlgorithmResult` dereferenced that pointer unconditionally at line 442:

```go
// before (panics when nominatingInfo is nil)
if podResult.scheduleResult.nominatingInfo.NominatedNodeName != "" && ...
```

The panic is caught by `HandleCrashWithContext`, which allows the scheduler goroutine to recover and retry — but it leaves the pod group in a broken state and adds latency, contributing to the flakiness reported in #137178 on ARM64 where the extra retry time pushes the test past the CI timeout.

## Fix

Add the same nil guard already present at line 324 of the same file:

```go
// after
if podResult.scheduleResult.nominatingInfo != nil &&
    podResult.scheduleResult.nominatingInfo.NominatedNodeName != "" && ...
```

## Testing

Reproduced the nil dereference crash locally (`TestPodGroupScheduling/gang_schedules_with_preemption`), applied the fix, and confirmed all 10 subtests pass consistently with `-timeout=300s`.

Fixes #137178