### PR TITLE
KEP-5832: Implement PodGroup admission

### DIFF
--- a/pkg/controlplane/apiserver/samples/generic/server/admission_test.go
+++ b/pkg/controlplane/apiserver/samples/generic/server/admission_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/network/defaultingressclass"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodedeclaredfeatures"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
+	"k8s.io/kubernetes/plugin/pkg/admission/podgroup"
 	"k8s.io/kubernetes/plugin/pkg/admission/podresize"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"
 	podpriority "k8s.io/kubernetes/plugin/pkg/admission/priority"
@@ -48,6 +49,7 @@ var intentionallyOffPlugins = sets.New[string](
 	defaultingressclass.PluginName,          // DefaultIngressClass
 	podsecurity.PluginName,                  // PodSecurity
 	podtopologylabels.PluginName,            // PodTopologyLabels
+	podgroup.PluginName,                     // PodGroupWorkloadExists
 	nodedeclaredfeatures.PluginName,         // NodeDeclaredFeatures
 	podresize.PluginName,                    // PodResize
 )

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/nodedeclaredfeatures"
 	"k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
+	"k8s.io/kubernetes/plugin/pkg/admission/podgroup"
 	"k8s.io/kubernetes/plugin/pkg/admission/podnodeselector"
 	"k8s.io/kubernetes/plugin/pkg/admission/podresize"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction"
@@ -101,6 +102,7 @@ var AllOrderedPlugins = []string{
 	defaultingressclass.PluginName,          // DefaultIngressClass
 	denyserviceexternalips.PluginName,       // DenyServiceExternalIPs
 	podtopologylabels.PluginName,            // PodTopologyLabels
+	podgroup.PluginName,                     // PodGroupWorkloadExists
 	nodedeclaredfeatures.PluginName,         // NodeDeclaredFeatureValidator
 	podresize.PluginName,                    // PodResizeValidator
 
@@ -156,6 +158,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	ctbattest.Register(plugins)
 	certsubjectrestriction.Register(plugins)
 	podtopologylabels.Register(plugins)
+	podgroup.Register(plugins)
 	nodedeclaredfeatures.Register(plugins)
 	podresize.Register(plugins)
 }
@@ -186,6 +189,7 @@ func DefaultOffAdmissionPlugins() sets.Set[string] {
 		podtopologylabels.PluginName,            // PodTopologyLabels, only active when feature gate PodTopologyLabelsAdmission is enabled.
 		mutatingadmissionpolicy.PluginName,      // Mutatingadmissionpolicy, only active when feature gate MutatingAdmissionpolicy is enabled
 		validatingadmissionpolicy.PluginName,    // ValidatingAdmissionPolicy, only active when feature gate ValidatingAdmissionPolicy is enabled
+		podgroup.PluginName,                     // PodGroupWorkloadExists, only active when feature gate GenericWorkload is enabled
 		nodedeclaredfeatures.PluginName,         // NodeDeclaredFeatureValidator, only active when feature gate NodeDeclaredFeatures is enabled
 		podresize.PluginName,                    // PodResizeValidator, only active when feature gate InPlacePodVerticalScaling is enabled
 	)

