### PR TITLE
kcm: Align initial controller sleep interval

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -97,8 +97,6 @@ func init() {
 }
 
 const (
-	// ControllerStartJitter is the Jitter used when starting controller managers
-	ControllerStartJitter = 1.0
 	// ConfigzName is the name used for register kube-controller manager /configz, same with GroupName.
 	ConfigzName = "kubecontrollermanager.config.k8s.io"
 	// kubeControllerManager defines variable used internally when referring to cloud-controller-manager component
@@ -288,7 +286,7 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 
 		// Actually start the controllers.
 		if len(controllers) > 0 {
-			if !RunControllers(ctx, controllerContext, controllers, ControllerStartJitter, c.ControllerShutdownTimeout) {
+			if !RunControllers(ctx, controllers, c.ControllerShutdownTimeout) {
 				return errors.New("controller shutdown timeout reached")
 			}
 		} else {
@@ -707,8 +705,7 @@ func BuildControllers(ctx context.Context, controllerCtx ControllerContext, cont
 // Once the context is cancelled, RunControllers waits for shutdownTimeout for all controllers to terminate.
 // When the timeout is reached, the function unblocks and returns false.
 // Zero shutdown timeout means that there is no timeout.
-func RunControllers(ctx context.Context, controllerCtx ControllerContext, controllers []Controller,
-	controllerStartJitterMaxFactor float64, shutdownTimeout time.Duration) bool {
+func RunControllers(ctx context.Context, controllers []Controller, shutdownTimeout time.Duration) bool {
 	logger := klog.FromContext(ctx)
 
 	// We gather running controllers names for logging purposes.
@@ -756,16 +753,6 @@ func RunControllers(ctx context.Context, controllerCtx ControllerContext, contro
 		for _, controller := range controllers {
 			go func() {
 				defer wg.Done()
-
-				// Since all controllers are started concurrently, we need to sleep within [0, factor * D].
-				// Jitter returns duration within [D, D + factor * D], so we need to subtract D.
-				baseInterval := controllerCtx.ComponentConfig.Generic.ControllerStartInterval.Duration
-				sleepInterval := wait.Jitter(baseInterval, controllerStartJitterMaxFactor) - baseInterval
-
-				// It would be better to unblock and return on context canceled here,
-				// but that makes tests more flaky regarding timing.
-				time.Sleep(sleepInterval)
-
 				logger.V(1).Info("Controller starting...", "controller", controller.Name())
 
 				runningControllersLock.Lock()

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -757,9 +757,14 @@ func RunControllers(ctx context.Context, controllerCtx ControllerContext, contro
 			go func() {
 				defer wg.Done()
 
-				// It would be better to unblock and return on context cancelled here,
+				// Since all controllers are started concurrently, we need to sleep within [0, factor * D].
+				// Jitter returns duration within [D, D + factor * D], so we need to subtract D.
+				baseInterval := controllerCtx.ComponentConfig.Generic.ControllerStartInterval.Duration
+				sleepInterval := wait.Jitter(baseInterval, controllerStartJitterMaxFactor) - baseInterval
+
+				// It would be better to unblock and return on context canceled here,
 				// but that makes tests more flaky regarding timing.
-				time.Sleep(wait.Jitter(controllerCtx.ComponentConfig.Generic.ControllerStartInterval.Duration, controllerStartJitterMaxFactor))
+				time.Sleep(sleepInterval)
 
 				logger.V(1).Info("Controller starting...", "controller", controller.Name())
 

--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -293,7 +293,6 @@ func TestRunControllers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
-			controllerCtx := ControllerContext{}
 
 			// testCtx is used to make sure the controller failing to shut down can exit after the test is finished.
 			testCtx, cancelTest := context.WithCancel(ctx)
@@ -304,7 +303,7 @@ func TestRunControllers(t *testing.T) {
 			ctx, cancelController := context.WithCancel(ctx)
 			cancelController()
 
-			cleanShutdown := RunControllers(ctx, controllerCtx, []Controller{tc.newController(testCtx)}, 0, tc.shutdownTimeout)
+			cleanShutdown := RunControllers(ctx, []Controller{tc.newController(testCtx)}, tc.shutdownTimeout)
 			if cleanShutdown != tc.expectedCleanTermination {
 				t.Errorf("expected clean shutdown %v, got %v", tc.expectedCleanTermination, cleanShutdown)
 			}
@@ -328,6 +327,6 @@ func runControllers(
 	if err != nil {
 		return err
 	}
-	RunControllers(ctx, controllerCtx, controllers, 0, 0)
+	RunControllers(ctx, controllers, 0)
 	return nil
 }

--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -71,8 +71,6 @@ func init() {
 }
 
 const (
-	// ControllerStartJitter is the jitter value used when starting controller managers.
-	ControllerStartJitter = 1.0
 	// ConfigzName is the name used for register cloud-controller manager /configz, same with GroupName.
 	ConfigzName = "cloudcontrollermanager.config.k8s.io"
 )
@@ -336,8 +334,6 @@ func startControllers(ctx context.Context, cloud cloudprovider.Interface, contro
 		}
 		controllerChecks = append(controllerChecks, check)
 		klog.Infof("Started %q", controllerName)
-
-		time.Sleep(wait.Jitter(c.ComponentConfig.Generic.ControllerStartInterval.Duration, ControllerStartJitter))
 	}
 
 	healthzHandler.AddHealthChecker(controllerChecks...)

--- a/staging/src/k8s.io/controller-manager/config/types.go
+++ b/staging/src/k8s.io/controller-manager/config/types.go
@@ -35,6 +35,8 @@ type GenericControllerManagerConfiguration struct {
 	// settings for the proxy server to use when communicating with the apiserver.
 	ClientConnection componentbaseconfig.ClientConnectionConfiguration
 	// How long to wait between starting controller managers
+	//
+	// Deprecated: There is no wait interval between starting controllers anymore.
 	ControllerStartInterval metav1.Duration
 	// leaderElection defines the configuration of leader election client.
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration

--- a/staging/src/k8s.io/controller-manager/options/generic.go
+++ b/staging/src/k8s.io/controller-manager/options/generic.go
@@ -62,6 +62,7 @@ func (o *GenericControllerManagerConfigurationOptions) AddFlags(fss *cliflag.Nam
 	genericfs.Float32Var(&o.ClientConnection.QPS, "kube-api-qps", o.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver.")
 	genericfs.Int32Var(&o.ClientConnection.Burst, "kube-api-burst", o.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver.")
 	genericfs.DurationVar(&o.ControllerStartInterval.Duration, "controller-start-interval", o.ControllerStartInterval.Duration, "Interval between starting controller managers.")
+	_ = genericfs.MarkDeprecated("controller-start-interval", "There is no wait interval between starting controllers anymore.")
 	genericfs.StringSliceVar(&o.Controllers, "controllers", o.Controllers, fmt.Sprintf(""+
 		"A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller "+
 		"named 'foo', '-foo' disables the controller named 'foo'.\nAll controllers: %s\nDisabled-by-default controllers: %s",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

After the last KCM refactoring all controllers are started concurrently. Since `wait.Jitter` is being used, which generates duration within `[D, D + factor*D]`, the controllers always sleep for `D` at least. This is unnecessary and this change makes the interval into `[0, factor*D]`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Aligned kube-controller-manager initial controller sleep interval not to be unnecessarily prolonged 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A