### PR TITLE
WIP: debugging e2e-gce, ignore

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -178,7 +178,7 @@ export PATH
 case "${E2E_TEST_DEBUG_TOOL:-ginkgo}" in
   ginkgo)
     program=("${ginkgo}")
-    program+=("--nodes=25")
+    program+=("--nodes=30")
     program+=("${ginkgo_args[@]:+${ginkgo_args[@]}}")
     ;;
   delve) program=("dlv" "exec") ;;

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -178,20 +178,7 @@ export PATH
 case "${E2E_TEST_DEBUG_TOOL:-ginkgo}" in
   ginkgo)
     program=("${ginkgo}")
-    if [[ -n "${GINKGO_PARALLEL_NODES:-}" ]]; then
-      program+=("--nodes=${GINKGO_PARALLEL_NODES}")
-    elif [[ ${GINKGO_PARALLEL} =~ ^[yY]$ ]]; then
-      if [[ "${KUBE_RACE:-}" == "-race" ]]; then
-        # When race detection is enabled, merely running 25 e2e.test instances was too much
-        # and the OOM killer shut down the Prow test pod because of the memory overhead.
-        #
-        # A CI job could control that via GINKGO_PARALLEL_NODES, but we should also have
-        # saner defaults which take this into account.
-        program+=("--nodes=10")
-      else
-        program+=("--nodes=25")
-      fi
-    fi
+    program+=("--nodes=25")
     program+=("${ginkgo_args[@]:+${ginkgo_args[@]}}")
     ;;
   delve) program=("dlv" "exec") ;;

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -295,7 +295,10 @@ case "${GINKGO_SHOW_COMMAND:-${CI:-no}}" in y|yes|true) set -x ;; esac
   ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"} \
   ${E2E_REPORT_PREFIX:+"--report-prefix=${E2E_REPORT_PREFIX}"} \
   "${suite_args[@]:+${suite_args[@]}}" \
-  "${@}" &
+  "${@}" \
+  --ginkgo.focus= '--ginkgo.skip=\[Serial\]' '--ginkgo.label-filter=Feature: isEmpty && !Slow && !Disruptive && !Flaky' &
+
+# ^^^ Same test selection as in https://testgrid.k8s.io/sig-release-master-blocking#kind-master
 
 set +x
 GINKGO_CLI_PID=$!


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

https://testgrid.k8s.io/sig-release-master-blocking#kind-master is much more stable than https://testgrid.k8s.io/sig-release-master-blocking#gce-ubuntu-master-containerd (although currently it seems fine?!).

This PR changes the Ginkgo test selection so that it always runs the same tests as kind-master, to make test runs more comparable.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
