### PR TITLE
Remove dep. Prometheus from test/e2e/node/pods.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/opencontainers/cgroups v0.0.6
 	github.com/opencontainers/selinux v1.13.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
-	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/robfig/cron/v3 v3.0.1
@@ -184,6 +183,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/hack/verify-prometheus-imports.sh
+++ b/hack/verify-prometheus-imports.sh
@@ -71,7 +71,6 @@ allowed_prometheus_importers=(
   ./staging/src/k8s.io/component-base/metrics/value.go
   ./staging/src/k8s.io/component-base/metrics/wrappers.go
   ./test/e2e/apimachinery/flowcontrol.go
-  ./test/e2e/node/pods.go
   ./test/instrumentation/main_test.go
   ./test/integration/apiserver/flowcontrol/concurrency_test.go
   ./test/integration/apiserver/flowcontrol/concurrency_util_test.go

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
@@ -114,6 +114,10 @@ func TextToMetricFamilies(in io.Reader) (map[string]*dto.MetricFamily, error) {
 	return textParser.TextToMetricFamilies(in)
 }
 
+func MetricFamilyToText(out io.Writer, in *dto.MetricFamily) (written int, err error) {
+	return expfmt.MetricFamilyToText(out, in)
+}
+
 // PrintSample returns formatted representation of metric Sample
 func PrintSample(sample *model.Sample) string {
 	buf := make([]string, 0)

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -39,6 +39,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
@@ -49,8 +51,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/expfmt"
 )
 
 var _ = SIGDescribe("Pods Extended", func() {
@@ -665,8 +665,8 @@ func createAndTestPodRepeatedly(ctx context.Context, workers, iterations int, sc
 		wg sync.WaitGroup
 	)
 
-	r := prometheus.NewRegistry()
-	h := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+	r := metrics.NewKubeRegistry()
+	h := metrics.NewSummaryVec(&metrics.SummaryOpts{ //nolint:staticcheck // SA1019
 		Name: "latency",
 		Objectives: map[float64]float64{
 			0.5:  0.05,
@@ -790,7 +790,7 @@ func createAndTestPodRepeatedly(ctx context.Context, workers, iterations int, sc
 	values, _ := r.Gather()
 	var buf bytes.Buffer
 	for _, m := range values {
-		expfmt.MetricFamilyToText(&buf, m)
+		_, _ = testutil.MetricFamilyToText(&buf, m)
 	}
 	framework.Logf("Summary of latencies:\n%s", buf.String())
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove dependency Prometheus in `test/e2e/node/pods.go`

#### Which issue(s) this PR is related to:

Related #89267

#### Special notes for your reviewer:

~`NewSummaryVec` in `component-base/metric` is marked as deprecated, move to `NewHistogramVec`.~

EDIT: reverted

Add the MetricFamilyToText in `component-base/metric/testutil`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
