### PR TITLE
docs(api): clarify env var key constraints for env-from fields

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2350,7 +2350,8 @@ type SecretKeySelector struct {
 
 // EnvFromSource represents the source of a set of ConfigMaps or Secrets
 type EnvFromSource struct {
-	// Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+	// Optional text to prepend to the name of each environment variable.
+	// May consist of any printable ASCII characters except '='.
 	// +optional
 	Prefix string
 	// The ConfigMap to select from.
@@ -2640,7 +2641,8 @@ type Container struct {
 	// +optional
 	Ports []ContainerPort
 	// List of sources to populate environment variables in the container.
-	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+	// The keys defined within a source may consist of any printable ASCII characters except '='.
+	// All invalid keys
 	// will be reported as an event when the container is starting. When a key exists in multiple
 	// sources, the value associated with the last source will take precedence.
 	// Values defined by an Env with a duplicate key will take precedence.
@@ -4427,7 +4429,8 @@ type EphemeralContainerCommon struct {
 	// +optional
 	Ports []ContainerPort
 	// List of sources to populate environment variables in the container.
-	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+	// The keys defined within a source may consist of any printable ASCII characters except '='.
+	// All invalid keys
 	// will be reported as an event when the container is starting. When a key exists in multiple
 	// sources, the value associated with the last source will take precedence.
 	// Values defined by an Env with a duplicate key will take precedence.


### PR DESCRIPTION
## What this PR does
Removes stale `C_IDENTIFIER` wording from three core API comments and aligns them with the current env-var key wording used elsewhere in core types and generated API docs.

Updated fields:
- `EnvFromSource.Prefix`
- `Container.EnvFrom`
- `EphemeralContainerCommon.EnvFrom`

New wording: `may consist of any printable ASCII characters except '='`.

## Why
`pkg/apis/core/types.go` still had a few legacy `C_IDENTIFIER` references while related env-var comments already use the newer wording (for example `EnvVar.Name`, `FileKeySelector.Key`, and corresponding `core/v1` comments). This PR makes those remaining comments consistent.

Ref: kubernetes/website#51187

## Verification
- Ran `hack/update-openapi-spec.sh` on this branch.
- No additional generated-file deltas were produced (`git status` clean after generation).

```release-note
NONE
```
