### PR TITLE
Update `pkg/controller` to use slices.Contains

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -19,6 +19,7 @@ package disruption
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -440,13 +441,7 @@ func verifyGroupKind(controllerRef *metav1.OwnerReference, expectedKind string, 
 		return false, nil
 	}
 
-	for _, group := range expectedGroups {
-		if group == gv.Group {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return slices.Contains(expectedGroups, gv.Group), nil
 }
 
 func (dc *DisruptionController) Run(ctx context.Context) {

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"sync"
 	"time"
 
@@ -621,12 +622,7 @@ func hasOrphanFinalizer(accessor metav1.Object) bool {
 
 func hasFinalizer(accessor metav1.Object, matchingFinalizer string) bool {
 	finalizers := accessor.GetFinalizers()
-	for _, finalizer := range finalizers {
-		if finalizer == matchingFinalizer {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(finalizers, matchingFinalizer)
 }
 
 // this function takes newAccessor directly because the caller already

--- a/pkg/controller/garbagecollector/patch.go
+++ b/pkg/controller/garbagecollector/patch.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -114,14 +115,7 @@ func (gc *GarbageCollector) deleteOwnerRefJSONMergePatch(item *node, ownerUIDs .
 	expectedObjectMeta.ResourceVersion = accessor.GetResourceVersion()
 	refs := accessor.GetOwnerReferences()
 	for _, ref := range refs {
-		var skip bool
-		for _, ownerUID := range ownerUIDs {
-			if ref.UID == ownerUID {
-				skip = true
-				break
-			}
-		}
-		if !skip {
+		if !slices.Contains(ownerUIDs, ref.UID) {
 			expectedObjectMeta.OwnerReferences = append(expectedObjectMeta.OwnerReferences, ref)
 		}
 	}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -2018,10 +2019,8 @@ func getCompletionMode(job *batch.Job) string {
 }
 
 func appendJobCompletionFinalizerIfNotFound(finalizers []string) []string {
-	for _, fin := range finalizers {
-		if fin == batch.JobTrackingFinalizer {
-			return finalizers
-		}
+	if slices.Contains(finalizers, batch.JobTrackingFinalizer) {
+		return finalizers
 	}
 	return append(finalizers, batch.JobTrackingFinalizer)
 }

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strconv"
 	"testing"
@@ -8026,10 +8027,8 @@ func (pb podBuilder) phase(p v1.PodPhase) podBuilder {
 }
 
 func (pb podBuilder) trackingFinalizer() podBuilder {
-	for _, f := range pb.Finalizers {
-		if f == batch.JobTrackingFinalizer {
-			return pb
-		}
+	if slices.Contains(pb.Finalizers, batch.JobTrackingFinalizer) {
+		return pb
 	}
 	pb.Finalizers = append(pb.Finalizers, batch.JobTrackingFinalizer)
 	return pb

--- a/pkg/controller/job/pod_failure_policy.go
+++ b/pkg/controller/job/pod_failure_policy.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"fmt"
+	"slices"
 
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -122,19 +123,9 @@ func getMatchingContainerFromList(containerStatuses []v1.ContainerStatus, requir
 func isOnExitCodesOperatorMatching(exitCode int32, requirement *batch.PodFailurePolicyOnExitCodesRequirement) bool {
 	switch requirement.Operator {
 	case batch.PodFailurePolicyOnExitCodesOpIn:
-		for _, value := range requirement.Values {
-			if value == exitCode {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(requirement.Values, exitCode)
 	case batch.PodFailurePolicyOnExitCodesOpNotIn:
-		for _, value := range requirement.Values {
-			if value == exitCode {
-				return false
-			}
-		}
-		return true
+		return !slices.Contains(requirement.Values, exitCode)
 	default:
 		return false
 	}

--- a/pkg/controller/job/tracking_utils.go
+++ b/pkg/controller/job/tracking_utils.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 
 	batch "k8s.io/api/batch/v1"
@@ -124,12 +125,7 @@ func newUIDTrackingExpectations() *uidTrackingExpectations {
 }
 
 func hasJobTrackingFinalizer(pod *v1.Pod) bool {
-	for _, fin := range pod.Finalizers {
-		if fin == batch.JobTrackingFinalizer {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(pod.Finalizers, batch.JobTrackingFinalizer)
 }
 
 func recordFinishedPodWithTrackingFinalizer(oldPod, newPod *v1.Pod) {

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -19,6 +19,7 @@ package resourceclaim
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 	"testing"
@@ -1522,13 +1523,7 @@ func TestEnqueuePodExtendedResourceClaims(t *testing.T) {
 			if test.pod.Status.ExtendedResourceClaimStatus != nil {
 				expectedClaimKey = claimKeyPrefix + test.pod.Namespace + "/" + test.pod.Status.ExtendedResourceClaimStatus.ResourceClaimName
 			}
-			found := false
-			for _, k := range keys {
-				if k == expectedClaimKey {
-					found = true
-					break
-				}
-			}
+			found := slices.Contains(keys, expectedClaimKey)
 			if test.expectExtendedClaimEnqueued && !found {
 				t.Errorf("expected extended claim key %q to be enqueued, got keys: %v", expectedClaimKey, keys)
 			}

--- a/pkg/controller/servicecidrs/servicecidrs_controller.go
+++ b/pkg/controller/servicecidrs/servicecidrs_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/netip"
+	"slices"
 	"sync"
 	"time"
 
@@ -416,10 +417,8 @@ func (c *Controller) canDeleteCIDR(ctx context.Context, serviceCIDR *networkinga
 }
 
 func (c *Controller) addServiceCIDRFinalizerIfNeeded(ctx context.Context, cidr *networkingapiv1.ServiceCIDR) error {
-	for _, f := range cidr.GetFinalizers() {
-		if f == ServiceCIDRProtectionFinalizer {
-			return nil
-		}
+	if slices.Contains(cidr.GetFinalizers(), ServiceCIDRProtectionFinalizer) {
+		return nil
 	}
 
 	patch := map[string]interface{}{
@@ -441,14 +440,7 @@ func (c *Controller) addServiceCIDRFinalizerIfNeeded(ctx context.Context, cidr *
 }
 
 func (c *Controller) removeServiceCIDRFinalizerIfNeeded(ctx context.Context, cidr *networkingapiv1.ServiceCIDR) error {
-	found := false
-	for _, f := range cidr.GetFinalizers() {
-		if f == ServiceCIDRProtectionFinalizer {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !slices.Contains(cidr.GetFinalizers(), ServiceCIDRProtectionFinalizer) {
 		return nil
 	}
 	patch := map[string]interface{}{

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"reflect"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -3407,10 +3408,8 @@ func isOrHasInternalError(err error) bool {
 	}
 	var agg utilerrors.Aggregate
 	if errors.As(err, &agg) {
-		for _, e := range agg.Errors() {
-			if apierrors.IsInternalError(e) {
-				return true
-			}
+		if slices.ContainsFunc(agg.Errors(), apierrors.IsInternalError) {
+			return true
 		}
 	}
 	return apierrors.IsInternalError(err)

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -712,13 +713,7 @@ func verifyAttachDetachCalls(t *testing.T, testPlugin *controllervolumetesting.T
 						expectedNode, verify_op, tries)
 				}
 				for _, expectedVolume := range expectedVolumeList {
-					volFound = false
-					for _, volume := range volumeList {
-						if expectedVolume == volume {
-							volFound = true
-							break
-						}
-					}
+					volFound = slices.Contains(volumeList, expectedVolume)
 					if !volFound && tries == 10 {
 						t.Fatalf("Expected %v operation not found, node:%v, volume: %v, tries: %d",
 							verify_op, expectedNode, expectedVolume, tries)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

Use the `slices.Contains` under `pkg/controller`. There aren't that many instances.

```sh
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -slicescontains -fix -test ./...
```

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```