### PR TITLE
kubectl top: add "stats" to SuggestFor

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
@@ -68,10 +68,11 @@ var (
 
 func NewCmdTop(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "top",
-		Short: i18n.T("Display resource (CPU/memory) usage"),
-		Long:  topLong,
-		Run:   cmdutil.DefaultSubCommandRun(streams.ErrOut),
+		Use:        "top",
+		Short:      i18n.T("Display resource (CPU/memory) usage"),
+		Long:       topLong,
+		Run:        cmdutil.DefaultSubCommandRun(streams.ErrOut),
+		SuggestFor: []string{"stats"},
 	}
 
 	// create subcommands


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds "stats" to the `SuggestFor` field of the top-level `kubectl top` command. Users coming from other container tooling ecosystems, such as Docker, may instinctively try `kubectl stats` when looking for CPU and memory usage information, similar to `docker stats`.

Since `kubectl top` serves a comparable purpose (displaying resource usage for pods and nodes), suggesting top when users type stats improves CLI ergonomics and user experience without changing any functionality.

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
[comment](https://github.com/kubernetes/kubectl/issues/1825#issuecomment-3960746257): as discussed from the last bug scrub meeting about SuggestFor, I think this change also does make sense. Would request reviewers to give their thoughts.
