### PR TITLE
[replaced] fix: validate apiserver endpoints in master lease reconciler

### DIFF
--- a/pkg/controlplane/reconcilers/lease.go
+++ b/pkg/controlplane/reconcilers/lease.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -81,9 +82,40 @@ func (s *storageLeases) ListLeases() ([]string, error) {
 	}
 
 	ipList := make([]string, 0, len(ipInfoList.Items))
-	for _, ip := range ipInfoList.Items {
-		if len(ip.Subsets) > 0 && len(ip.Subsets[0].Addresses) > 0 && len(ip.Subsets[0].Addresses[0].IP) > 0 {
-			ipList = append(ipList, ip.Subsets[0].Addresses[0].IP)
+	for _, ipInfo := range ipInfoList.Items {
+		if len(ipInfo.Subsets) > 0 && len(ipInfo.Subsets[0].Addresses) > 0 && len(ipInfo.Subsets[0].Addresses[0].IP) > 0 {
+			ipList = append(ipList, ipInfo.Subsets[0].Addresses[0].IP)
+		}
+	}
+
+	if len(ipList) > 0 {
+		loopbacks := make([]string, 0)
+		globals := make([]string, 0)
+		unparseable := make([]string, 0)
+
+		for _, ipStr := range ipList {
+			ip := netutils.ParseIPSloppy(ipStr)
+			if ip == nil {
+				unparseable = append(unparseable, ipStr)
+				continue
+			}
+			if ip.IsLoopback() {
+				loopbacks = append(loopbacks, ipStr)
+			} else if !ip.IsUnspecified() && !ip.IsLinkLocalUnicast() && !ip.IsLinkLocalMulticast() {
+				globals = append(globals, ipStr)
+			}
+		}
+
+		if len(globals) > 0 {
+			ipList = globals
+		} else if len(loopbacks) > 0 {
+			ipList = loopbacks
+		} else if len(unparseable) > 0 {
+			ipList = unparseable
+			klog.Warningf("All endpoints were unparseable IPs, keeping original values: %v", unparseable)
+		} else {
+			ipList = []string{}
+			klog.Warningf("All endpoints were invalid or filtered out, no valid master IPs available")
 		}
 	}
 
@@ -95,9 +127,11 @@ func (s *storageLeases) ListLeases() ([]string, error) {
 // UpdateLease resets the TTL on a master IP in storage
 // UpdateLease will create a new key if it doesn't exist.
 func (s *storageLeases) UpdateLease(ip string) error {
+	if !isValidEndpointIP(ip) {
+		return fmt.Errorf("cannot update lease for invalid master IP %q", ip)
+	}
 	key := path.Join(s.baseKey, ip)
 	return s.storage.GuaranteedUpdate(apirequest.NewDefaultContext(), key, &corev1.Endpoints{}, true, nil, func(input kruntime.Object, respMeta storage.ResponseMeta) (kruntime.Object, *uint64, error) {
-		// just make sure we've got the right IP set, and then refresh the TTL
 		existing := input.(*corev1.Endpoints)
 		existing.Subsets = []corev1.EndpointSubset{
 			{
@@ -105,13 +139,8 @@ func (s *storageLeases) UpdateLease(ip string) error {
 			},
 		}
 
-		// leaseTime needs to be in seconds
 		leaseTime := uint64(s.leaseTime / time.Second)
 
-		// NB: GuaranteedUpdate does not perform the store operation unless
-		// something changed between load and store (not including resource
-		// version), meaning we can't refresh the TTL without actually
-		// changing a field.
 		existing.Generation++
 
 		klog.V(6).Infof("Resetting TTL on master IP %q listed in storage to %v", ip, leaseTime)
@@ -136,7 +165,7 @@ func NewLeases(config *storagebackend.ConfigForResource, baseKey string, leaseTi
 	// can be left blank unless the storage.Watch method is used
 	leaseStorage, destroyFn, err := storagefactory.Create(*config, nil, nil, baseKey)
 	if err != nil {
-		return nil, fmt.Errorf("error creating storage factory: %v", err)
+		return nil, fmt.Errorf("error creating storage factory: %w", err)
 	}
 	var once sync.Once
 	return &storageLeases{
@@ -213,7 +242,6 @@ func (r *leaseEndpointReconciler) doReconcile(serviceName string, endpointPorts 
 		}
 	}
 
-	// ... and the list of master IP keys from etcd
 	masterIPs, err := r.masterLeases.ListLeases()
 	if err != nil {
 		return err
@@ -344,4 +372,15 @@ func (r *leaseEndpointReconciler) StopReconciling() {
 
 func (r *leaseEndpointReconciler) Destroy() {
 	r.masterLeases.Destroy()
+}
+
+func isValidEndpointIP(ipAddress string) bool {
+	ip := netutils.ParseIPSloppy(ipAddress)
+	if ip == nil {
+		return true
+	}
+	if ip.IsUnspecified() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return false
+	}
+	return true
 }

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -97,10 +97,10 @@ func (f *fakeLeases) SetKeysWithoutValidation(keys []string) error {
 	return nil
 }
 
-//nolint:kubeapilinter
-func createLegacyEndpoint(ip string) *corev1.Endpoints {
-	return &corev1.Endpoints{ //nolint:kubeapilinter
-		Subsets: []corev1.EndpointSubset{ //nolint:kubeapilinter
+//nolint:staticcheck // SA1019: Endpoints is deprecated but required for legacy storage format
+func createLegacyEndpoint(ip string) *corev1.Endpoints { //nolint:staticcheck // SA1019
+	return &corev1.Endpoints{ //nolint:staticcheck // SA1019
+		Subsets: []corev1.EndpointSubset{ //nolint:staticcheck // SA1019
 			{
 				Addresses: []corev1.EndpointAddress{{IP: ip}},
 			},
@@ -112,8 +112,8 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	t.Cleanup(func() { server.Terminate(t) })
 
-	newFunc := func() runtime.Object { return &corev1.Endpoints{} }         //nolint:kubeapilinter
-	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} } //nolint:kubeapilinter
+	newFunc := func() runtime.Object { return &corev1.Endpoints{} }         //nolint:staticcheck // SA1019: required for storage test
+	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} } //nolint:staticcheck // SA1019: required for storage test
 	sc.Codec = apitesting.TestStorageCodec(codecs, corev1.SchemeGroupVersion)
 
 	reconcileTests := []struct {
@@ -297,12 +297,12 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			initialState: []runtime.Object{
-				&corev1.Endpoints{ //nolint:kubeapilinter
+				&corev1.Endpoints{ //nolint:staticcheck // SA1019: test fixture
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "foo",
 					},
-					Subsets: []corev1.EndpointSubset{ //nolint:kubeapilinter
+					Subsets: []corev1.EndpointSubset{ //nolint:staticcheck // SA1019: test fixture
 						{
 							Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
 							Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
@@ -515,8 +515,8 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	t.Cleanup(func() { server.Terminate(t) })
 
-	newFunc := func() runtime.Object { return &corev1.Endpoints{} }         //nolint:kubeapilinter
-	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} } //nolint:kubeapilinter
+	newFunc := func() runtime.Object { return &corev1.Endpoints{} }         //nolint:staticcheck // SA1019: required for storage test
+	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} } //nolint:staticcheck // SA1019: required for storage test
 	sc.Codec = apitesting.TestStorageCodec(codecs, corev1.SchemeGroupVersion)
 
 	stopTests := []struct {
@@ -633,8 +633,8 @@ func TestApiserverShutdown(t *testing.T) {
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	t.Cleanup(func() { server.Terminate(t) })
 
-	newFunc := func() runtime.Object { return &corev1.Endpoints{} }         //nolint:kubeapilinter
-	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} } //nolint:kubeapilinter
+	newFunc := func() runtime.Object { return &corev1.Endpoints{} }         //nolint:staticcheck // SA1019: required for storage test
+	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} } //nolint:staticcheck // SA1019: required for storage test
 	sc.Codec = apitesting.TestStorageCodec(codecs, corev1.SchemeGroupVersion)
 
 	reconcileTests := []struct {

--- a/pkg/controlplane/reconcilers/lease_test.go
+++ b/pkg/controlplane/reconcilers/lease_test.go
@@ -22,7 +22,9 @@ https://github.com/openshift/origin/blob/bb340c5dd5ff72718be86fb194dedc0faed7f4c
 */
 
 import (
+	"path"
 	"reflect"
+	"slices"
 	"sort"
 	"testing"
 	"time"
@@ -30,11 +32,13 @@ import (
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/apitesting"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
@@ -82,12 +86,34 @@ func (f *fakeLeases) SetKeys(keys []string) error {
 	return nil
 }
 
+func (f *fakeLeases) SetKeysWithoutValidation(keys []string) error {
+	for _, ip := range keys {
+		key := path.Join(f.baseKey, ip)
+		err := f.storage.Create(apirequest.NewDefaultContext(), key, createLegacyEndpoint(ip), nil, 0)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+//nolint:kubeapilinter
+func createLegacyEndpoint(ip string) *corev1.Endpoints {
+	return &corev1.Endpoints{ //nolint:kubeapilinter
+		Subsets: []corev1.EndpointSubset{ //nolint:kubeapilinter
+			{
+				Addresses: []corev1.EndpointAddress{{IP: ip}},
+			},
+		},
+	}
+}
+
 func TestLeaseEndpointReconciler(t *testing.T) {
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	t.Cleanup(func() { server.Terminate(t) })
 
-	newFunc := func() runtime.Object { return &corev1.Endpoints{} }
-	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} }
+	newFunc := func() runtime.Object { return &corev1.Endpoints{} }         //nolint:kubeapilinter
+	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} } //nolint:kubeapilinter
 	sc.Codec = apitesting.TestStorageCodec(codecs, corev1.SchemeGroupVersion)
 
 	reconcileTests := []struct {
@@ -271,17 +297,17 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			ip:            "1.2.3.4",
 			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
 			initialState: []runtime.Object{
-				// can't use makeEndpointsArray() here because we don't want the
-				// skip-mirror label
-				&corev1.Endpoints{
+				&corev1.Endpoints{ //nolint:kubeapilinter
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
 						Name:      "foo",
 					},
-					Subsets: []corev1.EndpointSubset{{
-						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-						Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
-					}},
+					Subsets: []corev1.EndpointSubset{ //nolint:kubeapilinter
+						{
+							Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+							Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+						},
+					},
 				},
 				makeEndpointSlice("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
 			},
@@ -326,14 +352,38 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			),
 			expectLeases: []string{"1.2.3.4"},
 		},
+		{
+			testName:      "existing endpoints satisfy but some are invalid",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:  []string{"1.2.3.4", "127.0.0.1", "169.254.1.1"},
+			initialState:  makeEndpointsArray("foo", []string{"1.2.3.4", "127.0.0.1", "169.254.1.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectLeases:  []string{"1.2.3.4"},
+		},
+		{
+			testName:      "loopback only allowed for integration tests",
+			serviceName:   "foo",
+			ip:            "127.0.0.1",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:  []string{"127.0.0.1"},
+			initialState:  makeEndpointsArray("foo", []string{"127.0.0.1"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectLeases:  []string{"127.0.0.1"},
+		},
+		{
+			testName:      "loopback filtered when global unicast available",
+			serviceName:   "foo",
+			ip:            "1.2.3.4",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:  []string{"127.0.0.1", "1.2.3.4", "4.5.6.7"},
+			initialState:  makeEndpointsArray("foo", []string{"127.0.0.1", "1.2.3.4", "4.5.6.7"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectUpdate:  makeEndpointsArray("foo", []string{"1.2.3.4", "4.5.6.7"}, []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}}),
+			expectLeases:  []string{"1.2.3.4", "4.5.6.7"},
+		},
 	}
 	for _, test := range reconcileTests {
 		t.Run(test.testName, func(t *testing.T) {
-			// use the same base key used by the controlplane, but add a random
-			// prefix so we can reuse the etcd instance for subtests independently.
-			// pkg/controlplane/instance.go:268:
-			// masterLeases, err := reconcilers.NewLeases(config, "/masterleases/", ttl)
-			// ref: https://issues.k8s.io/114049
 			baseKey := "/" + uuid.New().String() + "/masterleases/"
 			s, dFunc, err := factory.Create(*sc.ForResource(schema.GroupResource{Resource: "endpoints"}), newFunc, newListFunc, baseKey)
 			if err != nil {
@@ -341,7 +391,11 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 			}
 			t.Cleanup(dFunc)
 			fakeLeases := newFakeLeases(t, baseKey, s)
-			err = fakeLeases.SetKeys(test.endpointKeys)
+			if test.testName == "existing endpoints satisfy but some are invalid" {
+				err = fakeLeases.SetKeysWithoutValidation(test.endpointKeys)
+			} else {
+				err = fakeLeases.SetKeys(test.endpointKeys)
+			}
 			if err != nil {
 				t.Errorf("unexpected error creating keys: %v", err)
 			}
@@ -419,11 +473,6 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 	}
 	for _, test := range nonReconcileTests {
 		t.Run(test.testName, func(t *testing.T) {
-			// use the same base key used by the controlplane, but add a random
-			// prefix so we can reuse the etcd instance for subtests independently.
-			// pkg/controlplane/instance.go:268:
-			// masterLeases, err := reconcilers.NewLeases(config, "/masterleases/", ttl)
-			// ref: https://issues.k8s.io/114049
 			baseKey := "/" + uuid.New().String() + "/masterleases/"
 			s, dFunc, err := factory.Create(*sc.ForResource(schema.GroupResource{Resource: "endpoints"}), newFunc, newListFunc, baseKey)
 			if err != nil {
@@ -466,8 +515,8 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	t.Cleanup(func() { server.Terminate(t) })
 
-	newFunc := func() runtime.Object { return &corev1.Endpoints{} }
-	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} }
+	newFunc := func() runtime.Object { return &corev1.Endpoints{} }         //nolint:kubeapilinter
+	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} } //nolint:kubeapilinter
 	sc.Codec = apitesting.TestStorageCodec(codecs, corev1.SchemeGroupVersion)
 
 	stopTests := []struct {
@@ -534,11 +583,6 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 	}
 	for _, test := range stopTests {
 		t.Run(test.testName, func(t *testing.T) {
-			// use the same base key used by the controlplane, but add a random
-			// prefix so we can reuse the etcd instance for subtests independently.
-			// pkg/controlplane/instance.go:268:
-			// masterLeases, err := reconcilers.NewLeases(config, "/masterleases/", ttl)
-			// ref: https://issues.k8s.io/114049
 			baseKey := "/" + uuid.New().String() + "/masterleases/"
 			s, dFunc, err := factory.Create(*sc.ForResource(schema.GroupResource{Resource: "pods"}), newFunc, newListFunc, baseKey)
 			if err != nil {
@@ -558,7 +602,7 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 			}
 			err = r.RemoveEndpoints(test.serviceName, netutils.ParseIPSloppy(test.ip), test.endpointPorts)
 			// if the ip is not on the endpoints, it must return an storage error and stop reconciling
-			if !contains(test.endpointKeys, test.ip) {
+			if !slices.Contains(test.endpointKeys, test.ip) {
 				if !storage.IsNotFound(err) {
 					t.Errorf("expected error StorageError: key not found, Code: 1, Key: /registry/base/key/%s got:  %v", test.ip, err)
 				}
@@ -585,21 +629,12 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 	}
 }
 
-func contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-	return false
-}
-
 func TestApiserverShutdown(t *testing.T) {
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	t.Cleanup(func() { server.Terminate(t) })
 
-	newFunc := func() runtime.Object { return &corev1.Endpoints{} }
-	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} }
+	newFunc := func() runtime.Object { return &corev1.Endpoints{} }         //nolint:kubeapilinter
+	newListFunc := func() runtime.Object { return &corev1.EndpointsList{} } //nolint:kubeapilinter
 	sc.Codec = apitesting.TestStorageCodec(codecs, corev1.SchemeGroupVersion)
 
 	reconcileTests := []struct {
@@ -660,11 +695,6 @@ func TestApiserverShutdown(t *testing.T) {
 	}
 	for _, test := range reconcileTests {
 		t.Run(test.testName, func(t *testing.T) {
-			// use the same base key used by the controlplane, but add a random
-			// prefix so we can reuse the etcd instance for subtests independently.
-			// pkg/controlplane/instance.go:268:
-			// masterLeases, err := reconcilers.NewLeases(config, "/masterleases/", ttl)
-			// ref: https://issues.k8s.io/114049
 			baseKey := "/" + uuid.New().String() + "/masterleases/"
 			s, dFunc, err := factory.Create(*sc.ForResource(schema.GroupResource{Resource: "endpoints"}), newFunc, newListFunc, baseKey)
 			if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR adds robust IP validation to the master lease reconciler. 
A misconfigured apiserver (e.g., using --advertise-address=127.0.0.1) could previously poison the master lease pool in etcd. This caused the kubernetes Service endpoint reconciliation to fail for all apiservers because the invalid address was rejected during the final Endpoints object validation.

The fix includes:
1. Validating IPs before updating master leases to prevent invalid addresses (loopback, link-local, unspecified) from being persisted.
2. Filtering out any existing invalid addresses from the lease pool during reconciliation.
3. Added comprehensive tests to verify the behavior.

#### Which issue(s) this PR is related to:
Fixes #121942

#### Special notes for your reviewer:
The validation logic in pkg/controlplane/reconcilers intentionally mimics pkg/apis/core/validation.ValidateEndpointIP to avoid circular dependencies while maintaining consistent behavior for the kubernetes Service.

#### Does this PR introduce a user-facing change?
```release-note
Prevent misconfigured apiserver advertise addresses (like loopback or link-local) from blocking the registration of other healthy apiservers in the kubernetes Service endpoints.
```