--- a/plugin/pkg/admission/podgroup/admission.go
+++ b/plugin/pkg/admission/podgroup/admission.go
@@ -1,0 +1,161 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podgroup
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	schedulingv1alpha2listers "k8s.io/client-go/listers/scheduling/v1alpha2"
+	"k8s.io/component-base/featuregate"
+	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// PluginName indicates name of admission plugin.
+const PluginName = "PodGroupWorkloadExists"
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewPodGroupWorkloadExists(), nil
+	})
+}
+
+var _ admission.ValidationInterface = &PodGroupWorkloadExists{}
+var _ genericadmissioninitializer.WantsExternalKubeInformerFactory = &PodGroupWorkloadExists{}
+var _ genericadmissioninitializer.WantsExternalKubeClientSet = &PodGroupWorkloadExists{}
+var _ genericadmissioninitializer.WantsFeatures = &PodGroupWorkloadExists{}
+
+// PodGroupWorkloadExists is an admission plugin that validates a PodGroup's
+// referenced Workload exists and contains the referenced PodGroupTemplate.
+type PodGroupWorkloadExists struct {
+	*admission.Handler
+	workloadLister         schedulingv1alpha2listers.WorkloadLister
+	client                 kubernetes.Interface
+	inspectedFeatureGates  bool
+	genericWorkloadEnabled bool
+}
+
+// NewPodGroupWorkloadExists creates a new PodGroupWorkloadExists admission plugin.
+func NewPodGroupWorkloadExists() *PodGroupWorkloadExists {
+	return &PodGroupWorkloadExists{
+		Handler: admission.NewHandler(admission.Create),
+	}
+}
+
+// InspectFeatureGates captures the feature gate states.
+func (p *PodGroupWorkloadExists) InspectFeatureGates(featureGates featuregate.FeatureGate) {
+	p.genericWorkloadEnabled = featureGates.Enabled(features.GenericWorkload)
+	p.inspectedFeatureGates = true
+}
+
+// SetExternalKubeClientSet sets the client for the plugin.
+func (p *PodGroupWorkloadExists) SetExternalKubeClientSet(client kubernetes.Interface) {
+	p.client = client
+}
+
+// SetExternalKubeInformerFactory sets the informer factory for the plugin.
+func (p *PodGroupWorkloadExists) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
+	if !p.genericWorkloadEnabled {
+		return
+	}
+	workloadInformer := f.Scheduling().V1alpha2().Workloads()
+	p.SetReadyFunc(workloadInformer.Informer().HasSynced)
+	p.workloadLister = workloadInformer.Lister()
+}
+
+// ValidateInitialization ensures the plugin is properly initialized.
+func (p *PodGroupWorkloadExists) ValidateInitialization() error {
+	if !p.inspectedFeatureGates {
+		return fmt.Errorf("%s has not inspected feature gates", PluginName)
+	}
+	if !p.genericWorkloadEnabled {
+		return nil
+	}
+	if p.workloadLister == nil {
+		return fmt.Errorf("missing Workload lister")
+	}
+	if p.client == nil {
+		return fmt.Errorf("missing client")
+	}
+	return nil
+}
+
+// Validate rejects PodGroup creation if the referenced Workload does not exist
+// or does not contain the referenced PodGroupTemplate.
+func (p *PodGroupWorkloadExists) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	if !p.genericWorkloadEnabled {
+		return nil
+	}
+
+	if a.GetResource().GroupResource() != scheduling.Resource("podgroups") {
+		return nil
+	}
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	podGroup, ok := a.GetObject().(*scheduling.PodGroup)
+	if !ok {
+		return apierrors.NewBadRequest("resource was marked with kind PodGroup but could not be converted")
+	}
+
+	if podGroup.Spec.PodGroupTemplateRef == nil || podGroup.Spec.PodGroupTemplateRef.Workload == nil {
+		return nil
+	}
+
+	if !p.WaitForReady() {
+		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+	}
+
+	workloadRef := podGroup.Spec.PodGroupTemplateRef.Workload
+	workload, err := p.workloadLister.Workloads(a.GetNamespace()).Get(workloadRef.WorkloadName)
+	if apierrors.IsNotFound(err) {
+		workload, err = p.client.SchedulingV1alpha2().Workloads(
+			a.GetNamespace()).Get(ctx, workloadRef.WorkloadName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return admission.NewForbidden(a,
+				fmt.Errorf("PodGroup rejected: Workload %q not found", workloadRef.WorkloadName))
+		}
+	}
+	if err != nil {
+		return apierrors.NewInternalError(err)
+	}
+
+	if workload.DeletionTimestamp != nil {
+		return admission.NewForbidden(a, fmt.Errorf("PodGroup rejected: Workload %q is being deleted", workloadRef.WorkloadName))
+	}
+
+	for _, tmpl := range workload.Spec.PodGroupTemplates {
+		if tmpl.Name == workloadRef.PodGroupTemplateName {
+			return nil
+		}
+	}
+
+	return admission.NewForbidden(a, fmt.Errorf(
+		"PodGroup rejected: PodGroupTemplate %q not found in Workload %q",
+		workloadRef.PodGroupTemplateName, workloadRef.WorkloadName,
+	))
+}

