### PR TITLE
Enable native histograms gated by feature flag in scheduler

### DIFF
--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/component-base/metrics"
+	metricsfeatures "k8s.io/component-base/metrics/features"
 	zpagesfeatures "k8s.io/component-base/zpages/features"
 	"k8s.io/klog/v2"
 	schedulerappconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
@@ -261,6 +262,7 @@ func (o *Options) ApplyTo(logger klog.Logger, c *schedulerappconfig.Config) erro
 			return err
 		}
 	}
+	metricsfeatures.ApplyFeatureGates(utilfeature.DefaultFeatureGate)
 	o.Metrics.Apply()
 
 	// Apply value independently instead of using ApplyDeprecated() because it can't be configured via ComponentConfig.

--- a/test/integration/metrics/nativehistograms/metrics_test.go
+++ b/test/integration/metrics/nativehistograms/metrics_test.go
@@ -18,8 +18,13 @@ package nativehistograms
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
+	"os"
+	"path"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +35,9 @@ import (
 	metricsfeatures "k8s.io/component-base/metrics/features"
 	"k8s.io/component-base/metrics/testutil"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	kubeschedulertesting "k8s.io/kubernetes/cmd/kube-scheduler/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func scrapeMetrics(s *kubeapiservertesting.TestServer) (testutil.Metrics, error) {
@@ -100,4 +107,89 @@ func TestAPIServerNativeHistogramMetrics(t *testing.T) {
 		"apiserver_request_duration_seconds_sum",
 		"apiserver_request_duration_seconds_count",
 	})
+}
+
+// TestSchedulerNativeHistogramMetrics verifies that native histogram metrics are properly
+// exposed in scheduler when the NativeHistograms feature gate is enabled.
+func TestSchedulerNativeHistogramMetrics(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, metricsfeatures.NativeHistograms, true)
+	s := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	defer s.TearDownFn()
+
+	apiserverConfig, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(apiserverConfig.Name()); err != nil {
+			t.Errorf("Failed to remove config file: %v", err)
+		}
+	}()
+
+	configStr := fmt.Sprintf(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: %s
+    certificate-authority: %s
+  name: integration
+contexts:
+- context:
+    cluster: integration
+    user: kube-scheduler
+  name: default-context
+current-context: default-context
+users:
+- name: kube-scheduler
+  user:
+    token: fake-token
+`, s.ClientConfig.Host, s.ServerOpts.SecureServing.ServerCert.CertKey.CertFile)
+
+	if _, err = apiserverConfig.WriteString(configStr); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	_, ctx := ktesting.NewTestContext(t)
+	schedulerServer, err := kubeschedulertesting.StartTestServer(
+		t, ctx,
+		[]string{"--kubeconfig", apiserverConfig.Name(), "--leader-elect=false", "--authentication-skip-lookup=true", "--authorization-always-allow-paths=/metrics"},
+	)
+	if err != nil {
+		t.Fatalf("Failed to start kube-scheduler server: %v", err)
+	}
+	if schedulerServer.TearDownFn != nil {
+		defer schedulerServer.TearDownFn()
+	}
+
+	secureInfo := schedulerServer.Config.SecureServing
+	secureOptions := schedulerServer.Options.SecureServing
+	url := fmt.Sprintf("https://%s", secureInfo.Listener.Addr().String())
+	url = strings.ReplaceAll(url, "[::]", "127.0.0.1")
+
+	pool := x509.NewCertPool()
+	serverCertPath := path.Join(secureOptions.ServerCert.CertDirectory, secureOptions.ServerCert.PairName+".crt")
+	serverCert, err := os.ReadFile(serverCertPath)
+	if err != nil {
+		t.Fatalf("Failed to read component server cert: %v", err)
+	}
+	pool.AppendCertsFromPEM(serverCert)
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+
+	histogramMetric := "scheduler_scheduling_algorithm_duration_seconds"
+	metrics, err := testutil.ScrapeMetricsProto(url+"/metrics", httpClient)
+	if err != nil {
+		t.Fatalf("failed to scrape metrics: %v", err)
+	}
+
+	mf, ok := metrics[histogramMetric]
+	if !ok {
+		t.Fatalf("metric %q not found", histogramMetric)
+	}
+
+	testutil.AssertHasNativeHistogram(t, mf, nil)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Enables Prometheus native histogram support in scheduler when feature gate is enabled.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Issue: https://github.com/kubernetes/enhancements/issues/5808

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Enables Prometheus native histogram support in scheduler when feature gate is enabled.
Histograms are exposed in both classic and native formats using
exponential bucket configuration (factor=1.1, max buckets=160)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
