### PR TITLE
Conditional Authz [1/n]: Add conditional capabilities to the authorizer interface

### DIFF
--- a/pkg/auth/authorizer/abac/abac.go
+++ b/pkg/auth/authorizer/abac/abac.go
@@ -241,6 +241,16 @@ func (pl PolicyList) Authorize(ctx context.Context, a authorizer.Attributes) (au
 	// Then, add Caching only if needed.
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (pl PolicyList) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(pl.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (PolicyList) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 // RulesFor returns rules for the given user and namespace.
 func (pl PolicyList) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	var (

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -243,7 +243,7 @@ func BuildGenericConfig(
 }
 
 // BuildAuthorizer constructs the authorizer. If authorization is not set in s, it returns nil, nil, false, nil
-func BuildAuthorizer(ctx context.Context, s options.CompletedOptions, egressSelector *egressselector.EgressSelector, apiserverID string, versionedInformers clientgoinformers.SharedInformerFactory) (authorizer.UnconditionalAuthorizer, authorizer.RuleResolver, bool, error) {
+func BuildAuthorizer(ctx context.Context, s options.CompletedOptions, egressSelector *egressselector.EgressSelector, apiserverID string, versionedInformers clientgoinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver, bool, error) {
 	authorizationConfig, err := s.Authorization.ToAuthorizationConfig(versionedInformers)
 	if err != nil {
 		return nil, nil, false, err

--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -79,7 +79,7 @@ type Config struct {
 // stopCh is used to shut down config reload goroutines when the server is shutting down.
 //
 // Note: the cel compiler construction depends on feature gates and the compatibility version to be initialized.
-func (config Config) New(ctx context.Context, serverID string) (authorizer.UnconditionalAuthorizer, authorizer.RuleResolver, error) {
+func (config Config) New(ctx context.Context, serverID string) (authorizer.Authorizer, authorizer.RuleResolver, error) {
 	if len(config.AuthorizationConfiguration.Authorizers) == 0 {
 		return nil, nil, fmt.Errorf("at least one authorization mode must be passed")
 	}

--- a/pkg/kubeapiserver/authorizer/reload.go
+++ b/pkg/kubeapiserver/authorizer/reload.go
@@ -74,7 +74,7 @@ type reloadableAuthorizerResolver struct {
 }
 
 type authorizerResolver struct {
-	authorizer   authorizer.UnconditionalAuthorizer
+	authorizer   authorizer.Authorizer
 	ruleResolver authorizer.RuleResolver
 }
 
@@ -82,18 +82,28 @@ func (r *reloadableAuthorizerResolver) Authorize(ctx context.Context, a authoriz
 	return r.current.Load().authorizer.Authorize(ctx, a)
 }
 
+// ConditionsAwareAuthorize delegates to the current authorizer.
+func (r *reloadableAuthorizerResolver) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return r.current.Load().authorizer.ConditionsAwareAuthorize(ctx, a)
+}
+
+// EvaluateConditions delegates to the current authorizer.
+func (r *reloadableAuthorizerResolver) EvaluateConditions(ctx context.Context, decision authorizer.ConditionsAwareDecision, data authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return r.current.Load().authorizer.EvaluateConditions(ctx, decision, data)
+}
+
 func (r *reloadableAuthorizerResolver) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	return r.current.Load().ruleResolver.RulesFor(ctx, user, namespace)
 }
 
 // newForConfig constructs
-func (r *reloadableAuthorizerResolver) newForConfig(authzConfig *authzconfig.AuthorizationConfiguration) (authorizer.UnconditionalAuthorizer, authorizer.RuleResolver, error) {
+func (r *reloadableAuthorizerResolver) newForConfig(authzConfig *authzconfig.AuthorizationConfiguration) (authorizer.Authorizer, authorizer.RuleResolver, error) {
 	if len(authzConfig.Authorizers) == 0 {
 		return nil, nil, fmt.Errorf("at least one authorization mode must be passed")
 	}
 
 	var (
-		authorizers   []authorizer.UnconditionalAuthorizer
+		authorizers   []authorizer.Authorizer
 		ruleResolvers []authorizer.RuleResolver
 	)
 

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicy/authz_test.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicy/authz_test.go
@@ -34,7 +34,7 @@ func TestAuthorization(t *testing.T) {
 		name             string
 		userInfo         user.Info
 		obj              *admissionregistration.MutatingAdmissionPolicy
-		auth             AuthFunc
+		auth             authorizer.AuthorizerFunc
 		resourceResolver resolver.ResourceResolverFunc
 		expectErr        bool
 	}{
@@ -122,10 +122,4 @@ func TestAuthorization(t *testing.T) {
 			})
 		})
 	}
-}
-
-type AuthFunc func(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error)
-
-func (f AuthFunc) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	return f(ctx, a)
 }

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/authz_test.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/authz_test.go
@@ -37,7 +37,7 @@ func TestAuthorization(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
 		userInfo          user.Info
-		auth              AuthFunc
+		auth              authorizer.AuthorizerFunc
 		policyGetter      PolicyGetterFunc
 		resourceResolver  resolver.ResourceResolverFunc
 		expectErrContains string
@@ -240,12 +240,6 @@ func TestAuthorization(t *testing.T) {
 			})
 		})
 	}
-}
-
-type AuthFunc func(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error)
-
-func (f AuthFunc) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	return f(ctx, a)
 }
 
 type PolicyGetterFunc func(ctx context.Context, name string) (*admissionregistration.MutatingAdmissionPolicy, error)

--- a/pkg/registry/admissionregistration/validatingadmissionpolicy/authz_test.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicy/authz_test.go
@@ -34,7 +34,7 @@ func TestAuthorization(t *testing.T) {
 		name             string
 		userInfo         user.Info
 		obj              *admissionregistration.ValidatingAdmissionPolicy
-		auth             AuthFunc
+		auth             authorizer.AuthorizerFunc
 		resourceResolver resolver.ResourceResolverFunc
 		expectErr        bool
 	}{
@@ -121,10 +121,4 @@ func TestAuthorization(t *testing.T) {
 			})
 		})
 	}
-}
-
-type AuthFunc func(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error)
-
-func (f AuthFunc) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	return f(ctx, a)
 }

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/authz_test.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/authz_test.go
@@ -37,7 +37,7 @@ func TestAuthorization(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
 		userInfo          user.Info
-		auth              AuthFunc
+		auth              authorizer.AuthorizerFunc
 		policyGetter      PolicyGetterFunc
 		resourceResolver  resolver.ResourceResolverFunc
 		expectErrContains string
@@ -218,12 +218,6 @@ func TestAuthorization(t *testing.T) {
 			})
 		})
 	}
