### PR TITLE
enable commentstart check on storagemigration API group

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -21059,15 +21059,15 @@
         },
         "metadata": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
-          "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+          "description": "metadata is standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
           "$ref": "#/definitions/io.k8s.api.storagemigration.v1beta1.StorageVersionMigrationSpec",
-          "description": "Specification of the migration."
+          "description": "spec is the specification of the migration."
         },
         "status": {
           "$ref": "#/definitions/io.k8s.api.storagemigration.v1beta1.StorageVersionMigrationStatus",
-          "description": "Status of the migration."
+          "description": "status is the status of the migration."
         }
       },
       "type": "object",
@@ -21087,7 +21087,7 @@
           "type": "string"
         },
         "items": {
-          "description": "Items is the list of StorageVersionMigration",
+          "description": "items is the list of StorageVersionMigration.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.storagemigration.v1beta1.StorageVersionMigration"
           },
@@ -21099,7 +21099,7 @@
         },
         "metadata": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
-          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+          "description": "metadata is standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
       "required": [
@@ -21119,7 +21119,7 @@
       "properties": {
         "resource": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupResource",
-          "description": "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable."
+          "description": "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable."
         }
       },
       "required": [
@@ -21131,7 +21131,7 @@
       "description": "Status of the storage version migration.",
       "properties": {
         "conditions": {
-          "description": "The latest available observations of the migration's current state.",
+          "description": "conditions is the latest available observations of the migration's current state.",
           "items": {
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
@@ -21144,7 +21144,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "resourceVersion": {
-          "description": "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+          "description": "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
           "type": "string"
         }
       },

--- a/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1beta1_openapi.json
@@ -19,7 +19,7 @@
               }
             ],
             "default": {},
-            "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+            "description": "metadata is standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
           },
           "spec": {
             "allOf": [
@@ -28,7 +28,7 @@
               }
             ],
             "default": {},
-            "description": "Specification of the migration."
+            "description": "spec is the specification of the migration."
           },
           "status": {
             "allOf": [
@@ -37,7 +37,7 @@
               }
             ],
             "default": {},
-            "description": "Status of the migration."
+            "description": "status is the status of the migration."
           }
         },
         "type": "object",
@@ -57,7 +57,7 @@
             "type": "string"
           },
           "items": {
-            "description": "Items is the list of StorageVersionMigration",
+            "description": "items is the list of StorageVersionMigration.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.storagemigration.v1beta1.StorageVersionMigration"
             },
@@ -74,7 +74,7 @@
               }
             ],
             "default": {},
-            "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+            "description": "metadata is standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
           }
         },
         "required": [
@@ -99,7 +99,7 @@
               }
             ],
             "default": {},
-            "description": "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable."
+            "description": "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable."
           }
         },
         "required": [
@@ -111,7 +111,7 @@
         "description": "Status of the storage version migration.",
         "properties": {
           "conditions": {
-            "description": "The latest available observations of the migration's current state.",
+            "description": "conditions is the latest available observations of the migration's current state.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
             },
@@ -124,7 +124,7 @@
             "x-kubernetes-patch-strategy": "merge"
           },
           "resourceVersion": {
-            "description": "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+            "description": "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
             "type": "string"
           }
         },

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -147,7 +147,9 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+      - text: "field .* is missing godoc comment"
+        path: "staging/src/k8s.io/api/autoscaling/"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -162,7 +162,9 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+      - text: "field .* is missing godoc comment"
+        path: "staging/src/k8s.io/api/autoscaling/"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -23,7 +23,9 @@
 # Commentstart - Ignore commentstart issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "godoc for field .* should start with '.* ...'"
-  path: "staging/src/k8s.io/api/(apps|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(apps|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+- text: "field .* is missing godoc comment"
+  path: "staging/src/k8s.io/api/autoscaling/"
 
 # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
 - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -57546,21 +57546,21 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigration(ref commo
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specification of the migration.",
+							Description: "spec is the specification of the migration.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(storagemigrationv1beta1.StorageVersionMigrationSpec{}.OpenAPIModelName()),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Status of the migration.",
+							Description: "status is the status of the migration.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(storagemigrationv1beta1.StorageVersionMigrationStatus{}.OpenAPIModelName()),
 						},
