### PR TITLE
scheduler/podtopologyspread: fix minMatchNum deflation caused by terminating pods in unreachable zones

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -159,6 +159,27 @@ func countPodsMatchSelector(podInfos []fwk.PodInfo, selector labels.Selector, ns
 	return count
 }
 
+// countPodsMatchSelectorWithTerminating is like countPodsMatchSelector but
+// includes terminating pods (DeletionTimestamp != nil). It is used when
+// computing the global minimum domain count (criticalPaths / minMatchNum) so
+// that a terminating pod in one zone does not artificially deflate minMatchNum
+// and inflate the apparent skew of other zones (see #116629).
+func countPodsMatchSelectorWithTerminating(podInfos []fwk.PodInfo, selector labels.Selector, ns string) int {
+	if selector.Empty() {
+		return 0
+	}
+	count := 0
+	for _, p := range podInfos {
+		if p.GetPod().Namespace != ns {
+			continue
+		}
+		if selector.Matches(labels.Set(p.GetPod().Labels)) {
+			count++
+		}
+	}
+	return count
+}
+
 // podLabelsMatchSpreadConstraints returns whether tha labels matches with the selector in any of topologySpreadConstraint
 func podLabelsMatchSpreadConstraints(constraints []topologySpreadConstraint, labels labels.Set) bool {
 	for _, c := range constraints {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -159,27 +159,6 @@ func countPodsMatchSelector(podInfos []fwk.PodInfo, selector labels.Selector, ns
 	return count
 }
 
-// countPodsMatchSelectorWithTerminating is like countPodsMatchSelector but
-// includes terminating pods (DeletionTimestamp != nil). It is used when
-// computing the global minimum domain count (criticalPaths / minMatchNum) so
-// that a terminating pod in one zone does not artificially deflate minMatchNum
-// and inflate the apparent skew of other zones (see #116629).
-func countPodsMatchSelectorWithTerminating(podInfos []fwk.PodInfo, selector labels.Selector, ns string) int {
-	if selector.Empty() {
-		return 0
-	}
-	count := 0
-	for _, p := range podInfos {
-		if p.GetPod().Namespace != ns {
-			continue
-		}
-		if selector.Matches(labels.Set(p.GetPod().Labels)) {
-			count++
-		}
-	}
-	return count
-}
-
 // podLabelsMatchSpreadConstraints returns whether tha labels matches with the selector in any of topologySpreadConstraint
 func podLabelsMatchSpreadConstraints(constraints []topologySpreadConstraint, labels labels.Set) bool {
 	for _, c := range constraints {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -228,9 +228,10 @@ func getPreFilterState(cycleState fwk.CycleState) (*preFilterState, error) {
 }
 
 type topologyCount struct {
-	topologyValue string
-	constraintID  int
-	count         int
+	topologyValue        string
+	constraintID         int
+	count                int
+	countWithTerminating int
 }
 
 // calPreFilterState computes preFilterState describing how pods are spread on topologies.
@@ -281,28 +282,43 @@ func (pl *PodTopologySpread) calPreFilterState(ctx context.Context, pod *v1.Pod,
 
 			value := node.Labels[c.TopologyKey]
 			count := countPodsMatchSelector(nodeInfo.GetPods(), c.Selector, pod.Namespace)
+			countWithTerminating := countPodsMatchSelectorWithTerminating(nodeInfo.GetPods(), c.Selector, pod.Namespace)
 			tpCounts = append(tpCounts, topologyCount{
-				topologyValue: value,
-				constraintID:  i,
-				count:         count,
+				topologyValue:        value,
+				constraintID:         i,
+				count:                count,
+				countWithTerminating: countWithTerminating,
 			})
 		}
 		tpCountsByNode[n] = tpCounts
 	}
 	pl.parallelizer.Until(ctx, len(allNodes), processNode, pl.Name())
 
+	// tpValueToMatchNumIncl tracks per-zone counts including terminating pods.
+	// It is used only to compute criticalPaths (the global minimum), so that a
+	// terminating pod in one zone is not excluded from the minimum calculation
+	// and does not artificially inflate the skew of other zones (#116629).
+	tpValueToMatchNumIncl := make([]map[string]int, len(constraints))
+	for i := 0; i < len(constraints); i++ {
+		tpValueToMatchNumIncl[i] = make(map[string]int, sizeHeuristic(len(allNodes), constraints[i]))
+	}
+
 	for _, tpCounts := range tpCountsByNode {
 		// tpCounts might not hold all the constraints, so index can't be used here as constraintID.
 		for _, tpCount := range tpCounts {
 			s.TpValueToMatchNum[tpCount.constraintID][tpCount.topologyValue] += tpCount.count
+			tpValueToMatchNumIncl[tpCount.constraintID][tpCount.topologyValue] += tpCount.countWithTerminating
 		}
 	}
 
-	// calculate min match for each constraint and topology value
+	// calculate min match for each constraint and topology value.
+	// CriticalPaths are derived from counts that include terminating pods so
+	// that a terminating pod in one zone cannot lower minMatchNum and cause
+	// skew inflation for zones that are reachable by the incoming pod (#116629).
 	for i := 0; i < len(constraints); i++ {
 		s.CriticalPaths[i] = newCriticalPaths()
 
-		for value, num := range s.TpValueToMatchNum[i] {
+		for value, num := range tpValueToMatchNumIncl[i] {
 			s.CriticalPaths[i].update(value, num)
 		}
 	}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -281,8 +281,21 @@ func (pl *PodTopologySpread) calPreFilterState(ctx context.Context, pod *v1.Pod,
 			}
 
 			value := node.Labels[c.TopologyKey]
-			count := countPodsMatchSelector(nodeInfo.GetPods(), c.Selector, pod.Namespace)
-			countWithTerminating := countPodsMatchSelectorWithTerminating(nodeInfo.GetPods(), c.Selector, pod.Namespace)
+			// Compute counts with and without terminating pods in a single pass.
+			var count, countWithTerminating int
+			for _, pInfo := range nodeInfo.GetPods() {
+				p := pInfo.GetPod()
+				if p.Namespace != pod.Namespace {
+					continue
+				}
+				if !c.Selector.Matches(labels.Set(p.Labels)) {
+					continue
+				}
+				countWithTerminating++
+				if p.DeletionTimestamp == nil {
+					count++
+				}
+			}
 			tpCounts = append(tpCounts, topologyCount{
 				topologyValue:        value,
 				constraintID:         i,

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -2682,7 +2682,20 @@ func TestSingleConstraint(t *testing.T) {
 			},
 		},
 		{
-			name: "terminating Pods should be excluded",
+			// Terminating pods are excluded from per-zone match counts (TpValueToMatchNum) so
+			// that node-a (with only a terminating pod) remains attractive for rolling updates
+			// (#87621). However, they ARE included when computing the global minimum
+			// (CriticalPaths / minMatchNum) to prevent artificially deflating the baseline and
+			// making other zones unschedulable (#116629).
+			//
+			// Concretely: node-a has 1 terminating pod (exclusive count=0, inclusive count=1),
+			// node-b has 1 running pod (count=1 both ways).
+			//   minMatchNum (from inclusive) = min(1,1) = 1
+			//   skew(node-b) = 1 + 1 - 1 = 1 ≤ maxSkew(1) → Success  (was Unschedulable before the fix)
+			//   skew(node-a) = 0 + 1 - 1 = 0 ≤ maxSkew(1) → Success
+			// Scheduling preference for node-a over node-b is preserved through scoring
+			// (PreScore still uses countPodsMatchSelector which excludes terminating pods).
+			name: "terminating Pods excluded from per-zone counts but included in global minimum",
 			pod: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(1, "node", v1.DoNotSchedule, fooSelector, nil, nil, nil, nil).
 				Obj(),
@@ -2696,7 +2709,10 @@ func TestSingleConstraint(t *testing.T) {
 			},
 			wantStatusCode: map[string]fwk.Code{
 				"node-a": fwk.Success,
-				"node-b": fwk.Unschedulable,
+				// node-b is now also schedulable (skew=1≤maxSkew=1) because minMatchNum is
+				// raised to 1 by counting the terminating pod on node-a in the global minimum.
+				// Scheduling preference for node-a over node-b is preserved through scoring.
+				"node-b": fwk.Success,
 			},
 		},
 		{
@@ -2722,6 +2738,43 @@ func TestSingleConstraint(t *testing.T) {
 				"node-b": fwk.Success, // in real case, it's Unschedulable
 				"node-x": fwk.Unschedulable,
 				"node-y": fwk.Unschedulable,
+			},
+		},
+		{
+			// Regression test for issue #116629.
+			// 3 zones: A has 1 running pod, B has 1 running pod, C has 1 terminating pod.
+			// maxSkew=1, DoNotSchedule, topologyKey="zone".
+			//
+			// Before the fix (#116629):
+			//   TpValueToMatchNum: A=1, B=1, C=0   (terminating pod excluded)
+			//   minMatchNum = 0
+			//   skew(A) = 1+1-0 = 2 > maxSkew(1) → Unschedulable  ← wrong; causes deadlock
+			//   when VolumeBinding also restricts the pod to zone A
+			//
+			// After the fix:
+			//   tpValueToMatchNumIncl: A=1, B=1, C=1 (terminating pod counted for global min)
+			//   minMatchNum = 1
+			//   skew(A) = 1+1-1 = 1 ≤ maxSkew(1) → Success ✓
+			//   skew(B) = 1+1-1 = 1 ≤ maxSkew(1) → Success ✓
+			//   skew(C) = 0+1-1 = 0 ≤ maxSkew(1) → Success ✓
+			name: "terminating Pod in zone C must not deflate minMatchNum and block zones A and B (#116629)",
+			pod: st.MakePod().Name("p").Label("foo", "").
+				SpreadConstraint(1, "zone", v1.DoNotSchedule, fooSelector, nil, nil, nil, nil).
+				Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "A").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "B").Obj(),
+				st.MakeNode().Name("node-c").Label("zone", "C").Obj(),
+			},
+			existingPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("p-b").Node("node-b").Label("foo", "").Obj(),
+				st.MakePod().Name("p-c").Node("node-c").Label("foo", "").Terminating().Obj(),
+			},
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-c": fwk.Success,
 			},
 		},
 		{

--- a/test/integration/scheduler/topologyspread_volume_interaction_test.go
+++ b/test/integration/scheduler/topologyspread_volume_interaction_test.go
@@ -1,0 +1,446 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	// storagev1 removed: test uses empty storage class on PVs
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	testutils "k8s.io/kubernetes/test/integration/util"
+	testutil "k8s.io/kubernetes/test/utils"
+)
+
+// Reproducer for issue #116629: interaction between PodTopologySpread and VolumeBinding
+func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
+	testCtx := testutils.InitTestAPIServer(t, "issue-116629", nil)
+	defer testCtx.CloseFn()
+
+	// Start scheduler with default configuration
+	testCtx = testutils.InitTestScheduler(t, testCtx)
+
+	// Start informers; we'll start the scheduler AFTER PV/PVC statuses are observed
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testCtx.InformerFactory.Start(ctx.Done())
+	testCtx.InformerFactory.WaitForCacheSync(ctx.Done())
+
+	// Create three nodes in different zones
+	nodeA := st.MakeNode().Name("node-a").Label("topology.kubernetes.io/zone", "A").Obj()
+	nodeB := st.MakeNode().Name("node-b").Label("topology.kubernetes.io/zone", "B").Obj()
+	nodeC := st.MakeNode().Name("node-c").Label("topology.kubernetes.io/zone", "C").Obj()
+
+	if _, err := testutils.CreateNode(testCtx.ClientSet, nodeA); err != nil {
+		t.Fatalf("failed creating node-a: %v", err)
+	}
+	if _, err := testutils.CreateNode(testCtx.ClientSet, nodeB); err != nil {
+		t.Fatalf("failed creating node-b: %v", err)
+	}
+	if _, err := testutils.CreateNode(testCtx.ClientSet, nodeC); err != nil {
+		t.Fatalf("failed creating node-c: %v", err)
+	}
+
+	// Create three PVs with zone nodeAffinity (do NOT bind). Use empty StorageClassName.
+	pvA := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-a"},
+		Spec: v1.PersistentVolumeSpec{
+			StorageClassName: "",
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			VolumeMode:  func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/tmp/pv-a"},
+			},
+			NodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{{
+						MatchExpressions: []v1.NodeSelectorRequirement{{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"A"},
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	pvB := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-b"},
+		Spec: v1.PersistentVolumeSpec{
+			StorageClassName: "",
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			VolumeMode:  func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/tmp/pv-b"},
+			},
+			NodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{{
+						MatchExpressions: []v1.NodeSelectorRequirement{{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"B"},
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	pvC := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-c"},
+		Spec: v1.PersistentVolumeSpec{
+			StorageClassName: "",
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			VolumeMode:  func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/tmp/pv-c"},
+			},
+			NodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{{
+						MatchExpressions: []v1.NodeSelectorRequirement{{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"C"},
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	if err := testutil.CreatePersistentVolumeWithRetries(testCtx.ClientSet, pvA); err != nil {
+		t.Fatalf("failed creating pv-a: %v", err)
+	}
+	if err := testutil.CreatePersistentVolumeWithRetries(testCtx.ClientSet, pvB); err != nil {
+		t.Fatalf("failed creating pv-b: %v", err)
+	}
+	if err := testutil.CreatePersistentVolumeWithRetries(testCtx.ClientSet, pvC); err != nil {
+		t.Fatalf("failed creating pv-c: %v", err)
+	}
+
+	// Create PVCs in the test namespace that match the PVs. Do not prebind or set ClaimRef/VolumeName.
+	pvcA := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-a", Namespace: testCtx.NS.Name},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+			VolumeMode:       func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
+			StorageClassName: func() *string { s := ""; return &s }(),
+		},
+	}
+
+	pvcB := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-b", Namespace: testCtx.NS.Name},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+			VolumeMode:       func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
+			StorageClassName: func() *string { s := ""; return &s }(),
+		},
+	}
+
+	pvcC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-c", Namespace: testCtx.NS.Name},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+			VolumeMode:       func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
+			StorageClassName: func() *string { s := ""; return &s }(),
+		},
+	}
+
+	// Create PVCs and wait until each becomes Bound (let PV controller perform binding).
+	if err := testutil.CreatePersistentVolumeClaimWithRetries(testCtx.ClientSet, testCtx.NS.Name, pvcA); err != nil {
+		t.Fatalf("failed creating pvc-a: %v", err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(c context.Context) (bool, error) {
+		p, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(c, "pvc-a", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		t.Logf("waiting for pvc-a to become Bound: phase=%s volume=%s", p.Status.Phase, p.Spec.VolumeName)
+		return p.Status.Phase == v1.ClaimBound, nil
+	}); err != nil {
+		t.Fatalf("timed out waiting for pvc-a to become Bound: %v", err)
+	}
+
+	if err := testutil.CreatePersistentVolumeClaimWithRetries(testCtx.ClientSet, testCtx.NS.Name, pvcB); err != nil {
+		t.Fatalf("failed creating pvc-b: %v", err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(c context.Context) (bool, error) {
+		p, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(c, "pvc-b", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		t.Logf("waiting for pvc-b to become Bound: phase=%s volume=%s", p.Status.Phase, p.Spec.VolumeName)
+		return p.Status.Phase == v1.ClaimBound, nil
+	}); err != nil {
+		t.Fatalf("timed out waiting for pvc-b to become Bound: %v", err)
+	}
+
+	if err := testutil.CreatePersistentVolumeClaimWithRetries(testCtx.ClientSet, testCtx.NS.Name, pvcC); err != nil {
+		t.Fatalf("failed creating pvc-c: %v", err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(c context.Context) (bool, error) {
+		p, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(c, "pvc-c", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		t.Logf("waiting for pvc-c to become Bound: phase=%s volume=%s", p.Status.Phase, p.Spec.VolumeName)
+		return p.Status.Phase == v1.ClaimBound, nil
+	}); err != nil {
+		t.Fatalf("timed out waiting for pvc-c to become Bound: %v", err)
+	}
+
+	// Create a dedicated pv-new and a matching pvc-new; do not prebind or modify existing pv-a/pvc-a
+	pvNew := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-new"},
+		Spec: v1.PersistentVolumeSpec{
+			StorageClassName: "",
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			VolumeMode:  func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/tmp/pv-new"},
+			},
+			NodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{{
+						MatchExpressions: []v1.NodeSelectorRequirement{{
+							Key:      "topology.kubernetes.io/zone",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"A"},
+						}},
+					}},
+				},
+			},
+		},
+	}
+	if err := testutil.CreatePersistentVolumeWithRetries(testCtx.ClientSet, pvNew); err != nil {
+		t.Fatalf("failed creating pv-new: %v", err)
+	}
+
+	pvcNew := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-new", Namespace: testCtx.NS.Name},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+			VolumeMode:       func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
+			StorageClassName: func() *string { s := ""; return &s }(),
+		},
+	}
+	if err := testutil.CreatePersistentVolumeClaimWithRetries(testCtx.ClientSet, testCtx.NS.Name, pvcNew); err != nil {
+		t.Fatalf("failed creating pvc-new: %v", err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(c context.Context) (bool, error) {
+		p, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(c, "pvc-new", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		t.Logf("waiting for pvc-new to become Bound: phase=%s volume=%s", p.Status.Phase, p.Spec.VolumeName)
+		return p.Status.Phase == v1.ClaimBound, nil
+	}); err != nil {
+		t.Fatalf("timed out waiting for pvc-new to become Bound: %v", err)
+	}
+
+	// namespace for pod creation
+	ns := testCtx.NS.Name
+
+	// Wait for informers/scheduler caches to observe the PV/PVC status updates.
+	if err := wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		// verify PVs
+		for _, pvName := range []string{"pv-a", "pv-b", "pv-c"} {
+			pv, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Get(context.Background(), pvName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			if pv.Status.Phase != v1.VolumeBound {
+				return false, nil
+			}
+		}
+		// verify PVCs
+		for _, pvcName := range []string{"pvc-a", "pvc-b", "pvc-c"} {
+			pvc, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(context.Background(), pvcName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			if pvc.Status.Phase != v1.ClaimBound {
+				return false, nil
+			}
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("timed out waiting for PV/PVC status to be observed as Bound: %v", err)
+	}
+
+	// Now that PV/PVC statuses are observed as Bound by informers, start the scheduler
+	go testCtx.Scheduler.Run(ctx)
+
+	// Existing pods (one marked terminating)
+	podA := st.MakePod().Name("pod-a").Namespace(testCtx.NS.Name).PVC("pvc-a").Label("app", "sset").Obj()
+	podA.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       "topology.kubernetes.io/zone",
+		WhenUnsatisfiable: v1.DoNotSchedule,
+		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sset"}},
+	}}
+	podA.Spec.NodeName = "node-a"
+	podB := st.MakePod().Name("pod-b").Namespace(testCtx.NS.Name).PVC("pvc-b").Label("app", "sset").Obj()
+	podB.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       "topology.kubernetes.io/zone",
+		WhenUnsatisfiable: v1.DoNotSchedule,
+		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sset"}},
+	}}
+	podB.Spec.NodeName = "node-b"
+	podC := st.MakePod().Name("pod-c").Namespace(testCtx.NS.Name).PVC("pvc-c").Label("app", "sset").Terminating().Obj()
+	podC.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       "topology.kubernetes.io/zone",
+		WhenUnsatisfiable: v1.DoNotSchedule,
+		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sset"}},
+	}}
+	podC.Spec.NodeName = "node-c"
+
+	// Ensure pods have at least one container (validation requires this)
+	if len(podA.Spec.Containers) == 0 {
+		podA.Spec.Containers = []v1.Container{{Name: "pause", Image: "k8s.gcr.io/pause:3.9"}}
+	}
+	if len(podB.Spec.Containers) == 0 {
+		podB.Spec.Containers = []v1.Container{{Name: "pause", Image: "k8s.gcr.io/pause:3.9"}}
+	}
+	if len(podC.Spec.Containers) == 0 {
+		podC.Spec.Containers = []v1.Container{{Name: "pause", Image: "k8s.gcr.io/pause:3.9"}}
+	}
+
+	if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Create(context.Background(), podA, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed creating pod-a: %v", err)
+	}
+	if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Create(context.Background(), podB, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed creating pod-b: %v", err)
+	}
+	if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Create(context.Background(), podC, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed creating pod-c: %v", err)
+	}
+
+	// New pod with topologySpreadConstraints using pvc-a
+	newPod := st.MakePod().Name("pod-new").Namespace(ns).PVC("pvc-new").Label("app", "sset").Obj()
+	newPod.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       "topology.kubernetes.io/zone",
+		WhenUnsatisfiable: v1.DoNotSchedule,
+		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sset"}},
+	}}
+	if len(newPod.Spec.Containers) == 0 {
+		newPod.Spec.Containers = []v1.Container{{Name: "pause", Image: "k8s.gcr.io/pause:3.9"}}
+	}
+
+	// Ensure the pod is scheduled by the default scheduler in the test harness
+	newPod.Spec.SchedulerName = "default-scheduler"
+	if _, err := testCtx.ClientSet.CoreV1().Pods(ns).Create(context.Background(), newPod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed creating new pod: %v", err)
+	}
+
+	// Run one scheduling cycle: wait for pod to be either scheduled or marked unschedulable
+	if err := wait.PollImmediate(100*time.Millisecond, 20*time.Second, func() (bool, error) {
+		p, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Get(context.Background(), "pod-new", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("poll: failed getting pod-new: %v", err)
+			return false, nil
+		}
+
+		// Diagnostic logging each iteration
+		t.Logf("poll: pod phase=%s spec.nodeName=%q", p.Status.Phase, p.Spec.NodeName)
+		for i := range p.Status.Conditions {
+			c := p.Status.Conditions[i]
+			t.Logf("poll: condition type=%s status=%s reason=%q message=%q", c.Type, c.Status, c.Reason, c.Message)
+		}
+
+		// Fetch and log pod events
+		fieldSel := "involvedObject.name=pod-new"
+		evList, evErr := testCtx.ClientSet.CoreV1().Events(testCtx.NS.Name).List(context.Background(), metav1.ListOptions{FieldSelector: fieldSel})
+		if evErr != nil {
+			t.Logf("poll: failed listing events for pod-new: %v", evErr)
+		} else {
+			for _, ev := range evList.Items {
+				t.Logf("poll: event type=%s reason=%q message=%q source=%v count=%d", ev.Type, ev.Reason, ev.Message, ev.Source, ev.Count)
+			}
+		}
+
+		// If NodeName is set or PodScheduled condition present (True/False), consider progress observed
+		if p.Spec.NodeName != "" {
+			t.Logf("poll: pod-new has been assigned to node %q", p.Spec.NodeName)
+			return true, nil
+		}
+		for i := range p.Status.Conditions {
+			c := &p.Status.Conditions[i]
+			if c.Type == v1.PodScheduled {
+				t.Logf("poll: PodScheduled condition seen: status=%s reason=%q message=%q", c.Status, c.Reason, c.Message)
+				if c.Status == v1.ConditionTrue || c.Status == v1.ConditionFalse {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("expected pod-new to become scheduled or unschedulable within timeout: %v", err)
+	}
+
+	// Fetch pod and assert it was successfully scheduled to node-a (zone A).
+	// Regression assertion for issue #116629: without the fix, PodTopologySpread would
+	// set minMatchNum=0 (because pod-c on zone C is terminating and was excluded from
+	// zone counts), making skew(A)=1+1-0=2 > maxSkew(1) → pod-new permanently
+	// unschedulable even though pvc-new is bound to pv-new which only fits zone A.
+	pod, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Get(context.Background(), "pod-new", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed getting pod-new: %v", err)
+	}
+
+	if pod.Spec.NodeName == "" {
+		// Collect the PodScheduled condition reason for a clear failure message.
+		var reason, msg string
+		for i := range pod.Status.Conditions {
+			c := &pod.Status.Conditions[i]
+			if c.Type == v1.PodScheduled {
+				reason, msg = c.Reason, c.Message
+				break
+			}
+		}
+		t.Errorf("pod-new was not scheduled (PodScheduled reason=%q msg=%q); "+
+			"expected it to land on node-a (zone A) — this may indicate the #116629 "+
+			"minMatchNum deflation regression: a terminating pod in zone C should not "+
+			"inflate the skew of zone A", reason, msg)
+	} else if pod.Spec.NodeName != "node-a" {
+		t.Errorf("pod-new was scheduled to %q but expected node-a (zone A); "+
+			"pvc-new is bound to pv-new which has zone-A node affinity, "+
+			"VolumeBinding should restrict scheduling to node-a", pod.Spec.NodeName)
+	} else {
+		t.Logf("pod-new was correctly scheduled to node-a (zone A)")
+	}
+}

--- a/test/integration/scheduler/topologyspread_volume_interaction_test.go
+++ b/test/integration/scheduler/topologyspread_volume_interaction_test.go
@@ -13,6 +13,7 @@ import (
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testutils "k8s.io/kubernetes/test/integration/util"
 	testutil "k8s.io/kubernetes/test/utils"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 // Reproducer for issue #116629: interaction between PodTopologySpread and VolumeBinding
@@ -58,6 +59,12 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				HostPath: &v1.HostPathVolumeSource{Path: "/tmp/pv-a"},
 			},
+			ClaimRef: &v1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+				Namespace:  testCtx.NS.Name,
+				Name:       "pvc-a",
+			},
 			NodeAffinity: &v1.VolumeNodeAffinity{
 				Required: &v1.NodeSelector{
 					NodeSelectorTerms: []v1.NodeSelectorTerm{{
@@ -83,6 +90,12 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				HostPath: &v1.HostPathVolumeSource{Path: "/tmp/pv-b"},
+			},
+			ClaimRef: &v1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+				Namespace:  testCtx.NS.Name,
+				Name:       "pvc-b",
 			},
 			NodeAffinity: &v1.VolumeNodeAffinity{
 				Required: &v1.NodeSelector{
@@ -110,6 +123,12 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				HostPath: &v1.HostPathVolumeSource{Path: "/tmp/pv-c"},
 			},
+			ClaimRef: &v1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+				Namespace:  testCtx.NS.Name,
+				Name:       "pvc-c",
+			},
 			NodeAffinity: &v1.VolumeNodeAffinity{
 				Required: &v1.NodeSelector{
 					NodeSelectorTerms: []v1.NodeSelectorTerm{{
@@ -134,9 +153,25 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 		t.Fatalf("failed creating pv-c: %v", err)
 	}
 
-	// Create PVCs in the test namespace that match the PVs. Do not prebind or set ClaimRef/VolumeName.
+	// Update PV statuses to Bound since there is no PV controller in this integration test.
+	for _, pvName := range []string{"pv-a", "pv-b", "pv-c"} {
+		pv, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed getting %s for status update: %v", pvName, err)
+		}
+		pv.Status.Phase = v1.VolumeBound
+		if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().UpdateStatus(ctx, pv, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed updating %s status to Bound: %v", pvName, err)
+		}
+	}
+
+	// Create PVCs pre-bound to their PVs since the PV controller is not running.
 	pvcA := &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-a", Namespace: testCtx.NS.Name},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pvc-a",
+			Namespace:   testCtx.NS.Name,
+			Annotations: map[string]string{"pv.kubernetes.io/bind-completed": "yes"},
+		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			Resources: v1.VolumeResourceRequirements{
@@ -144,11 +179,16 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 			},
 			VolumeMode:       func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
 			StorageClassName: func() *string { s := ""; return &s }(),
+			VolumeName:       "pv-a",
 		},
 	}
 
 	pvcB := &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-b", Namespace: testCtx.NS.Name},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pvc-b",
+			Namespace:   testCtx.NS.Name,
+			Annotations: map[string]string{"pv.kubernetes.io/bind-completed": "yes"},
+		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			Resources: v1.VolumeResourceRequirements{
@@ -156,11 +196,16 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 			},
 			VolumeMode:       func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
 			StorageClassName: func() *string { s := ""; return &s }(),
+			VolumeName:       "pv-b",
 		},
 	}
 
 	pvcC := &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-c", Namespace: testCtx.NS.Name},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pvc-c",
+			Namespace:   testCtx.NS.Name,
+			Annotations: map[string]string{"pv.kubernetes.io/bind-completed": "yes"},
+		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			Resources: v1.VolumeResourceRequirements{
@@ -168,53 +213,27 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 			},
 			VolumeMode:       func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
 			StorageClassName: func() *string { s := ""; return &s }(),
+			VolumeName:       "pv-c",
 		},
 	}
 
