### PR TITLE
validation-gen: fix opaqueType tag 

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
@@ -37,6 +37,10 @@ type T1 struct {
 
 	// +k8s:validateFalse="field T1.HasNoValFieldVal"
 	HasNoValFieldVal HasNoVal `json:"hasNoValFieldVal"`
+
+	ValidatedSlice  TypedefSliceWithValidations  `json:"validatedSlice"`
+	ValidatedMap    TypedefMapWithValidations    `json:"validatedMap"`
+	ValidatedMapKey TypedefMapWithKeyValidations `json:"validatedMapKey"`
 }
 
 // +k8s:validateFalse="type HasTypeVal"
@@ -74,3 +78,17 @@ type HasNoValNotLinked struct {
 	// Note: no field validation.
 	S string `json:"s"`
 }
+
+// +k8s:validateFalse="type OtherStruct"
+type OtherStruct struct {
+	S string `json:"s"`
+}
+
+// +k8s:validateFalse="type ValidatedKeyType"
+type ValidatedKeyType string
+
+type TypedefSliceWithValidations []OtherStruct
+
+type TypedefMapWithValidations map[string]OtherStruct
+
+type TypedefMapWithKeyValidations map[ValidatedKeyType]string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
@@ -41,6 +41,9 @@ type T1 struct {
 	ValidatedSlice  TypedefSliceWithValidations  `json:"validatedSlice"`
 	ValidatedMap    TypedefMapWithValidations    `json:"validatedMap"`
 	ValidatedMapKey TypedefMapWithKeyValidations `json:"validatedMapKey"`
+
+	DeepValidatedSlice DeepTypedefSlice `json:"deepValidatedSlice"`
+	DeepValidatedMap   DeepTypedefMap   `json:"deepValidatedMap"`
 }
 
 // +k8s:validateFalse="type HasTypeVal"
@@ -92,3 +95,7 @@ type TypedefSliceWithValidations []OtherStruct
 type TypedefMapWithValidations map[string]OtherStruct
 
 type TypedefMapWithKeyValidations map[ValidatedKeyType]string
+
+type DeepTypedefSlice TypedefSliceWithValidations
+
+type DeepTypedefMap TypedefMapWithValidations

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
@@ -44,6 +44,9 @@ type T1 struct {
 
 	DeepValidatedSlice DeepTypedefSlice `json:"deepValidatedSlice"`
 	DeepValidatedMap   DeepTypedefMap   `json:"deepValidatedMap"`
+
+	DoubleDeepValidatedSlice DoubleDeepTypedefSlice `json:"doubleDeepValidatedSlice           "`
+	DoubleDeepValidatedMap   DoubleDeepTypedefMap   `json:"doubleDeepValidatedMap"`
 }
 
 // +k8s:validateFalse="type HasTypeVal"
@@ -96,6 +99,14 @@ type TypedefMapWithValidations map[string]OtherStruct
 
 type TypedefMapWithKeyValidations map[ValidatedKeyType]string
 
+// FIXME: The following validation is not being generated for DoubleDeepTypedefSlice.
+// Validation-gen is ignoring this validation, because Go directly translates
+// DoubleDeepTypedefSlice to TypedefSliceWithValidations.
+// +k8s:eachVal=+k8s:validateFalse="type DeepTypedefSlice"
 type DeepTypedefSlice TypedefSliceWithValidations
 
 type DeepTypedefMap TypedefMapWithValidations
+
+type DoubleDeepTypedefSlice DeepTypedefSlice
+
+type DoubleDeepTypedefMap DeepTypedefMap

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/testdata/validate-false.json
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/testdata/validate-false.json
@@ -7,9 +7,23 @@
       "type OtherStruct"
     ],
     "deepValidatedSlice[0]": [
+      "type DeepTypedefSlice",
       "type OtherStruct"
     ],
     "deepValidatedSlice[1]": [
+      "type DeepTypedefSlice",
+      "type OtherStruct"
+    ],
+    "doubleDeepValidatedMap[滧ǖvq]": [
+      "type OtherStruct"
+    ],
+    "doubleDeepValidatedMap[黰¢ơđ?ȵɓf*Z迖瓼轊]": [
+      "type OtherStruct"
+    ],
+    "doubleDeepValidatedSlice           [0]": [
+      "type OtherStruct"
+    ],
+    "doubleDeepValidatedSlice           [1]": [
       "type OtherStruct"
     ],
     "hasFieldVal.s": [

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/testdata/validate-false.json
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/testdata/validate-false.json
@@ -1,5 +1,17 @@
 {
   "*elidenovalidations.T1": {
+    "deepValidatedMap[%ɜ¤0ȻG炕炎鷖Ʊ]": [
+      "type OtherStruct"
+    ],
+    "deepValidatedMap[tƓ晲銩靨能鷸ȳ琍殪]": [
+      "type OtherStruct"
+    ],
+    "deepValidatedSlice[0]": [
+      "type OtherStruct"
+    ],
+    "deepValidatedSlice[1]": [
+      "type OtherStruct"
+    ],
     "hasFieldVal.s": [
       "field HasFieldVal.S"
     ],
@@ -8,6 +20,22 @@
     ],
     "hasTypeVal": [
       "type HasTypeVal"
+    ],
+    "validatedMapKey": [
+      "type ValidatedKeyType",
+      "type ValidatedKeyType"
+    ],
+    "validatedMap[ʅȀʙĄĥ腲ʤaǇ趴]": [
+      "type OtherStruct"
+    ],
+    "validatedMap[赖{³*Ę鄏þƿ髈儱Ŀ蒫÷K]": [
+      "type OtherStruct"
+    ],
+    "validatedSlice[0]": [
+      "type OtherStruct"
+    ],
+    "validatedSlice[1]": [
+      "type OtherStruct"
     ]
   }
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
@@ -25,6 +25,7 @@ import (
 	context "context"
 	fmt "fmt"
 
+	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
@@ -99,6 +100,20 @@ func Validate_HasTypeVal(
 	}
 
 	// field HasTypeVal.S has no validation
+	return errs
+}
+
+// Validate_OtherStruct validates an instance of OtherStruct according
+// to declarative validation rules in the API schema.
+func Validate_OtherStruct(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *OtherStruct) (errs field.ErrorList) {
+
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct"); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
+	// field OtherStruct.S has no validation
 	return errs
 }
 
@@ -178,6 +193,112 @@ func Validate_T1(
 				return &oldObj.HasNoValFieldVal
 			})
 		errs = append(errs, fn(fldPath.Child("hasNoValFieldVal"), &obj.HasNoValFieldVal, oldVal, oldObj != nil)...)
