### PR TITLE
sig-windows: Fix SNAT SourceVIP fallback to NodeIP in winkernel proxier

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -1421,8 +1421,8 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 
 		klog.V(4).InfoS("Trying to apply Policies for service", "serviceInfo", svcInfo)
 		var hnsLoadBalancer *loadBalancerInfo
-		var sourceVip = proxier.sourceVip
-		if containsPublicIP || containsNodeIP {
+		sourceVip := proxier.sourceVip
+		if containsPublicIP || containsNodeIP || len(sourceVip) == 0 {
 			sourceVip = proxier.nodeIP.String()
 		}
 

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -110,15 +110,19 @@ func NewFakeProxier(t *testing.T, nodeName string, nodeIP net.IP, networkType st
 		sourceVip = "192::1:2"
 	}
 
-	// enable `WinDSR` feature gate
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.WinDSR, true)
-
 	config := config.KubeProxyWinkernelConfiguration{
 		SourceVip:             sourceVip,
 		EnableDSR:             enableDSR,
 		NetworkName:           testNetwork,
 		ForwardHealthCheckVip: true,
 	}
+
+	return NewFakeProxierWithConfig(t, nodeName, nodeIP, networkType, config, family)
+}
+
+func NewFakeProxierWithConfig(t *testing.T, nodeName string, nodeIP net.IP, networkType string, config config.KubeProxyWinkernelConfiguration, family v1.IPFamily) *Proxier {
+	// enable `WinDSR` feature gate
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.WinDSR, true)
 
 	hcnMock := getHcnMock(networkType)
 
@@ -1925,6 +1929,69 @@ func TestETPClusterIngressIPServiceWithPreferDualStack(t *testing.T) {
 
 func TestETPClusterIngressIPServiceWithRequireDualStack(t *testing.T) {
 	testDualStackService(t, false, v1.IPFamilyPolicyRequireDualStack, v1.ServiceExternalTrafficPolicyCluster)
+}
+
+func TestSnatSourceVipFallback(t *testing.T) {
+	nodeIP := "10.0.0.1"
+	proxier := NewFakeProxierWithConfig(t, testNodeName, netutils.ParseIPSloppy(nodeIP), NETWORK_TYPE_OVERLAY, config.KubeProxyWinkernelConfiguration{
+		SourceVip:             "", // Empty SourceVip to trigger fallback
+		EnableDSR:             true,
+		NetworkName:           testNetwork,
+		ForwardHealthCheckVip: true,
+	}, v1.IPv4Protocol)
+	if proxier == nil {
+		t.Fatal("Failed to create proxier")
+	}
+
+	svcIP := "10.20.30.41"
+	svcPort := 80
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "snat-fallback"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = "ClusterIP"
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: v1.ProtocolTCP,
+			}}
+		}),
+	)
+
+	// Add an endpoint to ensure we have a load balancer created
+	populateEndpointSlices(proxier,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{{
+				Addresses: []string{"192.168.1.10"},
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+	)
+
+	proxier.setInitialized(true)
+	proxier.syncProxyRules()
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo %q", svcPortName.String())
+	assert.NotEmpty(t, svcInfo.hnsID, "Expected HNS ID to be set for service %q", svcPortName.String())
+
+	lb, err := proxier.hcn.GetLoadBalancerByID(svcInfo.hnsID)
+	assert.NoError(t, err)
+	assert.NotNil(t, lb)
+
+	// Verify that SourceVIP is the Node IP because config.SourceVip was empty
+	assert.Equal(t, nodeIP, lb.SourceVIP, "SourceVIP should fallback to nodeIP when config.SourceVip is empty")
 }
 
 func makeNSN(namespace, name string) types.NamespacedName {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This change ensures that the Node IP is used for SNAT when no Source VIP is configured in the winkernel proxier. This prevents the Windows Host Network Service (HNS) from incorrectly defaulting to the LoadBalancer VIP for SNAT.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/137578

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: