### PR TITLE
kubelet: add terminated_containers_total metric

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -100,6 +100,7 @@ const (
 	StartedPodsTotalKey             = "started_pods_total"
 	StartedPodsErrorsTotalKey       = "started_pods_errors_total"
 	StartedContainersTotalKey       = "started_containers_total"
+	TerminatedContainersTotalKey    = "terminated_containers_total"
 	StartedContainersErrorsTotalKey = "started_containers_errors_total"
 
 	// Metrics to track HostProcess container usage by this kubelet
@@ -729,6 +730,16 @@ var (
 		},
 		[]string{"container_type"},
 	)
+	// TerminatedContainersTotal is a counter that tracks the number of container terminations
+	TerminatedContainersTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           TerminatedContainersTotalKey,
+			Help:           "Cumulative number of container terminations.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"container_type", "exit_code", "reason"},
+	)
 	// StartedContainersTotal is a counter that tracks the number of errors creating containers
 	StartedContainersErrorsTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -1258,6 +1269,7 @@ func Register() {
 		legacyregistry.MustRegister(StartedPodsTotal)
 		legacyregistry.MustRegister(StartedPodsErrorsTotal)
 		legacyregistry.MustRegister(StartedContainersTotal)
+		legacyregistry.MustRegister(TerminatedContainersTotal)
 		legacyregistry.MustRegister(StartedContainersErrorsTotal)
 		legacyregistry.MustRegister(StartedHostProcessContainersTotal)
 		legacyregistry.MustRegister(StartedHostProcessContainersErrorsTotal)

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -878,6 +879,33 @@ func (m *manager) updateStatusInternal(logger klog.Logger, pod *v1.Pod, status v
 		sort.Strings(containers)
 		loggerV.Info("updateStatusInternal", "version", cachedStatus.version+1, "podIsFinished", podIsFinished, "pod", klog.KObj(pod), "podUID", pod.UID, "containers", strings.Join(containers, " "))
 	}
+
+	// Increment container termination metric for newly terminated containers.
+	// We only want to count terminations once per container per pod.
+	// By comparing the new status to the old status before we apply it to the cache,
+	// we can detect exactly when a container in this pod transitions to the
+	// Terminated state and record the metric.
+	checkAndRecordTerminations := func(oldStatuses, newStatuses []v1.ContainerStatus, containerType string) {
+		for _, newCStat := range newStatuses {
+			if newCStat.State.Terminated != nil {
+				// Find the old status for this container.
+				var oldCStat *v1.ContainerStatus
+				for i := range oldStatuses {
+					if oldStatuses[i].Name == newCStat.Name {
+						oldCStat = &oldStatuses[i]
+						break
+					}
+				}
+				// If it wasn't terminated before (or is brand new and already terminated), record it.
+				if oldCStat == nil || oldCStat.State.Terminated == nil {
+					metrics.TerminatedContainersTotal.WithLabelValues(containerType, strconv.Itoa(int(newCStat.State.Terminated.ExitCode)), newCStat.State.Terminated.Reason).Inc()
+				}
+			}
+		}
+	}
+	checkAndRecordTerminations(oldStatus.InitContainerStatuses, status.InitContainerStatuses, metrics.InitContainer)
+	checkAndRecordTerminations(oldStatus.ContainerStatuses, status.ContainerStatuses, metrics.Container)
+	checkAndRecordTerminations(oldStatus.EphemeralContainerStatuses, status.EphemeralContainerStatuses, metrics.EphemeralContainer)
 
 	// The intent here is to prevent concurrent updates to a pod's status from
 	// clobbering each other so the phase of a pod progresses monotonically.

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -2093,6 +2093,99 @@ func TestMergePodStatus(t *testing.T) {
 	}
 }
 
