### PR TITLE
kube-controller-manager: reload --root-ca-file in CA cert publishers

### DIFF
--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -21,6 +21,7 @@ package app
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"time"
 
@@ -261,7 +262,7 @@ func newRootCACertificatePublisherControllerDescriptor() *ControllerDescriptor {
 }
 
 func newRootCACertificatePublisherController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	rootCA, err := getKubeAPIServerCAFileContents(controllerContext)
+	caProvider, caRun, err := getKubeAPIServerCAContentProvider(controllerContext)
 	if err != nil {
 		return nil, err
 	}
@@ -275,15 +276,17 @@ func newRootCACertificatePublisherController(ctx context.Context, controllerCont
 		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
 		controllerContext.InformerFactory.Core().V1().Namespaces(),
 		client,
-		rootCA,
+		caProvider,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating root CA certificate publisher: %w", err)
 	}
 
-	return newControllerLoop(func(ctx context.Context) {
-		sac.Run(ctx, 1)
-	}, controllerName), nil
+	runners := []runFunc{func(ctx context.Context) { sac.Run(ctx, 1) }}
+	if caRun != nil {
+		runners = append(runners, caRun)
+	}
+	return newControllerLoop(concurrentRun(runners...), controllerName), nil
 }
 
 func newKubeAPIServerSignerClusterTrustBundledPublisherDescriptor() *ControllerDescriptor {
@@ -299,17 +302,12 @@ type controllerConstructor func(string, dynamiccertificates.CAContentProvider, k
 func newKubeAPIServerSignerClusterTrustBundledPublisherController(
 	ctx context.Context, controllerContext ControllerContext, controllerName string,
 ) (Controller, error) {
-	rootCA, err := getKubeAPIServerCAFileContents(controllerContext)
+	servingSigners, caRun, err := getKubeAPIServerCAContentProvider(controllerContext)
 	if err != nil {
 		return nil, err
 	}
-	if len(rootCA) == 0 {
+	if len(servingSigners.CurrentCABundleContent()) == 0 {
 		return nil, nil
-	}
-
-	servingSigners, err := dynamiccertificates.NewStaticCAContent("kube-apiserver-serving", rootCA)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create a static CA content provider for the kube-apiserver-serving signer: %w", err)
 	}
 
 	schemaControllerMapping := map[schema.GroupVersion]controllerConstructor{
@@ -349,7 +347,11 @@ func newKubeAPIServerSignerClusterTrustBundledPublisherController(
 		return nil, nil
 	}
 
-	return newControllerLoop(runner.Run, controllerName), nil
+	runners := []runFunc{runner.Run}
+	if caRun != nil {
+		runners = append(runners, caRun)
+	}
+	return newControllerLoop(concurrentRun(runners...), controllerName), nil
 }
 
 func clusterTrustBundlesAvailable(client kubernetes.Interface, schemaVersion schema.GroupVersion) (bool, error) {
@@ -370,19 +372,42 @@ func clusterTrustBundlesAvailable(client kubernetes.Interface, schemaVersion sch
 	return false, err
 }
 
-func getKubeAPIServerCAFileContents(controllerContext ControllerContext) ([]byte, error) {
-	if controllerContext.ComponentConfig.SAController.RootCAFile == "" {
+// clientConfigCAContent is a static, non-validating CAContentProvider holding
+// the CA bundle from kube-controller-manager's own client config. Used when
+// --root-ca-file is not set. Unlike dynamiccertificates.NewStaticCAContent it
+// does not require the bytes to be parseable PEM, so an empty or malformed
+// bundle is passed through as-is.
+type clientConfigCAContent struct {
+	caBundle []byte
+}
+
+func (c clientConfigCAContent) Name() string                   { return "client-config" }
+func (c clientConfigCAContent) CurrentCABundleContent() []byte { return c.caBundle }
+func (c clientConfigCAContent) VerifyOptions() (x509.VerifyOptions, bool) {
+	return x509.VerifyOptions{}, false
+}
+func (c clientConfigCAContent) AddListener(dynamiccertificates.Listener) {}
+
+// getKubeAPIServerCAContentProvider returns a CA content provider for the
+// kube-apiserver serving CA, and a runFunc that drives the file watcher
+// (nil if there is nothing to watch).
+//
+// If --root-ca-file is set, the provider watches the file for changes.
+// Otherwise the CA bundle from kube-controller-manager's own client config is
+// used and never changes.
+func getKubeAPIServerCAContentProvider(controllerContext ControllerContext) (dynamiccertificates.CAContentProvider, runFunc, error) {
+	caFile := controllerContext.ComponentConfig.SAController.RootCAFile
+	if caFile == "" {
 		config, err := controllerContext.NewClientConfig("root-ca-cert-publisher")
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return config.CAData, nil
+		return clientConfigCAContent{caBundle: config.CAData}, nil, nil
 	}
 
-	rootCA, err := readCA(controllerContext.ComponentConfig.SAController.RootCAFile)
+	dyn, err := dynamiccertificates.NewDynamicCAContentFromFile("kube-apiserver-serving", caFile)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing root-ca-file at %s: %w", controllerContext.ComponentConfig.SAController.RootCAFile, err)
+		return nil, nil, fmt.Errorf("error parsing root-ca-file at %s: %w", caFile, err)
 	}
-	return rootCA, nil
-
+	return dyn, func(ctx context.Context) { dyn.Run(ctx, 1) }, nil
 }

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -26,8 +26,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -52,10 +54,14 @@ func init() {
 // NewPublisher construct a new controller which would manage the configmap
 // which stores certificates in each namespace. It will make sure certificate
 // configmap exists in each namespace.
-func NewPublisher(cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
+//
+// The CA bundle is read from ca on every sync. The Publisher registers
+// itself as a listener on ca and re-queues all namespaces when the bundle
+// changes.
+func NewPublisher(cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, ca dynamiccertificates.CAContentProvider) (*Publisher, error) {
 	e := &Publisher{
 		client: cl,
-		rootCA: rootCA,
+		ca:     ca,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
@@ -75,9 +81,12 @@ func NewPublisher(cmInformer coreinformers.ConfigMapInformer, nsInformer coreinf
 		AddFunc:    e.namespaceAdded,
 		UpdateFunc: e.namespaceUpdated,
 	})
+	e.nsLister = nsInformer.Lister()
 	e.nsListerSynced = nsInformer.Informer().HasSynced
 
 	e.syncHandler = e.syncNamespace
+
+	ca.AddListener(e)
 
 	return e, nil
 
@@ -86,7 +95,7 @@ func NewPublisher(cmInformer coreinformers.ConfigMapInformer, nsInformer coreinf
 // Publisher manages certificate ConfigMap objects inside Namespaces
 type Publisher struct {
 	client clientset.Interface
-	rootCA []byte
+	ca     dynamiccertificates.CAContentProvider
 
 	// To allow injection for testing.
 	syncHandler func(ctx context.Context, key string) error
@@ -94,6 +103,7 @@ type Publisher struct {
 	cmLister       corelisters.ConfigMapLister
 	cmListerSynced cache.InformerSynced
 
+	nsLister       corelisters.NamespaceLister
 	nsListerSynced cache.InformerSynced
 
 	queue workqueue.TypedRateLimitingInterface[string]
@@ -113,7 +123,7 @@ func (c *Publisher) Run(ctx context.Context, workers int) {
 		wg.Wait()
 	}()
 
-	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.cmListerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.cmListerSynced, c.nsListerSynced) {
 		return
 	}
 
@@ -162,6 +172,20 @@ func (c *Publisher) namespaceUpdated(oldObj interface{}, newObj interface{}) {
 	c.queue.Add(newNamespace.Name)
 }
 
+// Enqueue implements dynamiccertificates.Listener. It re-queues every
+// namespace so each kube-root-ca.crt ConfigMap is reconciled against the
+// current CA bundle.
+func (c *Publisher) Enqueue() {
+	namespaces, err := c.nsLister.List(labels.Everything())
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("root-ca-cert-publisher: listing namespaces after CA change: %w", err))
+		return
+	}
+	for _, ns := range namespaces {
+		c.queue.Add(ns.Name)
+	}
+}
+
 func (c *Publisher) runWorker(ctx context.Context) {
 	for c.processNextWorkItem(ctx) {
 	}
@@ -193,6 +217,7 @@ func (c *Publisher) syncNamespace(ctx context.Context, ns string) (err error) {
 		klog.FromContext(ctx).V(4).Info("Finished syncing namespace", "namespace", ns, "elapsedTime", time.Since(startTime))
 	}()
 
+	rootCA := c.ca.CurrentCABundleContent()
 	cm, err := c.cmLister.ConfigMaps(ns).Get(RootCACertConfigMapName)
 	switch {
 	case apierrors.IsNotFound(err):
@@ -202,7 +227,7 @@ func (c *Publisher) syncNamespace(ctx context.Context, ns string) (err error) {
 				Annotations: map[string]string{DescriptionAnnotation: Description},
 			},
 			Data: map[string]string{
-				"ca.crt": string(c.rootCA),
+				"ca.crt": string(rootCA),
 			},
 		}, metav1.CreateOptions{})
 		// don't retry a create if the namespace doesn't exist or is terminating
@@ -215,7 +240,7 @@ func (c *Publisher) syncNamespace(ctx context.Context, ns string) (err error) {
 	}
 
 	data := map[string]string{
-		"ca.crt": string(c.rootCA),
+		"ca.crt": string(rootCA),
 	}
 
 	// ensure the data and the one annotation describing usage of this configmap match.

--- a/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
@@ -18,13 +18,16 @@ package rootcacertpublisher
 
 import (
 	"context"
+	"crypto/x509"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -32,6 +35,46 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller"
 )
+
+// fakeCAContent is a mutable CAContentProvider that notifies its listeners
+// when setContent is called.
+type fakeCAContent struct {
+	mu        sync.Mutex
+	content   []byte
+	listeners []dynamiccertificates.Listener
+}
+
+func newFakeCAContent(content []byte) *fakeCAContent {
+	return &fakeCAContent{content: content}
+}
+
+func (f *fakeCAContent) Name() string { return "fake" }
+
+func (f *fakeCAContent) CurrentCABundleContent() []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.content
+}
+
+func (f *fakeCAContent) VerifyOptions() (x509.VerifyOptions, bool) {
+	return x509.VerifyOptions{}, false
+}
+
+func (f *fakeCAContent) AddListener(l dynamiccertificates.Listener) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listeners = append(f.listeners, l)
+}
+
+func (f *fakeCAContent) setContent(content []byte) {
+	f.mu.Lock()
+	f.content = content
+	ls := append([]dynamiccertificates.Listener(nil), f.listeners...)
+	f.mu.Unlock()
+	for _, l := range ls {
+		l.Enqueue()
+	}
+}
 
 func TestConfigMapCreation(t *testing.T) {
 	ns := metav1.NamespaceDefault
@@ -126,7 +169,7 @@ func TestConfigMapCreation(t *testing.T) {
 			informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 			cmInformer := informers.Core().V1().ConfigMaps()
 			nsInformer := informers.Core().V1().Namespaces()
-			controller, err := NewPublisher(cmInformer, nsInformer, client, fakeRootCA)
+			controller, err := NewPublisher(cmInformer, nsInformer, client, newFakeCAContent(fakeRootCA))
 			if err != nil {
 				t.Fatalf("error creating ServiceAccounts controller: %v", err)
 			}
@@ -259,7 +302,7 @@ func TestConfigMapUpdateNoHotLoop(t *testing.T) {
 			// Publisher manages certificate ConfigMap objects inside Namespaces
 			controller := Publisher{
 				client:         client,
-				rootCA:         []byte("fake"),
+				ca:             newFakeCAContent([]byte("fake")),
 				cmLister:       corev1listers.NewConfigMapLister(configMapIndexer),
 				cmListerSynced: func() bool { return true },
 				nsListerSynced: func() bool { return true },
@@ -271,5 +314,80 @@ func TestConfigMapUpdateNoHotLoop(t *testing.T) {
 			}
 			tc.ExpectActions(t, client.Actions())
 		})
+	}
+}
+
+func TestConfigMapRepublishOnCAChange(t *testing.T) {
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceDefault},
+		Status:     v1.NamespaceStatus{Phase: v1.NamespaceActive},
+	}
+
+	ca := newFakeCAContent([]byte("ca-v1"))
+	client := fake.NewSimpleClientset(ns)
+	informerFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
+	cmInformer := informerFactory.Core().V1().ConfigMaps()
+	nsInformer := informerFactory.Core().V1().Namespaces()
+
+	pub, err := NewPublisher(cmInformer, nsInformer, client, ca)
+	if err != nil {
+		t.Fatalf("error creating publisher: %v", err)
+	}
+	if len(ca.listeners) != 1 {
+		t.Fatalf("publisher did not register as listener: got %d listeners", len(ca.listeners))
+	}
+
+	if err := nsInformer.Informer().GetStore().Add(ns); err != nil {
+		t.Fatal(err)
+	}
+	cmStore := cmInformer.Informer().GetStore()
+	ctx := context.TODO()
+
+	// Initial publish: create kube-root-ca.crt with ca-v1.
+	if err := pub.syncNamespace(ctx, ns.Name); err != nil {
+		t.Fatal(err)
+	}
+	actions := client.Actions()
+	if len(actions) != 1 || actions[0].GetVerb() != "create" {
+		t.Fatalf("expected 1 create action, got %v", actions)
+	}
+	created := actions[0].(clienttesting.CreateAction).GetObject().(*v1.ConfigMap)
+	if got := created.Data["ca.crt"]; got != "ca-v1" {
+		t.Fatalf("expected ca-v1, got %q", got)
+	}
+	// Reflect the created object in the lister so the next sync takes the
+	// update path. Set Namespace explicitly: Create infers it from the
+	// request path and does not populate ObjectMeta.
+	cached := created.DeepCopy()
+	cached.Namespace = ns.Name
+	if err := cmStore.Add(cached); err != nil {
+		t.Fatal(err)
+	}
+	client.ClearActions()
+
+	// Sync again with unchanged CA: no-op.
+	if err := pub.syncNamespace(ctx, ns.Name); err != nil {
+		t.Fatal(err)
+	}
+	if actions := client.Actions(); len(actions) != 0 {
+		t.Fatalf("expected no actions on unchanged CA, got %v", actions)
+	}
+
+	// Change the CA: listener should re-queue the namespace.
+	ca.setContent([]byte("ca-v2"))
+	if pub.queue.Len() != 1 {
+		t.Fatalf("expected 1 queued namespace after CA change, got %d", pub.queue.Len())
+	}
+	for pub.queue.Len() != 0 {
+		pub.processNextWorkItem(ctx)
+	}
+
+	actions = client.Actions()
+	if len(actions) != 1 || actions[0].GetVerb() != "update" {
+		t.Fatalf("expected 1 update action after CA change, got %v", actions)
+	}
+	updated := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
+	if got := updated.Data["ca.crt"]; got != "ca-v2" {
+		t.Fatalf("expected ca-v2 after reload, got %q", got)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig auth

#### What this PR does / why we need it:

The `root-ca-cert-publisher` controller reads `--root-ca-file` once at kube-controller-manager startup and never re-reads it. If the file is updated on disk during a serving-CA rotation, the `kube-root-ca.crt` ConfigMaps in every namespace go stale until kube-controller-manager is restarted.

This is the server-side half of #119483. #132922 makes client-go reload the CA file projected from `kube-root-ca.crt`, but that file comes from the ConfigMap this controller publishes. With #132922 alone, client-go just keeps re-reading the same stale bytes. Both changes are needed for in-cluster clients to survive a serving-CA rotation without a restart, and for clusters with short CA lifetimes this has to happen online.

`rootcacertpublisher.NewPublisher` now takes a `dynamiccertificates.CAContentProvider` and registers itself as a listener, the same pattern `clustertrustbundlepublisher` already uses. When `--root-ca-file` is set, the publisher is backed by a `DynamicFileCAContent` (the fsnotify watcher kube-apiserver already uses for `--client-ca-file`) and re-queues every namespace when the file changes. When `--root-ca-file` is not set, a static provider holds the client-config CA bytes and nothing changes.

The `kube-apiserver-serving-clustertrustbundle-publisher` controller had the same bug: it read `--root-ca-file` once and passed it through `NewStaticCAContent`, even though the underlying controller is fully dynamic. Wiring it to the same file-watching provider is a call-site-only change, so it's included here.

#### Which issue(s) this PR is related to:

Related to #119483

(Not using `Fixes` because #132922 already has `Fixes #119483` in its body and both PRs are needed to actually close it.)

#### Special notes for your reviewer:

- **Prior art**: `pkg/controller/certificates/clustertrustbundlepublisher/publisher.go` already takes a `CAContentProvider` and calls `ca.AddListener(...)` in its constructor. This brings `rootcacertpublisher` to the same pattern.
- **No new watcher code**: reuses `DynamicFileCAContent` from `k8s.io/apiserver` and `concurrentRun` from this package.
- **No feature gate**: nothing changes unless the file on disk changes, and the CTB publisher already does this unconditionally. Happy to add one if preferred.
- `NewDynamicCAContentFromFile` validates PEM, same as the `readCA` helper it replaces, so startup validation for `--root-ca-file` is unchanged.
- The no-`--root-ca-file` path uses a local non-validating provider rather than `NewStaticCAContent` to avoid adding new validation of `config.CAData` that wasn't there before.

#### Does this PR introduce a user-facing change?

```release-note
kube-controller-manager: the root-ca-cert-publisher and kube-apiserver-serving-clustertrustbundle-publisher controllers now reload --root-ca-file from disk when it changes, keeping kube-root-ca.crt ConfigMaps and kube-apiserver-serving ClusterTrustBundles current without restarting kube-controller-manager.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
