### PR TITLE
apimachinery: replace WaitGroup with channel

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/mux.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/mux.go
@@ -122,16 +122,15 @@ func (m *Broadcaster) blockQueue(f func()) {
 		return
 	default:
 	}
-	var wg sync.WaitGroup
-	wg.Add(1)
+	done := make(chan struct{})
 	m.incoming <- Event{
 		Type: internalRunFunctionMarker,
 		Object: functionFakeRuntimeObject(func() {
-			defer wg.Done()
+			defer close(done)
 			f()
 		}),
 	}
-	wg.Wait()
+	<-done
 }
 
 // Watch adds a new watcher to the list and returns an Interface for it.

--- a/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/mux_test.go
@@ -209,6 +209,15 @@ func BenchmarkBroadCaster(b *testing.B) {
 	b.StopTimer()
 }
 
+var blockQueueFunc = func() {}
+
+func BenchmarkBlockQueue(b *testing.B) {
+	m := NewBroadcaster(0, WaitIfChannelFull)
+	for b.Loop() {
+		m.blockQueue(blockQueueFunc)
+	}
+}
+
 func TestBroadcasterWatchAfterShutdown(t *testing.T) {
 	event1 := Event{Type: Added, Object: &myType{"foo", "hello world 1"}}
 	event2 := Event{Type: Added, Object: &myType{"bar", "hello world 2"}}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

synctest is struggling with keeping track of which synctest bubble a WaitGroup belongs to because WaitGroup has no constructor. The heuristic is that the first Add for a certain WaitGroup (identified by its address) determines the bubble.

This heuristic occasionally fails in `go test -count=20 ./pkg/controller/devicetaints` or when running the same test under `stress`:

    fatal error: sync: WaitGroup.Add called from multiple synctest bubbles
    
    goroutine 8183 [running (durable), synctest bubble 61]:
    sync.fatal({0x2a5d494?, 0xc001241890?})
            /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/panic.go:1026 +0x18
    sync.(*WaitGroup).Add(0xc000a8c1b0, 0x1)
            /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/sync/waitgroup.go:94 +0x105
    k8s.io/apimachinery/pkg/watch.(*Broadcaster).blockQueue(0xc00002f310, 0xc001682348)
            /root/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/watch/mux.go:126 +0xa5
    k8s.io/apimachinery/pkg/watch.(*Broadcaster).Watch(0xc00002f310)
            /root/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/watch/mux.go:143 +0x7e
    k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher(0xc00148e800, 0xc000a08660)
            /root/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/record/event.go:396 +0x2a
    k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartRecordingToSink(0xc00148e800, {0x2df6820, 0xc00143e320})
            /root/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/record/event.go:277 +0x11d
    k8s.io/kubernetes/pkg/controller/devicetainteviction.(*Controller).Run(0xc001414160, {0x2dfe898, 0xc001951d60}, 0x1)
            /root/go/src/k8s.io/kubernetes/pkg/controller/devicetainteviction/device_taint_eviction.go:815 +0x9ba

Another, similar failure (*not* fixed here!):

    fatal error: sync: WaitGroup.Add called from multiple synctest bubbles

    goroutine 508 [running (durable), synctest bubble 5]:
    sync.fatal({0x2a5d494?, 0xc0007dd780?})
            /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/panic.go:1026 +0x18
    sync.(*WaitGroup).Add(0xc000822050, 0xffffffffffffffff)
            /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/sync/waitgroup.go:94 +0x105
    sync.(*WaitGroup).Done(...)
            /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/sync/waitgroup.go:156
    k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
            /root/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x5b
    created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 550
            /root/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73

Unfortunately, the caller of wait.Group.Start is unknown, so it's unclear which WaitGroup is involved here.

Replacing the WaitGroup with a channel avoids the false positive. It also is slightly faster in the benchmark:

Before:

    $ go test -benchmem -bench=BenchmarkBlockQueue -benchtime=5s -run=xxx ./staging/src/k8s.io/apimachinery/pkg/watch
    goos: linux
    goarch: amd64
    pkg: k8s.io/apimachinery/pkg/watch
    cpu: Intel(R) Core(TM) Ultra 9 285
    BenchmarkBlockQueue-24    	20962518	       285.0 ns/op	      40 B/op	       2 allocs/op

After:

    BenchmarkBlockQueue-24    	21270374	       279.0 ns/op	     136 B/op	       2 allocs/op

It needs a bit more memory, but not more allocations.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/136939

#### Special notes for your reviewer:

/cc @michaelasp @alaypatel07 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
