### PR TITLE
[WIP]fix flaky TestControllerSync due to watch event race

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -85,29 +85,16 @@ func TestControllerSync(t *testing.T) {
 		},
 		{
 			name:            "5-2-3 - complete bind when PV and PVC both exist and PV has AnnPreResizeCapacity annotation",
-			initialVolumes:  volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			initialVolumes:  volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController)),
 			expectedVolumes: volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "uid5-2", "claim5-2", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController)),
-			initialClaims:   withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil)),
+			initialClaims:   noclaims,
 			expectedClaims:  withExpectedCapacity("1Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "volume5-2", v1.ClaimBound, nil, volume.AnnBoundByController, volume.AnnBindCompleted)),
 			expectedEvents:  noevents,
 			errors:          noerrors,
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-				// Wait until volume5-2 is in ctrl.volumes.store AND has been
-				// processed by syncVolume (i.e. it has a ClaimRef=nil but
-				// Status.Phase is set to Available by syncVolume).
-				// Then force the claim to re-sync so findBestMatchForClaim
-				// can find the volume.
-				return wait.PollImmediate(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					_, found, err := ctrl.volumes.store.GetByKey("volume5-2")
-					if err != nil {
-						return false, err
-					}
-					if !found {
-						return false, nil
-					}
-					ctrl.claimQueue.Add("default/claim5-2")
-					return true, nil
-				})
+				claim := withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil))[0]
+				reactor.AddClaimEvent(claim)
+				return nil
 			},
 		},
 		{

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -85,16 +85,29 @@ func TestControllerSync(t *testing.T) {
 		},
 		{
 			name:            "5-2-3 - complete bind when PV and PVC both exist and PV has AnnPreResizeCapacity annotation",
-			initialVolumes:  volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController)),
+			initialVolumes:  volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			expectedVolumes: volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "uid5-2", "claim5-2", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController)),
-			initialClaims:   noclaims,
+			initialClaims:   withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil)),
 			expectedClaims:  withExpectedCapacity("1Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "volume5-2", v1.ClaimBound, nil, volume.AnnBoundByController, volume.AnnBindCompleted)),
 			expectedEvents:  noevents,
 			errors:          noerrors,
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-				claim := withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil))[0]
-				reactor.AddClaimEvent(claim)
-				return nil
+				// Wait until volume5-2 is in ctrl.volumes.store AND has been
+				// processed by syncVolume (i.e. it has a ClaimRef=nil but
+				// Status.Phase is set to Available by syncVolume).
+				// Then force the claim to re-sync so findBestMatchForClaim
+				// can find the volume.
+				return wait.PollImmediate(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+					_, found, err := ctrl.volumes.store.GetByKey("volume5-2")
+					if err != nil {
+						return false, err
+					}
+					if !found {
+						return false, nil
+					}
+					ctrl.claimQueue.Add("default/claim5-2")
+					return true, nil
+				})
 			},
 		},
 		{

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
@@ -87,13 +88,11 @@ func TestControllerSync(t *testing.T) {
 			name:            "5-2-3 - complete bind when PV and PVC both exist and PV has AnnPreResizeCapacity annotation",
 			initialVolumes:  volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController)),
 			expectedVolumes: volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "uid5-2", "claim5-2", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController)),
-			initialClaims:   noclaims,
+			initialClaims:   withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil)),
 			expectedClaims:  withExpectedCapacity("1Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "volume5-2", v1.ClaimBound, nil, volume.AnnBoundByController, volume.AnnBindCompleted)),
 			expectedEvents:  noevents,
 			errors:          noerrors,
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-				claim := withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil))[0]
-				reactor.AddClaimEvent(claim)
 				return nil
 			},
 		},
@@ -321,6 +320,21 @@ func TestControllerSync(t *testing.T) {
 		client.PrependWatchReactor("nodes", core.DefaultWatchReactor(watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger}), nil))
 		client.PrependWatchReactor("pods", core.DefaultWatchReactor(watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger}), nil))
 
+		client.AddReactor("list", "persistentvolumes", func(action core.Action) (bool, runtime.Object, error) {
+			pvList := &v1.PersistentVolumeList{}
+			for _, v := range test.initialVolumes {
+				pvList.Items = append(pvList.Items, *v.DeepCopy())
+			}
+			return true, pvList, nil
+		})
+		client.AddReactor("list", "persistentvolumeclaims", func(action core.Action) (bool, runtime.Object, error) {
+			pvcList := &v1.PersistentVolumeClaimList{}
+			for _, c := range test.initialClaims {
+				pvcList.Items = append(pvcList.Items, *c.DeepCopy())
+			}
+			return true, pvcList, nil
+		})
+
 		informers := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		ctrl, err := newTestController(ctx, client, informers, true)
 		if err != nil {
@@ -340,19 +354,15 @@ func TestControllerSync(t *testing.T) {
 		ctrl.classLister = storagelisters.NewStorageClassLister(indexer)
 
 		reactor := newVolumeReactor(ctx, client, ctrl, fakeVolumeWatch, fakeClaimWatch, test.errors)
-		for _, claim := range test.initialClaims {
-			claim = claim.DeepCopy()
-			reactor.AddClaim(claim)
-			go func(claim *v1.PersistentVolumeClaim) {
-				fakeClaimWatch.Add(claim)
-			}(claim)
-		}
 		for _, volume := range test.initialVolumes {
 			volume = volume.DeepCopy()
 			reactor.AddVolume(volume)
-			go func(volume *v1.PersistentVolume) {
-				fakeVolumeWatch.Add(volume)
-			}(volume)
+			informers.Core().V1().PersistentVolumes().Informer().GetIndexer().Add(volume)
+		}
+		for _, claim := range test.initialClaims {
+			claim = claim.DeepCopy()
+			reactor.AddClaim(claim)
+			informers.Core().V1().PersistentVolumeClaims().Informer().GetIndexer().Add(claim)
 		}
 
 		// Start the controller
@@ -373,7 +383,6 @@ func TestControllerSync(t *testing.T) {
 			return len(ctrl.claims.ListKeys()) >= len(test.initialClaims) &&
 				len(ctrl.volumes.store.ListKeys()) >= len(test.initialVolumes), nil
 		})
-
 		if err != nil {
 			t.Errorf("Test %q controller sync failed: %v", test.name, err)
 		}
@@ -397,7 +406,6 @@ func TestControllerSync(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			doit(test)
 		})


