### PR TITLE
controller/selinuxwarning/cache: Add reverse index to speed up DeletePod

### DIFF
--- a/pkg/controller/volume/selinuxwarning/cache/volumecache.go
+++ b/pkg/controller/volume/selinuxwarning/cache/volumecache.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/volume/selinuxwarning/translator"
@@ -57,6 +58,9 @@ type volumeCache struct {
 	seLinuxTranslator *translator.ControllerSELinuxTranslator
 	// All volumes of all existing Pods.
 	volumes map[v1.UniqueVolumeName]usedVolume
+	// Reverse index: maps each pod to the list of volumes it uses.
+	// The index is used during pod deletion.
+	podToVolumes map[cache.ObjectName]sets.Set[v1.UniqueVolumeName]
 }
 
 var _ VolumeCache = &volumeCache{}
@@ -66,6 +70,7 @@ func NewVolumeLabelCache(seLinuxTranslator *translator.ControllerSELinuxTranslat
 	return &volumeCache{
 		seLinuxTranslator: seLinuxTranslator,
 		volumes:           make(map[v1.UniqueVolumeName]usedVolume),
+		podToVolumes:      make(map[cache.ObjectName]sets.Set[v1.UniqueVolumeName]),
 	}
 }
 
@@ -111,6 +116,9 @@ func (c *volumeCache) AddVolume(logger klog.Logger, volumeName v1.UniqueVolumeNa
 			pods:      newPodInfoListForPod(podKey, label, changePolicy),
 		}
 		c.volumes[volumeName] = volume
+
+		// Add to reverse index
+		c.registerPodVolume(podKey, volumeName)
 		return conflicts
 	}
 
@@ -128,6 +136,9 @@ func (c *volumeCache) AddVolume(logger klog.Logger, volumeName v1.UniqueVolumeNa
 
 	// Add the updated pod info to the cache
 	volume.pods[podKey] = podInfo
+
+	// Add to reverse index
+	c.registerPodVolume(podKey, volumeName)
 
 	// Emit conflicts for the pod
 	for otherPodKey, otherPodInfo := range volume.pods {
@@ -177,11 +188,27 @@ func (c *volumeCache) DeletePod(logger klog.Logger, podKey cache.ObjectName) {
 	defer c.mutex.Unlock()
 	defer c.dump(logger)
 
-	for volumeName, volume := range c.volumes {
+	// Use reverse index to only iterate through volumes this pod actually uses.
+	for volumeName := range c.podToVolumes[podKey] {
+		volume, found := c.volumes[volumeName]
+		if !found {
+			continue
+		}
 		delete(volume.pods, podKey)
 		if len(volume.pods) == 0 {
 			delete(c.volumes, volumeName)
 		}
+	}
+	delete(c.podToVolumes, podKey)
+}
+
+// registerPodVolume adds volumeName to the pod volume index.
+// Make sure to hold c.mutex when calling this function.
+func (c *volumeCache) registerPodVolume(podKey cache.ObjectName, volumeName v1.UniqueVolumeName) {
+	if podVolumes, ok := c.podToVolumes[podKey]; ok {
+		podVolumes.Insert(volumeName)
+	} else {
+		c.podToVolumes[podKey] = sets.New(volumeName)
 	}
 }
 
@@ -213,6 +240,22 @@ func (c *volumeCache) dump(logger klog.Logger) {
 			podInfo := volume.pods[podKey]
 			logger.Info("  pod", "pod", podKey, "seLinuxLabel", podInfo.seLinuxLabel, "changePolicy", podInfo.changePolicy)
 		}
+	}
+
+	// Collect all pods, sort them and print the associated volumes.
+	podKeys := make([]cache.ObjectName, 0, len(c.podToVolumes))
+	for podKey := range c.podToVolumes {
+		podKeys = append(podKeys, podKey)
+	}
+	sort.Slice(podKeys, func(i, j int) bool {
+		return podKeys[i].String() < podKeys[j].String()
+	})
+
+	logger.Info("VolumeCache reverse index dump:")
+	for _, podKey := range podKeys {
+		podVolumes := sets.List(c.podToVolumes[podKey])
+		slices.Sort(podVolumes)
+		logger.Info("  pod", "pod", podKey, "volumes", podVolumes)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Added `podToVolumes` reverse index to optimize `DeletePod`. Currently we simply iterate through all the volumes and remove the pod being deleted from there. This is inefficient and takes longer the longer the volume list becomes.

Keeping a map `pod -> pod volumes` makes removing a pod fast. We can just jump to the relevant volumes directly and remove the pod from there.

#### Which issue(s) this PR is related to:

Found the optimization when working on https://github.com/kubernetes/kubernetes/issues/137218

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A