### PR TITLE
Fix zero PSI metrics emitted when OS doesn't enable PSI

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -778,7 +778,7 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 
 	if kubeDeps.CAdvisorInterface == nil {
 		imageFsInfoProvider := cadvisor.NewImageFsInfoProvider(s.ContainerRuntimeEndpoint)
-		kubeDeps.CAdvisorInterface, err = cadvisor.New(imageFsInfoProvider, s.RootDirectory, cgroupRoots, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntimeEndpoint), s.LocalStorageCapacityIsolation)
+		kubeDeps.CAdvisorInterface, err = cadvisor.New(klog.FromContext(ctx), imageFsInfoProvider, s.RootDirectory, cgroupRoots, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntimeEndpoint), s.LocalStorageCapacityIsolation)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -46,6 +46,8 @@ import (
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/manager"
 	"github.com/google/cadvisor/utils/sysfs"
+	"github.com/opencontainers/cgroups"
+	cgroupfs2 "github.com/opencontainers/cgroups/fs2"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
@@ -88,7 +90,7 @@ func init() {
 }
 
 // New creates a new cAdvisor Interface for linux systems.
-func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
+func New(logger klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
 	sysFs := sysfs.NewRealSysFs()
 
 	includedMetrics := cadvisormetrics.MetricSet{
@@ -102,7 +104,11 @@ func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots [
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI) {
-		includedMetrics[cadvisormetrics.PressureMetrics] = struct{}{}
+		if IsPsiEnabled(logger) {
+			includedMetrics[cadvisormetrics.PressureMetrics] = struct{}{}
+		} else {
+			logger.Info("PSI support not available")
+		}
 	}
 
 	if usingLegacyStats || localStorageCapacityIsolation {
@@ -160,6 +166,26 @@ func (cc *cadvisorClient) ImagesFsInfo(ctx context.Context) (cadvisorapiv2.FsInf
 		return cadvisorapiv2.FsInfo{}, err
 	}
 	return cc.getFsInfo(ctx, label)
+}
+
+// IsPsiEnabled checks whether PSI (Pressure Stall Information) is available on
+// the host by opening the root cgroup's cpu.pressure file using the same
+// opencontainers/cgroups library that cAdvisor uses to read actual PSI values.
+// PSI is a single kernel feature (CONFIG_PSI / boot param "psi=") so checking
+// cpu.pressure alone is sufficient to determine support for all three resources
+// (cpu, memory, io).
+func IsPsiEnabled(logger klog.Logger) bool {
+	return isPsiEnabled(logger, cgroupfs2.UnifiedMountpoint, "cpu.pressure")
+}
+
+func isPsiEnabled(logger klog.Logger, cgroupDir, psiFile string) bool {
+	f, err := cgroups.OpenFile(cgroupDir, psiFile, os.O_RDONLY)
+	if err != nil {
+		logger.V(4).Info("PSI not available", "dir", cgroupDir, "file", psiFile, "err", err)
+		return false
+	}
+	_ = f.Close()
+	return true
 }
 
 func (cc *cadvisorClient) RootFsInfo() (cadvisorapiv2.FsInfo, error) {

--- a/pkg/kubelet/cadvisor/cadvisor_linux_test.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux_test.go
@@ -20,13 +20,51 @@ package cadvisor
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/google/cadvisor/container/crio"
 	cadvisorfs "github.com/google/cadvisor/fs"
+	"github.com/opencontainers/cgroups"
+	"k8s.io/klog/v2"
 )
+
+func TestIsPsiEnabled(t *testing.T) {
+	testcases := []struct {
+		description   string
+		createPSIFile bool
+		expected      bool
+	}{{
+		description:   "PSI enabled when cgroup pressure file exists",
+		createPSIFile: true,
+		expected:      true,
+	}, {
+		description:   "PSI disabled when cgroup pressure file does not exist",
+		createPSIFile: false,
+		expected:      false,
+	}}
+
+	cgroups.TestMode = true
+	defer func() { cgroups.TestMode = false }()
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			if tc.createPSIFile {
+				err := os.WriteFile(filepath.Join(tmpDir, "cpu.pressure"), []byte("some avg10=0.00 avg60=0.00 avg300=0.00 total=0\n"), 0644)
+				require.NoError(t, err)
+			}
+
+			result := isPsiEnabled(klog.Background(), tmpDir, "cpu.pressure")
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
 
 func TestImageFsInfoLabel(t *testing.T) {
 	testcases := []struct {

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -24,6 +24,7 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	"k8s.io/klog/v2"
 )
 
 type cadvisorUnsupported struct {
@@ -32,7 +33,7 @@ type cadvisorUnsupported struct {
 var _ Interface = new(cadvisorUnsupported)
 
 // New creates a new cAdvisor Interface for unsupported systems.
-func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupsRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
+func New(_ klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupsRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
 	return &cadvisorUnsupported{}, nil
 }
 
@@ -72,4 +73,8 @@ func (cu *cadvisorUnsupported) ContainerFsInfo(context.Context) (cadvisorapiv2.F
 
 func (cu *cadvisorUnsupported) GetDirFsInfo(path string) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, nil
+}
+
+func IsPsiEnabled(_ klog.Logger) bool {
+	return false
 }

--- a/pkg/kubelet/cadvisor/cadvisor_windows.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows.go
@@ -23,7 +23,6 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
-
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/winstats"
 )
@@ -36,7 +35,7 @@ type cadvisorClient struct {
 var _ Interface = new(cadvisorClient)
 
 // New creates a cAdvisor and exports its API on the specified port if port > 0.
-func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
+func New(_ klog.Logger, imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots []string, usingLegacyStats, localStorageCapacityIsolation bool) (Interface, error) {
 	client, err := winstats.NewPerfCounterClient(klog.TODO())
 	return &cadvisorClient{
 		rootPath:       rootPath,
@@ -79,4 +78,8 @@ func (cu *cadvisorClient) RootFsInfo() (cadvisorapiv2.FsInfo, error) {
 
 func (cu *cadvisorClient) GetDirFsInfo(path string) (cadvisorapiv2.FsInfo, error) {
 	return cu.winStatsClient.GetDirFsInfo(path)
+}
+
+func IsPsiEnabled(_ klog.Logger) bool {
+	return false
 }

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -86,6 +86,7 @@ import (
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	apisgrpc "k8s.io/kubernetes/pkg/kubelet/apis/grpc"
 	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
+	kubeletcadvisor "k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/metrics/collectors"
 	"k8s.io/kubernetes/pkg/kubelet/prober"
@@ -468,7 +469,9 @@ func (s *Server) InstallAuthNotRequiredHandlers(ctx context.Context) {
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI) {
-		includedMetrics[cadvisormetrics.PressureMetrics] = struct{}{}
+		if kubeletcadvisor.IsPsiEnabled(logger) {
+			includedMetrics[cadvisormetrics.PressureMetrics] = struct{}{}
+		}
 	}
 
 	// cAdvisor metrics are exposed under the secured handler as well


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

When the `KubeletPSI` feature gate is enabled but the OS does not support PSI (either the kernel lacks `CONFIG_PSI` or was booted with `psi=0`), the kubelet could register `PressureMetrics` with cAdvisor. This causes zero-valued PSI metrics to be emitted, which is confusing for monitoring and alerting.

The previous `IsPsiEnabled()` implementation checked `/proc/pressure` and parsed `/proc/cmdline` for `psi=0`. This was unreliable because `/proc/pressure` can exist even when per-cgroup PSI files — which cAdvisor actually reads — are absent ( on cgroup v1 systems).

This PR simplifies `IsPsiEnabled()` to open `/sys/fs/cgroup/cpu.pressure` — the same type of per-cgroup file that cAdvisor reads PSI values from. This single check is sufficient because:
- PSI is a single kernel feature (`CONFIG_PSI` / boot param `psi=`) so checking `cpu.pressure` determines support for all three resources (cpu, memory, io).
- On cgroup v1 systems (where cAdvisor cannot read per-cgroup PSI anyway), this file does not exist, so we correctly skip PSI metrics.
- The `/proc/cmdline` parsing is no longer needed since the cgroup file's absence already covers the `psi=0` case.

#### Note:
PSI is a single kernel feature (`CONFIG_PSI` / boot param `psi=`) that exposes `/sys/fs/cgroup/cpu.pressure` atomically — checking onlys sys/fs/cgroup/cpu.pressure is sufficient to determine support for all three resource types.

The check is used in both `cadvisor.New()` and `Server.InstallAuthNotRequiredHandlers()` so that pressure metrics
are only collected when PSI is actually supported by the OS.

#### Screenshots:
After making the code changes , i have build it and copy kubelet to the local kind cluster and tested for both psi =0 and psi =1,  here are the results.
**Before (zero PSI metrics emitted):**
<img width="1638" height="196" alt="Screenshot From 2026-03-01 16-45-59" src="https://github.com/user-attachments/assets/2a9029ba-5c19-4b3b-b9cb-43dfad8eaf9c" />



**After (PSI metrics skipped when unsupported):**
<img width="1918" height="243" alt="Screenshot From 2026-03-01 16-37-20" src="https://github.com/user-attachments/assets/4ab138f0-dba4-4b3e-a0e4-8ed7de9e77c9" />



#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/136333

#### Special notes for your reviewer:

- Unit tests cover both cases (file present and file absent) and all pass.
- Manually tested on a kind cluster with PSI enabled and PSI disabled (`psi=0` via GRUB).




#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an issue where zero-valued PSI (Pressure Stall Information) metrics were emitted by the kubelet when the OS does not support PSI, even if the KubeletPSI feature gate was enabled.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