+	}
+
+	{ // field T1.ValidatedSlice
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj TypedefSliceWithValidations,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_TypedefSliceWithValidations(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *T1) TypedefSliceWithValidations {
+				return oldObj.ValidatedSlice
+			})
+		errs = append(errs, fn(fldPath.Child("validatedSlice"), obj.ValidatedSlice, oldVal, oldObj != nil)...)
+	}
+
+	{ // field T1.ValidatedMap
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj TypedefMapWithValidations,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_TypedefMapWithValidations(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *T1) TypedefMapWithValidations {
+				return oldObj.ValidatedMap
+			})
+		errs = append(errs, fn(fldPath.Child("validatedMap"), obj.ValidatedMap, oldVal, oldObj != nil)...)
+	}
+
+	{ // field T1.ValidatedMapKey
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj TypedefMapWithKeyValidations,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_TypedefMapWithKeyValidations(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *T1) TypedefMapWithKeyValidations {
+				return oldObj.ValidatedMapKey
+			})
+		errs = append(errs, fn(fldPath.Child("validatedMapKey"), obj.ValidatedMapKey, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_TypedefMapWithKeyValidations validates an instance of TypedefMapWithKeyValidations according
+// to declarative validation rules in the API schema.
+func Validate_TypedefMapWithKeyValidations(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj TypedefMapWithKeyValidations) (errs field.ErrorList) {
+
+	return errs
+}
+
+// Validate_TypedefMapWithValidations validates an instance of TypedefMapWithValidations according
+// to declarative validation rules in the API schema.
+func Validate_TypedefMapWithValidations(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj TypedefMapWithValidations) (errs field.ErrorList) {
+
+	return errs
+}
+
+// Validate_TypedefSliceWithValidations validates an instance of TypedefSliceWithValidations according
+// to declarative validation rules in the API schema.
+func Validate_TypedefSliceWithValidations(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj TypedefSliceWithValidations) (errs field.ErrorList) {
+
+	return errs
+}
+
+// Validate_ValidatedKeyType validates an instance of ValidatedKeyType according
+// to declarative validation rules in the API schema.
+func Validate_ValidatedKeyType(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *ValidatedKeyType) (errs field.ErrorList) {
+
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ValidatedKeyType"); len(e) != 0 {
+		errs = append(errs, e...)
 	}
 
 	return errs

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
@@ -56,6 +56,34 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 	return nil
 }
 
+// Validate_DeepTypedefMap validates an instance of DeepTypedefMap according
+// to declarative validation rules in the API schema.
+func Validate_DeepTypedefMap(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj DeepTypedefMap) (errs field.ErrorList) {
+
+	// iterate the map and call the value type's validation function
+	if e := validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, Validate_OtherStruct); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
+	return errs
+}
+
+// Validate_DeepTypedefSlice validates an instance of DeepTypedefSlice according
+// to declarative validation rules in the API schema.
+func Validate_DeepTypedefSlice(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj DeepTypedefSlice) (errs field.ErrorList) {
+
+	// iterate the list and call the type's validation function
+	if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_OtherStruct); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
+	return errs
+}
+
 // Validate_HasFieldVal validates an instance of HasFieldVal according
 // to declarative validation rules in the API schema.
 func Validate_HasFieldVal(
@@ -261,6 +289,50 @@ func Validate_T1(
 		errs = append(errs, fn(fldPath.Child("validatedMapKey"), obj.ValidatedMapKey, oldVal, oldObj != nil)...)
 	}
 
+	{ // field T1.DeepValidatedSlice
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj DeepTypedefSlice,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeepTypedefSlice(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *T1) DeepTypedefSlice {
+				return oldObj.DeepValidatedSlice
+			})
+		errs = append(errs, fn(fldPath.Child("deepValidatedSlice"), obj.DeepValidatedSlice, oldVal, oldObj != nil)...)
+	}
+
+	{ // field T1.DeepValidatedMap
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj DeepTypedefMap,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeepTypedefMap(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *T1) DeepTypedefMap {
+				return oldObj.DeepValidatedMap
+			})
+		errs = append(errs, fn(fldPath.Child("deepValidatedMap"), obj.DeepValidatedMap, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }
 
@@ -269,6 +341,11 @@ func Validate_T1(
 func Validate_TypedefMapWithKeyValidations(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj TypedefMapWithKeyValidations) (errs field.ErrorList) {
+
+	// iterate the map and call the key type's validation function
+	if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, Validate_ValidatedKeyType); len(e) != 0 {
+		errs = append(errs, e...)
+	}
 
 	return errs
 }
@@ -279,6 +356,11 @@ func Validate_TypedefMapWithValidations(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj TypedefMapWithValidations) (errs field.ErrorList) {
 
+	// iterate the map and call the value type's validation function
+	if e := validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, Validate_OtherStruct); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
 	return errs
 }
 
