### PR TITLE
Automated cherry pick of #137252: Use localhost Image Reference in PodObservedGenerationTracking E2E Test

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -695,7 +695,7 @@ var _ = SIGDescribe("Pods Extended (pod generation)", func() {
 			// Set the pod image to something that doesn't exist to induce a pull error
 			// to start with.
 			agnImage := pod.Spec.Containers[0].Image
-			pod.Spec.Containers[0].Image = "some-image-that-doesnt-exist"
+			pod.Spec.Containers[0].Image = "localhost/some-image-that-doesnt-exist"
 
 			ginkgo.By("submitting the pod to kubernetes")
 			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})


### PR DESCRIPTION
Cherry pick of #137252 on release-1.35.

#137252: Use localhost Image Reference in PodObservedGenerationTracking E2E Test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```

cc: @bitoku 