### PR TITLE
cleanup: remove suggestfor from wait command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -134,7 +134,6 @@ func NewCmdWait(restClientGetter genericclioptions.RESTClientGetter, streams gen
 			cmdutil.CheckErr(err)
 			cmdutil.CheckErr(o.RunWaitContext(cmd.Context()))
 		},
-		SuggestFor: []string{"list", "ps"},
 	}
 
 	flags.AddFlags(cmd)

--- a/test/cmd/results.sh
+++ b/test/cmd/results.sh
@@ -40,7 +40,6 @@ error: unknown command "list" for "kubectl"
 
 Did you mean this?
 	get
-	wait
 EOF
   kube::test::results::diff "${TEMP}/actual_stdout" "${TEMP}/actual_stderr" "$res" "${TEMP}/empty" "${TEMP}/expected_stderr" 1 "kubectl list"
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Remove `SuggestFor` from `kubectl wait`. The current entries (`"list"`, `"ps"`) cause `wait` to be suggested alongside `get`, which is misleading since `wait` is not a meaningful alternative for users typing `kubectl list` or `kubectl ps`.

#### Which issue(s) this PR is related to:
Fixes kubernetes/kubectl#1825

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
Removed misleading `SuggestFor` entries from `kubectl wait` so that it is no longer suggested when users type `kubectl list` or `kubectl ps`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
N/A
```