### PR TITLE
fix: [sig-apimachinery] flaky discovery integration test `TestReadinessAggregatedAPIServiceDiscovery`

### DIFF
--- a/test/integration/apiserver/discovery/framework.go
+++ b/test/integration/apiserver/discovery/framework.go
@@ -46,7 +46,7 @@ const acceptV1JSON = "application/json"
 const acceptV2JSON = "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList"
 const acceptV2JSONNoPeer = "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList;profile=nopeer"
 
-const maxTimeout = 10 * time.Second
+const maxTimeout = 30 * time.Second
 
 type testClient interface {
 	kubernetes.Interface


### PR DESCRIPTION
#### What this PR does / why we need it:

`TestReadinessAggregatedAPIServiceDiscovery` flakes intermittently with
`failed to fetch v2 discovery: client rate limiter Wait returned an error:
context deadline exceeded`

- Root Cause:
  - `framework.go` defines `maxTimeout = 10 * time.Second`, used by
`WaitForResultWithCondition` as the deadline for
`wait.PollUntilContextTimeout`. That function creates an internal
10-second deadline context passed to every `FetchV2Discovery` call,
where client-go's `rateLimiter.Wait(ctx)` immediately returns
`context deadline exceeded` when the deadline is nearly expired.

  - In `TestReadinessAggregatedAPIServiceDiscovery`, the third
`WaitForGroups` call runs **after**:
     1. `WaitForGroups(ctx, client, basicTestGroupStale)` — polls `/apis` for up to 10s
     2. `WaitForRootPaths(...)` — polls `/` for up to 10s
     3. `close(apiServiceWaitCh)` — unblocks fake APIService to start responding

  - After step 3, the aggregator must notice the APIService is reachable,
re-fetch its discovery document, and propagate `basicTestGroupWithFixup`
into the aggregated discovery response — a background operation that on a
**loaded CI node** running 100+ test packages in parallel takes longer
than 10 seconds, exhausting the deadline before the condition is met.

#### Changes:
   Increase `maxTimeout` from `10s` to `30s`. This gives the aggregator
sufficient time to complete its background refresh under CI load while
staying consistent with the 30-second timeout already used in
`WaitForPeerAggregatedDiscoveryWithCondition` in the same package.

**CHECK**:- [Prow](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/137448/pull-kubernetes-e2e-gce/2029565858325467136)
Fixes #137422

/sig api-machinery
/kind flake
cc @kubernetes/release-team-release-signal