### PR TITLE
client-go: Add pending notifications metric for processorListener

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/processor_listener_metrics.go
+++ b/staging/src/k8s.io/client-go/tools/cache/processor_listener_metrics.go
@@ -1,0 +1,66 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sync"
+)
+
+// ProcessorListenerMetricsProvider creates metrics for processorListener.
+type ProcessorListenerMetricsProvider interface {
+	// NewPendingNotificationsMetric returns a gauge metric for tracking the number of
+	// pending notifications buffered in a processorListener's ring buffer.
+	// The handlerName parameter distinguishes multiple handlers registered
+	// on the same informer (identified by id).
+	NewPendingNotificationsMetric(id InformerNameAndResource, handlerName string) GaugeMetric
+}
+
+type noopProcessorListenerMetricsProvider struct{}
+
+func (noopProcessorListenerMetricsProvider) NewPendingNotificationsMetric(InformerNameAndResource, string) GaugeMetric {
+	return noopMetric{}
+}
+
+var (
+	globalProcessorListenerMetricsProvider  ProcessorListenerMetricsProvider = noopProcessorListenerMetricsProvider{}
+	setProcessorListenerMetricsProviderOnce sync.Once
+)
+
+// processorListenerMetrics holds all metrics for a processorListener.
+type processorListenerMetrics struct {
+	pendingNotifications GaugeMetric
+}
+
+// SetProcessorListenerMetricsProvider sets the metrics provider for all subsequently created
+// processorListeners. Only the first call has an effect.
+func SetProcessorListenerMetricsProvider(provider ProcessorListenerMetricsProvider) {
+	setProcessorListenerMetricsProviderOnce.Do(func() {
+		globalProcessorListenerMetricsProvider = provider
+	})
+}
+
+func newProcessorListenerMetrics(id InformerNameAndResource, handlerName string) *processorListenerMetrics {
+	metrics := &processorListenerMetrics{
+		pendingNotifications: noopMetric{},
+	}
+
+	if id.Reserved() {
+		metrics.pendingNotifications = globalProcessorListenerMetricsProvider.NewPendingNotificationsMetric(id, handlerName)
+	}
+
+	return metrics
+}

--- a/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
@@ -60,7 +60,7 @@ func BenchmarkListener(b *testing.B) {
 		AddFunc: func(obj interface{}) {
 			swg.Done()
 		},
-	}, 0, 0, time.Now(), 1024*1024, newMockSynced(b, true))
+	}, 0, 0, time.Now(), 1024*1024, newMockSynced(b, true), InformerNameAndResource{}, "benchmark")
 	var wg wait.Group
 	defer wg.Wait()       // Wait for .run and .pop to stop
 	defer close(pl.addCh) // Tell .run and .pop to stop

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -277,6 +277,11 @@ type HandlerOptions struct {
 	//
 	// If nil, the default resync period of the shared informer is used.
 	ResyncPeriod *time.Duration
+
+	// Name is a identifier for this event handler, used as a
+	// label in metrics (e.g. pending notifications gauge). When empty,
+	// a name is derived automatically from the handler type or function names.
+	Name string
 }
 
 // SharedIndexInformer provides add and get Indexers ability based on SharedInformer.
@@ -904,7 +909,12 @@ func (s *sharedIndexInformer) AddEventHandlerWithOptions(handler ResourceEventHa
 		}
 	}
 
