### PR TITLE
Remove a hidden goroutine in kubelet.

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -356,7 +356,7 @@ func (m *imageManager) pullImage(ctx context.Context, logPrefix string, objRef *
 	startTime := time.Now()
 
 	pullChan := make(chan pullResult)
-	m.puller.pullImage(ctx, imgSpec, pullCredentials, pullChan, podSandboxConfig)
+	go m.puller.pullImage(ctx, imgSpec, pullCredentials, pullChan, podSandboxConfig)
 	imagePullResult := <-pullChan
 	if imagePullResult.err != nil {
 		m.logIt(objRef, v1.EventTypeWarning, events.FailedToPullImage, logPrefix, fmt.Sprintf("Failed to pull image %q: %v", image, imagePullResult.err), klog.Warning)

--- a/pkg/kubelet/images/puller.go
+++ b/pkg/kubelet/images/puller.go
@@ -53,26 +53,24 @@ func newParallelImagePuller(imageService kubecontainer.ImageService, maxParallel
 }
 
 func (pip *parallelImagePuller) pullImage(ctx context.Context, spec kubecontainer.ImageSpec, credentials []credentialprovider.TrackedAuthConfig, pullChan chan<- pullResult, podSandboxConfig *runtimeapi.PodSandboxConfig) {
-	go func() {
-		if pip.tokens != nil {
-			pip.tokens <- struct{}{}
-			defer func() { <-pip.tokens }()
-		}
-		startTime := time.Now()
-		imageRef, creds, err := pip.imageService.PullImage(ctx, spec, credentials, podSandboxConfig)
-		var size uint64
-		if err == nil && imageRef != "" {
-			// Getting the image size with best effort, ignoring the error.
-			size, _ = pip.imageService.GetImageSize(ctx, spec)
-		}
-		pullChan <- pullResult{
-			imageRef:        imageRef,
-			imageSize:       size,
-			err:             err,
-			pullDuration:    time.Since(startTime),
-			credentialsUsed: creds,
-		}
-	}()
+	if pip.tokens != nil {
+		pip.tokens <- struct{}{}
+		defer func() { <-pip.tokens }()
+	}
+	startTime := time.Now()
+	imageRef, creds, err := pip.imageService.PullImage(ctx, spec, credentials, podSandboxConfig)
+	var size uint64
+	if err == nil && imageRef != "" {
+		// Getting the image size with best effort, ignoring the error.
+		size, _ = pip.imageService.GetImageSize(ctx, spec)
+	}
+	pullChan <- pullResult{
+		imageRef:        imageRef,
+		imageSize:       size,
+		err:             err,
+		pullDuration:    time.Since(startTime),
+		credentialsUsed: creds,
+	}
 }
 
 // Maximum number of image pull requests than can be queued.


### PR DESCRIPTION
#### What type of PR is this?

This was found using a semgrep rule to look for functions that only contain a nested go routine. This doesn't seem to be good practice. Instead, the caller should just invoke it as a go-routine.

https://github.com/semgrep/semgrep-rules/blob/develop/go/lang/best-practice/hidden-goroutine.yaml

It may be intentional, but there are different blog posts that describe it as an anti-pattern.
AWS has [a page](https://docs.aws.amazon.com/amazonq/detector-library/go/hidden-goroutine/) about it as well.

It is not the only hidden go-routine. There are 4-5 more.

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

I haven't dug around with a profiler or something like that. As written, it may be intentional that this function is defined the way it is.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
