### PR TITLE
fix(kubelet/devicemanager): decide extended resource capacity based on manager state

### DIFF
--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -129,9 +129,9 @@ type ContainerManager interface {
 	// These checkers are integrated into the systemd watchdog to monitor the service's health.
 	GetHealthCheckers() []healthz.HealthChecker
 
-	// ShouldResetExtendedResourceCapacity returns whether or not the extended resources should be zeroed,
-	// due to node recreation.
-	ShouldResetExtendedResourceCapacity() bool
+	// ShouldResetExtendedResourceCapacity returns whether the extended resource
+	// should be zeroed or not, depending on whether the resource has an active provider.
+	ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool
 
 	// GetAllocateResourcesPodAdmitHandler returns an instance of a PodAdmitHandler responsible for allocating pod resources.
 	GetAllocateResourcesPodAdmitHandler() lifecycle.PodAdmitHandler

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -129,9 +129,9 @@ type ContainerManager interface {
 	// These checkers are integrated into the systemd watchdog to monitor the service's health.
 	GetHealthCheckers() []healthz.HealthChecker
 
-	// ShouldResetExtendedResourceCapacity returns whether or not the extended resources should be zeroed,
-	// due to node recreation.
-	ShouldResetExtendedResourceCapacity() bool
+	// ShouldResetExtendedResourceCapacity returns whether the extended resource
+	// should be zeroed or not, depending on whether the resource has an active provider.
+	ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool
 
 	// GetAllocateResourcesPodAdmitHandler returns an instance of a PodAdmitHandler responsible for allocating pod resources.
 	GetAllocateResourcesPodAdmitHandler(logger klog.Logger) lifecycle.PodAdmitHandler

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1090,8 +1090,8 @@ func (cm *containerManagerImpl) GetDynamicResources(pod *v1.Pod, container *v1.C
 	return containerDynamicResources
 }
 
-func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity() bool {
-	return cm.deviceManager.ShouldResetExtendedResourceCapacity()
+func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool {
+	return cm.deviceManager.ShouldResetExtendedResourceCapacity(extendedResource)
 }
 
 func (cm *containerManagerImpl) UpdateAllocatedDevices() {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1103,8 +1103,8 @@ func (cm *containerManagerImpl) GetDynamicResources(logger klog.Logger, pod *v1.
 	return containerDynamicResources
 }
 
-func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity() bool {
-	return cm.deviceManager.ShouldResetExtendedResourceCapacity()
+func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool {
+	return cm.deviceManager.ShouldResetExtendedResourceCapacity(extendedResource)
 }
 
 func (cm *containerManagerImpl) UpdateAllocatedDevices(logger klog.Logger) {

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -145,7 +145,7 @@ func (cm *containerManagerStub) GetAllocatableDevices() []*podresourcesapi.Conta
 	return nil
 }
 
-func (cm *containerManagerStub) ShouldResetExtendedResourceCapacity() bool {
+func (cm *containerManagerStub) ShouldResetExtendedResourceCapacity(_ v1.ResourceName) bool {
 	return cm.shouldResetExtendedResourceCapacity
 }
 

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -145,7 +145,7 @@ func (cm *containerManagerStub) GetAllocatableDevices(logger klog.Logger) []*pod
 	return nil
 }
 
-func (cm *containerManagerStub) ShouldResetExtendedResourceCapacity() bool {
+func (cm *containerManagerStub) ShouldResetExtendedResourceCapacity(_ v1.ResourceName) bool {
 	return cm.shouldResetExtendedResourceCapacity
 }
 

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -314,8 +314,8 @@ func (cm *containerManagerImpl) GetAllocatableDevices() []*podresourcesapi.Conta
 	return nil
 }
 
-func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity() bool {
-	return cm.deviceManager.ShouldResetExtendedResourceCapacity()
+func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool {
+	return cm.deviceManager.ShouldResetExtendedResourceCapacity(extendedResource)
 }
 
 func (cm *containerManagerImpl) GetAllocateResourcesPodAdmitHandler() lifecycle.PodAdmitHandler {

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -324,8 +324,8 @@ func (cm *containerManagerImpl) GetAllocatableDevices(_ klog.Logger) []*podresou
 	return nil
 }
 
-func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity() bool {
-	return cm.deviceManager.ShouldResetExtendedResourceCapacity()
+func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool {
+	return cm.deviceManager.ShouldResetExtendedResourceCapacity(extendedResource)
 }
 
 func (cm *containerManagerImpl) GetAllocateResourcesPodAdmitHandler(_ klog.Logger) lifecycle.PodAdmitHandler {

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -897,7 +897,7 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 		if err != nil {
 			return err
 		}
-		if allocDevices == nil || len(allocDevices) <= 0 {
+		if len(allocDevices) == 0 {
 			continue
 		}
 

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1226,15 +1226,15 @@ func (m *ManagerImpl) UpdateAllocatedResourcesStatus(pod *v1.Pod, status *v1.Pod
 	}
 }
 
-// ShouldResetExtendedResourceCapacity returns whether the extended resources should be zeroed or not,
-// depending on whether the node has been recreated. Absence of the checkpoint file strongly indicates the node
-// has been recreated.
-func (m *ManagerImpl) ShouldResetExtendedResourceCapacity() bool {
-	checkpoints, err := m.checkpointManager.ListCheckpoints()
-	if err != nil {
-		return false
-	}
-	return len(checkpoints) == 0
+// ShouldResetExtendedResourceCapacity returns whether the extended resource
+// should be zeroed or not, depending on whether the resource has an active provider.
+func (m *ManagerImpl) ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	// on manager start, the checkpoint is loaded and populates endpoints based
+	// on which plugin provided a given resource.
+	_, exists := m.endpoints[string(extendedResource)]
+	return !exists
 }
 
 func (m *ManagerImpl) isContainerAlreadyRunning(logger klog.Logger, podUID, cntName string) bool {

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -890,7 +890,7 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 		if err != nil {
 			return err
 		}
-		if allocDevices == nil || len(allocDevices) <= 0 {
+		if len(allocDevices) == 0 {
 			continue
 		}
 

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1218,15 +1218,15 @@ func (m *ManagerImpl) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1
 	}
 }
 
-// ShouldResetExtendedResourceCapacity returns whether the extended resources should be zeroed or not,
-// depending on whether the node has been recreated. Absence of the checkpoint file strongly indicates the node
-// has been recreated.
-func (m *ManagerImpl) ShouldResetExtendedResourceCapacity() bool {
-	checkpoints, err := m.checkpointManager.ListCheckpoints()
-	if err != nil {
-		return false
-	}
-	return len(checkpoints) == 0
+// ShouldResetExtendedResourceCapacity returns whether the extended resource
+// should be zeroed or not, depending on whether the resource has an active provider.
+func (m *ManagerImpl) ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	// on manager start, the checkpoint is loaded and populates endpoints based
+	// on which plugin provided a given resource.
+	_, exists := m.endpoints[string(extendedResource)]
+	return !exists
 }
 
 func (m *ManagerImpl) isContainerAlreadyRunning(logger klog.Logger, podUID, cntName string) bool {

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -1709,7 +1709,6 @@ func TestDevicePreStartContainer(t *testing.T) {
 }
 
 func TestResetExtendedResource(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
 	as := assert.New(t)
 	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	as.NoError(err)
@@ -1734,22 +1733,11 @@ func TestResetExtendedResource(t *testing.T) {
 		),
 	)
 
-	testManager.healthyDevices[extendedResourceName] = sets.New[string]()
-	testManager.healthyDevices[extendedResourceName].Insert("dev1")
-	// checkpoint is present, indicating node hasn't been recreated
-	err = testManager.writeCheckpoint(logger)
-	require.NoError(t, err)
+	testManager.endpoints[extendedResourceName] = endpointInfo{}
+	as.False(testManager.ShouldResetExtendedResourceCapacity(v1.ResourceName(extendedResourceName)))
 
-	as.False(testManager.ShouldResetExtendedResourceCapacity())
-
-	// checkpoint is absent, representing node recreation
-	ckpts, err := ckm.ListCheckpoints()
-	as.NoError(err)
-	for _, ckpt := range ckpts {
-		err = ckm.RemoveCheckpoint(ckpt)
-		as.NoError(err)
-	}
-	as.True(testManager.ShouldResetExtendedResourceCapacity())
+	delete(testManager.endpoints, extendedResourceName)
+	as.True(testManager.ShouldResetExtendedResourceCapacity(v1.ResourceName(extendedResourceName)))
 }
 
 func allocateStubFunc() func(devs []string) (*pluginapi.AllocateResponse, error) {

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -1747,7 +1747,6 @@ func TestDevicePreStartContainer(t *testing.T) {
 }
 
 func TestResetExtendedResource(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
 	as := assert.New(t)
 	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	as.NoError(err)
@@ -1774,22 +1773,11 @@ func TestResetExtendedResource(t *testing.T) {
 		),
 	)
 
-	testManager.healthyDevices[extendedResourceName] = sets.New[string]()
-	testManager.healthyDevices[extendedResourceName].Insert("dev1")
-	// checkpoint is present, indicating node hasn't been recreated
-	err = testManager.writeCheckpoint(logger)
-	require.NoError(t, err)
+	testManager.endpoints[extendedResourceName] = endpointInfo{}
+	as.False(testManager.ShouldResetExtendedResourceCapacity(v1.ResourceName(extendedResourceName)))
 
-	as.False(testManager.ShouldResetExtendedResourceCapacity())
-
-	// checkpoint is absent, representing node recreation
-	ckpts, err := ckm.ListCheckpoints()
-	as.NoError(err)
-	for _, ckpt := range ckpts {
-		err = ckm.RemoveCheckpoint(ckpt)
-		as.NoError(err)
-	}
-	as.True(testManager.ShouldResetExtendedResourceCapacity())
+	delete(testManager.endpoints, extendedResourceName)
+	as.True(testManager.ShouldResetExtendedResourceCapacity(v1.ResourceName(extendedResourceName)))
 }
 
 func allocateStubFunc() func(devs []string) (*pluginapi.AllocateResponse, error) {

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -76,10 +76,9 @@ type Manager interface {
 	// GetAllocatableDevices returns information about all the devices known to the manager
 	GetAllocatableDevices() ResourceDeviceInstances
 
-	// ShouldResetExtendedResourceCapacity returns whether the extended resources should be reset or not,
-	// depending on the checkpoint file availability. Absence of the checkpoint file strongly indicates
-	// the node has been recreated.
-	ShouldResetExtendedResourceCapacity() bool
+	// ShouldResetExtendedResourceCapacity returns whether the extended resource
+	// should be zeroed or not, depending on whether the resource has an active provider.
+	ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool
 
 	// TopologyManager HintProvider provider indicates the Device Manager implements the Topology Manager Interface
 	// and is consulted to make Topology aware resource alignments

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -76,10 +76,9 @@ type Manager interface {
 	// GetAllocatableDevices returns information about all the devices known to the manager
 	GetAllocatableDevices(logger klog.Logger) ResourceDeviceInstances
 
-	// ShouldResetExtendedResourceCapacity returns whether the extended resources should be reset or not,
-	// depending on the checkpoint file availability. Absence of the checkpoint file strongly indicates
-	// the node has been recreated.
-	ShouldResetExtendedResourceCapacity() bool
+	// ShouldResetExtendedResourceCapacity returns whether the extended resource
+	// should be zeroed or not, depending on whether the resource has an active provider.
+	ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool
 
 	// TopologyManager HintProvider provider indicates the Device Manager implements the Topology Manager Interface
 	// and is consulted to make Topology aware resource alignments

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -210,7 +210,7 @@ func (cm *FakeContainerManager) GetAllocatableDevices() []*podresourcesapi.Conta
 	return nil
 }
 
-func (cm *FakeContainerManager) ShouldResetExtendedResourceCapacity() bool {
+func (cm *FakeContainerManager) ShouldResetExtendedResourceCapacity(_ v1.ResourceName) bool {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "ShouldResetExtendedResourceCapacity")

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -208,7 +208,7 @@ func (cm *FakeContainerManager) GetAllocatableDevices(_ klog.Logger) []*podresou
 	return nil
 }
 
-func (cm *FakeContainerManager) ShouldResetExtendedResourceCapacity() bool {
+func (cm *FakeContainerManager) ShouldResetExtendedResourceCapacity(_ v1.ResourceName) bool {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "ShouldResetExtendedResourceCapacity")

--- a/pkg/kubelet/cm/testing/mocks.go
+++ b/pkg/kubelet/cm/testing/mocks.go
@@ -1350,16 +1350,16 @@ func (_c *MockContainerManager_PrepareDynamicResources_Call) RunAndReturn(run fu
 }
 
 // ShouldResetExtendedResourceCapacity provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) ShouldResetExtendedResourceCapacity() bool {
-	ret := _mock.Called()
+func (_mock *MockContainerManager) ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool {
+	ret := _mock.Called(extendedResource)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ShouldResetExtendedResourceCapacity")
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func() bool); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(v1.ResourceName) bool); ok {
+		r0 = returnFunc(extendedResource)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -1372,13 +1372,20 @@ type MockContainerManager_ShouldResetExtendedResourceCapacity_Call struct {
 }
 
 // ShouldResetExtendedResourceCapacity is a helper method to define mock.On call
-func (_e *MockContainerManager_Expecter) ShouldResetExtendedResourceCapacity() *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
-	return &MockContainerManager_ShouldResetExtendedResourceCapacity_Call{Call: _e.mock.On("ShouldResetExtendedResourceCapacity")}
+//   - extendedResource v1.ResourceName
+func (_e *MockContainerManager_Expecter) ShouldResetExtendedResourceCapacity(extendedResource interface{}) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
+	return &MockContainerManager_ShouldResetExtendedResourceCapacity_Call{Call: _e.mock.On("ShouldResetExtendedResourceCapacity", extendedResource)}
 }
 
-func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) Run(run func()) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
+func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) Run(run func(extendedResource v1.ResourceName)) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 v1.ResourceName
+		if args[0] != nil {
+			arg0 = args[0].(v1.ResourceName)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1388,7 +1395,7 @@ func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) Return(
 	return _c
 }
 
-func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) RunAndReturn(run func() bool) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
+func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) RunAndReturn(run func(extendedResource v1.ResourceName) bool) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/cm/testing/mocks.go
+++ b/pkg/kubelet/cm/testing/mocks.go
@@ -1527,16 +1527,16 @@ func (_c *MockContainerManager_PrepareDynamicResources_Call) RunAndReturn(run fu
 }
 
 // ShouldResetExtendedResourceCapacity provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) ShouldResetExtendedResourceCapacity() bool {
-	ret := _mock.Called()
+func (_mock *MockContainerManager) ShouldResetExtendedResourceCapacity(extendedResource v1.ResourceName) bool {
+	ret := _mock.Called(extendedResource)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ShouldResetExtendedResourceCapacity")
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func() bool); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(v1.ResourceName) bool); ok {
+		r0 = returnFunc(extendedResource)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -1549,13 +1549,20 @@ type MockContainerManager_ShouldResetExtendedResourceCapacity_Call struct {
 }
 
 // ShouldResetExtendedResourceCapacity is a helper method to define mock.On call
-func (_e *MockContainerManager_Expecter) ShouldResetExtendedResourceCapacity() *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
-	return &MockContainerManager_ShouldResetExtendedResourceCapacity_Call{Call: _e.mock.On("ShouldResetExtendedResourceCapacity")}
+//   - extendedResource v1.ResourceName
+func (_e *MockContainerManager_Expecter) ShouldResetExtendedResourceCapacity(extendedResource interface{}) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
+	return &MockContainerManager_ShouldResetExtendedResourceCapacity_Call{Call: _e.mock.On("ShouldResetExtendedResourceCapacity", extendedResource)}
 }
 
-func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) Run(run func()) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
+func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) Run(run func(extendedResource v1.ResourceName)) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 v1.ResourceName
+		if args[0] != nil {
+			arg0 = args[0].(v1.ResourceName)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1565,7 +1572,7 @@ func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) Return(
 	return _c
 }
 
-func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) RunAndReturn(run func() bool) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
+func (_c *MockContainerManager_ShouldResetExtendedResourceCapacity_Call) RunAndReturn(run func(extendedResource v1.ResourceName) bool) *MockContainerManager_ShouldResetExtendedResourceCapacity_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -191,10 +191,11 @@ func (kl *Kubelet) reconcileHugePageResource(logger klog.Logger, initialNode, ex
 // Zeros out extended resource capacity during reconciliation.
 func (kl *Kubelet) reconcileExtendedResource(logger klog.Logger, initialNode, node *v1.Node) bool {
 	requiresUpdate := updateDefaultResources(initialNode, node)
-	// Check with the device manager to see if node has been recreated, in which case extended resources should be zeroed until they are available
-	if kl.containerManager.ShouldResetExtendedResourceCapacity() {
-		for k := range node.Status.Capacity {
-			if v1helper.IsExtendedResourceName(k) {
+	for k := range node.Status.Capacity {
+		if v1helper.IsExtendedResourceName(k) {
+			// Check with the device manager to see if node is missing state for any of
+			// the extended resources, in which case should be zeroed until they become available/re-introduced.
+			if kl.containerManager.ShouldResetExtendedResourceCapacity(k) {
 				logger.Info("Zero out resource capacity in existing node", "resourceName", k, "node", klog.KObj(node))
 				node.Status.Capacity[k] = *resource.NewQuantity(int64(0), resource.DecimalSI)
 				node.Status.Allocatable[k] = *resource.NewQuantity(int64(0), resource.DecimalSI)

--- a/test/e2e_node/device_manager_test.go
+++ b/test/e2e_node/device_manager_test.go
@@ -223,10 +223,10 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 			devsLen := int64(deviceCount) // shortcut
 			ginkgo.By("Waiting for the resource exported by the sample device plugin to become available on the local node")
 
-			gomega.Eventually(ctx, isNodeReadyWithAllocatableSampleResources).
-				WithArguments(f, devsLen).
+			gomega.Eventually(ctx, getReadyLocalTestNode).
+				WithArguments(f).
 				WithTimeout(5 * time.Minute).
-				Should(HaveAllocatableDevices())
+				Should(HaveAllocatableDevices(devsLen))
 		})
 
 		framework.It("should deploy pod consuming devices first but fail with admission error after kubelet restart in case device plugin hasn't re-registered", framework.WithFlaky(), func(ctx context.Context) {
@@ -264,8 +264,6 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 			restartKubelet(ctx)
 
 			ginkgo.By("waiting for the kubelet to be ready again")
-			// Wait for the Kubelet to be ready.
-
 			gomega.Eventually(ctx, e2enode.TotalReady).
 				WithArguments(f.ClientSet).
 				WithTimeout(2 * time.Minute).
@@ -289,21 +287,94 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 			// `/var/lib/kubelet/device-plugins/registered`). Because of this, the capacity and allocatable corresponding
 			// to the resource exposed by the device plugin should be zero.
 
-			gomega.Eventually(ctx, isNodeReadyWithAllocatableSampleResources).
-				WithArguments(f, int64(0)).
+			gomega.Eventually(ctx, getReadyLocalTestNode).
+				WithArguments(f).
 				WithTimeout(5 * time.Minute).
-				Should(HaveAllocatableDevices())
+				Should(HaveAllocatableDevices(0))
 
 			ginkgo.By("Checking that pod requesting devices failed to start because of admission error")
 
 			// NOTE: The device plugin won't re-register again and this is intentional.
 			// Because of this, the testpod (requesting a device) should fail with an admission error.
 
-			gomega.Eventually(ctx, getPod).
+			gomega.Eventually(ctx, getPodByName).
 				WithArguments(f, testPod.Name).
 				WithTimeout(time.Minute).
-				Should(HaveFailedWithAdmissionError(),
+				Should(HaveFailedWithUnexpectedAdmissionError(),
 					"the pod succeeded to start, when it should fail with the admission error")
+
+			ginkgo.By("removing application pods")
+			e2epod.NewPodClient(f).DeleteSync(ctx, testPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+		})
+
+		// this test case specically targets how kubelet will handle a stateless
+		// restart in which it's node resource still has extended resources but
+		// the device manager checkpoint is missing. correctly updating the
+		// resource capacity to fix the mismatch allows the pod to be rejected
+		// in admission to the allocation manager.
+		framework.It("should deploy pod consuming devices first but fail with InsufficientResource error after kubelet restart with missing checkpoint", framework.WithFlaky(), func(ctx context.Context) {
+			var err error
+			podCMD := "while true; do sleep 1000; done;"
+
+			ginkgo.By(fmt.Sprintf("creating a pods requiring %d %q", deviceCount, e2enode.SampleDeviceResourceName))
+
+			pod := makeBusyboxDeviceRequiringPod(e2enode.SampleDeviceResourceName, podCMD)
+			testPod := e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			ginkgo.By("making sure all the pods are ready")
+
+			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, testPod.Namespace, testPod.Name, "Ready", 120*time.Second, testutils.PodRunningReady)
+			framework.ExpectNoError(err, "pod %s/%s did not go running", testPod.Namespace, testPod.Name)
+			framework.Logf("pod %s/%s running", testPod.Namespace, testPod.Name)
+
+			ginkgo.By("stopping the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+
+			ginkgo.By("removing kubelet device plugin data")
+			err = os.RemoveAll(devicePluginDir)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("stopping all the local containers - using CRI")
+			rs, _, err := getCRIClient(ctx)
+			framework.ExpectNoError(err)
+			sandboxes, err := rs.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{})
+			framework.ExpectNoError(err)
+			for _, sandbox := range sandboxes {
+				gomega.Expect(sandbox.Metadata).ToNot(gomega.BeNil())
+				ginkgo.By(fmt.Sprintf("deleting pod using CRI: %s/%s -> %s", sandbox.Metadata.Namespace, sandbox.Metadata.Name, sandbox.Id))
+
+				err := rs.RemovePodSandbox(ctx, sandbox.Id)
+				framework.ExpectNoError(err)
+			}
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet(ctx)
+
+			ginkgo.By("waiting for the kubelet to be ready again")
+			gomega.Eventually(ctx, e2enode.TotalReady).
+				WithArguments(f.ClientSet).
+				WithTimeout(2 * time.Minute).
+				Should(gomega.BeEquivalentTo(1))
+
+			ginkgo.By("Waiting for the resource capacity/allocatable exported by the sample device plugin to become zero")
+
+			// when the kubelet checkpoint is missing, the resource should be
+			// zero'd immediately instead of waiting for the stopped endpoint
+			// grace period (5 minutes).
+			// see: https://github.com/kubernetes/kubernetes/pull/137335
+
+			gomega.Expect(getLocalTestNode(ctx, f)).To(HaveAllocatableDevices(0))
+
+			ginkgo.By("Checking that pod requesting devices failed to start because of InsufficientResource error")
+
+			// NOTE: The device plugin won't re-register again and this is intentional.
+			// Because of this, the testpod (requesting a device) should fail with an admission error.
+
+			gomega.Eventually(ctx, getPodByName).
+				WithArguments(f, testPod.Name).
+				WithTimeout(time.Minute).
+				Should(HaveFailedWithInsufficientResourcesError(e2enode.SampleDeviceResourceName),
+					"the pod succeeded to start, when it should fail with the InsufficientResource error")
 
 			ginkgo.By("removing application pods")
 			e2epod.NewPodClient(f).DeleteSync(ctx, testPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
@@ -411,40 +482,16 @@ func isNodeReadyWithSampleResources(ctx context.Context, f *framework.Framework)
 }
 
 // HaveAllocatableDevices verifies that a node has allocatable devices.
-func HaveAllocatableDevices() types.GomegaMatcher {
-	return gomega.And(
-		// This additional matcher checks for the final error condition.
-		gcustom.MakeMatcher(func(hasAllocatable bool) (bool, error) {
-			if !hasAllocatable {
-				return false, fmt.Errorf("expected node to be have allocatable devices=%t", hasAllocatable)
-			}
-			return true, nil
-		}),
-		hasAllocatable(true),
-	)
-}
-
-// hasAllocatable matches if node is ready i.e. ready is true.
-func hasAllocatable(hasAllocatable bool) types.GomegaMatcher {
-	return gcustom.MakeMatcher(func(hasAllocatableDevices bool) (bool, error) {
-		return hasAllocatableDevices == hasAllocatable, nil
-	}).WithTemplate("expected Node with allocatable {{.To}} be in {{format .Data}}\nGot instead:\n{{.FormattedActual}}").WithTemplateData(hasAllocatable)
-}
-
-func isNodeReadyWithAllocatableSampleResources(ctx context.Context, f *framework.Framework, devCount int64) (bool, error) {
-	node, ready := getLocalTestNode(ctx, f)
-	if !ready {
-		return false, fmt.Errorf("expected node to be ready=%t", ready)
-	}
-
-	if e2enode.CountSampleDeviceCapacity(node) != devCount {
-		return false, fmt.Errorf("expected devices capacity to be: %d", devCount)
-	}
-
-	if e2enode.CountSampleDeviceAllocatable(node) != devCount {
-		return false, fmt.Errorf("expected devices allocatable to be: %d", devCount)
-	}
-	return true, nil
+func HaveAllocatableDevices(devCount int64) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(node *v1.Node) (bool, error) {
+		if e2enode.CountSampleDeviceCapacity(node) != devCount {
+			return false, fmt.Errorf("expected devices capacity to be: %d", devCount)
+		}
+		if e2enode.CountSampleDeviceAllocatable(node) != devCount {
+			return false, fmt.Errorf("expected devices allocatable to be: %d", devCount)
+		}
+		return true, nil
+	})
 }
 
 func isNodeReadyWithoutSampleResources(ctx context.Context, f *framework.Framework) (bool, error) {
@@ -459,48 +506,40 @@ func isNodeReadyWithoutSampleResources(ctx context.Context, f *framework.Framewo
 	return true, nil
 }
 
-// HaveFailedWithAdmissionError verifies that a pod fails at admission.
-func HaveFailedWithAdmissionError() types.GomegaMatcher {
-	return gomega.And(
-		gcustom.MakeMatcher(func(hasFailed bool) (bool, error) {
-			if !hasFailed {
-				return false, fmt.Errorf("expected pod to have failed=%t", hasFailed)
-			}
-			return true, nil
-		}),
-		hasFailed(true),
-	)
-}
-
-// hasFailed matches if pod has failed.
-func hasFailed(hasFailed bool) types.GomegaMatcher {
-	return gcustom.MakeMatcher(func(hasPodFailed bool) (bool, error) {
-		return hasPodFailed == hasFailed, nil
-	}).WithTemplate("expected Pod failed {{.To}} be in {{format .Data}}\nGot instead:\n{{.FormattedActual}}").WithTemplateData(hasFailed)
-}
-
 func getPodByName(ctx context.Context, f *framework.Framework, podName string) (*v1.Pod, error) {
 	return e2epod.NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
 }
 
-func getPod(ctx context.Context, f *framework.Framework, podName string) (bool, error) {
-	pod, err := getPodByName(ctx, f, podName)
-	if err != nil {
-		return false, err
-	}
+// HaveFailedWithUnexpectedAdmissionError verifies that a pod fails at admission
+// with an unexpected error.
+func HaveFailedWithUnexpectedAdmissionError() types.GomegaMatcher {
+	return haveFailedWithPodReasonAndMessage(
+		"UnexpectedAdmissionError",
+		"Allocate failed due to no healthy devices present; cannot allocate unhealthy devices",
+	)
+}
 
-	expectedStatusReason := "UnexpectedAdmissionError"
-	expectedStatusMessage := "Allocate failed due to no healthy devices present; cannot allocate unhealthy devices"
+// HaveFailedWithInsufficientResourcesError verifies that a pod fails at
+// admission with insufficient resources.
+func HaveFailedWithInsufficientResourcesError(resourceName string) types.GomegaMatcher {
+	return haveFailedWithPodReasonAndMessage(
+		"OutOf"+resourceName,
+		"Insufficient "+resourceName,
+	)
+}
 
-	// This additional matcher checks for the final error condition.
-	if pod.Status.Phase != v1.PodFailed {
-		return false, fmt.Errorf("expected pod to reach phase %q, got final phase %q instead.", v1.PodFailed, pod.Status.Phase)
-	}
-	if pod.Status.Reason != expectedStatusReason {
-		return false, fmt.Errorf("expected pod status reason to be %q, got %q instead.", expectedStatusReason, pod.Status.Reason)
-	}
-	if !strings.Contains(pod.Status.Message, expectedStatusMessage) {
-		return false, fmt.Errorf("expected pod status reason to contain %q, got %q instead.", expectedStatusMessage, pod.Status.Message)
-	}
-	return true, nil
+// haveFailedWithPodReasonAndMessage verifies that a pod fails with details.
+func haveFailedWithPodReasonAndMessage(expectedStatusReason, expectedStatusMessage string) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(pod *v1.Pod) (bool, error) {
+		if pod.Status.Phase != v1.PodFailed {
+			return false, fmt.Errorf("expected pod to reach phase %q, got final phase %q instead.", v1.PodFailed, pod.Status.Phase)
+		}
+		if pod.Status.Reason != expectedStatusReason {
+			return false, fmt.Errorf("expected pod status reason to be %q, got %q instead.", expectedStatusReason, pod.Status.Reason)
+		}
+		if !strings.Contains(pod.Status.Message, expectedStatusMessage) {
+			return false, fmt.Errorf("expected pod status reason to contain %q, got %q instead.", expectedStatusMessage, pod.Status.Message)
+		}
+		return true, nil
+	})
 }

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -1010,10 +1010,10 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
 
 			ginkgo.By("Waiting for the pod to fail with admission error as device plugin hasn't re-registered yet")
-			gomega.Eventually(ctx, getPod).
+			gomega.Eventually(ctx, getPodByName).
 				WithArguments(f, pod1.Name).
 				WithTimeout(time.Minute).
-				Should(HaveFailedWithAdmissionError(),
+				Should(HaveFailedWithUnexpectedAdmissionError(),
 					"the pod succeeded to start, when it should fail with the admission error")
 
 			// crosscheck from the device assignment is preserved and stable from perspective of the kubelet.

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -1010,10 +1010,10 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute))
 
 			ginkgo.By("Waiting for the pod to fail with admission error as device plugin hasn't re-registered yet")
-			gomega.Eventually(ctx, getPod).
+			gomega.Eventually(ctx, getPodByName).
 				WithArguments(f, pod1.Name).
 				WithTimeout(time.Minute).
-				Should(HaveFailedWithAdmissionError(),
+				Should(HaveFailedWithUnexpectedAdmissionError(),
 					"the pod succeeded to start, when it should fail with the admission error")
 
 			// crosscheck from the device assignment is preserved and stable from perspective of the kubelet.

--- a/test/e2e_node/testdeviceplugin/device-plugin.go
+++ b/test/e2e_node/testdeviceplugin/device-plugin.go
@@ -244,7 +244,10 @@ func (dp *DevicePlugin) RegisterDevicePlugin(ctx context.Context, uniqueName, re
 	}
 
 	ginkgo.By("Register the device plugin with the kubelet")
-	_, err = client.Register(ctx, reqt)
+	registerCtx, registerCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer registerCancel()
+	// Register the device plugin with the kubelet
+	_, err = client.Register(registerCtx, reqt, grpc.WaitForReady(true))
 	if err != nil {
 		return err
 	}

--- a/test/e2e_node/testdeviceplugin/device-plugin.go
+++ b/test/e2e_node/testdeviceplugin/device-plugin.go
@@ -221,7 +221,10 @@ func (dp *DevicePlugin) RegisterDevicePlugin(ctx context.Context, uniqueName, re
 	}
 
 	ginkgo.By("Register the device plugin with the kubelet")
-	_, err = client.Register(ctx, reqt)
+	registerCtx, registerCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer registerCancel()
+	// Register the device plugin with the kubelet
+	_, err = client.Register(registerCtx, reqt, grpc.WaitForReady(true))
 	if err != nil {
 		return err
 	}

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -263,6 +263,16 @@ func getLocalTestNode(ctx context.Context, f *framework.Framework) (*v1.Node, bo
 	return node, ready && schedulable
 }
 
+// getReadyLocalTestNode is a wrapper around getLocalTestNode that requires the
+// node to be ready or returns an error.
+func getReadyLocalTestNode(ctx context.Context, f *framework.Framework) (*v1.Node, error) {
+	node, ready := getLocalTestNode(ctx, f)
+	if !ready {
+		return nil, fmt.Errorf("expected node to be ready=%t", ready)
+	}
+	return node, nil
+}
+
 func getLocalNodeCPUDetails(ctx context.Context, f *framework.Framework) (cpuCapVal int64, cpuAllocVal int64, cpuResVal int64) {
 	localNodeCap := getLocalNode(ctx, f).Status.Capacity
 	cpuCap := localNodeCap[v1.ResourceCPU]

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -262,6 +262,16 @@ func getLocalTestNode(ctx context.Context, f *framework.Framework) (*v1.Node, bo
 	return node, ready && schedulable
 }
 
+// getReadyLocalTestNode is a wrapper around getLocalTestNode that requires the
+// node to be ready or returns an error.
+func getReadyLocalTestNode(ctx context.Context, f *framework.Framework) (*v1.Node, error) {
+	node, ready := getLocalTestNode(ctx, f)
+	if !ready {
+		return nil, fmt.Errorf("expected node to be ready=%t", ready)
+	}
+	return node, nil
+}
+
 func getLocalNodeCPUDetails(ctx context.Context, f *framework.Framework) (cpuCapVal int64, cpuAllocVal int64, cpuResVal int64) {
 	localNodeCap := getLocalNode(ctx, f).Status.Capacity
 	cpuCap := localNodeCap[v1.ResourceCPU]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

this PR updates `ShouldResetExtendedResourceCapacity` to refer to the presence of resources in the manager's `endpoints` map. because this is populated by a loaded checkpoint OR a registered device plugin, it should serve as a more robust check than the prior `len(checkpoints) == 0)` condition and avoids the issue with the presence of `kubelet.sock` in the checkpointdir.

because this mechanism also lends itself to being resource-aware, i tweaked the signature to handle individual resource names.

I had also been seeing an issue causing previously scheduled pods to bypass the device plugin by falling into the `!isDevicePluginResource` path due to the maps being empty upon startup with a missing checkpoint. i think this solution works to make it explicit that resources unseen in the loaded checkpoint need to be recreated/reregistered otherwise be zero'd out.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes https://github.com/kubernetes/kubernetes/issues/126943

#### Special notes for your reviewer:

this change/fix is a breaking change in how extended resources work, because it will result in them always being reset to zero on kubelet restart.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
