### PR TITLE
Fix TestAggregatedAPIServer flake from cleanup ordering

### DIFF
--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -277,7 +277,7 @@ func testFrontProxyConfig(t *testing.T, withUID bool) {
 	const wardleBinaryVersion = "1.1"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-	t.Cleanup(cancel)
+	defer cancel()
 
 	// Set the emulation version for the kube-apiserver testserver by mapping
 	// the wardle version to the kube version.
@@ -375,7 +375,10 @@ func testFrontProxyConfig(t *testing.T, withUID bool) {
 	)
 
 	wardleCertDir, _ := os.MkdirTemp("", "test-integration-wardle-server")
-	defer os.RemoveAll(wardleCertDir)
+	// Use t.Cleanup (not defer) so the cert dir is removed after defer cancel()
+	// runs. This ensures the wardle server receives the shutdown signal before
+	// its certificate files are deleted, preventing fsnotify errors.
+	t.Cleanup(func() { _ = os.RemoveAll(wardleCertDir) })
 
 	runPreparedWardleServer(ctx, t, wardleOptions, wardleCertDir, wardlePort, false, true, wardleBinaryVersion, kubeConfig, withUID)
 	waitForWardleAPIServiceReady(ctx, t, kubeConfig, wardleCertDir, testNamespace)
@@ -405,7 +408,7 @@ func testAggregatedAPIServer(t *testing.T, setWardleFeatureGate, banFlunder bool
 	const testNamespace = "kube-wardle"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-	t.Cleanup(cancel)
+	defer cancel()
 
 	// set the emulation version for the kube-apiserver testserver by mapping
 	// the wardle version to the kube version.
@@ -419,7 +422,10 @@ func testAggregatedAPIServer(t *testing.T, setWardleFeatureGate, banFlunder bool
 	kubeClientConfig := getKubeConfig(testKAS)
 
 	wardleCertDir, _ := os.MkdirTemp("", "test-integration-wardle-server")
-	defer os.RemoveAll(wardleCertDir)
+	// Use t.Cleanup (not defer) so the cert dir is removed after defer cancel()
+	// runs. This ensures the wardle server receives the shutdown signal before
+	// its certificate files are deleted, preventing fsnotify errors.
+	t.Cleanup(func() { _ = os.RemoveAll(wardleCertDir) })
 
 	directWardleClientConfig := runPreparedWardleServer(ctx, t, wardleOptions, wardleCertDir, wardlePort, setWardleFeatureGate, banFlunder, wardleEmulationVersionRaw, kubeClientConfig, false)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Fixes a test flake caused by incorrect cleanup ordering. During teardown, `defer os.RemoveAll(wardleCertDir)` ran before `t.Cleanup(cancel)` (Go runs all defers before any `t.Cleanup` functions), so the wardle server's cert files were deleted while it was still running. The fsnotify file watcher would then fail trying to re-watch the deleted files.

The fix uses `defer cancel()` and `t.Cleanup(os.RemoveAll)` so the context is cancelled first (stopping the server) before files are removed.

from the log below: 
```
I0223 16:12:33.409391   40862 dynamic_serving_content.go:195] "Failed to remove file watch, it may have been deleted" file="/tmp/test-integration-wardle-server2347956986/apiserver.key" err="fsnotify: can't remove non-existent watch: /tmp/test-integration-wardle-server2347956986/apiserver.key"
...
E0223 16:12:33.409701   40862 dynamic_serving_content.go:221] "Unhandled Error" err="key failed with : open /tmp/test-integration-wardle-server2347956986/apiserver.key: no such file or directory" logger="UnhandledError"
...
E0223 16:12:33.413012   40862 dynamic_serving_content.go:144] "Failed to watch cert and key file, will retry later" err="error adding watch for file /tmp/test-integration-wardle-server2347956986/apiserver.key: no such file or directory"
```

Not 100% sure this will fix the flake, but I think it improves our edge case handling.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/137207

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```