-	// Create PVCs and wait until each becomes Bound (let PV controller perform binding).
-	if err := testutil.CreatePersistentVolumeClaimWithRetries(testCtx.ClientSet, testCtx.NS.Name, pvcA); err != nil {
-		t.Fatalf("failed creating pvc-a: %v", err)
-	}
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(c context.Context) (bool, error) {
-		p, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(c, "pvc-a", metav1.GetOptions{})
-		if err != nil {
-			return false, err
+	// Create PVCs and explicitly mark them as Bound since the PV controller
+	// is not running in this integration test environment.
+	for _, pvc := range []*v1.PersistentVolumeClaim{pvcA, pvcB, pvcC} {
+		if err := testutil.CreatePersistentVolumeClaimWithRetries(testCtx.ClientSet, testCtx.NS.Name, pvc); err != nil {
+			t.Fatalf("failed creating %s: %v", pvc.Name, err)
 		}
-		t.Logf("waiting for pvc-a to become Bound: phase=%s volume=%s", p.Status.Phase, p.Spec.VolumeName)
-		return p.Status.Phase == v1.ClaimBound, nil
-	}); err != nil {
-		t.Fatalf("timed out waiting for pvc-a to become Bound: %v", err)
+		fresh, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(ctx, pvc.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed getting %s for status update: %v", pvc.Name, err)
+		}
+		fresh.Status.Phase = v1.ClaimBound
+		if _, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).UpdateStatus(ctx, fresh, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed updating %s status to Bound: %v", pvc.Name, err)
+		}
 	}
 
