### PR TITLE
Automated cherry pick of #137251: kubeadm: do not add learner member to etcd client endpoints

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -533,8 +533,10 @@ func (c *Client) addMember(name string, peerAddrs string, isLearner bool) ([]Mem
 		ret = append(ret, Member{Name: memberName, PeerURL: m.PeerURLs[0]})
 	}
 
-	// Add the new member client address to the list of endpoints
-	c.Endpoints = append(c.Endpoints, GetClientURLByIP(parsedPeerAddrs.Hostname()))
+	if !isLearner {
+		// Add the new member client address to the list of endpoints
+		c.Endpoints = append(c.Endpoints, GetClientURLByIP(parsedPeerAddrs.Hostname()))
+	}
 
 	return ret, nil
 }


### PR DESCRIPTION
Cherry pick of #137251 on release-1.34.

#137251: kubeadm: do not add learner member to etcd client endpoints

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: do not add learner member to etcd client endpoints
```