### PR TITLE
statefulset: wrap errors with %w in StatefulPodControl

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -260,7 +260,8 @@ func (spc *StatefulPodControl) ClaimsMatchRetentionPolicy(ctx context.Context, s
 		case apierrors.IsNotFound(err):
 			klog.FromContext(ctx).V(4).Info("Expected claim missing, continuing to pick up in next iteration", "PVC", klog.KObj(claim))
 		case err != nil:
-			return false, fmt.Errorf("Could not retrieve claim %s for %s when checking PVC deletion policy", claimName, pod.Name)
+			return false, fmt.Errorf(
+				"Could not retrieve claim %s for %s when checking PVC deletion policy: %w", claimName, pod.Name, err)
 		default:
 			if !isClaimOwnerUpToDate(logger, claim, set, pod) {
 				return false, nil
@@ -385,13 +386,13 @@ func (spc *StatefulPodControl) createPersistentVolumeClaims(set *apps.StatefulSe
 		case apierrors.IsNotFound(err):
 			err := spc.objectMgr.CreateClaim(&claim, set)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("failed to create PVC %s: %s", claim.Name, err))
+				errs = append(errs, fmt.Errorf("failed to create PVC %s: %w", claim.Name, err))
 			}
 			if err == nil || !apierrors.IsAlreadyExists(err) {
 				spc.recordClaimEvent("create", set, pod, &claim, err)
 			}
 		case err != nil:
-			errs = append(errs, fmt.Errorf("failed to retrieve PVC %s: %s", claim.Name, err))
+			errs = append(errs, fmt.Errorf("failed to retrieve PVC %s: %w", claim.Name, err))
 			spc.recordClaimEvent("create", set, pod, &claim, err)
 		default:
 			if pvc.DeletionTimestamp != nil {


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Some fmt.Errorf calls in StatefulPodControl used %s when formatting
errors returned from API calls.

Using %s converts the error to plain text and breaks the error chain,
preventing callers from using errors.Is / errors.As to detect specific
API errors (e.g. NotFound or Conflict).

This PR replaces %s with %w where appropriate to preserve the original
error. Additionally, one error path in ClaimsMatchRetentionPolicy
dropped the underlying error entirely; this change includes and wraps
that error.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
This aligns with existing error wrapping patterns already used elsewhere in the same file.

#### Does this PR introduce a user-facing change?
```release-note
NONE