### PR TITLE
Fix CSINode ownerReference reconciliation on Node UID change

### DIFF
--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
@@ -462,9 +462,40 @@ func (nim *nodeInfoManager) tryInitializeCSINodeWithAnnotation(csiKubeClient cli
 }
 
 // ensureNodeOwnsCSINode will ensure that the current CSINode object is owned by the node represented by this nodeInfoManager.
-// If not, it will delete the existing CSINode object and return an error.
+// If the CSINode has an OwnerReference with the same node name but a stale UID (e.g. after a node replacement),
+// the OwnerReference UID is reconciled to the current node's UID and persisted. This prevents the garbage collector
+// from deleting the CSINode while the UID is stale.
+// If the CSINode is owned by a completely different node, it will be deleted and an error returned.
 func (nim *nodeInfoManager) ensureNodeOwnsCSINode(nodeInfo *storagev1.CSINode) error {
 	if ok, csiNodeOwnerID := nim.nodeOwnsCSINode(nodeInfo); !ok {
+		// Before deleting, check if the CSINode has an OwnerReference with
+		// matching node name but stale UID. This happens when a Node is
+		// deleted and recreated with the same name but a different UID
+		// (common in cloud environments and automated provisioning).
+		// In that case, reconcile the UID in-place to prevent the garbage
+		// collector from deleting the CSINode before we can recreate it.
+		for i, ownerRef := range nodeInfo.OwnerReferences {
+			if ownerRef.Kind == nodeKind.Kind && ownerRef.Name == string(nim.nodeName) {
+				klog.V(2).Infof("reconciling CSINode %q OwnerReference UID from %q to %q",
+					nodeInfo.Name, ownerRef.UID, nim.nodeID)
+				nodeInfo.OwnerReferences[i].UID = nim.nodeID
+
+				csiKubeClient := nim.volumeHost.GetKubeClient()
+				if csiKubeClient == nil {
+					return goerrors.New("error getting CSI client")
+				}
+				updatedNodeInfo, err := csiKubeClient.StorageV1().CSINodes().Update(
+					context.TODO(), nodeInfo, metav1.UpdateOptions{})
+				if err != nil {
+					return fmt.Errorf("error reconciling CSINode %q OwnerReference: %w", nodeInfo.Name, err)
+				}
+				// Copy the updated object back so callers have the correct
+				// ResourceVersion for any subsequent updates.
+				*nodeInfo = *updatedNodeInfo
+				return nil
+			}
+		}
+
 		klog.V(2).Infof("existing CSINode %q is owned by different node (oldNodeID=%q, newNodeID=%q), cleaning up...", nodeInfo.Name, csiNodeOwnerID, nim.nodeID)
 		err := nim.DeleteCSINode()
 		if err != nil {

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -1095,7 +1096,7 @@ func TestCSINodeOwnerRefReconciliation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can't create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	host := volumetest.NewFakeVolumeHostWithCSINodeName(t,
 		tmpDir,
@@ -1110,11 +1111,11 @@ func TestCSINodeOwnerRefReconciliation(t *testing.T) {
 	// InitializeCSINodeWithAnnotation sets nim.nodeID from the Node API
 	// and then calls ensureNodeOwnsCSINode, which should reconcile the UID.
 	err = nim.InitializeCSINodeWithAnnotation()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify CSINode still exists and was NOT deleted/recreated.
 	csiNode, err := client.StorageV1().CSINodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if csiNode == nil {
 		t.Fatal("expected CSINode to exist after OwnerRef reconciliation, but it was not found")
 	}
@@ -1141,10 +1142,10 @@ func TestCSINodeOwnerRefReconciliation(t *testing.T) {
 
 	// Now verify that InstallCSIDriver still works correctly after reconciliation.
 	err = nim.InstallCSIDriver("com.example.csi/new-driver", "com.example.csi/new-node-id", 0, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	csiNode, err = client.StorageV1().CSINodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if csiNode == nil {
 		t.Fatal("expected CSINode to exist after InstallCSIDriver, but it was not found")
 	}

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
@@ -376,7 +376,15 @@ func TestInstallCSIDriver(t *testing.T) {
 				Spec: storage.CSINodeSpec{
 					Drivers: []storage.CSINodeDriver{
 						{
-							// Only the new driver should be present because the old CSINode represented a previous node.
+							// Old driver is preserved because the CSINode OwnerReference
+							// is reconciled in-place (UID updated) rather than deleting
+							// and recreating the CSINode. The kubelet will re-register
+							// its current drivers and stale entries will be cleaned up
+							// through normal UninstallCSIDriver operations.
+							Name:   "com.example.csi.old-driver",
+							NodeID: "com.example.csi/csi-node2",
+						},
+						{
 							Name:   "com.example.csi.driver1",
 							NodeID: "com.example.csi/csi-node1",
 						},
@@ -1039,6 +1047,112 @@ func TestInstallCSIDriverExistingAnnotation(t *testing.T) {
 			t.Errorf("expected Driver to be %q and NodeID to be %q, but got: %q:%q", driverName, nodeID, driver.Name, driver.NodeID)
 		}
 	}
+}
+
+// TestCSINodeOwnerRefReconciliation verifies that when a Node is replaced with
+// the same name but a different UID (common in cloud environments), the CSINode's
+// OwnerReference is reconciled in-place to point to the new Node's UID, rather
+// than deleting and recreating the CSINode. This prevents the garbage collector
+// from deleting the CSINode while the OwnerReference is stale.
+// Regression test for https://github.com/kubernetes/kubernetes/issues/136899
+func TestCSINodeOwnerRefReconciliation(t *testing.T) {
+	const nodeName = "node1"
+	const oldUID = types.UID("old-uid-123")
+	const newUID = types.UID("new-uid-456")
+
+	existingNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			UID:  newUID,
+		},
+	}
+
+	existingCSINode := &storage.CSINode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: nodeKind.Version,
+					Kind:       nodeKind.Kind,
+					Name:       nodeName,
+					UID:        oldUID,
+				},
+			},
+		},
+		Spec: storage.CSINodeSpec{
+			Drivers: []storage.CSINodeDriver{
+				{
+					Name:   "com.example.csi/existing-driver",
+					NodeID: "com.example.csi/existing-node-id",
+				},
+			},
+		},
+	}
+
+	client := getClientSet(existingNode, existingCSINode)
+
+	tmpDir, err := utiltesting.MkTmpdir("nodeinfomanager-test")
+	if err != nil {
+		t.Fatalf("can't create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	host := volumetest.NewFakeVolumeHostWithCSINodeName(t,
+		tmpDir,
+		client,
+		nil,
+		nodeName,
+		nil,
+		nil,
+	)
+	nim := NewNodeInfoManager(types.NodeName(nodeName), host, nil)
+
+	// InitializeCSINodeWithAnnotation sets nim.nodeID from the Node API
+	// and then calls ensureNodeOwnsCSINode, which should reconcile the UID.
+	err = nim.InitializeCSINodeWithAnnotation()
+	assert.NoError(t, err)
+
+	// Verify CSINode still exists and was NOT deleted/recreated.
+	csiNode, err := client.StorageV1().CSINodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	if csiNode == nil {
+		t.Fatal("expected CSINode to exist after OwnerRef reconciliation, but it was not found")
+	}
+
+	// Verify OwnerReference UID was reconciled to the new node's UID.
+	assert.Len(t, csiNode.OwnerReferences, 1, "expected exactly one OwnerReference")
+	assert.Equal(t, newUID, csiNode.OwnerReferences[0].UID,
+		"OwnerReference UID should be reconciled to the new node's UID")
+	assert.Equal(t, nodeName, csiNode.OwnerReferences[0].Name,
+		"OwnerReference Name should remain the same")
+
+	// Verify existing drivers were preserved (not lost due to delete+recreate).
+	assert.Len(t, csiNode.Spec.Drivers, 1, "existing drivers should be preserved")
+	assert.Equal(t, "com.example.csi/existing-driver", csiNode.Spec.Drivers[0].Name)
+	assert.Equal(t, "com.example.csi/existing-node-id", csiNode.Spec.Drivers[0].NodeID)
+
+	// Verify the CSINode was NOT deleted at any point by checking client actions.
+	// With the fix, there should be no "delete" action for CSINodes.
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "delete" && action.GetResource().Resource == "csinodes" {
+			t.Error("CSINode should not have been deleted during OwnerRef reconciliation")
+		}
+	}
+
+	// Now verify that InstallCSIDriver still works correctly after reconciliation.
+	err = nim.InstallCSIDriver("com.example.csi/new-driver", "com.example.csi/new-node-id", 0, nil)
+	assert.NoError(t, err)
+
+	csiNode, err = client.StorageV1().CSINodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	if csiNode == nil {
+		t.Fatal("expected CSINode to exist after InstallCSIDriver, but it was not found")
+	}
+
+	// Should have both the preserved old driver and the newly installed driver.
+	assert.Len(t, csiNode.Spec.Drivers, 2, "should have both old and new drivers")
+	// OwnerReference should still point to the new node.
+	assert.Equal(t, newUID, csiNode.OwnerReferences[0].UID)
 }
 
 func getClientSet(existingNode *v1.Node, existingCSINode *storage.CSINode) *fake.Clientset {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When a Node is deleted and recreated with the same name but a different UID (common in cloud environments with automated provisioning), the CSINode's OwnerReference still points to the stale UID. This causes the Kubernetes garbage collector to delete the CSINode object because the OwnerReference references a non-existent Node, leading to CSI driver disruptions.

## Which issue(s) this PR fixes

Fixes #136899

## Problem Statement

The kubelet's `nodeInfoManager.ensureNodeOwnsCSINode()` detects when a CSINode's OwnerReference UID doesn't match the current Node's UID. However, the current implementation handles this by **deleting the entire CSINode** and relying on a retry loop to recreate it. This introduces a race condition:

1. Node is replaced (same name, new UID)
2. CSINode's OwnerReference points to old UID → GC marks it for deletion
3. Before the kubelet can reconcile, GC deletes the CSINode
4. Even during kubelet reconciliation, the delete-then-recreate approach leaves a window where no CSINode exists

This is the same class of bug that was fixed for Lease objects in #109777.

## Root Cause Analysis

In `ensureNodeOwnsCSINode()`, when `nodeOwnsCSINode()` returns `false` (UID mismatch), the code unconditionally deletes the CSINode and returns an error, expecting the retry loop to create a new one. It does not distinguish between:

1. **Same node name, stale UID** (node was replaced) — should reconcile the OwnerReference
2. **Completely different owner** (different node name) — should delete

## Solution

Modified `ensureNodeOwnsCSINode()` to detect the "same name, stale UID" case and **reconcile the OwnerReference in-place** by updating the UID to match the current Node's UID, then persisting the change via API update. This:

- Eliminates the GC race condition window
- Preserves existing CSINode driver information across node replacements
- Falls back to the existing delete behavior only for truly different owners (different node name)

The updated CSINode object (including the new ResourceVersion from the API update) is copied back to the caller's pointer to ensure subsequent operations use the correct ResourceVersion.

## Design Tradeoffs Considered

1. **Preserving existing drivers**: The fix preserves CSINode driver entries from the previous node incarnation. This is acceptable because:
   - The kubelet re-registers all its current CSI drivers on startup, replacing stale same-name entries
   - Stale entries for drivers no longer present are cleaned up through normal `UninstallCSIDriver` operations
   - This avoids a window where the CSINode exists but has no driver information

2. **In-place update vs delete+recreate**: In-place update is strictly better because it's atomic (single API call vs two) and eliminates the GC race.

3. **Direct API persistence in ensureNodeOwnsCSINode**: The OwnerReference update is persisted immediately within `ensureNodeOwnsCSINode()` rather than relying on callers to persist it. This ensures the GC window is minimized, regardless of whether callers make additional updates.

## Changes

- `nodeinfomanager.go`: Modified `ensureNodeOwnsCSINode()` to reconcile same-name OwnerReferences in-place
- `nodeinfomanager_test.go`: Added `TestCSINodeOwnerRefReconciliation` regression test, updated existing test expectations

## How to test

```
go test ./pkg/volume/csi/nodeinfomanager/... -v -run TestCSINodeOwnerRefReconciliation -count=1
```

```release-note
Fix CSINode ownerReference reconciliation when a Node is replaced with the same name but a different UID, preventing the garbage collector from deleting the CSINode object.
```

/sig storage
/priority important-longterm
