### PR TITLE
kubelet: skip containerfs.inodesFree threshold on Windows

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -276,30 +276,37 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 				GracePeriod: softNodeFsDisk.GracePeriod,
 			})
 		}
-		if hardContainerFsINodes != -1 {
-			thresholds[hardContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, Operator: hardNodeINodeDisk.Operator, Value: hardNodeINodeDisk.Value, MinReclaim: hardNodeINodeDisk.MinReclaim,
+		// Only add containerfs inode thresholds if nodefs inode thresholds exist.
+		// On Windows, inodes are not supported, so nodefs.inodesFree thresholds
+		// will not be present and we should not add containerfs.inodesFree either.
+		if hardNodeINodeDisk.Signal != "" {
+			if hardContainerFsINodes != -1 {
+				thresholds[hardContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, Operator: hardNodeINodeDisk.Operator, Value: hardNodeINodeDisk.Value, MinReclaim: hardNodeINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:     evictionapi.SignalContainerFsInodesFree,
+					Operator:   hardNodeINodeDisk.Operator,
+					Value:      hardNodeINodeDisk.Value,
+					MinReclaim: hardNodeINodeDisk.MinReclaim,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:     evictionapi.SignalContainerFsInodesFree,
-				Operator:   hardNodeINodeDisk.Operator,
-				Value:      hardNodeINodeDisk.Value,
-				MinReclaim: hardNodeINodeDisk.MinReclaim,
-			})
 		}
-		if softContainerFsINodes != -1 {
-			thresholds[softContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softNodeINodeDisk.GracePeriod, Operator: softNodeINodeDisk.Operator, Value: softNodeINodeDisk.Value, MinReclaim: softNodeINodeDisk.MinReclaim,
+		if softNodeINodeDisk.Signal != "" {
+			if softContainerFsINodes != -1 {
+				thresholds[softContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softNodeINodeDisk.GracePeriod, Operator: softNodeINodeDisk.Operator, Value: softNodeINodeDisk.Value, MinReclaim: softNodeINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:      evictionapi.SignalContainerFsInodesFree,
+					Operator:    softNodeINodeDisk.Operator,
+					Value:       softNodeINodeDisk.Value,
+					MinReclaim:  softNodeINodeDisk.MinReclaim,
+					GracePeriod: softNodeINodeDisk.GracePeriod,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:      evictionapi.SignalContainerFsInodesFree,
-				Operator:    softNodeINodeDisk.Operator,
-				Value:       softNodeINodeDisk.Value,
-				MinReclaim:  softNodeINodeDisk.MinReclaim,
-				GracePeriod: softNodeINodeDisk.GracePeriod,
-			})
 		}
 	}
 	// Separate image filesystem case
@@ -329,30 +336,37 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 				GracePeriod: softImageFsDisk.GracePeriod,
 			})
 		}
