### PR TITLE
DRA: Make Allocators.Channel() consistent with thier consistency levels

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -6038,7 +6038,7 @@ func TestAllocator(t *testing.T,
 			expectResults:                   nil,
 			expectNumAllocateOneInvocations: 16,
 			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
-				internal.Incubating: 65,
+				internal.Stable: 65,
 			},
 		},
 		"check-combinations-within-single-request-single-pool-multiple-slices": {
@@ -6060,7 +6060,7 @@ func TestAllocator(t *testing.T,
 			expectResults:                   nil,
 			expectNumAllocateOneInvocations: 16,
 			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
-				internal.Incubating: 65,
+				internal.Stable: 65,
 			},
 		},
 		"check-combinations-within-single-request-multiple-pools-multiple-slices": {
@@ -6084,7 +6084,7 @@ func TestAllocator(t *testing.T,
 			expectResults:                   nil,
 			expectNumAllocateOneInvocations: 16,
 			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
-				internal.Incubating: 65,
+				internal.Stable: 65,
 			},
 		},
 		"check-combinations-within-single-request-many-pools": {
@@ -6110,7 +6110,7 @@ func TestAllocator(t *testing.T,
 			expectResults:                   nil,
 			expectNumAllocateOneInvocations: 16,
 			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
-				internal.Incubating: 65,
+				internal.Stable: 65,
 			},
 		},
 		"check-combinations-with-backtracking": {
@@ -6154,7 +6154,7 @@ func TestAllocator(t *testing.T,
 			)},
 			expectNumAllocateOneInvocations: 12,
 			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
-				internal.Incubating: 14,
+				internal.Stable: 14,
 			},
 		},
 		"check-combinations-with-backtracking-across-slices-and-pools": {
@@ -6209,7 +6209,7 @@ func TestAllocator(t *testing.T,
 			)},
 			expectNumAllocateOneInvocations: 12,
 			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
-				internal.Incubating: 14,
+				internal.Stable: 14,
 			},
 		},
 		"check-combinations-with-prioritized-list": {
@@ -6266,7 +6266,7 @@ func TestAllocator(t *testing.T,
 			)},
 			expectNumAllocateOneInvocations: 26,
 			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
-				internal.Incubating: 32,
+				internal.Stable: 32,
 			},
 		},
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -145,7 +145,7 @@ func NewAllocator(ctx context.Context,
 }
 
 func (a *Allocator) Channel() internal.AllocatorChannel {
-	return internal.Experimental
+	return internal.Incubating
 }
 
 func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resourceapi.ResourceClaim) (finalResult []resourceapi.AllocationResult, finalErr error) {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -104,7 +104,7 @@ func NewAllocator(ctx context.Context,
 }
 
 func (a *Allocator) Channel() internal.AllocatorChannel {
-	return internal.Incubating
+	return internal.Stable
 }
 
 func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resourceapi.ResourceClaim) (finalResult []resourceapi.AllocationResult, finalErr error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/136619 promoted DRA allocators(experimental -> incubating -> stable).

However, their stability levels defined in `Allocator.Channel()` methods were not promoted.

This PR makes stability levels of DRA allocators in `Allocator.Channel()` consistent.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
