### PR TITLE
fix: [sig-scheduling] deferred slice not capturing pod updates in cleanup

### DIFF
--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -552,7 +552,9 @@ func TestPreemptionAndNominatedNodeNameScenarios(t *testing.T) {
 					defer testCtx.Scheduler.SchedulingQueue.Close()
 
 					createdPods := []*v1.Pod{}
-					defer testutils.CleanupPods(testCtx.Ctx, cs, t, createdPods)
+					defer func() {
+						testutils.CleanupPods(testCtx.Ctx, cs, t, createdPods)
+					}()
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1347,7 +1347,9 @@ func TestAsyncPreemption(t *testing.T) {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerAsyncPreemption, true)
 
 				createdPods := []*v1.Pod{}
-				defer testutils.CleanupPods(testCtx.Ctx, cs, t, createdPods)
+				defer func() {
+					testutils.CleanupPods(testCtx.Ctx, cs, t, createdPods)
+				}()
 
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()


### PR DESCRIPTION
### What this PR does / why we need it:
- In two integration test functions, `testutils.CleanupPods` was registered via defer immediately after initializing an empty createdPods slice:

```go
createdPods := []*v1.Pod{}
defer testutils.CleanupPods(testCtx.Ctx, cs, t, createdPods)
```
CleanupPods was always called with the original empty slice, regardless of how many pods were appended to createdPods during the test — causing all created pods to be silently leaked after each test run.

The fix wraps the call in a closure so createdPods is evaluated at deferred execution time, when it contains all pods created during the test:

```go
createdPods := []*v1.Pod{}
defer func() {
    testutils.CleanupPods(testCtx.Ctx, cs, t, createdPods)
}()
```

### Which issue(s) this PR is related to:
Fixes #137267

### Does this PR introduce a user-facing change?
NONE

### What type of PR is this?

/kind cleanup
/sig scheduling