### PR TITLE
Cleanup: apimachinery test flowcontrol remove dep. prometheus

### DIFF
--- a/hack/verify-prometheus-imports.sh
+++ b/hack/verify-prometheus-imports.sh
@@ -74,8 +74,6 @@ allowed_prometheus_importers=(
   ./test/e2e/instrumentation/native_histograms.go
   ./hack/tools/instrumentation/main.go
   ./hack/tools/instrumentation/main_test.go
-  ./test/integration/apiserver/flowcontrol/concurrency_test.go
-  ./test/integration/apiserver/flowcontrol/concurrency_util_test.go
   ./test/integration/metrics/metrics_test.go
 )
 

--- a/hack/verify-prometheus-imports.sh
+++ b/hack/verify-prometheus-imports.sh
@@ -71,7 +71,6 @@ allowed_prometheus_importers=(
   ./staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
   ./staging/src/k8s.io/component-base/metrics/value.go
   ./staging/src/k8s.io/component-base/metrics/wrappers.go
-  ./test/e2e/apimachinery/flowcontrol.go
   ./test/e2e/instrumentation/native_histograms.go
   ./hack/tools/instrumentation/main.go
   ./hack/tools/instrumentation/main_test.go

--- a/hack/verify-prometheus-imports.sh
+++ b/hack/verify-prometheus-imports.sh
@@ -73,8 +73,6 @@ allowed_prometheus_importers=(
   ./test/e2e/instrumentation/native_histograms.go
   ./hack/tools/instrumentation/main.go
   ./hack/tools/instrumentation/main_test.go
-  ./test/integration/apiserver/flowcontrol/concurrency_test.go
-  ./test/integration/apiserver/flowcontrol/concurrency_util_test.go
   ./test/integration/metrics/metrics_test.go
 )
 

--- a/hack/verify-prometheus-imports.sh
+++ b/hack/verify-prometheus-imports.sh
@@ -70,7 +70,6 @@ allowed_prometheus_importers=(
   ./staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
   ./staging/src/k8s.io/component-base/metrics/value.go
   ./staging/src/k8s.io/component-base/metrics/wrappers.go
-  ./test/e2e/apimachinery/flowcontrol.go
   ./test/e2e/instrumentation/native_histograms.go
   ./hack/tools/instrumentation/main.go
   ./hack/tools/instrumentation/main_test.go

--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -17,11 +17,9 @@ limitations under the License.
 package apimachinery
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -29,8 +27,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
 
 	flowcontrol "k8s.io/api/flowcontrol/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,6 +41,7 @@ import (
 	"k8s.io/client-go/rest"
 	clientsideflowcontrol "k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/component-base/metrics/testutil"
 	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -761,27 +758,15 @@ func getPriorityLevelNominalConcurrency(ctx context.Context, c clientset.Interfa
 	if err != nil {
 		return 0, fmt.Errorf("error requesting metrics; request=%#+v, request.URL()=%s: %w", req, req.URL(), err)
 	}
-	sampleDecoder := expfmt.SampleDecoder{
-		Dec:  expfmt.NewDecoder(bytes.NewBuffer(resp), expfmt.NewFormat(expfmt.TypeTextPlain)),
-		Opts: &expfmt.DecodeOptions{},
+
+	m := testutil.NewMetrics()
+	if err := testutil.ParseMetrics(string(resp), &m); err != nil {
+		return 0, err
 	}
-	for {
-		var v model.Vector
-		err := sampleDecoder.Decode(&v)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return 0, err
-		}
-		for _, metric := range v {
-			if string(metric.Metric[model.MetricNameLabel]) != nominalConcurrencyLimitMetricName {
-				continue
-			}
-			if string(metric.Metric[priorityLevelLabelName]) != priorityLevelName {
-				continue
-			}
-			return int32(metric.Value), nil
+
+	for _, sample := range m[nominalConcurrencyLimitMetricName] {
+		if string(sample.Metric[testutil.LabelName(priorityLevelLabelName)]) == priorityLevelName {
+			return int32(sample.Value), nil
 		}
 	}
 	return 0, errPriorityLevelNotFound

--- a/test/integration/apiserver/flowcontrol/concurrency_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_test.go
@@ -18,21 +18,16 @@ package flowcontrol
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"strings"
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
 
 	flowcontrol "k8s.io/api/flowcontrol/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -174,29 +169,17 @@ func getNominalConcurrencyOfPriorityLevel(c clientset.Interface) (map[string]int
 		return nil, err
 	}
 
-	dec := expfmt.NewDecoder(strings.NewReader(string(resp)), expfmt.NewFormat(expfmt.TypeTextPlain))
-	decoder := expfmt.SampleDecoder{
-		Dec:  dec,
-		Opts: &expfmt.DecodeOptions{},
+	m := testutil.NewMetrics()
+	if err := testutil.ParseMetrics(resp, &m); err != nil {
+		return nil, err
 	}
 
 	concurrency := make(map[string]int)
-	for {
-		var v model.Vector
-		if err := decoder.Decode(&v); err != nil {
-			if err == io.EOF {
-				// Expected loop termination condition.
-				return concurrency, nil
-			}
-			return nil, fmt.Errorf("failed decoding metrics: %v", err)
-		}
-		for _, metric := range v {
-			switch name := string(metric.Metric[model.MetricNameLabel]); name {
-			case nominalConcurrencyMetricsName:
-				concurrency[string(metric.Metric[labelPriorityLevel])] = int(metric.Value)
-			}
-		}
+	for _, sample := range m[nominalConcurrencyMetricsName] {
+		concurrency[string(sample.Metric[labelPriorityLevel])] = int(sample.Value)
 	}
+
+	return concurrency, nil
 }
 
 func getRequestCountOfPriorityLevel(c clientset.Interface) (map[string]int, map[string]int, error) {
@@ -205,32 +188,22 @@ func getRequestCountOfPriorityLevel(c clientset.Interface) (map[string]int, map[
 		return nil, nil, err
 	}
 
-	dec := expfmt.NewDecoder(strings.NewReader(string(resp)), expfmt.NewFormat(expfmt.TypeTextPlain))
-	decoder := expfmt.SampleDecoder{
-		Dec:  dec,
-		Opts: &expfmt.DecodeOptions{},
+	m := testutil.NewMetrics()
+	if err := testutil.ParseMetrics(resp, &m); err != nil {
+		return nil, nil, err
 	}
 
 	allReqCounts := make(map[string]int)
-	rejectReqCounts := make(map[string]int)
-	for {
-		var v model.Vector
-		if err := decoder.Decode(&v); err != nil {
-			if err == io.EOF {
-				// Expected loop termination condition.
-				return allReqCounts, rejectReqCounts, nil
-			}
-			return nil, nil, fmt.Errorf("failed decoding metrics: %v", err)
-		}
-		for _, metric := range v {
-			switch name := string(metric.Metric[model.MetricNameLabel]); name {
-			case dispatchedRequestCountMetricsName:
-				allReqCounts[string(metric.Metric[labelPriorityLevel])] = int(metric.Value)
-			case rejectedRequestCountMetricsName:
-				rejectReqCounts[string(metric.Metric[labelPriorityLevel])] = int(metric.Value)
-			}
-		}
+	for _, sample := range m[dispatchedRequestCountMetricsName] {
+		allReqCounts[string(sample.Metric[labelPriorityLevel])] = int(sample.Value)
 	}
+
+	rejectReqCounts := make(map[string]int)
+	for _, sample := range m[rejectedRequestCountMetricsName] {
+		rejectReqCounts[string(sample.Metric[labelPriorityLevel])] = int(sample.Value)
+	}
+
+	return allReqCounts, rejectReqCounts, nil
 }
 
 func createPriorityLevelAndBindingFlowSchemaForUser(c clientset.Interface, username string, concurrencyShares, queuelength int) (*flowcontrol.PriorityLevelConfiguration, *flowcontrol.FlowSchema, error) {

--- a/test/integration/apiserver/flowcontrol/concurrency_util_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_util_test.go
@@ -18,20 +18,15 @@ package flowcontrol
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"math"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/controlplane"
 	"k8s.io/kubernetes/test/integration/framework"
@@ -317,48 +312,35 @@ func TestConcurrencyIsolation(t *testing.T) {
 }
 
 func getRequestMetricsSnapshot(c clientset.Interface) (metricSnapshot, error) {
-
 	resp, err := getMetrics(c)
 	if err != nil {
 		return nil, err
 	}
 
-	dec := expfmt.NewDecoder(strings.NewReader(string(resp)), expfmt.NewFormat(expfmt.TypeTextPlain))
-	decoder := expfmt.SampleDecoder{
-		Dec:  dec,
-		Opts: &expfmt.DecodeOptions{},
+	m := testutil.NewMetrics()
+	if err := testutil.ParseMetrics(resp, &m); err != nil {
+		return nil, err
 	}
 
 	snapshot := metricSnapshot{}
-
-	for {
-		var v model.Vector
-		if err := decoder.Decode(&v); err != nil {
-			if err == io.EOF {
-				// Expected loop termination condition.
-				return snapshot, nil
-			}
-			return nil, fmt.Errorf("failed decoding metrics: %v", err)
-		}
-		for _, metric := range v {
-			plLabel := string(metric.Metric[labelPriorityLevel])
-			entry := plMetrics{}
-			if v, ok := snapshot[plLabel]; ok {
-				entry = v
-			}
-			switch name := string(metric.Metric[model.MetricNameLabel]); name {
+	for metricName, samples := range m {
+		for _, sample := range samples {
+			plLabel := string(sample.Metric[testutil.LabelName(labelPriorityLevel)])
+			entry := snapshot[plLabel]
+			switch metricName {
 			case requestExecutionSecondsSumName:
-				entry.execSeconds.Sum = float64(metric.Value)
+				entry.execSeconds.Sum = float64(sample.Value)
 			case requestExecutionSecondsCountName:
-				entry.execSeconds.Count = int(metric.Value)
+				entry.execSeconds.Count = int(sample.Value)
 			case priorityLevelSeatUtilSumName:
-				entry.seatUtil.Sum = float64(metric.Value)
+				entry.seatUtil.Sum = float64(sample.Value)
 			case priorityLevelSeatUtilCountName:
-				entry.seatUtil.Count = int(metric.Value)
+				entry.seatUtil.Count = int(sample.Value)
 			case nominalConcurrencyLimitMetricsName:
-				entry.availableSeats = int(metric.Value)
+				entry.availableSeats = int(sample.Value)
 			}
 			snapshot[plLabel] = entry
 		}
 	}
+	return snapshot, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove directly prometheus dependency from `test/e2e/apimachinery` and `test/integration/apiserver/flowcontrol`

#### Which issue(s) this PR is related to:

No behavior change, test-only, related #89267

#### Special notes for your reviewer:

_(The following content has been described using AI for the convenience of the reviewers.)_

This PR is part of the long-running SIG Instrumentation effort tracked in #89267 to remove **direct** `github.com/prometheus/...` imports from k/k. The policy is that anything outside `staging/src/k8s.io/component-base/metrics` should consume Prometheus through the wrappers in `component-base/metrics` / `component-base/metrics/testutil`, not import the upstream client libraries themselves. `hack/verify-prometheus-imports.sh` enforces this with an allow-list — every file removed from that allow-list (this PR removes 3) is one more place that no longer reaches into Prometheus directly.

**No behavior change.** The three test files all do the same thing: hit `/metrics`, parse the Prometheus text exposition format, then look up specific flow-control metrics by name + label. They were doing this by streaming-decoding with `expfmt.SampleDecoder` + `model.Vector` from `prometheus/common`. This PR swaps that for `testutil.ParseMetrics` (from `k8s.io/component-base/metrics/testutil`), which internally uses the same Prometheus parser but returns a `map[metricName] -> []Sample` that callers can index directly.

- `hack/verify-prometheus-imports.sh` — drops the three files below from the allow-list.
- `test/e2e/apimachinery/flowcontrol.go` — `getPriorityLevelNominalConcurrency` rewritten to use `testutil.ParseMetrics` + map lookup instead of the EOF-loop decode pattern.
- `test/integration/apiserver/flowcontrol/concurrency_test.go` — same swap in `getNominalConcurrencyOfPriorityLevel` and `getRequestCountOfPriorityLevel`.
- `test/integration/apiserver/flowcontrol/concurrency_util_test.go` — same swap in `getRequestMetricsSnapshot`.

The net is `-106 / +43` because the parsed-map form collapses the previous "decode-loop + switch-on-metric-name + break-on-EOF" boilerplate into a single ranged map lookup per metric.

the only code touched lives under `test/e2e/apimachinery/` and `test/integration/apiserver/flowcontrol/`, which is why this needs API Machinery approval (`hack/OWNERS` is also touched because `verify-prometheus-imports.sh` lives under `hack/`). There is no production code change and no metric semantics change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
