### PR TITLE
Promote multiple validation-gen tags to beta

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -309,7 +309,7 @@ func (ektv eachKeyTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            ektv.TagName(),
 		Scopes:         ektv.ValidScopes().UnsortedList(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Description:    "Declares a validation for each value in a map or list.",
 		Payloads: []TagPayloadDoc{{
 			Description: "<validation-tag>",

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
@@ -59,7 +59,7 @@ func (immutableTagValidator) GetValidations(context Context, _ codetags.Tag) (Va
 func (itv immutableTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            itv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Scopes:         itv.ValidScopes().UnsortedList(),
 		Description:    "Indicates that a field may not be updated.",
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
@@ -323,7 +323,7 @@ func (utv uniqueTagValidator) GetValidations(context Context, tag codetags.Tag) 
 func (utv uniqueTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            utv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Scopes:         utv.ValidScopes().UnsortedList(),
 		Description:    "Declares that a list field's elements are unique. This tag can be used with listType=atomic to add uniqueness constraints, or independently to specify uniqueness semantics.",
 		Payloads: []TagPayloadDoc{{
@@ -373,7 +373,7 @@ func (cutv customUniqueTagValidator) GetValidations(context Context, tag codetag
 func (cutv customUniqueTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            cutv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Scopes:         cutv.ValidScopes().UnsortedList(),
 		Description:    "Indicates that uniqueness validation for this list is implemented via custom, handwritten validation. This disables generation of uniqueness validation for this list.",
 		Payloads:       nil,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/options.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/options.go
@@ -81,7 +81,7 @@ func (itv ifTagValidator) GetValidations(context Context, tag codetags.Tag) (Val
 func (itv ifTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            itv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Args: []TagArgDoc{{
 			Description: "<option>",
 			Type:        codetags.ArgTypeString,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
@@ -134,7 +134,7 @@ func constraintName(c validate.UpdateConstraint) string {
 func (utc updateTagCollector) Docs() TagDoc {
 	return TagDoc{
 		Tag:            utc.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Scopes:         utc.ValidScopes().UnsortedList(),
 		PayloadsType:   codetags.ValueTypeString,
 		Description: "Provides constraints on the allowed update operations of a field. " +


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR promotes the following `validation-gen` tags from Alpha to Beta:
- `customUnique`
- `eachKey`
- `ifDisabled`
- `ifEnabled`
- `immutable`
- `unique`
- `update`

As per KEP-5073, Beta tags are considered mature, have been tested, and are not expected to change in backward-incompatible ways. Promoting these tags allows usage of these tags with +k8s:beta validation tags. 

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md

#### Special notes for your reviewer:
These promotions fulfill the Alpha to Beta graduation criteria:
1. **Implementation Complete**: The validation logic for these tags is fully implemented and tested within the `validation-gen` framework. 
2. These tags are used in the k8s API. 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation:
```
- [KEP-5073]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
```

