### PR TITLE
Fix issue that CPUs fail to be allocated in partial uncore cache even though there are enough CPUs

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -564,61 +564,55 @@ func (a *cpuAccumulator) takeFullUncore() {
 }
 
 func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
-	// determine the number of cores needed whether SMT/hyperthread is enabled or disabled
-	numCoresNeeded := (a.numCPUsNeeded + a.topo.CPUsPerCore() - 1) / a.topo.CPUsPerCore()
-
-	// determine the N number of free cores (physical cpus) within the UncoreCache, then
-	// determine the M number of free cpus (virtual cpus) that correspond with the free cores
-	freeCores := a.details.CoresNeededInUncoreCache(numCoresNeeded, uncoreID)
-	freeCPUs := a.details.CPUsInCores(freeCores.UnsortedList()...)
-
-	// when SMT/hyperthread is enabled and remaining cpu requirement is an odd integer value:
-	// sort the free CPUs that were determined based on the cores that have available cpus.
-	// if the amount of free cpus is greather than the cpus needed, we can drop the last cpu
-	// since the odd integer request will only require one out of the two free cpus that
-	// correspond to the last core
-	if a.numCPUsNeeded%2 != 0 && a.topo.CPUsPerCore() > 1 {
-		// we sort freeCPUs to ensure we pack virtual cpu allocations, meaning we allocate
-		// whole core's worth of cpus as much as possible to reduce smt-misalignment
-		sortFreeCPUs := freeCPUs.List()
-		if len(sortFreeCPUs) > a.numCPUsNeeded {
-			// if we are in takePartialUncore, the accumulator is not satisfied after
-			// takeFullUncore, so freeCPUs.Size() can't be < 1
-			sortFreeCPUs = sortFreeCPUs[:freeCPUs.Size()-1]
-		}
-		freeCPUs = cpuset.New(sortFreeCPUs...)
-	}
-
-	// claim the cpus if the free cpus within the UncoreCache can satisfy the needed cpus
-	claimed := (a.numCPUsNeeded == freeCPUs.Size())
-	a.logger.V(4).Info("takePartialUncore: trying to claim partial uncore",
-		"uncore", uncoreID,
-		"claimed", claimed,
-		"needed", a.numCPUsNeeded,
-		"cores", freeCores.String(),
-		"cpus", freeCPUs.String())
-	if !claimed {
+	// Check if the uncoreID has enough CPUs to satisfy a.numCPUsNeeded
+	availableCPUsInUncore := a.details.CPUsInUncoreCaches(uncoreID).Size()
+	if availableCPUsInUncore < a.numCPUsNeeded {
 		return
-
 	}
-	a.take(freeCPUs)
+
+	// sort cores in the uncore
+	cores := a.details.CoresInUncoreCache(uncoreID).UnsortedList()
+	a.sort(cores, a.details.CPUsInCores)
+
+	// takes CPUs from free full cores in the uncore.
+	for _, core := range cores {
+		if !a.isCoreFree(core) {
+			continue
+		}
+		cpusInCore := a.details.CPUsInCores(core)
+		if !a.needsAtLeast(cpusInCore.Size()) {
+			break
+		}
+		a.logger.V(4).Info("takePartialUncore", "uncore", uncoreID, "core", core)
+		a.take(cpusInCore)
+		if a.isSatisfied() {
+			return
+		}
+	}
+
+	// Take remaining CPUs from the uncore
+	for _, core := range cores {
+		cpusInCore := a.details.CPUsInCores(core).List()
+		for _, cpu := range cpusInCore {
+			a.logger.V(4).Info("takePartialUncore: claiming CPU", "uncore", uncoreID, "cpu", cpu)
+			a.take(cpuset.New(cpu))
+			if a.isSatisfied() {
+				return
+			}
+		}
+	}
 }
 
 // First try to take full UncoreCache, if available and need is at least the size of the UncoreCache group.
 // Second try to take the partial UncoreCache if available and the request size can fit w/in the UncoreCache.
 func (a *cpuAccumulator) takeUncoreCache() {
-	numCPUsInUncore := a.topo.CPUsPerUncore()
+	// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
+	a.takeFullUncore()
+	if a.isSatisfied() {
+		return
+	}
+	// take partial UncoreCache if the CPUs needed is less than free UncoreCache size
 	for _, uncore := range a.sortAvailableUncoreCaches() {
-		// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
-		if a.needsAtLeast(numCPUsInUncore) {
-			a.takeFullUncore()
-		}
-
-		if a.isSatisfied() {
-			return
-		}
-
-		// take partial UncoreCache if the CPUs needed is less than free UncoreCache size
 		a.takePartialUncore(uncore)
 		if a.isSatisfied() {
 			return

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -749,6 +749,24 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 			"",
 			mustParseCPUSet(t, "4-7,12-15,1,9"),
 		},
+		{
+			"take even cpus from partial UncoreCache of single socket - SMT enabled",
+			topoUncoreSingleSocketSMT,
+			StaticPolicyOptions{PreferAlignByUncoreCacheOption: true},
+			mustParseCPUSet(t, "3,5,7,11-15"),
+			4,
+			"",
+			mustParseCPUSet(t, "5,7,13,15"),
+		},
+		{
+			"take odd cpus from partial UncoreCache of single socket - SMT enabled",
+			topoUncoreSingleSocketSMT,
+			StaticPolicyOptions{PreferAlignByUncoreCacheOption: true},
+			mustParseCPUSet(t, "3,5,7,11-15"),
+			5,
+			"",
+			mustParseCPUSet(t, "5,7,12,13,15"),
+		},
 	}...)
 
 	for _, tc := range testCases {

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -1784,7 +1784,7 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 				"with-single-container",
 			),
 			expCPUAlloc: true,
