### PR TITLE
fix: [sig-cli] flaky kubectl logs --all-pods --all-containers Deployment test

### DIFF
--- a/test/e2e/kubectl/logs.go
+++ b/test/e2e/kubectl/logs.go
@@ -75,13 +75,13 @@ func testingDeployment(name, ns string, numberOfPods int32) appsv1.Deployment {
 							Name:    "container-1",
 							Image:   imageutils.GetE2EImage(imageutils.Agnhost),
 							Command: []string{"/bin/sh", "-c"},
-							Args:    []string{"/agnhost logs-generator --log-lines-total 10 --run-duration 3s && /agnhost pause"},
+							Args:    []string{"/agnhost logs-generator --log-lines-total 10 --run-duration 30s && /agnhost pause"},
 						},
 						{
 							Name:    "container-2",
 							Image:   imageutils.GetE2EImage(imageutils.Agnhost),
 							Command: []string{"/bin/sh", "-c"},
-							Args:    []string{"/agnhost logs-generator --log-lines-total 20 --run-duration 3s && /agnhost pause"},
+							Args:    []string{"/agnhost logs-generator --log-lines-total 20 --run-duration 30s && /agnhost pause"},
 						},
 					},
 					RestartPolicy:                 v1.RestartPolicyAlways,
@@ -289,20 +289,24 @@ var _ = SIGDescribe("Kubectl logs", func() {
 			ginkgo.It("should get logs from all pods based on default container", func(ctx context.Context) {
 				ginkgo.By("Waiting for Deployment pods to be running.")
 
-				// get the pod names
 				pods, err := e2edeployment.GetPodsForDeployment(ctx, c, deploy)
 				framework.ExpectNoError(err, "failed to get pods for deployment")
 
 				podOne := pods.Items[0].GetName()
 				podTwo := pods.Items[1].GetName()
 
-				ginkgo.By("sleep 3s to wait for log generator produce data after pods get ready")
-				time.Sleep(3 * time.Second)
-
 				ginkgo.By("expecting logs from the default container from both pods in a deployment")
-				out := e2ekubectl.RunKubectlOrDie(ns, "logs", fmt.Sprintf("deploy/%s", deployName), "--all-pods")
-				gomega.Expect(strings.Contains(out, fmt.Sprintf("[pod/%s/container-2]", podOne))).To(gomega.BeTrueBecause("pod 1 container 2 log should be present"))
-				gomega.Expect(strings.Contains(out, fmt.Sprintf("[pod/%s/container-2]", podTwo))).To(gomega.BeTrueBecause("pod 2 container 2 log should be present"))
+				var out string
+				gomega.Eventually(func() (string, error) {
+					var runErr error
+					out, runErr = e2ekubectl.RunKubectl(ns, "logs", fmt.Sprintf("deploy/%s", deployName), "--all-pods")
+					return out, runErr
+				}, framework.PodStartTimeout, 5*time.Second).Should(
+					gomega.SatisfyAll(
+						gomega.ContainSubstring(fmt.Sprintf("[pod/%s/container-2]", podOne)),
+						gomega.ContainSubstring(fmt.Sprintf("[pod/%s/container-2]", podTwo)),
+					),
+				)
 
 				ginkgo.By("logs should NOT contain data from the non-default container from both pods in a deployment")
 				gomega.Expect(strings.Contains(out, fmt.Sprintf("[pod/%s/container-1]", podOne))).To(gomega.BeFalseBecause("pod 1 container 1 log should NOT be present"))
@@ -318,15 +322,17 @@ var _ = SIGDescribe("Kubectl logs", func() {
 				podOne := pods.Items[0].GetName()
 				podTwo := pods.Items[1].GetName()
 
-				ginkgo.By("sleep 3s to wait for log generator produce data after pods get ready")
-				time.Sleep(3 * time.Second)
-
 				ginkgo.By("expecting logs from all containers from both pods in a deployment")
-				out := e2ekubectl.RunKubectlOrDie(ns, "logs", fmt.Sprintf("deploy/%s", deployName), "--all-pods", "--all-containers")
-				gomega.Expect(strings.Contains(out, fmt.Sprintf("[pod/%s/container-1]", podOne))).To(gomega.BeTrueBecause("pod 1 container 1 log should be present"))
-				gomega.Expect(strings.Contains(out, fmt.Sprintf("[pod/%s/container-2]", podOne))).To(gomega.BeTrueBecause("pod 1 container 2 log should be present"))
-				gomega.Expect(strings.Contains(out, fmt.Sprintf("[pod/%s/container-1]", podTwo))).To(gomega.BeTrueBecause("pod 2 container 1 log should be present"))
-				gomega.Expect(strings.Contains(out, fmt.Sprintf("[pod/%s/container-2]", podTwo))).To(gomega.BeTrueBecause("pod 2 container 2 log should be present"))
+				gomega.Eventually(func() (string, error) {
+					return e2ekubectl.RunKubectl(ns, "logs", fmt.Sprintf("deploy/%s", deployName), "--all-pods", "--all-containers")
+				}, framework.PodStartTimeout, 5*time.Second).Should(
+					gomega.SatisfyAll(
+						gomega.ContainSubstring(fmt.Sprintf("[pod/%s/container-1]", podOne)),
+						gomega.ContainSubstring(fmt.Sprintf("[pod/%s/container-2]", podOne)),
+						gomega.ContainSubstring(fmt.Sprintf("[pod/%s/container-1]", podTwo)),
+						gomega.ContainSubstring(fmt.Sprintf("[pod/%s/container-2]", podTwo)),
+					),
+				)
 			})
 
 		})


### PR DESCRIPTION
## What this PR does / why we need it:
- The test [sig-cli] Kubectl logs all pod logs ... should get logs from each pod and each container in Deployment was flaking intermittently on GCE multi-node clusters with:

```javascript
[FAILED] pod 2 container 2 log should be present
In [It] at: k8s.io/kubernetes/test/e2e/kubectl/logs.go:329
```

- The Deployment's 2 replicas get scheduled to different physical GCE nodes. In the failing run, the slow node took `~17 seconds` to become ready versus `~2 seconds` for the fast node. Two compounding problems caused the failure:

  - `time.Sleep(3s)` is anchored to when `WaitForDeploymentComplete` returned — i.e., when the fast pod was ready — not the slow pod. It cannot account for real per-node startup variance on heterogeneous GCE hardware.

  - `--run-duration 3s` meant the log generator on the slow pod's `container-2` finished and transitioned to /agnhost pause only `~2 seconds` before kubectl logs ran. The kubelet log index for a container that just transitioned out of running state is not immediately stable, causing its log stream to be silently absent from `--all-containers` output.

## Changes:

- Replace the fixed sleep with `gomega.Eventually` to retry `kubectl logs ... --all-pods --all-containers` until all expected pod/container prefixes appear (or until timeout).

- Increase the log generator `--run-duration` in the deployment used by the test (e.g., from `3s` to `30s`) so logs are still being produced when the test collects them, reducing sensitivity to slow node startup.

## Testing:

- Traced the root cause from the Prow failure on `ci-kubernetes-e2e-ubuntu-gce-containerd (2026-02-18)` via kubelet event timestamps. Ran all four `sig-cli` Kubectl logs specs locally on kind:

<img width="1721" height="731" alt="Screenshot from 2026-02-24 18-46-02" src="https://github.com/user-attachments/assets/cb0cc107-9b3e-46ed-a5bf-9755098efb99" />

**CHECK**:- [Prow](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/137221/pull-kubernetes-e2e-containerd-gce/2026326867950178304)

Fixes #137180

/kind flake
/sig cli
cc @kubernetes/release-team-release-signal