### PR TITLE
Add templateParams to createPods, createAny, createNodes

### DIFF
--- a/test/integration/scheduler_perf/executor.go
+++ b/test/integration/scheduler_perf/executor.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"os"
 	"runtime"
@@ -802,7 +803,7 @@ func getNodePreparer(prefix string, cno *createNodesOp, clientset clientset.Inte
 
 	nodeTemplate := StaticNodeTemplate(makeBaseNode(prefix))
 	if cno.NodeTemplatePath != nil {
-		nodeTemplate = nodeTemplateFromFile(*cno.NodeTemplatePath)
+		nodeTemplate = nodeTemplateWithParams{path: *cno.NodeTemplatePath, params: cno.TemplateParams}
 	}
 
 	return NewIntegrationTestNodePreparer(
@@ -852,7 +853,7 @@ func waitUntilPodsScheduledInNamespace(tCtx ktesting.TContext, podInformer corei
 func getPodStrategy(cpo *createPodsOp) (testutils.TestPodCreateStrategy, error) {
 	podTemplate := testutils.StaticPodTemplate(makeBasePod())
 	if cpo.PodTemplatePath != nil {
-		podTemplate = podTemplateFromFile(*cpo.PodTemplatePath)
+		podTemplate = podTemplateWithParams{path: *cpo.PodTemplatePath, params: cpo.TemplateParams}
 	}
 	if cpo.PersistentVolumeClaimTemplatePath == nil {
 		return testutils.NewCustomCreatePodStrategy(podTemplate), nil
@@ -869,21 +870,35 @@ func getPodStrategy(cpo *createPodsOp) (testutils.TestPodCreateStrategy, error) 
 	return testutils.NewCreatePodWithPersistentVolumeStrategy(pvcTemplate, getCustomVolumeFactory(pvTemplate), podTemplate), nil
 }
 
-type nodeTemplateFromFile string
+type nodeTemplateWithParams struct {
+	path   string
+	params map[string]any
+}
 
-func (f nodeTemplateFromFile) GetNodeTemplate(index, count int) (*v1.Node, error) {
+func (n nodeTemplateWithParams) GetNodeTemplate(index, count int) (*v1.Node, error) {
+	env := make(map[string]any)
+	maps.Copy(env, n.params)
+	env["Index"] = index
+	env["Count"] = count
 	nodeSpec := &v1.Node{}
-	if err := getSpecFromTextTemplateFile(string(f), map[string]any{"Index": index, "Count": count}, nodeSpec); err != nil {
+	if err := getSpecFromTextTemplateFile(n.path, env, nodeSpec); err != nil {
 		return nil, fmt.Errorf("parsing Node: %w", err)
 	}
 	return nodeSpec, nil
 }
 
-type podTemplateFromFile string
+type podTemplateWithParams struct {
+	path   string
+	params map[string]any
+}
 
-func (f podTemplateFromFile) GetPodTemplate(index, count int) (*v1.Pod, error) {
+func (p podTemplateWithParams) GetPodTemplate(index, count int) (*v1.Pod, error) {
+	env := make(map[string]any)
+	maps.Copy(env, p.params)
+	env["Index"] = index
+	env["Count"] = count
 	podSpec := &v1.Pod{}
-	if err := getSpecFromTextTemplateFile(string(f), map[string]any{"Index": index, "Count": count}, podSpec); err != nil {
+	if err := getSpecFromTextTemplateFile(p.path, env, podSpec); err != nil {
 		return nil, fmt.Errorf("parsing Pod: %w", err)
 	}
 	return podSpec, nil

--- a/test/integration/scheduler_perf/operations.go
+++ b/test/integration/scheduler_perf/operations.go
@@ -22,8 +22,10 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"maps"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -54,6 +56,9 @@ type createAny struct {
 	// Count determines how many objects get created. Defaults to 1 if unset.
 	Count      *int
 	CountParam string
+	// Params to be passed to the template.
+	// Values with `$` prefix will be resolved to the workload parameters.
+	TemplateParams map[string]any
 }
 
 var _ runnableOp = &createAny{}
@@ -79,6 +84,13 @@ func (c createAny) patchParams(w *Workload) (realOp, error) {
 		}
 		c.Count = ptr.To(count)
 	}
+	if len(c.TemplateParams) > 0 {
+		var err error
+		c.TemplateParams, err = resolveTemplateParams(c.TemplateParams, w)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &c, c.isValid(false)
 }
 
@@ -95,7 +107,11 @@ func (c *createAny) run(tCtx ktesting.TContext) {
 		count = *c.Count
 	}
 	for index := 0; index < count; index++ {
-		c.create(tCtx, map[string]any{"Index": index, "Count": count})
+		env := make(map[string]any)
+		maps.Copy(env, c.TemplateParams)
+		env["Index"] = index
+		env["Count"] = count
+		c.create(tCtx, env)
 	}
 }
 
@@ -202,6 +218,9 @@ type createNodesOp struct {
 	NodeAllocatableStrategy  *testutils.NodeAllocatableStrategy
 	LabelNodePrepareStrategy *testutils.LabelNodePrepareStrategy
 	UniqueNodeLabelStrategy  *testutils.UniqueNodeLabelStrategy
+	// Params to be passed to the template.
+	// Values with `$` prefix will be resolved to the workload parameters.
+	TemplateParams map[string]any
 }
 
 func (cno *createNodesOp) isValid(allowParameterization bool) error {
@@ -216,9 +235,15 @@ func (*createNodesOp) collectsMetrics() bool {
 }
 
 func (cno createNodesOp) patchParams(w *Workload) (realOp, error) {
+	var err error
 	if cno.CountParam != "" {
-		var err error
 		cno.Count, err = w.Params.get(cno.CountParam[1:])
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(cno.TemplateParams) > 0 {
+		cno.TemplateParams, err = resolveTemplateParams(cno.TemplateParams, w)
 		if err != nil {
 			return nil, err
 		}
@@ -317,6 +342,9 @@ type createPodsOp struct {
 	// Optional
 	PersistentVolumeTemplatePath      *string
 	PersistentVolumeClaimTemplatePath *string
+	// Params to be passed to the template.
+	// Values with `$` prefix will be resolved to the workload parameters.
+	TemplateParams map[string]any
 }
 
 func (cpo *createPodsOp) isValid(allowParameterization bool) error {
@@ -343,8 +371,8 @@ func (cpo *createPodsOp) collectsMetrics() bool {
 }
 
 func (cpo createPodsOp) patchParams(w *Workload) (realOp, error) {
+	var err error
 	if cpo.CountParam != "" {
-		var err error
 		cpo.Count, err = w.Params.get(cpo.CountParam[1:])
 		if err != nil {
 			return nil, err
@@ -360,8 +388,13 @@ func (cpo createPodsOp) patchParams(w *Workload) (realOp, error) {
 		}
 	}
 	if cpo.SteadyStateParam != "" {
-		var err error
 		cpo.SteadyState, err = getParam[bool](w.Params, cpo.SteadyStateParam[1:])
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(cpo.TemplateParams) > 0 {
+		cpo.TemplateParams, err = resolveTemplateParams(cpo.TemplateParams, w)
 		if err != nil {
 			return nil, err
 		}
@@ -617,6 +650,26 @@ func (*stopCollectingMetricsOp) collectsMetrics() bool {
 
 func (scm stopCollectingMetricsOp) patchParams(_ *Workload) (realOp, error) {
 	return &scm, nil
+}
+
+// resolveTemplateParams resolves the template parameters using the workload parameters.
+func resolveTemplateParams(templateParams map[string]any, w *Workload) (map[string]any, error) {
+	if len(templateParams) == 0 {
+		return templateParams, nil
+	}
+	resolved := maps.Clone(templateParams)
+	for k, v := range resolved {
+		if s, ok := v.(string); ok && strings.HasPrefix(s, "$") {
+			paramKey := s[1:]
+			if val, found := w.Params.params[paramKey]; found {
+				w.Params.isUsed[paramKey] = true
+				resolved[k] = val
+				continue
+			}
+			return nil, fmt.Errorf("parameter %q not found", paramKey)
+		}
+	}
+	return resolved, nil
 }
 
 func getTemplateFuncs() template.FuncMap {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR introduces the possibility to pass custom parameters to the Pod/Any/Nodes templates in the . It allows for better customization of the yaml files used in scheduler perf tests. For example with this new logic it's possible to create such  aNode template:
```
apiVersion: v1
kind: Node
metadata:
  generateName: scheduler-perf-
  labels:
    topology-rack: replica-{{ Mod .Index .rackCount }}
...
```
with
```
  - opcode: createNodes
    countParam: $nodes
    nodeTemplatePath: templates/node-with-rack.yaml
    templateParams:
      rackCount: $rackCount
```
in workload template, to allow customization of the number of different "racks" available in the test scenario.



#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a second PR from the chain, where the end goal is to have an easy way of testing TAS performance (https://github.com/kubernetes/kubernetes/pull/136979)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
