### PR TITLE
pkg/controlplane: use modernize/slicescontains and modernize/rangeint

### DIFF
--- a/pkg/controlplane/controller/crdregistration/crdregistration_controller.go
+++ b/pkg/controlplane/controller/crdregistration/crdregistration_controller.go
@@ -134,7 +134,7 @@ func (c *crdRegistrationController) Run(workers int, stopCh <-chan struct{}) {
 	close(c.syncedInitialSet)
 
 	// start up your worker threads based on workers.  Some controllers have multiple kinds of workers
-	for i := 0; i < workers; i++ {
+	for range workers {
 		// runWorker will loop until "something bad" happens.  The .Until will then rekick the worker
 		// after one second
 		go wait.Until(c.runWorker, time.Second, stopCh)

--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
@@ -103,7 +103,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	}
 
 	klog.Infof("Workers: %d", workers)
-	for i := 0; i < workers; i++ {
+	for range workers {
 		klog.Infof("Starting worker")
 		go wait.UntilWithContext(ctx, c.runElectionWorker, time.Second)
 	}

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -23,6 +23,7 @@ https://github.com/openshift/origin/blob/bb340c5dd5ff72718be86fb194dedc0faed7f4c
 
 import (
 	"reflect"
+	"slices"
 	"sort"
 	"testing"
 	"time"
@@ -558,7 +559,7 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 			}
 			err = r.RemoveEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts)
 			// if the ip is not on the endpoints, it must return an storage error and stop reconciling
-			if !contains(test.endpointKeys, test.ip) {
+			if !slices.Contains(test.endpointKeys, test.ip) {
 				if !storage.IsNotFound(err) {
 					t.Errorf("expected error StorageError: key not found, Code: 1, Key: /registry/base/key/%s got:  %v", test.ip, err)
 				}
@@ -583,15 +584,6 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 			}
 		})
 	}
-}
-
-func contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-	return false
 }
 
 func TestApiserverShutdown(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Two simplifications from the modernize tool. I see functions doing exactly what `slices.Contains` does in many places.
There are two instances of `rangeint`. I suggest that they'd be fixed as well.

#### Which issue(s) this PR is related to:
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
