### PR TITLE
scheduler: add missing godoc comments to exported functions

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -133,6 +133,7 @@ func matchEventResources(r, resource fwk.EventResource) bool {
 		r == fwk.Pod && (resource == assignedPod || resource == unschedulablePod)
 }
 
+// MatchAnyClusterEvent returns true if the given ClusterEvent matches any event in the provided list.
 func MatchAnyClusterEvent(ce fwk.ClusterEvent, incomingEvents []fwk.ClusterEvent) bool {
 	for _, e := range incomingEvents {
 		if MatchClusterEvents(e, ce) {
@@ -142,6 +143,7 @@ func MatchAnyClusterEvent(ce fwk.ClusterEvent, incomingEvents []fwk.ClusterEvent
 	return false
 }
 
+// UnrollWildCardResource expands the wildcard resource into a list of all supported ClusterEvents.
 func UnrollWildCardResource() []fwk.ClusterEventWithHint {
 	events := []fwk.ClusterEventWithHint{
 		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.All}},

--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -123,6 +123,7 @@ type MetricAsyncRecorder struct {
 	IsStoppedCh chan struct{}
 }
 
+// NewMetricsAsyncRecorder creates a MetricAsyncRecorder that asynchronously records histogram metrics at the given interval.
 func NewMetricsAsyncRecorder(bufferSize int, interval time.Duration, stopCh <-chan struct{}) *MetricAsyncRecorder {
 	recorder := &MetricAsyncRecorder{
 		bufferCh:                      make(chan *histogramVecMetric, bufferSize),

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -200,6 +200,7 @@ func Register() {
 	})
 }
 
+// InitMetrics initializes all scheduler metrics variables.
 func InitMetrics() {
 	scheduleAttempts = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -562,6 +563,7 @@ func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()
 }
 
+// UnschedulableReason returns the gauge metric for the given plugin and profile reflecting why a pod is unschedulable.
 func UnschedulableReason(plugin string, profile string) metrics.GaugeMetric {
 	return unschedulableReasons.With(metrics.Labels{"plugin": plugin, "profile": profile})
 }


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup
/sig scheduling

## What this PR does / why we need it
Adds missing godoc comments to exported functions in `pkg/scheduler` that previously had none. This follows the Go documentation convention that all exported symbols should have a comment starting with the symbol name.

Functions updated:
- `metrics.InitMetrics`
- `metrics.UnschedulableReason`
- `metrics.NewMetricsAsyncRecorder`
- `framework.MatchAnyClusterEvent`
- `framework.UnrollWildCardResource`

## Does this PR introduce a user-facing change?
```release-note
NONE
```