### PR TITLE
client-go: fix goroutine hot-loop in StartEventWatcher on broadcaster shutdown

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -408,7 +408,10 @@ func (e *eventBroadcasterImpl) StartEventWatcher(eventHandler func(*v1.Event)) w
 			case <-e.cancelationCtx.Done():
 				watcher.Stop()
 				return
-			case watchEvent := <-watcher.ResultChan():
+			case watchEvent, ok := <-watcher.ResultChan():
+				if !ok {
+					return
+				}
 				event, ok := watchEvent.Object.(*v1.Event)
 				if !ok {
 					// This is all local, so there's no reason this should

--- a/staging/src/k8s.io/client-go/tools/record/event_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/event_test.go
@@ -135,6 +135,35 @@ func TestBroadcasterShutdown(t *testing.T) {
 	goleak.VerifyNone(t)
 }
 
+// TestStartEventWatcherExitsOnDirectShutdown is a regression test for the
+// hot-loop that occurred when Broadcaster.Shutdown() closed the watcher's
+// result channel before the cancellation context was cancelled.
+//
+// When NewBroadcaster is called without a context, Shutdown() sequentially:
+//
+//  1. Calls e.Broadcaster.Shutdown() → watcher result channels are closed via
+//     closeAll(); all queued events have already been delivered at this point.
+//  2. Calls e.cancel() → cancelationCtx is cancelled.
+//
+// Between steps 1 and 2 there is a window where ResultChan() is closed but
+// cancelationCtx.Done() has not yet fired. The goroutine inside
+// StartEventWatcher must detect the closed channel (ok == false) and return
+// cleanly instead of spinning. goleak.VerifyTestMain (installed in
+// main_test.go) will report a leaked goroutine if the fix regresses.
+func TestStartEventWatcherExitsOnDirectShutdown(t *testing.T) {
+	// No context → haveCtxCancelation is false, so no background Broadcaster
+	// shutdown goroutine; Shutdown() is fully synchronous here.
+	caster := NewBroadcaster(WithSleepDuration(0))
+	caster.StartStructuredLogging(0)
+
+	// Direct shutdown: closes watcher channels first, then cancels context.
+	caster.Shutdown()
+
+	// goleak.VerifyTestMain checks for leaks across the whole test binary, but
+	// explicitly verifying here surfaces any regression in this specific path.
+	goleak.VerifyNone(t)
+}
+
 func TestNonRacyShutdown(t *testing.T) {
 	// Attempt to simulate previously racy conditions, and ensure that no race
 	// occurs: Nominally, calling "Eventf" *followed by* shutdown from the same


### PR DESCRIPTION
/kind bug
/sig api-machinery

#### What this PR does / why we need it:

`StartEventWatcher` launches a goroutine that reads events from a `watch.Interface` channel:

```go
case watchEvent := <-watcher.ResultChan():
```

When `eventBroadcasterImpl.Shutdown()` is called, the following sequence occurs:

1. `e.Broadcaster.Shutdown()` blocks until `closeAll()` closes every watcher's result channel.
2. `e.cancel()` is called to signal the cancellation context.

Between steps 1 and 2 -- and also in configurations where no cancellation context exists -- the closed channel returns the zero-value `watch.Event` on every iteration without blocking. The goroutine enters a hot loop that burns CPU until the context is cancelled or the process exits.

This PR guards against the closed-channel condition using the idiomatic two-value receive:

```go
case watchEvent, ok := <-watcher.ResultChan():
    if !ok {
        return
    }
```

A regression test, `TestStartEventWatcherExitsOnDirectShutdown`, is added. It calls `Shutdown()` with no cancellation context and asserts via `goleak.VerifyNone` that no goroutines are leaked. This test fails on the un-patched code and passes after the fix.

##### On event safety

`watch.Broadcaster.Shutdown()` is fully synchronous: it drains the `incoming` channel completely before invoking `closeAll()`. All in-flight events are delivered to every watcher handler before the result channel is closed. Returning when `ok == false` therefore incurs zero event loss.

##### Why this is a real issue (re: @sttts)

This is not a theoretical concern. The window between `Broadcaster.Shutdown()` closing channels and `cancel()` firing is OS-scheduler dependent and can be arbitrarily long under load. The `goleak`-backed regression test reproduces the goroutine leak deterministically.

#### Which issue(s) this PR is related to:

Refs #135924

#### Special notes for your reviewer:

- The fix is a single idiomatic Go pattern (`v, ok := <-ch`), with no behavioral change on the normal event-processing path.
- `goleak.VerifyTestMain` is already installed in `main_test.go`, so goroutine leak detection is package-wide.

#### Does this PR introduce a user-facing change?

```release-note
Fix goroutine hot-loop in client-go StartEventWatcher when the event broadcaster shuts down before the cancellation context fires.
```
