### PR TITLE
deepcopy-gen: remove dead --bounding-dirs flag

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -202,7 +202,6 @@ function codegen::deepcopy() {
         -v "${KUBE_VERBOSE}" \
         --go-header-file "${BOILERPLATE_FILENAME}" \
         --output-file "${output_file}" \
-        --bounding-dirs "k8s.io/kubernetes,k8s.io/api" \
         "${tag_pkgs[@]}" \
         "$@"
 

--- a/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/args/args.go
@@ -24,7 +24,6 @@ import (
 
 type Args struct {
 	OutputFile   string
-	BoundingDirs []string // Only deal with types rooted under these dirs.
 	GoHeaderFile string
 }
 
@@ -37,8 +36,6 @@ func New() *Args {
 func (args *Args) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&args.OutputFile, "output-file", "generated.deepcopy.go",
 		"the name of the file to be generated")
-	fs.StringSliceVar(&args.BoundingDirs, "bounding-dirs", args.BoundingDirs,
-		"Comma-separated list of import paths which bound the types for which deep-copies will be generated.")
 	fs.StringVar(&args.GoHeaderFile, "go-header-file", "",
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")
 }

--- a/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy.go
+++ b/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy.go
@@ -128,16 +128,6 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 		klog.Fatalf("Failed loading boilerplate: %v", err)
 	}
 
-	boundingDirs := []string{}
-	if args.BoundingDirs == nil {
-		args.BoundingDirs = context.Inputs
-	}
-	for i := range args.BoundingDirs {
-		// Strip any trailing slashes - they are not exactly "correct" but
-		// this is friendlier.
-		boundingDirs = append(boundingDirs, strings.TrimRight(args.BoundingDirs[i], "/"))
-	}
-
 	targets := []generator.Target{}
 
 	for _, i := range context.Inputs {
@@ -197,7 +187,7 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 					},
 					GeneratorsFunc: func(c *generator.Context) (generators []generator.Generator) {
 						return []generator.Generator{
-							NewGenDeepCopy(args.OutputFile, pkg.Path, boundingDirs, (ptagValue == tagValuePackage), ptagRegister),
+							NewGenDeepCopy(args.OutputFile, pkg.Path, (ptagValue == tagValuePackage), ptagRegister),
 						}
 					},
 				})
@@ -210,20 +200,18 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 type genDeepCopy struct {
 	generator.GoGenerator
 	targetPackage string
-	boundingDirs  []string
 	allTypes      bool
 	registerTypes bool
 	imports       namer.ImportTracker
 	typesForInit  []*types.Type
 }
 
-func NewGenDeepCopy(outputFilename, targetPackage string, boundingDirs []string, allTypes, registerTypes bool) generator.Generator {
+func NewGenDeepCopy(outputFilename, targetPackage string, allTypes, registerTypes bool) generator.Generator {
 	return &genDeepCopy{
 		GoGenerator: generator.GoGenerator{
 			OutputFilename: outputFilename,
 		},
 		targetPackage: targetPackage,
-		boundingDirs:  boundingDirs,
 		allTypes:      allTypes,
 		registerTypes: registerTypes,
 		imports:       generator.NewImportTrackerForPackage(targetPackage),


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the dead `--bounding-dirs` flag and `BoundingDirs` field from deepcopy-gen.

This flag was added by @thockin back in 2016 ([kubernetes/gengo@14ae879](https://github.com/kubernetes/gengo/commit/14ae879d252a2289bd134f598c645c51494bb8ef)) to control which nested types deepcopy-gen could assume had generated DeepCopy functions. It got dropped when deepcopy-gen was rewritten for gengo v2 and moved to code-generator — the field and flag survived but `g.boundingDirs` is never actually read anywhere in the current code.

`hack/update-codegen.sh` still passed `--bounding-dirs "k8s.io/kubernetes,k8s.io/api"` but it had no effect.

#### Which issue(s) this PR is related to:

Discovered this while trying to use a similar bounding dir concept to address https://github.com/kubernetes/kube-openapi/issues/571.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Removes the dead `--bounding-dirs` flag and `BoundingDirs` field from deepcopy-gen.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```