### PR TITLE
kube-api-linter: enable preferredmarkers linter

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -236,6 +236,11 @@ linters:
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
         path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
       
+      # PreferredMarkers - Existing stable/deprecated API fields that intentionally
+      # retain kubebuilder:validation:Required markers for backward compatibility.
+      - text: 'preferredmarkers: field (PortStatus|IngressPortStatus)\.Error uses marker "kubebuilder:validation:Required", should use preferred marker "required" instead'
+        path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
+      
       # jsontags: 'Port' must be capitalized for backward compatibility
       - text: 'jsontags: field DaemonEndpoint.Port json tag does not match'
         path: "staging/src/k8s.io/api/core/v1/types.go"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -464,6 +464,16 @@ linters:
                   type: "All"
                   dependsOn:
                     - "k8s:optional"
+            preferredmarkers:
+              markers:
+                - preferredIdentifier: "optional"
+                  equivalentIdentifiers:
+                    - identifier: "k8s:optional"
+                    - identifier: "kubebuilder:validation:Optional"
+                - preferredIdentifier: "required"
+                  equivalentIdentifiers:
+                    - identifier: "k8s:required"
+                    - identifier: "kubebuilder:validation:Required"
             # jsonTags:
             #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
             # nomaps:

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -434,6 +434,7 @@ linters:
               - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
               - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
               - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
+              - "preferredmarkers" # Ensure preferred markers are used when multiple forms are available.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.
               # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -251,6 +251,11 @@ linters:
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
         path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
       
+      # PreferredMarkers - Existing stable/deprecated API fields that intentionally
+      # retain kubebuilder:validation:Required markers for backward compatibility.
+      - text: 'preferredmarkers: field (PortStatus|IngressPortStatus)\.Error uses marker "kubebuilder:validation:Required", should use preferred marker "required" instead'
+        path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
+      
       # jsontags: 'Port' must be capitalized for backward compatibility
       - text: 'jsontags: field DaemonEndpoint.Port json tag does not match'
         path: "staging/src/k8s.io/api/core/v1/types.go"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -477,6 +477,16 @@ linters:
                   type: "All"
                   dependsOn:
                     - "k8s:optional"
+            preferredmarkers:
+              markers:
+                - preferredIdentifier: "optional"
+                  equivalentIdentifiers:
+                    - identifier: "k8s:optional"
+                    - identifier: "kubebuilder:validation:Optional"
+                - preferredIdentifier: "required"
+                  equivalentIdentifiers:
+                    - identifier: "k8s:required"
+                    - identifier: "kubebuilder:validation:Required"
             # jsonTags:
             #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
             # nomaps:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -447,6 +447,7 @@ linters:
               - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
               - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
               - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
+              - "preferredmarkers" # Ensure preferred markers are used when multiple forms are available.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.
               # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -112,6 +112,11 @@
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
   path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
 
+# PreferredMarkers - Existing stable/deprecated API fields that intentionally
+# retain kubebuilder:validation:Required markers for backward compatibility.
+- text: 'preferredmarkers: field (PortStatus|IngressPortStatus)\.Error uses marker "kubebuilder:validation:Required", should use preferred marker "required" instead'
+  path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
+
 # jsontags: 'Port' must be capitalized for backward compatibility
 - text: 'jsontags: field DaemonEndpoint.Port json tag does not match'
   path: "staging/src/k8s.io/api/core/v1/types.go"

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -18,6 +18,7 @@ linters:
     - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
     - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
     - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
+    - "preferredmarkers" # Ensure preferred markers are used when multiple forms are available.
     # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
     - "ssatags" # Ensure lists have a listType tag.
     # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -48,6 +48,16 @@ lintersConfig:
         type: "All"
         dependsOn:
           - "k8s:optional"
+  preferredmarkers:
+    markers:
+      - preferredIdentifier: "optional"
+        equivalentIdentifiers:
+          - identifier: "k8s:optional"
+          - identifier: "kubebuilder:validation:Optional"
+      - preferredIdentifier: "required"
+        equivalentIdentifiers:
+          - identifier: "k8s:required"
+          - identifier: "kubebuilder:validation:Required"
   # jsonTags:
   #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
   # nomaps:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enables the `preferredmarkers` kube-api-linter rule so API marker usage is validated consistently when multiple marker forms are available.

#### Which issue(s) this PR is related to:

Fixes #136880

#### Special notes for your reviewer:

This PR only updates linter configuration:
- Enabled `preferredmarkers` in `hack/kube-api-linter/kube-api-linter.yaml`
- Regenerated `hack/golangci.yaml` and `hack/golangci-hints.yaml` from `hack/golangci.yaml.in`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

`N/A`

/sig api-machinery
/sig architecture
