### PR TITLE
ktesting: remove type alias

### DIFF
--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -284,7 +284,7 @@ type driverResourcesMutatorFunc func(map[string]resourceslice.DriverResources)
 //
 // Call this outside of ginkgo.It, then use the instance inside ginkgo.It.
 func NewDriver(f *framework.Framework, nodes *Nodes, driverResourcesGenerator driverResourcesGenFunc, driverResourcesMutators ...driverResourcesMutatorFunc) *Driver {
-	d := NewDriverInstance(nil)
+	d := NewDriverInstance(ktesting.TContext{} /* no namespace yet, will be set later */)
 
 	ginkgo.BeforeEach(func() {
 		tCtx := f.TContext(context.Background())
@@ -300,6 +300,7 @@ func NewDriver(f *framework.Framework, nodes *Nodes, driverResourcesGenerator dr
 
 // NewDriverInstance is a variant of NewDriver where the driver is inactive and must
 // be started explicitly with Run. May be used inside ginkgo.It or a Go unit test.
+// The context is used to determine the test's and thus the driver's namespace.
 func NewDriverInstance(tCtx ktesting.TContext) *Driver {
 	d := &Driver{
 		fail:       map[MethodInstance]bool{},
@@ -314,9 +315,7 @@ func NewDriverInstance(tCtx ktesting.TContext) *Driver {
 		WithRealNodes:              true,
 		ExpectResourceSliceRemoval: true,
 	}
-	if tCtx != nil {
-		d.initName(tCtx)
-	}
+	d.initName(tCtx)
 	return d
 }
 

--- a/test/utils/ktesting/clientcontext.go
+++ b/test/utils/ktesting/clientcontext.go
@@ -29,27 +29,25 @@ import (
 
 // WithRESTConfig initializes all client-go clients with new clients
 // created for the config. The current test name gets included in the UserAgent.
-func (tc *TC) WithRESTConfig(cfg *rest.Config) TContext {
+func (tCtx TContext) WithRESTConfig(cfg *rest.Config) TContext {
 	cfg = rest.CopyConfig(cfg)
-	cfg.UserAgent = fmt.Sprintf("%s -- %s", rest.DefaultKubernetesUserAgent(), tc.Name())
+	cfg.UserAgent = fmt.Sprintf("%s -- %s", rest.DefaultKubernetesUserAgent(), tCtx.Name())
 
-	tc = tc.clone()
-	tc.restConfig = cfg
-	tc.client = clientset.NewForConfigOrDie(cfg)
-	tc.dynamic = dynamic.NewForConfigOrDie(cfg)
-	tc.apiextensions = apiextensions.NewForConfigOrDie(cfg)
-	cachedDiscovery := memory.NewMemCacheClient(tc.client.Discovery())
-	tc.restMapper = restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscovery)
-	return tc
+	tCtx.restConfig = cfg
+	tCtx.client = clientset.NewForConfigOrDie(cfg)
+	tCtx.dynamic = dynamic.NewForConfigOrDie(cfg)
+	tCtx.apiextensions = apiextensions.NewForConfigOrDie(cfg)
+	cachedDiscovery := memory.NewMemCacheClient(tCtx.client.Discovery())
+	tCtx.restMapper = restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscovery)
+	return tCtx
 }
 
 // WithClients uses an existing config and clients.
-func (tc *TC) WithClients(cfg *rest.Config, mapper *restmapper.DeferredDiscoveryRESTMapper, client clientset.Interface, dynamic dynamic.Interface, apiextensions apiextensions.Interface) TContext {
-	tc = tc.clone()
-	tc.restConfig = cfg
-	tc.restMapper = mapper
-	tc.client = client
-	tc.dynamic = dynamic
-	tc.apiextensions = apiextensions
-	return tc
+func (tCtx TContext) WithClients(cfg *rest.Config, mapper *restmapper.DeferredDiscoveryRESTMapper, client clientset.Interface, dynamic dynamic.Interface, apiextensions apiextensions.Interface) TContext {
+	tCtx.restConfig = cfg
+	tCtx.restMapper = mapper
+	tCtx.client = client
+	tCtx.dynamic = dynamic
+	tCtx.apiextensions = apiextensions
+	return tCtx
 }

--- a/test/utils/ktesting/stepcontext.go
+++ b/test/utils/ktesting/stepcontext.go
@@ -26,10 +26,9 @@ package ktesting
 // The string should describe the operation that is about to happen ("starting
 // the controller", "list items") or what is being operated on ("HTTP server").
 // Multiple different prefixes get concatenated with a colon.
-func (tc *TC) WithStep(step string) *TC {
-	tc = tc.clone()
-	tc.steps += step + ": "
-	return tc
+func (tCtx TContext) WithStep(step string) TContext {
+	tCtx.steps += step + ": "
+	return tCtx
 }
 
 // Step is useful when the context with the step information is
@@ -45,22 +44,22 @@ func (tc *TC) WithStep(step string) *TC {
 // Inside the callback, the tCtx variable is the one where the step
 // has been added. This avoids the need to introduce multiple different
 // context variables and risk of using the wrong one.
-func (tc *TC) Step(step string, cb func(tCtx TContext)) {
-	tc.Helper()
-	cb(tc.WithStep(step))
+func (tCtx TContext) Step(step string, cb func(tCtx TContext)) {
+	tCtx.Helper()
+	cb(tCtx.WithStep(step))
 }
 
 // Value intercepts a search for the special "GINKGO_SPEC_CONTEXT" and
 // wraps the underlying reporter so that the steps are visible in the report.
-func (tc *TC) Value(key any) any {
-	if tc.steps != "" {
+func (tCtx TContext) Value(key any) any {
+	if tCtx.steps != "" {
 		if s, ok := key.(string); ok && s == ginkgoSpecContextKey {
-			if reporter, ok := tc.Context.Value(key).(ginkgoReporter); ok {
-				return ginkgoReporter(&stepReporter{reporter: reporter, steps: tc.steps})
+			if reporter, ok := tCtx.Context.Value(key).(ginkgoReporter); ok {
+				return ginkgoReporter(&stepReporter{reporter: reporter, steps: tCtx.steps})
 			}
 		}
 	}
-	return tc.Context.Value(key)
+	return tCtx.Context.Value(key)
 }
 
 type stepReporter struct {

--- a/test/utils/ktesting/withcontext.go
+++ b/test/utils/ktesting/withcontext.go
@@ -26,31 +26,29 @@ import (
 // WithCancel sets up cancellation in a [TContext.Cleanup] callback and
 // constructs a new TContext where [TContext.Cancel] cancels only the new
 // context.
-func (tc *TC) WithCancel() TContext {
-	ctx, cancel := context.WithCancelCause(tc)
+func (tCtx TContext) WithCancel() TContext {
+	ctx, cancel := context.WithCancelCause(tCtx)
 
-	tc = tc.clone()
-	tc.Context = ctx
-	tc.cancel = func(cause string) {
+	tCtx.Context = ctx
+	tCtx.cancel = func(cause string) {
 		var cancelCause error
 		if cause != "" {
 			cancelCause = canceledError(cause)
 		}
 		cancel(cancelCause)
 	}
-	return tc
+	return tCtx
 }
 
 // WithoutCancel causes the returned context to ignore cancellation of its parent.
 // Calling Cancel will not cancel the parent either.
 // This matches [context.WithoutCancel].
-func (tc *TC) WithoutCancel() TContext {
-	ctx := context.WithoutCancel(tc)
+func (tCtx TContext) WithoutCancel() TContext {
+	ctx := context.WithoutCancel(tCtx)
 
-	tc = tc.clone()
-	tc.Context = ctx
-	tc.cancel = nil
-	return tc
+	tCtx.Context = ctx
+	tCtx.cancel = nil
+	return tCtx
 }
 
 // WithTimeout sets up new context with a timeout. Canceling the timeout gets
@@ -58,20 +56,18 @@ func (tc *TC) WithoutCancel() TContext {
 // the new context. The cause is used as reason why the context is canceled
 // once the timeout is reached. It may be empty, in which case the usual
 // "context canceled" error is used.
-func (tc *TC) WithTimeout(timeout time.Duration, timeoutCause string) TContext {
-	ctx, cancel := withTimeout(tc, tc.TB(), timeout, timeoutCause)
+func (tCtx TContext) WithTimeout(timeout time.Duration, timeoutCause string) TContext {
+	ctx, cancel := withTimeout(tCtx, tCtx.TB(), timeout, timeoutCause)
 
-	tc = tc.clone()
-	tc.Context = ctx
-	tc.cancel = cancel
-	return tc
+	tCtx.Context = ctx
+	tCtx.cancel = cancel
+	return tCtx
 }
 
 // WithLogger constructs a new context with a different logger.
-func (tc *TC) WithLogger(logger klog.Logger) TContext {
-	ctx := klog.NewContext(tc, logger)
+func (tCtx TContext) WithLogger(logger klog.Logger) TContext {
+	ctx := klog.NewContext(tCtx, logger)
 
-	tc = tc.clone()
-	tc.Context = ctx
-	return tc
+	tCtx.Context = ctx
+	return tCtx
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The type alias made `go doc ./test/utils/ktesting.TContext` useless and was a weird workaround for preserving the original interface type name. Passing a TContext instance by value (almost) preserves the original API and is acceptable because the struct is still small. The only consumers which need to be updated are those which relied on passing nil as tCtx.

If we ever find that TContext is or becomes too large, then we can make it a wrapper around some pointer.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Before:

```console
$ go doc ./test/utils/ktesting.TContext
package ktesting // import "k8s.io/kubernetes/test/utils/ktesting"

type TContext = *TC
    TContext is the recommended type for storing a TC instance. The type alias
    is necessary because TContext used to be an interface.

func Init(tb TB, opts ...InitOption) TContext
func InitCtx(ctx context.Context, tb TB, _ ...InitOption) TContext
```

After:

```
$ go doc ./test/utils/ktesting.TContext
package ktesting // import "k8s.io/kubernetes/test/utils/ktesting"

type TContext struct {
	// Context makes the methods of the underlying context
	// available. It must not be modified.
	context.Context

	// Has unexported fields.
}
    TContext implements context.Context, testing.TB and some additional methods.
    TContext is the public pointer type for referencing a TC. Variables are
    usually called tCtx. To ensure that test code does not use `t` directly
    unintentionally, it is recommended to use two functions:

        func TestSomething(t *testing.T) { testSomething(ktesting.Init(t)) }
        func testSomething(tCtx ktesting.TContext) { ... }

    Log output is associated with the current test and includes a header
    similar to klog, which enables post-processing to distinguish between log
    output (starts with header) and failure messages (header comes later).
    Errors ([Error], [Errorf]) are recorded with "ERROR" as prefix, fatal errors
    ([Fatal], [Fatalf]) with "FATAL ERROR". Indention is used to ensure that
    follow-up lines belonging to the same log entry can be handled properly by
    post-processing and to make the header stand out more.

    tCtx provides features offered by Ginkgo also when using normal Go testing:
      - The context contains a deadline that expires soon enough before the
        overall timeout that cleanup code can still run.
      - Cleanup callbacks can get their own, separate contexts when registered
        via [CleanupCtx].
      - CTRL-C aborts, prints a progress report, and then cleans up before
        terminating.
      - SIGUSR1 prints a progress report without aborting.

    Progress reporting is more informative when doing polling with
    gomega.Eventually and gomega.Consistently. Without that, it can only report
    which tests are active.

func Init(tb TB, opts ...InitOption) TContext
func InitCtx(ctx context.Context, tb TB, _ ...InitOption) TContext
func (tCtx TContext) APIExtensions() apiextensions.Interface
func (tCtx TContext) Assert(actual interface{}, extra ...interface{}) gomega.Assertion
func (tCtx TContext) AssertConsistently(arg any) gomega.AsyncAssertion
func (tCtx TContext) AssertEventually(arg any) gomega.AsyncAssertion
func (tCtx TContext) AssertNoError(err error, explain ...interface{}) bool
func (tCtx TContext) Cancel(cause string)
func (tCtx TContext) CleanupCtx(cb func(TContext))
func (tCtx TContext) Client() clientset.Interface
func (tCtx TContext) Consistently(arg any) gomega.AsyncAssertion
func (tCtx TContext) Dynamic() dynamic.Interface
func (tCtx TContext) Error(args ...any)
func (tCtx TContext) Errorf(format string, args ...any)
func (tCtx TContext) Eventually(arg any) gomega.AsyncAssertion
func (tCtx TContext) Expect(actual interface{}, extra ...interface{}) gomega.Assertion
func (tCtx TContext) ExpectNoError(err error, explain ...interface{})
func (tCtx TContext) Fail()
func (tCtx TContext) FailNow()
func (tCtx TContext) Failed() bool
func (tCtx TContext) Fatal(args ...any)
func (tCtx TContext) Fatalf(format string, args ...any)
func (tCtx TContext) IsSyncTest() bool
func (tCtx TContext) Log(args ...any)
func (tCtx TContext) Logf(format string, args ...any)
func (tCtx TContext) Logger() klog.Logger
func (tCtx TContext) Namespace() string
func (tCtx TContext) Parallel()
func (tCtx TContext) RESTConfig() *rest.Config
func (tCtx TContext) RESTMapper() *restmapper.DeferredDiscoveryRESTMapper
func (tCtx TContext) Require(actual interface{}, extra ...interface{}) gomega.Assertion
func (tCtx TContext) Run(name string, cb func(tCtx TContext)) bool
func (tCtx TContext) Skip(args ...any)
func (tCtx TContext) Skipf(format string, args ...any)
func (tCtx TContext) Step(step string, cb func(tCtx TContext))
func (tCtx TContext) SyncTest(name string, cb func(tCtx TContext)) bool
func (tCtx TContext) TB() TB
func (tCtx TContext) Value(key any) any
func (tCtx TContext) Wait()
func (tCtx TContext) WithCancel() TContext
func (tCtx TContext) WithClients(cfg *rest.Config, mapper *restmapper.DeferredDiscoveryRESTMapper, ...) TContext
func (tCtx TContext) WithContext(ctx context.Context) TContext
func (tCtx TContext) WithError(err *error) (TContext, func())
func (tCtx TContext) WithLogger(logger klog.Logger) TContext
func (tCtx TContext) WithNamespace(namespace string) TContext
func (tCtx TContext) WithRESTConfig(cfg *rest.Config) TContext
func (tCtx TContext) WithStep(step string) TContext
func (tCtx TContext) WithTimeout(timeout time.Duration, timeoutCause string) TContext
func (tCtx TContext) WithValue(key, val any) TContext
func (tCtx TContext) WithoutCancel() TContext
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @nojnhuh 
/cc @Karthik-K-N 
/hold

For review by @nojnhuh as reviewer of the PR which introduced the type alias.
