### PR TITLE
kubectl: clarify --dry-run=client operation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -500,7 +500,7 @@ func AddDryRunFlag(cmd *cobra.Command) {
 	cmd.Flags().String(
 		"dry-run",
 		"none",
-		`Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.`,
+		`Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it (note the client strategy still requires access to the server to fetch discovery data and existing objects). If server strategy, submit server-side request without persisting the resource.`,
 	)
 	cmd.Flags().Lookup("dry-run").NoOptDefVal = "unchanged"
 }


### PR DESCRIPTION
--dry-run=client can be read as implying operation is isolated to the client, and thus requires no communication with the server.  As pointed out in the linked issue, this is not true.  Make it quite clear in the description.

Relates-to: https://github.com/kubernetes/kubernetes/issues/137214


/kind documentation

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```