### PR TITLE
default readonly_pkgs in kube_codegen.sh

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -179,6 +179,22 @@ function kube::codegen::gen_helpers() {
           | LC_ALL=C sort -u
     )
 
+
+    # This list needs to cover all of the types used transitively from the
+    # main API types. Validations defined on types in these packages will be
+    # used, but not regenerated, unless they are also listed as a "regular"
+    # input on the command-line.
+    #
+    # This list is the same as in kubernetes/kubernetes hack/update-codegen.sh
+    local validation_readonly_pkgs=(
+        k8s.io/apimachinery/pkg/apis/meta/v1
+        k8s.io/apimachinery/pkg/api/resource
+        k8s.io/apimachinery/pkg/runtime
+        k8s.io/apimachinery/pkg/types
+        k8s.io/apimachinery/pkg/util/intstr
+        time
+    )
+
     if [ "${#input_pkgs[@]}" != 0 ]; then
         echo "Generating validation code for ${#input_pkgs[@]} targets"
 
@@ -191,6 +207,7 @@ function kube::codegen::gen_helpers() {
         "${GOBIN}/validation-gen" \
             -v "${v}" \
             --output-file zz_generated.validations.go \
+            "$(printf -- " --readonly-pkg %s" "${validation_readonly_pkgs[@]}")" \
             --go-header-file "${boilerplate}" \
             "${input_pkgs[@]}"
     fi


### PR DESCRIPTION
These readonly packages are the same as in hack/update-codegen.sh. Without users of kube_codegen.sh will get an error from validation-gen if they use e.g. metav1.TypeMeta in their types.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/sig api-machinery

#### What this PR does / why we need it:
If a user of the `kube_codegen.sh` script provided in `src/staging/k8s.io/code-generator` is trying to generate validation for structs that contain an embedded `metav1.TypeMeta` the generation currently fails with: 
```
targets.go:358] failed to generate validations: v1alpha1.Config.TypeMeta: 
type k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta is in a non-included package;
either add this package to validation-gen's --readonly-pkg flag,
or add +k8s:opaqueType to the field to skip validation
```

In the [hack/update-codegen.sh script](https://github.com/kubernetes/kubernetes/blob/cf876463cdf5571d2051096859779d9d210074b3/hack/update-codegen.sh#L442-L453) packages are set as readonly-pkg by default. This PR adds these packages to the kube_codegen.sh script as well.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
/cc @thockin 
/cc @jpbetz 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
