### PR TITLE
add script to test go modules with advertised versions

### DIFF
--- a/staging/test/OWNERS
+++ b/staging/test/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - BenTheElder
+reviewers:
+  - BenTheElder
+labels:
+  - sig/testing
+  - sig/architecture

--- a/staging/test/test-modules-with-minimum-go.sh
+++ b/staging/test/test-modules-with-minimum-go.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script verifies that staging modules pass tests with their advertised
+# Go version (from go.mod). This script requires that the host has go 1.21+
+#
+# Usage: `staging/test/test-modules-with-minimum-go.sh`.
+
+set -o errexit -o nounset -o pipefail
+KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+# where we store test results
+ARTIFACTS="${ARTIFACTS:-"${KUBE_ROOT}/_artifacts"}"
+# Set to 'false' to disable reduction of the JUnit file to only the top level tests.
+KUBE_PRUNE_JUNIT_TESTS=${KUBE_PRUNE_JUNIT_TESTS:-true}
+
+staging_modules_root="${KUBE_ROOT}/staging/src/k8s.io"
+
+# NOTE: This script intentionally does not do kube::golang::setup_env as a normal
+# Kubernetes test / build script would do, because we are testing how other
+# project would consume the staging modules, NOT how we would build them
+# in a core Kubernetes binary.
+# We will test with Go / module defaults.
+#
+# BE VERY CAREFUL SOURCING 'library' SCRIPTS EXCEPT IN SUBSHELLS!!
+# We do not want to pollute the shell with any go build options.
+
+# setup etcd for integration tests
+. "${KUBE_ROOT}"/hack/lib/etcd.sh
+cleanup_etcd(){
+    kube::etcd::cleanup
+}
+. "${KUBE_ROOT}"/hack/install-etcd.sh
+kube::etcd::start
+trap cleanup_etcd EXIT
+
+# setup gotestsum, in a subshell to avoid manipulating go env
+(
+    . "${KUBE_ROOT}"/hack/lib/init.sh
+    kube::golang::setup_env
+    GOTOOLCHAIN="$(kube::golang::hack_tools_gotoolchain)" go -C "${KUBE_ROOT}/hack/tools" install gotest.tools/gotestsum
+    go -C "${KUBE_ROOT}/cmd/prune-junit-xml" install .
+)
+# shellcheck disable=SC2031 # we are intentionally isolating subshells
+export PATH="${PATH}:${KUBE_ROOT}/_output/local/go/bin"
+
+# NOTE: the choice of 1.21.0+auto is very deliberate
+#
+# This is the earliest version with GOTOOLCHAIN itself, but auto allows for
+# upgrading to a newer version based on go.mod.
+#
+# So we will use the version in go.mod, and NOT the version the host had
+# installed and NOT the version in .go-version (which we already test 
+# elsewhere with 'make test').
+# shellcheck disable=SC2031 # we are intentionally isolating subshells
+export GOTOOLCHAIN=go1.21.0+auto
+
+res=0
+for module_dir in "${staging_modules_root}"/*; do
+    module="${module_dir#"${staging_modules_root}"/}"
+    module_import="k8s.io/${module}"
+    junit_file="${ARTIFACTS}/junit_${module/\//_}.xml"
+    (
+        cd "$module_dir"
+        echo >&2 "Testing ${module_import} with: $(go version)"
+        gotestsum --junitfile="${junit_file}" ./...
+    ) || res=$?
+    prune-junit-xml -prune-tests="${KUBE_PRUNE_JUNIT_TESTS}" "${junit_file}"
+done
+
+if [[ "${res}" -eq 0 ]]; then
+    echo >&2 "All tests pass!"
+else
+    echo >&2 "Tests failed, exiting ${res}"
+fi
+exit $res


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Adds a script for testing staging modules as a library user would:
- With the minimum go version advertised in the module's go.mod
- With default go compilation settings instead of the various tweaks we apply when building the main repo

This runs both unit and integration tests and produces JUnit output for use in CI.

Spun out from investigating the publishing module in https://github.com/kubernetes/kubernetes/pull/137421#event-23314528716 and as part of https://docs.google.com/document/d/10HujH6PL0ez3vviA03I01_mbJWs9Xp99gIDWnnNXyco/edit?tab=t.0#heading=h.gijgu68n37kl

I think with this enabled in CI (follow-up?), we can consider in the future relaxing the minimum go version for specific modules (IE cri-streaming ...) x-ref: https://github.com/kubernetes/kubernetes/issues/130799

Even if we decide not to do that, we should still make sure that staging modules work at the Go version they're set to require.

This has overlap with the `-go-compatibility` jobs which test that the whole repo passes at the version first used for a release branch (manually configured) and the main test job (which tests at .go-version, the toolchain we use to release this repo)

However the go module version we set is not the same as either of those versions, and testing this only takes <15m, so it is cheap enough to also run in presubmit or at least a periodic.

I have tested this locally, but we'll want a CI job.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/130799

#### Special notes for your reviewer:

I setup an OWNERS for the subdir I placed this in under staging as I'd like to maintain this script, but I am not a staging OWNER. Staging OWNERS will also have inherited approval for this script.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @dims @liggitt 
/sig testing architecture