### PR TITLE
kubelet: prevent duplicate orphaned pod cgroup cleanup goroutines

### DIFF
--- a/pkg/kubelet/cm/fake_pod_container_manager.go
+++ b/pkg/kubelet/cm/fake_pod_container_manager.go
@@ -17,8 +17,10 @@ limitations under the License.
 package cm
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,13 +32,26 @@ type FakePodContainerManager struct {
 	sync.Mutex
 	CalledFunctions []string
 	Cgroups         map[types.UID]CgroupName
+	// DestroyDelay simulates slow Destroy operations by sleeping.
+	DestroyDelay time.Duration
+	// DestroyError if set, Destroy returns this error.
+	DestroyError error
+	// DestroyBlockCh if set, Destroy blocks until the channel is closed.
+	DestroyBlockCh <-chan struct{}
+	// DestroyStartedCh if set, Destroy signals when it starts.
+	DestroyStartedCh chan<- struct{}
+	// DestroyWG if set, Destroy calls Done() on completion.
+	DestroyWG *sync.WaitGroup
+	// DestroyCallCount tracks the number of Destroy calls per cgroup.
+	DestroyCallCount map[string]int
 }
 
 var _ PodContainerManager = &FakePodContainerManager{}
 
 func NewFakePodContainerManager() *FakePodContainerManager {
 	return &FakePodContainerManager{
-		Cgroups: make(map[types.UID]CgroupName),
+		Cgroups:          make(map[types.UID]CgroupName),
+		DestroyCallCount: make(map[string]int),
 	}
 }
 
