### PR TITLE
Convert {is,supports}SubResource to modern tag parsing

### DIFF
--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -63,7 +63,7 @@ type ScaleStatus struct {
 // +k8s:prerelease-lifecycle-gen:deprecated=1.8
 // +k8s:prerelease-lifecycle-gen:removed=1.16
 // +k8s:prerelease-lifecycle-gen:replacement=autoscaling,v1,Scale
-// +k8s:isSubresource=/scale
+// +k8s:isSubresource="/scale"
 
 // Scale represents a scaling request for a resource.
 type Scale struct {

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -66,7 +66,7 @@ type ScaleStatus struct {
 // +k8s:prerelease-lifecycle-gen:deprecated=1.9
 // +k8s:prerelease-lifecycle-gen:removed=1.16
 // +k8s:prerelease-lifecycle-gen:replacement=autoscaling,v1,Scale
-// +k8s:isSubresource=/scale
+// +k8s:isSubresource="/scale"
 
 // Scale represents a scaling request for a resource.
 type Scale struct {

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -123,7 +123,7 @@ type HorizontalPodAutoscalerList struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.2
-// +k8s:isSubresource=/scale
+// +k8s:isSubresource="/scale"
 
 // Scale represents a scaling request for a resource.
 type Scale struct {

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -39,8 +39,8 @@ option go_package = "k8s.io/api/certificates/v1";
 // This API can be used to request client certificates to authenticate to kube-apiserver
 // (with the "kubernetes.io/kube-apiserver-client" signerName),
 // or to obtain certificates from custom non-Kubernetes signers.
-// +k8s:supportsSubresource=/status
-// +k8s:supportsSubresource=/approval
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/approval"
 message CertificateSigningRequest {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -39,8 +39,8 @@ import (
 // This API can be used to request client certificates to authenticate to kube-apiserver
 // (with the "kubernetes.io/kube-apiserver-client" signerName),
 // or to obtain certificates from custom non-Kubernetes signers.
-// +k8s:supportsSubresource=/status
-// +k8s:supportsSubresource=/approval
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/approval"
 type CertificateSigningRequest struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -30,8 +30,8 @@ import "k8s.io/apimachinery/pkg/runtime/schema/generated.proto";
 option go_package = "k8s.io/api/certificates/v1beta1";
 
 // Describes a certificate signing request
-// +k8s:supportsSubresource=/status
-// +k8s:supportsSubresource=/approval
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/approval"
 message CertificateSigningRequest {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -32,8 +32,8 @@ import (
 // +k8s:prerelease-lifecycle-gen:replacement=certificates.k8s.io,v1,CertificateSigningRequest
 
 // Describes a certificate signing request
-// +k8s:supportsSubresource=/status
-// +k8s:supportsSubresource=/approval
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/approval"
 type CertificateSigningRequest struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5652,7 +5652,7 @@ type ReplicationControllerCondition struct {
 // +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.0
-// +k8s:supportsSubresource=/scale
+// +k8s:supportsSubresource="/scale"
 
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationController struct {

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -57,7 +57,7 @@ type ScaleStatus struct {
 // +k8s:prerelease-lifecycle-gen:introduced=1.1
 // +k8s:prerelease-lifecycle-gen:deprecated=1.2
 // +k8s:prerelease-lifecycle-gen:removed=1.16
-// +k8s:isSubresource=/scale
+// +k8s:isSubresource="/scale"
 
 // represents a scaling request for a resource.
 type Scale struct {

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -731,7 +731,7 @@ type ResourceSliceList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.34
-// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource="/status"
 
 // ResourceClaim describes a request for access to resources in the cluster,
 // for use by workloads. For example, if a workload needs an accelerator device

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -743,7 +743,7 @@ type ResourceSliceList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.32
-// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource="/status"
 
 // ResourceClaim describes a request for access to resources in the cluster,
 // for use by workloads. For example, if a workload needs an accelerator device

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -734,7 +734,7 @@ type ResourceSliceList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.33
-// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource="/status"
 
 // ResourceClaim describes a request for access to resources in the cluster,
 // for use by workloads. For example, if a workload needs an accelerator device

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -124,7 +124,7 @@ const (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.13
-// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource="/status"
 
 // VolumeAttachment captures the intent to attach or detach the specified volume
 // to/from the specified node.

--- a/staging/src/k8s.io/api/storage/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types.go
@@ -28,7 +28,7 @@ import (
 // +k8s:prerelease-lifecycle-gen:introduced=1.9
 // +k8s:prerelease-lifecycle-gen:deprecated=1.21
 // +k8s:prerelease-lifecycle-gen:replacement=storage.k8s.io,v1,VolumeAttachment
-// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource="/status"
 
 // VolumeAttachment captures the intent to attach or detach the specified volume
 // to/from the specified node.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -129,7 +129,7 @@ const (
 // +k8s:prerelease-lifecycle-gen:introduced=1.10
 // +k8s:prerelease-lifecycle-gen:deprecated=1.19
 // +k8s:prerelease-lifecycle-gen:replacement=storage.k8s.io,v1,VolumeAttachment
-// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource="/status"
 
 // VolumeAttachment captures the intent to attach or detach the specified volume
 // to/from the specified node.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/issubresource/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/issubresource/doc.go
@@ -27,7 +27,7 @@ var localSchemeBuilder = testscheme.New()
 
 // Root resource is supported by default
 
-// +k8s:isSubresource=/scale
+// +k8s:isSubresource="/scale"
 
 // T1 is a test type
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/subresource/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/supported_resources/subresource/doc.go
@@ -27,9 +27,9 @@ var localSchemeBuilder = testscheme.New()
 
 // Root resource is supported by default
 
-// +k8s:supportsSubresource=/status
-// +k8s:supportsSubresource=/scale
-// +k8s:supportsSubresource=/x/y
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/scale"
+// +k8s:supportsSubresource="/x/y"
 
 // T1 is a test type
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/code-generator/cmd/validation-gen/validators"
 	"k8s.io/gengo/v2"
+	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
 	"k8s.io/gengo/v2/types"
@@ -34,8 +35,8 @@ import (
 
 // These are the comment tags that carry parameters for validation generation.
 const (
-	tagName               = "k8s:validation-gen"
-	inputTagName          = "k8s:validation-gen-input"
+	mainTagName           = "k8s:validation-gen"                 // defines which types to generate validation for
+	inputTagName          = "k8s:validation-gen-input"           // indicates that input types are in a different package
 	schemeRegistryTagName = "k8s:validation-gen-scheme-registry" // defaults to k8s.io/apimachinery/pkg.runtime.Scheme
 	testFixtureTagName    = "k8s:validation-gen-test-fixture"    // if set, generate go test files for test fixtures.  Supported values: "validateFalse".
 
@@ -54,12 +55,31 @@ var (
 	listMetaType = types.Name{Package: metav1Pkg, Name: "ListMeta"}
 )
 
-func extractTag(comments []string) ([]string, bool) {
-	tags, err := gengo.ExtractFunctionStyleCommentTags("+", []string{tagName}, comments)
+// extractAndParseTag extracts all the values for a given tag, according to the
+// tag grammar.
+func extractAndParseTag(tagName string, comments []string) ([]codetags.Tag, error) {
+	extracted := codetags.Extract("+", comments)
+	var tags []codetags.Tag
+	for key, lines := range extracted {
+		if key != tagName {
+			continue
+		}
+		t, err := codetags.ParseAll(lines)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse tags: %w: %s", err, lines)
+		}
+		tags = append(tags, t...)
+	}
+	return tags, nil
+}
+
+func extractMainTag(comments []string) ([]string, bool) {
+	// TODO: convert to extractAndParseTag() and update all callers to use quoted values
+	tags, err := gengo.ExtractFunctionStyleCommentTags("+", []string{mainTagName}, comments)
 	if err != nil {
 		klog.Fatalf("Failed to extract tags: %v", err)
 	}
-	values, found := tags[tagName]
+	values, found := tags[mainTagName]
 	if !found || len(values) == 0 {
 		return nil, false
 	}
@@ -72,6 +92,7 @@ func extractTag(comments []string) ([]string, bool) {
 }
 
 func extractInputTag(comments []string) []string {
+	// TODO: convert to extractAndParseTag() and update all callers to use quoted values
 	tags, err := gengo.ExtractFunctionStyleCommentTags("+", []string{inputTagName}, comments)
 	if err != nil {
 		klog.Fatalf("Failed to extract input tags: %v", err)
@@ -88,12 +109,14 @@ func extractInputTag(comments []string) []string {
 	return result
 }
 
-func checkTag(comments []string, require ...string) bool {
-	tags, err := gengo.ExtractFunctionStyleCommentTags("+", []string{tagName}, comments)
+// TODO: this can just accept a single bool
+func checkMainTag(comments []string, require ...string) bool {
+	// TODO: convert to extractAndParseTag() and update all callers to use quoted values
+	tags, err := gengo.ExtractFunctionStyleCommentTags("+", []string{mainTagName}, comments)
 	if err != nil {
 		klog.Fatalf("Failed to extract tags: %v", err)
 	}
-	values, found := tags[tagName]
+	values, found := tags[mainTagName]
 	if !found {
 		return false
 	}
@@ -111,6 +134,7 @@ func checkTag(comments []string, require ...string) bool {
 }
 
 func schemeRegistryTag(pkg *types.Package) types.Name {
+	// TODO: convert to extractAndParseTag() and update all callers to use quoted values
 	tags, err := gengo.ExtractFunctionStyleCommentTags("+", []string{schemeRegistryTagName}, pkg.Comments)
 	if err != nil {
 		klog.Fatalf("Failed to extract scheme registry tags: %v", err)
@@ -129,34 +153,32 @@ func isSubresourceTag(t *types.Type) (string, bool) {
 	var comments []string
 	comments = append(comments, t.SecondClosestCommentLines...)
 	comments = append(comments, t.CommentLines...)
-	tags, err := gengo.ExtractFunctionStyleCommentTags("+", []string{isSubresourceTagName}, comments)
+	tags, err := extractAndParseTag(isSubresourceTagName, comments)
 	if err != nil {
 		klog.Fatalf("Failed to extract isSubresource tags: %v", err)
 	}
-	values, found := tags[isSubresourceTagName]
-	if !found || len(values) == 0 {
+	if len(tags) == 0 {
 		return "", false
 	}
-	if len(values) > 1 {
+	if len(tags) > 1 {
 		panic(fmt.Sprintf("Type %q contains more than one usage of %q", t.Name.String(), isSubresourceTagName))
 	}
-	return values[0].Value, true
+	return tags[0].Value, true
 }
 
 func supportedSubresourceTags(t *types.Type) sets.Set[string] {
 	var comments []string
 	comments = append(comments, t.SecondClosestCommentLines...)
 	comments = append(comments, t.CommentLines...)
-	tags, err := gengo.ExtractFunctionStyleCommentTags("+", []string{supportsSubresourceTagName}, comments)
+	tags, err := extractAndParseTag(supportsSubresourceTagName, comments)
 	if err != nil {
 		klog.Fatalf("Failed to extract supportedSubresource tags: %v", err)
 	}
-	values, found := tags[supportsSubresourceTagName]
-	if !found || len(values) == 0 {
+	if len(tags) == 0 {
 		return sets.New[string]()
 	}
 	subresources := sets.New[string]()
-	for _, tag := range values {
+	for _, tag := range tags {
 		subresources.Insert(tag.Value)
 	}
 	return subresources
@@ -166,6 +188,7 @@ var testFixtureTagValues = sets.New("validateFalse")
 
 func testFixtureTag(pkg *types.Package) sets.Set[string] {
 	result := sets.New[string]()
+	// TODO: convert to extractAndParseTag() and update all callers to use quoted values
 	tags, err := gengo.ExtractFunctionStyleCommentTags("+", []string{testFixtureTagName}, pkg.Comments)
 	if err != nil {
 		klog.Fatalf("Failed to extract test fixture tags: %v", err)
@@ -304,21 +327,21 @@ func GetTargets(context *generator.Context, args *Args) []generator.Target {
 
 		schemeRegistry := schemeRegistryTag(pkg)
 
-		typesWith, found := extractTag(pkg.Comments)
+		typesWith, found := extractMainTag(pkg.Comments)
 		if !found {
-			klog.V(2).InfoS("  did not find required tag", "tag", tagName)
+			klog.V(2).InfoS("  did not find required tag", "tag", mainTagName)
 			continue
 		}
 		if len(typesWith) == 1 && typesWith[0] == "" {
-			klog.Fatalf("found package tag %q with no value", tagName)
+			klog.Fatalf("found package tag %q with no value", mainTagName)
 		}
 		shouldCreateObjectValidationFn := func(t *types.Type) bool {
 			// opt-out
-			if checkTag(t.SecondClosestCommentLines, "false") {
+			if checkMainTag(t.SecondClosestCommentLines, "false") {
 				return false
 			}
 			// opt-in
-			if checkTag(t.SecondClosestCommentLines, "true") {
+			if checkMainTag(t.SecondClosestCommentLines, "true") {
 				return true
 			}
 


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR updates the `isSubresource` and `supportsSubresource` comment tags to use modern tag parsing logic. As part of this transition, the subresource paths (e.g., `/scale`, `/status`) are now required to be enclosed in double quotes (e.g., `"/scale"`, `"/status"`). 

These changes ensure consistency with the updated tag grammar and parsing utilities introduced in the `validation-gen` tool.

#### Which issue(s) this PR is related to:
This change is a follow-up to the updates in the `validation-gen` repository:
- **validation-gen PR:** [jpbetz/validation-gen#135](https://github.com/jpbetz/validation-gen/pull/135)

#### Special notes for your reviewer:
The core logic changes are located in `staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go`, where `extractAndParseTag` is introduced to handle the new parsing requirement. Corresponding updates have been applied to API type definitions across various groups (apps, autoscaling, certificates, core, extensions, resource, and storage).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```