### PR TITLE
Fix FSWatcher goroutine leak by adding ctx to Run()

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -383,7 +383,7 @@ func newPersistentVolumeAttachDetachController(ctx context.Context, controllerCo
 		csiDriverInformer,
 		controllerContext.InformerFactory.Storage().V1().VolumeAttachments(),
 		plugins,
-		GetDynamicPluginProber(controllerContext.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration),
+		GetDynamicPluginProber(ctx, controllerContext.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration),
 		controllerContext.ComponentConfig.AttachDetachController.DisableAttachDetachReconcilerSync,
 		controllerContext.ComponentConfig.AttachDetachController.ReconcilerSyncLoopPeriod.Duration,
 		controllerContext.ComponentConfig.AttachDetachController.DisableForceDetachOnTimeout,
@@ -1137,7 +1137,7 @@ func newSELinuxWarningController(ctx context.Context, controllerContext Controll
 		controllerContext.InformerFactory.Core().V1().PersistentVolumes(),
 		csiDriverInformer,
 		plugins,
-		GetDynamicPluginProber(controllerContext.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration),
+		GetDynamicPluginProber(ctx, controllerContext.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start SELinux warning controller: %w", err)

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -21,6 +21,7 @@ import (
 	// This should probably be part of some configuration fed into the build for a
 	// given binary target.
 
+	"context"
 	"fmt"
 
 	"k8s.io/klog/v2"
@@ -51,8 +52,8 @@ func ProbeAttachableVolumePlugins(logger klog.Logger, config persistentvolumecon
 // GetDynamicPluginProber gets the probers of dynamically discoverable plugins
 // for the attach/detach controller.
 // Currently only Flexvolume plugins are dynamically discoverable.
-func GetDynamicPluginProber(config persistentvolumeconfig.VolumeConfiguration) volume.DynamicPluginProber {
-	return flexvolume.GetDynamicPluginProber(config.FlexVolumePluginDir, exec.New() /*exec.Interface*/)
+func GetDynamicPluginProber(ctx context.Context, config persistentvolumeconfig.VolumeConfiguration) volume.DynamicPluginProber {
+	return flexvolume.GetDynamicPluginProber(ctx, config.FlexVolumePluginDir, exec.New() /*exec.Interface*/)
 }
 
 // ProbeExpandableVolumePlugins returns volume plugins which are expandable

--- a/cmd/kube-proxy/app/options.go
+++ b/cmd/kube-proxy/app/options.go
@@ -387,7 +387,7 @@ func (o *Options) Run(ctx context.Context) error {
 // Return an error when updated
 func (o *Options) runLoop(ctx context.Context) error {
 	if o.watcher != nil {
-		o.watcher.Run()
+		o.watcher.Run(ctx)
 	}
 
 	// run the proxy in goroutine

--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -73,6 +73,6 @@ func ProbeVolumePlugins(ctx context.Context, featureGate featuregate.FeatureGate
 // GetDynamicPluginProber gets the probers of dynamically discoverable plugins
 // for kubelet.
 // Currently only Flexvolume plugins are dynamically discoverable.
-func GetDynamicPluginProber(pluginDir string, runner exec.Interface) volume.DynamicPluginProber {
-	return flexvolume.GetDynamicPluginProber(pluginDir, runner)
+func GetDynamicPluginProber(ctx context.Context, pluginDir string, runner exec.Interface) volume.DynamicPluginProber {
+	return flexvolume.GetDynamicPluginProber(ctx, pluginDir, runner)
 }

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -528,7 +528,7 @@ func UnsecuredDependencies(ctx context.Context, s *options.KubeletServer, featur
 		OOMAdjuster:         oom.NewOOMAdjuster(),
 		OSInterface:         kubecontainer.RealOS{},
 		VolumePlugins:       plugins,
-		DynamicPluginProber: GetDynamicPluginProber(s.VolumePluginDir, pluginRunner),
+		DynamicPluginProber: GetDynamicPluginProber(ctx, s.VolumePluginDir, pluginRunner),
 		TLSOptions:          tlsOptions}, nil
 }
 

--- a/pkg/util/filesystem/watcher.go
+++ b/pkg/util/filesystem/watcher.go
@@ -32,7 +32,8 @@ type FSWatcher interface {
 
 	// Starts listening for events and errors.
 	// When an event or error occurs, the corresponding handler is called.
-	Run()
+	// The watcher stops and releases resources when ctx is canceled.
+	Run(ctx context.Context)
 
 	// Add a filesystem path to watch
 	AddWatch(path string) error
@@ -74,11 +75,13 @@ func (w *fsnotifyWatcher) Init(eventHandler FSEventHandler, errorHandler FSError
 	return nil
 }
 
-func (w *fsnotifyWatcher) Run() {
+func (w *fsnotifyWatcher) Run(ctx context.Context) {
 	go func() {
 		defer w.watcher.Close()
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case event := <-w.watcher.Events:
 				if w.eventHandler != nil {
 					w.eventHandler(event)

--- a/pkg/volume/flexvolume/fake_watcher.go
+++ b/pkg/volume/flexvolume/fake_watcher.go
@@ -17,6 +17,8 @@ limitations under the License.
 package flexvolume
 
 import (
+	"context"
+
 	"github.com/fsnotify/fsnotify"
 	utilfs "k8s.io/kubernetes/pkg/util/filesystem"
 )
@@ -40,7 +42,7 @@ func (w *fakeWatcher) Init(eventHandler utilfs.FSEventHandler, _ utilfs.FSErrorH
 	return nil
 }
 
-func (w *fakeWatcher) Run() { /* no-op */ }
+func (w *fakeWatcher) Run(_ context.Context) { /* no-op */ }
 
 func (w *fakeWatcher) AddWatch(path string) error {
 	w.watches = append(w.watches, path)

--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -17,6 +17,7 @@ limitations under the License.
 package flexvolume
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -39,18 +40,20 @@ type flexVolumeProber struct {
 	watcher        utilfs.FSWatcher
 	factory        PluginFactory
 	fs             utilfs.Filesystem
+	ctx            context.Context
 	probeAllNeeded bool
 	eventsMap      map[string]volume.ProbeOperation // the key is the driver directory path, the value is the corresponding operation
 }
 
 // GetDynamicPluginProber creates dynamic plugin prober
-func GetDynamicPluginProber(pluginDir string, runner exec.Interface) volume.DynamicPluginProber {
+func GetDynamicPluginProber(ctx context.Context, pluginDir string, runner exec.Interface) volume.DynamicPluginProber {
 	return &flexVolumeProber{
 		pluginDir: pluginDir,
 		watcher:   utilfs.NewFsnotifyWatcher(),
 		factory:   pluginFactory{},
 		runner:    runner,
 		fs:        &utilfs.DefaultFs{},
+		ctx:       ctx,
 	}
 }
 
@@ -261,7 +264,7 @@ func (prober *flexVolumeProber) initWatcher() error {
 		return fmt.Errorf("error adding watch on Flexvolume directory: %s", err)
 	}
 
-	prober.watcher.Run()
+	prober.watcher.Run(prober.ctx)
 
 	return nil
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Reopen of https://github.com/kubernetes/kubernetes/pull/135078. Addressed feedback https://github.com/kubernetes/kubernetes/pull/135078#issuecomment-3484884454 from @carlory 

FSWatcher.Run() spawned a goroutine with no exit mechanism, causing a goroutine leak. Add a ctx context.Context parameter to Run() so the goroutine can exit cleanly when the context is canceled, and defer-close the underlying fsnotify watcher on exit.

For kube-proxy, the existing ctx from runLoop() is passed directly. For the flexvolume prober, ctx is stored in flexVolumeProber at construction time via GetDynamicPluginProber(), representing the component lifetime (kubelet/controller-manager), which is the appropriate scope for this long-running watcher.

afaik these are internal k8s pkgs and should not have any compatibility concerns with changing function signature.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
