### PR TITLE
Add multi-group NUMA support for Windows CPU and memory affinity

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1096,7 +1096,7 @@ const (
 	WinOverlay featuregate.Feature = "WinOverlay"
 
 	// owner: @jsturtevant
-	// kep: https://kep.k8s.io/4888
+	// kep: https://kep.k8s.io/4885
 	//
 	// Add CPU and Memory Affinity support to Windows nodes with CPUManager, MemoryManager and Topology manager
 	WindowsCPUAndMemoryAffinity featuregate.Feature = "WindowsCPUAndMemoryAffinity"

--- a/pkg/kubelet/cm/internal_container_lifecycle_windows.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_windows.go
@@ -52,11 +52,11 @@ func (i *internalContainerLifecycleImpl) PreCreateContainer(logger klog.Logger, 
 	// Gather all CPUs associated with the selected NUMA nodes
 	var allNumaNodeCPUs []winstats.GroupAffinity
 	for _, numaNode := range sets.List(numaNodes) {
-		affinity, err := winstats.GetCPUsforNUMANode(uint16(numaNode))
+		affinities, err := winstats.GetCPUsforNUMANode(uint16(numaNode))
 		if err != nil {
 			return fmt.Errorf("failed to get CPUs for NUMA node %d: %v", numaNode, err)
 		}
-		allNumaNodeCPUs = append(allNumaNodeCPUs, *affinity)
+		allNumaNodeCPUs = append(allNumaNodeCPUs, affinities...)
 	}
 
 	var finalCPUSet = computeFinalCpuSet(allocatedCPUs, allNumaNodeCPUs)

--- a/pkg/kubelet/cm/internal_container_lifecycle_windows_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_windows_test.go
@@ -26,6 +26,14 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
+func makeRange(min, max int) []int {
+	a := make([]int, max-min+1)
+	for i := range a {
+		a[i] = min + i
+	}
+	return a
+}
+
 func TestComputeCPUSet(t *testing.T) {
 	affinities := []winstats.GroupAffinity{
 		{Mask: 0b1010, Group: 0}, // CPUs 1 and 3 in Group 0
@@ -145,6 +153,24 @@ func TestComputeFinalCpuSet(t *testing.T) {
 			allocatedCPUs:   cpuset.New(),
 			allNumaNodeCPUs: nil,
 			expectedCPUSet:  nil,
+		},
+		{
+			name:          "Multi-group NUMA: memory manager selects NUMA node spanning 2 groups",
+			allocatedCPUs: cpuset.New(),
+			allNumaNodeCPUs: []winstats.GroupAffinity{
+				{Mask: 0xFFFFFFFFFFFFFFFF, Group: 0}, // CPUs 0-63
+				{Mask: 0xFFFFFFFFFFFFFFFF, Group: 1}, // CPUs 64-127
+			},
+			expectedCPUSet: sets.New[int](makeRange(0, 127)...),
+		},
+		{
+			name:          "Multi-group NUMA: CPU manager CPUs in group 0, NUMA spans groups 0 and 1",
+			allocatedCPUs: cpuset.New(0, 1, 2, 3),
+			allNumaNodeCPUs: []winstats.GroupAffinity{
+				{Mask: 0xFFFFFFFFFFFFFFFF, Group: 0}, // CPUs 0-63
+				{Mask: 0xFFFFFFFFFFFFFFFF, Group: 1}, // CPUs 64-127
+			},
+			expectedCPUSet: sets.New[int](0, 1, 2, 3),
 		},
 	}
 

--- a/pkg/kubelet/winstats/cpu_topology.go
+++ b/pkg/kubelet/winstats/cpu_topology.go
@@ -31,7 +31,8 @@ import (
 var (
 	procGetLogicalProcessorInformationEx = modkernel32.NewProc("GetLogicalProcessorInformationEx")
 	getNumaAvailableMemoryNodeEx         = modkernel32.NewProc("GetNumaAvailableMemoryNodeEx")
-	procGetNumaNodeProcessorMaskEx       = modkernel32.NewProc("GetNumaNodeProcessorMaskEx")
+	procGetNumaNodeProcessorMask2        = modkernel32.NewProc("GetNumaNodeProcessorMask2")
+	procGetMaximumProcessorGroupCount    = modkernel32.NewProc("GetMaximumProcessorGroupCount")
 )
 
 type relationType int
@@ -109,18 +110,30 @@ func CpusToGroupAffinity(cpus []int) map[int]*GroupAffinity {
 }
 
 // GetCPUsForNUMANode queries the system for the CPUs that are part of the given NUMA node.
-func GetCPUsforNUMANode(nodeNumber uint16) (*GroupAffinity, error) {
-	var affinity GroupAffinity
-
-	r1, _, err := procGetNumaNodeProcessorMaskEx.Call(
-		uintptr(nodeNumber),
-		uintptr(unsafe.Pointer(&affinity)),
-	)
-	if r1 == 0 {
-		return nil, fmt.Errorf("Error getting CPU mask for NUMA node %d: %v", nodeNumber, err)
+// Uses GetNumaNodeProcessorMask2 which correctly returns all processor groups for NUMA nodes
+// spanning multiple groups (>64 logical processors). Requires Windows Server 2022+ (Build 20348+).
+func GetCPUsforNUMANode(nodeNumber uint16) ([]GroupAffinity, error) {
+	// Query the maximum number of processor groups to size the buffer.
+	r1, _, _ := procGetMaximumProcessorGroupCount.Call()
+	maxGroupCount := uint16(r1)
+	if maxGroupCount == 0 {
+		maxGroupCount = 1
 	}
 
-	return &affinity, nil
+	masks := make([]GroupAffinity, maxGroupCount)
+	var requiredCount uint16
+
+	r1, _, err := procGetNumaNodeProcessorMask2.Call(
+		uintptr(nodeNumber),
+		uintptr(unsafe.Pointer(&masks[0])),
+		uintptr(maxGroupCount),
+		uintptr(unsafe.Pointer(&requiredCount)),
+	)
+	if r1 == 0 {
+		return nil, fmt.Errorf("GetNumaNodeProcessorMask2 failed for NUMA node %d: %v", nodeNumber, err)
+	}
+
+	return masks[:requiredCount], nil
 }
 
 type numaNodeRelationship struct {

--- a/pkg/kubelet/winstats/cpu_topology_test.go
+++ b/pkg/kubelet/winstats/cpu_topology_test.go
@@ -295,6 +295,24 @@ func Test_convertWinApiToCadvisorApi(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:                 "multi-group NUMA node (128 cpus across 2 groups)",
+			buffer:               createProcessorRelationships(makeRange(0, 127)),
+			expectedNumOfCores:   1,
+			expectedNumOfSockets: 1,
+			expectedNodes: []cadvisorapi.Node{
+				{
+					Id: 0,
+					Cores: []cadvisorapi.Core{
+						{
+							Id:      1,
+							Threads: makeRange(0, 127),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:                 "buffer to small",
 			buffer:               createProcessorRelationships([]int{0, 64})[:48],
 			expectedNumOfCores:   1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is related with https://github.com/kubernetes/enhancements/issues/4885
Switch from GetNumaNodeProcessorMaskEx to GetNumaNodeProcessorMask2 so that NUMA nodes spanning more than one processor group (>64 logical CPUs) are handled correctly. Update GetCPUsforNUMANode to return a slice of GroupAffinity and fix the KEP reference from 4888 to 4885. Add multi-group test cases for computeFinalCpuSet and topology conversion.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
None
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
