### PR TITLE
Wait for RS to report status rather than count pods

### DIFF
--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -415,11 +415,11 @@ func testRSScaleSubresources(ctx context.Context, f *framework.Framework) {
 	replicas := int32(1)
 	ginkgo.By(fmt.Sprintf("Creating replica set %q that asks for more than the allowed pod quota", rsName))
 	rs := newRS(rsName, replicas, rsPodLabels, AgnhostImageName, AgnhostImage, nil)
-	_, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
+	createdRS, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Verify that the required pods have come up.
-	err = e2epod.VerifyPodsRunning(ctx, c, ns, podName, labels.SelectorFromSet(map[string]string{"name": podName}), false, replicas)
+	err = e2ereplicaset.WaitForReplicaSetTargetAvailableReplicas(ctx, c, createdRS, replicas)
 	framework.ExpectNoError(err, "error in waiting for pods to come up: %s", err)
 
 	ginkgo.By("getting scale subresource")


### PR DESCRIPTION
/kind flake
/sig apps

#### What this PR does / why we need it:
The current test was flaking because we were only waiting for pods to report readiness state, which doesn't guarantee the controller saw the same state. So this PR modifies to wait for controller to acknowledge the desired replicas. 

#### Which issue(s) this PR is related to:
Fixes #137393

#### Special notes for your reviewer:
/assign @janetkuo or @atiratree 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