+func TestContainerTerminationMetric(t *testing.T) {
+	metrics.Register()
+	manager := newTestManager(&fake.Clientset{})
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "metric-pod",
+			Namespace: "test",
+			UID:       "12345",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "test-container"},
+			},
+		},
+	}
+	manager.podManager.(mutablePodManager).AddPod(pod)
+
+	metrics.TerminatedContainersTotal.Reset()
+
+	initialStatus := v1.PodStatus{
+		Phase: v1.PodRunning,
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name: "test-container",
+				State: v1.ContainerState{
+					Running: &v1.ContainerStateRunning{},
+				},
+			},
+		},
+	}
+	manager.SetPodStatus(klog.Background(), pod, initialStatus)
+
+	manager.testSyncBatch(context.Background())
+
+	// Test successful termination (exit code 0)
+	successStatus := v1.PodStatus{
+		Phase: v1.PodSucceeded,
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name: "test-container",
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						ExitCode: 0,
+						Reason:   "Completed",
+					},
+				},
+			},
+		},
+	}
+	manager.SetPodStatus(klog.Background(), pod, successStatus)
+	manager.testSyncBatch(context.Background())
+
+	count, err := testutil.GetCounterMetricValue(metrics.TerminatedContainersTotal.WithLabelValues(metrics.Container, "0", "Completed"))
+	require.NoError(t, err)
+	assert.InDelta(t, 1.0, count, 0)
+
+	// Test error termination (exit code 1) for a second container to verify cumulative behavior
+	errorPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "error-pod",
+			Namespace: "test",
+			UID:       "67890",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "error-container"},
+			},
+		},
+	}
+	manager.podManager.(mutablePodManager).AddPod(errorPod)
+
+	errorStatus := v1.PodStatus{
+		Phase: v1.PodFailed,
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name: "error-container",
+				State: v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{
+						ExitCode: 1,
+						Reason:   "Error",
+					},
+				},
+			},
+		},
+	}
+	manager.SetPodStatus(klog.Background(), errorPod, errorStatus)
+	manager.testSyncBatch(context.Background())
+
+	count, err = testutil.GetCounterMetricValue(metrics.TerminatedContainersTotal.WithLabelValues(metrics.Container, "1", "Error"))
+	require.NoError(t, err)
+	assert.InDelta(t, 1.0, count, 0)
+}
+
 func TestPodResizeConditions(t *testing.T) {
 	m := NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, util.NewPodStartupLatencyTracker())
 	podUID := types.UID("12345")

--- a/test/e2e/node/container_termination_metrics.go
+++ b/test/e2e/node/container_termination_metrics.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+var _ = ginkgo.Describe("[sig-node] ContainerTerminationMetrics Validation", func() {
+	f := framework.NewDefaultFramework("metric-validation")
+
+	ginkgo.It("should report terminated_containers_total metric", func(ctx context.Context) {
+		pod := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "sigsegv-test-pod"},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyNever,
+				Containers: []v1.Container{{
+					Name:    "crash-container",
+					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+					Command: []string{"/bin/sh", "-c", "exit 139"},
+				}},
+			},
+		})
+
+		createdPod := e2epod.NewPodClient(f).Create(ctx, pod)
+
+		ginkgo.By("Checking kubelet metrics via API Server Proxy")
+		gomega.Eventually(ctx, func() error {
+			// Get the actual node the pod was scheduled on
+			p, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, createdPod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if p.Spec.NodeName == "" {
+				return fmt.Errorf("pod not yet scheduled")
+			}
+
+			metrics, err := e2emetrics.GetKubeletMetrics(ctx, f.ClientSet, p.Spec.NodeName)
+			if err != nil {
+				return err
+			}
+			if samples, found := metrics["terminated_containers_total"]; found {
+				for _, sample := range samples {
+					if string(sample.Metric["container_type"]) == "container" &&
+						string(sample.Metric["exit_code"]) == "139" {
+						framework.Logf("Found metric! Value: %v", sample.Value)
+						return nil
+					}
+				}
+			}
+			return fmt.Errorf("metric not found")
+		}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.Succeed())
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

 Add a new ALPHA stability metric terminated_containers_total to track
  container terminations (both successful and failed). This metric provides
  aggregate visibility into container exit patterns across the node,
  supporting detection of abnormal exits (e.g., SIGSEGV, OOMKilled) and
  enabling error-rate calculations.

  To ensure node stability and comply with Kubernetes instrumentation
  standards, the metric uses the following low-cardinality labels:
   - container_type (container, init_container, or ephemeral_container)
   - exit_code (the literal exit status)
   - reason (the termination reason from the runtime)

  High-cardinality labels (container_name, namespace_name) are deliberately
  omitted to prevent metric cardinality explosion. Problematic containers can
  be identified via standard troubleshooting workflows using Kubernetes
  Events or API status.

  Included:
   - Metric definition and registration in metrics.go.
   - Status manager implementation to record transitions exactly once.
   - Unit tests in status_manager_test.go verifying success/failure logic.
   - Node e2e test to verify correct metrics exposure.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note

Added the metric terminated_containers_total to track the number of containers failed or succeeded broken down by exit code

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

