### PR TITLE
 DRA: start scheduler after creating binding/non-binding slicesin Basicflow

### DIFF
--- a/test/integration/dra/binding_conditions_test.go
+++ b/test/integration/dra/binding_conditions_test.go
@@ -62,6 +62,28 @@ func testDeviceBindingConditionsBasicFlow(tCtx ktesting.TContext, enabled bool) 
 	class, driverName := createTestClass(tCtx, namespace)
 	startScheduler(tCtx)
 
+	// Create slice without binding conditions first so it gets allocated first
+	sliceWithoutBinding := &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: namespace + "-without-binding-",
+		},
+		Spec: resourceapi.ResourceSliceSpec{
+			NodeName: &nodeName,
+			Pool: resourceapi.ResourcePool{
+				Name:               poolWithoutBinding,
+				ResourceSliceCount: 1,
+			},
+			Driver: driverName,
+			Devices: []resourceapi.Device{
+				{
+					Name: "without-binding",
+				},
+			},
+		},
+	}
+	_, err := tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, sliceWithoutBinding, metav1.CreateOptions{FieldValidation: "Strict"})
+	tCtx.ExpectNoError(err, "create slice without binding conditions")
+
 	slice := &resourceapi.ResourceSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: namespace + "-",
@@ -82,7 +104,7 @@ func testDeviceBindingConditionsBasicFlow(tCtx ktesting.TContext, enabled bool) 
 			},
 		},
 	}
-	slice, err := tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, slice, metav1.CreateOptions{FieldValidation: "Strict"})
+	slice, err = tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, slice, metav1.CreateOptions{FieldValidation: "Strict"})
 	tCtx.ExpectNoError(err, "create slice")
 
 	haveBindingConditionFields := len(slice.Spec.Devices[0].BindingConditions) > 0 || len(slice.Spec.Devices[0].BindingFailureConditions) > 0
@@ -95,27 +117,6 @@ func testDeviceBindingConditionsBasicFlow(tCtx ktesting.TContext, enabled bool) 
 	if !haveBindingConditionFields {
 		tCtx.Fatalf("Expected device binding condition fields to be stored, got instead:\n%s", format.Object(slice, 1))
 	}
-
-	sliceWithoutBinding := &resourceapi.ResourceSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: namespace + "-without-binding-",
-		},
-		Spec: resourceapi.ResourceSliceSpec{
-			NodeName: &nodeName,
-			Pool: resourceapi.ResourcePool{
-				Name:               poolWithoutBinding,
-				ResourceSliceCount: 1,
-			},
-			Driver: driverName,
-			Devices: []resourceapi.Device{
-				{
-					Name: "without-binding",
-				},
-			},
-		},
-	}
-	_, err = tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, sliceWithoutBinding, metav1.CreateOptions{FieldValidation: "Strict"})
-	tCtx.ExpectNoError(err, "create slice without binding conditions")
 
 	// Schedule first pod and wait for the scheduler to reach the binding phase, which marks the claim as allocated.
 	start := time.Now()


### PR DESCRIPTION
/kind flake
/kind failing-test
Fixed https://github.com/kubernetes/kubernetes/issues/133435

What this PR does / why we need it:
This PR stabilizes TestDRA/all/DeviceBindingConditions/BasicFlow in binding_conditions_test.go.

The test expects the first claim to allocate without-binding, but in CI the first allocation occasionally came back as with-binding, causing a mismatch like:

actual first allocation: worker-0-with-binding / with-binding
expected first allocation: worker-0-without-binding / without-binding
```
Expected
        		    <v1.DeviceAllocationResult>: 
        		        results:
        		        - bindingConditions:
        		          - attached
        		          bindingFailureConditions:
        		          - failed
        		          device: with-binding
        		          driver: testdra-all-devicebindingconditions-basicflow-28t9x.driver
        		          pool: worker-0-with-binding
        		          request: req-1
        		to equal
        		    <v1.DeviceAllocationResult>: 
        		        results:
        		        - device: without-binding
        		          driver: testdra-all-devicebindingconditions-basicflow-28t9x.driver
        		          pool: worker-0-without-binding
        		          request: req-1
```
To make the test deterministic, the ResourceSlice without binding conditions is created before the slice with binding conditions, so the initial allocation path consistently matches test expectations.

Which issue(s) this PR is related to:
N/A

```release-note
NONE
```