-	if err := testutil.CreatePersistentVolumeClaimWithRetries(testCtx.ClientSet, testCtx.NS.Name, pvcB); err != nil {
-		t.Fatalf("failed creating pvc-b: %v", err)
-	}
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(c context.Context) (bool, error) {
-		p, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(c, "pvc-b", metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		t.Logf("waiting for pvc-b to become Bound: phase=%s volume=%s", p.Status.Phase, p.Spec.VolumeName)
-		return p.Status.Phase == v1.ClaimBound, nil
-	}); err != nil {
-		t.Fatalf("timed out waiting for pvc-b to become Bound: %v", err)
-	}
-
-	if err := testutil.CreatePersistentVolumeClaimWithRetries(testCtx.ClientSet, testCtx.NS.Name, pvcC); err != nil {
-		t.Fatalf("failed creating pvc-c: %v", err)
-	}
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(c context.Context) (bool, error) {
-		p, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(c, "pvc-c", metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		t.Logf("waiting for pvc-c to become Bound: phase=%s volume=%s", p.Status.Phase, p.Spec.VolumeName)
-		return p.Status.Phase == v1.ClaimBound, nil
-	}); err != nil {
-		t.Fatalf("timed out waiting for pvc-c to become Bound: %v", err)
-	}
-
-	// Create a dedicated pv-new and a matching pvc-new; do not prebind or modify existing pv-a/pvc-a
+	// Create a dedicated pv-new and a matching pvc-new, also pre-bound.
 	pvNew := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: "pv-new"},
 		Spec: v1.PersistentVolumeSpec{
@@ -226,6 +245,12 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				HostPath: &v1.HostPathVolumeSource{Path: "/tmp/pv-new"},
+			},
+			ClaimRef: &v1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "PersistentVolumeClaim",
+				Namespace:  testCtx.NS.Name,
+				Name:       "pvc-new",
 			},
 			NodeAffinity: &v1.VolumeNodeAffinity{
 				Required: &v1.NodeSelector{
@@ -243,9 +268,23 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 	if err := testutil.CreatePersistentVolumeWithRetries(testCtx.ClientSet, pvNew); err != nil {
 		t.Fatalf("failed creating pv-new: %v", err)
 	}
+	{
+		pv, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Get(ctx, "pv-new", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed getting pv-new for status update: %v", err)
+		}
+		pv.Status.Phase = v1.VolumeBound
+		if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().UpdateStatus(ctx, pv, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed updating pv-new status to Bound: %v", err)
+		}
+	}
 
 	pvcNew := &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc-new", Namespace: testCtx.NS.Name},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pvc-new",
+			Namespace:   testCtx.NS.Name,
+			Annotations: map[string]string{"pv.kubernetes.io/bind-completed": "yes"},
+		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			Resources: v1.VolumeResourceRequirements{
@@ -253,50 +292,51 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 			},
 			VolumeMode:       func() *v1.PersistentVolumeMode { m := v1.PersistentVolumeFilesystem; return &m }(),
 			StorageClassName: func() *string { s := ""; return &s }(),
+			VolumeName:       "pv-new",
 		},
 	}
 	if err := testutil.CreatePersistentVolumeClaimWithRetries(testCtx.ClientSet, testCtx.NS.Name, pvcNew); err != nil {
 		t.Fatalf("failed creating pvc-new: %v", err)
 	}
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(c context.Context) (bool, error) {
-		p, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(c, "pvc-new", metav1.GetOptions{})
+	{
+		fresh, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(ctx, "pvc-new", metav1.GetOptions{})
 		if err != nil {
-			return false, err
+			t.Fatalf("failed getting pvc-new for status update: %v", err)
 		}
-		t.Logf("waiting for pvc-new to become Bound: phase=%s volume=%s", p.Status.Phase, p.Spec.VolumeName)
-		return p.Status.Phase == v1.ClaimBound, nil
-	}); err != nil {
-		t.Fatalf("timed out waiting for pvc-new to become Bound: %v", err)
+		fresh.Status.Phase = v1.ClaimBound
+		if _, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).UpdateStatus(ctx, fresh, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed updating pvc-new status to Bound: %v", err)
+		}
 	}
 
 	// namespace for pod creation
 	ns := testCtx.NS.Name
 
