### PR TITLE
`kubectl delete`: add "remove" to SuggestFor

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -160,7 +160,7 @@ func NewCmdDelete(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunDelete(f))
 		},
-		SuggestFor: []string{"rm"},
+		SuggestFor: []string{"rm", "remove"},
 	}
 
 	deleteFlags.AddFlags(cmd)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR adds "remove" to the `SuggestFor` field of the top-level `kubectl delete` command.

remove is a direct and commonly used synonym for delete across many CLI tools. Users unfamiliar with Kubernetes may naturally attempt kubectl remove when trying to delete a resource. Suggesting delete in this case improves discoverability and CLI ergonomics.

The existing "rm" suggestion remains unchanged.


<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
[comment](https://github.com/kubernetes/kubectl/issues/1825#issuecomment-3960746257): as discussed from the last bug scrub meeting about SuggestFor, I think this change also does make sense. Would request reviewers to give their thoughts.
