### PR TITLE
Support async moveAllToActiveOrBackoffQueue in scheduler

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -880,6 +880,13 @@ const (
 	// which benefits to reduce the useless requeueing.
 	SchedulerQueueingHints featuregate.Feature = "SchedulerQueueingHints"
 
+	// owner: @KunWuLuan
+	//
+	// Enables batch processing of MoveAllToActiveOrBackoffQueue events.
+	// Instead of immediately moving unschedulable pods, events are buffered
+	// and processed in batch every 1 second to reduce lock contention.
+	SchedulerBatchMoveUnschedulablePods featuregate.Feature = "SchedulerBatchMoveUnschedulablePods"
+
 	// owner: @atosatto @yuanchen8911
 	// kep: http://kep.k8s.io/3902
 	//
@@ -1748,6 +1755,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	},
+
+	SchedulerBatchMoveUnschedulablePods: {
+		{Version: version.MustParse("1.36"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	SeparateTaintEvictionController: {

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -210,8 +210,18 @@ type PriorityQueue struct {
 	isSchedulingQueueHintEnabled bool
 	// isPopFromBackoffQEnabled indicates whether the feature gate SchedulerPopFromBackoffQ is enabled.
 	isPopFromBackoffQEnabled bool
+
 	// isGenericWorkloadEnabled indicates whether the feature gate GenericWorkload is enabled.
 	isGenericWorkloadEnabled bool
+
+	// isBatchMoveUnschedulablePodsEnabled indicates whether the feature gate
+	// SchedulerBatchMoveUnschedulablePods is enabled.
+	isBatchMoveUnschedulablePodsEnabled bool
+
+	// pendingMoveEvents buffers events from MoveAllToActiveOrBackoffQueue calls.
+	// These events are processed in batch by flushPendingMoveEvents every 1 second.
+	pendingMoveEventsLock sync.Mutex
+	pendingMoveEvents     []pendingMoveEvent
 }
 
 // QueueingHintFunction is the wrapper of QueueingHintFn that has PluginName.
@@ -227,6 +237,15 @@ type clusterEvent struct {
 	oldObj interface{}
 	// newObj is the object that involved this event.
 	newObj interface{}
+}
+
+// pendingMoveEvent stores a buffered MoveAllToActiveOrBackoffQueue event
+// for batch processing.
+type pendingMoveEvent struct {
+	event    fwk.ClusterEvent
+	oldObj   interface{}
+	newObj   interface{}
+	preCheck PreEnqueueCheck
 }
 
 type priorityQueueOptions struct {
@@ -358,25 +377,27 @@ func NewPriorityQueue(
 	isSchedulingQueueHintEnabled := utilfeature.DefaultFeatureGate.Enabled(features.SchedulerQueueingHints)
 	isPopFromBackoffQEnabled := utilfeature.DefaultFeatureGate.Enabled(features.SchedulerPopFromBackoffQ)
 	isGenericWorkloadEnabled := utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload)
+	isBatchMoveUnschedulablePodsEnabled := utilfeature.DefaultFeatureGate.Enabled(features.SchedulerBatchMoveUnschedulablePods)
 	lessConverted := convertLessFn(lessFn)
 
 	backoffQ := newBackoffQueue(options.clock, options.podInitialBackoffDuration, options.podMaxBackoffDuration, lessFn, isPopFromBackoffQEnabled)
 	pq := &PriorityQueue{
-		clock:                             options.clock,
-		stop:                              make(chan struct{}),
-		podMaxInUnschedulablePodsDuration: options.podMaxInUnschedulablePodsDuration,
-		backoffQ:                          backoffQ,
-		unschedulablePods:                 newUnschedulablePods(metrics.NewUnschedulablePodsRecorder(), metrics.NewGatedPodsRecorder()),
-		preEnqueuePluginMap:               options.preEnqueuePluginMap,
-		queueingHintMap:                   options.queueingHintMap,
-		pluginToEventsMap:                 buildEventMap(options.queueingHintMap),
-		metricsRecorder:                   options.metricsRecorder,
-		pluginMetricsSamplePercent:        options.pluginMetricsSamplePercent,
-		moveRequestCycle:                  -1,
-		apiDispatcher:                     options.apiDispatcher,
-		isSchedulingQueueHintEnabled:      isSchedulingQueueHintEnabled,
-		isPopFromBackoffQEnabled:          isPopFromBackoffQEnabled,
-		isGenericWorkloadEnabled:          isGenericWorkloadEnabled,
+		clock:                               options.clock,
+		stop:                                make(chan struct{}),
+		podMaxInUnschedulablePodsDuration:   options.podMaxInUnschedulablePodsDuration,
+		backoffQ:                            backoffQ,
+		unschedulablePods:                   newUnschedulablePods(metrics.NewUnschedulablePodsRecorder(), metrics.NewGatedPodsRecorder()),
+		preEnqueuePluginMap:                 options.preEnqueuePluginMap,
+		queueingHintMap:                     options.queueingHintMap,
+		pluginToEventsMap:                   buildEventMap(options.queueingHintMap),
+		metricsRecorder:                     options.metricsRecorder,
+		pluginMetricsSamplePercent:          options.pluginMetricsSamplePercent,
+		moveRequestCycle:                    -1,
+		apiDispatcher:                       options.apiDispatcher,
+		isSchedulingQueueHintEnabled:        isSchedulingQueueHintEnabled,
+		isGenericWorkloadEnabled:            isGenericWorkloadEnabled,
+		isPopFromBackoffQEnabled:            isPopFromBackoffQEnabled,
+		isBatchMoveUnschedulablePodsEnabled: isBatchMoveUnschedulablePodsEnabled,
 	}
 	var backoffQPopper backoffQPopper
 	if isPopFromBackoffQEnabled {
@@ -418,6 +439,13 @@ func (p *PriorityQueue) Run(logger klog.Logger) {
 	go wait.Until(func() {
 		p.flushUnschedulablePodsLeftover(logger)
 	}, 30*time.Second, p.stop)
+	// Flush buffered MoveAllToActiveOrBackoffQueue events every 1 second.
+	// Only when the feature gate is enabled.
+	if p.isBatchMoveUnschedulablePodsEnabled {
+		go wait.Until(func() {
+			p.flushPendingMoveEvents(logger)
+		}, 1*time.Second, p.stop)
+	}
 }
 
 // queueingStrategy indicates how the scheduling queue should enqueue the Pod from unschedulable pod pool.
@@ -974,6 +1002,74 @@ func (p *PriorityQueue) flushUnschedulablePodsLeftover(logger klog.Logger) {
 	}
 }
 
+// flushPendingMoveEvents drains the buffered events and processes all unschedulable pods.
+// For each pod, if it matches ANY buffered event, it is moved to activeQ or backoffQ.
+// This is called every 1 second by a background goroutine.
+func (p *PriorityQueue) flushPendingMoveEvents(logger klog.Logger) {
+	// Drain pending events atomically
+	p.pendingMoveEventsLock.Lock()
+	if len(p.pendingMoveEvents) == 0 {
+		p.pendingMoveEventsLock.Unlock()
+		return
+	}
+	events := p.pendingMoveEvents
+	p.pendingMoveEvents = nil
+	p.pendingMoveEventsLock.Unlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	// Filter to only events that some plugins are interested in
+	var interestingEvents []pendingMoveEvent
+	for _, e := range events {
+		if p.isEventOfInterest(logger, e.event) {
+			interestingEvents = append(interestingEvents, e)
+		}
+	}
+	if len(interestingEvents) == 0 {
+		return
+	}
+	// Build candidate list from unschedulable pods (to avoid modifying map during iteration)
+	candidates := make([]*framework.QueuedPodInfo, 0, len(p.unschedulablePods.podInfoMap))
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
+		candidates = append(candidates, pInfo)
+	}
+	activated := false
+	for _, pInfo := range candidates {
+		bestStrategy := queueSkip
+		var bestEventLabel string
+		for _, e := range interestingEvents {
+			// Apply preCheck filter
+			if e.preCheck != nil && !e.preCheck(pInfo.Pod) {
+				continue
+			}
+			// Check gating
+			if pInfo.Gated() && !framework.MatchAnyClusterEvent(e.event, pInfo.GatingPluginEvents) {
+				continue
+			}
+			hint := p.isPodWorthRequeuing(logger, pInfo, e.event, e.oldObj, e.newObj)
+			if hint == queueImmediately {
+				bestStrategy = queueImmediately
+				bestEventLabel = e.event.Label()
+				break // can't do better than immediate
+			}
+			if hint == queueAfterBackoff && bestStrategy == queueSkip {
+				bestStrategy = queueAfterBackoff
+				bestEventLabel = e.event.Label()
+			}
+		}
+		if bestStrategy != queueSkip {
+			p.unschedulablePods.delete(pInfo.Pod, pInfo.Gated())
+			queue := p.requeuePodWithQueueingStrategy(logger, pInfo, bestStrategy, bestEventLabel)
+			logger.V(5).Info("Pod moved to an internal scheduling queue during batch flush", "pod", klog.KObj(pInfo.Pod), "event", bestEventLabel, "queue", queue)
+			if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
+				activated = true
+			}
+		}
+	}
+	if activated {
+		p.activeQ.broadcast()
+	}
+}
+
 // Pop removes the head of the active queue and returns it. It blocks if the
 // activeQ is empty and waits until a new item is added to the queue. It
 // increments scheduling cycle when a pod is popped.
@@ -1226,10 +1322,8 @@ func (p *PriorityQueue) AssignedPodUpdated(logger klog.Logger, oldPod, newPod *v
 }
 
 // NOTE: this function assumes a lock has been acquired in the caller.
-// moveAllToActiveOrBackoffQueue moves all pods from unschedulablePods to activeQ or backoffQ.
-// This function adds all pods and then signals the condition variable to ensure that
-// if Pop() is waiting for an item, it receives the signal after all the pods are in the
-// queue and the head is the highest priority pod.
+// moveAllToActiveOrBackoffQueue buffers the event for batch processing if the feature gate is enabled.
+// The actual pod moves are performed by flushPendingMoveEvents every 1 second.
 func (p *PriorityQueue) moveAllToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck) {
 	if !p.isEventOfInterest(logger, event) {
 		// No plugin is interested in this event.
@@ -1237,23 +1331,71 @@ func (p *PriorityQueue) moveAllToActiveOrBackoffQueue(logger klog.Logger, event 
 		return
 	}
 
-	unschedulablePods := make([]*framework.QueuedPodInfo, 0, len(p.unschedulablePods.podInfoMap))
-	for _, pInfo := range p.unschedulablePods.podInfoMap {
-		if preCheck == nil || preCheck(pInfo.Pod) {
-			unschedulablePods = append(unschedulablePods, pInfo)
+	// If batch move is disabled, use the old behavior
+	if !p.isBatchMoveUnschedulablePodsEnabled {
+		unschedulablePods := make([]*framework.QueuedPodInfo, 0, len(p.unschedulablePods.podInfoMap))
+		for _, pInfo := range p.unschedulablePods.podInfoMap {
+			if preCheck == nil || preCheck(pInfo.Pod) {
+				unschedulablePods = append(unschedulablePods, pInfo)
+			}
+		}
+		p.movePodsToActiveOrBackoffQueue(logger, unschedulablePods, event, oldObj, newObj)
+		return
+	}
+
+	// Buffer the event for batch processing of unschedulable pods
+	p.pendingMoveEventsLock.Lock()
+	p.pendingMoveEvents = append(p.pendingMoveEvents, pendingMoveEvent{
+		event:    event,
+		oldObj:   oldObj,
+		newObj:   newObj,
+		preCheck: preCheck,
+	})
+	p.pendingMoveEventsLock.Unlock()
+
+	// Still update moveRequestCycle and register in-flight events immediately for correctness
+	p.moveRequestCycle = p.activeQ.schedulingCycle()
+	if p.isSchedulingQueueHintEnabled {
+		if added := p.activeQ.addEventIfAnyInFlight(oldObj, newObj, event); added {
+			logger.V(5).Info("Event received while pods are in flight", "event", event.Label())
 		}
 	}
-	p.movePodsToActiveOrBackoffQueue(logger, unschedulablePods, event, oldObj, newObj)
 }
 
-// MoveAllToActiveOrBackoffQueue moves all pods from unschedulablePods to activeQ or backoffQ.
-// This function adds all pods and then signals the condition variable to ensure that
-// if Pop() is waiting for an item, it receives the signal after all the pods are in the
-// queue and the head is the highest priority pod.
+// MoveAllToActiveOrBackoffQueue buffers the event for batch processing if the feature gate is enabled.
+// The actual pod moves are performed by flushPendingMoveEvents every 1 second.
+// A pod that matches ANY buffered event will be moved to activeQ or backoffQ.
 func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck) {
+	// If batch move is disabled, use the old behavior
+	if !p.isBatchMoveUnschedulablePodsEnabled {
+		p.lock.Lock()
+		defer p.lock.Unlock()
+		p.moveAllToActiveOrBackoffQueue(logger, event, oldObj, newObj, preCheck)
+		return
+	}
+
+	// Buffer the event for batch processing of unschedulable pods
+	p.pendingMoveEventsLock.Lock()
+	p.pendingMoveEvents = append(p.pendingMoveEvents, pendingMoveEvent{
+		event:    event,
+		oldObj:   oldObj,
+		newObj:   newObj,
+		preCheck: preCheck,
+	})
+	p.pendingMoveEventsLock.Unlock()
+
+	// Still update moveRequestCycle and register in-flight events immediately for correctness,
+	// but only if the event is of interest to any plugin (matching original behavior).
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	p.moveAllToActiveOrBackoffQueue(logger, event, oldObj, newObj, preCheck)
+	if p.isEventOfInterest(logger, event) {
+		p.moveRequestCycle = p.activeQ.schedulingCycle()
+		if p.isSchedulingQueueHintEnabled {
+			if added := p.activeQ.addEventIfAnyInFlight(oldObj, newObj, event); added {
+				logger.V(5).Info("Event received while pods are in flight", "event", event.Label())
+			}
+		}
+	}
 }
 
 // requeuePodWithQueueingStrategy tries to requeue Pod to activeQ, backoffQ or unschedulable pod pool based on schedulingHint.

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -820,6 +820,7 @@ func Test_InFlightPods(t *testing.T) {
 					popPod(t, logger, q, action.podPopped)
 				case action.eventHappens != nil:
 					q.MoveAllToActiveOrBackoffQueue(logger, *action.eventHappens, nil, nil, nil)
+					q.flushPendingMoveEvents(logger)
 				case action.podEnqueued != nil:
 					err := q.AddUnschedulableIfNotPresent(logger, action.podEnqueued, q.SchedulingCycle())
 					if err != nil {
@@ -947,6 +948,7 @@ func TestPop(t *testing.T) {
 
 			// Activate it again.
 			q.MoveAllToActiveOrBackoffQueue(logger, pvAdd, nil, nil, nil)
+			q.flushPendingMoveEvents(logger)
 
 			// Now check result of Pop.
 			poppedPod = popPod(t, logger, q, pod)
@@ -1022,6 +1024,7 @@ func TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff(t *testing.T) {
 
 	// move all pods to active queue when we were trying to schedule them
 	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 	oldCycle := q.SchedulingCycle()
 
 	firstPod, _ := q.Pop(logger)
@@ -1926,9 +1929,11 @@ func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
 					b.StartTimer()
 					if tt.moveEvent.Resource != "" {
 						q.MoveAllToActiveOrBackoffQueue(logger, tt.moveEvent, nil, nil, nil)
+						q.flushPendingMoveEvents(logger)
 					} else {
 						// Random case.
 						q.MoveAllToActiveOrBackoffQueue(logger, events[i%len(events)], nil, nil, nil)
+						q.flushPendingMoveEvents(logger)
 					}
 				}
 			})
@@ -2036,6 +2041,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithQueueingHint(t *testing.
 			cl.Step(test.duration)
 
 			q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+			q.flushPendingMoveEvents(logger)
 
 			if q.backoffQ.len() == 0 && test.expectedQ == backoffQ {
 				t.Fatalf("expected pod to be queued to backoffQ, but it was not")
@@ -2125,6 +2131,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueue(t *testing.T) {
 	// This NodeAdd event moves unschedulablePodInfo and highPriorityPodInfo to the backoffQ,
 	// because of the queueing hint function registered for NodeAdd/fooPlugin.
 	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 	q.Add(logger, medPriorityPodInfo.Pod)
 	if q.activeQ.len() != 1 {
 		t.Errorf("Expected 1 item to be in activeQ, but got: %v", q.activeQ.len())
@@ -2207,6 +2214,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueue(t *testing.T) {
 	c.Step(q.backoffQ.podMaxBackoffDuration())
 	q.flushBackoffQCompleted(logger) // flush the completed backoffQ to move hpp1 to activeQ.
 	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 	if q.activeQ.len() != 4 {
 		t.Errorf("Expected 4 items to be in activeQ, but got: %v", q.activeQ.len())
 	}
@@ -2265,6 +2273,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithoutQueueingHint(t *testi
 	// This NodeAdd event moves unschedulablePodInfo and highPriorityPodInfo to the backoffQ,
 	// because of the queueing hint function registered for NodeAdd/fooPlugin.
 	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 	if q.activeQ.len() != 1 {
 		t.Errorf("Expected 1 item to be in activeQ, but got: %v", q.activeQ.len())
 	}
@@ -2321,6 +2330,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithoutQueueingHint(t *testi
 	c.Step(q.backoffQ.podMaxBackoffDuration())
 	q.flushBackoffQCompleted(logger) // flush the completed backoffQ to move hpp1 to activeQ.
 	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 	if q.activeQ.len() != 4 {
 		t.Errorf("Expected 4 items to be in activeQ, but got: %v", q.activeQ.len())
 	}
@@ -2567,6 +2577,7 @@ func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
 			c.Step(DefaultPodInitialBackoffDuration + time.Second)
 
 			q.AssignedPodUpdated(logger, nil, tt.updatedAssignedPod, tt.event)
+			q.flushPendingMoveEvents(logger)
 
 			if q.activeQ.has(newQueuedPodInfoForLookup(tt.unschedPod)) != tt.wantToRequeue {
 				t.Fatalf("unexpected Pod move: Pod should be requeued: %v. Pod is actually requeued: %v", tt.wantToRequeue, !tt.wantToRequeue)
@@ -2702,6 +2713,7 @@ func TestPriorityQueue_PendingPods(t *testing.T) {
 	}
 	// Move all to active queue. We should still see the same set of pods.
 	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 	gotPods, gotSummary = q.PendingPods()
 	if diff := cmp.Diff(expectedSet, makeSet(gotPods)); diff != "" {
 		t.Errorf("Unexpected list of pending Pods (-want, +got):\n%s", diff)
@@ -2880,6 +2892,7 @@ func TestRecentlyTriedPodsGoBack(t *testing.T) {
 	c.Step(q.backoffQ.podMaxBackoffDuration())
 	// Move all unschedulable pods to the active queue.
 	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 	// Simulation is over. Now let's pop all pods. The pod popped first should be
 	// the last one we pop here.
 	for i := 0; i < 5; i++ {
@@ -2933,6 +2946,7 @@ func TestPodFailedSchedulingMultipleTimesDoesNotBlockNewerPod(t *testing.T) {
 	c.Step(DefaultPodInitialBackoffDuration + time.Second)
 	// Move all unschedulable pods to the active queue.
 	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 
 	// Simulate a pod being popped by the scheduler,
 	// At this time, unschedulable pod should be popped.
@@ -2965,6 +2979,7 @@ func TestPodFailedSchedulingMultipleTimesDoesNotBlockNewerPod(t *testing.T) {
 	c.Step(DefaultPodInitialBackoffDuration + time.Second)
 	// Move all unschedulable pods to the active queue.
 	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 
 	// At this time, newerPod should be popped
 	// because it is the oldest tried pod.
@@ -3010,6 +3025,7 @@ func TestHighPriorityBackoff(t *testing.T) {
 	}
 	// Move all unschedulable pods to the active/backoff queue.
 	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	q.flushPendingMoveEvents(logger)
 
 	p, err = q.Pop(logger)
 	if err != nil {
@@ -3316,6 +3332,7 @@ var (
 	}
 	moveAllToActiveOrBackoffQ = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
 		queue.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+		queue.flushPendingMoveEvents(logger)
 	}
 	flushBackoffQ = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
 		queue.clock.(*testingclock.FakeClock).Step(3 * time.Second)
@@ -4139,6 +4156,7 @@ func TestBackOffFlow(t *testing.T) {
 
 				// An event happens.
 				q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+				q.flushPendingMoveEvents(logger)
 
 				if !q.backoffQ.has(podInfo) {
 					t.Errorf("pod %v is not in the backoff queue", podID)
@@ -4251,6 +4269,7 @@ func TestMoveAllToActiveOrBackoffQueue_PreEnqueueChecks(t *testing.T) {
 				}
 			}
 			q.MoveAllToActiveOrBackoffQueue(logger, tt.event, nil, nil, tt.preEnqueueCheck)
+			q.flushPendingMoveEvents(logger)
 			got := sets.New[string]()
 			c.Step(2 * q.backoffQ.podMaxBackoffDuration())
 			gotPodInfos := q.backoffQ.popAllBackoffCompleted(logger)


### PR DESCRIPTION
What would you like to be added?
Kube-Scheduler uses scheduling hint to determine whether the pods should be moved to ActiveQ. Scheduler will lock and traverse all pods in unschedulableQ to find which pods might become schedulable due to the incoming event. Many operation on SchedulingQueue will be blocked if the events come too frequently.

For example, if someone updates assigned pod in a high frequency, the SchedulingQueue will be blocked by assignedPodUpdate() and new pods can not be added into the activeQ, result in scheduler hang.

I want to make moveAllToActiveOrBackoffQueue run in a background goroutine, check multi cluster events once a time, and limit its frequency to avoid influencing other SchedulingQueue operation.

Why is this needed?
If someone updates assigned pod in a high frequency, the SchedulingQueue will be blocked by assignedPodUpdate() and new pods can not be added into the activeQ, result in scheduler hang.

#136221