### PR TITLE
Add OWNERS file for test/integration/controlplane

### DIFF
--- a/test/integration/controlplane/OWNERS
+++ b/test/integration/controlplane/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - deads2k
+  - jpbetz
+  - sttts
+reviewers:
+  - deads2k
+  - jpbetz
+  - sttts
+labels:
+  - sig/api-machinery


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Ownership falls up to `test/OWNERS`. I don't think that's what we want.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig api-machinery
/cc @deads2k @fedebongio @sttts 