### PR TITLE
Use localhost Image Reference in PodObservedGenerationTracking E2E Test

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -695,7 +695,7 @@ var _ = SIGDescribe("Pods Extended (pod generation)", func() {
 			// Set the pod image to something that doesn't exist to induce a pull error
 			// to start with.
 			agnImage := pod.Spec.Containers[0].Image
-			pod.Spec.Containers[0].Image = "some-image-that-doesnt-exist"
+			pod.Spec.Containers[0].Image = "localhost/some-image-that-doesnt-exist"
 
 			ginkgo.By("submitting the pod to kubernetes")
 			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The `PodObservedGenerationTracking` e2e test creates a pod with an invalid image
(`some-image-that-doesnt-exist`) to induce a pull error, then updates the image to a
valid one and verifies that the pod conditions' `observedGeneration` field increments
from 1 to 2.

In a disconnected downstream test environment, we occasionally experience timeouts due
to DNS resolution issues — the kubelet spends too long trying to resolve the non-existent
image reference against external registries (often >30s), exceeding the test's 30-second
timeout before the `observedGeneration` update can be observed.

This PR changes the invalid image reference from `some-image-that-doesnt-exist` to
`localhost/some-image-that-doesnt-exist`, which fails instantly because there is no
container registry running on localhost. This eliminates the dependency on external
DNS/registry resolution timing.

**Files changed:**
- `test/e2e/node/pods.go` — Updated invalid image reference to use `localhost/`,
  ensuring instant pull failure regardless of environment network conditions.

**Output:** 

[sig-node] Pods Extended (pod generation) Pod Generation
  pod observedGeneration field set in pod conditions

  STEP: creating the pod
  STEP: submitting the pod to kubernetes
  STEP: verifying the pod conditions have observedGeneration values
  STEP: updating pod to have a valid image
  STEP: verifying the pod conditions have updated observedGeneration values
  STEP: deleting the pod
  • [8.041 seconds]

Ran 1 of 7432 Specs in 11.278 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 7431 Skipped
--- PASS: TestE2E (11.37s)
PASS

#### Which issue(s) this PR is related to:

[[OCPBUGS-76599](https://issues.redhat.com/browse/OCPBUGS-76599)]

#### Special notes for your reviewer:

The flake was observed on bare-metal test environments where DNS resolution for
non-existent images can take longer than 30 seconds, causing the test to time out
waiting for `PodReadyToStartContainers` generation to reach 2.

CRI-O performs the DNS resolution. When kubelet calls CRI-O's PullImage RPC with the unqualified image name some-image-that-doesnt-exist, CRI-O resolves it using the search registries configured in /etc/containers/registries.conf. It tries each registry in order, resolving hostnames via DNS to IPv6 addresses, then attempting TCP connections.

### CRI-O delay logs from the failing job:
#### Pull starts at 23:47:35
23:47:35 crio: Pulling image: some-image-that-doesnt-exist:latest
23:47:35 crio: Resolving "some-image-that-doesnt-exist" using unqualified-search registries (/etc/containers/registries.conf)
####  Registry 1: registry.access.redhat.com — 4 attempts, ~9s
23:47:35 crio: Trying to access "registry.access.redhat.com/some-image-that-doesnt-exist:latest"
23:47:35 crio: Failed, retrying in 1s ... (1/3). Error: dial tcp [2600:1f18:483:cf00:af67:510b:cf9c:7a0]:443: connect: network is unreachable
23:47:38 crio: Failed, retrying in 1s ... (2/3). Error: dial tcp [2600:1f18:483:cf00:af67:510b:cf9c:7a0]:443: connect: network is unreachable
23:47:41 crio: Failed, retrying in 1s ... (3/3). Error: dial tcp [2600:1f18:483:cf00:af67:510b:cf9c:7a0]:443: connect: network is unreachable
####  Registry 2: docker.io — 4 attempts, ~63s (includes ~22s TCP i/o timeouts)
23:47:44 crio: Trying to access "docker.io/library/some-image-that-doesnt-exist:latest"
23:48:20 crio: Failed, retrying in 1s ... (1/3). Error: dial tcp [2600:1f18:2148:bc00:dd52:4aa:861c:abce]:443: i/o timeout
23:48:33 crio: Failed, retrying in 1s ... (2/3). Error: dial tcp [2600:1f18:2148:bc00:7f80:bfb7:6189:bcf4]:443: connect: network is unreachable
23:48:40 crio: Failed, retrying in 1s ... (3/3). Error: dial tcp [2600:1f18:2148:bc00:7f80:bfb7:6189:bcf4]:443: connect: network is unreachable

####  Final failure at 23:48:47 — 72 seconds after pull started
23:48:47 kubelet: PullImage from image service failed: rpc error: code = DeadlineExceeded

DNS resolves the registry hostnames to IPv6 addresses successfully, but the bare-metal IPv6 environment cannot route to external registries, causing "network is unreachable" (instant fail) and "i/o timeout" (~22s) errors. CRI-O retries 3 times per registry with backoff, accumulating to 72 seconds total — far exceeding the test's 30-second timeout for observedGeneration to converge.

####  Regression Analysis
This is not a regression. The image name some-image-that-doesnt-exist was introduced in the original commit that added this test:
The test was likely developed and validated on GCE/cloud environments where connection failures to external registries happen quickly. On bare-metal IPv6 environments, the same image name causes CRI-O to spend 72 seconds iterating through unqualified-search registries with retries. This is an environment-specific failure that has existed since the test was introduced.

####  Fix
Change the image to localhost/some-image-that-doesnt-exist. With localhost:
- No unqualified-search registry resolution needed (the registry is explicitly localhost)
- Connection to localhost:443 is immediately refused (no registry listening)
- The pull fails in milliseconds instead of accumulating 72 seconds of retry delays



Tested the fix against a live cluster — the test passed in ~8 seconds:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NA
```