-		if hardContainerFsINodes != -1 {
-			thresholds[hardContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: hardImageINodeDisk.GracePeriod, Operator: hardImageINodeDisk.Operator, Value: hardImageINodeDisk.Value, MinReclaim: hardImageINodeDisk.MinReclaim,
+		// Only add containerfs inode thresholds if imagefs inode thresholds exist.
+		// On Windows, inodes are not supported, so imagefs.inodesFree thresholds
+		// will not be present and we should not add containerfs.inodesFree either.
+		if hardImageINodeDisk.Signal != "" {
+			if hardContainerFsINodes != -1 {
+				thresholds[hardContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: hardImageINodeDisk.GracePeriod, Operator: hardImageINodeDisk.Operator, Value: hardImageINodeDisk.Value, MinReclaim: hardImageINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:     evictionapi.SignalContainerFsInodesFree,
+					Operator:   hardImageINodeDisk.Operator,
+					Value:      hardImageINodeDisk.Value,
+					MinReclaim: hardImageINodeDisk.MinReclaim,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:     evictionapi.SignalContainerFsInodesFree,
-				Operator:   hardImageINodeDisk.Operator,
-				Value:      hardImageINodeDisk.Value,
-				MinReclaim: hardImageINodeDisk.MinReclaim,
-			})
 		}
-		if softContainerFsINodes != -1 {
-			thresholds[softContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softImageINodeDisk.GracePeriod, Operator: softImageINodeDisk.Operator, Value: softImageINodeDisk.Value, MinReclaim: softImageINodeDisk.MinReclaim,
+		if softImageINodeDisk.Signal != "" {
+			if softContainerFsINodes != -1 {
+				thresholds[softContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softImageINodeDisk.GracePeriod, Operator: softImageINodeDisk.Operator, Value: softImageINodeDisk.Value, MinReclaim: softImageINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:      evictionapi.SignalContainerFsInodesFree,
+					Operator:    softImageINodeDisk.Operator,
+					Value:       softImageINodeDisk.Value,
+					MinReclaim:  softImageINodeDisk.MinReclaim,
+					GracePeriod: softImageINodeDisk.GracePeriod,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:      evictionapi.SignalContainerFsInodesFree,
-				Operator:    softImageINodeDisk.Operator,
-				Value:       softImageINodeDisk.Value,
-				MinReclaim:  softImageINodeDisk.MinReclaim,
-				GracePeriod: softImageINodeDisk.GracePeriod,
-			})
 		}
 	}
 	return thresholds, err

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -241,11 +241,9 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 			softContainerFsDisk = idx
 		}
 		if threshold.Signal == evictionapi.SignalContainerFsInodesFree && isHardEvictionThreshold(threshold) {
-			err = errors.Join(fmt.Errorf("found containerfs.inodesFree for hard eviction. ignoring"))
 			hardContainerFsINodes = idx
 		}
 		if threshold.Signal == evictionapi.SignalContainerFsInodesFree && !isHardEvictionThreshold(threshold) {
-			err = errors.Join(fmt.Errorf("found containerfs.inodesFree for soft eviction. ignoring"))
 			softContainerFsINodes = idx
 		}
 	}
@@ -276,11 +274,15 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 				GracePeriod: softNodeFsDisk.GracePeriod,
 			})
 		}
-		// Only add containerfs inode thresholds if nodefs inode thresholds exist.
-		// On Windows, inodes are not supported, so nodefs.inodesFree thresholds
-		// will not be present and we should not add containerfs.inodesFree either.
+		// Only add containerfs inode thresholds if the source nodefs inode threshold exists.
+		// If nodefs.inodesFree is not configured (e.g., on Windows where inodes are not
+		// supported, or on any platform where inode thresholds are simply not set), there
+		// is no meaningful value to derive for containerfs.inodesFree. Adding it anyway
+		// would cause the eviction manager to log frequent spurious
+		// "no observation found for eviction signal" messages.
 		if hardNodeINodeDisk.Signal != "" {
 			if hardContainerFsINodes != -1 {
+				err = errors.Join(err, fmt.Errorf("found containerfs.inodesFree for hard eviction. ignoring"))
 				thresholds[hardContainerFsINodes] = evictionapi.Threshold{
 					Signal: evictionapi.SignalContainerFsInodesFree, Operator: hardNodeINodeDisk.Operator, Value: hardNodeINodeDisk.Value, MinReclaim: hardNodeINodeDisk.MinReclaim,
 				}
@@ -295,6 +297,7 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 		}
 		if softNodeINodeDisk.Signal != "" {
 			if softContainerFsINodes != -1 {
+				err = errors.Join(err, fmt.Errorf("found containerfs.inodesFree for soft eviction. ignoring"))
 				thresholds[softContainerFsINodes] = evictionapi.Threshold{
 					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softNodeINodeDisk.GracePeriod, Operator: softNodeINodeDisk.Operator, Value: softNodeINodeDisk.Value, MinReclaim: softNodeINodeDisk.MinReclaim,
 				}
@@ -336,11 +339,15 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 				GracePeriod: softImageFsDisk.GracePeriod,
 			})
 		}
