### PR TITLE
fix(events): return 410 error for watch with stale resourceVersion

### DIFF
--- a/pkg/registry/core/event/storage/storage.go
+++ b/pkg/registry/core/event/storage/storage.go
@@ -17,7 +17,15 @@ limitations under the License.
 package storage
 
 import (
+	"context"
+	"fmt"
+	"strconv"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -64,4 +72,78 @@ var _ rest.ShortNamesProvider = &REST{}
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
 func (r *REST) ShortNames() []string {
 	return []string{"ev"}
+}
+
+// Watch overrides the default Watch implementation to validate resourceVersion
+// and return a proper 410 Gone error when the resourceVersion is too old,
+// ensuring consistent behavior with resources that use the watch cache.
+// This fixes issue #137089 where Event watch requests with stale resourceVersion
+// would return HTTP 200 with an empty response body instead of the expected 410 error.
+func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	// If resourceVersion is specified, validate it before proceeding
+	if options != nil && options.ResourceVersion != "" {
+		requestRV, err := strconv.ParseUint(options.ResourceVersion, 10, 64)
+		if err != nil {
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("invalid resource version: %s", options.ResourceVersion))
+		}
+
+		// Get current resource version from storage
+		currentRV, err := r.Store.Storage.Storage.GetCurrentResourceVersion(ctx)
+		if err != nil {
+			// If we can't determine current RV, proceed with the watch request
+			// and let the underlying storage handle any errors
+			return r.Store.Watch(ctx, options)
+		}
+
+		// If requested RV is significantly older than current, return an error
+		// The 1000 threshold is consistent with the watch cache's compacted window check
+		// Note: This is a conservative check; the actual watch cache may allow larger windows
+		if requestRV > 0 && requestRV < currentRV && (currentRV-requestRV) > 1000 {
+			return newErrWatcher(apierrors.NewResourceExpired(fmt.Sprintf(
+				"too old resource version: %s (%d)", options.ResourceVersion, currentRV)))
+		}
+	}
+
+	return r.Store.Watch(ctx, options)
+}
+
+// errWatcher implements watch.Interface and returns a single error event
+type errWatcher struct {
+	result chan watch.Event
+}
+
+func newErrWatcher(err error) *errWatcher {
+	// Create an error event
+	errEvent := watch.Event{Type: watch.Error}
+	switch err := err.(type) {
+	case runtime.Object:
+		errEvent.Object = err
+	case *apierrors.StatusError:
+		errEvent.Object = &err.ErrStatus
+	default:
+		errEvent.Object = &metav1.Status{
+			Status:  metav1.StatusFailure,
+			Message: err.Error(),
+			Reason:  metav1.StatusReasonExpired,
+			Code:    410,
+		}
+	}
+
+	// Create a watcher with room for a single event, populate it, and close the channel
+	watcher := &errWatcher{result: make(chan watch.Event, 1)}
+	watcher.result <- errEvent
+	close(watcher.result)
+
+	return watcher
+}
+
+func (e *errWatcher) ResultChan() <-chan watch.Event {
+	return e.result
+}
+
+func (e *errWatcher) Stop() {
+}
+
+func (e *errWatcher) RequestWatchProgress() error {
+	return nil
 }

--- a/pkg/registry/core/event/storage/storage_test.go
+++ b/pkg/registry/core/event/storage/storage_test.go
@@ -17,13 +17,19 @@ limitations under the License.
 package storage
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
+	"k8s.io/apiserver/pkg/registry/rest"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -122,4 +128,119 @@ func TestShortNames(t *testing.T) {
 	defer storage.Store.DestroyFunc()
 	expected := []string{"ev"}
 	registrytest.AssertShortNames(t, storage, expected)
+}
+
+func TestWatchWithStaleResourceVersion(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+
+	// Create an event first to get the current resource version
+	event := validNewNewEvent("test-namespace")
+	_, err := storage.Store.Create(context.TODO(), event, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create event: %v", err)
+	}
+
+	// Test with resourceVersion="0" - should succeed
+	t.Run("resourceVersion zero", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		opts := &metainternalversion.ListOptions{ResourceVersion: "0"}
+		watcher, err := storage.Watch(ctx, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer watcher.Stop()
+
+		// Should be able to receive at least a bookmark event
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				t.Fatal("watch channel closed unexpectedly")
+			}
+			// Event type should not be Error
+			if event.Type == watch.Error {
+				t.Fatalf("unexpected error event: %v", event.Object)
+			}
+		case <-ctx.Done():
+			t.Fatal("timeout waiting for watch event")
+		}
+	})
+
+	// Test with very old resourceVersion - should return 410 error
+	t.Run("stale resourceVersion", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Use resourceVersion "1" which is definitely too old
+		opts := &metainternalversion.ListOptions{ResourceVersion: "1"}
+		watcher, err := storage.Watch(ctx, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer watcher.Stop()
+
+		// Should receive an error event
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				t.Fatal("watch channel closed without returning error event")
+			}
+			// Should be an error event
+			if event.Type != watch.Error {
+				t.Fatalf("expected error event, got %v", event.Type)
+			}
+
+			// Check the error is a 410 Gone
+			status, ok := event.Object.(*metav1.Status)
+			if !ok {
+				t.Fatalf("expected *metav1.Status, got %T", event.Object)
+			}
+			if status.Code != 410 {
+				t.Fatalf("expected status code 410, got %d", status.Code)
+			}
+			if status.Reason != metav1.StatusReasonExpired {
+				t.Fatalf("expected reason %q, got %q", metav1.StatusReasonExpired, status.Reason)
+			}
+		case <-ctx.Done():
+			t.Fatal("timeout waiting for error event")
+		}
+	})
+
+	// Test with invalid resourceVersion - should return BadRequest
+	t.Run("invalid resourceVersion", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		opts := &metainternalversion.ListOptions{ResourceVersion: "invalid"}
+		_, err := storage.Watch(ctx, opts)
+		if err == nil {
+			t.Fatal("expected error for invalid resourceVersion")
+		}
+		if !errors.IsBadRequest(err) {
+			t.Fatalf("expected BadRequest error, got %v", err)
+		}
+	})
+}
+
+func validNewNewEvent(namespace string) *api.Event {
+	someTime := metav1.NowMicro()
+	return &api.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-event-%d", time.Now().UnixNano()),
+			Namespace: namespace,
+		},
+		InvolvedObject: api.ObjectReference{
+			Name:      "test-pod",
+			Namespace: namespace,
+		},
+		EventTime:           someTime,
+		ReportingController: "test-controller",
+		ReportingInstance:   "test-node",
+		Action:              "Do",
+		Reason:              "forTesting",
+		Type:                "Normal",
+	}
 }


### PR DESCRIPTION
When watching Events with a stale resourceVersion, the server was returning HTTP 200 and immediately closing the connection without sending any error. This was inconsistent with other resources like Pods that properly return a 410 Gone error.

The root cause is that Events don't use the watch cache (cacher) due to their high volume and short TTL. The etcd3 watcher doesn't pre-validate resourceVersion like the cacher does.

This fix adds a Watch() method override on Event REST storage that:
1. Validates the requested resourceVersion
2. Compares it against the current etcd RV
3. Returns a 410 Gone error if the RV is too old (>1000 versions behind)
4. Falls back to default behavior if RV check fails

Fixes kubernetes/kubernetes#137089

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
