### PR TITLE
Fix the issue where the kubelet fails to start normally when the rotating certificate is corrupted

### DIFF
--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -24,7 +24,9 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"os"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -43,6 +45,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	netutils "k8s.io/utils/net"
 )
+
+const pairNamePrefix = "kubelet-client"
 
 func newGetTemplateFn(nodeName types.NodeName, getAddresses func() []v1.NodeAddress) func() *x509.CertificateRequest {
 	return func() *x509.CertificateRequest {
@@ -207,7 +211,7 @@ func NewKubeletClientCertificateManager(
 ) (certificate.Manager, error) {
 
 	certificateStore, err := certificate.NewFileStore(
-		"kubelet-client",
+		pairNamePrefix,
 		certDirectory,
 		certDirectory,
 		certFile,
@@ -247,6 +251,9 @@ func NewKubeletClientCertificateManager(
 		CertificateRenewFailure: certificateRenewFailure,
 	})
 	if err != nil {
+		if isParseRotateErr(err) {
+			removeRotateFile(certDirectory, pairNamePrefix)
+		}
 		return nil, fmt.Errorf("failed to initialize client certificate manager: %v", err)
 	}
 
@@ -319,4 +326,32 @@ func (m *kubeletServerCertificateDynamicFileManager) Stop() {
 // ServerHealthy always returns true since the file manager doesn't communicate with any server
 func (m *kubeletServerCertificateDynamicFileManager) ServerHealthy() bool {
 	return true
+}
+
+func isParseRotateErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if err.Error() == "" {
+		return false
+	}
+	if strings.Contains(err.Error(), certificate.ParserotateCertFailMsg) {
+		return true
+	}
+	return false
+}
+
+func removeRotateFile(certDirectory, certNamePrefix string) {
+	logger := klog.TODO()
+	store, err := certificate.NewFileStore(certNamePrefix, certDirectory, certDirectory, "", "")
+	if err != nil || store == nil {
+		logger.Info("Skip to delete residual rotation certificate file", "err", err)
+		return
+	}
+	fileName := store.CurrentPath()
+	logger.Info("Delete residual rotation certificate file", "path", fileName)
+	err = os.Remove(fileName)
+	if err != nil {
+		logger.Info("Delete residual rotation certificate file failed", "err", err)
+	}
 }

--- a/pkg/kubelet/certificate/kubelet_test.go
+++ b/pkg/kubelet/certificate/kubelet_test.go
@@ -19,6 +19,7 @@ package certificate
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
@@ -26,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,7 +35,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/certificate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	netutils "k8s.io/utils/net"
@@ -404,5 +408,60 @@ func TestNewCertificateManagerConfigGetTemplate(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func TestNewKubeletClientCertificateManager_ParseRotateCertFail(t *testing.T) {
+	certDir := t.TempDir()
+	nodeName := types.NodeName("test-node")
+
+	// Generate valid bootstrap cert and key
+	bootstrapCert, bootstrapKey, err := cert.GenerateSelfSignedCertKey("k8s.io", nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to generate bootstrap cert/key: %v", err)
+	}
+
+	// Create an invalid current cert file that will cause parse failure
+	// The file store looks for <pairNamePrefix>-current.pem first
+	currentCertFileName := filepath.Join(certDir, "kubelet-client-current.pem")
+	invalidCertData := []byte("invalid-certificate-data-that-will-cause-parse-failure")
+	if err := os.WriteFile(currentCertFileName, invalidCertData, 0644); err != nil {
+		t.Fatalf("Failed to write invalid current cert file: %v", err)
+	}
+
+	// Verify the current cert file exists before calling NewKubeletClientCertificateManager
+	if _, err := os.Stat(currentCertFileName); err != nil {
+		t.Fatalf("Current cert file should exist before test: %v", err)
+	}
+
+	// Call NewKubeletClientCertificateManager with bootstrap data
+	// This should trigger the parse rotate cert failure and cleanup
+	clientsetFn := func(current *tls.Certificate) (clientset.Interface, error) {
+		return nil, nil
+	}
+
+	_, err = NewKubeletClientCertificateManager(
+		certDir,
+		nodeName,
+		bootstrapCert,
+		bootstrapKey,
+		"", // certFile - empty, will use store
+		"", // keyFile - empty, will use store
+		clientsetFn,
+	)
+
+	// We expect an error containing ParserotatCertFailMsg
+	if err == nil {
+		t.Fatal("Expected error from NewKubeletClientCertificateManager, got nil")
+	}
+
+	// Verify the error contains the ParserotatCertFailMsg
+	if !strings.Contains(err.Error(), certificate.ParserotateCertFailMsg) {
+		t.Errorf("Expected error to contain %q, got: %v", certificate.ParserotateCertFailMsg, err)
+	}
+
+	// Verify the current cert file was cleaned up by removeRotateFile
+	if _, err := os.Stat(currentCertFileName); !os.IsNotExist(err) {
+		t.Errorf("Expected current cert file to be removed after parse failure, but it still exists")
 	}
 }

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_store.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_store.go
@@ -35,6 +35,8 @@ const (
 	pemExtension  = ".pem"
 	currentPair   = "current"
 	updatedPair   = "updated"
+
+	ParserotateCertFailMsg = "parse rotate cert failed"
 )
 
 type fileStore struct {
@@ -191,11 +193,11 @@ func loadFile(pairFile string) (*tls.Certificate, error) {
 	// the same file.
 	cert, err := tls.LoadX509KeyPair(pairFile, pairFile)
 	if err != nil {
-		return nil, fmt.Errorf("could not convert data from %q into cert/key pair: %v", pairFile, err)
+		return nil, fmt.Errorf("%s, could not convert data from %q into cert/key pair: %w", ParserotateCertFailMsg, pairFile, err)
 	}
 	certs, err := x509.ParseCertificates(cert.Certificate[0])
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse certificate data: %v", err)
+		return nil, fmt.Errorf("%s, unable to parse certificate data: %w", ParserotateCertFailMsg, err)
 	}
 	cert.Leaf = certs[0]
 	return &cert, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When the rotating certificate generated by kubelet becomes corrupted, it should be able to rotate again instead of continuously failing to start.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
When the kubelet starts and fails to load the rotating certificate, the current implementation directly returns an error, causing the kubelet to fail to start.
A more reasonable approach would be to continue attempting to use other certificate configurations.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 "NONE"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
