### PR TITLE
cache: add missing godoc comments to To*WithContext adapter functions

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -133,6 +133,7 @@ func matchEventResources(r, resource fwk.EventResource) bool {
 		r == fwk.Pod && (resource == assignedPod || resource == unschedulablePod)
 }
 
+// MatchAnyClusterEvent returns true if the given ClusterEvent matches any event in the provided list.
 func MatchAnyClusterEvent(ce fwk.ClusterEvent, incomingEvents []fwk.ClusterEvent) bool {
 	for _, e := range incomingEvents {
 		if MatchClusterEvents(e, ce) {
@@ -142,6 +143,7 @@ func MatchAnyClusterEvent(ce fwk.ClusterEvent, incomingEvents []fwk.ClusterEvent
 	return false
 }
 
+// UnrollWildCardResource expands the wildcard resource into a list of all supported ClusterEvents.
 func UnrollWildCardResource() []fwk.ClusterEventWithHint {
 	events := []fwk.ClusterEventWithHint{
 		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.All}},

--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -123,6 +123,7 @@ type MetricAsyncRecorder struct {
 	IsStoppedCh chan struct{}
 }
 
+// NewMetricsAsyncRecorder creates a MetricAsyncRecorder that asynchronously records histogram metrics at the given interval.
 func NewMetricsAsyncRecorder(bufferSize int, interval time.Duration, stopCh <-chan struct{}) *MetricAsyncRecorder {
 	recorder := &MetricAsyncRecorder{
 		bufferCh:                      make(chan *histogramVecMetric, bufferSize),

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -200,6 +200,7 @@ func Register() {
 	})
 }
 
+// InitMetrics initializes all scheduler metrics variables.
 func InitMetrics() {
 	scheduleAttempts = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -562,6 +563,7 @@ func SinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()
 }
 
+// UnschedulableReason returns the gauge metric for the given plugin and profile reflecting why a pod is unschedulable.
 func UnschedulableReason(plugin string, profile string) metrics.GaugeMetric {
 	return unschedulableReasons.With(metrics.Labels{"plugin": plugin, "profile": profile})
 }

--- a/staging/src/k8s.io/client-go/tools/cache/listwatch.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listwatch.go
@@ -45,6 +45,8 @@ type ListerWithContext interface {
 	ListWithContext(ctx context.Context, options metav1.ListOptions) (runtime.Object, error)
 }
 
+// ToListerWithContext wraps a Lister to implement ListerWithContext.
+// If l already implements ListerWithContext, it is returned as-is.
 func ToListerWithContext(l Lister) ListerWithContext {
 	if l, ok := l.(ListerWithContext); ok {
 		return l
@@ -86,6 +88,8 @@ type WatcherWithContext interface {
 	WatchWithContext(ctx context.Context, options metav1.ListOptions) (watch.Interface, error)
 }
 
+// ToWatcherWithContext wraps a Watcher to implement WatcherWithContext.
+// If w already implements WatcherWithContext, it is returned as-is.
 func ToWatcherWithContext(w Watcher) WatcherWithContext {
 	if w, ok := w.(WatcherWithContext); ok {
 		return w
@@ -117,6 +121,8 @@ type ListerWatcherWithContext interface {
 	WatcherWithContext
 }
 
+// ToListerWatcherWithContext wraps a ListerWatcher to implement ListerWatcherWithContext.
+// If lw already implements ListerWatcherWithContext, it is returned as-is.
 func ToListerWatcherWithContext(lw ListerWatcher) ListerWatcherWithContext {
 	if lw, ok := lw.(ListerWatcherWithContext); ok {
 		return lw


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup
/sig api-machinery

## What this PR does / why we need it
Adds missing godoc comments to three exported adapter functions in `staging/src/k8s.io/client-go/tools/cache/listwatch.go` that previously had none.

Functions updated:
- `ToListerWithContext`
- `ToWatcherWithContext`
- `ToListerWatcherWithContext`

This follows the Go documentation convention that all exported symbols should have a comment starting with the symbol name.

## Does this PR introduce a user-facing change?
```release-note
NONE
```