### PR TITLE
Ktesting: contexthelper panic + test fix

### DIFF
--- a/test/utils/ktesting/contexthelper_test.go
+++ b/test/utils/ktesting/contexthelper_test.go
@@ -119,7 +119,11 @@ func TestCause(t *testing.T) {
 						assert.Equal(t, tt.expectDeadline, time.Until(actualDeadline), "remaining time till Deadline()")
 					}
 				}
+				// Unblock background goroutines.
 				time.Sleep(tt.sleep)
+				// Wait for them to do their work.
+				synctest.Wait()
+				// Now check.
 				actualErr := ctx.Err()
 				actualCause := context.Cause(ctx)
 				assert.Equal(t, tt.expectErr, actualErr, "ctx.Err()")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

From the commit messages:

I've not been able to trigger the unit test flake, but it could happen:
- time.Sleep unblocks some background goroutines inside the synctest bubble.
- Those goroutines do not actually run yet.
- The main test checks for the result of those goroutines.
    
Adding a `synctest.Wait` ensures that all background processing is complete because it waits for all goroutines to be durably blocked.

If the goroutine happens to log after the test has already terminated, testing.T.Log panics. We must ensure that the goroutine has stopped before allowing the test to terminate.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a continuation of https://github.com/kubernetes/kubernetes/pull/137253.

/cc @tsj-30
/assign @Karthik-K-N 

#### Does this PR introduce a user-facing change?

Only affects tests, not user-facing.

```release-note
NONE
```