-		// Only add containerfs inode thresholds if imagefs inode thresholds exist.
-		// On Windows, inodes are not supported, so imagefs.inodesFree thresholds
-		// will not be present and we should not add containerfs.inodesFree either.
+		// Only add containerfs inode thresholds if the source imagefs inode threshold exists.
+		// If imagefs.inodesFree is not configured (e.g., on Windows where inodes are not
+		// supported, or on any platform where inode thresholds are simply not set), there
+		// is no meaningful value to derive for containerfs.inodesFree. Adding it anyway
+		// would cause the eviction manager to log frequent spurious
+		// "no observation found for eviction signal" messages.
 		if hardImageINodeDisk.Signal != "" {
 			if hardContainerFsINodes != -1 {
+				err = errors.Join(err, fmt.Errorf("found containerfs.inodesFree for hard eviction. ignoring"))
 				thresholds[hardContainerFsINodes] = evictionapi.Threshold{
 					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: hardImageINodeDisk.GracePeriod, Operator: hardImageINodeDisk.Operator, Value: hardImageINodeDisk.Value, MinReclaim: hardImageINodeDisk.MinReclaim,
 				}
@@ -355,6 +362,7 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 		}
 		if softImageINodeDisk.Signal != "" {
 			if softContainerFsINodes != -1 {
+				err = errors.Join(err, fmt.Errorf("found containerfs.inodesFree for soft eviction. ignoring"))
 				thresholds[softContainerFsINodes] = evictionapi.Threshold{
 					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softImageINodeDisk.GracePeriod, Operator: softImageINodeDisk.Operator, Value: softImageINodeDisk.Value, MinReclaim: softImageINodeDisk.MinReclaim,
 				}

--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -2180,6 +2180,7 @@ func TestAddContainerFsThresholds(t *testing.T) {
 		expectedContainerFsINodesHard evictionapi.Threshold
 		expectedContainerFsINodesSoft evictionapi.Threshold
 		expectErr                     bool
+		expectNoContainerFsInodes     bool
 		thresholdList                 []evictionapi.Threshold
 	}{
 		{
@@ -3116,6 +3117,219 @@ func TestAddContainerFsThresholds(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:               "single filesystem; no inode thresholds (Windows-like)",
+			imageFs:                   false,
+			containerFs:               false,
+			expectNoContainerFsInodes: true,
+			expectedContainerFsHard: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("100Mi"),
+				},
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			expectedContainerFsSoft: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("200Mi"),
+				},
+				GracePeriod: gracePeriod,
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			thresholdList: []evictionapi.Threshold{
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("100Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("200Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("100Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("300Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("2Gi"),
+					},
+				},
+			},
+		},
+		{
+			description:               "image filesystem; no inode thresholds (Windows-like)",
+			imageFs:                   true,
+			containerFs:               false,
+			expectNoContainerFsInodes: true,
+			expectedContainerFsHard: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("150Mi"),
+				},
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1.5Gi"),
+				},
+			},
+			expectedContainerFsSoft: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("300Mi"),
+				},
+				GracePeriod: gracePeriod,
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("3Gi"),
+				},
+			},
+			thresholdList: []evictionapi.Threshold{
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("100Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("200Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("150Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1.5Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("300Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("3Gi"),
+					},
+				},
+			},
+		},
+		{
+			description:               "split image and container filesystem; no inode thresholds (Windows-like)",
+			imageFs:                   true,
+			containerFs:               true,
+			expectNoContainerFsInodes: true,
+			expectedContainerFsHard: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("100Mi"),
+				},
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			expectedContainerFsSoft: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("200Mi"),
+				},
+				GracePeriod: gracePeriod,
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			thresholdList: []evictionapi.Threshold{
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("100Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("200Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("150Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1.5Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("300Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("3Gi"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -3142,12 +3356,18 @@ func TestAddContainerFsThresholds(t *testing.T) {
 					softContainerFsMatch = idx
 				}
 				if val.Signal == evictionapi.SignalContainerFsInodesFree && isHardEvictionThreshold(val) {
+					if testCase.expectNoContainerFsInodes {
+						t.Fatalf("did not expect hard containerfs.inodesFree but found one")
+					}
 					if !reflect.DeepEqual(val, testCase.expectedContainerFsINodesHard) {
 						t.Fatalf("want %v got %v", testCase.expectedContainerFsINodesHard, val)
 					}
 					hardContainerFsINodesMatch = idx
 				}
 				if val.Signal == evictionapi.SignalContainerFsInodesFree && !isHardEvictionThreshold(val) {
+					if testCase.expectNoContainerFsInodes {
+						t.Fatalf("did not expect soft containerfs.inodesFree but found one")
+					}
 					if !reflect.DeepEqual(val, testCase.expectedContainerFsINodesSoft) {
 						t.Fatalf("want %v got %v", testCase.expectedContainerFsINodesSoft, val)
 					}
@@ -3160,11 +3380,13 @@ func TestAddContainerFsThresholds(t *testing.T) {
 			if softContainerFsMatch == -1 {
 				t.Fatalf("did not find soft containerfs.available")
 			}
-			if hardContainerFsINodesMatch == -1 {
-				t.Fatalf("did not find hard containerfs.inodesfree")
-			}
-			if softContainerFsINodesMatch == -1 {
-				t.Fatalf("did not find soft containerfs.inodesfree")
+			if !testCase.expectNoContainerFsInodes {
+				if hardContainerFsINodesMatch == -1 {
+					t.Fatalf("did not find hard containerfs.inodesFree")
+				}
+				if softContainerFsINodesMatch == -1 {
+					t.Fatalf("did not find soft containerfs.inodesFree")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

On Windows, inodes are not supported and `nodefs.inodesFree` / `imagefs.inodesFree` thresholds are not present in `DefaultEvictionHard`. However, `UpdateContainerFsThresholds` unconditionally adds `containerfs.inodesFree` thresholds with zero/empty values derived from the absent source thresholds. Since the Windows container runtime never reports inode statistics, `makeSignalObservations` never creates an observation for `containerfs.inodesFree`, causing the eviction manager to log very frequently:

```
I0213 04:51:38.888080 1532 helpers.go:940] "Eviction manager: no observation found for eviction signal" signal="containerfs.inodesFree"
```

This PR adds a guard in `UpdateContainerFsThresholds` to only create `containerfs.inodesFree` thresholds when the source inode thresholds (`nodefs.inodesFree` or `imagefs.inodesFree`) actually exist. This follows the same pattern used in PR #67709 which addressed the equivalent issue for `nodefs.inodesFree`.

Both code paths in `UpdateContainerFsThresholds` are fixed:
- Single/split filesystem path (containerfs = nodefs): guard on `hardNodeINodeDisk.Signal != ""`
- Separate image filesystem path (containerfs = imagefs): guard on `hardImageINodeDisk.Signal != ""`

#### Which issue(s) this PR is related to:

Fixes #130142

#### Special notes for your reviewer:

This is the same class of bug that was previously fixed for `nodefs.inodesFree` in #67709 by @feiskyer. The `containerfs.inodesFree` signal was introduced later as part of the split disk KEP and did not include the same guard.

The fix was also reported in #73792 (comment) but was never addressed.

/sig node
/sig windows
/area kubelet

#### Does this PR introduce a user-facing change?

```release-note
Fixed kubelet eviction manager logging frequent spurious "no observation found for eviction signal containerfs.inodesFree" messages on Windows nodes where inodes are not supported.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
