### PR TITLE
fix(kube-proxy): fix health check binding failure in case of dual-stack

### DIFF
--- a/pkg/proxy/healthcheck/common.go
+++ b/pkg/proxy/healthcheck/common.go
@@ -26,9 +26,8 @@ import (
 
 // listener allows for testing of ServiceHealthServer and ProxyHealthServer.
 type listener interface {
-	// Listen is very much like netutils.MultiListen, except the second arg (network) is
-	// fixed to be "tcp".
-	Listen(ctx context.Context, addrs ...string) (net.Listener, error)
+	// Listen creates a netutils.MultiListen for the given network and addresses.
+	Listen(ctx context.Context, network string, addrs ...string) (net.Listener, error)
 }
 
 // httpServerFactory allows for testing of ServiceHealthServer and ProxyHealthServer.
@@ -48,8 +47,8 @@ type httpServer interface {
 // Implement listener in terms of net.Listen.
 type stdNetListener struct{}
 
-func (stdNetListener) Listen(ctx context.Context, addrs ...string) (net.Listener, error) {
-	return netutils.MultiListen(ctx, "tcp", addrs...)
+func (stdNetListener) Listen(ctx context.Context, network string, addrs ...string) (net.Listener, error) {
+	return netutils.MultiListen(ctx, network, addrs...)
 }
 
 var _ listener = stdNetListener{}

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -57,7 +57,7 @@ func (fake *fakeListener) hasPort(addr string) bool {
 	return fake.openPorts.Has(addr)
 }
 
-func (fake *fakeListener) Listen(_ context.Context, addrs ...string) (net.Listener, error) {
+func (fake *fakeListener) Listen(_ context.Context, network string, addrs ...string) (net.Listener, error) {
 	fake.openPorts.Insert(addrs...)
 	return &fakeNetListener{
 		parent: fake,
@@ -149,7 +149,7 @@ func TestServer(t *testing.T) {
 	nodePortAddresses := proxyutil.NewNodePortAddresses(v1.IPv4Protocol, []string{})
 	proxyChecker := &fakeProxyHealthChecker{true}
 
-	hcsi := newServiceHealthServer("hostname", nil, listener, httpFactory, nodePortAddresses, proxyChecker)
+	hcsi := newServiceHealthServer("hostname", nil, listener, httpFactory, nodePortAddresses, proxyChecker, v1.IPv4Protocol)
 	hcs := hcsi.(*server)
 	if len(hcs.services) != 0 {
 		t.Errorf("expected 0 services, got %d", len(hcs.services))
@@ -972,7 +972,7 @@ func TestServerWithSelectiveListeningAddress(t *testing.T) {
 	// machine nor testing ipv6 || ipv4. using loop back guarantees the test will work on any machine
 	nodePortAddresses := proxyutil.NewNodePortAddresses(v1.IPv4Protocol, []string{"127.0.0.0/8"})
 
-	hcsi := newServiceHealthServer("hostname", nil, listener, httpFactory, nodePortAddresses, proxyChecker)
+	hcsi := newServiceHealthServer("hostname", nil, listener, httpFactory, nodePortAddresses, proxyChecker, v1.IPv4Protocol)
 	hcs := hcsi.(*server)
 	if len(hcs.services) != 0 {
 		t.Errorf("expected 0 services, got %d", len(hcs.services))

--- a/pkg/proxy/healthcheck/proxy_health.go
+++ b/pkg/proxy/healthcheck/proxy_health.go
@@ -203,7 +203,8 @@ func (hs *ProxyHealthServer) Run(ctx context.Context) error {
 	serveMux.Handle("/livez", livezHandler{hs: hs})
 	server := hs.httpFactory.New(serveMux)
 
-	listener, err := hs.listener.Listen(ctx, hs.addr)
+	// using MultiListen to support both IPv4 and IPv6 addresses.
+	listener, err := hs.listener.Listen(ctx, "tcp", hs.addr)
 	if err != nil {
 		return fmt.Errorf("failed to start proxy healthz on %s: %w", hs.addr, err)
 	}

--- a/pkg/proxy/healthcheck/service_health.go
+++ b/pkg/proxy/healthcheck/service_health.go
@@ -57,10 +57,24 @@ type proxyHealthChecker interface {
 	Health() ProxyHealth
 }
 
-func newServiceHealthServer(nodeName string, recorder events.EventRecorder, listener listener, factory httpServerFactory, nodePortAddresses *proxyutil.NodePortAddresses, healthzServer proxyHealthChecker) ServiceHealthServer {
-	// It doesn't matter whether we listen on "0.0.0.0", "::", or ""; go
-	// treats them all the same.
-	nodeIPs := []net.IP{net.IPv4zero}
+func newServiceHealthServer(nodeName string, recorder events.EventRecorder, listener listener, factory httpServerFactory, nodePortAddresses *proxyutil.NodePortAddresses, healthzServer proxyHealthChecker, serviceFamily v1.IPFamily) ServiceHealthServer {
+	// Set listen addresses and network based on IP family; if unknown,
+	// let the system choose
+	var nodeIPs []net.IP
+	var network string
+
+	switch serviceFamily {
+	case v1.IPv4Protocol:
+		nodeIPs = []net.IP{net.IPv4zero}
+		network = "tcp4"
+	case v1.IPv6Protocol:
+		nodeIPs = []net.IP{net.IPv6zero}
+		network = "tcp6"
+	default:
+		// Let the system choose
+		nodeIPs = []net.IP{net.IPv4zero}
+		network = "tcp"
+	}
 
 	if !nodePortAddresses.MatchAll() {
 		ips, err := nodePortAddresses.GetNodeIPs(proxyutil.RealNetwork{})
@@ -79,12 +93,13 @@ func newServiceHealthServer(nodeName string, recorder events.EventRecorder, list
 		healthzServer: healthzServer,
 		services:      map[types.NamespacedName]*hcInstance{},
 		nodeIPs:       nodeIPs,
+		network:       network,
 	}
 }
 
 // NewServiceHealthServer allocates a new service healthcheck server manager
-func NewServiceHealthServer(nodeName string, recorder events.EventRecorder, nodePortAddresses *proxyutil.NodePortAddresses, healthzServer proxyHealthChecker) ServiceHealthServer {
-	return newServiceHealthServer(nodeName, recorder, stdNetListener{}, stdHTTPServerFactory{}, nodePortAddresses, healthzServer)
+func NewServiceHealthServer(nodeName string, recorder events.EventRecorder, nodePortAddresses *proxyutil.NodePortAddresses, healthzServer proxyHealthChecker, serviceFamily v1.IPFamily) ServiceHealthServer {
+	return newServiceHealthServer(nodeName, recorder, stdNetListener{}, stdHTTPServerFactory{}, nodePortAddresses, healthzServer, serviceFamily)
 }
 
 type server struct {
@@ -99,6 +114,9 @@ type server struct {
 
 	lock     sync.RWMutex
 	services map[types.NamespacedName]*hcInstance
+
+	// network type of the socket when listening for health checks
+	network string
 }
 
 func (hcs *server) SyncServices(newServices map[types.NamespacedName]uint16) error {
@@ -172,7 +190,7 @@ func (hcI *hcInstance) listenAndServeAll(hcs *server) error {
 		// create http server
 		httpSrv := hcs.httpFactory.New(hcHandler{name: hcI.nsn, hcs: hcs})
 		// start listener
-		listener, err = hcs.listener.Listen(context.TODO(), addr)
+		listener, err = hcs.listener.Listen(context.TODO(), hcs.network, addr)
 		if err != nil {
 			// must close whatever have been previously opened
 			// to allow a retry/or port ownership change as needed

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -263,7 +263,7 @@ func NewProxier(ctx context.Context,
 	masqueradeMark := fmt.Sprintf("%#08x", masqueradeValue)
 	logger.V(2).Info("Using iptables mark for masquerade", "mark", masqueradeMark)
 
-	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer)
+	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer, ipFamily)
 	nfacctRunner, err := nfacct.New()
 	if err != nil {
 		logger.Error(err, "Failed to create nfacct runner, nfacct based metrics won't be available")

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -354,7 +354,7 @@ func NewProxier(
 
 	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, nodePortAddressStrings)
 
-	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer)
+	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer, ipFamily)
 
 	// excludeCIDRs has been validated before, here we just parse it to IPNet list
 	parsedExcludeCIDRs, _ := netutils.ParseCIDRs(excludeCIDRs)

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -236,7 +236,7 @@ func NewProxier(ctx context.Context,
 
 	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, nodePortAddressStrings)
 
-	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer)
+	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer, ipFamily)
 
 	proxier := &Proxier{
 		ipFamily:            ipFamily,

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -652,7 +652,7 @@ func NewProxier(
 ) (*Proxier, error) {
 	// windows listens to all node addresses
 	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, nil)
-	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer)
+	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer, ipFamily)
 
 	var healthzPort int
 	if len(healthzBindAddress) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In case of dual-stack service with `externalTrafficPolicy: Local` kube-proxy fails to bind one of the health-check instances to a node address and port and instead outputs the following error:
```
E0303 10:33:40.628701       1 service_health.go:145] "Failed to start healthcheck" err="listen tcp 0.0.0.0:30270: bind: address already in use" node="tero-cilium" service="default/nginx-dual" port=30270
```
This happens because kube-proxy creates two instances that both try to bind to the same address and port.

This PR fixes the issue by binding the IPv4 health-check instance to an IPv4 socket and the IPv6 instance to an IPv6 socket, allowing both instances to bind successfully without producing an error.

#### Which issue(s) this PR is related to:

Fixes #114702
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This change does not address the scenario of a dual‑stack service with single‑stack endpoints; it's unclear whether that configuration is a valid use case. See #114702 for more information.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
