### PR TITLE
controller/selinuxwarning: Pre-parse SELinux label

### DIFF
--- a/pkg/controller/volume/selinuxwarning/cache/volumecache_test.go
+++ b/pkg/controller/volume/selinuxwarning/cache/volumecache_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/controller/volume/selinuxwarning/internal/parse"
 	"k8s.io/kubernetes/pkg/controller/volume/selinuxwarning/translator"
 )
 
@@ -436,6 +437,7 @@ func TestVolumeCache_AddVolumeSendConflicts(t *testing.T) {
 			}
 			expectedPodInfo := podInfo{
 				seLinuxLabel: tt.podToAdd.label,
+				seLinuxParts: parse.ParseSELinuxLabel(tt.podToAdd.label),
 				changePolicy: tt.podToAdd.changePolicy,
 			}
 			if !reflect.DeepEqual(existingInfo, expectedPodInfo) {

--- a/pkg/controller/volume/selinuxwarning/internal/parse/selinux_label.go
+++ b/pkg/controller/volume/selinuxwarning/internal/parse/selinux_label.go
@@ -1,0 +1,32 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parse
+
+import "strings"
+
+// ParseSELinuxLabel parses a SELinux label string into its components.
+// Format: "user:role:type:level" -> [user, role, type, level]
+// Missing components are represented as empty strings.
+func ParseSELinuxLabel(label string) [4]string {
+	var parts [4]string
+	if label == "" {
+		return parts
+	}
+	split := strings.SplitN(label, ":", 4)
+	copy(parts[:], split)
+	return parts
+}

--- a/pkg/controller/volume/selinuxwarning/internal/parse/selinux_label_test.go
+++ b/pkg/controller/volume/selinuxwarning/internal/parse/selinux_label_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parse
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSELinuxLabel(t *testing.T) {
+	tests := []struct {
+		name          string
+		label         string
+		expectedParts []string
+	}{
+		{
+			name:          "empty label",
+			label:         "",
+			expectedParts: []string{"", "", "", ""},
+		},
+		{
+			name:          "complete label with all components",
+			label:         "system_u:system_r:container_t:s0:c0,c1",
+			expectedParts: []string{"system_u", "system_r", "container_t", "s0:c0,c1"},
+		},
+		{
+			name:          "label with user, role, and type only",
+			label:         "system_u:system_r:container_t",
+			expectedParts: []string{"system_u", "system_r", "container_t", ""},
+		},
+		{
+			name:          "label with user and role only",
+			label:         "system_u:system_r",
+			expectedParts: []string{"system_u", "system_r", "", ""},
+		},
+		{
+			name:          "label with user only",
+			label:         "system_u",
+			expectedParts: []string{"system_u", "", "", ""},
+		},
+		{
+			name:          "label missing user but with role and type",
+			label:         ":system_r:container_t",
+			expectedParts: []string{"", "system_r", "container_t", ""},
+		},
+		{
+			name:          "label missing user and role but with type",
+			label:         "::container_t",
+			expectedParts: []string{"", "", "container_t", ""},
+		},
+		{
+			name:          "label missing user and role but with type and level",
+			label:         "::container_t:s0",
+			expectedParts: []string{"", "", "container_t", "s0"},
+		},
+		{
+			name:          "label with all empty components except level",
+			label:         ":::s0:c0,c1",
+			expectedParts: []string{"", "", "", "s0:c0,c1"},
+		},
+		{
+			name:          "label with special characters in components",
+			label:         "user_with_underscore:role-with-dash:type.with.dots:s0:c0.c1",
+			expectedParts: []string{"user_with_underscore", "role-with-dash", "type.with.dots", "s0:c0.c1"},
+		},
+		{
+			name:          "label with extra colons in level component",
+			label:         "user:role:type:s0:c0,c1:extra",
+			expectedParts: []string{"user", "role", "type", "s0:c0,c1:extra"},
+		},
+		{
+			name:          "multiple colons only",
+			label:         ":::",
+			expectedParts: []string{"", "", "", ""},
+		},
+		{
+			name:          "five colons",
+			label:         ":::::",
+			expectedParts: []string{"", "", "", "::"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parts := ParseSELinuxLabel(tt.label)
+			partsSlice := parts[:]
+			if !reflect.DeepEqual(partsSlice, tt.expectedParts) {
+				t.Errorf("ParseSELinuxLabel(%q) = %v, expected parts = %v", tt.label, partsSlice, tt.expectedParts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When calling `ControllerSELinuxTranslator.Conflicts()`, the SELinux label is internally split into `[]string` to detect conflicts. This causes a huge number of allocations and lingering CPU spikes when there are many comparisons.

This is now made more efficient by pre-parsing the SELinux label and storing it in `podInfo` as `[4]string` for fast comparison when needed.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/137218

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A