@@ -287,6 +369,11 @@ func Validate_TypedefMapWithValidations(
 func Validate_TypedefSliceWithValidations(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj TypedefSliceWithValidations) (errs field.ErrorList) {
+
+	// iterate the list and call the type's validation function
+	if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_OtherStruct); len(e) != 0 {
+		errs = append(errs, e...)
+	}
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
@@ -76,6 +76,41 @@ func Validate_DeepTypedefSlice(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj DeepTypedefSlice) (errs field.ErrorList) {
 
+	if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil,
+		func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
+			return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type DeepTypedefSlice")
+		}); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
+	// iterate the list and call the type's validation function
+	if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_OtherStruct); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
+	return errs
+}
+
+// Validate_DoubleDeepTypedefMap validates an instance of DoubleDeepTypedefMap according
+// to declarative validation rules in the API schema.
+func Validate_DoubleDeepTypedefMap(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj DoubleDeepTypedefMap) (errs field.ErrorList) {
+
+	// iterate the map and call the value type's validation function
+	if e := validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, Validate_OtherStruct); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
+	return errs
+}
+
+// Validate_DoubleDeepTypedefSlice validates an instance of DoubleDeepTypedefSlice according
+// to declarative validation rules in the API schema.
+func Validate_DoubleDeepTypedefSlice(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj DoubleDeepTypedefSlice) (errs field.ErrorList) {
+
 	// iterate the list and call the type's validation function
 	if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_OtherStruct); len(e) != 0 {
 		errs = append(errs, e...)
@@ -331,6 +366,50 @@ func Validate_T1(
 				return oldObj.DeepValidatedMap
 			})
 		errs = append(errs, fn(fldPath.Child("deepValidatedMap"), obj.DeepValidatedMap, oldVal, oldObj != nil)...)
+	}
+
+	{ // field T1.DoubleDeepValidatedSlice
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj DoubleDeepTypedefSlice,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DoubleDeepTypedefSlice(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *T1) DoubleDeepTypedefSlice {
+				return oldObj.DoubleDeepValidatedSlice
+			})
+		errs = append(errs, fn(fldPath.Child("doubleDeepValidatedSlice           "), obj.DoubleDeepValidatedSlice, oldVal, oldObj != nil)...)
+	}
+
+	{ // field T1.DoubleDeepValidatedMap
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj DoubleDeepTypedefMap,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DoubleDeepTypedefMap(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *T1) DoubleDeepTypedefMap {
+				return oldObj.DoubleDeepValidatedMap
+			})
+		errs = append(errs, fn(fldPath.Child("doubleDeepValidatedMap"), obj.DoubleDeepValidatedMap, oldVal, oldObj != nil)...)
 	}
 
 	return errs

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef_to_map/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef_to_map/zz_generated.validations.go
@@ -90,6 +90,7 @@ func Validate_MapTypedefType(
 		}); len(e) != 0 {
 		errs = append(errs, e...)
 	}
