### PR TITLE
Fix kubectl exec returning exit code 0 on connection loss

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/errorstream.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/errorstream.go
@@ -43,10 +43,8 @@ func watchErrorStream(logger klog.Logger, errorStream io.Reader, d errorStreamDe
 		switch {
 		case err != nil && err != io.EOF:
 			errorChan <- fmt.Errorf("error reading from error stream: %w", err)
-		case len(message) > 0:
-			errorChan <- d.decode(message)
 		default:
-			errorChan <- nil
+			errorChan <- d.decode(message)
 		}
 		close(errorChan)
 	}()

--- a/staging/src/k8s.io/client-go/tools/remotecommand/errorstream.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/errorstream.go
@@ -44,6 +44,8 @@ func watchErrorStream(logger klog.Logger, errorStream io.Reader, d errorStreamDe
 		case err != nil && err != io.EOF:
 			errorChan <- fmt.Errorf("error reading from error stream: %w", err)
 		default:
+			// Delegate to the protocol-specific decoder, including for empty messages.
+			// v2/v3 treat empty as success; v4/v5 treat empty as an interrupted connection.
 			errorChan <- d.decode(message)
 		}
 		close(errorChan)

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
@@ -202,6 +202,11 @@ type errorDecoderV2 struct{}
 
 func (d *errorDecoderV2) decode(message []byte) error {
 	if len(message) == 0 {
+		// In v2/v3, the error stream carries plain-text error messages and an empty
+		// stream indicates success (the command completed without error; see v1WriteStatusFunc in
+		// https://github.com/kubernetes/kubernetes/blob/c38abeb4ffeab8d736376f7a9d0fe5f8c5b0af10/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/httpstream.go#L432-L440).
+		// This differs from v4/v5, where the kubelet always writes a JSON-marshaled metav1.Status
+		// and an empty stream signals an interrupted connection.
 		return nil
 	}
 	return fmt.Errorf("error executing remote command: %s", message)

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
@@ -201,5 +201,8 @@ func (p *streamProtocolV2) stream(logger klog.Logger, conn streamCreator, ready 
 type errorDecoderV2 struct{}
 
 func (d *errorDecoderV2) decode(message []byte) error {
+	if len(message) == 0 {
+		return nil
+	}
 	return fmt.Errorf("error executing remote command: %s", message)
 }

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v2_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v2_test.go
@@ -213,6 +213,11 @@ func TestV2ErrorStreamReading(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:          "empty error stream (success)",
+			stream:        strings.NewReader(""),
+			expectedError: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v4.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v4.go
@@ -87,6 +87,11 @@ type errorDecoderV4 struct{}
 
 func (d *errorDecoderV4) decode(message []byte) error {
 	if len(message) == 0 {
+		// In v4/v5, the kubelet always writes a JSON-marshaled metav1.Status to the error stream
+		// when the command completes (see v4WriteStatusFunc in
+		// https://github.com/kubernetes/kubernetes/blob/c38abeb4ffeab8d736376f7a9d0fe5f8c5b0af10/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/httpstream.go#L444-L453).
+		// An empty error stream therefore means the connection was interrupted before the
+		// command finished (e.g., kubelet restart or network drop).
 		return fmt.Errorf("error stream closed before receiving a status message: command execution may have been interrupted")
 	}
 	status := metav1.Status{}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v4.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v4.go
@@ -86,6 +86,9 @@ func (p *streamProtocolV4) stream(logger klog.Logger, conn streamCreator, ready 
 type errorDecoderV4 struct{}
 
 func (d *errorDecoderV4) decode(message []byte) error {
+	if len(message) == 0 {
+		return fmt.Errorf("error stream closed before receiving a status message: command execution may have been interrupted")
+	}
 	status := metav1.Status{}
 	err := json.Unmarshal(message, &status)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v4_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v4_test.go
@@ -20,6 +20,10 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestV4ErrorDecoder(t *testing.T) {
@@ -31,6 +35,10 @@ func TestV4ErrorDecoder(t *testing.T) {
 	}
 
 	for _, test := range []Test{
+		{
+			message: "",
+			err:     "error stream closed before receiving a status message: command execution may have been interrupted",
+		},
 		{
 			message: "{}",
 			err:     "error stream protocol error: unknown error",
@@ -68,5 +76,29 @@ func TestV4ErrorDecoder(t *testing.T) {
 		if got := fmt.Sprintf("%v", err); !strings.Contains(got, want) {
 			t.Errorf("wrong error for message %q: want=%q, got=%q", test.message, want, got)
 		}
+	}
+}
+
+func TestV4WatchErrorStreamEmptyMessage(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	// Simulate an empty error stream (e.g., connection closed during kubelet restart).
+	// With errorDecoderV4, this should return an error, not nil.
+	h := newStreamProtocolV4(StreamOptions{}).(*streamProtocolV4)
+	h.errorStream = strings.NewReader("")
+
+	ch := watchErrorStream(logger, h.errorStream, &errorDecoderV4{})
+	if ch == nil {
+		t.Fatal("unexpected nil channel")
+	}
+
+	select {
+	case err := <-ch:
+		if err == nil {
+			t.Error("expected an error for empty error stream with v4 decoder, got nil")
+		} else if !strings.Contains(err.Error(), "error stream closed before receiving a status message") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("timed out waiting for error")
 	}
 }


### PR DESCRIPTION
When kubelet restarts (or the connection is otherwise lost) during kubectl exec, the error stream closes with EOF and 0 bytes read. Previously, watchErrorStream() returned nil for empty messages, causing kubectl to exit with code 0 — falsely indicating success.

This fix delegates empty-message handling to the error stream decoder. For v4/v5 protocols (which always expect a JSON Status message), an empty error stream now returns a descriptive error. For v2/v3 protocols (where empty stream = success), the existing behavior is preserved.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
When kubelet restarts (or the connection is otherwise lost) during `kubectl exec`, the SPDY/WebSocket error stream closes with EOF and 0 bytes read. Previously, `watchErrorStream()` in `errorstream.go` had a `default` case that returned `nil` for empty messages, causing `kubectl exec` to exit with code 0 — falsely indicating the remote command succeeded.

This PR fixes the issue by delegating empty-message handling to the protocol-specific error stream decoder instead of unconditionally returning `nil`:

- **v4/v5 protocols**: The kubelet *always* writes a JSON `metav1.Status` to the error stream on completion. An empty error stream therefore indicates the connection was interrupted before the command finished, and now returns a descriptive error.
- **v2/v3 protocols**: An empty error stream genuinely means success (kubelet writes nothing on success), so the existing behavior is preserved.

**Reproduction steps:**
1. `kubectl run pinger --image=busybox -- sleep 3600`
2. `kubectl exec pinger -- sleep 30 &`
3. Restart kubelet (e.g., `minikube ssh "sudo systemctl restart kubelet"`)
4. Observe `kubectl exec` exits with code 0 (before fix) vs non-zero (after fix)


#### Which issue(s) this PR is related to:
Fixes #130885

#### Special notes for your reviewer:
The fix is intentionally scoped to the error stream decoder layer in `client-go/tools/remotecommand` rather than in `kubectl` itself, since any consumer of the `remotecommand` streaming API would be affected by this behavior.

The key insight is that v4/v5 stream protocols (used by default since Kubernetes 1.4) always expect the kubelet to write a `Status` JSON object to the error stream. An empty error stream is not a valid success signal — it means the connection was severed. For v2/v3 protocols, empty error stream = success, so we preserve that behavior by having each decoder handle the empty case independently.

Files changed:
- `staging/src/k8s.io/client-go/tools/remotecommand/errorstream.go` — always delegate to decoder
- `staging/src/k8s.io/client-go/tools/remotecommand/v2.go` — handle empty message as success
- `staging/src/k8s.io/client-go/tools/remotecommand/v4.go` — handle empty message as error
- `staging/src/k8s.io/client-go/tools/remotecommand/v2_test.go` — test empty stream for v2
- `staging/src/k8s.io/client-go/tools/remotecommand/v4_test.go` — test empty stream for v4

#### Does this PR introduce a user-facing change?
```release-note
kubectl exec now returns a non-zero exit code when the connection to the kubelet is lost (e.g., during a kubelet restart), instead of silently returning exit code 0. A descriptive error message is printed to stderr indicating that command execution may have been interrupted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
