### PR TITLE
Invoke pluginManagerStopCh in tests to prevent race during cleanup

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1042,6 +1042,8 @@ func NewMainKubelet(ctx context.Context,
 		kubeDeps.Recorder,
 	)
 
+	klet.pluginManagerStopCh = wait.NeverStop
+
 	// If the experimentalMounterPathFlag is set, we do not want to
 	// check node capabilities since the mount path is not the default
 	if len(experimentalMounterPath) != 0 {
@@ -1842,11 +1844,7 @@ func (kl *Kubelet) initializeRuntimeDependentModules(ctx context.Context) {
 
 	// Start the plugin manager
 	logger.V(4).Info("Starting plugin manager")
-	pluginManagerStopCh := kl.pluginManagerStopCh
-	if pluginManagerStopCh == nil {
-		pluginManagerStopCh = wait.NeverStop
-	}
-	go kl.pluginManager.Run(ctx, kl.sourcesReady, pluginManagerStopCh)
+	go kl.pluginManager.Run(ctx, kl.sourcesReady, kl.pluginManagerStopCh)
 
 	err = kl.shutdownManager.Start(ctx)
 	if err != nil {

--- a/pkg/kubelet/kubelet_getters_test.go
+++ b/pkg/kubelet/kubelet_getters_test.go
@@ -31,6 +31,8 @@ import (
 
 func TestKubeletDirs(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	// Set pluginManagerStopCh to nil to avoid timeout in Cleanup() since Run() is not called
+	testKubelet.pluginManagerStopCh = nil
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
 	root := kubelet.rootDirectory

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -160,18 +160,19 @@ type TestKubelet struct {
 	fakeKubeClient       *fake.Clientset
 	fakeMirrorClient     *podtest.FakeMirrorClient
 	fakeClock            *testingclock.FakeClock
-	pluginManagerStopCh  chan struct{}
 	mounter              mount.Interface
+	pluginManagerStopCh  chan struct{}
 	volumePlugin         *volumetest.FakeVolumePlugin
 }
 
 func (tk *TestKubelet) Cleanup() {
 	if tk.kubelet != nil {
+		// Signal the plugin manager to shutdown. This prevents reconciliation during cleanup.
 		if tk.pluginManagerStopCh != nil {
 			close(tk.pluginManagerStopCh)
-			tk.pluginManagerStopCh = nil
-			// Allow the plugin manager goroutines to observe stopCh before TempDir cleanup.
-			time.Sleep(20 * time.Millisecond)
+			// Wait for the plugin manager to fully stop before removing rootDirectory, so its goroutines no longer access the filesystem.
+			// Stopped() returns immediately if Run() was never started.
+			<-tk.kubelet.pluginManager.Stopped()
 		}
 		os.RemoveAll(tk.kubelet.rootDirectory)
 		tk.kubelet = nil
@@ -458,11 +459,13 @@ func newTestKubeletWithImageList(
 		kubelet.recorder,
 		volumetest.NewBlockVolumePathHandler())
 
+	pluginManagerStopCh := make(chan struct{})
+	kubelet.pluginManagerStopCh = pluginManagerStopCh
 	kubelet.pluginManager = pluginmanager.NewPluginManager(
 		kubelet.getPluginsRegistrationDir(), /* sockDir */
 		kubelet.recorder,
 	)
-	pluginManagerStopCh := make(chan struct{})
+	pluginManagerStopCh = make(chan struct{})
 	kubelet.pluginManagerStopCh = pluginManagerStopCh
 	kubelet.setNodeStatusFuncs = kubelet.defaultNodeStatusFuncs()
 
@@ -473,17 +476,7 @@ func newTestKubeletWithImageList(
 	kubelet.AddPodSyncLoopHandler(activeDeadlineHandler)
 	kubelet.AddPodSyncHandler(activeDeadlineHandler)
 	kubelet.kubeletConfiguration.LocalStorageCapacityIsolation = localStorageCapacityIsolation
-	return &TestKubelet{
-		kubelet:              kubelet,
-		fakeRuntime:          fakeRuntime,
-		fakeContainerManager: fakeContainerManager,
-		fakeKubeClient:       fakeKubeClient,
-		fakeMirrorClient:     fakeMirrorClient,
-		fakeClock:            fakeClock,
-		pluginManagerStopCh:  pluginManagerStopCh,
-		mounter:              nil,
-		volumePlugin:         plug,
-	}
+	return &TestKubelet{kubelet, fakeRuntime, fakeContainerManager, fakeKubeClient, fakeMirrorClient, fakeClock, nil, pluginManagerStopCh, plug}
 }
 
 func newTestPods(count int) []*v1.Pod {

--- a/pkg/kubelet/pluginmanager/plugin_manager.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager.go
@@ -18,6 +18,7 @@ package pluginmanager
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -42,6 +43,9 @@ type PluginManager interface {
 	// the desired state of world cache in order to be used during plugin
 	// registration/deregistration
 	AddHandler(pluginType string, pluginHandler cache.PluginHandler)
+
+	// Stopped returns a closed channel once Run() has fully exited.
+	Stopped() <-chan struct{}
 }
 
 const (
@@ -76,7 +80,11 @@ func NewPluginManager(
 		reconciler:          reconciler,
 		desiredStateOfWorld: dsw,
 		actualStateOfWorld:  asw,
+		stopped:             make(chan struct{}),
 	}
+	// Close "stopped" channel immediately so Stopped() returns a closed channel
+	// if Run() is never called.
+	close(pm.stopped)
 	return pm
 }
 
@@ -102,30 +110,69 @@ type pluginManager struct {
 	// The data structure is populated by the desired state of the world
 	// populator (plugin watcher).
 	desiredStateOfWorld cache.DesiredStateOfWorld
+
+	// stopped is closed when Run() has fully exited.
+	// It's created closed and is reopened when Run() is called.
+	stopped chan struct{}
+
+	// stoppedMu protects access to stopped channel.
+	stoppedMu sync.RWMutex
+
+	// runOnce ensures Run() logic executes only once.
+	runOnce sync.Once
 }
 
 var _ PluginManager = &pluginManager{}
 
 func (pm *pluginManager) Run(ctx context.Context, sourcesReady config.SourcesReady, stopCh <-chan struct{}) {
-	defer runtime.HandleCrashWithContext(ctx)
+	pm.runOnce.Do(func() {
+		// Reopen the channel since it was created closed.
+		pm.stoppedMu.Lock()
+		pm.stopped = make(chan struct{})
+		pm.stoppedMu.Unlock()
 
-	logger := klog.FromContext(ctx)
+		defer close(pm.stopped)
+		defer runtime.HandleCrashWithContext(ctx)
 
-	if err := pm.desiredStateOfWorldPopulator.Start(ctx, stopCh); err != nil {
-		logger.Error(err, "The desired_state_of_world populator (plugin watcher) starts failed!")
-		return
-	}
+		// Check if a shutdown was requested before manager initialization.
+		// This prevents the filesystem/watcher setup from immediate Kubelet
+		// shutdowns either production or in the test scope.
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
 
-	logger.V(2).Info("The desired_state_of_world populator (plugin watcher) starts")
+		logger := klog.FromContext(ctx)
 
-	logger.Info("Starting Kubelet Plugin Manager")
-	go pm.reconciler.Run(stopCh)
+		if err := pm.desiredStateOfWorldPopulator.Start(ctx, stopCh); err != nil {
+			logger.Error(err, "The desired_state_of_world populator (plugin watcher) starts failed!")
+			return
+		}
 
-	metrics.Register(pm.actualStateOfWorld, pm.desiredStateOfWorld)
-	<-stopCh
-	logger.Info("Shutting down Kubelet Plugin Manager")
+		logger.V(2).Info("The desired_state_of_world populator (plugin watcher) starts")
+
+		logger.Info("Starting Kubelet Plugin Manager")
+		go pm.reconciler.Run(stopCh)
+
+		metrics.Register(pm.actualStateOfWorld, pm.desiredStateOfWorld)
+		<-stopCh
+		logger.Info("Shutting down Kubelet Plugin Manager")
+
+		// Wait for both reconciler and plugin watcher to stop
+		<-pm.reconciler.Stopped()
+		<-pm.desiredStateOfWorldPopulator.Stopped()
+	})
 }
 
 func (pm *pluginManager) AddHandler(pluginType string, handler cache.PluginHandler) {
 	pm.reconciler.AddHandler(pluginType, handler)
+}
+
+// Stopped returns a channel that is closed once Run() has fully exited.
+// If Run() was never called, the returned channel is already closed.
+func (pm *pluginManager) Stopped() <-chan struct{} {
+	pm.stoppedMu.RLock()
+	defer pm.stoppedMu.RUnlock()
+	return pm.stopped
 }

--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/fsnotify/fsnotify"
 	"k8s.io/klog/v2"
@@ -36,6 +37,11 @@ type Watcher struct {
 	fs                  utilfs.Filesystem
 	fsWatcher           *fsnotify.Watcher
 	desiredStateOfWorld cache.DesiredStateOfWorld
+	stopped             chan struct{}
+
+	// startOnce ensures Start() logic executes only once
+	startOnce sync.Once
+	startErr  error
 }
 
 // NewWatcher provides a new watcher for socket registration
@@ -44,58 +50,74 @@ func NewWatcher(sockDir string, desiredStateOfWorld cache.DesiredStateOfWorld) *
 		path:                sockDir,
 		fs:                  &utilfs.DefaultFs{},
 		desiredStateOfWorld: desiredStateOfWorld,
+		stopped:             make(chan struct{}),
 	}
 }
 
-// Start watches for the creation and deletion of plugin sockets at the path
+// Start watches for the creation and deletion of plugin sockets at the path.
+// It is safe to call Start() multiple times; only the first call will have effect.
 func (w *Watcher) Start(ctx context.Context, stopCh <-chan struct{}) error {
-	logger := klog.FromContext(ctx)
-	logger.V(2).Info("Plugin Watcher Start", "path", w.path)
+	var err error
+	w.startOnce.Do(func() {
+		logger := klog.FromContext(ctx)
+		logger.V(2).Info("Plugin Watcher Start", "path", w.path)
 
-	// Creating the directory to be watched if it doesn't exist yet,
-	// and walks through the directory to discover the existing plugins.
-	if err := w.init(ctx); err != nil {
-		return err
-	}
-
-	fsWatcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return fmt.Errorf("failed to start plugin fsWatcher, err: %v", err)
-	}
-	w.fsWatcher = fsWatcher
-
-	// Traverse plugin dir and add filesystem watchers before starting the plugin processing goroutine.
-	if err := w.traversePluginDir(ctx, w.path); err != nil {
-		logger.Error(err, "Failed to traverse plugin socket path", "path", w.path)
-	}
-
-	go func(fsWatcher *fsnotify.Watcher) {
-		for {
-			select {
-			case event := <-fsWatcher.Events:
-				//TODO: Handle errors by taking corrective measures
-				if event.Has(fsnotify.Create) {
-					err := w.handleCreateEvent(ctx, event)
-					if err != nil {
-						logger.Error(err, "Error when handling create event", "event", event)
-					}
-				} else if event.Has(fsnotify.Remove) {
-					w.handleDeleteEvent(ctx, event)
-				}
-				continue
-			case err := <-fsWatcher.Errors:
-				if err != nil {
-					logger.Error(err, "FsWatcher received error")
-				}
-				continue
-			case <-stopCh:
-				w.fsWatcher.Close()
-				return
-			}
+		// Creating the directory to be watched if it doesn't exist yet,
+		// and walks through the directory to discover the existing plugins.
+		if err = w.init(ctx); err != nil {
+			w.startErr = err
+			close(w.stopped)
+			return
 		}
-	}(fsWatcher)
 
-	return nil
+		w.fsWatcher, err = fsnotify.NewWatcher()
+		if err != nil {
+			w.startErr = fmt.Errorf("failed to start plugin fsWatcher, err: %w", err)
+			close(w.stopped)
+			return
+		}
+
+		// Traverse plugin dir and add filesystem watchers before starting the plugin processing goroutine.
+		if err := w.traversePluginDir(ctx, w.path); err != nil {
+			logger.Error(err, "Failed to traverse plugin socket path", "path", w.path)
+		}
+
+		go func(fsWatcher *fsnotify.Watcher) {
+			defer close(w.stopped)
+			for {
+				select {
+				case event := <-fsWatcher.Events:
+					//TODO: Handle errors by taking corrective measures
+					if event.Has(fsnotify.Create) {
+						err := w.handleCreateEvent(ctx, event)
+						if err != nil {
+							logger.Error(err, "Error when handling create event", "event", event)
+						}
+					} else if event.Has(fsnotify.Remove) {
+						w.handleDeleteEvent(ctx, event)
+					}
+					continue
+				case err := <-fsWatcher.Errors:
+					if err != nil {
+						logger.Error(err, "FsWatcher received error")
+					}
+					continue
+				case <-stopCh:
+					if err := w.fsWatcher.Close(); err != nil {
+						logger.Error(err, "Error closing fsWatcher")
+					}
+					return
+				}
+			}
+		}(w.fsWatcher)
+	})
+	// Return the initialization stored in w.startErr. Subsequent calls will return the error from the initial invocation.
+	return w.startErr
+}
+
+// Stopped returns a channel that is closed when the watcher's goroutine has exited
+func (w *Watcher) Stopped() <-chan struct{} {
+	return w.stopped
 }
 
 func (w *Watcher) init(ctx context.Context) error {

--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher_test.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher_test.go
@@ -260,6 +260,99 @@ func TestPluginRegistrationAtKubeletStart(t *testing.T) {
 	}
 }
 
+// TestWatcherStoppedOnInitError verifies that Stopped() doesn't block when init fails
+func TestWatcherStoppedOnInitError(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	// Create a temporary directory and a file within it.
+	dummyFile := filepath.Join(t.TempDir(), "dummy")
+	err := os.WriteFile(dummyFile, []byte(""), 0644)
+	require.NoError(t, err)
+
+	// Attempt to access the subpath within the path of the file.
+	socketDir := filepath.Join(dummyFile, "test-dir")
+	dsw := cache.NewDesiredStateOfWorld()
+
+	w := NewWatcher(socketDir, dsw)
+	err = w.Start(tCtx, wait.NeverStop)
+
+	// Start should return an error as the directory doesn't exist
+	require.Error(t, err)
+
+	// Stopped() should not block as the channel is closed
+	select {
+	case <-w.Stopped():
+		// Success - channel is closed
+	case <-time.After(1 * time.Second):
+		t.Fatal("Stopped() blocked after Start() failed - stopped channel was not closed")
+	}
+}
+
+// TestWatcherMultipleStartCalls to confirm that the plugin is initialized exactly once
+func TestWatcherMultipleStartCalls(t *testing.T) {
+	socketDir := t.TempDir()
+
+	tCtx := ktesting.Init(t)
+	dsw := cache.NewDesiredStateOfWorld()
+
+	w := NewWatcher(socketDir, dsw)
+
+	stopCh := make(chan struct{})
+
+	// First Start() should succeed
+	err := w.Start(tCtx, stopCh)
+	require.NoError(t, err)
+
+	// Second Start should be no-op (sync.Once guard)
+	err = w.Start(tCtx, stopCh)
+	require.NoError(t, err)
+
+	close(stopCh)
+
+	// Verify Stopped() channel closes properly
+	select {
+	case <-w.Stopped():
+		// Success - watcher stopped cleanly
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watcher did not stop within timeout")
+	}
+}
+
+// TestWatcherDoesNotRecreateDirectoryAfterStop verifies that the watcher does not recreate
+// the plugin directory after it has been stopped and the directory has been removed.
+func TestWatcherDoesNotRecreateDirectoryAfterStop(t *testing.T) {
+	socketDir := t.TempDir()
+
+	dsw := cache.NewDesiredStateOfWorld()
+	stopCh := make(chan struct{})
+
+	w := newWatcher(t, socketDir, dsw, stopCh)
+
+	// Verify directory exists after start
+	_, err := os.Stat(socketDir)
+	require.NoError(t, err, "Plugin directory should exist after watcher starts")
+
+	// Stop the watcher by closing stopCh
+	close(stopCh)
+
+	// Remove directory immediately after signaling stop to confirm
+	// that it's not re-created by the pluginWatcher during its teardown.
+	err = os.RemoveAll(socketDir)
+	require.NoError(t, err, "Should be able to remove plugin directory")
+
+	// Wait for watcher to fully stop
+	select {
+	case <-w.Stopped():
+		// Watcher has stopped
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watcher did not stop within timeout")
+	}
+
+	// Verify socket directory does not exist. Watcher should not recreate it after a successful stop.
+	_, err = os.Stat(socketDir)
+	require.True(t, os.IsNotExist(err), "Plugin directory should not be recreated after watcher stops and directory is removed")
+}
+
 func newWatcher(t *testing.T, socketDir string, desiredStateOfWorldCache cache.DesiredStateOfWorld, stopCh <-chan struct{}) *Watcher {
 	tCtx := ktesting.Init(t)
 	w := NewWatcher(socketDir, desiredStateOfWorldCache)

--- a/pkg/kubelet/pluginmanager/reconciler/reconciler.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler.go
@@ -44,6 +44,9 @@ type Reconciler interface {
 	// AddHandler adds the given plugin handler for a specific plugin type,
 	// which will be added to the actual state of world cache.
 	AddHandler(pluginType string, pluginHandler cache.PluginHandler)
+
+	// Stopped returns a channel that is closed when the reconciler has stopped.
+	Stopped() <-chan struct{}
 }
 
 // NewReconciler returns a new instance of Reconciler.
@@ -69,6 +72,7 @@ func NewReconciler(
 		desiredStateOfWorld: desiredStateOfWorld,
 		actualStateOfWorld:  actualStateOfWorld,
 		handlers:            make(map[string]cache.PluginHandler),
+		stopped:             make(chan struct{}),
 	}
 }
 
@@ -78,21 +82,41 @@ type reconciler struct {
 	desiredStateOfWorld cache.DesiredStateOfWorld
 	actualStateOfWorld  cache.ActualStateOfWorld
 	handlers            map[string]cache.PluginHandler
+	// stopped is closed when Run() exits. Unlike the parent PluginManager,
+	// this channel is not pre-closed because the reconciler is always started
+	// via Run() in normal operation which is managed by the parent.
+	// The parent PluginManager handles the pre-closed pattern to
+	// prevent deadlocks if its Run() is never called.
+	stopped chan struct{}
+	// runOnce ensures Run() logic executes only once
+	runOnce sync.Once
 	sync.RWMutex
 }
 
 var _ Reconciler = &reconciler{}
 
 func (rc *reconciler) Run(stopCh <-chan struct{}) {
-	// Use context.TODO() because we currently do not have a proper context to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
-	ctx := context.TODO()
+	rc.runOnce.Do(func() {
+		defer close(rc.stopped)
+		// Use context.TODO() because we currently do not have a proper context to pass in.
+		// Replace this with an appropriate context when refactoring this function to accept a context parameter.
+		ctx := context.TODO()
 
-	wait.Until(func() {
-		rc.reconcile(ctx)
-	},
-		rc.loopSleepDuration,
-		stopCh)
+		wait.Until(func() {
+			rc.reconcile(ctx)
+		},
+			rc.loopSleepDuration,
+			stopCh)
+	})
+}
+
+// Stopped returns a channel that is closed when the reconciler has stopped.
+// The caller must ensure that Run() is executed before waiting on this channel.
+// The lifecycle of the reconciler is managed by the parent PluginManager,
+// which guarantees this execution order. Calling Stopped() before Run()
+// will block forever.
+func (rc *reconciler) Stopped() <-chan struct{} {
+	return rc.stopped
 }
 
 func (rc *reconciler) AddHandler(pluginType string, pluginHandler cache.PluginHandler) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR handles the shutdown of the PluginManager once the tests complete. During stress testing, file descriptors are exhausted because the plugin manager's `fsnotify` watcher goroutines are not properly released after tests finish.
```
For eg: 
plugin_manager.go:115: E0303 01:33:04.297430] The desired_state_of_world populator (plugin watcher) starts failed! err="failed to start plugin fsWatcher, err: too many open files"
```

There is also a case where the PluginManager recreates the required directory during test cleanup, causing the tests to flake while performing a directory delete operation. This proper shutdown sequence prevents both issues.

#### Which issue(s) this PR is related to:
#136972

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The current implementation signalls the `stopCh`  to stop the PluginManager as a reliable fix. As discussed in the issue, I will be looking into migrating to cancellable contexts in a follow-up to move away  from using`stopCh`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
