### PR TITLE
pkg/registry: apply modernize/slicescontains

### DIFF
--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -19,6 +19,7 @@ package namespace
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -68,14 +69,7 @@ func (namespaceStrategy) PrepareForCreate(ctx context.Context, obj runtime.Objec
 	}
 	// on create, we require the kubernetes value
 	// we cannot use this in defaults conversion because we let it get removed over life of object
-	hasKubeFinalizer := false
-	for i := range namespace.Spec.Finalizers {
-		if namespace.Spec.Finalizers[i] == api.FinalizerKubernetes {
-			hasKubeFinalizer = true
-			break
-		}
-	}
-	if !hasKubeFinalizer {
+	if !slices.Contains(namespace.Spec.Finalizers, api.FinalizerKubernetes) {
 		if len(namespace.Spec.Finalizers) == 0 {
 			namespace.Spec.Finalizers = []api.FinalizerName{api.FinalizerKubernetes}
 		} else {

--- a/pkg/registry/core/service/ipallocator/controller/repairip.go
+++ b/pkg/registry/core/service/ipallocator/controller/repairip.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -416,12 +417,9 @@ func (r *RepairIPAddress) syncService(key string) error {
 				continue
 			}
 			// the IPAddress is duplicate but current Service is not the referenced, it has to be recreated
-			for _, clusterIP := range refService.Spec.ClusterIPs {
-				if ipAddress.Name == clusterIP {
-					r.recorder.Eventf(svc, nil, v1.EventTypeWarning, "ClusterIPAlreadyAllocated", "ClusterIPAllocation", "Cluster IP [%v]:%s was assigned to multiple services; please recreate service", family, ip)
-					runtime.HandleError(fmt.Errorf("the cluster IP [%v]:%s for service %s/%s was assigned to other services %s/%s; please recreate", family, ip, svc.Namespace, svc.Name, refService.Namespace, refService.Name))
-					break
-				}
+			if slices.Contains(refService.Spec.ClusterIPs, ipAddress.Name) {
+				r.recorder.Eventf(svc, nil, v1.EventTypeWarning, "ClusterIPAlreadyAllocated", "ClusterIPAllocation", "Cluster IP [%v]:%s was assigned to multiple services; please recreate service", family, ip)
+				runtime.HandleError(fmt.Errorf("the cluster IP [%v]:%s for service %s/%s was assigned to other services %s/%s; please recreate", family, ip, svc.Namespace, svc.Name, refService.Namespace, refService.Name))
 			}
 		}
 
@@ -540,10 +538,8 @@ func (r *RepairIPAddress) syncIPAddress(key string) error {
 	}
 	// The service exists, we have checked in previous loop that all Service to IPAddress are correct
 	// but we also have to check the reverse, that the IPAddress to Service relation is correct
-	for _, clusterIP := range svc.Spec.ClusterIPs {
-		if ipAddress.Name == clusterIP {
-			return nil
-		}
+	if slices.Contains(svc.Spec.ClusterIPs, ipAddress.Name) {
+		return nil
 	}
 
 	// There is a special case when we "break the immutability" of the Service ClusterIPs,

--- a/pkg/registry/core/service/portallocator/operation.go
+++ b/pkg/registry/core/service/portallocator/operation.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package portallocator
 
+import "slices"
+
 // Encapsulates the semantics of a port allocation 'transaction':
 // It is better to leak ports than to double-allocate them,
 // so we allocate immediately, but defer release.
@@ -112,10 +114,8 @@ func (op *PortAllocationOperation) Allocate(port int) error {
 		if op.pa.Has(port) {
 			return ErrAllocated
 		}
-		for _, a := range op.allocated {
-			if port == a {
-				return ErrAllocated
-			}
+		if slices.Contains(op.allocated, port) {
+			return ErrAllocated
 		}
 		op.allocated = append(op.allocated, port)
 		return nil

--- a/pkg/registry/core/service/storage/alloc.go
+++ b/pkg/registry/core/service/storage/alloc.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -817,7 +818,7 @@ func (al *Allocators) updateNodePorts(after After, before Before, nodePortOp *po
 		}
 		nodePort := ServiceNodePort{Protocol: servicePort.Protocol, NodePort: servicePort.NodePort}
 		if nodePort.NodePort != 0 {
-			if !containsNumber(oldNodePortsNumbers, int(nodePort.NodePort)) && !portAllocated[int(nodePort.NodePort)] {
+			if !slices.Contains(oldNodePortsNumbers, int(nodePort.NodePort)) && !portAllocated[int(nodePort.NodePort)] {
 				err := nodePortOp.Allocate(int(nodePort.NodePort))
 				if err != nil {
 					el := field.ErrorList{field.Invalid(field.NewPath("spec", "ports").Index(i).Child("nodePort"), nodePort.NodePort, err.Error())}
@@ -836,7 +837,7 @@ func (al *Allocators) updateNodePorts(after After, before Before, nodePortOp *po
 			servicePort.NodePort = int32(nodePortNumber)
 			nodePort.NodePort = servicePort.NodePort
 		}
-		if containsNodePort(newNodePorts, nodePort) {
+		if slices.Contains(newNodePorts, nodePort) {
 			return fmt.Errorf("duplicate nodePort: %v", nodePort)
 		}
 		newNodePorts = append(newNodePorts, nodePort)
@@ -847,7 +848,7 @@ func (al *Allocators) updateNodePorts(after After, before Before, nodePortOp *po
 	// The comparison loops are O(N^2), but we don't expect N to be huge
 	// (there's a hard-limit at 2^16, because they're ports; and even 4 ports would be a lot)
 	for _, oldNodePortNumber := range oldNodePortsNumbers {
-		if containsNumber(newNodePortsNumbers, oldNodePortNumber) {
+		if slices.Contains(newNodePortsNumbers, oldNodePortNumber) {
 			continue
 		}
 		nodePortOp.ReleaseDeferred(int(oldNodePortNumber))
@@ -934,28 +935,6 @@ func (al *Allocators) Destroy() {
 	for _, a := range al.serviceIPAllocatorsByFamily {
 		a.Destroy()
 	}
-}
-
-// This is O(N), but we expect haystack to be small;
-// so small that we expect a linear search to be faster
-func containsNumber(haystack []int, needle int) bool {
-	for _, v := range haystack {
-		if v == needle {
-			return true
-		}
-	}
-	return false
-}
-
-// This is O(N), but we expect serviceNodePorts to be small;
-// so small that we expect a linear search to be faster
-func containsNodePort(serviceNodePorts []ServiceNodePort, serviceNodePort ServiceNodePort) bool {
-	for _, snp := range serviceNodePorts {
-		if snp == serviceNodePort {
-			return true
-		}
-	}
-	return false
 }
 
 // Loop through the service ports list, find one with the same port number and

--- a/pkg/registry/rbac/escalation_check.go
+++ b/pkg/registry/rbac/escalation_check.go
@@ -19,6 +19,7 @@ package rbac
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -37,13 +38,7 @@ func EscalationAllowed(ctx context.Context) bool {
 
 	// system:masters is special because the API server uses it for privileged loopback connections
 	// therefore we know that a member of system:masters can always do anything
-	for _, group := range u.GetGroups() {
-		if group == user.SystemPrivilegedGroup {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(u.GetGroups(), user.SystemPrivilegedGroup)
 }
 
 var roleResources = map[schema.GroupResource]bool{

--- a/pkg/registry/rbac/validation/rule.go
+++ b/pkg/registry/rbac/validation/rule.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -269,22 +270,13 @@ func appliesTo(user user.Info, bindingSubjects []rbacv1.Subject, namespace strin
 	return 0, false
 }
 
-func has(set []string, ele string) bool {
-	for _, s := range set {
-		if s == ele {
-			return true
-		}
-	}
-	return false
-}
-
 func appliesToUser(user user.Info, subject rbacv1.Subject, namespace string) bool {
 	switch subject.Kind {
 	case rbacv1.UserKind:
 		return user.GetName() == subject.Name
 
 	case rbacv1.GroupKind:
-		return has(user.GetGroups(), subject.Name)
+		return slices.Contains(user.GetGroups(), subject.Name)
 
 	case rbacv1.ServiceAccountKind:
 		// default the namespace to namespace we're working in if its available.  This allows rolebindings that reference


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A few more cases of functions defined that can be leveraged entirely to `slices.Contains`

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

I try to limit my changes to a subset that does not span multiple approver groups.

Although tempted to do so, there are quite a few cases of `rangeint`, so that can be done in a separate PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