### PR DESCRIPTION
**Problem**

TestControllerSync subtest 5-2-3 - complete bind when PV and PVC both exist and PV has AnnPreResizeCapacity annotation was intermittently failing under stress testing with approximately 0.1% failure rate.
The test was failing with the claim stuck in Pending phase and the volume remaining Available and unbound, when the expected outcome was both being Bound.

```
Phase:     "Pending"  (expected "Bound")
VolumeName: ""        (expected "volume5-2")
ClaimRef:   nil       (expected claim5-2)
```

**Root Cause**

 The PersistentVolumeController runs two independent workers concurrently — volumeWorker and claimWorker. When the test had both initialVolumes and initialClaims set, both workers started processing simultaneously during controller startup with no ordering guarantee.
If the claimWorker ran syncUnboundClaim before the volumeWorker had processed volume5-2 into ctrl.volumes.store, then findBestMatchForClaim found no matching volume and the claim stayed Pending. By the time the volumeWorker processed the volume, the claim was already stuck.
This is a pure goroutine scheduling race — it passed most of the time because the volume worker happened to run first, but failed intermittently under stress.
Additionally, the original initialVolumes incorrectly included volume.AnnBoundByController annotation on an unbound volume. That annotation should only be present after binding has occurred.

**Fix**

Two changes:
1. Move claim from initialClaims to test function via AddClaimEvent
Instead of having the claim exist at controller startup (where it races against the volume worker), the claim is now injected only after the controller has fully synced and the volume is guaranteed to be in ctrl.volumes.store. This follows the same pattern used by the existing 5-2 test case.
2. Remove incorrect volume.AnnBoundByController from initialVolumes
The initial volume is unbound, so it should not carry AnnBoundByController. The annotation is correctly present in expectedVolumes as it gets added during binding.

Before
```
goinitialVolumes: volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi",
    newVolumeArray("volume5-2", "2Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty,   volume.AnnBoundByController)),
    initialClaims: withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil)),
    test: func(...) error {
    return nil
},
```
After
```
goinitialVolumes: volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi",
    newVolumeArray("volume5-2", "2Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
    initialClaims: noclaims,
    test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
       claim := withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil))[0]
       reactor.AddClaimEvent(claim)
       return nil
},
```

### Testing

Verified with `stress` tool running `TestControllerSync` for over 20000 iterations with 0 failures after the fix, compared to ~0.1% failure rate before.
```
stress ./persistentvolume.test -test.run 'TestControllerSync'
8m0s: 14295 runs so far, 0 failures, 8 active
8m5s: 14445 runs so far, 0 failures, 8 active
8m10s: 14597 runs so far, 0 failures, 8 active
8m15s: 14745 runs so far, 0 failures, 8 active
8m20s: 14894 runs so far, 0 failures, 8 active
8m25s: 15042 runs so far, 0 failures, 8 active
8m30s: 15192 runs so far, 0 failures, 8 active
8m35s: 15341 runs so far, 0 failures, 8 active
8m40s: 15490 runs so far, 0 failures, 8 active
8m45s: 15640 runs so far, 0 failures, 8 active
8m50s: 15793 runs so far, 0 failures, 8 active
8m55s: 15942 runs so far, 0 failures, 8 active
9m0s: 16095 runs so far, 0 failures, 8 active
9m5s: 16244 runs so far, 0 failures, 8 active
9m10s: 16394 runs so far, 0 failures, 8 active
9m15s: 16543 runs so far, 0 failures, 8 active
9m20s: 16695 runs so far, 0 failures, 8 active
9m25s: 16840 runs so far, 0 failures, 8 active
9m30s: 16993 runs so far, 0 failures, 8 active
9m35s: 17142 runs so far, 0 failures, 8 active
9m40s: 17296 runs so far, 0 failures, 8 active
9m45s: 17448 runs so far, 0 failures, 8 active
9m50s: 17600 runs so far, 0 failures, 8 active
9m55s: 17748 runs so far, 0 failures, 8 active
10m0s: 17900 runs so far, 0 failures, 8 active
10m5s: 18049 runs so far, 0 failures, 8 active
10m10s: 18200 runs so far, 0 failures, 8 active
10m15s: 18350 runs so far, 0 failures, 8 active
10m20s: 18499 runs so far, 0 failures, 8 active
10m25s: 18644 runs so far, 0 failures, 8 active
10m30s: 18795 runs so far, 0 failures, 8 active
10m35s: 18942 runs so far, 0 failures, 8 active
10m40s: 19093 runs so far, 0 failures, 8 active
10m45s: 19243 runs so far, 0 failures, 8 active
10m50s: 19392 runs so far, 0 failures, 8 active
10m55s: 19542 runs so far, 0 failures, 8 active
11m0s: 19693 runs so far, 0 failures, 8 active
11m5s: 19843 runs so far, 0 failures, 8 active
11m10s: 19995 runs so far, 0 failures, 8 active
11m15s: 20142 runs so far, 0 failures, 8 active
11m20s: 20294 runs so far, 0 failures, 8 active
11m25s: 20443 runs so far, 0 failures, 8 active

```

Fixes #137263 