### PR TITLE
kubelet: fix cgroup-per-qos kill race for DRA health monitoring on containerd 1.7

### DIFF
--- a/pkg/kubelet/cm/fake_pod_container_manager.go
+++ b/pkg/kubelet/cm/fake_pod_container_manager.go
@@ -30,6 +30,10 @@ type FakePodContainerManager struct {
 	sync.Mutex
 	CalledFunctions []string
 	Cgroups         map[types.UID]CgroupName
+	// ExistsReturn controls what Exists() returns. When nil, defaults to true.
+	// Set to a false pointer to simulate pcm.Exists() returning false after
+	// EnsureExists() (e.g., cgroup v2/systemd race condition).
+	ExistsReturn *bool
 }
 
 var _ PodContainerManager = &FakePodContainerManager{}
@@ -50,6 +54,9 @@ func (m *FakePodContainerManager) Exists(_ *v1.Pod) bool {
 	m.Lock()
 	defer m.Unlock()
 	m.CalledFunctions = append(m.CalledFunctions, "Exists")
+	if m.ExistsReturn != nil {
+		return *m.ExistsReturn
+	}
 	return true
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -722,6 +722,7 @@ func NewMainKubelet(ctx context.Context,
 	klet.containerLogManager = containerLogManager
 
 	klet.reasonCache = NewReasonCache()
+	klet.podCgroupsInitialized = make(map[types.UID]struct{})
 	klet.workQueue = queue.NewBasicWorkQueue(klet.clock)
 	klet.podWorkers = newPodWorkers(
 		klet,
@@ -1566,6 +1567,40 @@ type Kubelet struct {
 
 	// flagz is the Reader interface to get flags for flagz page.
 	flagz flagz.Reader
+
+	// podCgroupsInitializedLock protects podCgroupsInitialized.
+	podCgroupsInitializedLock sync.RWMutex
+	// podCgroupsInitialized tracks pod UIDs for which EnsureExists has
+	// been called during this kubelet process lifetime. This distinguishes
+	// pods whose cgroups were already set up (pcm.Exists() returning false
+	// is a validation issue) from pods inherited from a previous kubelet
+	// lifetime that genuinely need cgroup migration.
+	podCgroupsInitialized map[types.UID]struct{}
+}
+
+// markPodCgroupInitialized records that EnsureExists has been called for
+// this pod during the current kubelet process lifetime.
+func (kl *Kubelet) markPodCgroupInitialized(uid types.UID) {
+	kl.podCgroupsInitializedLock.Lock()
+	defer kl.podCgroupsInitializedLock.Unlock()
+	kl.podCgroupsInitialized[uid] = struct{}{}
+}
+
+// isPodCgroupInitialized returns true if EnsureExists was called for this
+// pod during the current kubelet process lifetime.
+func (kl *Kubelet) isPodCgroupInitialized(uid types.UID) bool {
+	kl.podCgroupsInitializedLock.RLock()
+	defer kl.podCgroupsInitializedLock.RUnlock()
+	_, ok := kl.podCgroupsInitialized[uid]
+	return ok
+}
+
+// clearPodCgroupInitialized removes a pod from the cgroup tracking set.
+// Called when a pod is removed to prevent unbounded memory growth.
+func (kl *Kubelet) clearPodCgroupInitialized(uid types.UID) {
+	kl.podCgroupsInitializedLock.Lock()
+	defer kl.podCgroupsInitializedLock.Unlock()
+	delete(kl.podCgroupsInitialized, uid)
 }
 
 // ListPodStats is delegated to StatsProvider, which implements stats.Provider interface
@@ -2113,9 +2148,13 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 			}
 		}
 		// Don't kill containers in pod if pod's cgroups already
-		// exists or the pod is running for the first time
+		// exists or the pod is running for the first time.
+		// Also skip the kill if we already called EnsureExists for
+		// this pod in the current kubelet lifetime — pcm.Exists()
+		// returning false after EnsureExists indicates a cgroup
+		// validation issue, not a need for cgroup migration.
 		podKilled := false
-		if !pcm.Exists(pod) && !firstSync {
+		if !pcm.Exists(pod) && !firstSync && !kl.isPodCgroupInitialized(pod.UID) {
 			p := kubecontainer.ConvertPodStatusToRunningPod(kl.getRuntime().Type(), podStatus)
 			if err := kl.killPod(ctx, pod, p, nil); err == nil {
 				podKilled = true
@@ -2151,6 +2190,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 					kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedToCreatePodContainer, "unable to ensure pod container exists: %v", err)
 					return false, fmt.Errorf("failed to ensure that the pod: %v cgroups exist and are correctly applied: %v", pod.UID, err)
 				}
+				kl.markPodCgroupInitialized(pod.UID)
 
 				if err = kl.containerRuntime.UpdateActuatedPodLevelResources(pod); err != nil {
 					return false, fmt.Errorf("failed to update the state of pod-level resources for the pod %v : %w", pod.UID, err)
@@ -2446,6 +2486,7 @@ func (kl *Kubelet) SyncTerminatedPod(ctx context.Context, pod *v1.Pod, podStatus
 		if err := pcm.Destroy(logger, name); err != nil {
 			return err
 		}
+		kl.clearPodCgroupInitialized(pod.UID)
 		logger.V(4).Info("Pod termination removed cgroups", "pod", klog.KObj(pod), "podUID", pod.UID)
 	}
 
@@ -2997,6 +3038,7 @@ func (kl *Kubelet) HandlePodRemoves(ctx context.Context, pods []*v1.Pod) {
 		kl.podCertificateManager.ForgetPod(ctx, pod)
 		kl.podManager.RemovePod(pod)
 		kl.allocationManager.RemovePod(pod.UID)
+		kl.clearPodCgroupInitialized(pod.UID)
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
 		if wasMirror {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -5111,6 +5111,69 @@ func generateCAAndCertKeyWithOptions(host string, alternateIPs []net.IP, alterna
 	return caCertBytes, leafCertBytes, key, err
 }
 
+// TestSyncPodCgroupKillRaceWithInitializedPod reproduces the race condition
+// where pcm.Exists() returns false after EnsureExists() was already called
+// (e.g., on cgroup v2 with systemd cgroup driver, where systemd may delete
+// cgroup subsystems that libcontainer created). Without the fix, SyncPod
+// would kill pods in this scenario. With the fix, pods that have already
+// had EnsureExists called are not killed.
+func TestSyncPodCgroupKillRaceWithInitializedPod(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	fakeRuntime := testKubelet.fakeRuntime
+	fakeContainerManager := testKubelet.fakeContainerManager
+
+	// Enable cgroups-per-qos so the cgroup kill path is active
+	kl.cgroupsPerQOS = true
+
+	// Simulate pcm.Exists() returning false (the race condition)
+	existsReturn := false
+	fakeContainerManager.PodContainerManager.ExistsReturn = &existsReturn
+
+	pod := podWithUIDNameNsSpec("race-test-uid", "race-test-pod", "default", v1.PodSpec{
+		Containers: []v1.Container{
+			{Name: "test-container", Image: "busybox"},
+		},
+	})
+
+	kl.podManager.SetPods([]*v1.Pod{pod})
+
+	// Provide a kubecontainer.PodStatus with a running container so that
+	// generateAPIPodStatus produces ContainerStatuses with State.Running,
+	// which makes firstSync=false in SyncPod's cgroup kill path.
+	podStatus := &kubecontainer.PodStatus{
+		ID: pod.UID,
+		ContainerStatuses: []*kubecontainer.Status{
+			{
+				Name:  "test-container",
+				State: kubecontainer.ContainerStateRunning,
+				ID:    kubecontainer.ContainerID{Type: "test", ID: "fake-container-id"},
+			},
+		},
+	}
+
+	// Case 1: Without markPodCgroupInitialized — pod SHOULD be killed
+	// (pcm.Exists=false, firstSync=false, not initialized)
+	fakeRuntime.KilledPods = nil
+	_, err := kl.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, nil, podStatus)
+	// We expect either success or an error, but killPod should have been called
+	_ = err
+	if len(fakeRuntime.KilledPods) == 0 {
+		t.Error("Case 1: Expected pod to be killed when pcm.Exists()=false, firstSync=false, and pod cgroup NOT initialized")
+	}
+
+	// Case 2: WITH markPodCgroupInitialized — pod should NOT be killed
+	kl.markPodCgroupInitialized(pod.UID)
+	fakeRuntime.KilledPods = nil
+	_, err = kl.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, nil, podStatus)
+	_ = err
+	if len(fakeRuntime.KilledPods) > 0 {
+		t.Error("Case 2: Pod should NOT be killed when pcm.Exists()=false but pod cgroup IS initialized (fix prevents unnecessary kill)")
+	}
+}
+
 func TestPodCgroupInitializedTracking(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -311,6 +311,7 @@ func newTestKubeletWithImageList(
 	kubelet.containerRuntime = fakeRuntime
 	kubelet.runtimeCache = containertest.NewFakeRuntimeCache(kubelet.containerRuntime)
 	kubelet.reasonCache = NewReasonCache()
+	kubelet.podCgroupsInitialized = make(map[types.UID]struct{})
 	kubelet.podCache = containertest.NewFakeCache(kubelet.containerRuntime)
 	kubelet.podWorkers = &fakePodWorkers{
 		syncPodFn: kubelet.SyncPod,
@@ -5108,4 +5109,80 @@ func generateCAAndCertKeyWithOptions(host string, alternateIPs []net.IP, alterna
 	}
 
 	return caCertBytes, leafCertBytes, key, err
+}
+
+func TestPodCgroupInitializedTracking(t *testing.T) {
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	uid := types.UID("test-pod-uid")
+
+	// Initially not tracked
+	if kl.isPodCgroupInitialized(uid) {
+		t.Error("Pod cgroup should not be marked initialized before markPodCgroupInitialized")
+	}
+
+	// Mark initialized
+	kl.markPodCgroupInitialized(uid)
+	if !kl.isPodCgroupInitialized(uid) {
+		t.Error("Pod cgroup should be marked initialized after markPodCgroupInitialized")
+	}
+
+	// Idempotent
+	kl.markPodCgroupInitialized(uid)
+	if !kl.isPodCgroupInitialized(uid) {
+		t.Error("Pod cgroup should still be marked initialized after duplicate call")
+	}
+
+	// Clear
+	kl.clearPodCgroupInitialized(uid)
+	if kl.isPodCgroupInitialized(uid) {
+		t.Error("Pod cgroup should not be marked initialized after clearPodCgroupInitialized")
+	}
+
+	// Clear non-existent is a no-op
+	kl.clearPodCgroupInitialized(types.UID("nonexistent"))
+}
+
+func TestHandlePodRemovesClearsPodCgroupInitialized(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	kl.nodeLister = testNodeLister{nodes: []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
+			Status: v1.NodeStatus{
+				Allocatable: v1.ResourceList{
+					v1.ResourcePods: *resource.NewQuantity(110, resource.DecimalSI),
+				},
+			},
+		},
+	}}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "remove-test-uid",
+			Name:      "remove-test-pod",
+			Namespace: "default",
+		},
+	}
+
+	// Simulate that EnsureExists was called for this pod during SyncPod
+	kl.markPodCgroupInitialized(pod.UID)
+	if !kl.isPodCgroupInitialized(pod.UID) {
+		t.Fatal("Pod cgroup should be marked initialized")
+	}
+
+	// Add the pod to the manager so HandlePodRemoves can find it
+	kl.podManager.AddPod(pod)
+
+	// Remove the pod
+	kl.HandlePodRemoves(tCtx, []*v1.Pod{pod})
+
+	// Should no longer be tracked
+	if kl.isPodCgroupInitialized(pod.UID) {
+		t.Error("Pod cgroup should not be marked initialized after HandlePodRemoves")
+	}
 }

--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -1725,6 +1725,21 @@ func matchResourcesByNodeName(nodeName string) types.GomegaMatcher {
 	return gomega.HaveField("Spec.NodeName", gstruct.PointTo(gomega.Equal(nodeName)))
 }
 
+// podHasAllocatedResourcesStatus checks if a pod has any allocatedResourcesStatus
+// entries, indicating the DRA health pipeline is active and processing updates.
+func podHasAllocatedResourcesStatus(f *framework.Framework, namespace, podName string) (bool, error) {
+	pod, err := f.ClientSet.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if len(cs.AllocatedResourcesStatus) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // This helper function queries the main API server for the pod's status.
 func getDeviceHealthFromAPIServer(f *framework.Framework, namespace, podName, driverName, claimName, poolName, deviceName string) (string, error) {
 	// Get the Pod object from the API server
@@ -1898,6 +1913,11 @@ func setupAndVerifyHealthyPod(
 	ginkgo.By("Waiting for the pod to be running")
 	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
 
+	ginkgo.By("Waiting for DRA health pipeline to be active (allocatedResourcesStatus present)")
+	gomega.Eventually(ctx, func(ctx context.Context) (bool, error) {
+		return podHasAllocatedResourcesStatus(f, pod.Namespace, pod.Name)
+	}).WithTimeout(60 * time.Second).WithPolling(1 * time.Second).Should(gomega.BeTrueBecause("Pod should have allocatedResourcesStatus entries once DRA health pipeline is active"))
+
 	ginkgo.By("Forcing a 'Healthy' status update to establish a baseline")
 	plugin.HealthControlChan <- testdriver.DeviceHealthUpdate{
 		PoolName:   poolName,
@@ -1908,7 +1928,7 @@ func setupAndVerifyHealthyPod(
 	ginkgo.By("Verifying device health is now Healthy in the pod status")
 	gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
 		return getDeviceHealthFromAPIServer(f, pod.Namespace, pod.Name, driverName, claimName, poolName, deviceName)
-	}).WithTimeout(30*time.Second).WithPolling(1*time.Second).Should(gomega.Equal("Healthy"), "Device health should be Healthy after explicit update")
+	}).WithTimeout(60*time.Second).WithPolling(1*time.Second).Should(gomega.Equal("Healthy"), "Device health should be Healthy after explicit update")
 
 	return pod, claimName, poolName, deviceName
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind regression
/kind failing-test

#### What this PR does / why we need it:

PR #135196 promoted `ResourceHealthStatus` from Alpha to Beta (default: true),
causing DRA health monitoring e2e tests to run for the first time in the
`ci-node-e2e-containerd-1-7-dra` CI job. These tests fail intermittently due to
a pre-existing kubelet race in the cgroup-per-qos kill path.

**Root cause:** During PLEG-triggered `SyncPod`, the cgroup-per-qos code path at
`kubelet.go:~2108` checks `!pcm.Exists(pod) && !firstSync`. On cgroup v2 with
the systemd cgroup driver (containerd 1.7), `pcm.Exists()` can return false
after `EnsureExists` has already been called — systemd may delete cgroup
subsystems (particularly cpuset) that libcontainer created via `Apply(-1)`,
causing the `Exists()` validation to fail when it checks all whitelisted
controller paths. This triggers `killPod` with a 30s grace period, blocking
the pod worker and preventing DRA health updates from propagating to the pod
status. The test's 30s timeout races with the kill's 30s grace period.

On containerd 2.0 (also systemd cgroup driver), this race is not observed,
likely due to differences in how the runtime interacts with cgroup subsystem
creation.

**Fix (three commits):**

1. **Test-level fix** (`test/e2e_node`): Wait for `allocatedResourcesStatus` to
   appear in the pod status (indicating the DRA health pipeline is active) before
   sending health updates. Also increase the verification timeout from 30s to 60s.

2. **Kubelet-level fix** (`pkg/kubelet`): Track pods for which `EnsureExists` has
   been called during the current kubelet process lifetime. Skip the cgroup kill
   path for these pods, since `pcm.Exists()` returning false after `EnsureExists`
   indicates a cgroup validation issue rather than a need for cgroup migration.
   The tracking set is empty on kubelet startup, preserving the original
   kubelet-restart cgroup migration behavior.

3. **Unit test** (`pkg/kubelet`): Add `TestSyncPodCgroupKillRaceWithInitializedPod`
   that directly reproduces the race condition by configuring `FakePodContainerManager`
   to return `Exists()=false` and verifying that SyncPod kills the pod without the
   fix but skips the kill when `markPodCgroupInitialized()` was called.

#### Which issue(s) this PR is related to:

Regression introduced by #135196
Failing CI job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-node-e2e-containerd-1-7-dra/2029019384965500928

#### Special notes for your reviewer:

The three commits are intentionally separate and could be split into individual PRs
if preferred:
- Commit 1 (test fix) unblocks CI immediately with no kubelet behavior change.
- Commit 2 (kubelet fix) addresses the root cause.
- Commit 3 (unit test) reproduces the race condition and verifies the fix.

The kubelet fix preserves the key invariant: on kubelet restart, the
`podCgroupsInitialized` set is empty, so the cgroup kill path still triggers for
containers from a previous kubelet lifetime that need cgroup migration. The fix
only suppresses the kill for pods whose cgroups were already initialized in the
current process lifetime.

Cleanup of the tracking set happens in both `HandlePodRemoves` and
`SyncTerminatedPod` (after `pcm.Destroy()`) to prevent memory leaks across all
pod lifecycle paths (removal, eviction, termination).

/sig node
/area kubelet
/priority critical-urgent
/cc @pohly @harche @bart0sh

#### Does this PR introduce a user-facing change?

```release-note
Fixed a kubelet race condition in the cgroup-per-qos kill path where
pcm.Exists() could return false for pods whose cgroups were already initialized
(on cgroup v2 with the systemd cgroup driver), causing newly created pods to be
unnecessarily killed during PLEG-triggered SyncPod. This also fixes intermittent
DRA health monitoring test failures on containerd 1.7.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```