@@ -57596,14 +57596,14 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigrationList(ref c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ListMeta{}.OpenAPIModelName()),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Items is the list of StorageVersionMigration",
+							Description: "items is the list of StorageVersionMigration.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -57632,7 +57632,7 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigrationSpec(ref c
 				Properties: map[string]spec.Schema{
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
+							Description: "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.GroupResource{}.OpenAPIModelName()),
 						},
@@ -57665,7 +57665,7 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigrationStatus(ref
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "The latest available observations of the migration's current state.",
+							Description: "conditions is the latest available observations of the migration's current state.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -57678,7 +57678,7 @@ func schema_k8sio_api_storagemigration_v1beta1_StorageVersionMigrationStatus(ref
 					},
 					"resourceVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+							Description: "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
@@ -32,34 +32,34 @@ option go_package = "k8s.io/api/storagemigration/v1beta1";
 // storage version.
 // +k8s:supportsSubresource="/status"
 message StorageVersionMigration {
-  // Standard object metadata.
+  // metadata is standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Specification of the migration.
+  // spec is the specification of the migration.
   // +optional
   optional StorageVersionMigrationSpec spec = 2;
 
-  // Status of the migration.
+  // status is the status of the migration.
   // +optional
   optional StorageVersionMigrationStatus status = 3;
 }
 
 // StorageVersionMigrationList is a collection of storage version migrations.
 message StorageVersionMigrationList {
-  // Standard list metadata
+  // metadata is standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // Items is the list of StorageVersionMigration
+  // items is the list of StorageVersionMigration.
   repeated StorageVersionMigration items = 2;
 }
 
 // Spec of the storage version migration.
 message StorageVersionMigrationSpec {
-  // The resource that is being migrated. The migrator sends requests to
+  // resource is the resource that is being migrated. The migrator sends requests to
   // the endpoint serving the resource.
   // Immutable.
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupResource resource = 1;
@@ -67,7 +67,7 @@ message StorageVersionMigrationSpec {
 
 // Status of the storage version migration.
 message StorageVersionMigrationStatus {
-  // The latest available observations of the migration's current state.
+  // conditions is the latest available observations of the migration's current state.
   // +patchMergeKey=type
   // +patchStrategy=merge
   // +listType=map
@@ -75,7 +75,7 @@ message StorageVersionMigrationStatus {
   // +optional
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 
-  // ResourceVersion to compare with the GC cache for performing the migration.
+  // resourceVersion to compare with the GC cache for performing the migration.
   // This is the current resource version of given group, version and resource when
   // kube-controller-manager first observes this StorageVersionMigration resource.
   optional string resourceVersion = 2;

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
@@ -29,22 +29,22 @@ import (
 // storage version.
 // +k8s:supportsSubresource="/status"
 type StorageVersionMigration struct {
-	metav1.TypeMeta `json:""`
-	// Standard object metadata.
+	metav1.TypeMeta `json:",inline"`
+	// metadata is standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	// Specification of the migration.
+	// spec is the specification of the migration.
 	// +optional
 	Spec StorageVersionMigrationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-	// Status of the migration.
+	// status is the status of the migration.
 	// +optional
 	Status StorageVersionMigrationStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // Spec of the storage version migration.
 type StorageVersionMigrationSpec struct {
-	// The resource that is being migrated. The migrator sends requests to
+	// resource is the resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
 	Resource metav1.GroupResource `json:"resource" protobuf:"bytes,1,opt,name=resource"`
@@ -63,14 +63,14 @@ const (
 
 // Status of the storage version migration.
 type StorageVersionMigrationStatus struct {
-	// The latest available observations of the migration's current state.
+	// conditions is the latest available observations of the migration's current state.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
-	// ResourceVersion to compare with the GC cache for performing the migration.
+	// resourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
 	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,2,opt,name=resourceVersion"`
@@ -83,10 +83,10 @@ type StorageVersionMigrationStatus struct {
 type StorageVersionMigrationList struct {
 	metav1.TypeMeta `json:""`
 
-	// Standard list metadata
+	// metadata is standard list metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	// Items is the list of StorageVersionMigration
+	// items is the list of StorageVersionMigration.
 	Items []StorageVersionMigration `json:"items" protobuf:"bytes,2,rep,name=items"`
 }

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/types_swagger_doc_generated.go
@@ -29,9 +29,9 @@ package v1beta1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_StorageVersionMigration = map[string]string{
 	"":         "StorageVersionMigration represents a migration of stored data to the latest storage version.",
-	"metadata": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"spec":     "Specification of the migration.",
-	"status":   "Status of the migration.",
+	"metadata": "metadata is standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "spec is the specification of the migration.",
+	"status":   "status is the status of the migration.",
 }
 
 func (StorageVersionMigration) SwaggerDoc() map[string]string {
@@ -40,8 +40,8 @@ func (StorageVersionMigration) SwaggerDoc() map[string]string {
 
 var map_StorageVersionMigrationList = map[string]string{
 	"":         "StorageVersionMigrationList is a collection of storage version migrations.",
-	"metadata": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"items":    "Items is the list of StorageVersionMigration",
+	"metadata": "metadata is standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"items":    "items is the list of StorageVersionMigration.",
 }
 
 func (StorageVersionMigrationList) SwaggerDoc() map[string]string {
@@ -50,7 +50,7 @@ func (StorageVersionMigrationList) SwaggerDoc() map[string]string {
 
 var map_StorageVersionMigrationSpec = map[string]string{
 	"":         "Spec of the storage version migration.",
-	"resource": "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
+	"resource": "resource is the resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.",
 }
 
 func (StorageVersionMigrationSpec) SwaggerDoc() map[string]string {
@@ -59,8 +59,8 @@ func (StorageVersionMigrationSpec) SwaggerDoc() map[string]string {
 
 var map_StorageVersionMigrationStatus = map[string]string{
 	"":                "Status of the storage version migration.",
-	"conditions":      "The latest available observations of the migration's current state.",
-	"resourceVersion": "ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
+	"conditions":      "conditions is the latest available observations of the migration's current state.",
+	"resourceVersion": "resourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.",
 }
 
 func (StorageVersionMigrationStatus) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigration.go
@@ -33,13 +33,13 @@ import (
 // StorageVersionMigration represents a migration of stored data to the latest
 // storage version.
 type StorageVersionMigrationApplyConfiguration struct {
-	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object metadata.
+	v1.TypeMetaApplyConfiguration `json:",inline"`
+	// metadata is standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Specification of the migration.
+	// spec is the specification of the migration.
 	Spec *StorageVersionMigrationSpecApplyConfiguration `json:"spec,omitempty"`
-	// Status of the migration.
+	// status is the status of the migration.
 	Status *StorageVersionMigrationStatusApplyConfiguration `json:"status,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigrationspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigrationspec.go
@@ -27,7 +27,7 @@ import (
 //
 // Spec of the storage version migration.
 type StorageVersionMigrationSpecApplyConfiguration struct {
-	// The resource that is being migrated. The migrator sends requests to
+	// resource is the resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
 	Resource *v1.GroupResourceApplyConfiguration `json:"resource,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigrationstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1beta1/storageversionmigrationstatus.go
@@ -27,9 +27,9 @@ import (
 //
 // Status of the storage version migration.
 type StorageVersionMigrationStatusApplyConfiguration struct {
-	// The latest available observations of the migration's current state.
+	// conditions is the latest available observations of the migration's current state.
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
-	// ResourceVersion to compare with the GC cache for performing the migration.
+	// resourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
 	ResourceVersion *string `json:"resourceVersion,omitempty"`


### PR DESCRIPTION
#### What type of PR is this?
/kind api-change

#### What this PR does / why we need it:
Ensure comments start with the serialized version of the field name.

#### Which issue(s) this PR is related to:
Relates to #134671

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```