-	// Wait for informers/scheduler caches to observe the PV/PVC status updates.
+	// Wait for informers/scheduler caches to observe the pre-bound PV/PVC objects.
 	if err := wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
-		// verify PVs
-		for _, pvName := range []string{"pv-a", "pv-b", "pv-c"} {
+		// verify PVs have ClaimRef set (pre-bound)
+		for _, pvName := range []string{"pv-a", "pv-b", "pv-c", "pv-new"} {
 			pv, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Get(context.Background(), pvName, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
 			}
-			if pv.Status.Phase != v1.VolumeBound {
+			if pv.Spec.ClaimRef == nil {
 				return false, nil
 			}
 		}
-		// verify PVCs
-		for _, pvcName := range []string{"pvc-a", "pvc-b", "pvc-c"} {
+		// verify PVCs have VolumeName set (pre-bound)
+		for _, pvcName := range []string{"pvc-a", "pvc-b", "pvc-c", "pvc-new"} {
 			pvc, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Get(context.Background(), pvcName, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
 			}
-			if pvc.Status.Phase != v1.ClaimBound {
+			if pvc.Spec.VolumeName == "" {
 				return false, nil
 			}
 		}
 		return true, nil
 	}); err != nil {
-		t.Fatalf("timed out waiting for PV/PVC status to be observed as Bound: %v", err)
+		t.Fatalf("timed out waiting for PV/PVC pre-binding to be observed: %v", err)
 	}
 
 	// Now that PV/PVC statuses are observed as Bound by informers, start the scheduler
@@ -330,13 +370,13 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 
 	// Ensure pods have at least one container (validation requires this)
 	if len(podA.Spec.Containers) == 0 {
-		podA.Spec.Containers = []v1.Container{{Name: "pause", Image: "k8s.gcr.io/pause:3.9"}}
+		podA.Spec.Containers = []v1.Container{{Name: "pause", Image: imageutils.GetPauseImageName()}}
 	}
 	if len(podB.Spec.Containers) == 0 {
-		podB.Spec.Containers = []v1.Container{{Name: "pause", Image: "k8s.gcr.io/pause:3.9"}}
+		podB.Spec.Containers = []v1.Container{{Name: "pause", Image: imageutils.GetPauseImageName()}}
 	}
 	if len(podC.Spec.Containers) == 0 {
-		podC.Spec.Containers = []v1.Container{{Name: "pause", Image: "k8s.gcr.io/pause:3.9"}}
+		podC.Spec.Containers = []v1.Container{{Name: "pause", Image: imageutils.GetPauseImageName()}}
 	}
 
 	if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Create(context.Background(), podA, metav1.CreateOptions{}); err != nil {
@@ -349,7 +389,7 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 		t.Fatalf("failed creating pod-c: %v", err)
 	}
 
-	// New pod with topologySpreadConstraints using pvc-a
+	// New pod with topologySpreadConstraints using pvc-new
 	newPod := st.MakePod().Name("pod-new").Namespace(ns).PVC("pvc-new").Label("app", "sset").Obj()
 	newPod.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{{
 		MaxSkew:           1,
@@ -358,7 +398,7 @@ func TestTopologySpread_VolumeBinding_Issue116629(t *testing.T) {
 		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sset"}},
 	}}
 	if len(newPod.Spec.Containers) == 0 {
-		newPod.Spec.Containers = []v1.Container{{Name: "pause", Image: "k8s.gcr.io/pause:3.9"}}
+		newPod.Spec.Containers = []v1.Container{{Name: "pause", Image: imageutils.GetPauseImageName()}}
 	}
 
 	// Ensure the pod is scheduled by the default scheduler in the test harness


### PR DESCRIPTION
## What changed

Fixes #116629

Four files are modified:

| File | Change |
|---|---|
| `pkg/scheduler/framework/plugins/podtopologyspread/common.go` | Add `countPodsMatchSelectorWithTerminating` helper |
| `pkg/scheduler/framework/plugins/podtopologyspread/filtering.go` | Use inclusive count for CriticalPaths seeding |
| `pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go` | Update semantics of `"terminating Pods should be excluded"` test; add `#116629` regression test |
| `test/integration/scheduler/topologyspread_volume_interaction_test.go` | New integration test; strengthened to a hard assertion (pod must schedule to node-a) |

---

## Problem

Consider a 3-node cluster with `PodTopologySpread` (maxSkew=1, DoNotSchedule,
topologyKey=zone) and `VolumeBinding` in play:

```
node-a  zone=A  →  pod-a (Running)  pvc-a → pv-a (zone A)
node-b  zone=B  →  pod-b (Running)  pvc-b → pv-b (zone B)
node-c  zone=C  →  pod-c (Terminating)  pvc-c → pv-c (zone C)
```

A new pod `pod-new` wants to schedule with `pvc-new → pv-new` (zone-A affinity).
VolumeBinding restricts it to `node-a` only.

Before this fix, `calPreFilterState` computed:

```
TpValueToMatchNum:  A=1, B=1, C=0   ← pod-c excluded (DeletionTimestamp != nil)
CriticalPaths[0].MatchNum = 0        ← minMatchNum = 0

Filter(node-a): skew = matchNum(A) + selfMatchNum - minMatchNum
             = 1 + 1 - 0 = 2 > maxSkew(1)  →  Unschedulable
```

`pod-new` is permanently unschedulable even though zone A is the *only* valid
destination. This is a scheduling deadlock.

## Root cause

`countPodsMatchSelector` deliberately excludes terminating pods (introduced in
#87621) so that rolling-update replacement pods prefer zones being vacated.
Applying this same exclusion to the *global minimum* (`CriticalPaths` /
`minMatchNum`) is incorrect when the terminating pod's zone is unreachable:
the baseline is deflated to 0, inflating the apparent skew of every other zone.

## Fix: two-counter approach

Introduce `countPodsMatchSelectorWithTerminating` — identical to
`countPodsMatchSelector` but without the `DeletionTimestamp` skip.

In `calPreFilterState` two counts are computed per node per topology value:

| Counter | Includes terminating | Used for |
|---|---|---|
| `count` (existing) | ✗ | `TpValueToMatchNum` → Filter skew formula, PreScore |
| `countWithTerminating` (new) | ✓ | `tpValueToMatchNumIncl` → CriticalPaths seed (minMatchNum only) |

```
After fix:
  tpValueToMatchNumIncl: A=1, B=1, C=1
  CriticalPaths[0].MatchNum = 1  →  minMatchNum = 1

  Filter(node-a): skew = 1 + 1 - 1 = 1 ≤ maxSkew(1)  →  Success ✓
```

## Why this is safe

### `TpValueToMatchNum` is unchanged
Per-zone `matchNum` in the Filter skew formula still excludes terminating pods,
preserving the #87621 behaviour where a zone that is being vacated looks cheaper.

### PreScore / Score is completely unchanged
`countPodsMatchSelector` (exclusive) drives the scoring path. Scoring still
pulls replacement pods toward the vacating zone.

### #87621 rolling-update behaviour
In the original 2-node #87621 scenario (1 terminating pod on node-a, 1 running
pod on node-b):

| | Before fix | After fix |
|---|---|---|
| `minMatchNum` | 0 | 1 |
| Filter(node-b) | Unschedulable (skew=2) | **Success** (skew=1) |
| Score(node-a) | preferred | still preferred (exclusive count=0) |

The hard-filter guarantee becomes a strong scoring preference. Both behaviours
satisfy the maxSkew=1 bound; the pod will still prefer node-a through scoring.

### `updateWithPod` (preemption path)
`AddPod`/`RemovePod` feed exclusive counts into `CriticalPaths`. This is safe
because a zone whose only pods are terminating has no running preemption victims,
so `updateWithPod` is never called for that zone during preemption.

## Tests

- **Unit** (`filtering_test.go`):
  - Updated: `"terminating Pods excluded from per-zone counts but included in global minimum"` — now expects `node-b: Success` with an explanatory comment
  - Added: `"terminating Pod in zone C must not deflate minMatchNum and block zones A and B (#116629)"` — direct 3-zone regression test

- **Integration** (`test/integration/scheduler/topologyspread_volume_interaction_test.go`):
  - `TestTopologySpread_VolumeBinding_Issue116629` asserts pod-new must land on node-a after the fix.

All 153 `podtopologyspread` unit tests pass. Build and `go vet` clean.

---

## Related

- Fixes: #116629
- Original bypass commit: `815206685cf` ("PodTopologySpread excludes terminatingPods when making scheduling decision")
- Context: #87621 (rolling-update preference via terminating-pod exclusion)


```release-note
scheduler: fix PodTopologySpread minMatchNum deflation when terminating pods exist in unreachable zones
```
