### PR TITLE
Revert the graduation of maxLength

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -79,7 +79,7 @@ func (maxLengthTagValidator) GetValidations(context Context, tag codetags.Tag) (
 func (mltv maxLengthTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mltv.TagName(),
-		StabilityLevel: TagStabilityLevelStable,
+		StabilityLevel: TagStabilityLevelBeta,
 		Scopes:         mltv.ValidScopes().UnsortedList(),
 		Description:    "Indicates that a string field has a limit on its length.",
 		Payloads: []TagPayloadDoc{{


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:
This PR reverts the `maxLength` validation tag stability to beta.

The working group has determined that the previous implementation misunderstood the intent of the `maxLength` property. According to the OpenAPI specification, `maxLength` refers to the number of Unicode code points, not the number of bytes.

This is the one validations on the string length. 

### Does this PR introduce a user-facing change?
```
NONE
```

### Additional documentation eg, KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```