### PR TITLE
client-go: make fake Pods.GetLogs honor reactors

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
@@ -64,10 +64,16 @@ func (c *fakePods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Requ
 	action.Subresource = "log"
 	action.Value = opts
 
-	obj, err := c.Fake.Invokes(action, &runtime.Unknown{Raw: []byte("fake logs")})
-	logs := []byte("fake logs")
-	if unknown, ok := obj.(*runtime.Unknown); ok && unknown != nil {
-		logs = unknown.Raw
+	defaultLogResponse := &runtime.Unknown{Raw: []byte("fake logs")}
+	obj, err := c.Fake.Invokes(action, defaultLogResponse)
+	logs := defaultLogResponse.Raw
+	if err == nil {
+		unknown, ok := obj.(*runtime.Unknown)
+		if !ok || unknown == nil {
+			err = fmt.Errorf("fake Pods.GetLogs expected reactor to return *runtime.Unknown, got %T", obj)
+		} else {
+			logs = unknown.Raw
+		}
 	}
 
 	fakeClient := &fakerest.RESTClient{

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
@@ -56,30 +56,13 @@ func (c *fakePods) GetBinding(name string) (result *v1.Binding, err error) {
 	return obj.(*v1.Binding), err
 }
 
-// getPodLogsActionImpl carries the standard get action shape (including pod name)
-// along with pod log options so reactors can inspect both.
-type getPodLogsActionImpl struct {
-	core.GetActionImpl
-	Value interface{}
-}
-
-func (a getPodLogsActionImpl) GetValue() interface{} {
-	return a.Value
-}
-
-func (a getPodLogsActionImpl) DeepCopy() core.Action {
-	return getPodLogsActionImpl{
-		GetActionImpl: a.GetActionImpl.DeepCopy().(core.GetActionImpl),
-		// Keep existing fake GenericAction semantics for value copying.
-		Value: a.Value,
-	}
-}
-
 func (c *fakePods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Request {
-	action := getPodLogsActionImpl{
-		GetActionImpl: core.NewGetSubresourceAction(c.Resource(), c.Namespace(), "log", name),
-		Value:         opts,
-	}
+	action := core.GenericActionImpl{}
+	action.Verb = "get"
+	action.Namespace = c.Namespace()
+	action.Resource = c.Resource()
+	action.Subresource = "log"
+	action.Value = opts
 
 	obj, err := c.Fake.Invokes(action, &runtime.Unknown{Raw: []byte("fake logs")})
 	logs := []byte("fake logs")


### PR DESCRIPTION
#### What this PR does / why we need it
`fakePods.GetLogs` currently always returns a static stream and ignores reactor return values, which prevents tests from mocking log responses/errors via fake client reactors.

This PR makes `GetLogs` reactor-aware by:
- using a `getPodLogsActionImpl` action that carries both pod name (`GetAction`) and log options (`GenericAction`)
- propagating reactor errors to `Request.Stream()`
- allowing reactors to provide log payloads via `runtime.Unknown{Raw: ...}`

#### Which issue(s) this PR fixes
Fixes #117144

#### Special notes for your reviewer
None.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```