### PR TITLE
Remove redundant variable re-assignment in for-loops under pkg

### DIFF
--- a/pkg/api/testing/defaulting_test.go
+++ b/pkg/api/testing/defaulting_test.go
@@ -244,7 +244,6 @@ func TestDefaulting(t *testing.T) {
 	sort.Sort(testTypes)
 
 	for _, gvk := range testTypes {
-		gvk := gvk
 		t.Run(gvk.String(), func(t *testing.T) {
 			// Each sub-tests gets its own fuzzer instance to make running it independent
 			// from what other tests ran before.

--- a/pkg/apis/apps/v1/defaults_test.go
+++ b/pkg/apis/apps/v1/defaults_test.go
@@ -595,7 +595,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MaxUnavailableStatefulSet, test.enableMaxUnavailablePolicy)
 

--- a/pkg/apis/apps/v1beta1/defaults_test.go
+++ b/pkg/apis/apps/v1beta1/defaults_test.go
@@ -492,7 +492,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MaxUnavailableStatefulSet, test.enableMaxUnavailablePolicy)
 			obj2 := roundTrip(t, runtime.Object(test.original))

--- a/pkg/apis/apps/v1beta2/defaults_test.go
+++ b/pkg/apis/apps/v1beta2/defaults_test.go
@@ -467,7 +467,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MaxUnavailableStatefulSet, test.enableMaxUnavailablePolicy)
 			obj2 := roundTrip(t, runtime.Object(test.original))

--- a/pkg/apis/core/v1/helper/helpers_test.go
+++ b/pkg/apis/core/v1/helper/helpers_test.go
@@ -54,7 +54,6 @@ func TestIsNativeResource(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("resourceName input=%s, expected value=%v", tc.resourceName, tc.expectVal), func(t *testing.T) {
 			t.Parallel()
 			v := IsNativeResource(tc.resourceName)
@@ -95,8 +94,6 @@ func TestHugePageSizeFromResourceName(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		i := i
-		tc := tc
 		t.Run(fmt.Sprintf("resourceName input=%s, expected value=%v", tc.resourceName, tc.expectVal), func(t *testing.T) {
 			t.Parallel()
 			v, err := HugePageSizeFromResourceName(tc.resourceName)
@@ -164,8 +161,6 @@ func TestHugePageSizeFromMedium(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		i := i
-		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 			v, err := HugePageSizeFromMedium(tc.medium)
@@ -206,7 +201,6 @@ func TestIsOvercommitAllowed(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("resourceName input=%s, expected value=%v", tc.resourceName, tc.expectVal), func(t *testing.T) {
 			t.Parallel()
 			v := IsOvercommitAllowed(tc.resourceName)

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -499,7 +499,6 @@ func Test_signer_duration(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -1247,8 +1247,6 @@ func TestControllerV2SyncCronJob(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
-		name := name
-		tc := tc
 
 		t.Run(name, func(t *testing.T) {
 			cj := cronJob()

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -4198,7 +4198,6 @@ func TestSyncJobWithJobPodFailurePolicy(t *testing.T) {
 			}
 			sharedInformerFactory.Batch().V1().Jobs().Informer().GetIndexer().Add(job)
 			for i, pod := range tc.pods {
-				pod := pod
 				pb := podBuilder{Pod: &pod}.name(fmt.Sprintf("mypod-%d", i)).job(job)
 				if job.Spec.CompletionMode != nil && *job.Spec.CompletionMode == batch.IndexedCompletion {
 					pb.index(fmt.Sprintf("%v", i))
@@ -5904,7 +5903,6 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 			}
 			sharedInformerFactory.Batch().V1().Jobs().Informer().GetIndexer().Add(job)
 			for i, pod := range tc.pods {
-				pod := pod
 				pb := podBuilder{Pod: &pod}.name(fmt.Sprintf("mypod-%d", i)).job(job)
 				if job.Spec.CompletionMode != nil && *job.Spec.CompletionMode == batch.IndexedCompletion {
 					pb.index(fmt.Sprintf("%v", getCompletionIndex(pod.Annotations)))

--- a/pkg/controller/job/tracking_utils_test.go
+++ b/pkg/controller/job/tracking_utils_test.go
@@ -91,7 +91,6 @@ func TestUIDTrackingExpectations(t *testing.T) {
 		wg.Add(len(track.firstRound) + 1)
 		track := track
 		for _, uid := range track.firstRound {
-			uid := uid
 			go func() {
 				expectations.finalizerRemovalObserved(logger, track.job, uid)
 				wg.Done()

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -809,7 +809,6 @@ func runSyncTests(t *testing.T, ctx context.Context, tests []controllerTest, sto
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			doit(t, test)
 		})
@@ -944,7 +943,6 @@ func runMultisyncTests(t *testing.T, ctx context.Context, tests []controllerTest
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			run(t, test)

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -394,7 +394,6 @@ func TestControllerSync(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			doit(test)
 		})

--- a/pkg/credentialprovider/plugin/plugin_test.go
+++ b/pkg/credentialprovider/plugin/plugin_test.go
@@ -571,7 +571,6 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			klog.SetOutput(&buf)
@@ -657,7 +656,6 @@ func Test_ProvideParallel(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			var wg sync.WaitGroup
@@ -1292,9 +1290,7 @@ func TestGenerateServiceAccountCacheKey_Deterministic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		for _, tc2 := range testCases {
-			tc2 := tc2
 			t.Run(fmt.Sprintf("%+v-%+v", tc, tc2), func(t *testing.T) {
 				serviceAccountCacheKey1, err1 := generateServiceAccountCacheKey(cacheKeyParams{
 					namespace:          tc.serviceAccountNamespace,

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -325,7 +325,6 @@ func TestNewPodContainerManager(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			pcm := c.cm.NewPodContainerManager()

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1507,7 +1507,6 @@ func TestCreateMirrorPod(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)

--- a/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
@@ -161,7 +161,6 @@ func TestMonitorShutdown(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			fakeSystemBus := &fakeSystemDBus{}
 			bus := DBusCon{

--- a/pkg/probe/util_test.go
+++ b/pkg/probe/util_test.go
@@ -78,7 +78,6 @@ func TestFindPortByName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := findPortByName(tt.args.container, tt.args.portName)
@@ -181,7 +180,6 @@ func TestResolveContainerPort(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := ResolveContainerPort(tt.args.param, tt.args.container)

--- a/pkg/registry/certificates/certificates/storage/metrics_test.go
+++ b/pkg/registry/certificates/certificates/storage/metrics_test.go
@@ -384,7 +384,6 @@ func Test_countCSRDurationMetric(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/registry/certificates/certificates/strategy_test.go
+++ b/pkg/registry/certificates/certificates/strategy_test.go
@@ -132,7 +132,6 @@ func TestStrategyCreate(t *testing.T) {
 	}
 
 	for k, tc := range tests {
-		tc := tc
 		t.Run(k, func(t *testing.T) {
 			obj := tc.obj
 			Strategy.PrepareForCreate(tc.ctx, obj)

--- a/pkg/registry/core/service/portallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/portallocator/storage/storage_test.go
@@ -129,7 +129,6 @@ func TestAllocate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // NOTE: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 		t.Run(tt.name, func(t *testing.T) {
 			err := storage.Allocate(tt.port)
 			if (err == nil) != (tt.errMsg == "") {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -2899,7 +2899,6 @@ func (tc *testContext) listAll(tCtx ktesting.TContext) (objects []metav1.Object)
 	claims, err := tc.client.ResourceV1().ResourceClaims("").List(tCtx, metav1.ListOptions{})
 	tCtx.ExpectNoError(err, "list claims")
 	for _, claim := range claims.Items {
-		claim := claim
 		objects = append(objects, &claim)
 	}
 	sortObjects(objects)

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -2104,7 +2104,6 @@ func TestBindPodVolumes(t *testing.T) {
 	}
 
 	for name, scenario := range scenarios {
-		scenario := scenario
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			run(t, scenario)

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -1094,7 +1094,6 @@ func TestRunPreScorePlugins(t *testing.T) {
 			r := make(Registry)
 			enabled := make([]config.Plugin, len(tt.plugins))
 			for i, p := range tt.plugins {
-				p := p
 				enabled[i].Name = p.name
 				if err := r.Register(p.name, func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
 					return p, nil
@@ -1731,7 +1730,6 @@ func TestRunPreFilterPlugins(t *testing.T) {
 			r := make(Registry)
 			enabled := make([]config.Plugin, len(tt.plugins))
 			for i, p := range tt.plugins {
-				p := p
 				enabled[i].Name = p.name
 				if err := r.Register(p.name, func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
 					return p, nil
@@ -1826,7 +1824,6 @@ func TestRunPreFilterExtensionRemovePod(t *testing.T) {
 			r := make(Registry)
 			enabled := make([]config.Plugin, len(tt.plugins))
 			for i, p := range tt.plugins {
-				p := p
 				enabled[i].Name = p.name
 				if err := r.Register(p.name, func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
 					return p, nil
@@ -1914,7 +1911,6 @@ func TestRunPreFilterExtensionAddPod(t *testing.T) {
 			r := make(Registry)
 			enabled := make([]config.Plugin, len(tt.plugins))
 			for i, p := range tt.plugins {
-				p := p
 				enabled[i].Name = p.name
 				if err := r.Register(p.name, func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
 					return p, nil

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -548,7 +548,6 @@ func doTestSetUp(sc scenario, mounter volume.Mounter) []error {
 	var fakeOutputs []fakeexec.FakeAction
 	var fcmd fakeexec.FakeCmd
 	for _, expected := range expecteds {
-		expected := expected
 		if expected.cmd[1] == "clone" {
 			// Calculate the subdirectory clone would create (if any)
 			// git clone -- https://github.com/kubernetes/kubernetes.git target_dir --> target_dir

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -1060,7 +1060,6 @@ func TestWriteAgainAfterUnexpectedExit(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			targetDir, err := utiltesting.MkTmpdir("atomic-write")
 			if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This the [forvar](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_forvar) rule from modernize. The semantics of the for-loop changed from Go 1.22 to make this pattern obsolete.

The rule has already been applied under test in #136518.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

The affected files are only test-files.

No post-editing was done after running:
```sh
cd pkg
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -forvar -fix -test ./...
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
