### PR TITLE
KEP-5710: Add WorkloadAwarePreemption feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1093,6 +1093,13 @@ const (
 	//
 	// Enables support for joining Windows containers to a hosts' network namespace.
 	WindowsHostNetwork featuregate.Feature = "WindowsHostNetwork"
+
+	// owner: @wojtek-t
+	// kep: https://kep.k8s.io/5710
+	//
+	// Enables support for workload-aware preemption in pod group scheduling cycle
+	// and related PodGroup and Workload API fields.
+	WorkloadAwarePreemption featuregate.Feature = "WorkloadAwarePreemption"
 )
 
 // defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys with VersionedSpecs.
@@ -1906,6 +1913,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated},
 	},
 
+	WorkloadAwarePreemption: {
+		{Version: version.MustParse("1.36"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	apiextensionsfeatures.CRDObservedGenerationTracking: {
 		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Beta},
 	},
@@ -2454,6 +2465,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	WindowsGracefulNodeShutdown: {GracefulNodeShutdown},
 
 	WindowsHostNetwork: {},
+
+	WorkloadAwarePreemption: {GangScheduling},
 
 	apiextensionsfeatures.CRDObservedGenerationTracking: {},
 

--- a/test/compatibility_lifecycle/reference/feature_list.md
+++ b/test/compatibility_lifecycle/reference/feature_list.md
@@ -216,6 +216,7 @@
 | WindowsCPUAndMemoryAffinity |  |  | 1.32– |  |  |  |  | [code](https://cs.k8s.io/?q=%5CbWindowsCPUAndMemoryAffinity%5Cb&i=nope&files=&excludeFiles=CHANGELOG&repos=kubernetes/kubernetes) [KEPs](https://cs.k8s.io/?q=%5CbWindowsCPUAndMemoryAffinity%5Cb&i=nope&files=&excludeFiles=CHANGELOG&repos=kubernetes/enhancements) |
 | WindowsGracefulNodeShutdown | :ballot_box_with_check:&nbsp;1.34+ |  | 1.32–1.33 | 1.34– |  |  | GracefulNodeShutdown | [code](https://cs.k8s.io/?q=%5CbWindowsGracefulNodeShutdown%5Cb&i=nope&files=&excludeFiles=CHANGELOG&repos=kubernetes/kubernetes) [KEPs](https://cs.k8s.io/?q=%5CbWindowsGracefulNodeShutdown%5Cb&i=nope&files=&excludeFiles=CHANGELOG&repos=kubernetes/enhancements) |
 | WindowsHostNetwork |  |  | 1.26–1.32 |  |  | 1.33– |  | [code](https://cs.k8s.io/?q=%5CbWindowsHostNetwork%5Cb&i=nope&files=&excludeFiles=CHANGELOG&repos=kubernetes/kubernetes) [KEPs](https://cs.k8s.io/?q=%5CbWindowsHostNetwork%5Cb&i=nope&files=&excludeFiles=CHANGELOG&repos=kubernetes/enhancements) |
+| WorkloadAwarePreemption |  |  | 1.36– |  |  |  | GangScheduling | [code](https://cs.k8s.io/?q=%5CbWorkloadAwarePreemption%5Cb&i=nope&files=&excludeFiles=CHANGELOG&repos=kubernetes/kubernetes) [KEPs](https://cs.k8s.io/?q=%5CbWorkloadAwarePreemption%5Cb&i=nope&files=&excludeFiles=CHANGELOG&repos=kubernetes/enhancements) |
 
 ## Legend
 

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -2065,3 +2065,9 @@
     lockToDefault: true
     preRelease: GA
     version: "1.34"
+- name: WorkloadAwarePreemption
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.36"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
The feature gate is needed for implementation of https://github.com/kubernetes/enhancements/issues/5710.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5710

#### Special notes for your reviewer:
/sig scheduling
/area workload-aware

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```