-}
-
-type AuthFunc func(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error)
-
-func (f AuthFunc) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	return f(ctx, a)
 }
 
 type PolicyGetterFunc func(ctx context.Context, name string) (*admissionregistration.ValidatingAdmissionPolicy, error)

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -106,6 +106,16 @@ func (r *NodeAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace
 	return nil, nil, false, nil
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (r *NodeAuthorizer) ConditionsAwareAuthorize(ctx context.Context, attrs authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(r.Authorize(ctx, attrs))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (*NodeAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 func (r *NodeAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
 	nodeName, isNode := r.identifier.NodeIdentity(attrs.GetUser())
 	if !isNode {

--- a/plugin/pkg/auth/authorizer/rbac/rbac.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac.go
@@ -129,6 +129,16 @@ func (r *RBACAuthorizer) Authorize(ctx context.Context, requestAttributes author
 	return authorizer.DecisionNoOpinion, reason, nil
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (r *RBACAuthorizer) ConditionsAwareAuthorize(ctx context.Context, requestAttributes authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(r.Authorize(ctx, requestAttributes))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (*RBACAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 func (r *RBACAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	var (
 		resourceRules    []authorizer.ResourceRuleInfo

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/authorizer/caching_authorizer.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/authorizer/caching_authorizer.go
@@ -34,7 +34,8 @@ type authzResult struct {
 	err        error
 }
 
-var _ = authorizer.Authorizer(&cachingAuthorizer{})
+// For now, secondary authorization checks in admission only support unconditional authorization
+var _ = authorizer.UnconditionalAuthorizer(&cachingAuthorizer{})
 
 type cachingAuthorizer struct {
 	authorizer authorizer.UnconditionalAuthorizer

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/conditions.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/conditions.go
@@ -95,10 +95,8 @@ func ConditionsAwareDecisionFromParts(unconditional Decision, reason string, err
 	}
 }
 
-// INVARIANT: Exactly one of Is* must return true at all times.
-
-// IsAllowed returns true if the decision is an unconditional Allow.
-func (d ConditionsAwareDecision) IsAllowed() bool {
+// IsAllow returns true if the decision is an unconditional Allow.
+func (d ConditionsAwareDecision) IsAllow() bool {
 	return d.unconditionalDecision == DecisionAllow
 }
 
@@ -107,54 +105,14 @@ func (d ConditionsAwareDecision) IsNoOpinion() bool {
 	return d.unconditionalDecision == DecisionNoOpinion
 }
 
-// IsDenied returns true if the decision is an unconditional Deny.
-func (d ConditionsAwareDecision) IsDenied() bool {
+// IsDeny returns true if the decision is an unconditional Deny.
+func (d ConditionsAwareDecision) IsDeny() bool {
 	return d.unconditionalDecision == DecisionDeny // == 0 == zero value
 }
 
-// IsUnconditional is true if d is Allowed, Denied or NoOpinion.
+// IsUnconditional is true if d is Allow, Deny or NoOpinion.
 func (d ConditionsAwareDecision) IsUnconditional() bool {
-	return d.IsAllowed() || d.IsDenied() || d.IsNoOpinion()
-}
-
-// UnconditionalParts turns a ConditionsAwareDecision into the
-// triple that Authorizer.Authorize expects. If the decision is
-// conditional, the returned condition is Deny if there were at least
-// some Deny condition, otherwise NoOpinion.
-// This function is meant to be called when IsUnconditional() == true.
-//
-// If the authorizer is conditions-aware, it can choose to only implement
-// real business logic in the ConditionsAwareAuthorize method, and implement
-// Authorize() as "return self.ConditionsAwareAuthorize(ctx, attrs).UnconditionalParts()"
-func (d ConditionsAwareDecision) UnconditionalParts() (Decision, string, error) {
-	switch {
-	case d.IsAllowed():
-		return DecisionAllow, d.Reason(), d.Error()
-	case d.IsDenied():
-		return DecisionDeny, d.Reason(), d.Error()
-	case d.IsNoOpinion():
-		return DecisionNoOpinion, d.Reason(), d.Error()
-	default:
-		// An error is not returned here, as that could yield a HTTP response code of 500 instead of 403.
-		// For the use-case described above with regards to calling this function in Authorize, not returning
-		// an error is important, as it is valid to always fail closed, as if this happens, no unconditional
-		// permissions were given the requestor.
-		return d.FailClosedDecision(), "failed closed: tried to return conditional decision to conditions-unaware authorizer", nil
-	}
-}
-
-// FailClosedDecision returns either a Deny or NoOpinion decision to fail closed
-// whenever processing a decision fails. If the decision contains one or
-// more Deny decisions or conditions, one must fail closed with Deny, as that could or would
-// have been the if the condition evaluation did not error. Otherwise, NoOpinion is returned.
-func (d ConditionsAwareDecision) FailClosedDecision() Decision {
-	if d.IsAllowed() || d.IsNoOpinion() {
-		return DecisionNoOpinion
-	}
-	// TODO(luxas): In the follow-up PR, add the logic for ConditionsMap and Union here, which
-	// makes this function useful.
-	// => d.IsDenied() == true
-	return DecisionDeny
+	return d.IsAllow() || d.IsDeny() || d.IsNoOpinion()
 }
 
 // Reason returns the reason associated with the decision.
@@ -182,7 +140,7 @@ func (d ConditionsAwareDecision) String() string {
 		}
 		return fmt.Sprintf("(%s)", strings.Join(params, ", "))
 	}
-	if d.IsAllowed() {
+	if d.IsAllow() {
 		return fmt.Sprintf("Allow%s", paramsStr())
 	}
 	if d.IsNoOpinion() {

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/conditions.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/conditions.go
@@ -1,0 +1,200 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// ErrorConditionEvaluationNotSupported is returned by authorizer implementations
+// that do not support condition evaluation.
+var ErrorConditionEvaluationNotSupported = errors.New("condition evaluation not supported")
+
+// ConditionsAwareDecision models an authorization decision that is conditions-aware.
+// It is an enum type of the following five variants:
+// - Allow: unconditional Allow.
+// - Deny: unconditional Deny.
+// - NoOpinion: unconditional NoOpinion.
+// - Conditional: conditional on some previously-unseen data.
+// - Union: an ordered list of sub-decisions, which forms a tree of decisions.
+//
+// The zero value (ConditionsAwareDecision{}) is equivalent to ConditionsAwareDecisionDeny().
+// A ConditionsAwareDecision is passed by value.
+type ConditionsAwareDecision struct {
+	unconditionalDecision Decision
+
+	reason string
+	err    error
+}
+
+// ConditionsAwareDecisionDeny constructs a Deny decision with the given reason and error.
+func ConditionsAwareDecisionDeny(reason string, err error) ConditionsAwareDecision {
+	return ConditionsAwareDecision{
+		// DecisionDeny == int(0) == zero value
+		// => ConditionsAwareDecision{} == ConditionsAwareDecisionDeny()
+		unconditionalDecision: DecisionDeny,
+		reason:                reason,
+		err:                   err,
+	}
+}
+
+// ConditionsAwareDecisionAllow constructs an Allow decision with the given reason and error.
+func ConditionsAwareDecisionAllow(reason string, err error) ConditionsAwareDecision {
+	return ConditionsAwareDecision{
+		unconditionalDecision: DecisionAllow,
+		reason:                reason,
+		err:                   err,
+	}
+}
+
+// ConditionsAwareDecisionNoOpinion constructs a NoOpinion decision with the given reason and error.
+func ConditionsAwareDecisionNoOpinion(reason string, err error) ConditionsAwareDecision {
+	return ConditionsAwareDecision{
+		unconditionalDecision: DecisionNoOpinion,
+		reason:                reason,
+		err:                   err,
+	}
+}
+
+// ConditionsAwareDecisionFromParts is meant to be used by conditions-unaware Authorizer implementations
+// in order to implement Authorizer.ConditionsAwareAuthorize as:
+// "return authorizer.ConditionsAwareDecisionFromParts(self.Authorize(ctx, a))"
+func ConditionsAwareDecisionFromParts(unconditional Decision, reason string, err error) ConditionsAwareDecision {
+	switch unconditional {
+	case DecisionAllow:
+		return ConditionsAwareDecisionAllow(reason, err)
+	case DecisionNoOpinion:
+		return ConditionsAwareDecisionNoOpinion(reason, err)
+	case DecisionDeny:
+		return ConditionsAwareDecisionDeny(reason, err)
+	default:
+		return ConditionsAwareDecisionDeny(reason, utilerrors.NewAggregate(
+			[]error{
+				err,
+				fmt.Errorf("unknown unconditional decision type: %d", unconditional),
+			},
+		))
+	}
+}
+
+// INVARIANT: Exactly one of Is* must return true at all times.
+
+// IsAllowed returns true if the decision is an unconditional Allow.
+func (d ConditionsAwareDecision) IsAllowed() bool {
+	return d.unconditionalDecision == DecisionAllow
+}
+
+// IsNoOpinion returns true if the decision is an unconditional NoOpinion.
+func (d ConditionsAwareDecision) IsNoOpinion() bool {
+	return d.unconditionalDecision == DecisionNoOpinion
+}
+
+// IsDenied returns true if the decision is an unconditional Deny.
+func (d ConditionsAwareDecision) IsDenied() bool {
+	return d.unconditionalDecision == DecisionDeny // == 0 == zero value
+}
+
+// IsUnconditional is true if d is Allowed, Denied or NoOpinion.
+func (d ConditionsAwareDecision) IsUnconditional() bool {
+	return d.IsAllowed() || d.IsDenied() || d.IsNoOpinion()
+}
+
+// UnconditionalParts turns a ConditionsAwareDecision into the
+// triple that Authorizer.Authorize expects. If the decision is
+// conditional, the returned condition is Deny if there were at least
+// some Deny condition, otherwise NoOpinion.
+// This function is meant to be called when IsUnconditional() == true.
+//
+// If the authorizer is conditions-aware, it can choose to only implement
+// real business logic in the ConditionsAwareAuthorize method, and implement
+// Authorize() as "return self.ConditionsAwareAuthorize(ctx, attrs).UnconditionalParts()"
+func (d ConditionsAwareDecision) UnconditionalParts() (Decision, string, error) {
+	switch {
+	case d.IsAllowed():
+		return DecisionAllow, d.Reason(), d.Error()
+	case d.IsDenied():
+		return DecisionDeny, d.Reason(), d.Error()
+	case d.IsNoOpinion():
+		return DecisionNoOpinion, d.Reason(), d.Error()
+	default:
+		// An error is not returned here, as that could yield a HTTP response code of 500 instead of 403.
+		// For the use-case described above with regards to calling this function in Authorize, not returning
+		// an error is important, as it is valid to always fail closed, as if this happens, no unconditional
+		// permissions were given the requestor.
+		return d.FailClosedDecision(), "failed closed: tried to return conditional decision to conditions-unaware authorizer", nil
+	}
+}
+
+// FailClosedDecision returns either a Deny or NoOpinion decision to fail closed
+// whenever processing a decision fails. If the decision contains one or
+// more Deny decisions or conditions, one must fail closed with Deny, as that could or would
+// have been the if the condition evaluation did not error. Otherwise, NoOpinion is returned.
+func (d ConditionsAwareDecision) FailClosedDecision() Decision {
+	if d.IsAllowed() || d.IsNoOpinion() {
+		return DecisionNoOpinion
+	}
+	// TODO(luxas): In the follow-up PR, add the logic for ConditionsMap and Union here, which
+	// makes this function useful.
+	// => d.IsDenied() == true
+	return DecisionDeny
+}
+
+// Reason returns the reason associated with the decision.
+func (d ConditionsAwareDecision) Reason() string {
+	return d.reason
+}
+
+// Error returns the error associated with the decision.
+func (d ConditionsAwareDecision) Error() error {
+	return d.err
+}
+
+// String returns a human-readable representation of the decision.
+func (d ConditionsAwareDecision) String() string {
+	params := []string{}
+	if len(d.reason) != 0 {
+		params = append(params, fmt.Sprintf("reason=%q", d.reason))
+	}
+	if d.err != nil {
+		params = append(params, fmt.Sprintf("err=%q", d.err.Error()))
+	}
+	paramsStr := func() string {
+		if len(params) == 0 {
+			return ""
+		}
+		return fmt.Sprintf("(%s)", strings.Join(params, ", "))
+	}
+	if d.IsAllowed() {
+		return fmt.Sprintf("Allow%s", paramsStr())
+	}
+	if d.IsNoOpinion() {
+		return fmt.Sprintf("NoOpinion%s", paramsStr())
+	}
+	// Deny is written such that if none of the other modes apply,
+	// IsDenied() is true.
+	return fmt.Sprintf("Deny%s", paramsStr())
+}
+
+// ConditionsData is an enum type for various evaluation targets conditions
+// can be written against.
+// TODO(luxas): Implement this in the follow-up PR.
+type ConditionsData struct {
+}

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/conditions_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/conditions_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestConditionsAwareDecision(t *testing.T) {
+	unexpectedErr := fmt.Errorf("unexpected things happened")
+	otherErr := fmt.Errorf("other error")
+
+	ctx := t.Context()
+	sampleAttrs := authorizer.AttributesRecord{}
+
+	tests := []struct {
+		name                 string
+		testDecisions        []authorizer.ConditionsAwareDecision
+		wantIsAllowed        bool
+		wantIsNoOpinion      bool
+		wantIsDenied         bool
+		wantIsUnconditional  bool
+		wantFailClosedIsDeny bool
+		wantReason           string
+		wantAnyError         bool
+		wantErrorIs          error
+		wantString           string
+	}{
+		{
+			name: "zero value",
+			testDecisions: []authorizer.ConditionsAwareDecision{
+				{},
+				authorizer.ConditionsAwareDecisionFromParts(0, "", nil),
+				authorizer.AuthorizerFunc(func(_ context.Context, _ authorizer.Attributes) (named1 authorizer.Decision, named2 string, named3 error) {
+					return
+				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
+			},
+			wantIsDenied:         true,
+			wantIsUnconditional:  true,
+			wantFailClosedIsDeny: true,
+			wantReason:           "",
+			wantErrorIs:          nil,
+			wantString:           `Deny`,
+		},
+		{
+			name: "deny constructor",
+			testDecisions: []authorizer.ConditionsAwareDecision{
+				authorizer.ConditionsAwareDecisionDeny("foo", unexpectedErr),
+				authorizer.ConditionsAwareDecisionFromParts(authorizer.DecisionDeny, "foo", unexpectedErr),
+				authorizer.AuthorizerFunc(func(_ context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+					return authorizer.DecisionDeny, "foo", unexpectedErr
+				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
+			},
+			wantIsDenied:         true,
+			wantIsUnconditional:  true,
+			wantFailClosedIsDeny: true,
+			wantReason:           "foo",
+			wantErrorIs:          unexpectedErr,
+			wantString:           `Deny(reason="foo", err="unexpected things happened")`,
+		},
+		{
+			name: "allow constructor",
+			testDecisions: []authorizer.ConditionsAwareDecision{
+				authorizer.ConditionsAwareDecisionAllow("ok", nil),
+				authorizer.ConditionsAwareDecisionFromParts(authorizer.DecisionAllow, "ok", nil),
+				authorizer.AuthorizerFunc(func(_ context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+					return authorizer.DecisionAllow, "ok", nil
+				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
+			},
+			wantIsAllowed:       true,
+			wantIsUnconditional: true,
+			wantReason:          "ok",
+			wantErrorIs:         nil,
+			wantString:          `Allow(reason="ok")`,
+		},
+		{
+			name: "noopinion constructor",
+			testDecisions: []authorizer.ConditionsAwareDecision{
+				authorizer.ConditionsAwareDecisionNoOpinion("", nil),
+				authorizer.ConditionsAwareDecisionFromParts(authorizer.DecisionNoOpinion, "", nil),
+				authorizer.AuthorizerFunc(func(_ context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+					return authorizer.DecisionNoOpinion, "", nil
+				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
+			},
+			wantIsNoOpinion:     true,
+			wantIsUnconditional: true,
+			wantReason:          "",
+			wantErrorIs:         nil,
+			wantString:          `NoOpinion`,
+		},
+		{
+			name: "from parts: unsupported mode",
+			testDecisions: []authorizer.ConditionsAwareDecision{
+				authorizer.ConditionsAwareDecisionFromParts(42, "", nil),
+				authorizer.AuthorizerFunc(func(_ context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+					return 42, "", nil
+				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
+			},
+			wantIsDenied:         true,
+			wantIsUnconditional:  true,
+			wantFailClosedIsDeny: true,
+			wantReason:           "",
+			wantAnyError:         true,
+			wantString:           `Deny(err="unknown unconditional decision type: 42")`,
+		},
+		{
+			name: "from parts: unsupported mode with other error",
+			testDecisions: []authorizer.ConditionsAwareDecision{
+				authorizer.ConditionsAwareDecisionFromParts(42, "foo", otherErr),
+				authorizer.AuthorizerFunc(func(_ context.Context, _ authorizer.Attributes) (authorizer.Decision, string, error) {
+					return 42, "foo", otherErr
+				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
+			},
+			wantIsDenied:         true,
+			wantIsUnconditional:  true,
+			wantFailClosedIsDeny: true,
+			wantReason:           "foo",
+			wantErrorIs:          otherErr,
+			wantString:           `Deny(reason="foo", err="[other error, unknown unconditional decision type: 42]")`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i, d := range tt.testDecisions {
+				t.Run(fmt.Sprint(i), func(t *testing.T) {
+					isAllowed := d.IsAllowed()
+					if isAllowed != tt.wantIsAllowed {
+						t.Errorf("IsAllowed() = %v, want %v", isAllowed, tt.wantIsAllowed)
+					}
+					isNoOpinion := d.IsNoOpinion()
+					if isNoOpinion != tt.wantIsNoOpinion {
+						t.Errorf("IsNoOpinion() = %v, want %v", isNoOpinion, tt.wantIsNoOpinion)
+					}
+					isDenied := d.IsDenied()
+					if isDenied != tt.wantIsDenied {
+						t.Errorf("IsDenied() = %v, want %v", isDenied, tt.wantIsDenied)
+					}
+					isUnconditional := d.IsUnconditional()
+					if isUnconditional != tt.wantIsUnconditional {
+						t.Errorf("IsUnconditional() = %v, want %v", isUnconditional, tt.wantIsUnconditional)
+					}
+					gotReason := d.Reason()
+					if gotReason != tt.wantReason {
+						t.Errorf("Reason() = %v, want %v", gotReason, tt.wantReason)
+					}
+					gotError := d.Error()
+					if tt.wantAnyError {
+						if gotError == nil {
+							t.Errorf("Error() = %v, want some error", nil)
+						}
+					} else {
+						if !errors.Is(gotError, tt.wantErrorIs) {
+							t.Errorf("Error() = %v, want %v", gotError, tt.wantErrorIs)
+						}
+					}
+					failClosed := d.FailClosedDecision()
+					if tt.wantFailClosedIsDeny {
+						if failClosed != authorizer.DecisionDeny {
+							t.Errorf("want FailClosedDecision() == Deny; got %s", failClosed)
+						}
+					} else {
+						if failClosed != authorizer.DecisionNoOpinion {
+							t.Errorf("want FailClosedDecision() == NoOpinion; got %s", failClosed)
+						}
+					}
+
+					gotString := d.String()
+					if gotString != tt.wantString {
+						t.Errorf("String() = %v, want %v", gotString, tt.wantString)
+					}
+				})
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/conditions_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/conditions_test.go
@@ -33,17 +33,16 @@ func TestConditionsAwareDecision(t *testing.T) {
 	sampleAttrs := authorizer.AttributesRecord{}
 
 	tests := []struct {
-		name                 string
-		testDecisions        []authorizer.ConditionsAwareDecision
-		wantIsAllowed        bool
-		wantIsNoOpinion      bool
-		wantIsDenied         bool
-		wantIsUnconditional  bool
-		wantFailClosedIsDeny bool
-		wantReason           string
-		wantAnyError         bool
-		wantErrorIs          error
-		wantString           string
+		name                string
+		testDecisions       []authorizer.ConditionsAwareDecision
+		wantIsAllowed       bool
+		wantIsNoOpinion     bool
+		wantIsDenied        bool
+		wantIsUnconditional bool
+		wantReason          string
+		wantAnyError        bool
+		wantErrorIs         error
+		wantString          string
 	}{
 		{
 			name: "zero value",
@@ -54,12 +53,11 @@ func TestConditionsAwareDecision(t *testing.T) {
 					return
 				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
 			},
-			wantIsDenied:         true,
-			wantIsUnconditional:  true,
-			wantFailClosedIsDeny: true,
-			wantReason:           "",
-			wantErrorIs:          nil,
-			wantString:           `Deny`,
+			wantIsDenied:        true,
+			wantIsUnconditional: true,
+			wantReason:          "",
+			wantErrorIs:         nil,
+			wantString:          `Deny`,
 		},
 		{
 			name: "deny constructor",
@@ -70,12 +68,11 @@ func TestConditionsAwareDecision(t *testing.T) {
 					return authorizer.DecisionDeny, "foo", unexpectedErr
 				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
 			},
-			wantIsDenied:         true,
-			wantIsUnconditional:  true,
-			wantFailClosedIsDeny: true,
-			wantReason:           "foo",
-			wantErrorIs:          unexpectedErr,
-			wantString:           `Deny(reason="foo", err="unexpected things happened")`,
+			wantIsDenied:        true,
+			wantIsUnconditional: true,
+			wantReason:          "foo",
+			wantErrorIs:         unexpectedErr,
+			wantString:          `Deny(reason="foo", err="unexpected things happened")`,
 		},
 		{
 			name: "allow constructor",
@@ -115,12 +112,11 @@ func TestConditionsAwareDecision(t *testing.T) {
 					return 42, "", nil
 				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
 			},
-			wantIsDenied:         true,
-			wantIsUnconditional:  true,
-			wantFailClosedIsDeny: true,
-			wantReason:           "",
-			wantAnyError:         true,
-			wantString:           `Deny(err="unknown unconditional decision type: 42")`,
+			wantIsDenied:        true,
+			wantIsUnconditional: true,
+			wantReason:          "",
+			wantAnyError:        true,
+			wantString:          `Deny(err="unknown unconditional decision type: 42")`,
 		},
 		{
 			name: "from parts: unsupported mode with other error",
@@ -130,19 +126,18 @@ func TestConditionsAwareDecision(t *testing.T) {
 					return 42, "foo", otherErr
 				}).ConditionsAwareAuthorize(ctx, sampleAttrs),
 			},
-			wantIsDenied:         true,
-			wantIsUnconditional:  true,
-			wantFailClosedIsDeny: true,
-			wantReason:           "foo",
-			wantErrorIs:          otherErr,
-			wantString:           `Deny(reason="foo", err="[other error, unknown unconditional decision type: 42]")`,
+			wantIsDenied:        true,
+			wantIsUnconditional: true,
+			wantReason:          "foo",
+			wantErrorIs:         otherErr,
+			wantString:          `Deny(reason="foo", err="[other error, unknown unconditional decision type: 42]")`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for i, d := range tt.testDecisions {
 				t.Run(fmt.Sprint(i), func(t *testing.T) {
-					isAllowed := d.IsAllowed()
+					isAllowed := d.IsAllow()
 					if isAllowed != tt.wantIsAllowed {
 						t.Errorf("IsAllowed() = %v, want %v", isAllowed, tt.wantIsAllowed)
 					}
@@ -150,7 +145,7 @@ func TestConditionsAwareDecision(t *testing.T) {
 					if isNoOpinion != tt.wantIsNoOpinion {
 						t.Errorf("IsNoOpinion() = %v, want %v", isNoOpinion, tt.wantIsNoOpinion)
 					}
-					isDenied := d.IsDenied()
+					isDenied := d.IsDeny()
 					if isDenied != tt.wantIsDenied {
 						t.Errorf("IsDenied() = %v, want %v", isDenied, tt.wantIsDenied)
 					}
@@ -170,16 +165,6 @@ func TestConditionsAwareDecision(t *testing.T) {
 					} else {
 						if !errors.Is(gotError, tt.wantErrorIs) {
 							t.Errorf("Error() = %v, want %v", gotError, tt.wantErrorIs)
-						}
-					}
-					failClosed := d.FailClosedDecision()
-					if tt.wantFailClosedIsDeny {
-						if failClosed != authorizer.DecisionDeny {
-							t.Errorf("want FailClosedDecision() == Deny; got %s", failClosed)
-						}
-					} else {
-						if failClosed != authorizer.DecisionNoOpinion {
-							t.Errorf("want FailClosedDecision() == NoOpinion; got %s", failClosed)
 						}
 					}
 

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
@@ -26,8 +26,9 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
-// Attributes is an interface used by an Authorizer to get information about a request
-// that is used to make an authorization decision.
+// Attributes is an interface used by an Authorizer to get information about a
+// request's metadata, that is used to compute an unconditional or conditional
+// authorization decision.
 type Attributes interface {
 	// GetUser returns the user.Info object to authorize
 	GetUser() user.Info
@@ -99,15 +100,38 @@ type UnconditionalAuthorizer interface {
 type Authorizer interface {
 	UnconditionalAuthorizer
 
-	// TODO(luxas): Add the conditions-aware methods in a follow-up PR.
+	// ConditionsAwareAuthorize returns an unconditional, conditional, or unioned
+	// decision, where the error and reason is part of the Decision struct.
+	//
+	// An authorizer who is not conditions-aware MUST implement this function as
+	// "return authorizer.ConditionsAwareDecisionFromParts(self.Authorize(ctx, a))",
+	// such that conditions-aware callers to this authorizer get the same output
+	// as if they called Authorize. Callers are only expected to call one of
+	// Authorize or ConditionsAwareAuthorize, not both.
+	ConditionsAwareAuthorize(ctx context.Context, a Attributes) ConditionsAwareDecision
+
+	// EvaluateConditions evaluates a conditional or unioned ConditionsAwareDecision against previously-unknown data.
+	//
+	// An authorizer who does not support conditions should fail closed and
+	// return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+	EvaluateConditions(ctx context.Context, decision ConditionsAwareDecision, data ConditionsData) (authorized Decision, reason string, err error)
 }
 
+// AuthorizerFunc implements Authorizer
 var _ Authorizer = AuthorizerFunc(nil)
 
 type AuthorizerFunc func(ctx context.Context, a Attributes) (Decision, string, error)
 
 func (f AuthorizerFunc) Authorize(ctx context.Context, a Attributes) (Decision, string, error) {
 	return f(ctx, a)
+}
+
+func (f AuthorizerFunc) ConditionsAwareAuthorize(ctx context.Context, a Attributes) ConditionsAwareDecision {
+	return ConditionsAwareDecisionFromParts(f.Authorize(ctx, a))
+}
+
+func (f AuthorizerFunc) EvaluateConditions(_ context.Context, _ ConditionsAwareDecision, _ ConditionsData) (Decision, string, error) {
+	return DecisionDeny, "", ErrorConditionEvaluationNotSupported
 }
 
 // RuleResolver provides a mechanism for resolving the list of rules that apply to a given user within a namespace.
@@ -192,6 +216,8 @@ func (a AttributesRecord) GetLabelSelector() (labels.Requirements, error) {
 	return a.LabelSelectorRequirements, a.LabelSelectorParsingErr
 }
 
+// Decision represents an final, unconditional authorization decision.
+// The zero value (0) of Decision is DecisionDeny.
 type Decision int
 
 const (
@@ -200,7 +226,8 @@ const (
 	// DecisionAllow means that an authorizer decided to allow the action.
 	DecisionAllow
 	// DecisionNoOpinion means that an authorizer has no opinion on whether
-	// to allow or deny an action.
+	// to allow or deny an action. If there are multiple unioned authorizers,
+	// this means that the request can thus get allowed by some later authorizer.
 	DecisionNoOpinion
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/builtin.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/builtin.go
@@ -36,6 +36,16 @@ func (alwaysAllowAuthorizer) Authorize(ctx context.Context, a authorizer.Attribu
 	return authorizer.DecisionAllow, "", nil
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (a alwaysAllowAuthorizer) ConditionsAwareAuthorize(ctx context.Context, attrs authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(a.Authorize(ctx, attrs))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (alwaysAllowAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 func (alwaysAllowAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	return []authorizer.ResourceRuleInfo{
 			&authorizer.DefaultResourceRuleInfo{
@@ -67,6 +77,16 @@ func (alwaysDenyAuthorizer) Authorize(ctx context.Context, a authorizer.Attribut
 	return authorizer.DecisionNoOpinion, "Everything is forbidden.", nil
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (d alwaysDenyAuthorizer) ConditionsAwareAuthorize(ctx context.Context, attrs authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(d.Authorize(ctx, attrs))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (alwaysDenyAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 func (alwaysDenyAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	return []authorizer.ResourceRuleInfo{}, []authorizer.NonResourceRuleInfo{}, false, nil
 }
@@ -79,6 +99,16 @@ var _ = authorizer.Authorizer(&privilegedGroupAuthorizer{})
 
 type privilegedGroupAuthorizer struct {
 	groups []string
+}
+
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (r *privilegedGroupAuthorizer) ConditionsAwareAuthorize(ctx context.Context, attr authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(r.Authorize(ctx, attr))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (r *privilegedGroupAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
 }
 
 func (r *privilegedGroupAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/delegating.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/delegating.go
@@ -48,7 +48,7 @@ type DelegatingAuthorizerConfig struct {
 	WebhookRetryBackoff *wait.Backoff
 }
 
-func (c DelegatingAuthorizerConfig) New() (authorizer.UnconditionalAuthorizer, error) {
+func (c DelegatingAuthorizerConfig) New() (authorizer.Authorizer, error) {
 	if c.WebhookRetryBackoff == nil {
 		return nil, errors.New("retry backoff parameters for delegating authorization webhook has not been specified")
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics.go
@@ -99,10 +99,10 @@ func (a *instrumentedAuthorizer) ConditionsAwareAuthorize(ctx context.Context, a
 	switch {
 	case decision.IsNoOpinion():
 		// non-terminal, not reported
-	case decision.IsAllowed():
+	case decision.IsAllow():
 		// matches SubjectAccessReview status.allowed field name
 		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "allowed")
-	case decision.IsDenied():
+	case decision.IsDeny():
 		// matches SubjectAccessReview status.denied field name
 		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "denied")
 	default:

--- a/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics.go
@@ -59,7 +59,7 @@ func RecordAuthorizationDecision(authorizerType, authorizerName, decision string
 	authorizationDecisionsTotal.WithLabelValues(authorizerType, authorizerName, decision).Inc()
 }
 
-func InstrumentedAuthorizer(authorizerType string, authorizerName string, delegate authorizer.UnconditionalAuthorizer) authorizer.UnconditionalAuthorizer {
+func InstrumentedAuthorizer(authorizerType string, authorizerName string, delegate authorizer.Authorizer) authorizer.Authorizer {
 	RegisterMetrics()
 	return &instrumentedAuthorizer{
 		authorizerType: string(authorizerType),
@@ -73,11 +73,50 @@ var _ = authorizer.Authorizer(&instrumentedAuthorizer{})
 type instrumentedAuthorizer struct {
 	authorizerType string
 	authorizerName string
-	delegate       authorizer.UnconditionalAuthorizer
+	delegate       authorizer.Authorizer
 }
 
 func (a *instrumentedAuthorizer) Authorize(ctx context.Context, attributes authorizer.Attributes) (authorizer.Decision, string, error) {
 	decision, reason, err := a.delegate.Authorize(ctx, attributes)
+	switch decision {
+	case authorizer.DecisionNoOpinion:
+		// non-terminal, not reported
+	case authorizer.DecisionAllow:
+		// matches SubjectAccessReview status.allowed field name
+		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "allowed")
+	case authorizer.DecisionDeny:
+		// matches SubjectAccessReview status.denied field name
+		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "denied")
+	default:
+		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "unknown")
+	}
+	return decision, reason, err
+}
+
+// ConditionsAwareAuthorize delegates to the wrapped authorizer.
+func (a *instrumentedAuthorizer) ConditionsAwareAuthorize(ctx context.Context, attributes authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	decision := a.delegate.ConditionsAwareAuthorize(ctx, attributes)
+	switch {
+	case decision.IsNoOpinion():
+		// non-terminal, not reported
+	case decision.IsAllowed():
+		// matches SubjectAccessReview status.allowed field name
+		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "allowed")
+	case decision.IsDenied():
+		// matches SubjectAccessReview status.denied field name
+		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "denied")
+	default:
+		// the ConditionsAwareDecision enforces that there are no other possible states
+		// than Allow/Deny/NoOpinion/ConditionsMap/Union. The latter two are conditional
+		// decisions.
+		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "conditional")
+	}
+	return decision
+}
+
+// EvaluateConditions delegates to the wrapped authorizer, and registers the metric just like Authorize.
+func (a *instrumentedAuthorizer) EvaluateConditions(ctx context.Context, unevaluatedDecision authorizer.ConditionsAwareDecision, data authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	decision, reason, err := a.delegate.EvaluateConditions(ctx, unevaluatedDecision, data)
 	switch decision {
 	case authorizer.DecisionNoOpinion:
 		// non-terminal, not reported

--- a/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics_test.go
@@ -38,7 +38,9 @@ func TestRecordAuthorizationDecisionsTotal(t *testing.T) {
 	RegisterMetrics()
 
 	dummyAuthorizer := &dummyAuthorizer{}
+	dummyConditionalAuthorizer := &dummyConditionalAuthorizer{}
 	a := InstrumentedAuthorizer("mytype", "myname", dummyAuthorizer)
+	ac := InstrumentedAuthorizer("myconditionaltype", "myconditionalname", dummyConditionalAuthorizer)
 
 	// allow
 	{
@@ -46,6 +48,19 @@ func TestRecordAuthorizationDecisionsTotal(t *testing.T) {
 		_, _, _ = a.Authorize(context.Background(), nil)
 		expectedValue := prefix + `
 			apiserver_authorization_decisions_total{decision="allowed",name="myname",type="mytype"} 1
+		`
+		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+			t.Fatal(err)
+		}
+		authorizationDecisionsTotal.Reset()
+	}
+
+	// allow (conditional authorizer)
+	{
+		dummyConditionalAuthorizer.authorizeDecision = authorizer.ConditionsAwareDecisionAllow("", nil)
+		_, _, _ = ac.Authorize(context.Background(), nil)
+		expectedValue := prefix + `
+			apiserver_authorization_decisions_total{decision="allowed",name="myconditionalname",type="myconditionaltype"} 1
 		`
 		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
 			t.Fatal(err)
@@ -67,11 +82,38 @@ func TestRecordAuthorizationDecisionsTotal(t *testing.T) {
 		authorizationDecisionsTotal.Reset()
 	}
 
+	// deny (conditional authorizer)
+	{
+		dummyConditionalAuthorizer.authorizeDecision = authorizer.ConditionsAwareDecisionDeny("", nil)
+		_, _, _ = ac.Authorize(context.Background(), nil)
+		_, _, _ = ac.Authorize(context.Background(), nil)
+		expectedValue := prefix + `
+			apiserver_authorization_decisions_total{decision="denied",name="myconditionalname",type="myconditionaltype"} 2
+		`
+		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+			t.Fatal(err)
+		}
+		authorizationDecisionsTotal.Reset()
+	}
+
 	// no-opinion emits no metric
 	{
 		dummyAuthorizer.decision = authorizer.DecisionNoOpinion
 		_, _, _ = a.Authorize(context.Background(), nil)
 		_, _, _ = a.Authorize(context.Background(), nil)
+		expectedValue := prefix + `
+		`
+		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+			t.Fatal(err)
+		}
+		authorizationDecisionsTotal.Reset()
+	}
+
+	// no-opinion emits no metric (conditional authorizer)
+	{
+		dummyConditionalAuthorizer.authorizeDecision = authorizer.ConditionsAwareDecisionNoOpinion("", nil)
+		_, _, _ = ac.Authorize(context.Background(), nil)
+		_, _, _ = ac.Authorize(context.Background(), nil)
 		expectedValue := prefix + `
 		`
 		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
@@ -92,7 +134,7 @@ func TestRecordAuthorizationDecisionsTotal(t *testing.T) {
 		}
 		authorizationDecisionsTotal.Reset()
 	}
-
+	// TODO(luxas): Add a test for getting a conditional decision from ConditionsAwareAuthorize, and evaluating a condition, once introduced
 }
 
 type dummyAuthorizer struct {
@@ -102,4 +144,32 @@ type dummyAuthorizer struct {
 
 func (d *dummyAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
 	return d.decision, "", d.err
+}
+
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (d *dummyAuthorizer) ConditionsAwareAuthorize(ctx context.Context, attrs authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(d.Authorize(ctx, attrs))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (*dummyAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
+type dummyConditionalAuthorizer struct {
+	authorizeDecision authorizer.ConditionsAwareDecision
+	evalDecision      authorizer.Decision
+	evalErr           error
+}
+
+func (d *dummyConditionalAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
+	return d.ConditionsAwareAuthorize(ctx, attrs).UnconditionalParts()
+}
+
+func (d *dummyConditionalAuthorizer) ConditionsAwareAuthorize(ctx context.Context, attrs authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return d.authorizeDecision
+}
+
+func (d *dummyConditionalAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return d.evalDecision, "", d.evalErr
 }

--- a/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics_test.go
@@ -163,7 +163,16 @@ type dummyConditionalAuthorizer struct {
 }
 
 func (d *dummyConditionalAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
-	return d.ConditionsAwareAuthorize(ctx, attrs).UnconditionalParts()
+	switch {
+	case d.authorizeDecision.IsAllow():
+		return authorizer.DecisionAllow, d.authorizeDecision.Reason(), d.authorizeDecision.Error()
+	case d.authorizeDecision.IsNoOpinion():
+		return authorizer.DecisionNoOpinion, d.authorizeDecision.Reason(), d.authorizeDecision.Error()
+	case d.authorizeDecision.IsDeny():
+		return authorizer.DecisionDeny, d.authorizeDecision.Reason(), d.authorizeDecision.Error()
+	default: // Conditional case
+		return authorizer.DecisionDeny, "failed closed: wanted to return a conditional decision, but called on the conditions-unaware method", nil
+	}
 }
 
 func (d *dummyConditionalAuthorizer) ConditionsAwareAuthorize(ctx context.Context, attrs authorizer.Attributes) authorizer.ConditionsAwareDecision {

--- a/staging/src/k8s.io/apiserver/pkg/authorization/path/path.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/path/path.go
@@ -27,7 +27,7 @@ import (
 
 // NewAuthorizer returns an authorizer which accepts a given set of paths.
 // Each path is either a fully matching path or it ends in * in case a prefix match is done. A leading / is optional.
-func NewAuthorizer(alwaysAllowPaths []string) (authorizer.UnconditionalAuthorizer, error) {
+func NewAuthorizer(alwaysAllowPaths []string) (authorizer.Authorizer, error) {
 	var prefixes []string
 	paths := sets.NewString()
 	for _, p := range alwaysAllowPaths {

--- a/staging/src/k8s.io/apiserver/pkg/authorization/union/union.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/union/union.go
@@ -36,10 +36,10 @@ import (
 var _ = authorizer.Authorizer(unionAuthzHandler{})
 
 // unionAuthzHandler authorizer against a chain of authorizer.Authorizer
-type unionAuthzHandler []authorizer.UnconditionalAuthorizer
+type unionAuthzHandler []authorizer.Authorizer
 
 // New returns an authorizer that authorizes against a chain of authorizer.Authorizer objects
-func New(authorizationHandlers ...authorizer.UnconditionalAuthorizer) authorizer.UnconditionalAuthorizer {
+func New(authorizationHandlers ...authorizer.Authorizer) authorizer.Authorizer {
 	return unionAuthzHandler(authorizationHandlers)
 }
 
@@ -68,6 +68,16 @@ func (authzHandler unionAuthzHandler) Authorize(ctx context.Context, a authorize
 	}
 
 	return authorizer.DecisionNoOpinion, strings.Join(reasonlist, "\n"), utilerrors.NewAggregate(errlist)
+}
+
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (authzHandler unionAuthzHandler) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(authzHandler.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (unionAuthzHandler) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
 }
 
 // unionAuthzRulesHandler authorizer against a chain of authorizer.RuleResolver

--- a/staging/src/k8s.io/apiserver/pkg/authorization/union/union_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/union/union_test.go
@@ -37,6 +37,16 @@ func (mock *mockAuthzHandler) Authorize(ctx context.Context, a authorizer.Attrib
 	return mock.decision, "", mock.err
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (mock *mockAuthzHandler) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(mock.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (*mockAuthzHandler) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 func TestAuthorizationSecondPasses(t *testing.T) {
 	handler1 := &mockAuthzHandler{decision: authorizer.DecisionNoOpinion}
 	handler2 := &mockAuthzHandler{decision: authorizer.DecisionAllow}
@@ -223,15 +233,15 @@ func getNonResourceRules(infos []authorizer.NonResourceRuleInfo) []authorizer.De
 
 func TestAuthorizationUnequivocalDeny(t *testing.T) {
 	cs := []struct {
-		authorizers []authorizer.UnconditionalAuthorizer
+		authorizers []authorizer.Authorizer
 		decision    authorizer.Decision
 	}{
 		{
-			authorizers: []authorizer.UnconditionalAuthorizer{},
+			authorizers: []authorizer.Authorizer{},
 			decision:    authorizer.DecisionNoOpinion,
 		},
 		{
-			authorizers: []authorizer.UnconditionalAuthorizer{
+			authorizers: []authorizer.Authorizer{
 				&mockAuthzHandler{decision: authorizer.DecisionNoOpinion},
 				&mockAuthzHandler{decision: authorizer.DecisionAllow},
 				&mockAuthzHandler{decision: authorizer.DecisionDeny},
@@ -239,7 +249,7 @@ func TestAuthorizationUnequivocalDeny(t *testing.T) {
 			decision: authorizer.DecisionAllow,
 		},
 		{
-			authorizers: []authorizer.UnconditionalAuthorizer{
+			authorizers: []authorizer.Authorizer{
 				&mockAuthzHandler{decision: authorizer.DecisionNoOpinion},
 				&mockAuthzHandler{decision: authorizer.DecisionDeny},
 				&mockAuthzHandler{decision: authorizer.DecisionAllow},
@@ -247,7 +257,7 @@ func TestAuthorizationUnequivocalDeny(t *testing.T) {
 			decision: authorizer.DecisionDeny,
 		},
 		{
-			authorizers: []authorizer.UnconditionalAuthorizer{
+			authorizers: []authorizer.Authorizer{
 				&mockAuthzHandler{decision: authorizer.DecisionNoOpinion},
 				&mockAuthzHandler{decision: authorizer.DecisionDeny, err: errors.New("webhook failed closed")},
 				&mockAuthzHandler{decision: authorizer.DecisionAllow},

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation/constrained_impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation/constrained_impersonation.go
@@ -275,7 +275,8 @@ func (t *impersonationModesTracker) getImpersonatedUser(ctx context.Context, wan
 	return nil, errors.New("all impersonation modes failed")
 }
 
-var _ = authorizer.Authorizer(&metricsAuthorizer{})
+// For now, constrained impersonation only supports unconditional authorization
+var _ = authorizer.UnconditionalAuthorizer(&metricsAuthorizer{})
 
 type metricsAuthorizer struct {
 	delegate                authorizer.UnconditionalAuthorizer

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -394,7 +394,7 @@ type AuthenticationInfo struct {
 type AuthorizationInfo struct {
 	// Authorizer determines whether the subject is allowed to make the request based only
 	// on the RequestURI
-	Authorizer authorizer.UnconditionalAuthorizer
+	Authorizer authorizer.Authorizer
 }
 
 func init() {

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -534,6 +534,16 @@ func (authz *mockAuthorizer) Authorize(ctx context.Context, a authorizer.Attribu
 	return authorizer.DecisionAllow, "", nil
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (authz *mockAuthorizer) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(authz.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (*mockAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 type testGetterStorage struct {
 	Version string
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -174,8 +174,8 @@ func (s *DelegatingAuthorizationOptions) ApplyTo(c *server.AuthorizationInfo) er
 	return err
 }
 
-func (s *DelegatingAuthorizationOptions) toAuthorizer(client kubernetes.Interface) (authorizer.UnconditionalAuthorizer, error) {
-	var authorizers []authorizer.UnconditionalAuthorizer
+func (s *DelegatingAuthorizationOptions) toAuthorizer(client kubernetes.Interface) (authorizer.Authorizer, error) {
+	var authorizers []authorizer.Authorizer
 
 	if len(s.AlwaysAllowGroups) > 0 {
 		authorizers = append(authorizers, authorizerfactory.NewPrivilegedGroups(s.AlwaysAllowGroups...))

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -293,6 +293,16 @@ func (w *WebhookAuthorizer) Authorize(ctx context.Context, attr authorizer.Attri
 
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (w *WebhookAuthorizer) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(w.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (*WebhookAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 func resourceAttributesFrom(attr authorizer.Attributes) *authorizationv1.ResourceAttributes {
 	ret := &authorizationv1.ResourceAttributes{
 		Namespace:   attr.GetNamespace(),

--- a/test/integration/apiserver/flowcontrol/concurrency_util_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_util_test.go
@@ -132,6 +132,16 @@ func (d *noxuDelayingAuthorizer) Authorize(ctx context.Context, a authorizer.Att
 	return d.Authorizer.Authorize(ctx, a)
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (d *noxuDelayingAuthorizer) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(d.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (*noxuDelayingAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 // TestConcurrencyIsolation tests the concurrency isolation between priority levels.
 // The test defines two priority levels for this purpose, and corresponding flow schemas.
 // To one priority level, this test sends many more concurrent requests than the configuration

--- a/test/integration/auth/accessreview_test.go
+++ b/test/integration/auth/accessreview_test.go
@@ -47,6 +47,16 @@ func (sarAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (au
 	return authorizer.DecisionAllow, "you're not dave", nil
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (s sarAuthorizer) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(s.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (sarAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 func alwaysAlice(req *http.Request) (*authenticator.Response, bool, error) {
 	return &authenticator.Response{
 		User: &user.DefaultInfo{

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -814,6 +814,16 @@ func (impersonateAuthorizer) Authorize(ctx context.Context, a authorizer.Attribu
 	return authorizer.DecisionNoOpinion, "I can't allow that.  Go ask alice.", nil
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (i impersonateAuthorizer) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(i.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (impersonateAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 func TestImpersonateIsForbidden(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
@@ -1830,6 +1840,16 @@ type trackingAuthorizer struct {
 func (a *trackingAuthorizer) Authorize(ctx context.Context, attributes authorizer.Attributes) (authorizer.Decision, string, error) {
 	a.requestAttributes = append(a.requestAttributes, attributes)
 	return authorizer.DecisionAllow, "", nil
+}
+
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (a *trackingAuthorizer) ConditionsAwareAuthorize(ctx context.Context, attributes authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(a.Authorize(ctx, attributes))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (a *trackingAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
 }
 
 // TestAuthorizationAttributeDetermination tests that authorization attributes are built correctly

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -95,7 +95,7 @@ func (getter *testRESTOptionsGetter) GetRESTOptions(resource schema.GroupResourc
 	return generic.RESTOptions{StorageConfig: storageConfig, Decorator: generic.UndecoratedStorage, ResourcePrefix: resource.Resource}, nil
 }
 
-func newRBACAuthorizer(t *testing.T, config *controlplane.Config) (authorizer.UnconditionalAuthorizer, func()) {
+func newRBACAuthorizer(t *testing.T, config *controlplane.Config) (authorizer.Authorizer, func()) {
 	optsGetter := &testRESTOptionsGetter{config}
 	roleRest, err := rolestore.NewREST(optsGetter)
 	if err != nil {
@@ -566,7 +566,7 @@ func TestRBAC(t *testing.T) {
 					// Append our custom test authenticator
 					config.ControlPlane.Generic.Authentication.Authenticator = unionauthn.New(config.ControlPlane.Generic.Authentication.Authenticator, authenticator)
 					// Append our custom test authorizer
-					var rbacAuthz authorizer.UnconditionalAuthorizer
+					var rbacAuthz authorizer.Authorizer
 					rbacAuthz, tearDownAuthorizerFn = newRBACAuthorizer(t, config)
 					config.ControlPlane.Generic.Authorization.Authorizer = unionauthz.New(config.ControlPlane.Generic.Authorization.Authorizer, rbacAuthz)
 				},
@@ -972,7 +972,7 @@ func TestRBACContextContamination(t *testing.T) {
 			tearDownAuthorizerFn()
 		}
 	}()
-	var rbacAuthz authorizer.UnconditionalAuthorizer
+	var rbacAuthz authorizer.Authorizer
 	_, kubeConfig, tearDownFn := framework.StartTestServer(context.Background(), t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

Prefactoring for the Conditional Authorization KEP (https://github.com/kubernetes/enhancements/issues/5681).

Broken out from https://github.com/kubernetes/kubernetes/pull/137372
Builds on top of https://github.com/kubernetes/kubernetes/pull/138801

Please only review the two last commits: https://github.com/kubernetes/kubernetes/pull/137204/changes/dbf3bbe23c03b0c5e7797a1ebf968cecf6cba4fd..a73f82cd5818eb213e7962b9aa685db570dd38d9

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds two new methods to the Authorizer interface, which will be used for conditional authorization. Existing authorizers forward the `ConditionsAwareAuthorize` function to `Authorize`, and fail closed with an error for `EvaluateConditions`, which existing authorizers do not support.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/5681

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Made it possible for authorizers to return conditional decisions in addition to unconditional (Allow/Deny/NoOpinion).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
TODO
```
