### PR TITLE
Replace PLEG watch conditions

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -70,8 +70,8 @@ type RuntimeHelper interface {
 	// UnprepareDynamicResources unprepares resources for a a pod.
 	UnprepareDynamicResources(ctx context.Context, pod *v1.Pod) error
 
-	// SetPodWatchCondition flags a pod to be inspected until the condition is met.
-	SetPodWatchCondition(types.UID, string, func(*PodStatus) bool)
+	// RequestPodReinspect flags a pod to be inspected on the next relist.
+	RequestPodReinspect(types.UID)
 
 	// PodCPUAndMemoryStats reads the latest CPU & memory usage stats.
 	PodCPUAndMemoryStats(context.Context, *v1.Pod, *PodStatus) (*statsapi.PodStats, error)

--- a/pkg/kubelet/container/testing/fake_runtime_helper.go
+++ b/pkg/kubelet/container/testing/fake_runtime_helper.go
@@ -118,7 +118,7 @@ func (f *FakeRuntimeHelper) UnprepareDynamicResources(ctx context.Context, pod *
 	return nil
 }
 
-func (f *FakeRuntimeHelper) SetPodWatchCondition(_ kubetypes.UID, _ string, _ func(*kubecontainer.PodStatus) bool) {
+func (f *FakeRuntimeHelper) RequestPodReinspect(_ kubetypes.UID) {
 	// Not implemented.
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3376,6 +3376,6 @@ func (kl *Kubelet) fastStaticPodsRegistration(ctx context.Context) {
 	}
 }
 
-func (kl *Kubelet) SetPodWatchCondition(podUID types.UID, conditionKey string, condition pleg.WatchCondition) {
-	kl.pleg.SetPodWatchCondition(podUID, conditionKey, condition)
+func (kl *Kubelet) RequestPodReinspect(podUID types.UID) {
+	kl.pleg.RequestReinspect(podUID)
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -951,7 +951,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 
 	// Always update the pod status once. Even if there was a resize error, the resize may have been
 	// partially actuated.
-	defer m.runtimeHelper.SetPodWatchCondition(pod.UID, "doPodResizeAction", func(*kubecontainer.PodStatus) bool { return true })
+	defer m.runtimeHelper.RequestPodReinspect(pod.UID)
 
 	if len(podContainerChanges.ContainersToUpdate[v1.ResourceMemory]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
 		if podResources.Memory == nil {

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -416,6 +416,6 @@ func (e *EventedPLEG) updateLatencyMetric(event *runtimeapi.ContainerEventRespon
 	metrics.EventedPLEGConnLatency.Observe(duration.Seconds())
 }
 
-func (e *EventedPLEG) SetPodWatchCondition(podUID types.UID, conditionKey string, condition WatchCondition) {
-	e.genericPleg.SetPodWatchCondition(podUID, conditionKey, condition)
+func (e *EventedPLEG) RequestReinspect(podUID types.UID) {
+	e.genericPleg.RequestReinspect(podUID)
 }

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -65,7 +65,7 @@ type GenericPLEG struct {
 	clock clock.Clock
 	// Pods that failed to have their status retrieved during a relist. These pods will be
 	// retried during the next relisting.
-	podsToReinspect map[types.UID]*kubecontainer.Pod
+	podsToReinspect sync.Map // map: podUID -> empty
 	// Stop the Generic PLEG by closing the channel.
 	stopCh chan struct{}
 	// Locks the relisting of the Generic PLEG
@@ -78,17 +78,10 @@ type GenericPLEG struct {
 	relistDuration *RelistDuration
 	// logger is used for contextual logging
 	logger klog.Logger
-	// watchConditions tracks pod watch conditions, guarded by watchConditionsLock
-	// watchConditions is a map of pod UID -> condition key -> condition
-	watchConditions     map[types.UID]map[string]versionedWatchCondition
-	watchConditionsLock sync.Mutex
 }
 
-type versionedWatchCondition struct {
-	key       string
-	condition WatchCondition
-	version   uint32
-}
+// Empty placeholder value for podsToReinspect (shared pointer reduces allocations).
+var empty = &struct{}{}
 
 // plegContainerState has a one-to-one mapping to the
 // kubecontainer.State except for the non-existent state. This state
@@ -133,14 +126,13 @@ func NewGenericPLEG(logger klog.Logger, runtime kubecontainer.Runtime, eventChan
 		panic("cache cannot be nil")
 	}
 	return &GenericPLEG{
-		logger:          logger,
-		relistDuration:  relistDuration,
-		runtime:         runtime,
-		eventChannel:    eventChannel,
-		podRecords:      make(podRecords),
-		cache:           cache,
-		clock:           clock,
-		watchConditions: make(map[types.UID]map[string]versionedWatchCondition),
+		logger:         logger,
+		relistDuration: relistDuration,
+		runtime:        runtime,
+		eventChannel:   eventChannel,
+		podRecords:     make(podRecords),
+		cache:          cache,
+		clock:          clock,
 	}
 }
 
@@ -261,9 +253,6 @@ func (g *GenericPLEG) Relist() {
 	// update running pod and container count
 	updateRunningPodAndContainerMetrics(pods)
 	g.podRecords.setCurrent(pods)
-	g.cleanupOrphanedWatchConditions()
-
-	needsReinspection := make(map[types.UID]*kubecontainer.Pod)
 
 	for pid := range g.podRecords {
 		// Compare the old and the current pods, and generate events.
@@ -277,10 +266,9 @@ func (g *GenericPLEG) Relist() {
 			events = append(events, containerEvents...)
 		}
 
-		watchConditions := g.getPodWatchConditions(pid)
-		_, reinspect := g.podsToReinspect[pid]
+		_, reinspect := g.podsToReinspect.LoadAndDelete(pid)
 
-		if len(events) == 0 && len(watchConditions) == 0 && !reinspect {
+		if len(events) == 0 && !reinspect {
 			// Nothing else needed for this pod.
 			continue
 		}
@@ -300,7 +288,7 @@ func (g *GenericPLEG) Relist() {
 			g.logger.V(4).Info("PLEG: Ignoring events for pod", "pod", klog.KRef(pod.Namespace, pod.Name), "err", err)
 
 			// make sure we try to reinspect the pod during the next relisting
-			needsReinspection[pid] = pod
+			g.podsToReinspect.Store(pid, empty)
 
 			continue
 		} else if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
@@ -309,19 +297,9 @@ func (g *GenericPLEG) Relist() {
 			}
 		}
 
-		var completedConditions []versionedWatchCondition
-		for _, condition := range watchConditions {
-			if condition.condition(status) {
-				// condition was met: add it to the list of completed conditions.
-				completedConditions = append(completedConditions, condition)
-			}
-		}
-		if len(completedConditions) > 0 {
-			g.completeWatchConditions(pid, completedConditions)
-			// If at least 1 condition completed, emit a ConditionMet event to trigger a pod sync.
-			// We only emit 1 event even if multiple conditions are met, since SyncPod reevaluates
-			// all containers in the pod with the latest status.
-			events = append(events, &PodLifecycleEvent{ID: pid, Type: ConditionMet})
+		if len(events) == 0 {
+			// Make sure we always trigger a PodSync after a full reinspection.
+			events = append(events, &PodLifecycleEvent{ID: pid, Type: PodSync})
 		}
 
 		// Update the internal storage and send out the events.
@@ -363,9 +341,6 @@ func (g *GenericPLEG) Relist() {
 	// Update the cache timestamp.  This needs to happen *after*
 	// all pods have been properly updated in the cache.
 	g.cache.UpdateTime(timestamp)
-
-	// make sure we retain the list of pods that need reinspecting the next time relist is called
-	g.podsToReinspect = needsReinspection
 }
 
 func getContainersFromPods(pods ...*kubecontainer.Pod) []*kubecontainer.Container {
@@ -484,87 +459,8 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 	return status, g.cache.Set(pod.ID, status, err, timestamp), err
 }
 
-// SetPodWatchCondition flags the pod for reinspection on every Relist iteration until the watch
-// condition is met. The condition is keyed so it can be updated before the condition
-// is met.
-func (g *GenericPLEG) SetPodWatchCondition(podUID types.UID, conditionKey string, condition WatchCondition) {
-	g.watchConditionsLock.Lock()
-	defer g.watchConditionsLock.Unlock()
-
-	conditions, ok := g.watchConditions[podUID]
-	if !ok {
-		conditions = make(map[string]versionedWatchCondition)
-	}
-
-	versioned, found := conditions[conditionKey]
-	if found {
-		// Watch condition was already set. Increment its version & update the condition function.
-		versioned.version++
-		versioned.condition = condition
-		conditions[conditionKey] = versioned
-	} else {
-		conditions[conditionKey] = versionedWatchCondition{
-			key:       conditionKey,
-			condition: condition,
-		}
-	}
-
-	g.watchConditions[podUID] = conditions
-}
-
-// getPodWatchConditions returns a list of the active watch conditions for the pod.
-func (g *GenericPLEG) getPodWatchConditions(podUID types.UID) []versionedWatchCondition {
-	g.watchConditionsLock.Lock()
-	defer g.watchConditionsLock.Unlock()
-
-	podConditions, ok := g.watchConditions[podUID]
-	if !ok {
-		return nil
-	}
-
-	// Flatten the map into a list of conditions. This also serves to create a copy, so the lock can
-	// be released.
-	conditions := make([]versionedWatchCondition, 0, len(podConditions))
-	for _, condition := range podConditions {
-		conditions = append(conditions, condition)
-	}
-	return conditions
-}
-
-// completeWatchConditions removes the completed watch conditions, unless they have been updated
-// since the condition was checked.
-func (g *GenericPLEG) completeWatchConditions(podUID types.UID, completedConditions []versionedWatchCondition) {
-	g.watchConditionsLock.Lock()
-	defer g.watchConditionsLock.Unlock()
-
-	conditions, ok := g.watchConditions[podUID]
-	if !ok {
-		// Pod was deleted, nothing to do.
-		return
-	}
-
-	for _, completed := range completedConditions {
-		condition := conditions[completed.key]
-		// Only clear the condition if it has not been updated.
-		if condition.version == completed.version {
-			delete(conditions, completed.key)
-		}
-	}
-	g.watchConditions[podUID] = conditions
-}
-
-// cleanupOrphanedWatchConditions purges the watchConditions map of any pods that were removed from
-// the pod records. Events are not emitted for removed pods.
-func (g *GenericPLEG) cleanupOrphanedWatchConditions() {
-	g.watchConditionsLock.Lock()
-	defer g.watchConditionsLock.Unlock()
-
-	for podUID := range g.watchConditions {
-		if g.podRecords.getCurrent(podUID) == nil {
-			// Pod was deleted, remove it from the watch conditions.
-			delete(g.watchConditions, podUID)
-		}
-	}
+func (g *GenericPLEG) RequestReinspect(podUID types.UID) {
+	g.podsToReinspect.Store(podUID, empty)
 }
 
 func getContainerState(pod *kubecontainer.Pod, cid *kubecontainer.ContainerID) plegContainerState {

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -456,75 +455,172 @@ func TestHealthy(t *testing.T) {
 	assert.False(t, ok, "pleg should be unhealthy")
 }
 
-func TestRelistWithReinspection(t *testing.T) {
+func TestReinspect(t *testing.T) {
 	ctx := context.Background()
-	runtimeMock := containertest.NewMockRuntime(t)
 
-	pleg := newTestGenericPLEGWithRuntimeMock(runtimeMock)
-	ch := pleg.Watch()
-
-	infraContainer := createTestContainer("infra", kubecontainer.ContainerStateRunning)
-
-	podID := types.UID("test-pod")
-	pods := []*kubecontainer.Pod{{
-		ID:         podID,
-		Containers: []*kubecontainer.Container{infraContainer},
-	}}
-	runtimeMock.EXPECT().GetPods(ctx, true).Return(pods, nil).Times(1)
-
-	goodStatus := &kubecontainer.PodStatus{
-		ID:                podID,
-		ContainerStatuses: []*kubecontainer.Status{{ID: infraContainer.ID, State: infraContainer.State}},
+	tests := []struct {
+		name              string
+		requestReinspect  bool
+		alreadyReinspect  bool
+		updateCacheError  error
+		podDeleted        bool
+		expectUpdateCache bool
+		expectReinspect   bool // value in podsToReinspect AFTER relist
+		expectEvent       bool
+		expectStatus      bool
+	}{
+		{
+			name:              "RequestReinspect a pod not previously listed, success",
+			requestReinspect:  true,
+			alreadyReinspect:  false,
+			updateCacheError:  nil,
+			expectUpdateCache: true,
+			expectReinspect:   false,
+			expectEvent:       true,
+			expectStatus:      true,
+		},
+		{
+			name:              "RequestReinspect a pod not previously listed, failure",
+			requestReinspect:  true,
+			alreadyReinspect:  false,
+			updateCacheError:  errors.New("fail"),
+			expectUpdateCache: true,
+			expectReinspect:   true,
+			expectEvent:       false,
+			expectStatus:      true,
+		},
+		{
+			name:              "RequestReinspect of a pod already listed for reinspection, success",
+			requestReinspect:  true,
+			alreadyReinspect:  true,
+			updateCacheError:  nil,
+			expectUpdateCache: true,
+			expectReinspect:   false,
+			expectEvent:       true,
+			expectStatus:      true,
+		},
+		{
+			name:              "RequestReinspect of a pod already listed for reinspection, failure",
+			requestReinspect:  true,
+			alreadyReinspect:  true,
+			updateCacheError:  errors.New("fail"),
+			expectUpdateCache: true,
+			expectReinspect:   true,
+			expectEvent:       false,
+			expectStatus:      true,
+		},
+		{
+			name:              "Don't request reinspection",
+			requestReinspect:  false,
+			alreadyReinspect:  false,
+			updateCacheError:  nil,
+			expectUpdateCache: false,
+			expectReinspect:   false,
+			expectEvent:       false,
+			expectStatus:      false,
+		},
+		{
+			name:              "Don't request reinspection, but already listed for reinspection, success",
+			requestReinspect:  false,
+			alreadyReinspect:  true,
+			updateCacheError:  nil,
+			expectUpdateCache: true,
+			expectReinspect:   false,
+			expectEvent:       true,
+			expectStatus:      true,
+		},
+		{
+			name:              "Don't request reinspection, but already listed for reinspection, failure",
+			requestReinspect:  false,
+			alreadyReinspect:  true,
+			updateCacheError:  errors.New("fail"),
+			expectUpdateCache: true,
+			expectReinspect:   true,
+			expectEvent:       false,
+			expectStatus:      true,
+		},
+		{
+			name:              "Pod deleted, should clear reinspect",
+			requestReinspect:  false,
+			alreadyReinspect:  true,
+			podDeleted:        true,
+			updateCacheError:  nil,
+			expectUpdateCache: true,
+			expectReinspect:   false,
+			expectEvent:       true,
+			expectStatus:      false, // Deleted from cache
+		},
 	}
-	runtimeMock.EXPECT().GetPodStatus(ctx, podID, "", "").Return(goodStatus, nil).Times(1)
 
-	goodEvent := &PodLifecycleEvent{ID: podID, Type: ContainerStarted, Data: infraContainer.ID.ID}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runtimeMock := containertest.NewMockRuntime(t)
+			pleg := newTestGenericPLEGWithRuntimeMock(runtimeMock)
+			ch := pleg.Watch()
 
-	// listing 1 - everything ok, infra container set up for pod
-	pleg.Relist()
-	actualEvents := getEventsFromChannel(ch)
-	actualStatus, actualErr := pleg.cache.Get(podID)
-	assert.Equal(t, goodStatus, actualStatus)
-	assert.NoError(t, actualErr)
-	assert.Exactly(t, []*PodLifecycleEvent{goodEvent}, actualEvents)
+			podID := types.UID("test-pod")
+			if tc.alreadyReinspect {
+				pleg.RequestReinspect(podID)
+			}
 
-	// listing 2 - pretend runtime was in the middle of creating the non-infra container for the pod
-	// and return an error during inspection
-	transientContainer := createTestContainer("transient", kubecontainer.ContainerStateUnknown)
-	podsWithTransientContainer := []*kubecontainer.Pod{{
-		ID:         podID,
-		Containers: []*kubecontainer.Container{infraContainer, transientContainer},
-	}}
-	runtimeMock.EXPECT().GetPods(ctx, true).Return(podsWithTransientContainer, nil).Times(1)
+			if tc.requestReinspect {
+				pleg.RequestReinspect(podID)
+			}
 
-	badStatus := &kubecontainer.PodStatus{
-		ID:                podID,
-		ContainerStatuses: []*kubecontainer.Status{},
+			pod := &kubecontainer.Pod{ID: podID, Name: "name", Namespace: "ns"}
+			// Populate podRecords.
+			pleg.podRecords[podID] = &podRecord{old: pod, current: pod}
+
+			if tc.podDeleted {
+				runtimeMock.EXPECT().GetPods(ctx, true).Return([]*kubecontainer.Pod{}, nil)
+			} else {
+				runtimeMock.EXPECT().GetPods(ctx, true).Return([]*kubecontainer.Pod{pod}, nil)
+			}
+
+			var expectedStatus *kubecontainer.PodStatus
+			if tc.updateCacheError == nil {
+				expectedStatus = &kubecontainer.PodStatus{ID: podID, TimeStamp: time.Now()}
+			}
+			if tc.expectUpdateCache {
+				if tc.podDeleted {
+					// updateCache(ctx, nil, podID) will be called, it doesn't call GetPodStatus
+				} else {
+					runtimeMock.EXPECT().GetPodStatus(ctx, podID, "name", "ns").Return(expectedStatus, tc.updateCacheError)
+				}
+			}
+
+			pleg.Relist()
+
+			_, actualReinspect := pleg.podsToReinspect.Load(podID)
+			assert.Equal(t, tc.expectReinspect, actualReinspect)
+
+			actualEvents := getEventsFromChannel(ch)
+			if tc.expectEvent {
+				assert.NotEmpty(t, actualEvents, "Expected events to be emitted")
+				// We expect at least a PodSync event since pod state didn't change in test setup
+				hasPodSync := false
+				for _, e := range actualEvents {
+					if e.ID == podID && e.Type == PodSync {
+						hasPodSync = true
+						break
+					}
+				}
+				assert.True(t, hasPodSync, "Expected PodSync event for pod")
+			} else {
+				assert.Empty(t, actualEvents, "Expected no events to be emitted")
+			}
+
+			if tc.expectStatus {
+				actualStatus, actualErr := pleg.cache.Get(podID)
+				assert.Equal(t, expectedStatus, actualStatus)
+				assert.Equal(t, tc.updateCacheError, actualErr)
+			} else if tc.podDeleted {
+				actualStatus, _ := pleg.cache.Get(podID)
+				// If deleted, Get returns an empty status with the ID
+				assert.Equal(t, &kubecontainer.PodStatus{ID: podID}, actualStatus)
+			}
+		})
 	}
-	runtimeMock.EXPECT().GetPodStatus(ctx, podID, "", "").Return(badStatus, errors.New("inspection error")).Times(1)
-
-	pleg.Relist()
-	actualEvents = getEventsFromChannel(ch)
-	actualStatus, actualErr = pleg.cache.Get(podID)
-	assert.Equal(t, badStatus, actualStatus)
-	assert.Equal(t, errors.New("inspection error"), actualErr)
-	assert.Exactly(t, []*PodLifecycleEvent{}, actualEvents)
-
-	// listing 3 - pretend the transient container has now disappeared, leaving just the infra
-	// container. Make sure the pod is reinspected for its status and the cache is updated.
-	runtimeMock.EXPECT().GetPods(ctx, true).Return(pods, nil).Times(1)
-	runtimeMock.EXPECT().GetPodStatus(ctx, podID, "", "").Return(goodStatus, nil).Times(1)
-
-	pleg.Relist()
-	actualEvents = getEventsFromChannel(ch)
-	actualStatus, actualErr = pleg.cache.Get(podID)
-	assert.Equal(t, goodStatus, actualStatus)
-	assert.NoError(t, actualErr)
-	// no events are expected because relist #1 set the old pod record which has the infra container
-	// running. relist #2 had the inspection error and therefore didn't modify either old or new.
-	// relist #3 forced the reinspection of the pod to retrieve its status, but because the list of
-	// containers was the same as relist #1, nothing "changed", so there are no new events.
-	assert.Exactly(t, []*PodLifecycleEvent{}, actualEvents)
 }
 
 // Test detecting sandbox state changes.
@@ -735,263 +831,6 @@ kubelet_running_pods 2
 			if err := testutil.GatherAndCompare(metrics.GetGather(), strings.NewReader(tc.wants), tc.metricsName); err != nil {
 				t.Fatal(err)
 			}
-		})
-	}
-}
-
-func TestWatchConditions(t *testing.T) {
-	pods := []*kubecontainer.Pod{{
-		Name: "running-pod",
-		ID:   "running",
-		Sandboxes: []*kubecontainer.Container{
-			createTestContainer("s", kubecontainer.ContainerStateRunning),
-		},
-		Containers: []*kubecontainer.Container{
-			createTestContainer("c", kubecontainer.ContainerStateRunning),
-		},
-	}, {
-		Name: "running-pod-2",
-		ID:   "running-2",
-		Sandboxes: []*kubecontainer.Container{
-			createTestContainer("s", kubecontainer.ContainerStateRunning),
-		},
-		Containers: []*kubecontainer.Container{
-			createTestContainer("c-exited", kubecontainer.ContainerStateExited),
-			createTestContainer("c-running", kubecontainer.ContainerStateRunning),
-		},
-	}, {
-		Name: "terminating-pod",
-		ID:   "terminating",
-		Sandboxes: []*kubecontainer.Container{
-			createTestContainer("s", kubecontainer.ContainerStateExited),
-		},
-	}, {
-		Name: "reinspect-pod",
-		ID:   "reinspect",
-		Sandboxes: []*kubecontainer.Container{
-			createTestContainer("s", kubecontainer.ContainerStateRunning),
-		},
-	}}
-	initialPods := pods
-	initialPods = append(initialPods, &kubecontainer.Pod{
-		Name: "terminated-pod",
-		ID:   "terminated",
-		Sandboxes: []*kubecontainer.Container{
-			createTestContainer("s", kubecontainer.ContainerStateExited),
-		},
-	})
-
-	alwaysComplete := func(_ *kubecontainer.PodStatus) bool {
-		return true
-	}
-	neverComplete := func(_ *kubecontainer.PodStatus) bool {
-		return false
-	}
-
-	var pleg *GenericPLEG
-	var updatingCond WatchCondition
-	// updatingCond always completes, but updates the condition first.
-	updatingCond = func(_ *kubecontainer.PodStatus) bool {
-		pleg.SetPodWatchCondition("running", "updating", updatingCond)
-		return true
-	}
-
-	// resettingCond decrements the version before it completes.
-	var resettingCond = func(_ *kubecontainer.PodStatus) bool {
-		versioned := pleg.watchConditions["running"]["resetting"]
-		versioned.version = 0
-		pleg.watchConditions["running"]["resetting"] = versioned
-		return true
-	}
-
-	// makeContainerCond returns a RunningContainerWatchCondition that asserts the expected container status
-	makeContainerCond := func(expectedContainerName string, complete bool) WatchCondition {
-		return RunningContainerWatchCondition(expectedContainerName, func(status *kubecontainer.Status) bool {
-			if status.Name != expectedContainerName {
-				panic(fmt.Sprintf("unexpected container name: got %q, want %q", status.Name, expectedContainerName))
-			}
-			return complete
-		})
-	}
-
-	testCases := []struct {
-		name                    string
-		podUID                  types.UID
-		watchConditions         map[string]WatchCondition
-		incrementInitialVersion bool                               // Whether to call SetPodWatchCondition multiple times to increment the version
-		expectEvaluated         bool                               // Whether the watch conditions should be evaluated
-		expectRemoved           bool                               // Whether podUID should be present in the watch conditions map
-		expectWatchConditions   map[string]versionedWatchCondition // The expected watch conditions for the podUID (only key & version checked)
-	}{{
-		name:   "no watch conditions",
-		podUID: "running",
-	}, {
-		name:   "running pod with conditions",
-		podUID: "running",
-		watchConditions: map[string]WatchCondition{
-			"completing": alwaysComplete,
-			"watching":   neverComplete,
-			"updating":   updatingCond,
-		},
-		expectEvaluated: true,
-		expectWatchConditions: map[string]versionedWatchCondition{
-			"watching": {version: 0},
-			"updating": {version: 1},
-		},
-	}, {
-		name:                    "conditions with incremented versions",
-		podUID:                  "running",
-		incrementInitialVersion: true,
-		watchConditions: map[string]WatchCondition{
-			"completing": alwaysComplete,
-			"watching":   neverComplete,
-			"updating":   updatingCond,
-		},
-		expectEvaluated: true,
-		expectWatchConditions: map[string]versionedWatchCondition{
-			"watching": {version: 1},
-			"updating": {version: 2},
-		},
-	}, {
-		name:                    "completed watch condition with older version",
-		podUID:                  "running",
-		incrementInitialVersion: true,
-		watchConditions: map[string]WatchCondition{
-			"resetting": resettingCond,
-		},
-		expectEvaluated: true,
-		expectWatchConditions: map[string]versionedWatchCondition{
-			"resetting": {version: 0},
-		},
-	}, {
-		name:   "non-existent pod",
-		podUID: "non-existent",
-		watchConditions: map[string]WatchCondition{
-			"watching": neverComplete,
-		},
-		expectEvaluated: false,
-		expectRemoved:   true,
-	}, {
-		name:   "terminated pod",
-		podUID: "terminated",
-		watchConditions: map[string]WatchCondition{
-			"watching": neverComplete,
-		},
-		expectEvaluated: false,
-		expectRemoved:   true,
-	}, {
-		name:   "reinspecting pod",
-		podUID: "reinspect",
-		watchConditions: map[string]WatchCondition{
-			"watching": neverComplete,
-		},
-		expectEvaluated: true,
-		expectWatchConditions: map[string]versionedWatchCondition{
-			"watching": {version: 0},
-		},
-	}, {
-		name:   "single container conditions",
-		podUID: "running",
-		watchConditions: map[string]WatchCondition{
-			"completing": makeContainerCond("c", true),
-			"watching":   makeContainerCond("c", false),
-		},
-		expectEvaluated: true,
-		expectWatchConditions: map[string]versionedWatchCondition{
-			"watching": {version: 0},
-		},
-	}, {
-		name:   "multi-container conditions",
-		podUID: "running-2",
-		watchConditions: map[string]WatchCondition{
-			"completing:exited":  makeContainerCond("c-exited", true),
-			"watching:exited":    makeContainerCond("c-exited", false),
-			"completing:running": makeContainerCond("c-running", true),
-			"watching:running":   makeContainerCond("c-running", false),
-			"completing:dne":     makeContainerCond("c-dne", true),
-			"watching:dne":       makeContainerCond("c-dne", false),
-		},
-		expectEvaluated: true,
-		expectWatchConditions: map[string]versionedWatchCondition{
-			"watching:running": {version: 0},
-		},
-	}}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			runtimeMock := containertest.NewMockRuntime(t)
-			pleg = newTestGenericPLEGWithRuntimeMock(runtimeMock)
-
-			// Mock pod statuses
-			for _, pod := range initialPods {
-				podStatus := &kubecontainer.PodStatus{
-					ID:        pod.ID,
-					Name:      pod.Name,
-					Namespace: pod.Namespace,
-				}
-				for _, c := range pod.Containers {
-					podStatus.ContainerStatuses = append(podStatus.ContainerStatuses, &kubecontainer.Status{
-						ID:    c.ID,
-						Name:  c.Name,
-						State: c.State,
-					})
-				}
-				runtimeMock.EXPECT().
-					GetPodStatus(mock.Anything, pod.ID, pod.Name, pod.Namespace).
-					Return(podStatus, nil).Maybe()
-			}
-
-			// Setup initial pod records.
-			runtimeMock.EXPECT().GetPods(mock.Anything, true).Return(initialPods, nil).Once()
-			pleg.Relist()
-			pleg.podsToReinspect["reinspect"] = nil
-
-			// Remove "terminated" pod.
-			runtimeMock.EXPECT().GetPods(mock.Anything, true).Return(pods, nil).Once()
-
-			var evaluatedConditions []string
-			for key, condition := range test.watchConditions {
-				wrappedCondition := func(status *kubecontainer.PodStatus) bool {
-					defer func() {
-						if r := recover(); r != nil {
-							require.Fail(t, "condition error", r)
-						}
-					}()
-					assert.Equal(t, test.podUID, status.ID, "podUID")
-					if !test.expectEvaluated {
-						assert.Fail(t, "conditions should not be evaluated")
-					} else {
-						evaluatedConditions = append(evaluatedConditions, key)
-					}
-					return condition(status)
-				}
-				pleg.SetPodWatchCondition(test.podUID, key, wrappedCondition)
-				if test.incrementInitialVersion {
-					// Set the watch condition a second time to increment the version.
-					pleg.SetPodWatchCondition(test.podUID, key, wrappedCondition)
-				}
-			}
-			pleg.Relist()
-
-			if test.expectEvaluated {
-				assert.Len(t, evaluatedConditions, len(test.watchConditions), "all conditions should be evaluated")
-			}
-
-			if test.expectRemoved {
-				assert.NotContains(t, pleg.watchConditions, test.podUID, "Pod should be removed from watch conditions")
-			} else {
-				actualConditions := pleg.watchConditions[test.podUID]
-				assert.Len(t, actualConditions, len(test.expectWatchConditions), "expected number of conditions")
-				for key, expected := range test.expectWatchConditions {
-					if !assert.Contains(t, actualConditions, key) {
-						continue
-					}
-					actual := actualConditions[key]
-					assert.Equal(t, key, actual.key)
-					assert.Equal(t, expected.version, actual.version)
-				}
-			}
-
 		})
 	}
 }

--- a/pkg/kubelet/pleg/pleg.go
+++ b/pkg/kubelet/pleg/pleg.go
@@ -47,8 +47,6 @@ const (
 	PodSync PodLifeCycleEventType = "PodSync"
 	// ContainerChanged - event type when the new state of container is unknown.
 	ContainerChanged PodLifeCycleEventType = "ContainerChanged"
-	// ConditionMet - event type triggered when any number of watch conditions are met.
-	ConditionMet PodLifeCycleEventType = "ConditionMet"
 )
 
 // PodLifecycleEvent is an event that reflects the change of the pod state.
@@ -68,10 +66,8 @@ type PodLifecycleEventGenerator interface {
 	Start()
 	Watch() chan *PodLifecycleEvent
 	Healthy() (bool, error)
-	// SetPodWatchCondition flags the pod for reinspection on every Relist iteration until the watch
-	// condition is met. The condition is keyed so it can be updated before the condition
-	// is met.
-	SetPodWatchCondition(podUID types.UID, conditionKey string, condition WatchCondition)
+	// RequestReinspect flags the pod for reinspection on the next Relist iteration.
+	RequestReinspect(podUID types.UID)
 }
 
 // podLifecycleEventGeneratorHandler contains functions that are useful for different PLEGs


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We don't use watch conditions any more. This simplifies the code to just requesting a reinspection of the pod status.

#### Special notes for your reviewer:

This has overlap with https://github.com/kubernetes/kubernetes/pull/131024. By pulling it out to a separate PR, PLEG PRs that build on it (e.g. https://github.com/kubernetes/kubernetes/pull/137362) get easier to review.

/cc @HirazawaUi 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon
/assign @natasha41575 