@@ -69,8 +84,37 @@ func (m *FakePodContainerManager) GetPodContainerName(_ *v1.Pod) (CgroupName, st
 
 func (m *FakePodContainerManager) Destroy(_ klog.Logger, name CgroupName) error {
 	m.Lock()
-	defer m.Unlock()
 	m.CalledFunctions = append(m.CalledFunctions, "Destroy")
+	cgroupKey := fmt.Sprintf("%v", name)
+	m.DestroyCallCount[cgroupKey]++
+	delay := m.DestroyDelay
+	returnErr := m.DestroyError
+	blockCh := m.DestroyBlockCh
+	startedCh := m.DestroyStartedCh
+	wg := m.DestroyWG
+	m.Unlock()
+
+	if startedCh != nil {
+		select {
+		case startedCh <- struct{}{}:
+		default:
+		}
+	}
+	if blockCh != nil {
+		<-blockCh
+	}
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	if wg != nil {
+		defer wg.Done()
+	}
+	if returnErr != nil {
+		return returnErr
+	}
+
+	m.Lock()
+	defer m.Unlock()
 	for key, cgname := range m.Cgroups {
 		if reflect.DeepEqual(cgname, name) {
 			delete(m.Cgroups, key)
@@ -125,4 +169,11 @@ func (cm *FakePodContainerManager) SetPodCgroupConfig(_ klog.Logger, pod *v1.Pod
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "SetPodCgroupConfig")
 	return nil
+}
+
+func (m *FakePodContainerManager) GetDestroyCallCount(name CgroupName) int {
+	m.Lock()
+	defer m.Unlock()
+	cgroupKey := fmt.Sprintf("%v", name)
+	return m.DestroyCallCount[cgroupKey]
 }

--- a/pkg/kubelet/cm/fake_pod_container_manager_test.go
+++ b/pkg/kubelet/cm/fake_pod_container_manager_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+func TestFakePodContainerManagerDestroyBlocksAndSignals(t *testing.T) {
+	manager := NewFakePodContainerManager()
+	podUID := types.UID("pod-1")
+	cgroupName := CgroupName{"pod-1"}
+	manager.Cgroups[podUID] = cgroupName
+
+	startedCh := make(chan struct{}, 1)
+	blockCh := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	manager.DestroyStartedCh = startedCh
+	manager.DestroyBlockCh = blockCh
+	manager.DestroyWG = wg
+	manager.DestroyError = fmt.Errorf("boom")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- manager.Destroy(klog.Background(), cgroupName)
+	}()
+
+	select {
+	case <-startedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Destroy to start")
+	}
+
+	if got := manager.GetDestroyCallCount(cgroupName); got != 1 {
+		t.Fatalf("expected Destroy to be called once, got %d", got)
+	}
+
+	close(blockCh)
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Destroy to finish")
+	}
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if _, ok := manager.Cgroups[podUID]; !ok {
+		t.Fatal("cgroup should not be deleted when Destroy returns error")
+	}
+}
+
+func TestFakePodContainerManagerDestroyDeletesCgroup(t *testing.T) {
+	manager := NewFakePodContainerManager()
+	podUID := types.UID("pod-2")
+	cgroupName := CgroupName{"pod-2"}
+	manager.Cgroups[podUID] = cgroupName
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	manager.DestroyWG = wg
+
+	if err := manager.Destroy(klog.Background(), cgroupName); err != nil {
+		t.Fatalf("Destroy returned error: %v", err)
+	}
+
+	wg.Wait()
+
+	if got := manager.GetDestroyCallCount(cgroupName); got != 1 {
+		t.Fatalf("expected Destroy to be called once, got %d", got)
+	}
+	if _, ok := manager.Cgroups[podUID]; ok {
+		t.Fatal("cgroup should be deleted on successful Destroy")
+	}
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -607,6 +607,7 @@ func NewMainKubelet(ctx context.Context,
 		sourcesReady:                 config.NewSourcesReady(kubeDeps.PodConfig.SeenAllSources),
 		registerNode:                 registerNode,
 		registerWithTaints:           registerWithTaints,
+		cgroupsBeingCleaned:          make(map[types.UID]bool),
 		dnsConfigurer:                dns.NewConfigurer(kubeDeps.Recorder, nodeRef, nodeIPs, clusterDNS, kubeCfg.ClusterDomain, kubeCfg.ResolverConfig),
 		serviceLister:                serviceLister,
 		serviceHasSynced:             serviceHasSynced,
@@ -1154,6 +1155,10 @@ type Kubelet struct {
 
 	// onRepeatedHeartbeatFailure is called when a heartbeat operation fails more than once. optional.
 	onRepeatedHeartbeatFailure func()
+	// cgroupCleanupMux protects cgroupsBeingCleaned.
+	cgroupCleanupMux sync.Mutex
+	// cgroupsBeingCleaned tracks pod UIDs whose cgroups are currently being cleaned up.
+	cgroupsBeingCleaned map[types.UID]bool
 
 	// podManager stores the desired set of admitted pods and mirror pods that the kubelet should be
 	// running. The actual set of running pods is stored on the podWorkers. The manager is populated

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2851,16 +2851,32 @@ func (kl *Kubelet) cleanupOrphanedPodCgroups(logger klog.Logger, pcm cm.PodConta
 			continue
 		}
 		logger.V(3).Info("Orphaned pod found, removing pod cgroups", "podUID", uid)
+		kl.cgroupCleanupMux.Lock()
+		if kl.cgroupsBeingCleaned == nil {
+			kl.cgroupsBeingCleaned = make(map[types.UID]bool)
+		}
+		if kl.cgroupsBeingCleaned[uid] {
+			kl.cgroupCleanupMux.Unlock()
+			logger.V(4).Info("Cgroup cleanup already in progress, skipping", "podUID", uid)
+			continue
+		}
+		kl.cgroupsBeingCleaned[uid] = true
+		kl.cgroupCleanupMux.Unlock()
 		// Destroy all cgroups of pods that should not be running,
 		// by first killing all the attached processes in these cgroups.
 		// The error return value of Destroy is explicitly checked and logged,
 		// but errors are tolerated since the housekeeping loop loop would
 		// again try to delete these unwanted pod cgroups.
-		go func() {
-			if err := pcm.Destroy(logger, val); err != nil {
-				logger.Info("Failed to destroy orphaned pod cgroup", "podUID", uid, "err", err)
+		go func(podUID types.UID, cgroupName cm.CgroupName) {
+			defer func() {
+				kl.cgroupCleanupMux.Lock()
+				delete(kl.cgroupsBeingCleaned, podUID)
+				kl.cgroupCleanupMux.Unlock()
+			}()
+			if err := pcm.Destroy(logger, cgroupName); err != nil {
+				logger.Info("Failed to destroy orphaned pod cgroup", "podUID", podUID, "err", err)
 			}
-		}()
+		}(uid, val)
 	}
 }
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -582,6 +583,145 @@ func TestHandlePodCleanupsPerQOS(t *testing.T) {
 	// Destroy() count in not deterministic on the actual number.
 	// https://github.com/kubernetes/kubernetes/blob/29fdbb065b5e0d195299eb2d260b975cbc554673/pkg/kubelet/kubelet_pods.go#L2006
 	assert.GreaterOrEqual(t, destroyCount, 1, "Expect 1 or more destroys")
+}
+
+func TestHandlePodCleanupsPreventsDuplicateGoroutines(t *testing.T) {
+	ctx := context.Background()
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+
+	pod := &kubecontainer.Pod{
+		ID:        "test-pod-123",
+		Name:      "test-pod",
+		Namespace: "test-namespace",
+		Containers: []*kubecontainer.Container{
+			{Name: "test-container"},
+		},
+	}
+
+	fakeRuntime := testKubelet.fakeRuntime
+	fakeContainerManager := testKubelet.fakeContainerManager
+	kubelet := testKubelet.kubelet
+	kubelet.cgroupsPerQOS = true
+	kubelet.cgroupsBeingCleaned = nil
+
+	fakeContainerManager.PodContainerManager.AddPodFromCgroups(pod)
+
+	destroyStartedCh := make(chan struct{}, 1)
+	destroyBlockCh := make(chan struct{})
+	destroyWG := &sync.WaitGroup{}
+	destroyWG.Add(1)
+	fakeContainerManager.PodContainerManager.DestroyStartedCh = destroyStartedCh
+	fakeContainerManager.PodContainerManager.DestroyBlockCh = destroyBlockCh
+	fakeContainerManager.PodContainerManager.DestroyWG = destroyWG
+
+	fakeRuntime.PodList = nil
+
+	kubelet.HandlePodCleanups(ctx)
+	select {
+	case <-destroyStartedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Destroy to start")
+	}
+
+	for i := 0; i < 5; i++ {
+		kubelet.HandlePodCleanups(ctx)
+	}
+
+	close(destroyBlockCh)
+	done := make(chan struct{})
+	go func() {
+		destroyWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Destroy to complete")
+	}
+
+	cgroupName := []string{pod.Name}
+	destroyCount := fakeContainerManager.PodContainerManager.GetDestroyCallCount(cgroupName)
+	assert.Equal(t, 1, destroyCount, "Destroy should be called exactly once while cleanup is in progress")
+
+	err := wait.Poll(10*time.Millisecond, 1*time.Second, func() (bool, error) {
+		kubelet.cgroupCleanupMux.Lock()
+		_, stillTracked := kubelet.cgroupsBeingCleaned[pod.ID]
+		kubelet.cgroupCleanupMux.Unlock()
+		return !stillTracked, nil
+	})
+	assert.NoError(t, err, "Pod should be removed from tracking map after cleanup completes")
+}
+
+func TestHandlePodCleanupsWithFailedDestroy(t *testing.T) {
+	ctx := context.Background()
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+
+	pod := &kubecontainer.Pod{
+		ID:        "failed-pod-456",
+		Name:      "failed-pod",
+		Namespace: "test-namespace",
+		Containers: []*kubecontainer.Container{
+			{Name: "test-container"},
+		},
+	}
+
+	fakeRuntime := testKubelet.fakeRuntime
+	fakeContainerManager := testKubelet.fakeContainerManager
+	kubelet := testKubelet.kubelet
+	kubelet.cgroupsPerQOS = true
+	kubelet.cgroupsBeingCleaned = nil
+
+	fakeContainerManager.PodContainerManager.AddPodFromCgroups(pod)
+
+	fakeContainerManager.PodContainerManager.DestroyError = fmt.Errorf("simulated destroy failure")
+	destroyWG := &sync.WaitGroup{}
+	destroyWG.Add(1)
+	fakeContainerManager.PodContainerManager.DestroyWG = destroyWG
+
+	fakeRuntime.PodList = nil
+
+	kubelet.HandlePodCleanups(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		destroyWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Destroy to complete")
+	}
+
+	err := wait.Poll(10*time.Millisecond, 1*time.Second, func() (bool, error) {
+		kubelet.cgroupCleanupMux.Lock()
+		_, stillTracked := kubelet.cgroupsBeingCleaned[pod.ID]
+		kubelet.cgroupCleanupMux.Unlock()
+		return !stillTracked, nil
+	})
+	assert.NoError(t, err, "Pod should be removed from tracking map even when Destroy fails")
+
+	fakeContainerManager.PodContainerManager.DestroyError = nil
+	destroyWG.Add(1)
+
+	kubelet.HandlePodCleanups(ctx)
+
+	done = make(chan struct{})
+	go func() {
+		destroyWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Destroy to complete")
+	}
+
+	cgroupName := []string{pod.Name}
+	destroyCount := fakeContainerManager.PodContainerManager.GetDestroyCallCount(cgroupName)
+	assert.Equal(t, 2, destroyCount, "Destroy should be retried after previous failure")
 }
 
 func TestDispatchWorkOfCompletedPod(t *testing.T) {


### PR DESCRIPTION
  #### What type of PR is this?
  /kind bug

  #### What this PR does / why we need it:
  `cleanupOrphanedPodCgroups()` runs from kubelet housekeeping periodically.
  Today, if cgroup destroy is slow or repeatedly failing, kubelet can spawn multiple concurrent `Destroy()` goroutines
  for the same Pod UID across housekeeping iterations.

  In high-density nodes (many pods and many mounts), this can lead to excessive goroutine growth and memory pressure.

  This PR adds in-flight deduplication for orphaned pod cgroup cleanup:
  - Track pod UIDs currently under cgroup cleanup.
  - Skip launching a new cleanup goroutine if cleanup is already in progress for that UID.
  - Always clear tracking on goroutine exit (both success and failure), so retries still happen in subsequent
  housekeeping loops.

  This keeps retry behavior while preventing duplicate concurrent cleanup for the same pod.

  #### Why this is safe:
  - No behavior change for the successful cleanup path.
  - Only suppresses duplicate in-flight work per Pod UID.
  - Failed cleanup is still retried later (tracking is released in `defer`).

  #### Additional test coverage:
  - `TestHandlePodCleanupsPreventsDuplicateGoroutines`
    verifies repeated housekeeping does not spawn duplicate destroy goroutines for one pod while cleanup is in flight.
  - `TestHandlePodCleanupsWithFailedDestroy`
    verifies tracking is cleaned up on failure and subsequent housekeeping can retry cleanup.
  - `cm` fake manager tests validate blocking/error/call-count behavior used by the kubelet tests.

  #### Which issue(s) this PR fixes:
  None.

  #### Special notes for your reviewer:
  This addresses repeated duplicate `Destroy()` calls for the same orphaned pod cgroup under slow/failing cgroup teardown
  conditions.

  #### Does this PR introduce a user-facing change?
  ```release-note
  NONE