### PR TITLE
Fix incorrect error message in container restart policy validation

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3703,7 +3703,7 @@ func validateContainerRestartPolicy(policy *core.ContainerRestartPolicy, rules [
 			allowedActions = supportedContainerRestartRuleActionsWithRestartAllContainers
 		}
 		if !allowedActions.Has(rule.Action) {
-			allErrs = append(allErrs, field.NotSupported(policyRulesFld.Child("action"), rule.Action, sets.List(supportedContainerRestartRuleActions)))
+			allErrs = append(allErrs, field.NotSupported(policyRulesFld.Child("action"), rule.Action, sets.List(allowedActions)))
 		}
 
 		if rule.ExitCodes != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

This PR fixes a bug in the container restart policy validation where the error message always shows only the basic set of supported actions (`["Restart"]`) instead of the actual allowed actions when the `RestartAllContainersOnContainerExits` feature gate is enabled.

**Which issue(s) this PR fixes:**

Fixes #137368 

**Does this PR introduce a user-facing change?**
```release-note
Fix container restart policy validation error message to correctly show available actions when RestartAllContainersOnContainerExits feature gate is enabled
```