### PR TITLE
Fix partial uncoreCache CPU allocation with partially available cores

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -569,24 +569,25 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 
 	// determine the N number of free cores (physical cpus) within the UncoreCache, then
 	// determine the M number of free cpus (virtual cpus) that correspond with the free cores
+	allFreeCores := a.details.CoresNeededInUncoreCache(a.topo.NumCores, uncoreID)
 	freeCores := a.details.CoresNeededInUncoreCache(numCoresNeeded, uncoreID)
 	freeCPUs := a.details.CPUsInCores(freeCores.UnsortedList()...)
 
-	// when SMT/hyperthread is enabled and remaining cpu requirement is an odd integer value:
-	// sort the free CPUs that were determined based on the cores that have available cpus.
-	// if the amount of free cpus is greather than the cpus needed, we can drop the last cpu
-	// since the odd integer request will only require one out of the two free cpus that
-	// correspond to the last core
-	if a.numCPUsNeeded%2 != 0 && a.topo.CPUsPerCore() > 1 {
-		// we sort freeCPUs to ensure we pack virtual cpu allocations, meaning we allocate
-		// whole core's worth of cpus as much as possible to reduce smt-misalignment
+	// when some cores are partially available (not all sibling threads free),
+	// the initial numCoresNeeded may not provide enough CPUs.
+	// incrementally try more cores until we have enough CPUs or exhaust all cores.
+	for freeCPUs.Size() < a.numCPUsNeeded && numCoresNeeded < allFreeCores.Size() {
+		numCoresNeeded++
+		freeCores = a.details.CoresNeededInUncoreCache(numCoresNeeded, uncoreID)
+		freeCPUs = a.details.CPUsInCores(freeCores.UnsortedList()...)
+	}
+
+	// when SMT/hyperthread is enabled and we have more free CPUs than needed:
+	// sort the free CPUs and trim to the exact number needed, packing whole
+	// cores as much as possible to reduce smt-misalignment
+	if a.topo.CPUsPerCore() > 1 && freeCPUs.Size() > a.numCPUsNeeded {
 		sortFreeCPUs := freeCPUs.List()
-		if len(sortFreeCPUs) > a.numCPUsNeeded {
-			// if we are in takePartialUncore, the accumulator is not satisfied after
-			// takeFullUncore, so freeCPUs.Size() can't be < 1
-			sortFreeCPUs = sortFreeCPUs[:freeCPUs.Size()-1]
-		}
-		freeCPUs = cpuset.New(sortFreeCPUs...)
+		freeCPUs = cpuset.New(sortFreeCPUs[:a.numCPUsNeeded]...)
 	}
 
 	// claim the cpus if the free cpus within the UncoreCache can satisfy the needed cpus

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -749,6 +749,24 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 			"",
 			mustParseCPUSet(t, "4-7,12-15,1,9"),
 		},
+		{
+			"take cpus from partial UncoreCache with partially available cores - SMT enabled",
+			topoUncoreSingleSocketSMT,
+			StaticPolicyOptions{PreferAlignByUncoreCacheOption: true},
+			mustParseCPUSet(t, "3,5,7,11-15"),
+			5,
+			"",
+			cpuset.New(5, 7, 12, 13, 14),
+		},
+		{
+			"take even cpus from partial UncoreCache with partially available cores - SMT enabled",
+			topoUncoreSingleSocketSMT,
+			StaticPolicyOptions{PreferAlignByUncoreCacheOption: true},
+			mustParseCPUSet(t, "3,5,7,11-15"),
+			4,
+			"",
+			cpuset.New(5, 12, 13, 14),
+		},
 	}...)
 
 	for _, tc := range testCases {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
When SMT is enabled and some cores have only one sibling thread available, takePartialUncore may select cores that don't provide enough CPUs. This happens because numCoresNeeded assumes all cores have full CPUsPerCore threads free.

For example, with topoUncoreSingleSocketSMT and available CPUs {3,5,7,11-15}, requesting 5 CPUs calculates numCoresNeeded=3, but the first 3 cores in UncoreCache 1 only yield 4 CPUs. This causes partial uncore allocation to fail and fall back to a cross-uncoreCache path.
Fixes #137315

```release-note

```

```docs

```