--- a/plugin/pkg/admission/podgroup/admission_test.go
+++ b/plugin/pkg/admission/podgroup/admission_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podgroup
+
+import (
+	"testing"
+
+	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2/ktesting"
+	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+const (
+	testNamespace    = "test"
+	testWorkloadName = "my-workload"
+	testTemplateName = "worker"
+)
+
+func newPodGroup(mutators ...func(*scheduling.PodGroup)) admission.Attributes {
+	pg := &scheduling.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: testNamespace},
+		Spec: scheduling.PodGroupSpec{
+			PodGroupTemplateRef: &scheduling.PodGroupTemplateReference{
+				Workload: &scheduling.WorkloadPodGroupTemplateReference{
+					WorkloadName:         testWorkloadName,
+					PodGroupTemplateName: testTemplateName,
+				},
+			},
+		},
+	}
+	for _, m := range mutators {
+		m(pg)
+	}
+	return admission.NewAttributesRecord(
+		pg, nil,
+		scheduling.Kind("PodGroup").WithVersion("version"),
+		testNamespace, "pg",
+		scheduling.Resource("podgroups").WithVersion("version"),
+		"", admission.Create, &metav1.CreateOptions{}, false, &user.DefaultInfo{},
+	)
+}
+
+func withWorkloadRef(workloadName, templateName string) func(*scheduling.PodGroup) {
+	return func(pg *scheduling.PodGroup) {
+		pg.Spec.PodGroupTemplateRef.Workload.WorkloadName = workloadName
+		pg.Spec.PodGroupTemplateRef.Workload.PodGroupTemplateName = templateName
+	}
+}
+
+func newWorkload(name string, templateNames ...string) *schedulingv1alpha2.Workload {
+	w := &schedulingv1alpha2.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec: schedulingv1alpha2.WorkloadSpec{
+			PodGroupTemplates: make([]schedulingv1alpha2.PodGroupTemplate, 0, len(templateNames)),
+		},
+	}
+	for _, tn := range templateNames {
+		w.Spec.PodGroupTemplates = append(w.Spec.PodGroupTemplates, schedulingv1alpha2.PodGroupTemplate{Name: tn})
+	}
+	return w
+}
+
+func TestHandles(t *testing.T) {
+	plugin := NewPodGroupWorkloadExists()
+	for op, shouldHandle := range map[admission.Operation]bool{
+		admission.Create:  true,
+		admission.Update:  false,
+		admission.Delete:  false,
+		admission.Connect: false,
+	} {
+		if e, a := shouldHandle, plugin.Handles(op); e != a {
+			t.Errorf("%v: shouldHandle=%t, handles=%t", op, e, a)
+		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	now := metav1.Now()
+
+	deletingWorkload := newWorkload("deleting-workload", testTemplateName)
+	deletingWorkload.DeletionTimestamp = &now
+
+	workload := newWorkload(testWorkloadName, testTemplateName, "driver")
+
+	cases := map[string]struct {
+		enableFeatureGate bool
+		workloads         []*schedulingv1alpha2.Workload
+		attrs             admission.Attributes
+		wantErr           bool
+	}{
+		"feature gate disabled, always allow": {
+			attrs: newPodGroup(withWorkloadRef("non-existent", "worker")),
+		},
+		"no podGroupTemplateRef, allow": {
+			enableFeatureGate: true,
+			attrs: newPodGroup(func(pg *scheduling.PodGroup) {
+				pg.Spec.PodGroupTemplateRef = nil
+			}),
+		},
+		"nil workload ref, allow": {
+			enableFeatureGate: true,
+			attrs: newPodGroup(func(pg *scheduling.PodGroup) {
+				pg.Spec.PodGroupTemplateRef = &scheduling.PodGroupTemplateReference{}
+			}),
+		},
+		"workload found, template exists": {
+			enableFeatureGate: true,
+			workloads:         []*schedulingv1alpha2.Workload{workload},
+			attrs:             newPodGroup(),
+		},
+		"workload not found": {
+			enableFeatureGate: true,
+			attrs:             newPodGroup(withWorkloadRef("non-existent", testTemplateName)),
+			wantErr:           true,
+		},
+		"workload being deleted": {
+			enableFeatureGate: true,
+			workloads:         []*schedulingv1alpha2.Workload{deletingWorkload},
+			attrs:             newPodGroup(withWorkloadRef("deleting-workload", testTemplateName)),
+			wantErr:           true,
+		},
+		"workload found but template name does not match": {
+			enableFeatureGate: true,
+			workloads:         []*schedulingv1alpha2.Workload{workload},
+			attrs:             newPodGroup(withWorkloadRef(testWorkloadName, "non-existent-template")),
+			wantErr:           true,
+		},
+		"ignores non-PodGroup resources": {
+			enableFeatureGate: true,
+			attrs: admission.NewAttributesRecord(
+				nil, nil,
+				scheduling.Kind("Workload").WithVersion("version"),
+				testNamespace, "w1",
+				scheduling.Resource("workloads").WithVersion("version"),
+				"", admission.Create, &metav1.CreateOptions{}, false, &user.DefaultInfo{},
+			),
+		},
+		"ignores subresources": {
+			enableFeatureGate: true,
+			attrs: admission.NewAttributesRecord(
+				&scheduling.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: testNamespace}}, nil,
+				scheduling.Kind("PodGroup").WithVersion("version"),
+				testNamespace, "pg",
+				scheduling.Resource("podgroups").WithVersion("version"),
+				"status", admission.Create, &metav1.CreateOptions{}, false, &user.DefaultInfo{},
+			),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t,
+				utilfeature.DefaultFeatureGate, features.GenericWorkload, tc.enableFeatureGate)
+
+			plugin := NewPodGroupWorkloadExists()
+			plugin.InspectFeatureGates(utilfeature.DefaultFeatureGate)
+
+			informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
+			plugin.SetExternalKubeInformerFactory(informerFactory)
+			for _, w := range tc.workloads {
+				if err := informerFactory.Scheduling().V1alpha2().Workloads().Informer().GetStore().Add(w); err != nil {
+					t.Fatalf("failed to add Workload: %v", err)
+				}
+			}
+			plugin.SetReadyFunc(func() bool { return true })
+			plugin.SetExternalKubeClientSet(fake.NewSimpleClientset())
+
+			err := plugin.Validate(ctx, tc.attrs, nil)
+			if tc.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -539,7 +539,7 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 			RemovedVersion:    "1.42",
 		},
 		gvr("scheduling.k8s.io", "v1alpha2", "podgroups"): {
-			Stub:              `{"metadata": {"name": "pg1"}, "spec": {"podGroupTemplateRef": {"workload": {"podGroupTemplateName": "t", "workloadName": "w"}}, "schedulingPolicy": {"basic": {}}}}`,
+			Stub:              `{"metadata": {"name": "pg1"}, "spec": {"schedulingPolicy": {"basic": {}}}}`,
 			ExpectedEtcdPath:  "/registry/podgroups/" + namespace + "/pg1",
 			IntroducedVersion: "1.36",
 			RemovedVersion:    "1.42",

--- a/test/integration/scheduler/podgroup/admission/admission_test.go
+++ b/test/integration/scheduler/podgroup/admission/admission_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"testing"
+
+	schedulingapi "k8s.io/api/scheduling/v1alpha2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	testutils "k8s.io/kubernetes/test/integration/util"
+)
+
+func TestPodGroupAdmission(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload: true,
+	})
+
+	defaultWorkload := st.MakeWorkload().Name("test-workload").
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("worker").MinCount(3).Obj()).
+		Obj()
+
+	terminatingWorkload := func() *schedulingapi.Workload {
+		w := defaultWorkload.DeepCopy()
+		w.Finalizers = []string{"test.k8s.io/block-deletion"}
+		return w
+	}()
+
+	tests := []struct {
+		name           string
+		workload       *schedulingapi.Workload
+		deleteWorkload bool
+		podGroup       func(ns string) *schedulingapi.PodGroup
+		expectError    bool
+	}{
+		{
+			name: "PodGroup referencing non-existent Workload is rejected",
+			podGroup: func(ns string) *schedulingapi.PodGroup {
+				return st.MakePodGroup().Name("pg1").Namespace(ns).TemplateRef("worker", "non-existent-workload").MinCount(3).Obj()
+			},
+			expectError: true,
+		},
+		{
+			name:     "PodGroup referencing non-existent template is rejected",
+			workload: defaultWorkload,
+			podGroup: func(ns string) *schedulingapi.PodGroup {
+				return st.MakePodGroup().Name("pg1").Namespace(ns).TemplateRef("non-existent-template", "test-workload").MinCount(3).Obj()
+			},
+			expectError: true,
+		},
+		{
+			name:     "PodGroup referencing valid Workload and template is accepted",
+			workload: defaultWorkload,
+			podGroup: func(ns string) *schedulingapi.PodGroup {
+				return st.MakePodGroup().Name("pg1").Namespace(ns).TemplateRef("worker", "test-workload").MinCount(3).Obj()
+			},
+			expectError: false,
+		},
+		{
+			name: "PodGroup without templateRef is accepted",
+			podGroup: func(ns string) *schedulingapi.PodGroup {
+				return &schedulingapi.PodGroup{
+					ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: ns},
+					Spec: schedulingapi.PodGroupSpec{
+						SchedulingPolicy: schedulingapi.PodGroupSchedulingPolicy{
+							Gang: &schedulingapi.GangSchedulingPolicy{MinCount: 3},
+						},
+					},
+				}
+			},
+			expectError: false,
+		},
+		{
+			name:           "PodGroup referencing terminating Workload is rejected",
+			workload:       terminatingWorkload,
+			deleteWorkload: true,
+			podGroup: func(ns string) *schedulingapi.PodGroup {
+				return st.MakePodGroup().Name("pg1").Namespace(ns).TemplateRef("worker", "test-workload").MinCount(3).Obj()
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testCtx := testutils.InitTestSchedulerWithNS(t, "podgroup-admission",
+				scheduler.WithPodMaxBackoffSeconds(0),
+				scheduler.WithPodInitialBackoffSeconds(0))
+			cs, ns := testCtx.ClientSet, testCtx.NS.Name
+
+			if tt.workload != nil {
+				tt.workload.Namespace = ns
+				if _, err := cs.SchedulingV1alpha2().Workloads(ns).Create(testCtx.Ctx, tt.workload, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create Workload: %v", err)
+				}
+				if tt.deleteWorkload {
+					if err := cs.SchedulingV1alpha2().Workloads(ns).Delete(testCtx.Ctx, tt.workload.Name, metav1.DeleteOptions{}); err != nil {
+						t.Fatalf("Failed to delete Workload: %v", err)
+					}
+				}
+			}
+
+			_, err := cs.SchedulingV1alpha2().PodGroups(ns).Create(testCtx.Ctx, tt.podGroup(ns), metav1.CreateOptions{})
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("Expected PodGroup creation to be rejected, but it succeeded")
+				}
+				if !apierrors.IsForbidden(err) {
+					t.Fatalf("Expected Forbidden error, got: %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("Expected PodGroup creation to succeed, got: %v", err)
+			}
+		})
+	}
+}

