### PR TITLE
apimachinery: fix DeepDerivative slice trailing removals

### DIFF
--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
@@ -348,7 +348,7 @@ func (e Equalities) deepValueDerive(v1, v2 reflect.Value, visited map[visit]bool
 		if v1.IsNil() || v1.Len() == 0 {
 			return true
 		}
-		if v1.Len() > v2.Len() {
+		if v1.Len() != v2.Len() {
 			return false
 		}
 		if v1.Pointer() == v2.Pointer() {

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
@@ -151,7 +151,7 @@ func TestDerivatives(t *testing.T) {
 		{[]string(nil), []string{}, true},
 		{[]string{"1"}, []string(nil), false},
 		{[]string{}, []string{"1", "2", "3"}, true},
-		{[]string{"1"}, []string{"1", "2", "3"}, true},
+		{[]string{"1"}, []string{"1", "2", "3"}, false},
 		{[]string{"1", "2", "3"}, []string{}, false},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
This fixes `equality.Semantic.DeepDerivative` for slices by rejecting prefix-only matches.
Previously, extra trailing items in existing were ignored; now desired slices must match existing length (eg `["--foo","--bar"]` vs `["--foo","--bar","--baz"]` returns false).
#### Which issue(s) this PR is related to:
Fixes #136991

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `apiequality.Semantic.DeepDerivative` function fixes slice comparisons to treat a RHS slice with additional items compared to a non-empty LHS slice as different. For example, `[1]` and `[1,2,3]` were previously considered identical, and are now considered different.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
