### PR TITLE
DRA scheduler: fix potential panic when DRABindingConditions are enabled

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -1244,8 +1244,17 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, ind
 		// preconditions. The apiserver will tell us with a
 		// non-conflict error if this isn't possible.
 		claim.Status.ReservedFor = append(claim.Status.ReservedFor, resourceapi.ResourceClaimConsumerReference{Resource: "pods", Name: pod.Name, UID: pod.UID})
-		if pl.fts.EnableDRADeviceBindingConditions && pl.fts.EnableDRAResourceClaimDeviceStatus && claim.Status.Allocation.AllocationTimestamp == nil {
-			claim.Status.Allocation.AllocationTimestamp = &metav1.Time{Time: time.Now()}
+		if pl.fts.EnableDRADeviceBindingConditions &&
+			pl.fts.EnableDRAResourceClaimDeviceStatus {
+			// Once the feature gate checks get removed, this code can be moved into an else branch
+			// for `if allocation != nil` above. For now it is kept here to avoid changing normal
+			// behavior.
+			if claim.Status.Allocation == nil {
+				return fmt.Errorf("claim %s got deallocated elsewhere in the meantime", klog.KObj(claim))
+			}
+			if claim.Status.Allocation.AllocationTimestamp == nil {
+				claim.Status.Allocation.AllocationTimestamp = &metav1.Time{Time: time.Now()}
+			}
 		}
 		updatedClaim, err := pl.clientset.ResourceV1().ResourceClaims(claim.Namespace).UpdateStatus(ctx, claim, metav1.UpdateOptions{})
 		if err != nil {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -770,6 +770,7 @@ var (
 	}()
 
 	allocationResultWithBindingConditions = &resourceapi.AllocationResult{
+		AllocationTimestamp: new(metav1.Time), // Non-nil, actual value not checked.
 		Devices: resourceapi.DeviceAllocationResult{
 			Results: []resourceapi.DeviceRequestAllocationResult{{
 				Driver:                   driver,
@@ -784,6 +785,7 @@ var (
 	}
 
 	allocationResultWithBindingConditions2 = &resourceapi.AllocationResult{
+		AllocationTimestamp: new(metav1.Time), // Non-nil, actual value not checked.
 		Devices: resourceapi.DeviceAllocationResult{
 			Results: []resourceapi.DeviceRequestAllocationResult{{
 				Driver:                   driver2,
@@ -796,6 +798,10 @@ var (
 		},
 		NodeSelector: st.MakeNodeSelector().In("metadata.name", []string{nodeName}, st.NodeSelectorTypeMatchFields).Obj(),
 	}
+
+	bindClaim = st.FromResourceClaim(allocatedClaim).
+			Allocation(allocationResultWithBindingConditions).
+			Obj()
 
 	boundClaim = st.FromResourceClaim(allocatedClaim).
 			Allocation(allocationResultWithBindingConditions).
@@ -870,6 +876,17 @@ func reserve(claim *resourceapi.ResourceClaim, pod *v1.Pod) *resourceapi.Resourc
 	return st.FromResourceClaim(claim).
 		ReservedForPod(pod.Name, types.UID(pod.UID)).
 		Obj()
+}
+
+// addAllocationTimestamp adds an AllocationTimestamp to a claim.
+// Non-nil is all that matters for the go-cmp comparison.
+// Test cases involving binding conditions must ensure that they
+// have such a non-nil time stamp in their expected claims starting
+// with PreBind because PreBind adds it when the feature is on.
+func addAllocationTimestamp(claim *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
+	claim = claim.DeepCopy()
+	claim.Status.Allocation.AllocationTimestamp = new(metav1.Time)
+	return claim
 }
 
 func adminAccess(claim *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
@@ -1798,11 +1815,11 @@ func testPlugin(tCtx ktesting.TContext) {
 					inFlightClaims: []metav1.Object{extendedResourceClaimNoName2},
 				},
 				prebind: result{
-					assumedClaim: reserve(extendedResourceClaim2, podWithExtendedResourceName2),
-					added:        []metav1.Object{reserve(extendedResourceClaim2, podWithExtendedResourceName2)},
+					assumedClaim: addAllocationTimestamp(reserve(extendedResourceClaim2, podWithExtendedResourceName2)),
+					added:        []metav1.Object{addAllocationTimestamp(reserve(extendedResourceClaim2, podWithExtendedResourceName2))},
 				},
 				postbind: result{
-					assumedClaim: reserve(extendedResourceClaim2, podWithExtendedResourceName2),
+					assumedClaim: addAllocationTimestamp(reserve(extendedResourceClaim2, podWithExtendedResourceName2)),
 				},
 			},
 		},
@@ -2172,6 +2189,133 @@ func testPlugin(tCtx ktesting.TContext) {
 				},
 			},
 		},
+		"dont-add-allocation-timestamp": {
+			pod:     podWithClaimName,
+			claims:  []*resourceapi.ResourceClaim{pendingClaim},
+			classes: []*resourceapi.DeviceClass{deviceClass},
+			objs:    []apiruntime.Object{workerNodeSlice},
+			want: want{
+				reserve: result{
+					inFlightClaims: []metav1.Object{allocatedClaim},
+				},
+				prebind: result{
+					assumedClaim: reserve(allocatedClaim, podWithClaimName),
+					changes: change{
+						claim: func(in *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
+							return reserve(allocatedClaim, podWithClaimName)
+						},
+					},
+				},
+			},
+		},
+		"add-allocation-timestamp": {
+			enableDRADeviceBindingConditions:   true,
+			enableDRAResourceClaimDeviceStatus: true,
+			pod:                                podWithClaimName,
+			claims:                             []*resourceapi.ResourceClaim{pendingClaim},
+			classes:                            []*resourceapi.DeviceClass{deviceClass},
+			objs:                               []apiruntime.Object{workerNodeSlice},
+			want: want{
+				reserve: result{
+					inFlightClaims: []metav1.Object{allocatedClaim},
+				},
+				prebind: result{
+					assumedClaim: addAllocationTimestamp(reserve(allocatedClaim, podWithClaimName)),
+					changes: change{
+						claim: func(in *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
+							return addAllocationTimestamp(reserve(allocatedClaim, podWithClaimName))
+						},
+					},
+				},
+			},
+		},
+		"add-allocation-timestamp-failure": {
+			enableDRADeviceBindingConditions:   true,
+			enableDRAResourceClaimDeviceStatus: true,
+			pod:                                podWithClaimName,
+			claims:                             []*resourceapi.ResourceClaim{allocatedClaim},
+			prepare: prepare{
+				prebind: change{
+					claim: func(in *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
+						// Simulate deallocation before PreBind runs.
+						return st.FromResourceClaim(in).
+							Allocation(nil).
+							Obj()
+					},
+				},
+			},
+			want: want{
+				prebind: result{
+					status: fwk.AsStatus(fmt.Errorf("claim %s got deallocated elsewhere in the meantime", klog.KObj(allocatedClaim))),
+				},
+			},
+		},
+		"bind-claim-with-binding-conditions": {
+			enableDRADeviceBindingConditions:   true,
+			enableDRAResourceClaimDeviceStatus: true,
+			pod:                                podWithClaimName,
+			claims:                             []*resourceapi.ResourceClaim{pendingClaim},
+			classes:                            []*resourceapi.DeviceClass{deviceClass},
+			objs:                               []apiruntime.Object{fabricSlice},
+			args: &config.DynamicResourcesArgs{
+				// Time out quickly in PreBind. There's no controller which sets the
+				// binding conditions.
+				BindingTimeout: &metav1.Duration{Duration: time.Second},
+			},
+			want: want{
+				reserve: result{
+					inFlightClaims: []metav1.Object{func() *resourceapi.ResourceClaim {
+						claim := bindClaim.DeepCopy()
+						// Will get set in PreBind.
+						claim.Status.Allocation.AllocationTimestamp = nil
+						return claim
+					}()},
+				},
+				prebind: result{
+					assumedClaim: reserve(bindClaim, podWithClaimName),
+					changes: change{
+						claim: func(in *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
+							return reserve(bindClaim, podWithClaimName)
+						},
+					},
+					// From PreBind itself, when checking isPodReadyForBinding times out.
+					status: fwk.AsStatus(errors.New("device binding timeout")),
+				},
+			},
+		},
+		"bind-failure-concurrent-deallocation": {
+			enableDRADeviceBindingConditions:   true,
+			enableDRAResourceClaimDeviceStatus: true,
+			pod:                                podWithClaimName,
+			claims:                             []*resourceapi.ResourceClaim{pendingClaim},
+			classes:                            []*resourceapi.DeviceClass{deviceClass},
+			objs:                               []apiruntime.Object{fabricSlice},
+			args: &config.DynamicResourcesArgs{
+				// Time out quickly in PreBind. There's no controller which sets the
+				// binding conditions.
+				BindingTimeout: &metav1.Duration{Duration: time.Second},
+			},
+			want: want{
+				reserve: result{
+					inFlightClaims: []metav1.Object{func() *resourceapi.ResourceClaim {
+						claim := bindClaim.DeepCopy()
+						// Will get set in PreBind.
+						claim.Status.Allocation.AllocationTimestamp = nil
+						return claim
+					}()},
+				},
+				prebind: result{
+					assumedClaim: reserve(bindClaim, podWithClaimName),
+					changes: change{
+						claim: func(in *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
+							return reserve(bindClaim, podWithClaimName)
+						},
+					},
+					// From PreBind itself, when checking isPodReadyForBinding times out.
+					status: fwk.AsStatus(errors.New("device binding timeout")),
+				},
+			},
+		},
 		"bound-claim-with-succeeded-binding-conditions": {
 			enableDRADeviceBindingConditions:   true,
 			enableDRAResourceClaimDeviceStatus: true,
@@ -2307,6 +2451,7 @@ func testPlugin(tCtx ktesting.TContext) {
 								Obj()
 						},
 					},
+					// From isPodReadyForBinding.
 					status: fwk.AsStatus(errors.New("claim " + claim.Name + " binding timeout")),
 				},
 			},
@@ -2362,12 +2507,13 @@ func testPlugin(tCtx ktesting.TContext) {
 			claims: []*resourceapi.ResourceClaim{allocatedClaim, otherClaim},
 			want: want{
 				prebind: result{
-					assumedClaim: reserve(allocatedClaim, podWithClaimTemplateInStatus),
+					assumedClaim: addAllocationTimestamp(reserve(allocatedClaim, podWithClaimTemplateInStatus)),
 					changes: change{
 						claim: func(claim *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
 							if claim.Name == claimName {
 								claim = claim.DeepCopy()
 								claim.Status.ReservedFor = inUseClaim.Status.ReservedFor
+								claim = addAllocationTimestamp(claim)
 							}
 							return claim
 						},
@@ -2838,10 +2984,18 @@ func (tc *testContext) verify(tCtx ktesting.TContext, expected result, initialOb
 	// Sometimes assert strips the diff too much, let's do it ourselves...
 	ignoreFieldsInResourceClaims := []cmp.Option{
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "UID", "ResourceVersion"),
-		cmpopts.IgnoreFields(resourceapi.AllocationResult{}, "AllocationTimestamp"),
+		cmp.Transformer("AllocationTimestamp", func(result resourceapi.AllocationResult) resourceapi.AllocationResult {
+			// Replace all allocation timestamps with the empty timestamp before comparison
+			// because the actual value is unpredictable (not running in a synctest bubble).
+			if result.AllocationTimestamp != nil {
+				result.AllocationTimestamp = new(metav1.Time)
+			}
+			return result
+		}),
 		// It does not matter which specific device is allocated for the testing purpose.
 		cmpopts.IgnoreFields(resourceapi.DeviceRequestAllocationResult{}, "Device"),
 	}
+
 	if diff := cmp.Diff(wantObjects, objects, ignoreFieldsInResourceClaims...); diff != "" {
 		tCtx.Errorf("Stored objects are different (- expected, + actual):\n%s", diff)
 	}
@@ -3144,7 +3298,7 @@ func createReactor(tracker cgotesting.ObjectTracker, failPatch bool) func(action
 				return true, nil, errors.New("internal error: unexpected old object type")
 			}
 			if oldObjMeta.GetResourceVersion() != resourceVersion {
-				return true, nil, errors.New("ResourceVersion must match the object that gets updated")
+				return true, nil, apierrors.NewConflict(action.GetResource().GroupResource(), obj.GetName(), errors.New("ResourceVersion must match the object that gets updated"))
 			}
 
 			obj.SetResourceVersion(fmt.Sprintf("%d", resourceVersionCounter))

--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -1514,7 +1514,12 @@ func testControllerManagerMetrics(tCtx ktesting.TContext) {
 	)
 
 	// Start the controller (this will run in background and stop when tCtx is cancelled)
-	runResourceClaimController()
+	var wg sync.WaitGroup
+	tCtx.Cleanup(func() {
+		tCtx.Cancel("test is done")
+		wg.Wait()
+	})
+	wg.Go(runResourceClaimController)
 
 	tCtx.Log("ResourceClaim controller started successfully")
 	tCtx.Log("Testing ResourceClaim controller success metrics with admin access labels")

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -126,6 +126,8 @@ func StartScheduler(tCtx ktesting.TContext, cfg *kubeschedulerconfig.KubeSchedul
 	return sched, informerFactory
 }
 
+// CreateResourceClaimController creates a ResourceClaim controller and returns a blocking run function.
+// The caller is responsible for the management of the goroutine where that method is invoked.
 func CreateResourceClaimController(ctx context.Context, tb ktesting.TB, clientSet clientset.Interface, informerFactory informers.SharedInformerFactory) func() {
 	podInformer := informerFactory.Core().V1().Pods()
 	claimInformer := informerFactory.Resource().V1().ResourceClaims()
@@ -139,7 +141,7 @@ func CreateResourceClaimController(ctx context.Context, tb ktesting.TB, clientSe
 		tb.Fatalf("Error creating claim controller: %v", err)
 	}
 	return func() {
-		go claimController.Run(ctx, 5 /* workers */)
+		claimController.Run(ctx, 5 /* workers */)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It can happen that a claim gets deallocated in parallel to adding a new pod to
ReservedFor. Without binding conditions, that was caught by the apiserver
validation. With binding conditions, the code which checks and sets
AllocationTimestamp panics with a nil pointer access.

This has been observed in the TestDRA/all/ShareResourceClaimSequentially
integration test, but couldn't be reproduced locally:

    E0303 07:43:20.158261   39037 panic.go:262] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
    	goroutine 554266 [running]:
    	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x69ce9f0, 0xc017bc00f0}, {0x59381a0, 0x91c6570})
    		/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0xbc
    	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x69ce8d8, 0x93d87a0}, {0x59381a0, 0x91c6570}, {0xc020506f00, 0x0, 0x200?})
    		/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0x116
    	k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc00685ddc0?})
    		/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:64 +0x17b
    	panic({0x59381a0?, 0x91c6570?})
    		/usr/local/go/src/runtime/panic.go:783 +0x132
    	k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources.(*DynamicResources).bindClaim.func2()
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go:1247 +0x730
    	k8s.io/client-go/util/retry.OnError.func1()
    		/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/retry/util.go:51 +0x30
    	k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0x9ebcca?)
    		/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:150 +0x3e
    	k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff({0x989680, 0x3ff0000000000000, 0x3fb999999999999a, 0x2, 0x0}, 0xc020507410)
    		/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:477 +0x5a
    	k8s.io/client-go/util/retry.OnError({0x989680, 0x3ff0000000000000, 0x3fb999999999999a, 0x5, 0x0}, 0xc02c2d5380?, 0x4?)
    		/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/retry/util.go:50 +0x96
    	k8s.io/client-go/util/retry.RetryOnConflict(...)
    		/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/retry/util.go:104
    	k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources.(*DynamicResources).bindClaim(0xc0024adb20, {0x69cea28, 0xc0061acbe0}, 0xc011876800, 0x0, 0xc025163408, {0xc021909d80, 0x8})
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go:1207 +0x845
    	k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources.(*DynamicResources).PreBind-range1(...)
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go:1073
    	k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources.(*DynamicResources).PreBind.(*claimStore).all.func2(...)
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/claims.go:72
    	k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources.(*DynamicResources).PreBind(0xc0024adb20, {0x69cea28, 0xc0061acbe0}, {0x69fc840?, 0xc0286f2540?}, 0xc025163408, {0xc021909d80, 0x8})
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go:1071 +0x246
    	k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).runPreBindPlugin(0xc009628dc8, {0x69cea28, 0xc0061acbe0}, {0x7eabfddddb30, 0xc0024adb20}, {0x69fc840, 0xc0286f2540}, 0xc025163408, {0xc021909d80, 0x8})
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/runtime/framework.go:1532 +0x2e2
    	k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).RunPreBindPlugins.func2({0x7eabfddddb30, 0xc0024adb20})
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/runtime/framework.go:1461 +0x1cf
    	k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).RunPreBindPlugins(0xc009628dc8, {0x69cea28, 0xc0061ac690}, {0x69fc840, 0xc0286f2540}, 0xc025163408, {0xc021909d80, 0x8})
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/runtime/framework.go:1484 +0x623
    	k8s.io/kubernetes/pkg/scheduler.(*Scheduler).bindingCycle(0xc02a6a7500, {0x69cea28, 0xc00f22a690}, {0x69fc840, 0xc0286f2540}, {0x6a32e60, 0xc009628dc8}, {{0xc021909d80, 0x8}, 0x8, ...}, ...)
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:457 +0x72a
    	k8s.io/kubernetes/pkg/scheduler.(*Scheduler).runBindingCycle(0xc02a6a7500, {0x69ce9f0?, 0xc0027e5470?}, {0x69fc840, 0xc0286f2540}, {0x6a32e60, 0xc009628dc8}, {{0xc021909d80, 0x8}, 0x8, ...}, ...)
    		/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:164 +0x1e8

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/137367

#### Special notes for your reviewer:

This also includes a commit which fixes a (temporary) goroutine leak.

#### Does this PR introduce a user-facing change?

```release-note
DRA BindingConditions: when the DRABindingConditions feature was enabled, reusing the same claim among different pods may have caused a panic in the scheduler when deallocation happens in parallel (a rare race condition).
```
