### PR TITLE
fix(kube-proxy): fix IPv6 support check for Linux

### DIFF
--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
@@ -106,7 +107,14 @@ func (s *ProxyServer) platformCheckSupported(ctx context.Context) (ipv4Supported
 
 	// Check if the OS has IPv6 enabled, by verifying if the IPv6 interfaces are available
 	_, errIPv6 := os.Stat("/proc/net/if_inet6")
-	if errIPv6 != nil {
+	if errIPv6 == nil {
+		// Also check that IPv6 hasn't been disabled
+		content, err := os.ReadFile("/proc/sys/net/ipv6/conf/all/disable_ipv6")
+		if err == nil && strings.TrimSpace(string(content)) == "1" {
+			logger.Info("Kernel support disabled for family", "ipFamily", v1.IPv6Protocol)
+			ipv6Supported = false
+		}
+	} else {
 		logger.Info("No kernel support for family", "ipFamily", v1.IPv6Protocol)
 		ipv6Supported = false
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The current Linux implementation checks whether a node supports IPv6 by testing for the presence of `/proc/net/if_inet6`. However, that check does not confirm that IPv6 support is actually enabled. As a result, `kube-proxy` can incorrectly enable dual‑stack support on nodes that do not have IPv6 enabled.

The possibility to disable IPv6 support has existed since Linux kernel v2.6.27.

Update the IPv6 support check to also consider the contents of `/proc/sys/net/ipv6/conf/all/disable_ipv6`.

#### Which issue(s) this PR is related to:
Fixes #137401 
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
