### PR TITLE
fix: exclude fully reserved NUMA nodes consistently from topology hints, not just memory manager decisions

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/opencontainers/cgroups"
 	"github.com/opencontainers/cgroups/manager"
 	"k8s.io/klog/v2"
@@ -87,6 +88,15 @@ type systemContainer struct {
 	// Manager for the cgroups of the external container.
 	manager cgroups.Manager
 }
+
+var (
+	getCgroupSubsystems = GetCgroupSubsystems
+	swapIsOn            = swap.IsSwapOn
+	pidlimitStats       = pidlimit.Stats
+	newDeviceManager    = func(topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (devicemanager.Manager, error) {
+		return devicemanager.NewManagerImpl(topology, topologyAffinityStore)
+	}
+)
 
 func newSystemCgroups(containerName string) (*systemContainer, error) {
 	manager, err := createManager(containerName)
@@ -209,12 +219,12 @@ func validateSystemRequirements(logger klog.Logger, mountUtil mount.Interface) (
 func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadvisorInterface cadvisor.Interface, nodeConfig NodeConfig, failSwapOn bool, recorder record.EventRecorder, kubeClient clientset.Interface) (ContainerManager, error) {
 	logger := klog.FromContext(ctx)
 
-	subsystems, err := GetCgroupSubsystems()
+	subsystems, err := getCgroupSubsystems()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get mounted cgroup subsystems: %v", err)
 	}
 
-	isSwapOn, err := swap.IsSwapOn()
+	isSwapOn, err := swapIsOn()
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine if swap is on: %w", err)
 	}
@@ -245,7 +255,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	for k, v := range capacity {
 		internalCapacity[k] = v
 	}
-	pidlimits, err := pidlimit.Stats()
+	pidlimits, err := pidlimitStats()
 	if err == nil && pidlimits != nil && pidlimits.MaxPID != nil {
 		internalCapacity[pidlimit.PIDs] = *resource.NewQuantity(
 			int64(*pidlimits.MaxPID),
@@ -295,8 +305,23 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 		qosContainerManager: qosContainerManager,
 	}
 
+	topology := machineInfo.Topology
+	if len(nodeConfig.MemoryManagerReservedMemory) > 0 {
+		reservedNUMANodes, err := memorymanager.GetReservedMemoryNUMANodes(machineInfo, cm.GetNodeAllocatableReservation(), nodeConfig.MemoryManagerReservedMemory)
+		if err != nil {
+			return nil, err
+		}
+		if len(reservedNUMANodes) > 0 {
+			logger.Info("Excluding fully reserved NUMA nodes from topology hints", "numaNodes", reservedNUMANodes)
+			topology = filterNUMATopology(topology, reservedNUMANodes)
+			if len(topology) == 0 {
+				return nil, fmt.Errorf("all NUMA nodes excluded by --reserved-memory; at least one NUMA node must remain active")
+			}
+		}
+	}
+
 	cm.topologyManager, err = topologymanager.NewManager(
-		machineInfo.Topology,
+		topology,
 		nodeConfig.TopologyManagerPolicy,
 		nodeConfig.TopologyManagerScope,
 		nodeConfig.TopologyManagerPolicyOptions,
@@ -307,7 +332,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	}
 
 	logger.Info("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(machineInfo.Topology, cm.topologyManager)
+	cm.deviceManager, err = newDeviceManager(topology, cm.topologyManager)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/opencontainers/cgroups"
 	"github.com/stretchr/testify/assert"
@@ -33,12 +34,19 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
+	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
 	cmqos "k8s.io/kubernetes/pkg/kubelet/cm/qos"
+	"k8s.io/kubernetes/pkg/kubelet/cm/resourceupdates"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/mount-utils"
 	"k8s.io/utils/cpuset"
 )
@@ -47,6 +55,14 @@ type mockCPUAllocationReader struct {
 	cpumanager.Manager
 	sets            map[string]cpuset.CPUSet
 	isolationLevels map[string]cmqos.ResourceIsolationLevel
+}
+
+type fakeDeviceManager struct {
+	devicemanager.Manager
+}
+
+func (m *fakeDeviceManager) Updates() <-chan resourceupdates.Update {
+	return make(chan resourceupdates.Update)
 }
 
 func (m *mockCPUAllocationReader) GetExclusiveCPUs(podUID, containerName string) cpuset.CPUSet {
@@ -290,6 +306,100 @@ func TestGetCapacity(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestNewContainerManagerFiltersReservedMemoryNUMANodesWithMemoryManagerNone(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+
+	machineInfo := &cadvisorapi.MachineInfo{
+		NumCores:   2,
+		NumSockets: 2,
+		Topology: []cadvisorapi.Node{
+			{
+				Id:     0,
+				Memory: 2 * 1024 * 1024 * 1024,
+				Cores: []cadvisorapi.Core{
+					{SocketID: 0, Id: 0, Threads: []int{0}},
+				},
+			},
+			{
+				Id:     1,
+				Memory: 2 * 1024 * 1024 * 1024,
+				Cores: []cadvisorapi.Core{
+					{SocketID: 1, Id: 0, Threads: []int{1}},
+				},
+			},
+		},
+	}
+
+	mockCadvisor := cadvisortest.NewMockInterface(t)
+	mockCadvisor.EXPECT().MachineInfo().Return(machineInfo, nil)
+
+	oldGetCgroupSubsystems := getCgroupSubsystems
+	oldSwapIsOn := swapIsOn
+	oldPidlimitStats := pidlimitStats
+	oldNewDeviceManager := newDeviceManager
+	defer func() {
+		getCgroupSubsystems = oldGetCgroupSubsystems
+		swapIsOn = oldSwapIsOn
+		pidlimitStats = oldPidlimitStats
+		newDeviceManager = oldNewDeviceManager
+	}()
+
+	getCgroupSubsystems = func() (*CgroupSubsystems, error) {
+		return &CgroupSubsystems{}, nil
+	}
+	swapIsOn = func() (bool, error) {
+		return false, nil
+	}
+	pidlimitStats = func() (*statsapi.RlimitStats, error) {
+		return nil, nil
+	}
+
+	var gotDeviceManagerTopology []cadvisorapi.Node
+	var gotTopologyManagerNUMANodes []int
+	newDeviceManager = func(topology []cadvisorapi.Node, store topologymanager.Store) (devicemanager.Manager, error) {
+		gotDeviceManagerTopology = append([]cadvisorapi.Node(nil), topology...)
+		gotTopologyManagerNUMANodes = append([]int(nil), store.GetNUMANodeIDs()...)
+		return &fakeDeviceManager{}, nil
+	}
+
+	nodeConfig := NodeConfig{
+		KubeletRootDir:        t.TempDir(),
+		CPUManagerPolicy:      string(cpumanager.PolicyNone),
+		MemoryManagerPolicy:   string(memorymanager.PolicyTypeNone),
+		TopologyManagerPolicy: topologymanager.PolicyNone,
+		TopologyManagerScope:  topologymanager.ContainerTopologyScope,
+		NodeAllocatableConfig: NodeAllocatableConfig{
+			SystemReserved: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
+		MemoryManagerReservedMemory: []kubeletconfig.MemoryReservation{
+			{
+				NumaNode: 1,
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+
+	manager, err := NewContainerManager(ctx, fakeContainerMgrMountInt(), mockCadvisor, nodeConfig, false, record.NewFakeRecorder(1), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cm := manager.(*containerManagerImpl)
+	if got := cm.topologyManager.GetNUMANodeIDs(); len(got) != 1 || got[0] != 0 {
+		t.Fatalf("expected filtered topology manager NUMA nodes [0], got %v", got)
+	}
+	if len(gotTopologyManagerNUMANodes) != 1 || gotTopologyManagerNUMANodes[0] != 0 {
+		t.Fatalf("expected device manager store NUMA nodes [0], got %v", gotTopologyManagerNUMANodes)
+	}
+	if len(gotDeviceManagerTopology) != 1 || gotDeviceManagerTopology[0].Id != 0 {
+		t.Fatalf("expected device manager to receive filtered topology [0], got %v", gotDeviceManagerTopology)
 	}
 }
 

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -139,10 +139,25 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	cm.topologyManager = topologymanager.NewFakeManager()
 	cm.cpuManager = cpumanager.NewFakeManager(logger)
 	cm.memoryManager = memorymanager.NewFakeManager(logger)
+	topology := machineInfo.Topology
 
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
+		if len(nodeConfig.MemoryManagerReservedMemory) > 0 {
+			reservedNUMANodes, err := memorymanager.GetReservedMemoryNUMANodes(machineInfo, cm.GetNodeAllocatableReservation(), nodeConfig.MemoryManagerReservedMemory)
+			if err != nil {
+				return nil, err
+			}
+			if len(reservedNUMANodes) > 0 {
+				logger.Info("Excluding fully reserved NUMA nodes from topology hints", "numaNodes", reservedNUMANodes)
+				topology = filterNUMATopology(topology, reservedNUMANodes)
+				if len(topology) == 0 {
+					return nil, fmt.Errorf("all NUMA nodes excluded by --reserved-memory; at least one NUMA node must remain active")
+				}
+			}
+		}
+
 		logger.Info("Creating topology manager")
-		cm.topologyManager, err = topologymanager.NewManager(machineInfo.Topology,
+		cm.topologyManager, err = topologymanager.NewManager(topology,
 			nodeConfig.TopologyManagerPolicy,
 			nodeConfig.TopologyManagerScope,
 			nodeConfig.TopologyManagerPolicyOptions)

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -957,12 +957,14 @@ func (p *staticPolicy) GetPodTopologyHints(logger logr.Logger, s state.State, po
 // bits set as the narrowest matching NUMANodeAffinity with 'Preferred: true', and
 // marking all others with 'Preferred: false'.
 func (p *staticPolicy) generateCPUTopologyHints(availableCPUs cpuset.CPUSet, reusableCPUs cpuset.CPUSet, request int) []topologymanager.TopologyHint {
+	numaNodes := p.getNUMANodesForTopologyHints()
+
 	// Initialize minAffinitySize to include all NUMA Nodes.
-	minAffinitySize := p.topology.CPUDetails.NUMANodes().Size()
+	minAffinitySize := len(numaNodes)
 
 	// Iterate through all combinations of numa nodes bitmask and build hints from them.
 	hints := []topologymanager.TopologyHint{}
-	bitmask.IterateBitMasks(p.topology.CPUDetails.NUMANodes().List(), func(mask bitmask.BitMask) {
+	bitmask.IterateBitMasks(numaNodes, func(mask bitmask.BitMask) {
 		// First, update minAffinitySize for the current request size.
 		cpusInMask := p.topology.CPUDetails.CPUsInNUMANodes(mask.GetBits()...).Size()
 		if cpusInMask >= request && mask.Count() < minAffinitySize {
@@ -1017,6 +1019,31 @@ func (p *staticPolicy) generateCPUTopologyHints(availableCPUs cpuset.CPUSet, reu
 	}
 
 	return hints
+}
+
+func (p *staticPolicy) getNUMANodesForTopologyHints() []int {
+	topologyNUMANodes := p.topology.CPUDetails.NUMANodes().List()
+	if p.affinity == nil {
+		return topologyNUMANodes
+	}
+
+	hintNUMANodes := p.affinity.GetNUMANodeIDs()
+	if len(hintNUMANodes) == 0 {
+		return topologyNUMANodes
+	}
+
+	hintNodeSet := map[int]struct{}{}
+	for _, nodeID := range hintNUMANodes {
+		hintNodeSet[nodeID] = struct{}{}
+	}
+
+	var filteredNUMANodes []int
+	for _, nodeID := range topologyNUMANodes {
+		if _, ok := hintNodeSet[nodeID]; ok {
+			filteredNUMANodes = append(filteredNUMANodes, nodeID)
+		}
+	}
+	return filteredNUMANodes
 }
 
 // isHintSocketAligned function return true if numa nodes in hint are socket aligned.

--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -46,6 +46,26 @@ type testCase struct {
 	podLevelResourceManagersEnabled bool
 }
 
+type topologyStoreMock struct {
+	numaNodes []int
+}
+
+func (m *topologyStoreMock) GetAffinity(string, string) topologymanager.TopologyHint {
+	return topologymanager.TopologyHint{}
+}
+
+func (m *topologyStoreMock) GetPolicy() topologymanager.Policy {
+	return nil
+}
+
+func (m *topologyStoreMock) Name() string {
+	return "mock"
+}
+
+func (m *topologyStoreMock) GetNUMANodeIDs() []int {
+	return m.numaNodes
+}
+
 func returnMachineInfo() cadvisorapi.MachineInfo {
 	return cadvisorapi.MachineInfo{
 		NumCores: 12,
@@ -283,6 +303,35 @@ func TestGetTopologyHints(t *testing.T) {
 		if !reflect.DeepEqual(tc.expectedHints, hints) {
 			t.Errorf("Test case %q: Expected in result to be %v , got %v", tc.name, tc.expectedHints, hints)
 		}
+	}
+}
+
+func TestGenerateCPUTopologyHintsHonorsTopologyManagerNUMANodes(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	machineInfo := returnMachineInfo()
+	topo, err := topology.Discover(logger, &machineInfo)
+	if err != nil {
+		t.Fatalf("expected no error from Discover, got %v", err)
+	}
+
+	policy := staticPolicy{
+		topology: topo,
+		affinity: &topologyStoreMock{
+			numaNodes: []int{1},
+		},
+	}
+
+	hints := policy.generateCPUTopologyHints(topo.CPUDetails.CPUs(), cpuset.New(), 2)
+	expectedMask, _ := bitmask.NewBitMask(1)
+	expectedHints := []topologymanager.TopologyHint{
+		{
+			NUMANodeAffinity: expectedMask,
+			Preferred:        true,
+		},
+	}
+
+	if !reflect.DeepEqual(expectedHints, hints) {
+		t.Fatalf("expected topology hints %v, got %v", expectedHints, hints)
 	}
 }
 

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -143,9 +143,28 @@ func NewManagerImpl(topology []cadvisorapi.Node, topologyAffinityStore topologym
 func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
 	logger.V(2).Info("Creating Device Plugin manager", "path", socketPath)
 
-	var numaNodes []int
+	topologyNUMANodes := make([]int, 0, len(topology))
 	for _, node := range topology {
-		numaNodes = append(numaNodes, node.Id)
+		topologyNUMANodes = append(topologyNUMANodes, node.Id)
+	}
+	sort.Ints(topologyNUMANodes)
+
+	// Derive the set of NUMA nodes used for topology hint iteration.
+	// The topology manager store carries the active NUMA set after reserved-memory
+	// filtering, while the local topology slice is the set this device manager
+	// can reason about. When both are available, only use their intersection.
+	numaNodes := append([]int{}, topologyNUMANodes...)
+	if topologyAffinityStore != nil {
+		topologyManagerNUMANodes := topologyAffinityStore.GetNUMANodeIDs()
+		if len(topologyManagerNUMANodes) > 0 {
+			hintNodeSet := sets.New[int](topologyManagerNUMANodes...)
+			numaNodes = numaNodes[:0]
+			for _, nodeID := range topologyNUMANodes {
+				if hintNodeSet.Has(nodeID) {
+					numaNodes = append(numaNodes, nodeID)
+				}
+			}
+		}
 	}
 
 	manager := &ManagerImpl{

--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"testing"
 
+	cadvisorapi "github.com/google/cadvisor/info/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,8 @@ import (
 )
 
 type mockAffinityStore struct {
-	hint topologymanager.TopologyHint
+	hint      topologymanager.TopologyHint
+	numaNodes []int
 }
 
 func (m *mockAffinityStore) GetAffinity(podUID string, containerName string) topologymanager.TopologyHint {
@@ -46,6 +48,10 @@ func (m *mockAffinityStore) GetPolicy() topologymanager.Policy {
 
 func (m *mockAffinityStore) Name() string {
 	return "container"
+}
+
+func (m *mockAffinityStore) GetNUMANodeIDs() []int {
+	return m.numaNodes
 }
 
 func makeNUMADevice(id string, numa int) *pluginapi.Device {
@@ -426,7 +432,7 @@ func TestTopologyAlignedAllocation(t *testing.T) {
 			podDevices:            newPodDevices(),
 			sourcesReady:          &sourcesReadyStub{},
 			activePods:            func() []*v1.Pod { return []*v1.Pod{} },
-			topologyAffinityStore: &mockAffinityStore{tc.hint},
+			topologyAffinityStore: &mockAffinityStore{hint: tc.hint},
 		}
 
 		m.allDevices[tc.resource] = make(DeviceInstances)
@@ -616,7 +622,7 @@ func TestGetPreferredAllocationParameters(t *testing.T) {
 			podDevices:            newPodDevices(),
 			sourcesReady:          &sourcesReadyStub{},
 			activePods:            func() []*v1.Pod { return []*v1.Pod{} },
-			topologyAffinityStore: &mockAffinityStore{tc.hint},
+			topologyAffinityStore: &mockAffinityStore{hint: tc.hint},
 		}
 
 		m.allDevices[tc.resource] = make(DeviceInstances)
@@ -2040,5 +2046,188 @@ func getPodScopeTestCases() []topologyHintTestCase {
 				},
 			},
 		},
+	}
+}
+
+func TestNewManagerImplUsesTopologyManagerNUMANodes(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	fullTopology := []cadvisorapi.Node{
+		{Id: 0}, {Id: 1}, {Id: 2}, {Id: 3},
+	}
+
+	tests := []struct {
+		name          string
+		store         topologymanager.Store
+		expectedNUMAs []int
+	}{
+		{
+			name:          "uses GetNUMANodeIDs when store provides filtered nodes",
+			store:         &mockAffinityStore{numaNodes: []int{0, 1}},
+			expectedNUMAs: []int{0, 1},
+		},
+		{
+			name:          "intersects GetNUMANodeIDs with local topology",
+			store:         &mockAffinityStore{numaNodes: []int{0, 4, 5}},
+			expectedNUMAs: []int{0},
+		},
+		{
+			name:          "falls back to topology when GetNUMANodeIDs returns nil",
+			store:         &mockAffinityStore{numaNodes: nil},
+			expectedNUMAs: []int{0, 1, 2, 3},
+		},
+		{
+			name:          "falls back to topology when store is nil",
+			store:         nil,
+			expectedNUMAs: []int{0, 1, 2, 3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, err := newManagerImpl(logger, t.TempDir(), fullTopology, tc.store)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(mgr.numaNodes, tc.expectedNUMAs) {
+				t.Errorf("expected numaNodes %v, got %v", tc.expectedNUMAs, mgr.numaNodes)
+			}
+		})
+	}
+}
+
+func TestDevicesOnExcludedNUMANodesNotInHints(t *testing.T) {
+	resourceName := "testdevice"
+
+	tcases := []struct {
+		description   string
+		numaNodes     []int
+		devices       []*pluginapi.Device
+		request       int
+		expectedHints []topologymanager.TopologyHint
+	}{
+		{
+			description: "devices only on active NUMA nodes produce normal hints",
+			numaNodes:   []int{0, 1},
+			devices: []*pluginapi.Device{
+				makeNUMADevice("Dev1", 0),
+				makeNUMADevice("Dev2", 1),
+			},
+			request: 1,
+			expectedHints: []topologymanager.TopologyHint{
+				{NUMANodeAffinity: makeSocketMask(0), Preferred: true},
+				{NUMANodeAffinity: makeSocketMask(1), Preferred: true},
+				{NUMANodeAffinity: makeSocketMask(0, 1), Preferred: false},
+			},
+		},
+		{
+			description: "devices on excluded NUMA nodes are invisible to hints",
+			numaNodes:   []int{0, 1},
+			devices: []*pluginapi.Device{
+				makeNUMADevice("Dev1", 0),
+				makeNUMADevice("Dev2", 1),
+				makeNUMADevice("Dev3", 2),
+				makeNUMADevice("Dev4", 3),
+			},
+			request: 1,
+			expectedHints: []topologymanager.TopologyHint{
+				{NUMANodeAffinity: makeSocketMask(0), Preferred: true},
+				{NUMANodeAffinity: makeSocketMask(1), Preferred: true},
+				{NUMANodeAffinity: makeSocketMask(0, 1), Preferred: false},
+			},
+		},
+		{
+			description: "all devices on excluded NUMA nodes yields empty hints",
+			numaNodes:   []int{0, 1},
+			devices: []*pluginapi.Device{
+				makeNUMADevice("Dev1", 2),
+				makeNUMADevice("Dev2", 3),
+			},
+			request:       1,
+			expectedHints: []topologymanager.TopologyHint{},
+		},
+		{
+			description: "request unsatisfiable from active NUMA nodes alone yields empty hints",
+			numaNodes:   []int{0},
+			devices: []*pluginapi.Device{
+				makeNUMADevice("Dev1", 0),
+				makeNUMADevice("Dev2", 1),
+			},
+			request:       2,
+			expectedHints: []topologymanager.TopologyHint{},
+		},
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "fakePod"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "fakeContainer",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceName(resourceName): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.description, func(t *testing.T) {
+			pod.Spec.Containers[0].Resources.Limits[v1.ResourceName(resourceName)] =
+				resource.MustParse(fmt.Sprintf("%d", tc.request))
+
+			m := ManagerImpl{
+				allDevices:       NewResourceDeviceInstances(),
+				healthyDevices:   make(map[string]sets.Set[string]),
+				allocatedDevices: make(map[string]sets.Set[string]),
+				podDevices:       newPodDevices(),
+				sourcesReady:     &sourcesReadyStub{},
+				activePods:       func() []*v1.Pod { return []*v1.Pod{pod} },
+				numaNodes:        tc.numaNodes,
+			}
+
+			m.allDevices[resourceName] = make(DeviceInstances)
+			m.healthyDevices[resourceName] = sets.New[string]()
+			for _, d := range tc.devices {
+				m.allDevices[resourceName][d.ID] = d
+				m.healthyDevices[resourceName].Insert(d.ID)
+			}
+
+			// Verify GetTopologyHints
+			containerHints := m.GetTopologyHints(pod, &pod.Spec.Containers[0])
+			gotHints := containerHints[resourceName]
+			sort.SliceStable(gotHints, func(i, j int) bool {
+				return gotHints[i].LessThan(gotHints[j])
+			})
+			sort.SliceStable(tc.expectedHints, func(i, j int) bool {
+				return tc.expectedHints[i].LessThan(tc.expectedHints[j])
+			})
+			if !reflect.DeepEqual(gotHints, tc.expectedHints) {
+				t.Errorf("GetTopologyHints: expected %v, got %v", tc.expectedHints, gotHints)
+			}
+
+			// Verify no hint references an excluded NUMA node
+			activeSet := sets.New(tc.numaNodes...)
+			for _, h := range gotHints {
+				for _, bit := range h.NUMANodeAffinity.GetBits() {
+					if !activeSet.Has(bit) {
+						t.Errorf("hint %v references excluded NUMA node %d", h, bit)
+					}
+				}
+			}
+
+			// Verify GetPodTopologyHints matches
+			podHints := m.GetPodTopologyHints(pod)
+			gotPodHints := podHints[resourceName]
+			sort.SliceStable(gotPodHints, func(i, j int) bool {
+				return gotPodHints[i].LessThan(gotPodHints[j])
+			})
+			if !reflect.DeepEqual(gotPodHints, tc.expectedHints) {
+				t.Errorf("GetPodTopologyHints: expected %v, got %v", tc.expectedHints, gotPodHints)
+			}
+		})
 	}
 }

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"sort"
 	"sync"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
@@ -140,7 +141,7 @@ func NewManager(logger klog.Logger, policyName string, machineInfo *cadvisorapi.
 
 	switch policyType(policyName) {
 
-	case policyTypeNone:
+	case PolicyTypeNone:
 		policy = NewPolicyNone(logger)
 
 	case PolicyTypeStatic:
@@ -483,6 +484,65 @@ func getSystemReservedMemory(machineInfo *cadvisorapi.MachineInfo, nodeAllocatab
 	}
 
 	return reservedMemoryConverted, nil
+}
+
+// GetReservedMemoryNUMANodes returns NUMA nodes whose memory resources are fully reserved.
+//
+// A NUMA node is considered fully reserved if all allocatable memory resources
+// on that node (regular memory and hugepages) are reserved through
+// --reserved-memory and therefore not available for workloads.
+func GetReservedMemoryNUMANodes(machineInfo *cadvisorapi.MachineInfo, nodeAllocatableReservation v1.ResourceList, reservedMemory []kubeletconfig.MemoryReservation) ([]int, error) {
+	systemReserved, err := getSystemReservedMemory(machineInfo, nodeAllocatableReservation, reservedMemory)
+	if err != nil {
+		return nil, err
+	}
+
+	var reservedNUMANodes []int
+	for _, node := range machineInfo.Topology {
+		if isNodeMemoryFullyReserved(node, systemReserved) {
+			reservedNUMANodes = append(reservedNUMANodes, node.Id)
+		}
+	}
+	sort.Ints(reservedNUMANodes)
+
+	return reservedNUMANodes, nil
+}
+
+// isNodeMemoryFullyReserved reports whether all allocatable memory on a NUMA
+// node is covered by --reserved-memory. A node with zero memory and no
+// hugepages (e.g. CPU-less GPU-memory NUMA nodes on NVIDIA GB200) is
+// considered fully reserved because there is nothing left for workloads.
+func isNodeMemoryFullyReserved(node cadvisorapi.Node, systemReserved systemReservedMemory) bool {
+	var hugepagesCapacity uint64
+	for _, hugepage := range node.HugePages {
+		hugepageSize := hugepage.NumPages * hugepage.PageSize * 1024
+		hugepagesCapacity += hugepageSize
+
+		hugepageQuantity := resource.NewQuantity(int64(hugepage.PageSize)*1024, resource.BinarySI)
+		resourceName := corev1helper.HugePageResourceName(*hugepageQuantity)
+		if getResourceSystemReserved(systemReserved, node.Id, resourceName) < hugepageSize {
+			return false
+		}
+	}
+
+	// node.Memory is cadvisor's MemTotal which includes memory backing
+	// hugepages. Subtract hugepagesCapacity to get the regular (non-
+	// hugepage) allocatable memory for this NUMA node.
+	allocatableMemory := node.Memory
+	if allocatableMemory > hugepagesCapacity {
+		allocatableMemory -= hugepagesCapacity
+	} else {
+		allocatableMemory = 0
+	}
+
+	return getResourceSystemReserved(systemReserved, node.Id, v1.ResourceMemory) >= allocatableMemory
+}
+
+func getResourceSystemReserved(systemReserved systemReservedMemory, nodeID int, resourceName v1.ResourceName) uint64 {
+	if nodeSystemReserved, ok := systemReserved[nodeID]; ok {
+		return nodeSystemReserved[resourceName]
+	}
+	return 0
 }
 
 // GetAllocatableMemory returns the amount of allocatable memory for each NUMA node

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -27,6 +27,7 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
@@ -81,7 +82,7 @@ func returnPolicyByName(logger klog.Logger, testCase testMemoryManager) Policy {
 	case PolicyTypeStatic:
 		policy, _ := NewPolicyStatic(logger, &testCase.machineInfo, testCase.reserved, topologymanager.NewFakeManager())
 		return policy
-	case policyTypeNone:
+	case PolicyTypeNone:
 		return NewPolicyNone(logger)
 	}
 	return nil
@@ -328,6 +329,203 @@ func TestValidateReservedMemory(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetReservedMemoryNUMANodes(t *testing.T) {
+	machineInfo := returnMachineInfo()
+
+	testCases := []struct {
+		description                string
+		nodeAllocatableReservation v1.ResourceList
+		reservedMemory             []kubeletconfig.MemoryReservation
+		expectedReservedNodes      []int
+		expectedError              string
+	}{
+		{
+			description: "single NUMA node fully reserved",
+			nodeAllocatableReservation: v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+				hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+			},
+			reservedMemory: []kubeletconfig.MemoryReservation{
+				{
+					NumaNode: 0,
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+						hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+					},
+				},
+			},
+			expectedReservedNodes: []int{0},
+		},
+		{
+			description: "NUMA node partially reserved",
+			nodeAllocatableReservation: v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(2*gb, resource.BinarySI),
+				hugepages1G:       *resource.NewQuantity(2*gb, resource.BinarySI),
+			},
+			reservedMemory: []kubeletconfig.MemoryReservation{
+				{
+					NumaNode: 0,
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: *resource.NewQuantity(2*gb, resource.BinarySI),
+						hugepages1G:       *resource.NewQuantity(2*gb, resource.BinarySI),
+					},
+				},
+			},
+			expectedReservedNodes: []int{},
+		},
+		{
+			description: "all NUMA nodes fully reserved",
+			nodeAllocatableReservation: v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(10*gb, resource.BinarySI),
+				hugepages1G:       *resource.NewQuantity(10*gb, resource.BinarySI),
+			},
+			reservedMemory: []kubeletconfig.MemoryReservation{
+				{
+					NumaNode: 0,
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+						hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+					},
+				},
+				{
+					NumaNode: 1,
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+						hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+					},
+				},
+			},
+			expectedReservedNodes: []int{0, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			reservedNodes, err := GetReservedMemoryNUMANodes(&machineInfo, tc.nodeAllocatableReservation, tc.reservedMemory)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.expectedReservedNodes, reservedNodes)
+		})
+	}
+}
+
+func TestGetReservedMemoryNUMANodesZeroMemory(t *testing.T) {
+	machineInfo := cadvisorapi.MachineInfo{
+		Topology: []cadvisorapi.Node{
+			{
+				Id:     0,
+				Memory: 10 * gb,
+				HugePages: []cadvisorapi.HugePagesInfo{
+					{PageSize: pageSize1Gb, NumPages: 5},
+				},
+			},
+			{
+				Id:     1,
+				Memory: 10 * gb,
+				HugePages: []cadvisorapi.HugePagesInfo{
+					{PageSize: pageSize1Gb, NumPages: 5},
+				},
+			},
+			{Id: 2, Memory: 0},
+			{Id: 3, Memory: 0},
+		},
+	}
+
+	reservedNodes, err := GetReservedMemoryNUMANodes(
+		&machineInfo,
+		v1.ResourceList{
+			v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+			hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+		},
+		[]kubeletconfig.MemoryReservation{
+			{
+				NumaNode: 0,
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+					hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []int{0, 2, 3}, reservedNodes,
+		"nodes with zero memory should be treated as fully reserved without explicit --reserved-memory entries")
+}
+
+func TestGetReservedMemoryNUMANodesMultipleHugepageSizes(t *testing.T) {
+	const pageSize2Mb = 2048 // 2Mi in KB
+
+	machineInfo := cadvisorapi.MachineInfo{
+		Topology: []cadvisorapi.Node{
+			{
+				Id:     0,
+				Memory: 10 * gb,
+				HugePages: []cadvisorapi.HugePagesInfo{
+					{PageSize: pageSize1Gb, NumPages: 5},
+					{PageSize: pageSize2Mb, NumPages: 512},
+				},
+			},
+			{
+				Id:     1,
+				Memory: 10 * gb,
+				HugePages: []cadvisorapi.HugePagesInfo{
+					{PageSize: pageSize1Gb, NumPages: 5},
+				},
+			},
+		},
+	}
+
+	t.Run("1G hugepages fully reserved but 2M hugepages not reserved", func(t *testing.T) {
+		reservedNodes, err := GetReservedMemoryNUMANodes(
+			&machineInfo,
+			v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+				hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+			},
+			[]kubeletconfig.MemoryReservation{
+				{
+					NumaNode: 0,
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+						hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		assert.Empty(t, reservedNodes,
+			"node 0 should not be fully reserved because 2M hugepages are not reserved")
+	})
+
+	t.Run("all hugepage sizes fully reserved", func(t *testing.T) {
+		reservedNodes, err := GetReservedMemoryNUMANodes(
+			&machineInfo,
+			v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+				hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+				hugepages2M:       *resource.NewQuantity(int64(512*2*mb), resource.BinarySI),
+			},
+			[]kubeletconfig.MemoryReservation{
+				{
+					NumaNode: 0,
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: *resource.NewQuantity(5*gb, resource.BinarySI),
+						hugepages1G:       *resource.NewQuantity(5*gb, resource.BinarySI),
+						hugepages2M:       *resource.NewQuantity(int64(512*2*mb), resource.BinarySI),
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []int{0}, reservedNodes,
+			"node 0 should be fully reserved when all hugepage sizes are reserved")
+	})
 }
 
 func TestConvertPreReserved(t *testing.T) {
@@ -1047,7 +1245,7 @@ func TestAddContainer(t *testing.T) {
 		{
 			description:               "Shouldn't return any error when policy is set as None",
 			updateError:               nil,
-			policyName:                policyTypeNone,
+			policyName:                PolicyTypeNone,
 			machineInfo:               machineInfo,
 			reserved:                  reserved,
 			machineState:              state.NUMANodeMap{},
@@ -1994,7 +2192,7 @@ func TestNewManager(t *testing.T) {
 		},
 		{
 			description:                "Should create manager with \"none\" policy",
-			policyName:                 policyTypeNone,
+			policyName:                 PolicyTypeNone,
 			machineInfo:                machineInfo,
 			nodeAllocatableReservation: v1.ResourceList{},
 			systemReservedMemory:       []kubeletconfig.MemoryReservation{},

--- a/pkg/kubelet/cm/memorymanager/policy_none.go
+++ b/pkg/kubelet/cm/memorymanager/policy_none.go
@@ -23,7 +23,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 )
 
-const policyTypeNone policyType = "None"
+// PolicyTypeNone is the name of the "None" memory manager policy.
+const PolicyTypeNone policyType = "None"
 
 // none is implementation of the policy interface for the none policy, using none
 // policy is the same as disable memory management
@@ -37,7 +38,7 @@ func NewPolicyNone(logger klog.Logger) Policy {
 }
 
 func (p *none) Name() string {
-	return string(policyTypeNone)
+	return string(PolicyTypeNone)
 }
 
 func (p *none) Start(logger klog.Logger, s state.State) error {

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -241,6 +241,11 @@ func (p *staticPolicy) AllocatePod(logger klog.Logger, s state.State, pod *v1.Po
 		bestHint = *extendedHint
 	}
 
+	// TODO(#138495): TopologyManager best-effort may select a cross-NUMA hint (e.g. {0,1})
+	// that the static memory manager rejects here because one of those NUMA nodes already has a single-node allocation.
+	// This surfaces as UnexpectedAdmissionError even though resources exist.
+	// A proper fix needs the memory manager to participate in hint preference scoring or TopologyManager
+	// to re-evaluate on allocation failure. See tracking issue for details.
 	if isAffinityViolatingNUMAAllocations(machineState, bestHint.NUMANodeAffinity) {
 		return fmt.Errorf("[memorymanager] preferred hint violates NUMA node allocation")
 	}
@@ -496,6 +501,9 @@ func (p *staticPolicy) Allocate(logger klog.Logger, s state.State, pod *v1.Pod, 
 	// the best hint might violate the NUMA allocation rule on which
 	// NUMA node cannot have both single and cross NUMA node allocations
 	// https://kubernetes.io/blog/2021/08/11/kubernetes-1-22-feature-memory-manager-moves-to-beta/#single-vs-cross-numa-node-allocation
+	//
+	// TODO(#138495): Same best-effort-vs-strict mismatch as the pod-level
+	// path in allocatePod — see tracking issue.
 	if isAffinityViolatingNUMAAllocations(machineState, bestHint.NUMANodeAffinity) {
 		return fmt.Errorf("[memorymanager] preferred hint violates NUMA node allocation")
 	}
@@ -885,11 +893,7 @@ func getContainerRequestedResources(logger logr.Logger, pod *v1.Pod, container *
 }
 
 func (p *staticPolicy) calculateHints(machineState state.NUMANodeMap, pod *v1.Pod, requestedResources map[v1.ResourceName]uint64) map[string][]topologymanager.TopologyHint {
-	var numaNodes []int
-	for n := range machineState {
-		numaNodes = append(numaNodes, n)
-	}
-	sort.Ints(numaNodes)
+	numaNodes := p.getNUMANodesForTopologyHints(machineState)
 
 	// Initialize minAffinitySize to include all NUMA Cells.
 	minAffinitySize := len(numaNodes)
@@ -977,6 +981,37 @@ func (p *staticPolicy) calculateHints(machineState state.NUMANodeMap, pod *v1.Po
 	}
 
 	return hints
+}
+
+func (p *staticPolicy) getNUMANodesForTopologyHints(machineState state.NUMANodeMap) []int {
+	var topologyNUMANodes []int
+	for nodeID := range machineState {
+		topologyNUMANodes = append(topologyNUMANodes, nodeID)
+	}
+	sort.Ints(topologyNUMANodes)
+
+	if p.affinity == nil {
+		return topologyNUMANodes
+	}
+
+	hintNUMANodes := p.affinity.GetNUMANodeIDs()
+	if len(hintNUMANodes) == 0 {
+		return topologyNUMANodes
+	}
+
+	hintNodeSet := map[int]struct{}{}
+	for _, nodeID := range hintNUMANodes {
+		hintNodeSet[nodeID] = struct{}{}
+	}
+
+	var filteredNUMANodes []int
+	for _, nodeID := range topologyNUMANodes {
+		if _, ok := hintNodeSet[nodeID]; ok {
+			filteredNUMANodes = append(filteredNUMANodes, nodeID)
+		}
+	}
+
+	return filteredNUMANodes
 }
 
 func (p *staticPolicy) isHintPreferred(maskBits []int, minAffinitySize int) bool {

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -204,6 +204,75 @@ func newNUMAAffinity(bits ...int) bitmask.BitMask {
 	return affinity
 }
 
+type fakeNUMANodeStore struct {
+	numaNodeIDs []int
+}
+
+func (f *fakeNUMANodeStore) GetAffinity(string, string) topologymanager.TopologyHint {
+	return topologymanager.TopologyHint{}
+}
+
+func (f *fakeNUMANodeStore) GetPolicy() topologymanager.Policy {
+	return nil
+}
+
+func (f *fakeNUMANodeStore) Name() string {
+	return "fake"
+}
+
+func (f *fakeNUMANodeStore) GetNUMANodeIDs() []int {
+	if f.numaNodeIDs == nil {
+		return nil
+	}
+	return append([]int{}, f.numaNodeIDs...)
+}
+
+func TestStaticPolicyGetNUMANodesForTopologyHints(t *testing.T) {
+	machineState := state.NUMANodeMap{
+		0: &state.NUMANodeState{},
+		1: &state.NUMANodeState{},
+		3: &state.NUMANodeState{},
+		5: &state.NUMANodeState{},
+	}
+
+	testCases := []struct {
+		description string
+		affinity    topologymanager.Store
+		expected    []int
+	}{
+		{
+			description: "returns all NUMA nodes when affinity store is nil",
+			affinity:    nil,
+			expected:    []int{0, 1, 3, 5},
+		},
+		{
+			description: "returns all NUMA nodes when affinity does not expose a node filter",
+			affinity:    &fakeNUMANodeStore{numaNodeIDs: nil},
+			expected:    []int{0, 1, 3, 5},
+		},
+		{
+			description: "returns only NUMA nodes exposed by topology manager",
+			affinity:    &fakeNUMANodeStore{numaNodeIDs: []int{0, 1}},
+			expected:    []int{0, 1},
+		},
+		{
+			description: "ignores NUMA nodes not present in machine state",
+			affinity:    &fakeNUMANodeStore{numaNodeIDs: []int{1, 2, 3}},
+			expected:    []int{1, 3},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			p := &staticPolicy{affinity: testCase.affinity}
+			numaNodes := p.getNUMANodesForTopologyHints(machineState)
+			if !reflect.DeepEqual(numaNodes, testCase.expected) {
+				t.Fatalf("unexpected NUMA nodes: got %v, want %v", numaNodes, testCase.expected)
+			}
+		})
+	}
+}
+
 func TestStaticPolicyNew(t *testing.T) {
 	testCases := []testStaticPolicy{
 		{

--- a/pkg/kubelet/cm/topology_utils.go
+++ b/pkg/kubelet/cm/topology_utils.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	cadvisorapi "github.com/google/cadvisor/info/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// filterNUMATopology returns a new slice of cadvisorapi.Node excluding nodes
+// whose IDs appear in excludedNUMANodes. Each kept node is deep-copied so
+// callers can mutate the result without affecting the original topology.
+func filterNUMATopology(topology []cadvisorapi.Node, excludedNUMANodes []int) []cadvisorapi.Node {
+	excludedSet := sets.New(excludedNUMANodes...)
+	filtered := make([]cadvisorapi.Node, 0, len(topology))
+	for _, node := range topology {
+		if !excludedSet.Has(node.Id) {
+			cp := cadvisorapi.Node{
+				Id:     node.Id,
+				Memory: node.Memory,
+			}
+			cp.HugePages = append([]cadvisorapi.HugePagesInfo(nil), node.HugePages...)
+			cp.Cores = make([]cadvisorapi.Core, len(node.Cores))
+			for i, core := range node.Cores {
+				cp.Cores[i] = core
+				cp.Cores[i].Threads = append([]int(nil), core.Threads...)
+				cp.Cores[i].Caches = append([]cadvisorapi.Cache(nil), core.Caches...)
+				cp.Cores[i].UncoreCaches = append([]cadvisorapi.Cache(nil), core.UncoreCaches...)
+			}
+			cp.Caches = append([]cadvisorapi.Cache(nil), node.Caches...)
+			cp.Distances = append([]uint64(nil), node.Distances...)
+			filtered = append(filtered, cp)
+		}
+	}
+	return filtered
+}

--- a/pkg/kubelet/cm/topology_utils_test.go
+++ b/pkg/kubelet/cm/topology_utils_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"testing"
+
+	cadvisorapi "github.com/google/cadvisor/info/v1"
+)
+
+func TestFilterNUMATopology(t *testing.T) {
+	topology := []cadvisorapi.Node{
+		{Id: 0, Memory: 64 * 1024 * 1024 * 1024},
+		{Id: 1, Memory: 64 * 1024 * 1024 * 1024},
+		{Id: 2, Memory: 0},
+		{Id: 3, Memory: 0},
+		{Id: 4, Memory: 0},
+	}
+
+	tests := []struct {
+		name        string
+		excluded    []int
+		expectedIDs []int
+	}{
+		{
+			name:        "no exclusions keeps all nodes",
+			excluded:    nil,
+			expectedIDs: []int{0, 1, 2, 3, 4},
+		},
+		{
+			name:        "exclude zero-memory nodes",
+			excluded:    []int{2, 3, 4},
+			expectedIDs: []int{0, 1},
+		},
+		{
+			name:        "exclude subset of nodes",
+			excluded:    []int{3},
+			expectedIDs: []int{0, 1, 2, 4},
+		},
+		{
+			name:        "exclude all nodes",
+			excluded:    []int{0, 1, 2, 3, 4},
+			expectedIDs: []int{},
+		},
+		{
+			name:        "exclude non-existent node IDs is harmless",
+			excluded:    []int{99, 100},
+			expectedIDs: []int{0, 1, 2, 3, 4},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filtered := filterNUMATopology(topology, tc.excluded)
+			gotIDs := make([]int, len(filtered))
+			for i, n := range filtered {
+				gotIDs[i] = n.Id
+			}
+			if len(gotIDs) != len(tc.expectedIDs) {
+				t.Fatalf("expected %v, got %v", tc.expectedIDs, gotIDs)
+			}
+			for i := range gotIDs {
+				if gotIDs[i] != tc.expectedIDs[i] {
+					t.Fatalf("expected %v, got %v", tc.expectedIDs, gotIDs)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterNUMATopologyDeepCopy(t *testing.T) {
+	topology := []cadvisorapi.Node{
+		{
+			Id:     0,
+			Memory: 64 * 1024 * 1024 * 1024,
+			Cores: []cadvisorapi.Core{
+				{
+					Id:      0,
+					Threads: []int{0, 1},
+					Caches: []cadvisorapi.Cache{
+						{Id: 0, Size: 32 * 1024, Type: "data", Level: 1},
+					},
+					UncoreCaches: []cadvisorapi.Cache{
+						{Id: 1, Size: 32 * 1024 * 1024, Type: "unified", Level: 3},
+					},
+				},
+			},
+			Caches: []cadvisorapi.Cache{
+				{Id: 2, Size: 32 * 1024 * 1024, Type: "unified", Level: 3},
+			},
+			Distances: []uint64{10, 20},
+		},
+		{Id: 1, Memory: 0},
+	}
+
+	filtered := filterNUMATopology(topology, []int{1})
+	if len(filtered) != 1 || filtered[0].Id != 0 {
+		t.Fatalf("expected [0], got %v", filtered)
+	}
+
+	// Mutating the filtered result must not affect the original.
+	filtered[0].Cores[0].Id = 99
+	filtered[0].Cores[0].Threads[0] = 99
+	filtered[0].Cores[0].Caches[0].Id = 99
+	filtered[0].Cores[0].UncoreCaches[0].Id = 99
+	filtered[0].Caches[0].Id = 99
+	filtered[0].Distances[0] = 999
+
+	if topology[0].Cores[0].Id != 0 {
+		t.Error("filterNUMATopology did not deep-copy Cores: original was mutated")
+	}
+	if topology[0].Cores[0].Threads[0] != 0 {
+		t.Error("filterNUMATopology did not deep-copy Core Threads: original was mutated")
+	}
+	if topology[0].Cores[0].Caches[0].Id != 0 {
+		t.Error("filterNUMATopology did not deep-copy Core Caches: original was mutated")
+	}
+	if topology[0].Cores[0].UncoreCaches[0].Id != 1 {
+		t.Error("filterNUMATopology did not deep-copy Core UncoreCaches: original was mutated")
+	}
+	if topology[0].Caches[0].Id != 2 {
+		t.Error("filterNUMATopology did not deep-copy Node Caches: original was mutated")
+	}
+	if topology[0].Distances[0] != 10 {
+		t.Error("filterNUMATopology did not deep-copy Distances: original was mutated")
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -88,6 +88,10 @@ func (m *fakeManager) Name() string {
 	return m.scope
 }
 
+func (m *fakeManager) GetNUMANodeIDs() []int {
+	return nil
+}
+
 func (m *fakeManager) AddHintProvider(logger klog.Logger, h HintProvider) {
 	logger.Info("AddHintProvider", "hintProvider", h)
 }

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
@@ -94,6 +94,12 @@ func (s *scope) GetAffinity(podUID string, containerName string) TopologyHint {
 
 func (s *scope) GetPolicy() Policy {
 	return s.policy
+}
+
+// GetNUMANodeIDs returns nil so hint providers fall back to their own topology view,
+// the filtered NUMA set lives on the top-level manager.
+func (s *scope) GetNUMANodeIDs() []int {
+	return nil
 }
 
 func (s *scope) AddHintProvider(h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -19,6 +19,7 @@ package topologymanager
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
@@ -98,6 +99,8 @@ type Manager interface {
 type manager struct {
 	//Topology Manager Scope
 	scope Scope
+	// NUMA nodes available to topology-aware hint providers.
+	numaNodes []int
 }
 
 // HintProvider is an interface for components that want to collaborate to
@@ -128,6 +131,8 @@ type Store interface {
 	GetAffinity(podUID string, containerName string) TopologyHint
 	GetPolicy() Policy
 	Name() string
+	// GetNUMANodeIDs returns NUMA nodes available for topology-aware placement.
+	GetNUMANodeIDs() []int
 }
 
 // TopologyHint is a struct containing the NUMANodeAffinity for a Container
@@ -170,7 +175,10 @@ func NewManager(topology []cadvisorapi.Node, topologyPolicyName string, topology
 	// When policy is none, the scope is not relevant, so we can short circuit here.
 	if topologyPolicyName == PolicyNone {
 		logger.Info("Creating topology manager with none policy")
-		return &manager{scope: NewNoneScope()}, nil
+		return &manager{
+			scope:     NewNoneScope(),
+			numaNodes: extractNUMANodes(topology),
+		}, nil
 	}
 
 	opts, err := NewPolicyOptions(logger, topologyPolicyOptions)
@@ -219,12 +227,22 @@ func NewManager(topology []cadvisorapi.Node, topologyPolicyName string, topology
 	}
 
 	manager := &manager{
-		scope: scope,
+		scope:     scope,
+		numaNodes: extractNUMANodes(topology),
 	}
 
 	manager.initializeMetrics()
 
 	return manager, nil
+}
+
+func extractNUMANodes(topology []cadvisorapi.Node) []int {
+	numaNodes := make([]int, 0, len(topology))
+	for _, node := range topology {
+		numaNodes = append(numaNodes, node.Id)
+	}
+	sort.Ints(numaNodes)
+	return numaNodes
 }
 
 func (m *manager) initializeMetrics() {
@@ -245,6 +263,10 @@ func (m *manager) GetPolicy() Policy {
 
 func (m *manager) Name() string {
 	return m.scope.Name()
+}
+
+func (m *manager) GetNUMANodeIDs() []int {
+	return append([]int{}, m.numaNodes...)
 }
 
 func (m *manager) AddHintProvider(_ klog.Logger, h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -588,3 +588,55 @@ func TestAdmit(t *testing.T) {
 		}
 	}
 }
+
+func TestManagerGetNUMANodeIDsReturnsFilteredSet(t *testing.T) {
+	topology := []cadvisorapi.Node{
+		{Id: 0}, {Id: 2}, {Id: 5},
+	}
+
+	mgr, err := NewManager(topology, PolicyBestEffort, ContainerTopologyScope, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := mgr.GetNUMANodeIDs()
+	expected := []int{0, 2, 5}
+	if len(got) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+	for i := range expected {
+		if got[i] != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
+	}
+
+	// Mutating the returned slice must not affect the manager's internal state.
+	got[0] = 99
+	second := mgr.GetNUMANodeIDs()
+	if second[0] != 0 {
+		t.Fatalf("GetNUMANodeIDs returned a reference to internal state; expected defensive copy")
+	}
+}
+
+func TestScopeGetNUMANodeIDsReturnsNil(t *testing.T) {
+	for _, scopeName := range []string{ContainerTopologyScope, PodTopologyScope} {
+		t.Run(scopeName, func(t *testing.T) {
+			topology := []cadvisorapi.Node{{Id: 0}, {Id: 1}}
+			mgr, err := NewManager(topology, PolicyBestEffort, scopeName, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			m := mgr.(*manager)
+			scopeResult := m.scope.GetNUMANodeIDs()
+			if scopeResult != nil {
+				t.Errorf("scope.GetNUMANodeIDs() should return nil, got %v", scopeResult)
+			}
+
+			managerResult := mgr.GetNUMANodeIDs()
+			if len(managerResult) == 0 {
+				t.Errorf("manager.GetNUMANodeIDs() should return the filtered set, got %v", managerResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
This PR makes kubelet topology hint generation consistently honor NUMA nodes that are fully reserved by `--reserved-memory`.

**Before this change:**
Reserved memory could make a NUMA node unavailable to memory allocation, but TopologyManager and some hint providers could still evaluate hints against the full machine NUMA topology. On systems with many NUMA nodes, including systems with zero-memory NUMA nodes, that could generate hints for nodes that should not be considered for workload placement and could significantly expand the hint search space.

**What this commit does:**
- Computes NUMA nodes whose regular memory and hugepages are fully reserved by `--reserved-memory`.
- Evaluates that path whenever `--reserved-memory` / `MemoryManagerReservedMemory` is configured, regardless of `memoryManagerPolicy`.
- Filters fully reserved NUMA nodes before creating TopologyManager, and propagates the active NUMA set to CPUManager, MemoryManager, and DeviceManager hint generation.
- Exposes the active NUMA set through `topologymanager.Store.GetNUMANodeIDs()`.
- Scopes CPUManager, DeviceManager, and MemoryManager topology hint enumeration to that active NUMA set, intersected with each provider's local topology view.
- Preserves existing fallback behavior when no active NUMA set is exposed.
- Fails kubelet startup with a clear error if filtering would exclude every NUMA node.
 
#### Which issue(s) this PR is related to:
Mitigates #135541 
Related PR and discussion #135581 
Related KEP discussion: kubernetes/enhancements#5726
Related draft KEP PR: kubernetes/enhancements#5992

#### Special notes for your reviewer:

- hints calculation is still a 2^N algorithm over the **selected NUMA set**.
- If filtering is not active (for example, no effective reserved-memory-based reduction / no NUMA filter exposed), N can still be large.
- For NVIDIA Grace-family systems such as GB200, with the fix path active, N is reduced from the full machine NUMA count to the active non-fully-reserved NUMA set.

e.g. it works on GB200 system. Reserve node0 and node1
```yaml
memoryManagerPolicy: Static
reservedMemory:
- numaNode: 0
  limits:
    memory: "2098Mi"
- numaNode: 1
  limits:
    memory: "2098Mi"
```
so with this fix path, the fully reserved / zero-memory NUMA nodes are excluded automatically.
```bash
87:Mar 06 00:43:47. kubelet[1931217]: I0306 00:43:47.739279 1931217 container_manager_linux.go:303] "Excluding fully reserved NUMA nodes from topology hints" numaNodes=[3,4,5,6,7,8,9,11,12,13,14,15,16,17,19,20,21,22,23,24,25,27,28,29,30,31,32,33]
89:Mar 06 00:43:47  kubelet[1931217]: I0306 00:43:47.739307 1931217 topology_manager.go:160] "Creating topology manager with policy per scope" topologyPolicyName="best-effort" topologyScopeName="container" topologyPolicyOptions={"PreferClosestNUMA":false,"MaxAllowableNUMANodes":34}
130:Mar 06 00:43:47  kubelet[1931217]: I0306 00:43:47.819912 1931217 memory_manager.go:188] "Starting memorymanager" policy="Static"
```

**Current limitation:**
- Static Memory Manager enforces a strict rule: a NUMA node cannot be used in both `single-node` and `cross-node` allocations at the same time.
- If any earlier Guaranteed container gets memory on {0} or {1}, a later container requesting preferred {0,1} can be rejected.
- This is enforced as a hard failure in allocation (`[memorymanager] preferred hint violates NUMA node allocation`) rather than fallback.
- Topology Manager best-effort may still choose {0,1} as preferred (from CPU/GPU hints), creating a mismatch with Memory Manager admission.
- Switching topologyManagerScope from pod to container does not eliminate it; container ordering can still trigger the same conflict.
- Result: pod admission fails with UnexpectedAdmissionError even though resources exist.


#### Does this PR introduce a user-facing change?

**release-note**
```release-note
ACTION REQUIRED: Kubelet topology hint generation now excludes NUMA nodes that are fully reserved via `--reserved-memory` from the active NUMA set used by CPU, memory, and device hint providers, not just memory manager internal decisions. On systems with many zero-memory NUMA nodes (for example, NVIDIA Grace-system), this keeps the TopologyManager NUMA set accurate and avoids generating hints for fully reserved nodes.
The kubelet now refuses to start with a clear error if `--reserved-memory` filtering would exclude every NUMA node.
The internal `topologymanager.Store` interface gained a new method: `GetNUMANodeIDs() []int`. Out-of-tree hint providers implementing this interface must add the method; returning `nil` preserves existing fallback behavior.
The `memorymanager.PolicyTypeNone` constant is now exported for use outside the `memorymanager` package.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
