### PR TITLE
Refactor emptydir setup layering

### DIFF
--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -263,15 +263,16 @@ func (ed *emptyDir) SetUpAt(dir string, mounterArgs volume.MounterArgs) error {
 		}
 	}
 
-	switch {
-	case ed.medium == v1.StorageMediumDefault:
-		err = ed.setupDir(dir)
-	case ed.medium == v1.StorageMediumMemory:
-		err = ed.setupTmpfs(dir)
-	case v1helper.IsHugePageMedium(ed.medium):
-		err = ed.setupHugepages(dir)
-	default:
-		err = fmt.Errorf("unknown storage medium %q", ed.medium)
+	err = ed.setupDir(dir)
+	if err == nil {
+		switch {
+		case ed.medium == v1.StorageMediumMemory:
+			err = ed.setupTmpfs(dir)
+		case v1helper.IsHugePageMedium(ed.medium):
+			err = ed.setupHugepages(dir)
+		case ed.medium != v1.StorageMediumDefault:
+			err = fmt.Errorf("unknown storage medium %q", ed.medium)
+		}
 	}
 
 	ownershipChanger := volume.NewVolumeOwnership(ed, dir, mounterArgs.FsGroup, nil /*fsGroupChangePolicy*/, volumeutil.FSGroupCompleteHook(ed.plugin, nil))
@@ -315,12 +316,13 @@ func (ed *emptyDir) assignQuota(dir string, mounterSize *resource.Quantity) erro
 }
 
 // setupTmpfs creates a tmpfs mount at the specified directory.
