### PR TITLE
test/e2e: fix TOCTOU race in pod resize actuation check

### DIFF
--- a/test/e2e/common/node/framework/podresize/resize.go
+++ b/test/e2e/common/node/framework/podresize/resize.go
@@ -362,6 +362,7 @@ func verifyOomScoreAdj(f *framework.Framework, pod *v1.Pod, containerName string
 func WaitForPodResizeActuation(ctx context.Context, f *framework.Framework, podClient *e2epod.PodClient, pod *v1.Pod, expectedContainers []ResizableContainerInfo) *v1.Pod {
 	ginkgo.GinkgoHelper()
 	// Wait for resize to complete.
+	var resizedPod *v1.Pod
 
 	framework.ExpectNoError(framework.Gomega().
 		Eventually(ctx, framework.RetryNotFound(framework.GetObject(f.ClientSet.CoreV1().Pods(pod.Namespace).Get, pod.Name, metav1.GetOptions{}))).
@@ -392,12 +393,11 @@ func WaitForPodResizeActuation(ctx context.Context, f *framework.Framework, podC
 			if !podutils.IsPodReady(pod) {
 				return func() string { return "pod is not ready" }, nil
 			}
+			resizedPod = pod
 			return nil, nil
 		})),
 	)
 
-	resizedPod, err := framework.GetObject(podClient.Get, pod.Name, metav1.GetOptions{})(ctx)
-	framework.ExpectNoError(err, "failed to get resized pod")
 	return resizedPod
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

[WaitForPodResizeActuation](cci:1://file:///Users/administrator/go/src/k8s.io/kubernetes/test/e2e/common/node/framework/podresize/resize.go:361:0-401:1) polls until the pod reaches the expected resize state, but then fetches the pod again with a separate `Get` call. Between these two operations, the pod state can change (e.g. an extra container restart), causing [ExpectPodResized](cci:1://file:///Users/administrator/go/src/k8s.io/kubernetes/test/e2e/common/node/framework/podresize/resize.go:403:0-456:1) to fail.

This fix captures the pod from the successful `Eventually` iteration instead of making a redundant `Get` call, eliminating the race condition.

#### Which issue(s) this PR is related to:

#136783

#### Special notes for your reviewer:

This is my first contribution to Kubernetes. The fix is a small, targeted change — removing the redundant `Get` call and reusing the pod object that already passed all validation checks inside the `Eventually` loop.

All failing tests from the issue involve `RestartContainer` resize policies, where the container restart during resize creates a window for an extra restart between the `Eventually` success and the subsequent `Get`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```