### PR TITLE
Automated cherry pick of #137253:  DRA: start scheduler after creating binding/non-binding slicesin Basicflow

### DIFF
--- a/test/integration/dra/binding_conditions_test.go
+++ b/test/integration/dra/binding_conditions_test.go
@@ -62,6 +62,28 @@ func testDeviceBindingConditionsBasicFlow(tCtx ktesting.TContext, enabled bool) 
 	class, driverName := createTestClass(tCtx, namespace)
 	startScheduler(tCtx)
 
+	// Create slice without binding conditions first so it gets allocated first
+	sliceWithoutBinding := &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: namespace + "-without-binding-",
+		},
+		Spec: resourceapi.ResourceSliceSpec{
+			NodeName: &nodeName,
+			Pool: resourceapi.ResourcePool{
+				Name:               poolWithoutBinding,
+				ResourceSliceCount: 1,
+			},
+			Driver: driverName,
+			Devices: []resourceapi.Device{
+				{
+					Name: "without-binding",
+				},
+			},
+		},
+	}
+	_, err := tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, sliceWithoutBinding, metav1.CreateOptions{FieldValidation: "Strict"})
+	tCtx.ExpectNoError(err, "create slice without binding conditions")
+
 	slice := &resourceapi.ResourceSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: namespace + "-",
@@ -82,7 +104,7 @@ func testDeviceBindingConditionsBasicFlow(tCtx ktesting.TContext, enabled bool) 
 			},
 		},
 	}
-	slice, err := tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, slice, metav1.CreateOptions{FieldValidation: "Strict"})
+	slice, err = tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, slice, metav1.CreateOptions{FieldValidation: "Strict"})
 	tCtx.ExpectNoError(err, "create slice")
 
 	haveBindingConditionFields := len(slice.Spec.Devices[0].BindingConditions) > 0 || len(slice.Spec.Devices[0].BindingFailureConditions) > 0
@@ -95,27 +117,6 @@ func testDeviceBindingConditionsBasicFlow(tCtx ktesting.TContext, enabled bool) 
 	if !haveBindingConditionFields {
 		tCtx.Fatalf("Expected device binding condition fields to be stored, got instead:\n%s", format.Object(slice, 1))
 	}
-
-	sliceWithoutBinding := &resourceapi.ResourceSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: namespace + "-without-binding-",
-		},
-		Spec: resourceapi.ResourceSliceSpec{
-			NodeName: &nodeName,
-			Pool: resourceapi.ResourcePool{
-				Name:               poolWithoutBinding,
-				ResourceSliceCount: 1,
-			},
-			Driver: driverName,
-			Devices: []resourceapi.Device{
-				{
-					Name: "without-binding",
-				},
-			},
-		},
-	}
-	_, err = tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, sliceWithoutBinding, metav1.CreateOptions{FieldValidation: "Strict"})
-	tCtx.ExpectNoError(err, "create slice without binding conditions")
 
 	// Schedule first pod and wait for the scheduler to reach the binding phase, which marks the claim as allocated.
 	start := time.Now()


### PR DESCRIPTION
Cherry pick of #137253 on release-1.35.

#137253:  DRA: start scheduler after creating binding/non-binding slicesin Basicflow

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```