### PR TITLE
Check condition cast to avoid potential panic in kubectl wait

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/condition.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/condition.go
@@ -59,7 +59,10 @@ func (w ConditionalWait) checkCondition(obj *unstructured.Unstructured) (bool, e
 		return false, nil
 	}
 	for _, conditionUncast := range conditions {
-		condition := conditionUncast.(map[string]interface{})
+		condition, ok := conditionUncast.(map[string]interface{})
+		if !ok {
+			continue
+		}
 		name, found, err := unstructured.NestedString(condition, "type")
 		if !found || err != nil || !strings.EqualFold(name, w.conditionName) {
 			continue

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -1924,3 +1924,47 @@ func TestWaitForMultipleConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestConditionalWaitCheckConditionHandlesMalformedConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []interface{}
+		expectMet  bool
+	}{
+		{
+			name: "single malformed condition item",
+			conditions: []interface{}{
+				"not-a-map",
+			},
+			expectMet: false,
+		},
+		{
+			name: "malformed condition followed by matching condition",
+			conditions: []interface{}{
+				"not-a-map",
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+			expectMet: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := newUnstructured("group/version", "TheKind", "ns-foo", "name-foo")
+			require.NoError(t, unstructured.SetNestedSlice(obj.Object, tc.conditions, "status", "conditions"))
+
+			w := ConditionalWait{
+				conditionName:   "Ready",
+				conditionStatus: "True",
+				errOut:          io.Discard,
+			}
+
+			met, err := w.checkCondition(obj)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectMet, met)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes an edge case panic that can occur if you use `kubectl wait` for a condition on a CRD that has conditions which cannot be cast to a map. 

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

Steps to reproduce panic:
```shell
cat <<'EOF' | kubectl apply -f -
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: foos.example.com
spec:
  group: example.com
  scope: Namespaced
  names:
    plural: foos
    singular: foo
    kind: foo
  versions:
  - name: v1
    served: true
    storage: true
    schema:
      openAPIV3Schema:
        type: object
        x-kubernetes-preserve-unknown-fields: true
EOF

kubectl wait --for=condition=Established crd/foos.example.com

kubectl apply -f - << EOF
apiVersion: example.com/v1
kind: foo
metadata:
  name: example123
status:
  conditions:
  - "oops"
EOF

kubectl wait --for=condition=Ready foo/example123 --timeout=5s
```

Output:
```
panic: interface conversion: interface {} is string, not map[string]interface {}

goroutine 1 [running]:
k8s.io/kubectl/pkg/cmd/wait.ConditionalWait.checkCondition({{0x16bd7b5f5, 0x5}, {0x1058dca73, 0x4}, {0x1063f86b8, 0x1400009e038}}, 0x140008140b0)
	k8s.io/kubectl/pkg/cmd/wait/condition.go:62 +0x254
k8s.io/kubectl/pkg/cmd/wait.ConditionalWait.isConditionMet({{0x16bd7b5f5, 0x5}, {0x1058dca73, 0x4}, {0x1063f86b8, 0x1400009e038}}, {{0x1058dd897?, 0x106159c40?}, {0x106403ad8?, 0x140008140b0?}})
	k8s.io/kubectl/pkg/cmd/wait/condition.go:97 +0x138
k8s.io/client-go/tools/watch.UntilWithoutRetry({0x106420c00, 0x1400004c140}, {0x106406e28, 0x140002023a0}, {0x140004e5168, 0x1, 0x1400009e2c8?})
	k8s.io/client-go/tools/watch/until.go:80 +0x290
k8s.io/client-go/tools/watch.UntilWithSync({0x106420c00, 0x1400004c140}, {0x106404438, 0x14000156a20}, {0x106403ad8, 0x1400009e2c8}, 0x140004e5318, {0x140004e5168, 0x1, 0x1})
	k8s.io/client-go/tools/watch/until.go:152 +0x1f8
k8s.io/kubectl/pkg/cmd/wait.getObjAndCheckCondition.func4()
	k8s.io/kubectl/pkg/cmd/wait/condition.go:167 +0xa4
k8s.io/kubectl/pkg/util/interrupt.(*Handler).Run(0x14000156c60, 0x140004e5380)
	k8s.io/kubectl/pkg/util/interrupt/interrupt.go:103 +0x104
k8s.io/kubectl/pkg/cmd/wait.getObjAndCheckCondition({0x106420c38, 0x14000210850}, 0x1400082c500, 0x140008a0cf0, 0x140004e5460, 0x140004e5428)
	k8s.io/kubectl/pkg/cmd/wait/condition.go:166 +0x2fc
k8s.io/kubectl/pkg/cmd/wait.ConditionalWait.IsConditionMet({{0x16bd7b5f5, 0x5}, {0x1058dca73, 0x4}, {0x1063f86b8, 0x1400009e038}}, {0x106420c38?, 0x14000210850?}, 0x140004e5508?, 0x1051f32ec?)
	k8s.io/kubectl/pkg/cmd/wait/condition.go:50 +0xc0
k8s.io/kubectl/pkg/cmd/wait.(*WaitOptions).RunWait.func2(0x1400082c500?, {0x0?, 0x0?})
	k8s.io/kubectl/pkg/cmd/wait/wait.go:359 +0x58
k8s.io/cli-runtime/pkg/resource.(*DecoratedVisitor).Visit.DecoratedVisitor.Visit.func1(0x1400082c500, {0x0?, 0x0?})
	k8s.io/cli-runtime/pkg/resource/visitor.go:368 +0xc4
k8s.io/cli-runtime/pkg/resource.ContinueOnErrorVisitor.Visit.func1(0x1060243e0?, {0x0?, 0x0?})
	k8s.io/cli-runtime/pkg/resource/visitor.go:392 +0xf4
k8s.io/cli-runtime/pkg/resource.(*FlattenListVisitor).Visit.FlattenListVisitor.Visit.func1(0x300000000?, {0x0?, 0x0?})
	k8s.io/cli-runtime/pkg/resource/visitor.go:429 +0xc4
k8s.io/cli-runtime/pkg/resource.EagerVisitorList.Visit.func1(0x18?, {0x0?, 0x0?})
	k8s.io/cli-runtime/pkg/resource/visitor.go:246 +0xf4
k8s.io/cli-runtime/pkg/resource.(*Info).Visit(0x140004e5888?, 0x1040f7308?)
	k8s.io/cli-runtime/pkg/resource/visitor.go:96 +0x2c
k8s.io/cli-runtime/pkg/resource.EagerVisitorList.Visit({0x14000b096d0, 0x1, 0x14000508801?}, 0x1400082ad40)
	k8s.io/cli-runtime/pkg/resource/visitor.go:241 +0xd0
k8s.io/cli-runtime/pkg/resource.FlattenListVisitor.Visit(...)
	k8s.io/cli-runtime/pkg/resource/visitor.go:424
k8s.io/cli-runtime/pkg/resource.ContinueOnErrorVisitor.Visit({{0x1063fa2c0?, 0x14000791800?}}, 0x1400082ad00)
	k8s.io/cli-runtime/pkg/resource/visitor.go:387 +0xa0
k8s.io/cli-runtime/pkg/resource.DecoratedVisitor.Visit(...)
	k8s.io/cli-runtime/pkg/resource/visitor.go:359
k8s.io/cli-runtime/pkg/resource.(*Result).Visit(0x140006c0900, 0xf?)
	k8s.io/cli-runtime/pkg/resource/result.go:99 +0x48
k8s.io/kubectl/pkg/cmd/wait.(*WaitOptions).RunWait(0x140008a0cf0)
	k8s.io/kubectl/pkg/cmd/wait/wait.go:375 +0x2c0
k8s.io/kubectl/pkg/cmd/wait.NewCmdWait.func1(0x140005ea308?, {0x140006c6390?, 0x1?, 0x3?})
	k8s.io/kubectl/pkg/cmd/wait/wait.go:135 +0x4c
github.com/spf13/cobra.(*Command).execute(0x140005ea308, {0x140006c6330, 0x3, 0x3})
	github.com/spf13/cobra@v1.9.1/command.go:1019 +0x82c
github.com/spf13/cobra.(*Command).ExecuteC(0x14000952308)
	github.com/spf13/cobra@v1.9.1/command.go:1148 +0x384
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.9.1/command.go:1071
k8s.io/component-base/cli.run(0x14000952308)
	k8s.io/component-base/cli/run.go:143 +0x20c
k8s.io/component-base/cli.RunNoErrOutput(...)
	k8s.io/component-base/cli/run.go:82
main.main()
	k8s.io/kubernetes/cmd/kubectl/kubectl.go:40 +0x40
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
