### PR TITLE
kubeadm: do not add learner member to etcd client endpoints

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -533,8 +533,10 @@ func (c *Client) addMember(name string, peerAddrs string, isLearner bool) ([]Mem
 		ret = append(ret, Member{Name: memberName, PeerURL: m.PeerURLs[0]})
 	}
 
-	// Add the new member client address to the list of endpoints
-	c.Endpoints = append(c.Endpoints, GetClientURLByIP(parsedPeerAddrs.Hostname()))
+	if !isLearner {
+		// Add the new member client address to the list of endpoints
+		c.Endpoints = append(c.Endpoints, GetClientURLByIP(parsedPeerAddrs.Hostname()))
+	}
 
 	return ret, nil
 }


### PR DESCRIPTION
When adding an etcd learner, skip appending its client URL to c.Endpoints since learners do not serve client traffic.


#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubeadm/issues/3287

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: do not add learner member to etcd client endpoints
```
