### PR TITLE
[InPlacePodVerticalScaling] deflake pod resize oom_score_adj check

### DIFF
--- a/test/e2e/common/node/framework/cgroups/cgroups.go
+++ b/test/e2e/common/node/framework/cgroups/cgroups.go
@@ -411,11 +411,11 @@ func VerifyOomScoreAdjValue(f *framework.Framework, pod *v1.Pod, cName, expected
 		pod.Namespace, pod.Name, cName, expectedOomScoreAdj)
 	oomScoreAdj, _, err := e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, cName, "/bin/sh", "-c", cmd)
 	if err != nil {
-		return fmt.Errorf("failed to find expected value %s for container app process", expectedOomScoreAdj)
+		return fmt.Errorf("failed to find expected oom_score_adj value %s for container %s in pod %s", expectedOomScoreAdj, cName, pod.Name)
 	}
 	oomScoreAdj = strings.Trim(oomScoreAdj, "\n")
 	if oomScoreAdj != expectedOomScoreAdj {
-		return fmt.Errorf("oom_score_adj value %s not equal to expected %s", oomScoreAdj, expectedOomScoreAdj)
+		return fmt.Errorf("oom_score_adj value %s not equal to expected %s for container %s in pod %s", oomScoreAdj, expectedOomScoreAdj, cName, pod.Name)
 	}
 	return nil
 }

--- a/test/e2e/common/node/framework/podresize/resize.go
+++ b/test/e2e/common/node/framework/podresize/resize.go
@@ -305,22 +305,22 @@ func VerifyPodContainersCgroupValues(ctx context.Context, f *framework.Framework
 	return utilerrors.NewAggregate(errs)
 }
 
-func verifyPodRestarts(f *framework.Framework, pod *v1.Pod, wantInfo []ResizableContainerInfo) error {
+func verifyPodRestarts(ctx context.Context, f *framework.Framework, pod *v1.Pod, wantInfo []ResizableContainerInfo) error {
 	ginkgo.GinkgoHelper()
 
 	initCtrStatuses, ctrStatuses := separateContainerStatuses(wantInfo)
 	errs := []error{}
-	if err := verifyContainerRestarts(f, pod, pod.Status.InitContainerStatuses, initCtrStatuses); err != nil {
+	if err := verifyContainerRestarts(ctx, f, pod, pod.Status.InitContainerStatuses, initCtrStatuses); err != nil {
 		errs = append(errs, err)
 	}
-	if err := verifyContainerRestarts(f, pod, pod.Status.ContainerStatuses, ctrStatuses); err != nil {
+	if err := verifyContainerRestarts(ctx, f, pod, pod.Status.ContainerStatuses, ctrStatuses); err != nil {
 		errs = append(errs, err)
 	}
 
 	return utilerrors.NewAggregate(errs)
 }
 
-func verifyContainerRestarts(f *framework.Framework, pod *v1.Pod, gotStatuses []v1.ContainerStatus, wantStatuses []v1.ContainerStatus) error {
+func verifyContainerRestarts(ctx context.Context, f *framework.Framework, pod *v1.Pod, gotStatuses []v1.ContainerStatus, wantStatuses []v1.ContainerStatus) error {
 	ginkgo.GinkgoHelper()
 
 	if len(gotStatuses) != len(wantStatuses) {
@@ -333,7 +333,7 @@ func verifyContainerRestarts(f *framework.Framework, pod *v1.Pod, gotStatuses []
 		if gotStatus.RestartCount != wantStatuses[i].RestartCount {
 			errs = append(errs, fmt.Errorf("unexpected number of restarts for container %s: got %d, want %d", gotStatus.Name, gotStatus.RestartCount, wantStatuses[i].RestartCount))
 		} else if gotStatus.RestartCount > 0 {
-			if err := verifyOomScoreAdj(f, pod, gotStatus.Name); err != nil {
+			if err := verifyOomScoreAdj(ctx, f, pod, gotStatus.Name); err != nil {
 				errs = append(errs, err)
 			}
 		}
@@ -341,7 +341,7 @@ func verifyContainerRestarts(f *framework.Framework, pod *v1.Pod, gotStatuses []
 	return utilerrors.NewAggregate(errs)
 }
 
-func verifyOomScoreAdj(f *framework.Framework, pod *v1.Pod, containerName string) error {
+func verifyOomScoreAdj(ctx context.Context, f *framework.Framework, pod *v1.Pod, containerName string) error {
 	container := e2epod.FindContainerInPod(pod, containerName)
 	if container == nil {
 		return fmt.Errorf("failed to find container %s in pod %s", containerName, pod.Name)
@@ -356,7 +356,9 @@ func verifyOomScoreAdj(f *framework.Framework, pod *v1.Pod, containerName string
 	oomScoreAdj := kubeqos.GetContainerOOMScoreAdjust(pod, container, int64(nodeMemoryCapacity.Value()))
 	expectedOomScoreAdj := strconv.FormatInt(int64(oomScoreAdj), 10)
 
-	return cgroups.VerifyOomScoreAdjValue(f, pod, container.Name, expectedOomScoreAdj)
+	return framework.Gomega().Eventually(ctx, framework.HandleRetry(func(ctx context.Context) (error, error) {
+		return cgroups.VerifyOomScoreAdjValue(f, pod, container.Name, expectedOomScoreAdj), nil
+	})).WithTimeout(framework.PollShortTimeout).Should(gomega.Succeed())
 }
 
 func WaitForPodResizeActuation(ctx context.Context, f *framework.Framework, podClient *e2epod.PodClient, pod *v1.Pod, expectedContainers []ResizableContainerInfo) *v1.Pod {
@@ -438,7 +440,7 @@ func ExpectPodResized(ctx context.Context, f *framework.Framework, resizedPod *v
 		errs = append(errs, fmt.Errorf("container status resources don't match expected: %w", formatErrors(resourceErrs)))
 	}
 
-	if restartErrs := verifyPodRestarts(f, resizedPod, expectedContainers); restartErrs != nil {
+	if restartErrs := verifyPodRestarts(ctx, f, resizedPod, expectedContainers); restartErrs != nil {
 		errs = append(errs, fmt.Errorf("container restart counts don't match expected: %w", formatErrors(restartErrs)))
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

We are occasionally seeing a flake with this error text:

```
container restart counts don't match expected: [
failed to find expected value -997 for container app process
]
```

which comes from `verifyOomScoreAdjust` here: https://github.com/kubernetes/kubernetes/blob/44b486f43c9792e812f849d9509449ac69edf55c/test/e2e/common/node/framework/podresize/resize.go#L336

This flake only occurs in the case that a container restarts due to IPPR. The theory (see https://github.com/kubernetes/kubernetes/issues/136783#issuecomment-3974773645), is that in some rare cases, there is a delay after a container restart for the oom_score_adj value to get propagated through the CRI->runc->kernel. 

This PR tries to deflake it by implementing retries for the oom_score_adj verification with linear backoff. 

#### Which issue(s) this PR is related to:

One of two flakes noticed in https://github.com/kubernetes/kubernetes/issues/136783.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/assign @ndixita @tallclair 

/priority important-soon
This flake is showing up in the release-blocking and release-informing CI jobs. 