+// Precondition: setupDir must have been called on dir beforehand.
 func (ed *emptyDir) setupTmpfs(dir string) error {
 	if ed.mounter == nil {
 		return fmt.Errorf("memory storage requested, but mounter is nil")
 	}
-	if err := ed.setupDir(dir); err != nil {
-		return err
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("directory %q does not exist: setupDir must be called before setupTmpfs", dir)
 	}
 	// Make SetUp idempotent.
 	medium, isMnt, _, err := ed.mountDetector.GetMountMedium(dir, ed.medium)
@@ -340,12 +342,13 @@ func (ed *emptyDir) setupTmpfs(dir string) error {
 }
 
 // setupHugepages creates a hugepage mount at the specified directory.
+// Precondition: setupDir must have been called on dir beforehand.
 func (ed *emptyDir) setupHugepages(dir string) error {
 	if ed.mounter == nil {
 		return fmt.Errorf("memory storage requested, but mounter is nil")
 	}
-	if err := ed.setupDir(dir); err != nil {
-		return err
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("directory %q does not exist: setupDir must be called before setupHugepages", dir)
 	}
 	// Make SetUp idempotent.
 	medium, isMnt, mountPageSize, err := ed.mountDetector.GetMountMedium(dir, ed.medium)

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -960,6 +960,27 @@ func TestSetupHugepages(t *testing.T) {
 			},
 			shouldFail: true,
 		},
+		"Invalid: directory does not exist": {
+			path: filepath.Join(tmpdir, "nonexistent-subdir", "gone"),
+			ed: &emptyDir{
+				medium: v1.StorageMediumHugePages,
+				pod: &v1.Pod{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceName("hugepages-2Mi"): resource.MustParse("100Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+				mounter: &mount.FakeMounter{},
+			},
+			shouldFail: true,
+		},
 	}
 
 	for testCaseName, testCase := range testCases {
@@ -1203,6 +1224,136 @@ func TestTmpfsMountOptions(t *testing.T) {
 			}
 			if expectedOption := fmt.Sprintf("size=%d", testCase.sizeLimit.Value()); !testCase.sizeLimit.IsZero() && !doesStringArrayContainSubstring(options, expectedOption) {
 				t.Errorf("size option is not expected when is zero. options: %v", options)
+			}
+		})
+	}
+}
+
+type testTmpfsMountDetector struct {
+	medium   v1.StorageMedium
+	isMnt    bool
+	pageSize *resource.Quantity
+	err      error
+}
+
+func (md *testTmpfsMountDetector) GetMountMedium(path string, requestedMedium v1.StorageMedium) (v1.StorageMedium, bool, *resource.Quantity, error) {
+	return md.medium, md.isMnt, md.pageSize, md.err
+}
+
+func TestSetupTmpfs(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "TestSetupTmpfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	testCases := map[string]struct {
+		path       string
+		ed         *emptyDir
+		shouldFail bool
+	}{
+		"Valid: already mounted with memory medium": {
+			path: tmpdir,
+			ed: &emptyDir{
+				medium:  v1.StorageMediumMemory,
+				mounter: mount.NewFakeMounter([]mount.MountPoint{{Path: tmpdir}}),
+				mountDetector: &testTmpfsMountDetector{
+					medium: v1.StorageMediumMemory,
+					isMnt:  true,
+				},
+			},
+			shouldFail: false,
+		},
+		"Invalid: mounter is nil": {
+			path: tmpdir,
+			ed: &emptyDir{
+				medium:  v1.StorageMediumMemory,
+				mounter: nil,
+			},
+			shouldFail: true,
+		},
+		"Invalid: directory does not exist": {
+			path: filepath.Join(tmpdir, "nonexistent-subdir", "gone"),
+			ed: &emptyDir{
+				medium:  v1.StorageMediumMemory,
+				mounter: &mount.FakeMounter{},
+			},
+			shouldFail: true,
+		},
+		"Invalid: GetMountMedium error": {
+			path: tmpdir,
+			ed: &emptyDir{
+				medium:  v1.StorageMediumMemory,
+				mounter: &mount.FakeMounter{},
+				mountDetector: &testTmpfsMountDetector{
+					err: fmt.Errorf("GetMountMedium error"),
+				},
+			},
+			shouldFail: true,
+		},
+	}
+
+	for testCaseName, testCase := range testCases {
+		t.Run(testCaseName, func(t *testing.T) {
+			err := testCase.ed.setupTmpfs(testCase.path)
+			if testCase.shouldFail && err == nil {
+				t.Errorf("%s: Unexpected success", testCaseName)
+			} else if !testCase.shouldFail && err != nil {
+				t.Errorf("%s: Unexpected error: %v", testCaseName, err)
+			}
+		})
+	}
+}
+
+func TestSetupDir(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "TestSetupDir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	testCases := map[string]struct {
+		preCreate bool
+		prePerm   os.FileMode
+	}{
+		"Valid: creates new directory": {
+			preCreate: false,
+		},
+		"Valid: existing directory with correct permissions": {
+			preCreate: true,
+			prePerm:   perm,
+		},
+		"Valid: existing directory with wrong permissions gets corrected": {
+			preCreate: true,
+			prePerm:   0700,
+		},
+	}
+
+	ed := &emptyDir{}
+
+	for testCaseName, testCase := range testCases {
+		t.Run(testCaseName, func(t *testing.T) {
+			dir := filepath.Join(tmpdir, testCaseName)
+			if testCase.preCreate {
+				if err := os.MkdirAll(dir, testCase.prePerm); err != nil {
+					t.Errorf("failed to pre-create directory: %v", err)
+				}
+				if err := os.Chmod(dir, testCase.prePerm); err != nil {
+					t.Errorf("failed to set pre-permissions: %v", err)
+				}
+			}
+
+			err := ed.setupDir(dir)
+			if err != nil {
+				t.Errorf("%s: Unexpected error: %v", testCaseName, err)
+			}
+
+			info, err := os.Lstat(dir)
+			if err != nil {
+				t.Errorf("%s: failed to stat directory after setupDir: %v", testCaseName, err)
+			}
+			if err == nil && info.Mode().Perm() != perm.Perm() {
+				t.Errorf("%s: Expected permissions %v, got %v", testCaseName, perm.Perm(), info.Mode().Perm())
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig node
<!--
Add one of the following kinds:


-->

#### What this PR does / why we need it:
Refactored the  pkg/volume/emptydir/empty_dir.go  code 


**Problem:**
`setupTmpfs` and `setupHugepages` had an implicit precondition that `setupDir` must be called first. For default medium, `setupDir` was called directly. For memory-backed and hugepages volumes, `setupTmpfs` and `setupHugepages` called `setupDir` internally as a wrapper. This created a code smell — `setupDir` was buried inside functions whose responsibility is mounting, not directory creation.

Additionally, `setupDir` had no dedicated unit tests for its permission verification and correction logic.

**Solution:**
- Refactored `setupDir` out of `setupTmpfs` and `setupHugepages`. Directory creation now always happens first in `SetUpAt`, then the medium-specific mount function runs. This makes the flow clean and readable.
- Added `os.Stat` precondition guards in `setupTmpfs` and `setupHugepages` to fail fast with clear error messages if the
  directory was not created beforehand.
- The added `stat` calls are O(1) per volume setup and take microseconds on Linux — negligible compared to the existing `MkdirAll` and `mount` syscalls in the same code path.
**Tests added:**
- `TestSetupHugepages` — added case for the new `os.Stat` guard
- `TestSetupTmpfs` — new test function covering the `os.Stat` guard,  nil mounter, mount detector error, and idempotency (previously had no dedicated test coverage)
- `TestSetupDir` — dedicated unit tests for the permission verification and `os.Chmod` correction logic, which was previously only tested indirectly through the full `SetUp` flow




#### Which issue(s) this PR is related to:
<!-- 
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->Fixes #138054

#### Special notes for your reviewer:
- `setupTmpfs` and `setupHugepages` no longer call `setupDir` internally. Directory creation is now handled once in `SetUpAt` before the medium-specific mount function runs.


#### Does this PR introduce a user-facing change?
<!-- NONE
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```

