### PR TITLE
Add credential plugin`kubectl kuberc set` options

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -121,7 +121,7 @@ func NewCmdKubeRCSet(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&o.Section, "section", o.Section, "Section to modify: 'defaults', 'aliases', or 'credentialplugin'")
 	cmd.MarkFlagRequired("section") // nolint:errcheck
 	cmd.Flags().StringVar(&o.Command, "command", o.Command, "Command to configure (e.g., 'get', 'create', 'set env')")
-	// cmd.MarkFlagRequired("command") // nolint:errcheck
+	cmd.MarkFlagRequired("command") // nolint:errcheck
 	cmd.Flags().StringVar(&o.AliasName, "name", o.AliasName, "Alias name (required for --section=aliases)")
 	cmd.Flags().StringVar(&o.PluginPolicy, "policy", o.PluginPolicy, "Plugin policy to use for exec credential plugins")
 	cmd.Flags().StringArrayVar(&o.Options, "option", o.Options, "Flag option in the form flag=value (can be specified multiple times)")
@@ -168,6 +168,30 @@ func (o *SetOptions) Validate() error {
 
 	if o.Section == sectionDefaults && (len(o.PrependArgs) > 0 || len(o.AppendArgs) > 0) {
 		return fmt.Errorf("--prependarg and --appendarg are only valid for --section=%s", sectionAliases)
+	}
+
+	if o.Section != sectionCredentialPlugin && o.Command == "" {
+		return fmt.Errorf("required flag 'command' not set")
+	}
+
+	if o.Section == sectionCredentialPlugin {
+		if o.PluginPolicy == "" {
+			return fmt.Errorf("--policy is required when --section=%s", sectionCredentialPlugin)
+		}
+
+		switch v1beta1.CredentialPluginPolicy(o.PluginPolicy) {
+		case v1beta1.PluginPolicyAllowAll, v1beta1.PluginPolicyDenyAll:
+			if len(o.AllowlistEntries) != 0 {
+				return fmt.Errorf("--allowlist-entry may only be used when --section=%s and --policy=%s", sectionCredentialPlugin, v1beta1.PluginPolicyAllowlist)
+			}
+		case v1beta1.PluginPolicyAllowlist:
+			if len(o.AllowlistEntries) == 0 {
+				return fmt.Errorf("--allowlist-entry is required when --section=%s and --policy=%s", sectionCredentialPlugin, v1beta1.PluginPolicyAllowlist)
+			}
+		default:
+			return fmt.Errorf("invalid value for --policy: %q", o.PluginPolicy)
+		}
+
 	}
 
 	return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -379,8 +379,7 @@ func getAllowlistEntries(o *SetOptions) ([]v1beta1.AllowlistEntry, error) {
 	var entries []v1beta1.AllowlistEntry
 	// Check if this alias already exists
 	for _, entry := range o.AllowlistEntries {
-		kvs := strings.Split(entry, ",")
-		for _, kv := range kvs {
+		for kv := range strings.SplitSeq(entry, ",") {
 			k, v, ok := strings.Cut(kv, "=")
 			if !ok {
 				errs = append(errs, fmt.Errorf("improperly formatted allowlist entry: %q", kv))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -17,25 +17,30 @@ limitations under the License.
 package kuberc
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/kuberc"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/config/v1beta1"
+	"k8s.io/kubectl/pkg/kuberc"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	"sigs.k8s.io/yaml"
 )
 
 const (
-	sectionDefaults = "defaults"
-	sectionAliases  = "aliases"
+	sectionDefaults         = "defaults"
+	sectionAliases          = "aliases"
+	sectionCredentialPlugin = "credentialplugin"
+
+	allowlistEntryFieldName    = "name"
+	allowlistEntryFieldCommand = "command"
 )
 
 var (
@@ -69,14 +74,16 @@ var (
 
 // SetOptions contains the options for setting kuberc configuration
 type SetOptions struct {
-	KubeRCFile  string
-	Section     string // "defaults" or "aliases"
-	Command     string
-	AliasName   string   // for aliases
-	Options     []string // flag=value pairs
-	PrependArgs []string
-	AppendArgs  []string
-	Overwrite   bool
+	KubeRCFile       string
+	Section          string // "defaults", "aliases", or "credentialplugin"
+	Command          string
+	AliasName        string   // for aliases
+	Options          []string // flag=value pairs
+	PrependArgs      []string
+	AppendArgs       []string
+	Overwrite        bool
+	PluginPolicy     string
+	AllowlistEntries []string
 
 	preferences kuberc.PreferencesHandler
 
@@ -111,14 +118,16 @@ func NewCmdKubeRCSet(streams genericiooptions.IOStreams) *cobra.Command {
 	}
 
 	o.preferences.AddFlags(cmd.Flags())
-	cmd.Flags().StringVar(&o.Section, "section", o.Section, "Section to modify: 'defaults' or 'aliases'")
+	cmd.Flags().StringVar(&o.Section, "section", o.Section, "Section to modify: 'defaults', 'aliases', or 'credentialplugin'")
 	cmd.MarkFlagRequired("section") // nolint:errcheck
 	cmd.Flags().StringVar(&o.Command, "command", o.Command, "Command to configure (e.g., 'get', 'create', 'set env')")
-	cmd.MarkFlagRequired("command") // nolint:errcheck
+	// cmd.MarkFlagRequired("command") // nolint:errcheck
 	cmd.Flags().StringVar(&o.AliasName, "name", o.AliasName, "Alias name (required for --section=aliases)")
+	cmd.Flags().StringVar(&o.PluginPolicy, "policy", o.PluginPolicy, "Plugin policy to use for exec credential plugins")
 	cmd.Flags().StringArrayVar(&o.Options, "option", o.Options, "Flag option in the form flag=value (can be specified multiple times)")
 	cmd.Flags().StringArrayVar(&o.PrependArgs, "prependarg", o.PrependArgs, "Argument to prepend to the command (can be specified multiple times, for aliases only)")
 	cmd.Flags().StringArrayVar(&o.AppendArgs, "appendarg", o.AppendArgs, "Argument to append to the command (can be specified multiple times, for aliases only)")
+	cmd.Flags().StringArrayVar(&o.AllowlistEntries, "allowlist-entry", o.AllowlistEntries, "Allowlist Entry the form field=value (can be specified multiple times)")
 	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", o.Overwrite, "Allow overwriting existing entries")
 
 	return cmd
@@ -145,8 +154,8 @@ func (o *SetOptions) Validate() error {
 		return fmt.Errorf("KUBERC is disabled via KUBERC=off environment variable")
 	}
 
-	if o.Section != sectionDefaults && o.Section != sectionAliases {
-		return fmt.Errorf("--section must be %q or %q, got: %s", sectionDefaults, sectionAliases, o.Section)
+	if o.Section != sectionDefaults && o.Section != sectionAliases && o.Section != sectionCredentialPlugin {
+		return fmt.Errorf("--section must be %q, %q, or %q, got: %s", sectionDefaults, sectionAliases, sectionCredentialPlugin, o.Section)
 	}
 
 	if o.Section == sectionAliases && o.AliasName == "" {
@@ -181,6 +190,8 @@ func (o *SetOptions) Run() error {
 		err = o.setDefaults(pref, optionDefaults)
 	case sectionAliases:
 		err = o.setAlias(pref, optionDefaults)
+	case sectionCredentialPlugin:
+		err = o.setCredentialPlugin(pref, optionDefaults)
 	}
 	if err != nil {
 		return err
@@ -311,4 +322,66 @@ func (o *SetOptions) setAlias(pref *v1beta1.Preference, options []v1beta1.Comman
 	})
 
 	return nil
+}
+
+// setAlias updates the aliases section of the preference
+func (o *SetOptions) setCredentialPlugin(pref *v1beta1.Preference, options []v1beta1.CommandOptionDefault) error {
+	policy := v1beta1.CredentialPluginPolicy(o.PluginPolicy)
+
+	switch policy {
+	case v1beta1.PluginPolicyAllowAll, v1beta1.PluginPolicyDenyAll:
+		if len(o.AllowlistEntries) != 0 {
+			return fmt.Errorf("credential plugin allowlist entries provided when policy was not %q", v1beta1.PluginPolicyAllowlist)
+		}
+	case v1beta1.PluginPolicyAllowlist:
+		entries, err := getAllowlistEntries(o)
+		if err != nil {
+			return err
+		}
+		pref.CredentialPluginAllowlist = entries
+	default:
+		return fmt.Errorf("invalid plugin policy: %q", policy)
+	}
+
+	pref.CredentialPluginPolicy = policy
+	return nil
+}
+
+func getAllowlistEntries(o *SetOptions) ([]v1beta1.AllowlistEntry, error) {
+	if len(o.AllowlistEntries) == 0 {
+		return nil, fmt.Errorf("--allowlist-entry must be provided when policy is %q", v1beta1.PluginPolicyAllowlist)
+	}
+
+	var errs []error
+	var entries []v1beta1.AllowlistEntry
+	// Check if this alias already exists
+	for _, entry := range o.AllowlistEntries {
+		kvs := strings.Split(entry, ",")
+		for _, kv := range kvs {
+			k, v, ok := strings.Cut(kv, "=")
+			if !ok {
+				errs = append(errs, fmt.Errorf("improperly formatted allowlist entry: %q", kv))
+				continue
+			}
+
+			var entry v1beta1.AllowlistEntry
+			switch k {
+			case allowlistEntryFieldName:
+				errs = append(errs, fmt.Errorf("allowlist entry field %q is deprecated, use %q instead", allowlistEntryFieldName, allowlistEntryFieldCommand))
+				continue
+			case allowlistEntryFieldCommand:
+				entry.Command = v
+			default:
+				errs = append(errs, fmt.Errorf("unrecognized allowlist entry field: %q", k))
+				continue
+			}
+
+			entries = append(entries, entry)
+		}
+	}
+
+	if errs != nil {
+		return nil, errors.Join(errs...)
+	}
+	return entries, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -121,7 +121,6 @@ func NewCmdKubeRCSet(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&o.Section, "section", o.Section, "Section to modify: 'defaults', 'aliases', or 'credentialplugin'")
 	cmd.MarkFlagRequired("section") // nolint:errcheck
 	cmd.Flags().StringVar(&o.Command, "command", o.Command, "Command to configure (e.g., 'get', 'create', 'set env')")
-	cmd.MarkFlagRequired("command") // nolint:errcheck
 	cmd.Flags().StringVar(&o.AliasName, "name", o.AliasName, "Alias name (required for --section=aliases)")
 	cmd.Flags().StringVar(&o.PluginPolicy, "policy", o.PluginPolicy, "Plugin policy to use for exec credential plugins")
 	cmd.Flags().StringArrayVar(&o.Options, "option", o.Options, "Flag option in the form flag=value (can be specified multiple times)")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -399,6 +399,11 @@ func getAllowlistEntries(o *SetOptions) ([]v1beta1.AllowlistEntry, error) {
 				continue
 			}
 
+			if len(strings.TrimSpace(v)) == 0 {
+				errs = append(errs, fmt.Errorf("empty value in allowlist entry for field %q", k))
+				continue
+			}
+
 			entries = append(entries, entry)
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -170,7 +170,7 @@ func (o *SetOptions) Validate() error {
 	}
 
 	if o.Section != sectionCredentialPlugin && o.Command == "" {
-		return fmt.Errorf("required flag 'command' not set")
+		return fmt.Errorf("--command is required when --section=%s or --section=%s", sectionAliases, sectionDefaults)
 	}
 
 	if o.Section == sectionCredentialPlugin {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kuberc
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -25,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/config/v1beta1"
@@ -69,7 +69,10 @@ var (
 		kubectl kuberc set --section aliases --name runx --command run --option image=nginx --appendarg "--" --appendarg custom-arg1
 
 		# Overwrite an existing default
-		kubectl kuberc set --section defaults --command get --option output=json --overwrite`))
+		kubectl kuberc set --section defaults --command get --option output=json --overwrite
+
+		# Set the credential plugin policy and allowlist
+		kubectl kuberc set --section credentialplugin --policy Allowlist --allowlist-entry command=cloud-credential-helper`))
 )
 
 // SetOptions contains the options for setting kuberc configuration
@@ -126,7 +129,7 @@ func NewCmdKubeRCSet(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringArrayVar(&o.Options, "option", o.Options, "Flag option in the form flag=value (can be specified multiple times)")
 	cmd.Flags().StringArrayVar(&o.PrependArgs, "prependarg", o.PrependArgs, "Argument to prepend to the command (can be specified multiple times, for aliases only)")
 	cmd.Flags().StringArrayVar(&o.AppendArgs, "appendarg", o.AppendArgs, "Argument to append to the command (can be specified multiple times, for aliases only)")
-	cmd.Flags().StringArrayVar(&o.AllowlistEntries, "allowlist-entry", o.AllowlistEntries, "Allowlist Entry the form field=value (can be specified multiple times)")
+	cmd.Flags().StringArrayVar(&o.AllowlistEntries, "allowlist-entry", o.AllowlistEntries, "Allowlist entry the form field=value (can be specified multiple times)")
 	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", o.Overwrite, "Allow overwriting existing entries")
 
 	return cmd
@@ -188,7 +191,7 @@ func (o *SetOptions) Validate() error {
 				return fmt.Errorf("--allowlist-entry is required when --section=%s and --policy=%s", sectionCredentialPlugin, v1beta1.PluginPolicyAllowlist)
 			}
 		default:
-			return fmt.Errorf(" --policy must be  %q, %q, or %q, got: %s",v1beta1.PluginPolicyAllowAll, v1beta1.PluginPolicyDenyAll, v1beta1.PluginPolicyAllowlist,  o.PluginPolicy)
+			return fmt.Errorf(" --policy must be  %q, %q, or %q, got: %s", v1beta1.PluginPolicyAllowAll, v1beta1.PluginPolicyDenyAll, v1beta1.PluginPolicyAllowlist, o.PluginPolicy)
 		}
 
 	}
@@ -347,11 +350,13 @@ func (o *SetOptions) setAlias(pref *v1beta1.Preference, options []v1beta1.Comman
 	return nil
 }
 
-// setAlias updates the aliases section of the preference
+// setCredentialPlugin sets the credential plugin policy and (optionally) the allowlist
 func (o *SetOptions) setCredentialPlugin(pref *v1beta1.Preference, options []v1beta1.CommandOptionDefault) error {
 	policy := v1beta1.CredentialPluginPolicy(o.PluginPolicy)
 
 	switch policy {
+	case "":
+		return fmt.Errorf("credential plugin policy cannot be empty")
 	case v1beta1.PluginPolicyAllowAll, v1beta1.PluginPolicyDenyAll:
 		if len(o.AllowlistEntries) != 0 {
 			return fmt.Errorf("credential plugin allowlist entries provided when policy was not %q", v1beta1.PluginPolicyAllowlist)
@@ -377,29 +382,28 @@ func getAllowlistEntries(o *SetOptions) ([]v1beta1.AllowlistEntry, error) {
 
 	var errs []error
 	var entries []v1beta1.AllowlistEntry
-	// Check if this alias already exists
-	for _, entry := range o.AllowlistEntries {
-		for kv := range strings.SplitSeq(entry, ",") {
-			k, v, ok := strings.Cut(kv, "=")
-			if !ok {
-				errs = append(errs, fmt.Errorf("improperly formatted allowlist entry: %q", kv))
+	for _, keyValuepairs := range o.AllowlistEntries {
+		for keyValuePair := range strings.SplitSeq(keyValuepairs, ",") {
+			field, value, hasSeparator := strings.Cut(keyValuePair, "=")
+			if !hasSeparator {
+				errs = append(errs, fmt.Errorf("improperly formatted allowlist entry: %q", keyValuePair))
 				continue
 			}
 
 			var entry v1beta1.AllowlistEntry
-			switch k {
+			switch field {
 			case allowlistEntryFieldName:
 				errs = append(errs, fmt.Errorf("allowlist entry field %q is deprecated, use %q instead", allowlistEntryFieldName, allowlistEntryFieldCommand))
 				continue
 			case allowlistEntryFieldCommand:
-				entry.Command = v
+				entry.Command = value
 			default:
-				errs = append(errs, fmt.Errorf("unrecognized allowlist entry field: %q", k))
+				errs = append(errs, fmt.Errorf("unrecognized allowlist entry field: %q", field))
 				continue
 			}
 
-			if len(strings.TrimSpace(v)) == 0 {
-				errs = append(errs, fmt.Errorf("empty value in allowlist entry for field %q", k))
+			if len(strings.TrimSpace(value)) == 0 {
+				errs = append(errs, fmt.Errorf("empty value in allowlist entry for field %q", field))
 				continue
 			}
 
@@ -407,8 +411,5 @@ func getAllowlistEntries(o *SetOptions) ([]v1beta1.AllowlistEntry, error) {
 		}
 	}
 
-	if errs != nil {
-		return nil, errors.Join(errs...)
-	}
-	return entries, nil
+	return entries, utilerrors.NewAggregate(errs)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -125,7 +125,7 @@ func NewCmdKubeRCSet(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.MarkFlagRequired("section") // nolint:errcheck
 	cmd.Flags().StringVar(&o.Command, "command", o.Command, "Command to configure (e.g., 'get', 'create', 'set env')")
 	cmd.Flags().StringVar(&o.AliasName, "name", o.AliasName, "Alias name (required for --section=aliases)")
-	cmd.Flags().StringVar(&o.PluginPolicy, "policy", o.PluginPolicy, "Plugin policy to use for exec credential plugins")
+	cmd.Flags().StringVar(&o.PluginPolicy, "policy", o.PluginPolicy, "Plugin policy to use for exec credential plugins, must be one of 'AllowAll', 'DenyAll' or 'Allowlist'")
 	cmd.Flags().StringArrayVar(&o.Options, "option", o.Options, "Flag option in the form flag=value (can be specified multiple times)")
 	cmd.Flags().StringArrayVar(&o.PrependArgs, "prependarg", o.PrependArgs, "Argument to prepend to the command (can be specified multiple times, for aliases only)")
 	cmd.Flags().StringArrayVar(&o.AppendArgs, "appendarg", o.AppendArgs, "Argument to append to the command (can be specified multiple times, for aliases only)")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -188,7 +188,7 @@ func (o *SetOptions) Validate() error {
 				return fmt.Errorf("--allowlist-entry is required when --section=%s and --policy=%s", sectionCredentialPlugin, v1beta1.PluginPolicyAllowlist)
 			}
 		default:
-			return fmt.Errorf("invalid value for --policy: %q", o.PluginPolicy)
+			return fmt.Errorf(" --policy must be  %q, %q, or %q, got: %s",v1beta1.PluginPolicyAllowAll, v1beta1.PluginPolicyDenyAll, v1beta1.PluginPolicyAllowlist,  o.PluginPolicy)
 		}
 
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set_test.go
@@ -731,3 +731,315 @@ aliases:
 		})
 	}
 }
+
+func TestSetOptions_Run_CredentialPlugin(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingKuberc string
+		options        SetOptions
+		expectedPref   *v1beta1.Preference
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:           "plugin policy AllowAll",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:      sectionCredentialPlugin,
+				PluginPolicy: string(v1beta1.PluginPolicyAllowAll),
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyAllowAll,
+			},
+		},
+		{
+			name:           "plugin policy DenyAll",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:      sectionCredentialPlugin,
+				PluginPolicy: string(v1beta1.PluginPolicyDenyAll),
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyDenyAll,
+			},
+		},
+		{
+			name:           "plugin policy Allowlist with single valid entry",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyAllowlist),
+				AllowlistEntries: []string{"command=foobar"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyAllowlist,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: "foobar"},
+				},
+			},
+		},
+		{
+			name:           "plugin policy Allowlist with multiple valid entries",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyAllowlist),
+				AllowlistEntries: []string{"command=foobar", "command=barbaz"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyAllowlist,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: "foobar"},
+					{Command: "barbaz"},
+				},
+			},
+		},
+		{
+			name:           "plugin policy Allowlist with no entries",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:      sectionCredentialPlugin,
+				PluginPolicy: string(v1beta1.PluginPolicyAllowlist),
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyAllowlist,
+			},
+			expectError: true,
+		},
+		{
+			name:           "plugin policy Allowlist with one invalid entry",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyAllowlist),
+				AllowlistEntries: []string{"calvinball=asdf"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyAllowlist,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: "hello"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:           "plugin policy Allowlist with empty command",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyAllowlist),
+				AllowlistEntries: []string{"command="},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyAllowlist,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: ""},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:           "plugin policy Allowlist with both valid and invalid entries",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyAllowlist),
+				AllowlistEntries: []string{"command=hello", "calvinball=asdf"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyAllowlist,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: "hello"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:           "invalid plugin policy",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:      sectionCredentialPlugin,
+				PluginPolicy: "Foo",
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.CredentialPluginPolicy("Foo"),
+			},
+			expectError: true,
+		},
+		{
+			name:           "allowlist entries with AllowAll policy",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyAllowAll),
+				AllowlistEntries: []string{"command=foo"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyAllowAll,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: "foo"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:           "allowlist entries with DenyAll policy",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyDenyAll),
+				AllowlistEntries: []string{"command=foo"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyDenyAll,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: "foo"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:           "use of deprecated name field",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyAllowlist),
+				AllowlistEntries: []string{"name=foo"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyDenyAll,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: "foo"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:           "improperly formatted allowlist entry",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyAllowlist),
+				AllowlistEntries: []string{"command:foo"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyDenyAll,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: "foo"},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "kuberc-set-test-")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer func() {
+				os.RemoveAll(tmpDir) // nolint:errcheck
+			}()
+
+			kubercPath := filepath.Join(tmpDir, "kuberc")
+			if tt.existingKuberc != "" {
+				if err := os.WriteFile(kubercPath, []byte(tt.existingKuberc), 0644); err != nil {
+					t.Fatalf("failed to write existing kuberc file: %v", err)
+				}
+			}
+
+			streams, _, out, _ := genericiooptions.NewTestIOStreams()
+			tt.options.KubeRCFile = kubercPath
+			tt.options.IOStreams = streams
+
+			err = tt.options.Run()
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain %q, got: %v", tt.errorContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Run() unexpected error = %v", err)
+			}
+
+			// Verify the file was written
+			data, err := os.ReadFile(kubercPath)
+			if err != nil {
+				t.Fatalf("failed to read written kuberc file: %v", err)
+			}
+
+			var actualPref v1beta1.Preference
+			if err := yaml.Unmarshal(data, &actualPref); err != nil {
+				t.Fatalf("failed to unmarshal actual output: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.expectedPref, &actualPref); diff != "" {
+				t.Errorf("Run() output mismatch (-expected +got):\n%s", diff)
+			}
+
+			// Verify output message
+			if !strings.Contains(out.String(), "Updated") {
+				t.Errorf("expected output to contain 'Updated', got: %s", out.String())
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set_test.go
@@ -903,6 +903,21 @@ func TestSetOptions_Run_CredentialPlugin(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:           "empty plugin policy",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:      sectionCredentialPlugin,
+				PluginPolicy: "",
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+			},
+			expectError: true,
+		},
+		{
 			name:           "allowlist entries with AllowAll policy",
 			existingKuberc: "",
 			options: SetOptions{
@@ -982,6 +997,27 @@ func TestSetOptions_Run_CredentialPlugin(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name:           "improperly formatted allowlist entry",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:          sectionCredentialPlugin,
+				PluginPolicy:     string(v1beta1.PluginPolicyAllowlist),
+				AllowlistEntries: []string{"command=foo,command=bar"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				CredentialPluginPolicy: v1beta1.PluginPolicyAllowlist,
+				CredentialPluginAllowlist: []v1beta1.AllowlistEntry{
+					{Command: "foo"},
+					{Command: "bar"},
+				},
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1005,14 +1041,20 @@ func TestSetOptions_Run_CredentialPlugin(t *testing.T) {
 			tt.options.KubeRCFile = kubercPath
 			tt.options.IOStreams = streams
 
-			err = tt.options.Run()
-
+			validationErr := tt.options.Validate()
+			runErr := tt.options.Run()
 			if tt.expectError {
-				if err == nil {
+				if validationErr == nil && runErr == nil {
 					t.Fatalf("expected error but got none")
 				}
-				if !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error to contain %q, got: %v", tt.errorContains, err)
+
+				firstErr := validationErr
+				if firstErr == nil {
+					firstErr = runErr
+				}
+
+				if !strings.Contains(firstErr.Error(), tt.errorContains) {
+					t.Errorf("expected firstError to contain %q, got: %v", tt.errorContains, firstErr)
 				}
 				return
 			}

--- a/test/cmd/kuberc.sh
+++ b/test/cmd/kuberc.sh
@@ -122,6 +122,10 @@ EOF
   output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=Allowlist --allowlist-entry=command=barbaz --allowlist-entry=name_foobar 2>&1)
   kube::test::if_has_string "${output_message}" "improperly formatted allowlist entry: \"name_foobar\""
 
+  # Test: Error cases - empty command
+  output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=Allowlist --allowlist-entry=command=barbaz --allowlist-entry=command= 2>&1)
+  kube::test::if_has_string "${output_message}" "empty value in allowlist entry for field \"command\""
+
   # Restore getn alias back to "namespace" for remaining tests
   kubectl kuberc set --kuberc="$KUBERC_FILE" --section=aliases --name=getn --command=get --prependarg=namespace --option=output=wide --overwrite
   # Restore get defaults back to namespace=test-kuberc-ns and output=json for remaining tests

--- a/test/cmd/kuberc.sh
+++ b/test/cmd/kuberc.sh
@@ -42,6 +42,7 @@ EOF
   kubectl kuberc set --kuberc="$KUBERC_FILE" --section=aliases --name=getrole --command=get --option=output=json
   kubectl kuberc set --kuberc="$KUBERC_FILE" --section=aliases --name=runx --command=run --option=image=nginx --option=labels=app=test,env=test --option=env=DNS_DOMAIN=test --option=namespace=test-kuberc-ns --appendarg=test-pod-2 --appendarg=-- --appendarg=custom-arg1 --appendarg=custom-arg2
   kubectl kuberc set --kuberc="$KUBERC_FILE" --section=aliases --name=setx --command="set image" --appendarg=pod/test-pod-2 --appendarg=test-pod-2=busybox
+  kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=Allowlist --allowlist-entry=command=foobar
 
   kube::log::status "Testing kubectl kuberc view commands"
   # Test: kubectl kuberc view
@@ -52,6 +53,8 @@ EOF
   kube::test::if_has_string "${output_message}" "name: runx"
   kube::test::if_has_string "${output_message}" "server-side"
   kube::test::if_has_string "${output_message}" "interactive"
+  kube::test::if_has_string "${output_message}" "credentialPluginPolicy: Allowlist"
+  kube::test::if_has_string "${output_message}" "command: foobar"
 
   # Test: kubectl kuberc view with json output
   output_message=$(kubectl kuberc view --kuberc="$KUBERC_FILE" -o json)
@@ -78,7 +81,8 @@ EOF
   kube::test::if_has_string "${output_message}" "required flag(s) \"section\" not set"
 
   output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=defaults --option=output=wide 2>&1)
-  kube::test::if_has_string "${output_message}" "required flag(s) \"command\" not set"
+  # Initial dash expressed as [-] to prevent grep from interpreting it as a flag
+  kube::test::if_has_string "${output_message}" "[-]-command is required when --section=aliases or --section=defaults"
 
   # Test: KUBERC=off with view command
   output_message=$(! KUBERC=off kubectl kuberc view 2>&1)
@@ -87,6 +91,36 @@ EOF
   # Test: KUBERC=off with set command
   output_message=$(! KUBERC=off kubectl kuberc set --section=defaults --command=get --option=output=wide 2>&1)
   kube::test::if_has_string "${output_message}" "KUBERC is disabled via KUBERC=off environment variable"
+
+  # Test: Error cases - missing required flags
+  output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin 2>&1)
+  # Initial dash expressed as [-] to prevent grep from interpreting it as a flag
+  kube::test::if_has_string "${output_message}" "[-]-policy is required when --section=credentialplugin"
+
+  output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=Allowlist 2>&1)
+  # Initial dash expressed as [-] to prevent grep from interpreting it as a flag
+  kube::test::if_has_string "${output_message}" "[-]-allowlist-entry is required when --section=credentialplugin and --policy=Allowlist"
+
+  # Test: Error cases - invalid policy
+  output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=Foo 2>&1)
+  kube::test::if_has_string "${output_message}" "invalid value for --policy: \"Foo\""
+
+  # Test: Error cases - invalid flag combination
+  output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=AllowAll --allowlist-entry=command=foobar 2>&1)
+  # Initial dash expressed as [-] to prevent grep from interpreting it as a flag
+  kube::test::if_has_string "${output_message}" "[-]-allowlist-entry may only be used when --section=credentialplugin and --policy=Allowlist"
+
+  # Test: Error cases - invalid field in allowlist-entry
+  output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=Allowlist --allowlist-entry=calvinball=foobar 2>&1)
+  kube::test::if_has_string "${output_message}" "unrecognized allowlist entry field: \"calvinball\""
+
+  # Test: Error cases - use of deprecated name field in allowlist entry
+  output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=Allowlist --allowlist-entry=command=barbaz --allowlist-entry=name=foobar 2>&1)
+  kube::test::if_has_string "${output_message}" "allowlist entry field \"name\" is deprecated, use \"command\" instead"
+
+  # Test: Error cases - badly formed allowlist entry
+  output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=Allowlist --allowlist-entry=command=barbaz --allowlist-entry=name_foobar 2>&1)
+  kube::test::if_has_string "${output_message}" "improperly formatted allowlist entry: \"name_foobar\""
 
   # Restore getn alias back to "namespace" for remaining tests
   kubectl kuberc set --kuberc="$KUBERC_FILE" --section=aliases --name=getn --command=get --prependarg=namespace --option=output=wide --overwrite

--- a/test/cmd/kuberc.sh
+++ b/test/cmd/kuberc.sh
@@ -103,7 +103,8 @@ EOF
 
   # Test: Error cases - invalid policy
   output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=Foo 2>&1)
-  kube::test::if_has_string "${output_message}" "invalid value for --policy: \"Foo\""
+  # Initial dash expressed as [-] to prevent grep from interpreting it as a flag
+  kube::test::if_has_string "${output_message}" "[-]-policy must be  \"AllowAll\", \"DenyAll\", or \"Allowlist\", got: Foo"
 
   # Test: Error cases - invalid flag combination
   output_message=$(! kubectl kuberc set --kuberc="$KUBERC_FILE" --section=credentialplugin --policy=AllowAll --allowlist-entry=command=foobar 2>&1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
`kubectl kuberc set` currently allows for setting other sections of the config file from the command line. This PR updates `kubectl kuberc set` to allow for setting the fields related to credential exec plugins.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Resolves #135558
KEP: https://github.com/kubernetes/enhancements/issues/3104

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update `kubectl kuberc set` with options for setting `credentialPluginPolicy` and `credentialPluginAllowlist`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