-			expCSet:     cpuset.New(4, 5, 68, 69),
+			expCSet:     cpuset.New(2, 3, 66, 67),
 		},
 		{
 			// large odd integer cpu required on smt-enabled
@@ -1819,7 +1819,7 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 				PreferAlignByUnCoreCacheOption: "true",
 			},
 			stAssignments:   state.ContainerCPUAssignments{},
-			stDefaultCPUSet: topoSingleSocketSingleNumaPerSocketSMTSmallUncore.CPUDetails.CPUs(),
+			stDefaultCPUSet: topoDualSocketSubNumaPerSocketHTMonolithicUncore.CPUDetails.CPUs(),
 			pod: WithPodUID(
 				makeMultiContainerPod(
 					[]struct{ request, limit string }{}, // init container
@@ -1842,7 +1842,7 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 				PreferAlignByUnCoreCacheOption: "true",
 			},
 			stAssignments:   state.ContainerCPUAssignments{},
-			stDefaultCPUSet: topoSingleSocketSingleNumaPerSocketSMTSmallUncore.CPUDetails.CPUs(),
+			stDefaultCPUSet: topoDualSocketSubNumaPerSocketHTMonolithicUncore.CPUDetails.CPUs(),
 			pod: WithPodUID(
 				makeMultiContainerPod(
 					[]struct{ request, limit string }{}, // init container

--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -155,7 +155,7 @@ func (d CPUDetails) UncoreInNUMANodes(ids ...int) cpuset.CPUSet {
 // CoresNeededInUncoreCache returns either the full list of all available unique core IDs associated with the given
 // UnCoreCache IDs in this CPUDetails or subset that matches the ask.
 func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpuset.CPUSet {
-	coreIDs := d.coresInUncoreCache(ids...)
+	coreIDs := d.CoresInUncoreCache(ids...)
 	if coreIDs.Size() <= numCoresNeeded {
 		return coreIDs
 	}
@@ -164,7 +164,7 @@ func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpu
 }
 
 // Helper function that just gets the cores
-func (d CPUDetails) coresInUncoreCache(ids ...int) cpuset.CPUSet {
+func (d CPUDetails) CoresInUncoreCache(ids ...int) cpuset.CPUSet {
 	var coreIDs []int
 	for _, id := range ids {
 		for _, info := range d {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When the static CPU manager is configured and prefer-align-cpus-by-uncorecache is enabled in platforms where SMT is enabled, the behavior of CPU allocation to a guaranteed pod should follow the description in [KEP #4800](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4800-cpumanager-split-uncorecache), Specifically:
`Once the current required total number of CPUs for the container is less than the size of the total amount of CPUs to an uncore cache, determine if all required CPUs can fit within the uncore cache domain. Allocate the CPUs if the container's required CPUs can be satisfied from the unallocated CPUs within the single uncore cache domain.`

However, there is an issue where CPUs cannot be allocated from a partial uncore cache in some cases, even though sufficient CPUs are available.

This PR refactor the function of `takePartialUncore` to fixes this issue, clearing the code logic and ensuring that the behavior of allocating partial uncore cache CPUs matches the default behavior. If the CPUs in a partial uncore cache can satisfy the required number of CPUs, the allocation will first take full free cores and then take other CPUs.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #137315

#### Special notes for your reviewer:
1. Fix a issue
2. Correct some the UT cases

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
No
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
No
```
