### PR TITLE
Wait for node authorizer graph to populate

### DIFF
--- a/test/integration/podcertificaterequests/podcertificate_integration_test.go
+++ b/test/integration/podcertificaterequests/podcertificate_integration_test.go
@@ -510,7 +510,7 @@ func TestNodeAuthorization(t *testing.T) {
 		// Getting the PCR could fail if there is lag in the node authorizer graph population.
 		// Poll until it succeeds.
 		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
-			_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("default").Get(ctx, "pcr1", metav1.GetOptions{})
+			_, err := node1Client.CertificatesV1beta1().PodCertificateRequests("default").Get(ctx, "pcr1", metav1.GetOptions{})
 			if err != nil {
 				t.Logf("Get PodCertificateRequest default/pcr1 as node1 failed with error: %v, retrying...", err)
 				return false, nil

--- a/test/integration/podcertificaterequests/podcertificate_integration_test.go
+++ b/test/integration/podcertificaterequests/podcertificate_integration_test.go
@@ -497,7 +497,8 @@ func TestNodeAuthorization(t *testing.T) {
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("default").Create(ctx, pcr, metav1.CreateOptions{})
 		if err != nil {
-			return false, err
+			t.Logf("Create PodCertificateRequest default/pcr1 as node1 failed with error: %v, retrying...", err)
+			return false, nil
 		}
 		return true, nil
 	})
@@ -506,7 +507,16 @@ func TestNodeAuthorization(t *testing.T) {
 	}
 
 	t.Run("node1 can directly get pcr1", func(t *testing.T) {
-		_, err := node1Client.CertificatesV1beta1().PodCertificateRequests("default").Get(ctx, "pcr1", metav1.GetOptions{})
+		// Getting the PCR could fail if there is lag in the node authorizer graph population.
+		// Poll until it succeeds.
+		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+			_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("default").Get(ctx, "pcr1", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("Get PodCertificateRequest default/pcr1 as node1 failed with error: %v, retrying...", err)
+				return false, nil
+			}
+			return true, nil
+		})
 		if err != nil {
 			t.Fatalf("Unexpected error listing PodCertificateRequests as node1: %v", err)
 		}

--- a/test/integration/podcertificaterequests/podcertificate_integration_test.go
+++ b/test/integration/podcertificaterequests/podcertificate_integration_test.go
@@ -509,7 +509,7 @@ func TestNodeAuthorization(t *testing.T) {
 	t.Run("node1 can directly get pcr1", func(t *testing.T) {
 		// Getting the PCR could fail if there is lag in the node authorizer graph population.
 		// Poll until it succeeds.
-		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, err := node1Client.CertificatesV1beta1().PodCertificateRequests("default").Get(ctx, "pcr1", metav1.GetOptions{})
 			if err != nil {
 				t.Logf("Get PodCertificateRequest default/pcr1 as node1 failed with error: %v, retrying...", err)


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

Fixes #137179

The flake seen in the issue tagged, comes from [this line of code](https://github.com/kubernetes/kubernetes/blob/214ef42236333fc2152eeb0747a1e81fdbcd729d/plugin/pkg/auth/authorizer/node/node_authorizer.go#L231)

https://github.com/kubernetes/kubernetes/blob/214ef42236333fc2152eeb0747a1e81fdbcd729d/plugin/pkg/auth/authorizer/node/node_authorizer.go#L522 

Given that, the get against the PCR is being done immediately after create, the edge that needs to be established in the node authorizer graph may not be established, hence adding the timeout

