### PR TITLE
De-alias SIG API Machinery OWNERS files

### DIFF
--- a/pkg/controller/garbagecollector/OWNERS
+++ b/pkg/controller/garbagecollector/OWNERS
@@ -1,9 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-api-machinery-approvers
+  - deads2k
+  - jpbetz
+  - sttts
 reviewers:
-  - sig-api-machinery-reviewers
+  - deads2k
+  - jpbetz
+  - sttts
 labels:
   - sig/api-machinery
 emeritus_approvers:

--- a/pkg/controller/namespace/OWNERS
+++ b/pkg/controller/namespace/OWNERS
@@ -1,10 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-api-machinery-approvers
+  - deads2k
+  - jpbetz
+  - sttts
 reviewers:
   - derekwaynecarr
   - smarterclayton
-  - sig-api-machinery-reviewers
+  - deads2k
+  - jpbetz
+  - sttts
 labels:
   - sig/api-machinery

--- a/pkg/controller/storageversiongc/OWNERS
+++ b/pkg/controller/storageversiongc/OWNERS
@@ -2,8 +2,12 @@
 
 approvers:
   - enj
-  - sig-api-machinery-approvers
+  - deads2k
+  - jpbetz
+  - sttts
 reviewers:
-  - sig-api-machinery-reviewers
+  - deads2k
+  - jpbetz
+  - sttts
 labels:
   - sig/api-machinery

--- a/pkg/controller/storageversionmigrator/OWNERS
+++ b/pkg/controller/storageversionmigrator/OWNERS
@@ -2,9 +2,13 @@
 
 approvers:
   - enj
-  - sig-api-machinery-approvers
+  - deads2k
+  - jpbetz
+  - sttts
 reviewers:
   - michaelasp
-  - sig-api-machinery-reviewers
+  - deads2k
+  - jpbetz
+  - sttts
 labels:
   - sig/api-machinery

--- a/pkg/controller/validatingadmissionpolicystatus/OWNERS
+++ b/pkg/controller/validatingadmissionpolicystatus/OWNERS
@@ -1,8 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-api-machinery-approvers
+  - deads2k
+  - jpbetz
+  - sttts
 reviewers:
-  - sig-api-machinery-reviewers
+  - deads2k
+  - jpbetz
+  - sttts
 labels:
   - sig/api-machinery

--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/OWNERS
@@ -1,6 +1,8 @@
 approvers:
   - sig-instrumentation-approvers
-  - sig-api-machinery-approvers
+  - deads2k
+  - jpbetz
+  - sttts
 reviewers:
   - sig-instrumentation-reviewers
 labels:

--- a/staging/src/k8s.io/apiserver/pkg/server/statusz/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/server/statusz/OWNERS
@@ -1,6 +1,8 @@
 approvers:
   - sig-instrumentation-approvers
-  - sig-api-machinery-approvers
+  - deads2k
+  - jpbetz
+  - sttts
 reviewers:
   - sig-instrumentation-reviewers
 labels:

--- a/staging/src/k8s.io/component-base/codec/OWNERS
+++ b/staging/src/k8s.io/component-base/codec/OWNERS
@@ -4,8 +4,12 @@
 # decoding KRM style manifests.
 
 approvers:
-  - sig-api-machinery-api-approvers
+  - deads2k
+  - jpbetz
+  - sttts
 reviewers:
-  - sig-api-machinery-api-reviewers
+  - deads2k
+  - jpbetz
+  - sttts
 labels:
   - sig/api-machinery

--- a/staging/src/k8s.io/component-base/compatibility/OWNERS
+++ b/staging/src/k8s.io/component-base/compatibility/OWNERS
@@ -4,10 +4,13 @@
 # an interface to the version definition in "k8s.io/apiserver/pkg/util/compatibility".
 
 approvers:
-  - sig-api-machinery-api-approvers
+  - deads2k
   - jpbetz
+  - sttts
 reviewers:
-  - sig-api-machinery-api-reviewers
+  - deads2k
+  - jpbetz
+  - sttts
   - siyuanfoundation
   - jefftree
 labels:

--- a/staging/src/k8s.io/component-base/version/OWNERS
+++ b/staging/src/k8s.io/component-base/version/OWNERS
@@ -6,10 +6,14 @@
 # each release.
 
 approvers:
-  - sig-api-machinery-api-approvers
+  - deads2k
+  - jpbetz
+  - sttts
   - release-engineering-approvers
 reviewers:
-  - sig-api-machinery-api-reviewers
+  - deads2k
+  - jpbetz
+  - sttts
   - release-managers
 labels:
   - sig/api-machinery

--- a/staging/src/k8s.io/component-helpers/apimachinery/OWNERS
+++ b/staging/src/k8s.io/component-helpers/apimachinery/OWNERS
@@ -1,8 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-api-machinery-api-approvers
+  - deads2k
+  - jpbetz
+  - sttts
 reviewers:
-  - sig-api-machinery-api-reviewers
+  - deads2k
+  - jpbetz
+  - sttts
 labels:
   - sig/api-machinery

--- a/test/compatibility_lifecycle/OWNERS
+++ b/test/compatibility_lifecycle/OWNERS
@@ -2,15 +2,17 @@
 
 approvers:
   - feature-approvers
-  - sig-api-machinery-api-approvers
+  - deads2k
   - jpbetz
+  - sttts
   - siyuanfoundation
   - aaron-prindle # For migration of unversioned feature gates to versioned
   - jefftree # For migration of unversioned feature gates to versioned
 reviewers:
   - feature-approvers
-  - sig-api-machinery-api-reviewers
+  - deads2k
   - jpbetz
+  - sttts
   - siyuanfoundation
   - aaron-prindle # For migration of unversioned feature gates to versioned
   - jefftree # For migration of unversioned feature gates to versioned


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Using aliases in this way is an anti-pattern. Switching existing usages away means that future contributors perpetuate this pattern via copy-paste.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig api-machinery

/assign @BenTheElder @pohly 
