### PR TITLE
Add WithMinEmulationVersion option to DV validation test suit

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -223,6 +223,13 @@ type validationOption struct {
 	// to the versioned object fails.
 	IgnoreObjectConversionErrors bool
 
+	// MinEmulationVersion is the minimum emulation version that can be used in the
+	// "hand written validation" sub-test. When the test has already enabled a feature
+	// gate introduced after 1.35 (e.g. in 1.36+), setting the emulation version to
+	// 1.35 would fail because the feature gate did not exist at that version.
+	// If set to a version greater than 1.35, the sub-test is skipped.
+	MinEmulationVersion *version.Version
+
 	// Fuzzer is the fuzzer to use for generating test objects.
 	Fuzzer *randfill.Filler
 }
@@ -248,6 +255,16 @@ func WithIgnoreObjectConversionErrors() ValidationTestConfig {
 func WithFuzzer(fuzzer *randfill.Filler) ValidationTestConfig {
 	return func(o *validationOption) {
 		o.Fuzzer = fuzzer
+	}
+}
+
+// WithMinEmulationVersion sets the minimum emulation version that can be used in the
+// "hand written validation" sub-test. Use this when the test has already enabled a
+// feature gate that was introduced after 1.35, which would cause the emulation version
+// downgrade to 1.35 to fail.
+func WithMinEmulationVersion(v *version.Version) ValidationTestConfig {
+	return func(o *validationOption) {
+		o.MinEmulationVersion = v
 	}
 }
 
@@ -366,12 +383,17 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 	})
 	// 3. Legacy Hand Written Validation
 	// TODO: Remove this test case in 1.39 when emulation for 1.35 is no longer needed.
+	emulationVersion := version.MustParse("1.35")
+	skipHandWritten := opt.MinEmulationVersion != nil && opt.MinEmulationVersion.GreaterThan(emulationVersion)
 	t.Run("hand written validation", func(t *testing.T) {
+		if skipHandWritten {
+			t.Skipf("skipping: minimum emulation version %s is greater than %s", opt.MinEmulationVersion, emulationVersion)
+		}
 		// Even when DeclarativeValidation gate is disabled, if the object's strategy has explicit
 		// declarative enforcement enabled, Standard declarative validations still run and are enforced.
 		// Emulating 1.35 ensures the DeclarativeValidationBeta gate is also effectively disabled (evaluated as false)
 		// because the feature gate was not introduced until 1.36.
-		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.35"))
+		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, emulationVersion)
 		featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 			features.DeclarativeValidation: false,
 		})
@@ -428,13 +450,15 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 		equivalenceMatcher = equivalenceMatcher.ByField()
 	}
 
-	// The imperative validation may produce duplicate errors, which is not supported by the ErrorMatcher.
-	// TODO: remove this once ErrorMatcher has been extended to handle this form of deduplication.
-	imperativeErrs = deDuplicateErrors(imperativeErrs, equivalenceMatcher)
+	if !skipHandWritten {
+		// The imperative validation may produce duplicate errors, which is not supported by the ErrorMatcher.
+		// TODO: remove this once ErrorMatcher has been extended to handle this form of deduplication.
+		imperativeErrs = deDuplicateErrors(imperativeErrs, equivalenceMatcher)
 
-	// Verify equivalence across all scenarios
-	equivalenceMatcher.Test(t, imperativeErrs, declarativeBetaEnabledErrs)
-	equivalenceMatcher.Test(t, imperativeErrs, declarativeBetaDisabledErrs)
+		// Verify equivalence across all scenarios
+		equivalenceMatcher.Test(t, imperativeErrs, declarativeBetaEnabledErrs)
+		equivalenceMatcher.Test(t, imperativeErrs, declarativeBetaDisabledErrs)
+	}
 }
 
 // deDuplicateErrors removes duplicate errors from an ErrorList based on the provided matcher.


### PR DESCRIPTION
When a test enables a feature gate introduced after 1.35, the "hand written validation" sub-test fails because SetFeatureGateEmulationVersionDuringTest cannot downgrade to 1.35 for features that did not exist at that version. This adds a WithMinEmulationVersion option so callers can declare the minimum supported emulation version and skip the sub-test when incompatible.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
- Adds WithMinEmulationVersion option to VerifyValidationEquivalence / VerifyUpdateValidationEquivalence
- When a test enables a feature gate introduced after 1.35 (e.g. in 1.36+), the "hand written validation" sub-test that downgrades the emulation version to 1.35 fails because the feature gate didn't exist at
   that version
- Callers can now pass WithMinEmulationVersion(version.MustParse("1.36")) to skip that sub-test and its equivalence comparison

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
