### PR TITLE
bug: Fix link file ownership of projected serviceAccountToken

### DIFF
--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -445,7 +445,7 @@ func (w *AtomicWriter) writePayloadToDir(payload map[string]FileProjection, dir 
 			continue
 		}
 
-		if err := w.chown(fullPath, int(*fileProjection.FsUser), -1); err != nil {
+		if err := w.lchown(fullPath, int(*fileProjection.FsUser), -1); err != nil {
 			klog.Errorf("%s: unable to change file %s with owner %v: %v", w.logContext, fullPath, int(*fileProjection.FsUser), err)
 			return err
 		}
@@ -465,7 +465,7 @@ func (w *AtomicWriter) writePayloadToDir(payload map[string]FileProjection, dir 
 // foo -> ..data/foo
 // baz -> ..data/baz
 func (w *AtomicWriter) createUserVisibleFiles(payload map[string]FileProjection) error {
-	for userVisiblePath := range payload {
+	for userVisiblePath, fileProjection := range payload {
 		slashpos := strings.Index(userVisiblePath, string(os.PathSeparator))
 		if slashpos == -1 {
 			slashpos = len(userVisiblePath)
@@ -479,6 +479,15 @@ func (w *AtomicWriter) createUserVisibleFiles(payload map[string]FileProjection)
 
 			err = os.Symlink(dataDirFile, visibleFile)
 			if err != nil {
+				return err
+			}
+
+			if fileProjection.FsUser == nil {
+				continue
+			}
+
+			if err := w.lchown(visibleFile, int(*fileProjection.FsUser), -1); err != nil {
+				klog.Errorf("%s: unable to change file %s with owner %v: %v", w.logContext, visibleFile, int(*fileProjection.FsUser), err)
 				return err
 			}
 		}

--- a/pkg/volume/util/atomic_writer_linux.go
+++ b/pkg/volume/util/atomic_writer_linux.go
@@ -20,7 +20,8 @@ package util
 
 import "os"
 
-// chown changes the numeric uid and gid of the named file.
-func (w *AtomicWriter) chown(name string, uid, gid int) error {
-	return os.Chown(name, uid, gid)
+// lchown changes the numeric uid and gid of the named file.
+// If the file is a symbolic link, it changes the uid and gid of the link itself.
+func (w *AtomicWriter) lchown(name string, uid, gid int) error {
+	return os.Lchown(name, uid, gid)
 }

--- a/pkg/volume/util/atomic_writer_unsupported.go
+++ b/pkg/volume/util/atomic_writer_unsupported.go
@@ -24,9 +24,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// chown changes the numeric uid and gid of the named file.
+// lchown changes the numeric uid and gid of the named file.
+// If the file is a symbolic link, it changes the uid and gid of the link itself.
 // This is a no-op on unsupported platforms.
-func (w *AtomicWriter) chown(name string, uid, _ /* gid */ int) error {
+func (w *AtomicWriter) lchown(name string, uid, _ /* gid */ int) error {
 	klog.Warningf("%s: skipping change of Linux owner %v for file %s; unsupported on %s", w.logContext, uid, name, runtime.GOOS)
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When creating a pod with a projected `serviceAccountToken` volume and all containers have the same `runAsUser`, kubelet configure the file owner UID of the token file to the the `runAsUser`.

However, the existing implementation only sets the file owner of file in the timestamped directory. The link file is still owned by root. This is because `pkg/volume/util/atomic_writer_linux.go#chown` makes use of `os.Chown()`, which applies changes to the link's target instead of the link file itself.

We can use `os.Lchown()` to configure owner UID of the link file properly.

#### Which issue(s) this PR is related to:

Fixes #137331

#### Special notes for your reviewer:

For now, I have performed manual testing to verify the fix. Updates to end-to-end tests are blocked by #137334. E2E tests have been passing because the `agnhost` image `mounttest` makes use of `syscall.Stat()` to read owner UID, which read the owner UID of the target file.

I'm adding some new arguments to `mounttest` that make use of `syscall.Lstat()` instead. With the new arguments, we can read the owner UID of the link files themselves. Afterwards, I can improve the projected volume e2e tests to also verify the link files.

```
$ ls -lA
total 0
drwxr-xr-x    2 root     root            60 Mar  1 20:30 ..2026_03_01_20_30_09.1574988082
lrwxrwxrwx    1 root     root            32 Mar  1 20:30 ..data -> ..2026_03_01_20_30_09.1574988082
lrwxrwxrwx    1 1000     root            12 Mar  1 20:30 token -> ..data/token

$ ls -lA ..2026_03_01_20_30_09.1574988082/
total 4
-rw-------    1 1000     root          1089 Mar  1 20:30 token

$ ls -lA ..data/
total 4
-rw-------    1 1000     root          1089 Mar  1 20:30 token
```

#### Does this PR introduce a user-facing change?

```release-note
Fix link file ownership of projected serviceAccountToken.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