+
 	// iterate the map and call the value type's validation function
 	if e := validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, Validate_StringType); len(e) != 0 {
 		errs = append(errs, e...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/default_behavior/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/default_behavior/zz_generated.validations.go
@@ -140,6 +140,7 @@ func Validate_AliasMapKeyType(
 	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapKeyType"); len(e) != 0 {
 		errs = append(errs, e...)
 	}
+
 	// iterate the map and call the key type's validation function
 	if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, Validate_S); len(e) != 0 {
 		errs = append(errs, e...)
@@ -157,6 +158,7 @@ func Validate_AliasMapValueType(
 	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapValueType"); len(e) != 0 {
 		errs = append(errs, e...)
 	}
+
 	// iterate the map and call the value type's validation function
 	if e := validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, Validate_S); len(e) != 0 {
 		errs = append(errs, e...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef_to_slice/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef_to_slice/zz_generated.validations.go
@@ -90,6 +90,7 @@ func Validate_ListTypedefType(
 		}); len(e) != 0 {
 		errs = append(errs, e...)
 	}
+
 	// iterate the list and call the type's validation function
 	if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_StringType); len(e) != 0 {
 		errs = append(errs, e...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_map/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_map/zz_generated.validations.go
@@ -84,6 +84,7 @@ func Validate_MapTypedefType(
 		}); len(e) != 0 {
 		errs = append(errs, e...)
 	}
+
 	// iterate the map and call the value type's validation function
 	if e := validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, Validate_StringType); len(e) != 0 {
 		errs = append(errs, e...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
@@ -87,6 +87,29 @@ type OtherStruct struct {
 	StringField string `json:"stringField"`
 }
 
+// OpaqueFieldsStruct contains fields with the opaque markers, contains no field validations.
+// Validations should not be generated for these fields.
+type OpaqueFieldsStruct struct {
+	// +k8s:opaqueType
+	OtherStruct
+
+	// +k8s:eachVal=+k8s:opaqueType
+	OpaqueSliceField []OtherStruct `json:"opaqueSliceField"`
+
+	// +k8s:eachKey=+k8s:opaqueType
+	// +k8s:eachVal=+k8s:opaqueType
+	OpaqueMapField map[OtherString]OtherStruct `json:"opaqueMapField"`
+
+	TypedefOpaqueStructField TypedefOpaqueStruct `json:"typedefOpaqueStructField"`
+
+	TypedefOpaqueSliceField TypedefOpaqueSlice `json:"typedefOpaqueSliceField"`
+
+	TypedefOpaqueMapField TypedefOpaqueMap `json:"typedefOpaqueMapField"`
+
+	// +k8s:opaqueType
+	IsolatedOpaqueStructField OtherStruct `json:"isolatedOpaqueStructField"`
+}
+
 // +k8s:validateFalse="type OtherString"
 type OtherString string
 
@@ -94,6 +117,18 @@ type OtherString string
 // fixing it requires fixing randfill.  That is a tomorrow problem.  For now, the
 // following types have been tested to generate correct code with
 // +k8s:opaqueType.
+
+// +k8s:opaqueType
+type TypedefOpaqueStruct struct {
+	StringField string `json:"stringField"`
+}
+
+// +k8s:eachVal=+k8s:opaqueType
+type TypedefOpaqueSlice []OtherStruct
+
+// +k8s:eachKey=+k8s:opaqueType
+// +k8s:eachVal=+k8s:opaqueType
+type TypedefOpaqueMap map[OtherString]OtherStruct
 
 // +k8s:validateTrue="type TypedefSliceOther"
 // +k8s:eachVal=+k8s:opaqueType

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
@@ -89,6 +89,7 @@ type OtherStruct struct {
 
 // OpaqueFieldsStruct contains fields with the opaque markers, contains no field validations.
 // Validations should not be generated for these fields.
+// +k8s:validateTrue="type OpaqueFieldsStruct"
 type OpaqueFieldsStruct struct {
 	// +k8s:opaqueType
 	OtherStruct

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
@@ -139,3 +139,27 @@ type TypedefSliceOther []OtherStruct
 // +k8s:eachKey=+k8s:opaqueType
 // +k8s:eachVal=+k8s:opaqueType
 type TypedefMapOther map[OtherString]OtherStruct
+
+type NoValidationStruct struct {
+	StringField string `json:"stringField"`
+}
+
+type NoValidationString string
+
+// OpaqueNoValidationFieldsStruct tests that when a type/key/val is opaque but the opaque type
+// does not have any validation, we correctly do not emit any validation calls.
+// +k8s:validateTrue="type OpaqueNoValidationFieldsStruct"
+type OpaqueNoValidationFieldsStruct struct {
+	// +k8s:opaqueType
+	NoValidationStruct
+
+	// +k8s:eachVal=+k8s:opaqueType
+	OpaqueSliceField []NoValidationStruct `json:"opaqueSliceField"`
+
+	// +k8s:eachKey=+k8s:opaqueType
+	// +k8s:eachVal=+k8s:opaqueType
+	OpaqueMapField map[NoValidationString]NoValidationStruct `json:"opaqueMapField"`
+
+	// +k8s:opaqueType
+	IsolatedOpaqueStructField NoValidationStruct `json:"isolatedOpaqueStructField"`
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc_test.go
@@ -86,4 +86,11 @@ func Test(t *testing.T) {
 		TypedefOpaqueMapField:     map[OtherString]OtherStruct{"a": {"foo"}},
 		IsolatedOpaqueStructField: OtherStruct{"foo"},
 	}).ExpectValid()
+
+	st.Value(&OpaqueNoValidationFieldsStruct{
+		NoValidationStruct:        NoValidationStruct{"foo"},
+		OpaqueSliceField:          []NoValidationStruct{{"foo"}},
+		OpaqueMapField:            map[NoValidationString]NoValidationStruct{"a": {"foo"}},
+		IsolatedOpaqueStructField: NoValidationStruct{"foo"},
+	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc_test.go
@@ -24,7 +24,9 @@ func Test(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	st.Value(&Struct{
+		StructField:                    OtherStruct{},
 		StructPtrField:                 &OtherStruct{},
+		OpaqueStructField:              OtherStruct{},
 		OpaqueStructPtrField:           &OtherStruct{},
 		SliceOfStructField:             []OtherStruct{{}, {}},
 		SliceOfOpaqueStructField:       []OtherStruct{{}, {}},
@@ -74,4 +76,14 @@ func Test(t *testing.T) {
 		"mapOfStringToOpaqueStructField[a]": {"field Struct.MapOfStringToOpaqueStructField vals"},
 		"mapOfStringToOpaqueStructField[b]": {"field Struct.MapOfStringToOpaqueStructField vals"},
 	})
+
+	st.Value(&OpaqueFieldsStruct{
+		OtherStruct:               OtherStruct{"foo"},
+		OpaqueSliceField:          []OtherStruct{{"foo"}},
+		OpaqueMapField:            map[OtherString]OtherStruct{"a": {"foo"}},
+		TypedefOpaqueStructField:  TypedefOpaqueStruct{"foo"},
+		TypedefOpaqueSliceField:   []OtherStruct{{"foo"}},
+		TypedefOpaqueMapField:     map[OtherString]OtherStruct{"a": {"foo"}},
+		IsolatedOpaqueStructField: OtherStruct{"foo"},
+	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
@@ -38,6 +38,14 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
+	// type OpaqueFieldsStruct
+	scheme.AddValidationFunc((*OpaqueFieldsStruct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_OpaqueFieldsStruct(ctx, op, nil /* fldPath */, obj.(*OpaqueFieldsStruct), safe.Cast[*OpaqueFieldsStruct](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type OtherString
 	scheme.AddValidationFunc(
 		(*OtherString)(nil),
@@ -114,6 +122,19 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 			}
 		})
 	return nil
+}
+
+// Validate_OpaqueFieldsStruct validates an instance of OpaqueFieldsStruct according
+// to declarative validation rules in the API schema.
+func Validate_OpaqueFieldsStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OpaqueFieldsStruct) (errs field.ErrorList) {
+	// field OpaqueFieldsStruct.OtherStruct has no validation
+	// field OpaqueFieldsStruct.OpaqueSliceField has no validation
+	// field OpaqueFieldsStruct.OpaqueMapField has no validation
+	// field OpaqueFieldsStruct.TypedefOpaqueStructField has no validation
+	// field OpaqueFieldsStruct.TypedefOpaqueSliceField has no validation
+	// field OpaqueFieldsStruct.TypedefOpaqueMapField has no validation
+	// field OpaqueFieldsStruct.IsolatedOpaqueStructField has no validation
+	return errs
 }
 
 // Validate_OtherString validates an instance of OtherString according

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
@@ -137,6 +137,10 @@ func Validate_OpaqueFieldsStruct(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *OpaqueFieldsStruct) (errs field.ErrorList) {
 
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "type OpaqueFieldsStruct"); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
 	// field OpaqueFieldsStruct.OtherStruct has no validation
 	// field OpaqueFieldsStruct.OpaqueSliceField has no validation
 	// field OpaqueFieldsStruct.OpaqueMapField has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
@@ -39,13 +39,20 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
 	// type OpaqueFieldsStruct
-	scheme.AddValidationFunc((*OpaqueFieldsStruct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/":
-			return Validate_OpaqueFieldsStruct(ctx, op, nil /* fldPath */, obj.(*OpaqueFieldsStruct), safe.Cast[*OpaqueFieldsStruct](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
+	scheme.AddValidationFunc(
+		(*OpaqueFieldsStruct)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/":
+				return Validate_OpaqueFieldsStruct(
+					ctx, op, nil, /* fldPath */
+					obj.(*OpaqueFieldsStruct),
+					safe.Cast[*OpaqueFieldsStruct](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
 	// type OtherString
 	scheme.AddValidationFunc(
 		(*OtherString)(nil),
@@ -126,7 +133,10 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 
 // Validate_OpaqueFieldsStruct validates an instance of OpaqueFieldsStruct according
 // to declarative validation rules in the API schema.
-func Validate_OpaqueFieldsStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OpaqueFieldsStruct) (errs field.ErrorList) {
+func Validate_OpaqueFieldsStruct(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *OpaqueFieldsStruct) (errs field.ErrorList) {
+
 	// field OpaqueFieldsStruct.OtherStruct has no validation
 	// field OpaqueFieldsStruct.OpaqueSliceField has no validation
 	// field OpaqueFieldsStruct.OpaqueMapField has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
@@ -53,6 +53,21 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
 			}
 		})
+	// type OpaqueNoValidationFieldsStruct
+	scheme.AddValidationFunc(
+		(*OpaqueNoValidationFieldsStruct)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/":
+				return Validate_OpaqueNoValidationFieldsStruct(
+					ctx, op, nil, /* fldPath */
+					obj.(*OpaqueNoValidationFieldsStruct),
+					safe.Cast[*OpaqueNoValidationFieldsStruct](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
 	// type OtherString
 	scheme.AddValidationFunc(
 		(*OtherString)(nil),
@@ -148,6 +163,23 @@ func Validate_OpaqueFieldsStruct(
 	// field OpaqueFieldsStruct.TypedefOpaqueSliceField has no validation
 	// field OpaqueFieldsStruct.TypedefOpaqueMapField has no validation
 	// field OpaqueFieldsStruct.IsolatedOpaqueStructField has no validation
+	return errs
+}
+
+// Validate_OpaqueNoValidationFieldsStruct validates an instance of OpaqueNoValidationFieldsStruct according
+// to declarative validation rules in the API schema.
+func Validate_OpaqueNoValidationFieldsStruct(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *OpaqueNoValidationFieldsStruct) (errs field.ErrorList) {
+
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "type OpaqueNoValidationFieldsStruct"); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
+	// field OpaqueNoValidationFieldsStruct.NoValidationStruct has no validation
+	// field OpaqueNoValidationFieldsStruct.OpaqueSliceField has no validation
+	// field OpaqueNoValidationFieldsStruct.OpaqueMapField has no validation
+	// field OpaqueNoValidationFieldsStruct.IsolatedOpaqueStructField has no validation
 	return errs
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -419,7 +419,7 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 			if util.NonPointer(util.NativeType(t)).Kind == types.Map && util.NonPointer(util.NativeType(t)).Elem.Kind == types.Slice {
 				return nil, fmt.Errorf("field %s: validation for map of slices is not supported", fldPath)
 			}
-			klog.V(5).InfoS("found type-attached validations", "n", validations.Len(), "type", t)
+			klog.V(5).InfoS("found type-attached validations", "n", len(validations.Functions), "type", t)
 			thisNode.typeValidations.Add(validations)
 		}
 
@@ -692,7 +692,7 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 		} else if validations.Empty() {
 			klog.V(6).InfoS("no field-attached validations", "field", childPath)
 		} else {
-			klog.V(5).InfoS("found field-attached validations", "n", validations.Len(), "field", childPath)
+			klog.V(5).InfoS("found field-attached validations", "n", len(validations.Functions), "field", childPath)
 			if util.NonPointer(util.NativeType(childType)).Kind == types.Map && util.NonPointer(util.NativeType(childType)).Elem.Kind == types.Slice {
 				return fmt.Errorf("field %s: validation for map of slices is not supported", childPath)
 			}
@@ -915,21 +915,37 @@ func (g *genValidations) hasValidationsImpl(n *typeNode, seen map[*typeNode]bool
 	}
 	seen[n] = true
 
-	if !n.typeValidations.Empty() {
+	if n.typeValidations.HasEmitable() {
 		return true
 	}
+
 	allChildren := n.fields
+	if n.underlying != nil {
+		switch n.underlying.childType.Kind {
+		case types.Slice:
+			if n.typeValIterations.HasEmitable() && g.hasValidationsImpl(n.underlying.node.elem.node, seen) {
+				return true
+			}
+		case types.Map:
+			if n.typeKeyIterations.HasEmitable() && g.hasValidationsImpl(n.underlying.node.key.node, seen) {
+				return true
+			}
+			if n.typeValIterations.HasEmitable() && g.hasValidationsImpl(n.underlying.node.elem.node, seen) {
+				return true
+			}
+		default:
+			allChildren = append(allChildren, n.underlying)
+		}
+	}
+
 	if n.key != nil {
 		allChildren = append(allChildren, n.key)
 	}
 	if n.elem != nil {
 		allChildren = append(allChildren, n.elem)
 	}
-	if n.underlying != nil {
-		allChildren = append(allChildren, n.underlying)
-	}
 	for _, c := range allChildren {
-		if !c.fieldValidations.Empty() {
+		if c.fieldValidations.HasEmitable() {
 			return true
 		}
 		if g.hasValidationsImpl(c.node, seen) {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -249,6 +249,28 @@ type typeNode struct {
 	typeKeyIterations validators.Validations // validations on each key
 }
 
+// ResolveElemNode traverses underlying alias nodes to find the concrete element node (for slices/maps).
+func (n *typeNode) ResolveElemNode() *typeNode {
+	if n.elem != nil {
+		return n.elem.node
+	}
+	if n.underlying != nil && n.underlying.node != nil && n.underlying.node.elem != nil {
+		return n.underlying.node.elem.node
+	}
+	return nil
+}
+
+// ResolveKeyNode traverses underlying alias nodes to find the concrete key node (for maps).
+func (n *typeNode) ResolveKeyNode() *typeNode {
+	if n.key != nil {
+		return n.key.node
+	}
+	if n.underlying != nil && n.underlying.node != nil && n.underlying.node.key != nil {
+		return n.underlying.node.key.node
+	}
+	return nil
+}
+
 // DiscoverType walks the given type recursively, building a type-graph in this
 // typeDiscoverer.  If this is called multiple times for different types, the
 // graphs will be will be merged.
@@ -432,17 +454,16 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 		// before we know if there are other validations, again so we don't emit
 		// empty functions.
 		if t.Kind == types.Alias {
-			underlying := thisNode.underlying
-
-			switch t.Underlying.Kind {
+			switch util.NonPointer(util.NativeType(t)).Kind {
 			case types.Slice:
 				// Validate each value.
-				if elemNode := underlying.node.elem.node; elemNode == nil {
+				elemNode := thisNode.ResolveElemNode()
+				if elemNode == nil {
 					if !thisNode.typeValidations.OpaqueValType {
 						return nil, fmt.Errorf("%v: value type %v is in a non-included package; "+
 							"either add this package to validation-gen's --readonly-pkg flag, "+
 							"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
-							fldPath, underlying.node.elem.childType)
+							fldPath, util.NativeType(t).Elem)
 					}
 				} else if thisNode.typeValidations.OpaqueValType {
 					// If the type is marked as opaque, we can treat it as it is
@@ -469,12 +490,13 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 				}
 			case types.Map:
 				// Validate each key.
-				if keyNode := underlying.node.key.node; keyNode == nil {
+				keyNode := thisNode.ResolveKeyNode()
+				if keyNode == nil {
 					if !thisNode.typeValidations.OpaqueKeyType {
 						return nil, fmt.Errorf("%v: key type %v is in a non-included package; "+
 							"either add this package to validation-gen's --readonly-pkg flag, "+
 							"or add +k8s:eachKey=+k8s:opaqueType to the field to skip validation",
-							fldPath, underlying.node.elem.childType)
+							fldPath, util.NativeType(t).Key)
 					}
 				} else if thisNode.typeValidations.OpaqueKeyType {
 					// If the type is marked as opaque, we can treat it as it is
@@ -489,7 +511,7 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 						//
 						// Note: the first argument to Function() is really
 						// only for debugging.
-						v, err := validators.ForEachKey(fldPath, underlying.childType,
+						v, err := validators.ForEachKey(fldPath, thisNode.valueType,
 							validators.Function("iterateMapKeys", validators.DefaultFlags, funcName).
 								WithComment("iterate the map and call the key type's validation function"))
 						if err != nil {
@@ -500,12 +522,13 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 					}
 				}
 				// Validate each value.
-				if elemNode := underlying.node.elem.node; elemNode == nil {
+				elemNode := thisNode.ResolveElemNode()
+				if elemNode == nil {
 					if !thisNode.typeValidations.OpaqueValType {
 						return nil, fmt.Errorf("%v: value type %v is in a non-included package; "+
 							"either add this package to validation-gen's --readonly-pkg flag, "+
 							"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
-							fldPath, underlying.node.elem.childType)
+							fldPath, util.NativeType(t).Elem)
 					}
 				} else if thisNode.typeValidations.OpaqueValType {
 					// If the type is marked as opaque, we can treat it as it is
@@ -520,7 +543,7 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 						//
 						// Note: the first argument to Function() is really
 						// only for debugging.
-						v, err := validators.ForEachVal(fldPath, underlying.childType,
+						v, err := validators.ForEachVal(fldPath, thisNode.valueType,
 							validators.Function("iterateMapValues", validators.DefaultFlags, funcName).
 								WithComment("iterate the map and call the value type's validation function"))
 						if err != nil {
@@ -919,39 +942,41 @@ func (g *genValidations) hasValidationsImpl(n *typeNode, seen map[*typeNode]bool
 		return true
 	}
 
-	allChildren := n.fields
 	if n.underlying != nil {
-		switch n.underlying.childType.Kind {
-		case types.Slice:
-			if n.typeValIterations.HasEmitable() && g.hasValidationsImpl(n.underlying.node.elem.node, seen) {
+		if n.typeKeyIterations.HasEmitable() {
+			if keyNode := n.ResolveKeyNode(); keyNode != nil && g.hasValidationsImpl(keyNode, seen) {
 				return true
 			}
-		case types.Map:
-			if n.typeKeyIterations.HasEmitable() && g.hasValidationsImpl(n.underlying.node.key.node, seen) {
+		}
+		if n.typeValIterations.HasEmitable() {
+			if elemNode := n.ResolveElemNode(); elemNode != nil && g.hasValidationsImpl(elemNode, seen) {
 				return true
 			}
-			if n.typeValIterations.HasEmitable() && g.hasValidationsImpl(n.underlying.node.elem.node, seen) {
-				return true
-			}
-		default:
-			allChildren = append(allChildren, n.underlying)
+		}
+		if g.hasValidationsImpl(n.underlying.node, seen) {
+			return true
 		}
 	}
 
-	if n.key != nil {
-		allChildren = append(allChildren, n.key)
-	}
-	if n.elem != nil {
-		allChildren = append(allChildren, n.elem)
-	}
-	for _, c := range allChildren {
+	for _, c := range n.fields {
 		if c.fieldValidations.HasEmitable() {
 			return true
+		}
+		if c.fieldKeyIterations.HasEmitable() {
+			if keyNode := c.node.ResolveKeyNode(); keyNode != nil && g.hasValidationsImpl(keyNode, seen) {
+				return true
+			}
+		}
+		if c.fieldValIterations.HasEmitable() {
+			if elemNode := c.node.ResolveElemNode(); elemNode != nil && g.hasValidationsImpl(elemNode, seen) {
+				return true
+			}
 		}
 		if g.hasValidationsImpl(c.node, seen) {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -1111,33 +1136,28 @@ func (g *genValidations) emitValidationForChild(c *generator.Context, thisChild 
 		}
 		emitComments(validations.Comments, sw)
 		emitCallsToValidators(c, validations.Functions, sw)
-		if thisNode.valueType.Kind == types.Alias {
-			underlyingNode := thisNode.underlying.node
-			switch underlyingNode.valueType.Kind {
-			case types.Slice:
-				// If this field is a list and the value-type has validations,
-				// call its validation function.
-				if validations := thisNode.typeValIterations; g.hasValidations(underlyingNode.elem.node) && !validations.Empty() {
-					emitComments(validations.Comments, sw)
-					emitCallsToValidators(c, validations.Functions, sw)
-				}
-			case types.Map:
-				// If this field is a map and the key-type has validations,
-				// call its validation function.
-				if validations := thisNode.typeKeyIterations; g.hasValidations(underlyingNode.key.node) && !validations.Empty() {
-					emitComments(validations.Comments, sw)
-					emitCallsToValidators(c, validations.Functions, sw)
-				}
-				// If this field is a map and the value-type has validations,
-				// call its validation function.
-				if validations := thisNode.typeValIterations; g.hasValidations(underlyingNode.elem.node) && !validations.Empty() {
-					emitComments(validations.Comments, sw)
-					emitCallsToValidators(c, validations.Functions, sw)
-				}
-			}
-		}
 		sw.Do("\n", nil)
 		didSome = true
+	}
+
+	if validations := thisNode.typeKeyIterations; !validations.Empty() {
+		keyNode := thisNode.ResolveKeyNode()
+		if keyNode != nil && g.hasValidations(keyNode) {
+			emitComments(validations.Comments, sw)
+			emitCallsToValidators(c, validations.Functions, sw)
+			sw.Do("\n", nil)
+			didSome = true
+		}
+	}
+
+	if validations := thisNode.typeValIterations; !validations.Empty() {
+		elemNode := thisNode.ResolveElemNode()
+		if elemNode != nil && g.hasValidations(elemNode) {
+			emitComments(validations.Comments, sw)
+			emitCallsToValidators(c, validations.Functions, sw)
+			sw.Do("\n", nil)
+			didSome = true
+		}
 	}
 
 	// Descend into the type.
@@ -1232,50 +1252,28 @@ func (g *genValidations) emitValidationForChild(c *generator.Context, thisChild 
 						}
 						g.emitCallToOtherTypeFunc(c, fld.node, bufsw)
 					}
-				case types.Slice:
-					// If this field is a list and the value-type has
-					// validations, call its validation function.
-					if validations := fld.fieldValIterations; g.hasValidations(fld.node.elem.node) && !validations.Empty() {
-						emitComments(validations.Comments, bufsw)
-						if len(validations.Functions) > 0 {
-							if !fldRatchetingChecked {
-								emitRatchetingCheck(c, fld.childType, bufsw)
-								fldRatchetingChecked = true
-							}
-							emitCallsToValidators(c, validations.Functions, bufsw)
-						}
+				}
 
+				emitIterations := func(iterations validators.Validations, node *typeNode) {
+					if iterations.Empty() {
+						return
 					}
-					// Descend into this field.
-					g.emitValidationForChild(c, fld, bufsw)
-				case types.Map:
-					// If this field is a map and the key-type has
-					// validations, call its validation function.
-					if validations := fld.fieldKeyIterations; g.hasValidations(fld.node.key.node) && !validations.Empty() {
-						emitComments(validations.Comments, bufsw)
-						if len(validations.Functions) > 0 {
+					if node != nil && g.hasValidations(node) {
+						emitComments(iterations.Comments, bufsw)
+						if len(iterations.Functions) > 0 {
 							if !fldRatchetingChecked {
 								emitRatchetingCheck(c, fld.childType, bufsw)
 								fldRatchetingChecked = true
 							}
-							emitCallsToValidators(c, validations.Functions, bufsw)
+							emitCallsToValidators(c, iterations.Functions, bufsw)
 						}
 					}
-					// If this field is a map and the value-type has
-					// validations, call its validation function.
-					if validations := fld.fieldValIterations; g.hasValidations(fld.node.elem.node) && !validations.Empty() {
-						emitComments(validations.Comments, bufsw)
-						if len(validations.Functions) > 0 {
-							if !fldRatchetingChecked {
-								emitRatchetingCheck(c, fld.childType, bufsw)
-								fldRatchetingChecked = true
-							}
-							emitCallsToValidators(c, validations.Functions, bufsw)
-						}
-					}
-					// Descend into this field.
-					g.emitValidationForChild(c, fld, bufsw)
-				default:
+				}
+
+				emitIterations(fld.fieldKeyIterations, fld.node.ResolveKeyNode())
+				emitIterations(fld.fieldValIterations, fld.node.ResolveElemNode())
+
+				if fld.node.valueType.Kind == types.Slice || fld.node.valueType.Kind == types.Map {
 					// Descend into this field.
 					g.emitValidationForChild(c, fld, bufsw)
 				}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -249,8 +249,8 @@ type typeNode struct {
 	typeKeyIterations validators.Validations // validations on each key
 }
 
-// ResolveElemNode traverses underlying alias nodes to find the concrete element node (for slices/maps).
-func (n *typeNode) ResolveElemNode() *typeNode {
+// resolveElemNode traverses underlying alias nodes to find the concrete element node (for slices/maps).
+func (n *typeNode) resolveElemNode() *typeNode {
 	if n.elem != nil {
 		return n.elem.node
 	}
@@ -260,8 +260,8 @@ func (n *typeNode) ResolveElemNode() *typeNode {
 	return nil
 }
 
-// ResolveKeyNode traverses underlying alias nodes to find the concrete key node (for maps).
-func (n *typeNode) ResolveKeyNode() *typeNode {
+// resolveKeyNode traverses underlying alias nodes to find the concrete key node (for maps).
+func (n *typeNode) resolveKeyNode() *typeNode {
 	if n.key != nil {
 		return n.key.node
 	}
@@ -457,7 +457,7 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 			switch util.NonPointer(util.NativeType(t)).Kind {
 			case types.Slice:
 				// Validate each value.
-				elemNode := thisNode.ResolveElemNode()
+				elemNode := thisNode.resolveElemNode()
 				if elemNode == nil {
 					if !thisNode.typeValidations.OpaqueValType {
 						return nil, fmt.Errorf("%v: value type %v is in a non-included package; "+
@@ -490,7 +490,7 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 				}
 			case types.Map:
 				// Validate each key.
-				keyNode := thisNode.ResolveKeyNode()
+				keyNode := thisNode.resolveKeyNode()
 				if keyNode == nil {
 					if !thisNode.typeValidations.OpaqueKeyType {
 						return nil, fmt.Errorf("%v: key type %v is in a non-included package; "+
@@ -522,7 +522,7 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 					}
 				}
 				// Validate each value.
-				elemNode := thisNode.ResolveElemNode()
+				elemNode := thisNode.resolveElemNode()
 				if elemNode == nil {
 					if !thisNode.typeValidations.OpaqueValType {
 						return nil, fmt.Errorf("%v: value type %v is in a non-included package; "+
@@ -944,12 +944,12 @@ func (g *genValidations) hasValidationsImpl(n *typeNode, seen map[*typeNode]bool
 
 	if n.underlying != nil {
 		if n.typeKeyIterations.HasEmitable() {
-			if keyNode := n.ResolveKeyNode(); keyNode != nil && g.hasValidationsImpl(keyNode, seen) {
+			if keyNode := n.resolveKeyNode(); keyNode != nil && g.hasValidationsImpl(keyNode, seen) {
 				return true
 			}
 		}
 		if n.typeValIterations.HasEmitable() {
-			if elemNode := n.ResolveElemNode(); elemNode != nil && g.hasValidationsImpl(elemNode, seen) {
+			if elemNode := n.resolveElemNode(); elemNode != nil && g.hasValidationsImpl(elemNode, seen) {
 				return true
 			}
 		}
@@ -963,12 +963,12 @@ func (g *genValidations) hasValidationsImpl(n *typeNode, seen map[*typeNode]bool
 			return true
 		}
 		if c.fieldKeyIterations.HasEmitable() {
-			if keyNode := c.node.ResolveKeyNode(); keyNode != nil && g.hasValidationsImpl(keyNode, seen) {
+			if keyNode := c.node.resolveKeyNode(); keyNode != nil && g.hasValidationsImpl(keyNode, seen) {
 				return true
 			}
 		}
 		if c.fieldValIterations.HasEmitable() {
-			if elemNode := c.node.ResolveElemNode(); elemNode != nil && g.hasValidationsImpl(elemNode, seen) {
+			if elemNode := c.node.resolveElemNode(); elemNode != nil && g.hasValidationsImpl(elemNode, seen) {
 				return true
 			}
 		}
@@ -1141,7 +1141,7 @@ func (g *genValidations) emitValidationForChild(c *generator.Context, thisChild 
 	}
 
 	if validations := thisNode.typeKeyIterations; !validations.Empty() {
-		keyNode := thisNode.ResolveKeyNode()
+		keyNode := thisNode.resolveKeyNode()
 		if keyNode != nil && g.hasValidations(keyNode) {
 			emitComments(validations.Comments, sw)
 			emitCallsToValidators(c, validations.Functions, sw)
@@ -1151,7 +1151,7 @@ func (g *genValidations) emitValidationForChild(c *generator.Context, thisChild 
 	}
 
 	if validations := thisNode.typeValIterations; !validations.Empty() {
-		elemNode := thisNode.ResolveElemNode()
+		elemNode := thisNode.resolveElemNode()
 		if elemNode != nil && g.hasValidations(elemNode) {
 			emitComments(validations.Comments, sw)
 			emitCallsToValidators(c, validations.Functions, sw)
@@ -1270,8 +1270,8 @@ func (g *genValidations) emitValidationForChild(c *generator.Context, thisChild 
 					}
 				}
 
-				emitIterations(fld.fieldKeyIterations, fld.node.ResolveKeyNode())
-				emitIterations(fld.fieldValIterations, fld.node.ResolveElemNode())
+				emitIterations(fld.fieldKeyIterations, fld.node.resolveKeyNode())
+				emitIterations(fld.fieldValIterations, fld.node.resolveElemNode())
 
 				if fld.node.valueType.Kind == types.Slice || fld.node.valueType.Kind == types.Map {
 					// Descend into this field.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -128,7 +128,7 @@ func (evtv eachValTagValidator) GetValidations(context Context, tag codetags.Tag
 		return Validations{}, fmt.Errorf("nested deferred validations are not supported for eachVal value")
 	}
 
-	if result.Empty() && !result.OpaqueValType {
+	if result.Empty() {
 		return Validations{}, fmt.Errorf("no validation functions found")
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -347,12 +347,14 @@ type Validations struct {
 }
 
 func (v *Validations) Empty() bool {
-	return v.Len() == 0
+	return !v.HasEmitable() &&
+		!v.OpaqueType &&
+		!v.OpaqueKeyType &&
+		!v.OpaqueValType
 }
 
-func (v *Validations) Len() int {
-	n := len(v.Functions) + len(v.Variables) + len(v.Comments) + len(v.Deferred)
-	return n
+func (v *Validations) HasEmitable() bool {
+	return len(v.Functions) > 0 || len(v.Variables) > 0 || len(v.Comments) > 0 || len(v.Deferred) > 0
 }
 
 func (v *Validations) AddFunction(fn FunctionGen) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The `+k8s:opaqueType` tag was being ignored on (non)embedded fields because the generator treated any field without explicitly attached validation functions/variables as having "empty" validations. This caused the generator to ignore the opaque flag on the field and subsequently emit validation calls for its underlying type.

This commit updates `validators.Validations.Empty()` to return `false` if any of the opaque flags (`OpaqueType`, `OpaqueKeyType`, `OpaqueValType`) are set. 

#### Which issue(s) this PR is related to:
Fixes #N/A



#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation:
N/A