-	listener := newProcessListener(logger, handler, resyncPeriod, determineResyncPeriod(logger, resyncPeriod, s.resyncCheckPeriod), s.clock.Now(), initialBufferSize, s.HasSyncedChecker())
+	handlerName := options.Name
+	if handlerName == "" {
+		handlerName = nameForHandler(handler)
+	}
+
+	listener := newProcessListener(logger, handler, resyncPeriod, determineResyncPeriod(logger, resyncPeriod, s.resyncCheckPeriod), s.clock.Now(), initialBufferSize, s.HasSyncedChecker(), s.identifier, handlerName)
 
 	if !s.started {
 		return s.processor.addListener(listener), nil
@@ -1049,6 +1059,19 @@ func (p *sharedProcessor) addListener(listener *processorListener) ResourceEvent
 
 	if p.listeners == nil {
 		p.listeners = make(map[*processorListener]bool)
+	}
+
+	// First-wins dedup: if a listener with the same handlerName already
+	// exists, downgrade the new listener's metrics to noop so that two
+	// handlers sharing a Prometheus label don't corrupt each other's gauge.
+	for l := range p.listeners {
+		if l.handlerName == listener.handlerName {
+			listener.logger.Info("Warning: duplicate event handler name detected; metrics for this handler registration will not be published", "handlerName", listener.handlerName)
+			listener.metrics = &processorListenerMetrics{
+				pendingNotifications: noopMetric{},
+			}
+			break
+		}
 	}
 
 	p.listeners[listener] = true
@@ -1221,6 +1244,8 @@ type processorListener struct {
 	// TODO: This is no worse than before, since reflectors were backed by unbounded DeltaFIFOs, but
 	// we should try to do something better.
 	pendingNotifications buffer.RingGrowing
+	metrics              *processorListenerMetrics
+	handlerName          string
 
 	// requestedResyncPeriod is how frequently the listener wants a
 	// full resync from the shared informer, but modified by two
@@ -1257,7 +1282,7 @@ func (p *processorListener) HasSyncedChecker() DoneChecker {
 	return p.syncTracker
 }
 
-func newProcessListener(logger klog.Logger, handler ResourceEventHandler, requestedResyncPeriod, resyncPeriod time.Duration, now time.Time, bufferSize int, hasSynced DoneChecker) *processorListener {
+func newProcessListener(logger klog.Logger, handler ResourceEventHandler, requestedResyncPeriod, resyncPeriod time.Duration, now time.Time, bufferSize int, hasSynced DoneChecker, id InformerNameAndResource, handlerName string) *processorListener {
 	ret := &processorListener{
 		logger:                logger,
 		nextCh:                make(chan interface{}),
@@ -1265,8 +1290,10 @@ func newProcessListener(logger klog.Logger, handler ResourceEventHandler, reques
 		done:                  make(chan struct{}),
 		upstreamHasSynced:     hasSynced,
 		handler:               handler,
-		syncTracker:           synctrack.NewSingleFileTracker(fmt.Sprintf("%s + event handler %s", hasSynced.Name(), nameForHandler(handler))),
+		syncTracker:           synctrack.NewSingleFileTracker(fmt.Sprintf("%s + event handler %s", hasSynced.Name(), handlerName)),
 		pendingNotifications:  *buffer.NewRingGrowing(bufferSize),
+		metrics:               newProcessorListenerMetrics(id, handlerName),
+		handlerName:           handlerName,
 		requestedResyncPeriod: requestedResyncPeriod,
 		resyncPeriod:          resyncPeriod,
 	}
@@ -1299,6 +1326,7 @@ func (p *processorListener) pop() {
 			if !ok { // Nothing to pop
 				nextCh = nil // Disable this select case
 			}
+			p.metrics.pendingNotifications.Set(float64(p.pendingNotifications.Len()))
 		case notificationToAdd, ok := <-p.addCh:
 			if !ok {
 				return
@@ -1309,6 +1337,7 @@ func (p *processorListener) pop() {
 				nextCh = p.nextCh
 			} else { // There is already a notification waiting to be dispatched
 				p.pendingNotifications.WriteOne(notificationToAdd)
+				p.metrics.pendingNotifications.Set(float64(p.pendingNotifications.Len()))
 			}
 		}
 	}

--- a/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/listener/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/listener/metrics.go
@@ -1,0 +1,81 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package listener
+
+import (
+	"sync"
+
+	"k8s.io/client-go/tools/cache"
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	subsystem = "informer"
+
+	pendingNotifications = k8smetrics.NewGaugeVec(
+		&k8smetrics.GaugeOpts{
+			Subsystem:      subsystem,
+			Name:           "pending_notifications",
+			Help:           "Number of pending notifications in the processor listener ring buffer.",
+			StabilityLevel: k8smetrics.ALPHA,
+		},
+		[]string{"name", "group", "version", "resource", "handler"},
+	)
+	registerOnce sync.Once
+)
+
+func init() {
+	Register()
+}
+
+// Register registers processor listener metrics and sets the metrics provider.
+func Register() {
+	registerOnce.Do(func() {
+		legacyregistry.MustRegister(pendingNotifications)
+	})
+	cache.SetProcessorListenerMetricsProvider(processorListenerMetricsProvider{})
+}
+
+type processorListenerMetricsProvider struct{}
+
+func (processorListenerMetricsProvider) NewPendingNotificationsMetric(id cache.InformerNameAndResource, handlerName string) cache.GaugeMetric {
+	return &reservedGaugeMetric{
+		id: id,
+		gauge: pendingNotifications.WithLabelValues(
+			id.Name(),
+			id.GroupVersionResource().Group,
+			id.GroupVersionResource().Version,
+			id.GroupVersionResource().Resource,
+			handlerName,
+		),
+	}
+}
+
+// reservedGaugeMetric wraps a gauge and only updates it if the identifier
+// is still reserved. This supports dynamic informers (e.g., GC, ResourceQuota)
+// that may shut down while the process is still running.
+type reservedGaugeMetric struct {
+	id    cache.InformerNameAndResource
+	gauge cache.GaugeMetric
+}
+
+func (r *reservedGaugeMetric) Set(value float64) {
+	if r.id.Reserved() {
+		r.gauge.Set(value)
+	}
+}

--- a/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/metrics.go
@@ -19,6 +19,7 @@ package clientgo
 import (
 	_ "k8s.io/component-base/metrics/prometheus/clientgo/fifo"           // load fifo metrics
 	_ "k8s.io/component-base/metrics/prometheus/clientgo/leaderelection" // load leaderelection metrics
+	_ "k8s.io/component-base/metrics/prometheus/clientgo/listener"       // load processor listener metrics
 	_ "k8s.io/component-base/metrics/prometheus/restclient"              // load restclient metrics
 	_ "k8s.io/component-base/metrics/prometheus/workqueue"               // load the workqueue metrics
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

processorListener uses an unbounded `RingGrowing` ring buffer (`pendingNotifications`) to buffer notifications between the `addCh` and `nextCh` channels. When an event handler is slow or stalled, this buffer grows without bound, eventually leading to OOM — but there is currently no way to observe this happening.

  This PR adds an `informer_pending_notifications` metric that tracks the length of each `processorListener`'s pending notification buffer. This gives operators visibility into growing backlogs so they can detect and alert on problematic handlers before OOM occurs.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/121474

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