--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
@@ -1302,6 +1302,13 @@ func runTestScenario(t *testing.T, tt scenario, gangSchedulingEnabled bool) {
 		scheduler.WithPodInitialBackoffSeconds(0))
 	cs, ns := testCtx.ClientSet, testCtx.NS.Name
 
+	workload := st.MakeWorkload().Name("workload").Namespace(ns).
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t1").MinCount(1).Obj()).
+		Obj()
+	if _, err := cs.SchedulingV1alpha2().Workloads(ns).Create(testCtx.Ctx, workload, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Workload: %v", err)
+	}
+
 	for i, step := range tt.steps {
 		t.Logf("Executing step %d: %s", i, step.name)
 		switch {

--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -83,6 +83,8 @@ type CoreResourceEnqueueTestCase struct {
 	InitialVolumeAttachment []*storagev1.VolumeAttachment
 	// InitialDeviceClasses are the list of DeviceClass to be created at first.
 	InitialDeviceClasses []*resourceapi.DeviceClass
+	// InitialWorkloads is the list of Workloads to be created at first.
+	InitialWorkloads []*schedulingapi.Workload
 	// InitialPodGroups is the list of PodGroups to be created at first.
 	InitialPodGroups []*schedulingapi.PodGroup
 	// Pods are the list of Pods to be created.
@@ -2655,6 +2657,9 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialNodes: []*v1.Node{
 			st.MakeNode().Name("fake-node1").Obj(),
 		},
+		InitialWorkloads: []*schedulingapi.Workload{
+			st.MakeWorkload().Name("w").PodGroupTemplate(st.MakePodGroupTemplate().Name("t").MinCount(2).Obj()).Obj(),
+		},
 		InitialPodGroups: []*schedulingapi.PodGroup{
 			st.MakePodGroup().Name("pg1").MinCount(2).TemplateRef("t", "w").Obj(),
 		},
@@ -2679,6 +2684,9 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		EnablePlugins: []string{names.GangScheduling},
 		InitialNodes: []*v1.Node{
 			st.MakeNode().Name("fake-node1").Obj(),
+		},
+		InitialWorkloads: []*schedulingapi.Workload{
+			st.MakeWorkload().Name("w").PodGroupTemplate(st.MakePodGroupTemplate().Name("t").MinCount(1).Obj()).Obj(),
 		},
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PodGroupName("pg1").Obj(),
@@ -2823,6 +2831,13 @@ func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
 		pvc.Namespace = ns
 		if _, err := testutils.CreatePVC(cs, pvc); err != nil {
 			t.Fatalf("Failed to create a PVC %q: %v", pvc.Name, err)
+		}
+	}
+
+	for _, w := range tt.InitialWorkloads {
+		w.Namespace = ns
+		if _, err := cs.SchedulingV1alpha2().Workloads(ns).Create(testCtx.Ctx, w, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create a Workload %q: %v", w.Name, err)
 		}
 	}
 


### PR DESCRIPTION


#### What type of PR is this?

/kind feature
/sig scheduling
/sig apps
/area workload-aware

#### What this PR does / why we need it:
This PR introduces an admission plugin as part of KEP-5832. The plugin enforces referential integrity between PodGroup and Workload resources at admission time. Specifically, it validates on PodGroup creation that:

- If a PodGroup references a Workload via workloadRef, the referenced Workload must already exist in the same namespace.
- The PodGroup spec fields must match the corresponding PodGroupTemplate defined in the referenced Workload. 
- Standalone PodGroup resources (no workloadRef) pass through without validation.

This prevents drift between the template declared on the Workload and the actual PodGroup being created.

It also:
- Adds integration tests covering valid creation, missing workload rejection, spec mismatch rejection, standalone PodGroup creation, and invalid template references.
- Updates test/integration/etcd/data.go to use a standalone PodGroup stub so existing storage encoding tests remain unaffected.

#### Which issue(s) this PR is related to:
KEP-5832: [Decouple PodGroup API](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5832-decouple-podgroup-api)
Related: 
- #137611 
- #137641  
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Add admission plugin that validates PodGroup resources reference an existing Workload and match the declared PodGroupTemplate spec.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP-5832: [link](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5832-decouple-podgroup-api) 

```docs

```
