### PR TITLE
Pod status redundant relist

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -19,6 +19,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -89,6 +90,9 @@ type Runtime interface {
 	// specifies whether the runtime returns all containers including those already
 	// exited and dead containers (used for garbage collection).
 	GetPods(ctx context.Context, all bool) ([]*Pod, error)
+	// GetPod fetches the current sandboxes & containers for a pod.
+	// Returns ErrPodNotFound when no sandboxes are found for the requested pod.
+	GetPod(ctx context.Context, podUID types.UID) (*Pod, error)
 	// GarbageCollect removes dead containers using the specified container gc policy
 	// If allSourcesReady is not true, it means that kubelet doesn't have the
 	// complete list of pods from all available sources (e.g., apiserver, http,
@@ -148,6 +152,11 @@ type Runtime interface {
 	// UpdateActuatedPodLevelResources updates pod-level resources in actuatedState
 	UpdateActuatedPodLevelResources(actuatedPod *v1.Pod) error
 }
+
+var (
+	// ErrPodNotFound is returned by GetPod when no sandboxes are found for the requested pod.
+	ErrPodNotFound = errors.New("pod sandboxes not found")
+)
 
 // StreamingRuntime is the interface implemented by runtimes that handle the serving of the
 // streaming calls (exec/attach/port-forward) themselves. In this case, Kubelet should redirect to
@@ -209,6 +218,7 @@ type Pod struct {
 	// List of sandboxes associated with this pod. The sandboxes are converted
 	// to Container temporarily to avoid substantial changes to other
 	// components. This is only populated by kuberuntime.
+	// Sandboxes are sorted by creation time, newest -> oldest.
 	// TODO: use the runtimeApi.PodSandbox type directly.
 	Sandboxes []*Container
 }
@@ -318,6 +328,10 @@ type Container struct {
 	Hash uint64
 	// State is the state of the container.
 	State State
+	// ID of the sandbox to which this container belongs.
+	PodSandboxID string
+	// Creation time of the container in nanoseconds.
+	CreatedAt int64
 }
 
 // PodStatus represents the status of the pod and its containers.

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -113,7 +113,7 @@ type Runtime interface {
 	KillPod(ctx context.Context, pod *v1.Pod, runningPod Pod, gracePeriodOverride *int64) error
 	// GetPodStatus retrieves the status of the pod, including the
 	// information of all containers in the pod that are visible in Runtime.
-	GetPodStatus(ctx context.Context, uid types.UID, name, namespace string) (*PodStatus, error)
+	GetPodStatus(ctx context.Context, pod *Pod) (*PodStatus, error)
 	// TODO(vmarmol): Unify pod and containerID args.
 	// GetContainerLogs returns logs of a specific container. By
 	// default, it returns a snapshot of the container log. Set 'follow' to true to

--- a/pkg/kubelet/container/testing/fake_cache.go
+++ b/pkg/kubelet/container/testing/fake_cache.go
@@ -33,7 +33,11 @@ func NewFakeCache(runtime container.Runtime) container.Cache {
 }
 
 func (c *fakeCache) Get(id types.UID) (*container.PodStatus, error) {
-	return c.runtime.GetPodStatus(context.TODO(), id, "", "")
+	pod, err := c.runtime.GetPod(context.TODO(), id)
+	if err != nil {
+		pod = &container.Pod{ID: id}
+	}
+	return c.runtime.GetPodStatus(context.TODO(), pod)
 }
 
 func (c *fakeCache) GetNewerThan(id types.UID, minTime time.Time) (*container.PodStatus, error) {

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -324,7 +324,7 @@ func (f *FakeRuntime) GeneratePodStatus(event *runtimeapi.ContainerEventResponse
 	return &status
 }
 
-func (f *FakeRuntime) GetPodStatus(_ context.Context, uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
+func (f *FakeRuntime) GetPodStatus(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -237,6 +237,27 @@ func (f *FakeRuntime) GetPods(_ context.Context, all bool) ([]*kubecontainer.Pod
 	return pods, f.Err
 }
 
+func (f *FakeRuntime) GetPod(_ context.Context, podUID types.UID) (*kubecontainer.Pod, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	if f.Err != nil {
+		return nil, f.Err
+	}
+
+	for _, fakePod := range f.PodList {
+		if fakePod.Pod.ID == podUID {
+			return fakePod.Pod, nil
+		}
+	}
+	for _, fakePod := range f.AllPodList {
+		if fakePod.Pod.ID == podUID {
+			return fakePod.Pod, nil
+		}
+	}
+	return nil, kubecontainer.ErrPodNotFound
+}
+
 func (f *FakeRuntime) SyncPod(_ context.Context, pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Secret, backOff *flowcontrol.Backoff, _ bool) (result kubecontainer.PodSyncResult) {
 	f.Lock()
 	defer f.Unlock()

--- a/pkg/kubelet/container/testing/mocks.go
+++ b/pkg/kubelet/container/testing/mocks.go
@@ -766,8 +766,8 @@ func (_c *MockRuntime_GetPod_Call) RunAndReturn(run func(ctx context.Context, po
 }
 
 // GetPodStatus provides a mock function for the type MockRuntime
-func (_mock *MockRuntime) GetPodStatus(ctx context.Context, uid types.UID, name string, namespace string) (*container.PodStatus, error) {
-	ret := _mock.Called(ctx, uid, name, namespace)
+func (_mock *MockRuntime) GetPodStatus(ctx context.Context, pod *container.Pod) (*container.PodStatus, error) {
+	ret := _mock.Called(ctx, pod)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPodStatus")
@@ -775,18 +775,18 @@ func (_mock *MockRuntime) GetPodStatus(ctx context.Context, uid types.UID, name 
 
 	var r0 *container.PodStatus
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, types.UID, string, string) (*container.PodStatus, error)); ok {
-		return returnFunc(ctx, uid, name, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *container.Pod) (*container.PodStatus, error)); ok {
+		return returnFunc(ctx, pod)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, types.UID, string, string) *container.PodStatus); ok {
-		r0 = returnFunc(ctx, uid, name, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *container.Pod) *container.PodStatus); ok {
+		r0 = returnFunc(ctx, pod)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*container.PodStatus)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, types.UID, string, string) error); ok {
-		r1 = returnFunc(ctx, uid, name, namespace)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *container.Pod) error); ok {
+		r1 = returnFunc(ctx, pod)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -800,36 +800,24 @@ type MockRuntime_GetPodStatus_Call struct {
 
 // GetPodStatus is a helper method to define mock.On call
 //   - ctx context.Context
-//   - uid types.UID
-//   - name string
-//   - namespace string
-func (_e *MockRuntime_Expecter) GetPodStatus(ctx interface{}, uid interface{}, name interface{}, namespace interface{}) *MockRuntime_GetPodStatus_Call {
-	return &MockRuntime_GetPodStatus_Call{Call: _e.mock.On("GetPodStatus", ctx, uid, name, namespace)}
+//   - pod *container.Pod
+func (_e *MockRuntime_Expecter) GetPodStatus(ctx interface{}, pod interface{}) *MockRuntime_GetPodStatus_Call {
+	return &MockRuntime_GetPodStatus_Call{Call: _e.mock.On("GetPodStatus", ctx, pod)}
 }
 
-func (_c *MockRuntime_GetPodStatus_Call) Run(run func(ctx context.Context, uid types.UID, name string, namespace string)) *MockRuntime_GetPodStatus_Call {
+func (_c *MockRuntime_GetPodStatus_Call) Run(run func(ctx context.Context, pod *container.Pod)) *MockRuntime_GetPodStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 types.UID
+		var arg1 *container.Pod
 		if args[1] != nil {
-			arg1 = args[1].(types.UID)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
+			arg1 = args[1].(*container.Pod)
 		}
 		run(
 			arg0,
 			arg1,
-			arg2,
-			arg3,
 		)
 	})
 	return _c
@@ -840,7 +828,7 @@ func (_c *MockRuntime_GetPodStatus_Call) Return(podStatus *container.PodStatus, 
 	return _c
 }
 
-func (_c *MockRuntime_GetPodStatus_Call) RunAndReturn(run func(ctx context.Context, uid types.UID, name string, namespace string) (*container.PodStatus, error)) *MockRuntime_GetPodStatus_Call {
+func (_c *MockRuntime_GetPodStatus_Call) RunAndReturn(run func(ctx context.Context, pod *container.Pod) (*container.PodStatus, error)) *MockRuntime_GetPodStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/container/testing/mocks.go
+++ b/pkg/kubelet/container/testing/mocks.go
@@ -697,6 +697,74 @@ func (_c *MockRuntime_GetImageSize_Call) RunAndReturn(run func(ctx context.Conte
 	return _c
 }
 
+// GetPod provides a mock function for the type MockRuntime
+func (_mock *MockRuntime) GetPod(ctx context.Context, podUID types.UID) (*container.Pod, error) {
+	ret := _mock.Called(ctx, podUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPod")
+	}
+
+	var r0 *container.Pod
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.UID) (*container.Pod, error)); ok {
+		return returnFunc(ctx, podUID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.UID) *container.Pod); ok {
+		r0 = returnFunc(ctx, podUID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*container.Pod)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, types.UID) error); ok {
+		r1 = returnFunc(ctx, podUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRuntime_GetPod_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPod'
+type MockRuntime_GetPod_Call struct {
+	*mock.Call
+}
+
+// GetPod is a helper method to define mock.On call
+//   - ctx context.Context
+//   - podUID types.UID
+func (_e *MockRuntime_Expecter) GetPod(ctx interface{}, podUID interface{}) *MockRuntime_GetPod_Call {
+	return &MockRuntime_GetPod_Call{Call: _e.mock.On("GetPod", ctx, podUID)}
+}
+
+func (_c *MockRuntime_GetPod_Call) Run(run func(ctx context.Context, podUID types.UID)) *MockRuntime_GetPod_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 types.UID
+		if args[1] != nil {
+			arg1 = args[1].(types.UID)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRuntime_GetPod_Call) Return(pod *container.Pod, err error) *MockRuntime_GetPod_Call {
+	_c.Call.Return(pod, err)
+	return _c
+}
+
+func (_c *MockRuntime_GetPod_Call) RunAndReturn(run func(ctx context.Context, podUID types.UID) (*container.Pod, error)) *MockRuntime_GetPod_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetPodStatus provides a mock function for the type MockRuntime
 func (_mock *MockRuntime) GetPodStatus(ctx context.Context, uid types.UID, name string, namespace string) (*container.PodStatus, error) {
 	ret := _mock.Called(ctx, uid, name, namespace)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2272,8 +2272,7 @@ func (kl *Kubelet) SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatu
 	if err := kl.killPod(ctx, pod, p, gracePeriod); err != nil {
 		kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedToKillPod, "error killing pod: %v", err)
 		// there was an error killing the pod, so we return that error directly
-		utilruntime.HandleError(err)
-		return err
+		return fmt.Errorf("error killing terminating pod: %w", err)
 	}
 
 	// Once the containers are stopped, we can stop probing for liveness and readiness.
@@ -2287,10 +2286,22 @@ func (kl *Kubelet) SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatu
 	// catch race conditions introduced by callers updating pod status out of order.
 	// TODO: have KillPod return the terminal status of stopped containers and write that into the
 	//  cache immediately
-	stoppedPodStatus, err := kl.containerRuntime.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
+	runtimePod, err := kl.containerRuntime.GetPod(ctx, pod.UID)
 	if err != nil {
-		logger.Error(err, "Unable to read pod status prior to final pod termination", "pod", klog.KObj(pod), "podUID", pod.UID)
-		return err
+		if errors.Is(err, kubecontainer.ErrPodNotFound) {
+			// If pod sandboxes were already cleaned up, proceed with an empty runtimePod.
+			runtimePod = &kubecontainer.Pod{
+				ID:        pod.UID,
+				Name:      pod.Name,
+				Namespace: pod.Namespace,
+			}
+		} else {
+			return fmt.Errorf("unable to get pod prior to final pod termination: %w", err)
+		}
+	}
+	stoppedPodStatus, err := kl.containerRuntime.GetPodStatus(ctx, runtimePod)
+	if err != nil {
+		return fmt.Errorf("unable to read pod status prior to final pod termination: %w", err)
 	}
 	preserveDataFromBeforeStopping(stoppedPodStatus, podStatus)
 	var runningContainers []string

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -119,6 +119,8 @@ func (m *kubeGenericRuntimeManager) toKubeContainer(ctx context.Context, c *runt
 		Image:               c.Image.Image,
 		Hash:                annotatedInfo.Hash,
 		State:               toKubeContainerState(c.State),
+		PodSandboxID:        c.PodSandboxId,
+		CreatedAt:           c.CreatedAt,
 	}, nil
 }
 
@@ -132,8 +134,10 @@ func (m *kubeGenericRuntimeManager) sandboxToKubeContainer(s *runtimeapi.PodSand
 	}
 
 	return &kubecontainer.Container{
-		ID:    kubecontainer.ContainerID{Type: m.runtimeName, ID: s.Id},
-		State: kubecontainer.SandboxToContainerState(s.State),
+		ID:           kubecontainer.ContainerID{Type: m.runtimeName, ID: s.Id},
+		State:        kubecontainer.SandboxToContainerState(s.State),
+		PodSandboxID: s.Id,
+		CreatedAt:    s.CreatedAt,
 	}, nil
 }
 

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -18,6 +18,7 @@ package kuberuntime
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,10 +39,23 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-type podStatusProviderFunc func(uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error)
+type fakePodStatusProvider struct {
+	pod    *kubecontainer.Pod
+	status *kubecontainer.PodStatus
+}
 
-func (f podStatusProviderFunc) GetPodStatus(_ context.Context, uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
-	return f(uid, name, namespace)
+func (f fakePodStatusProvider) GetPod(_ context.Context, uid types.UID) (*kubecontainer.Pod, error) {
+	if uid != f.pod.ID {
+		return nil, fmt.Errorf("unexpected pod UID: got %s, want %s", uid, f.pod.ID)
+	}
+	return f.pod, nil
+}
+
+func (f fakePodStatusProvider) GetPodStatus(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
+	if pod != f.pod {
+		return nil, fmt.Errorf("Unexpected pod: %v", pod)
+	}
+	return f.status, nil
 }
 
 func TestIsInitContainerFailed(t *testing.T) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -641,20 +641,14 @@ func (m *kubeGenericRuntimeManager) getSandboxes(ctx context.Context, opts listO
 }
 
 // getPodContainerStatuses gets all containers' statuses for the pod.
-func (m *kubeGenericRuntimeManager) getPodContainerStatuses(ctx context.Context, uid kubetypes.UID, name, namespace, activePodSandboxID string) ([]*kubecontainer.Status, []*kubecontainer.Status, error) {
+func (m *kubeGenericRuntimeManager) getPodContainerStatuses(ctx context.Context, pod *kubecontainer.Pod, activePodSandboxID string) ([]*kubecontainer.Status, []*kubecontainer.Status, error) {
 	logger := klog.FromContext(ctx)
-	// Select all containers of the given pod.
-	containers, err := m.getContainers(ctx, listOptions{podUID: uid})
-	if err != nil {
-		logger.Error(err, "ListContainers error")
-		return nil, nil, err
-	}
 
 	statuses := []*kubecontainer.Status{}
 	activeContainerStatuses := []*kubecontainer.Status{}
 	// TODO: optimization: set maximum number of containers per container name to examine.
-	for _, c := range containers {
-		resp, err := m.runtimeService.ContainerStatus(ctx, c.Id, false)
+	for _, c := range pod.Containers {
+		resp, err := m.runtimeService.ContainerStatus(ctx, c.ID.ID, false)
 		// Between List (ListContainers) and check (ContainerStatus) another thread might remove a container, and that is normal.
 		// The previous call (ListContainers) never fails due to a pod container not existing.
 		// Therefore, this method should not either, but instead act as if the previous call failed,
@@ -664,16 +658,16 @@ func (m *kubeGenericRuntimeManager) getPodContainerStatuses(ctx context.Context,
 		}
 		if err != nil {
 			// Merely log this here; GetPodStatus will actually report the error out.
-			logger.V(4).Info("ContainerStatus return error", "containerID", c.Id, "err", err)
+			logger.V(4).Info("ContainerStatus return error", "containerID", c.ID.ID, "err", err)
 			return nil, nil, err
 		}
 		status := resp.GetStatus()
 		if status == nil {
 			return nil, nil, remote.ErrContainerStatusNil
 		}
-		cStatus := m.convertToKubeContainerStatus(ctx, uid, status)
+		cStatus := m.convertToKubeContainerStatus(ctx, pod.ID, status)
 		statuses = append(statuses, cStatus)
-		if c.PodSandboxId == activePodSandboxID {
+		if c.PodSandboxID == activePodSandboxID {
 			activeContainerStatuses = append(activeContainerStatuses, cStatus)
 		}
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -533,27 +533,6 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 	return volumeMounts
 }
 
-// getKubeletContainers lists containers managed by kubelet.
-// The boolean parameter specifies whether returns all containers including
-// those already exited and dead containers (used for garbage collection).
-func (m *kubeGenericRuntimeManager) getKubeletContainers(ctx context.Context, allContainers bool) ([]*runtimeapi.Container, error) {
-	logger := klog.FromContext(ctx)
-	filter := &runtimeapi.ContainerFilter{}
-	if !allContainers {
-		filter.State = &runtimeapi.ContainerStateValue{
-			State: runtimeapi.ContainerState_CONTAINER_RUNNING,
-		}
-	}
-
-	containers, err := m.runtimeService.ListContainers(ctx, filter)
-	if err != nil {
-		logger.Error(err, "ListContainers failed")
-		return nil, err
-	}
-
-	return containers, nil
-}
-
 // makeUID returns a randomly generated string.
 func makeUID() string {
 	return fmt.Sprintf("%08x", rand.Uint32())
@@ -618,13 +597,54 @@ func (m *kubeGenericRuntimeManager) convertToKubeContainerStatus(ctx context.Con
 	return cStatus
 }
 
+type listOptions struct {
+	// podUID of the pod to filter to.
+	// Optional.
+	podUID kubetypes.UID
+	// onlyRunningReady filters the results to only ready sandboxes or running containers.
+	// Optional.
+	onlyRunningReady bool
+}
+
+func (o *listOptions) containerFilter() *runtimeapi.ContainerFilter {
+	filter := &runtimeapi.ContainerFilter{}
+	if o.podUID != "" {
+		filter.LabelSelector = map[string]string{kubelettypes.KubernetesPodUIDLabel: string(o.podUID)}
+	}
+	if o.onlyRunningReady {
+		filter.State = &runtimeapi.ContainerStateValue{
+			State: runtimeapi.ContainerState_CONTAINER_RUNNING,
+		}
+	}
+	return filter
+}
+
+func (o *listOptions) sandboxFilter() *runtimeapi.PodSandboxFilter {
+	filter := &runtimeapi.PodSandboxFilter{}
+	if o.podUID != "" {
+		filter.LabelSelector = map[string]string{kubelettypes.KubernetesPodUIDLabel: string(o.podUID)}
+	}
+	if o.onlyRunningReady {
+		filter.State = &runtimeapi.PodSandboxStateValue{
+			State: runtimeapi.PodSandboxState_SANDBOX_READY,
+		}
+	}
+	return filter
+}
+
+func (m *kubeGenericRuntimeManager) getContainers(ctx context.Context, opts listOptions) ([]*runtimeapi.Container, error) {
+	return m.runtimeService.ListContainers(ctx, opts.containerFilter())
+}
+
+func (m *kubeGenericRuntimeManager) getSandboxes(ctx context.Context, opts listOptions) ([]*runtimeapi.PodSandbox, error) {
+	return m.runtimeService.ListPodSandbox(ctx, opts.sandboxFilter())
+}
+
 // getPodContainerStatuses gets all containers' statuses for the pod.
 func (m *kubeGenericRuntimeManager) getPodContainerStatuses(ctx context.Context, uid kubetypes.UID, name, namespace, activePodSandboxID string) ([]*kubecontainer.Status, []*kubecontainer.Status, error) {
 	logger := klog.FromContext(ctx)
 	// Select all containers of the given pod.
-	containers, err := m.runtimeService.ListContainers(ctx, &runtimeapi.ContainerFilter{
-		LabelSelector: map[string]string{kubelettypes.KubernetesPodUIDLabel: string(uid)},
-	})
+	containers, err := m.getContainers(ctx, listOptions{podUID: uid})
 	if err != nil {
 		logger.Error(err, "ListContainers error")
 		return nil, nil, err

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -1920,7 +1920,9 @@ func TestUpdatePodSandboxResources(t *testing.T) {
 	fakeSandbox, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
 	assert.Len(t, fakeContainers, 1)
 
-	_, _, err := m.getPodContainerStatuses(tCtx, pod.UID, pod.Name, pod.Namespace, "")
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	_, _, err = m.getPodContainerStatuses(tCtx, runtimePod, "")
 	require.NoError(t, err)
 
 	resourceConfig := &cm.ResourceConfig{}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -563,16 +563,21 @@ func testLifeCycleHook(t *testing.T, testPod *v1.Pod, testContainer *v1.Containe
 
 	fakeRunner := &containertest.FakeContainerCommandRunner{}
 	fakeHTTP := &fakeHTTP{}
-	fakePodStatusProvider := podStatusProviderFunc(func(uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
-		return &kubecontainer.PodStatus{
-			ID:        uid,
-			Name:      name,
-			Namespace: namespace,
+	fakePodStatusProvider := fakePodStatusProvider{
+		pod: &kubecontainer.Pod{
+			ID:        testPod.UID,
+			Name:      testPod.Name,
+			Namespace: testPod.Namespace,
+		},
+		status: &kubecontainer.PodStatus{
+			ID:        testPod.UID,
+			Name:      testPod.Name,
+			Namespace: testPod.Namespace,
 			IPs: []string{
 				"127.0.0.1",
 			},
-		}, nil
-	})
+		},
+	}
 
 	lcHanlder := lifecycle.NewHandlerRunner(
 		fakeHTTP,
@@ -1032,8 +1037,10 @@ func TestUpdateContainerResources(t *testing.T) {
 	_, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
 	assert.Len(t, fakeContainers, 1)
 
-	cStatus, _, err := m.getPodContainerStatuses(tCtx, pod.UID, pod.Name, pod.Namespace, "")
-	assert.NoError(t, err)
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	cStatus, _, err := m.getPodContainerStatuses(tCtx, runtimePod, "")
+	require.NoError(t, err)
 	containerID := cStatus[0].ID
 
 	err = m.updateContainerResources(tCtx, pod, &pod.Spec.Containers[0], containerID)

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -190,7 +190,7 @@ func (cgc *containerGC) removeSandbox(ctx context.Context, sandboxID string) {
 // evictableContainers gets all containers that are evictable. Evictable containers are: not running
 // and created more than MinAge ago.
 func (cgc *containerGC) evictableContainers(ctx context.Context, minAge time.Duration) (containersByEvictUnit, error) {
-	containers, err := cgc.manager.getKubeletContainers(ctx, true)
+	containers, err := cgc.manager.getContainers(ctx, listOptions{})
 	if err != nil {
 		return containersByEvictUnit{}, err
 	}
@@ -279,12 +279,12 @@ func (cgc *containerGC) evictContainers(ctx context.Context, gcPolicy kubecontai
 //  3. belong to a non-existent (i.e., already removed) pod, or is not the
 //     most recently created sandbox for the pod.
 func (cgc *containerGC) evictSandboxes(ctx context.Context, evictNonDeletedPods bool) error {
-	containers, err := cgc.manager.getKubeletContainers(ctx, true)
+	containers, err := cgc.manager.getContainers(ctx, listOptions{})
 	if err != nil {
 		return err
 	}
 
-	sandboxes, err := cgc.manager.getKubeletSandboxes(ctx, true)
+	sandboxes, err := cgc.manager.getSandboxes(ctx, listOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -422,16 +422,57 @@ func (m *kubeGenericRuntimeManager) Status(ctx context.Context) (*kubecontainer.
 	return toKubeRuntimeStatus(resp.GetStatus(), resp.GetRuntimeHandlers(), resp.GetFeatures()), nil
 }
 
+// GetPod fetches the current sandboxes & containers for a pod.
+func (m *kubeGenericRuntimeManager) GetPod(ctx context.Context, podUID kubetypes.UID) (*kubecontainer.Pod, error) {
+	pods, err := m.getPods(ctx, listOptions{podUID: podUID})
+	if err != nil {
+		return nil, err
+	}
+
+	pod := pods[podUID]
+	if pod == nil {
+		return nil, kubecontainer.ErrPodNotFound
+	}
+	return pod, nil
+}
+
 // GetPods returns a list of containers grouped by pods. The boolean parameter
 // specifies whether the runtime returns all containers including those already
 // exited and dead containers (used for garbage collection).
 func (m *kubeGenericRuntimeManager) GetPods(ctx context.Context, all bool) ([]*kubecontainer.Pod, error) {
 	logger := klog.FromContext(ctx)
-	pods := make(map[kubetypes.UID]*kubecontainer.Pod)
-	sandboxes, err := m.getKubeletSandboxes(ctx, all)
+	pods, err := m.getPods(ctx, listOptions{onlyRunningReady: !all})
 	if err != nil {
 		return nil, err
 	}
+
+	// Convert map to list.
+	var result []*kubecontainer.Pod
+	for _, pod := range pods {
+		result = append(result, pod)
+	}
+
+	// There are scenarios where multiple pods are running in parallel having
+	// the same name, because one of them have not been fully terminated yet.
+	// To avoid unexpected behavior on container name based search (for example
+	// by calling *Kubelet.findContainer() without specifying a pod ID), we now
+	// return the list of pods ordered by their creation time.
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].CreatedAt > result[j].CreatedAt
+	})
+	logger.V(4).Info("Retrieved pods from runtime", "all", all)
+	return result, nil
+}
+
+func (m *kubeGenericRuntimeManager) getPods(ctx context.Context, opts listOptions) (map[kubetypes.UID]*kubecontainer.Pod, error) {
+	logger := klog.FromContext(ctx)
+	pods := make(map[kubetypes.UID]*kubecontainer.Pod)
+	sandboxes, err := m.getSandboxes(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	// Sort sandboxes by creation time, newest first.
+	sort.Sort(podSandboxByCreated(sandboxes))
 	for i := range sandboxes {
 		s := sandboxes[i]
 		if s.Metadata == nil {
@@ -456,7 +497,7 @@ func (m *kubeGenericRuntimeManager) GetPods(ctx context.Context, all bool) ([]*k
 		p.CreatedAt = uint64(s.GetCreatedAt())
 	}
 
-	containers, err := m.getKubeletContainers(ctx, all)
+	containers, err := m.getContainers(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -487,22 +528,7 @@ func (m *kubeGenericRuntimeManager) GetPods(ctx context.Context, all bool) ([]*k
 		pod.Containers = append(pod.Containers, converted)
 	}
 
-	// Convert map to list.
-	var result []*kubecontainer.Pod
-	for _, pod := range pods {
-		result = append(result, pod)
-	}
-
-	// There are scenarios where multiple pods are running in parallel having
-	// the same name, because one of them have not been fully terminated yet.
-	// To avoid unexpected behavior on container name based search (for example
-	// by calling *Kubelet.findContainer() without specifying a pod ID), we now
-	// return the list of pods ordered by their creation time.
-	sort.SliceStable(result, func(i, j int) bool {
-		return result[i].CreatedAt > result[j].CreatedAt
-	})
-	logger.V(4).Info("Retrieved pods from runtime", "all", all)
-	return result, nil
+	return pods, nil
 }
 
 // containerKillReason explains what killed a given container
@@ -1924,7 +1950,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 	// Anyhow, we only promised "best-effort" restart count reporting, we can just ignore
 	// these limitations now.
 	// TODO: move this comment to SyncPod.
-	podSandboxIDs, err := m.getSandboxIDByPodUID(ctx, uid, nil)
+	podSandboxIDs, err := m.getSandboxIDByPodUID(ctx, uid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1935,7 +1935,7 @@ func (m *kubeGenericRuntimeManager) GeneratePodStatus(event *runtimeapi.Containe
 
 // GetPodStatus retrieves the status of the pod, including the
 // information of all containers in the pod that are visible in Runtime.
-func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubetypes.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
+func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
 	logger := klog.FromContext(ctx)
 	// Now we retain restart count of container as a container label. Each time a container
 	// restarts, pod will read the restart count from the registered dead container, increment
@@ -1950,22 +1950,14 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 	// Anyhow, we only promised "best-effort" restart count reporting, we can just ignore
 	// these limitations now.
 	// TODO: move this comment to SyncPod.
-	podSandboxIDs, err := m.getSandboxIDByPodUID(ctx, uid)
-	if err != nil {
-		return nil, err
+	podFullName := format.PodDesc(pod.Name, pod.Namespace, pod.ID)
+	logger = logger.WithValues("pod", podFullName)
+	ctx = klog.NewContext(ctx, logger)
+
+	podSandboxIDs := make([]string, len(pod.Sandboxes))
+	for i, s := range pod.Sandboxes {
+		podSandboxIDs[i] = s.ID.ID
 	}
-
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			UID:       uid,
-		},
-	}
-
-	podFullName := format.Pod(pod)
-
-	logger.V(4).Info("getSandboxIDByPodUID got sandbox IDs for pod", "podSandboxID", podSandboxIDs, "pod", klog.KObj(pod))
 
 	sandboxStatuses := []*runtimeapi.PodSandboxStatus{}
 	containerStatuses := []*kubecontainer.Status{}
@@ -1976,7 +1968,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 	var activePodSandboxID string
 	for idx, podSandboxID := range podSandboxIDs {
 		resp, err := m.runtimeService.PodSandboxStatus(ctx, podSandboxID, false)
-		// Between List (getSandboxIDByPodUID) and check (PodSandboxStatus) another thread might remove a container, and that is normal.
+		// Between List (ListPodSandbox) and check (PodSandboxStatus) another thread might remove a container, and that is normal.
 		// The previous call (getSandboxIDByPodUID) never fails due to a pod sandbox not existing.
 		// Therefore, this method should not either, but instead act as if the previous call failed,
 		// which means the error should be ignored.
@@ -1984,7 +1976,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 			continue
 		}
 		if err != nil {
-			logger.Error(err, "PodSandboxStatus of sandbox for pod", "podSandboxID", podSandboxID, "pod", klog.KObj(pod))
+			logger.Error(err, "PodSandboxStatus of sandbox for pod", "podSandboxID", podSandboxID)
 			return nil, err
 		}
 		if resp.GetStatus() == nil {
@@ -1994,7 +1986,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 		sandboxStatuses = append(sandboxStatuses, resp.Status)
 		// Only get pod IP from latest sandbox
 		if idx == 0 && resp.Status.State == runtimeapi.PodSandboxState_SANDBOX_READY {
-			podIPs = m.determinePodSandboxIPs(ctx, namespace, name, resp.Status)
+			podIPs = m.determinePodSandboxIPs(ctx, pod.Namespace, pod.Name, resp.Status)
 			activePodSandboxID = podSandboxID
 		}
 
@@ -2005,11 +1997,11 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 				// e.g. CI job 'pull-kubernetes-e2e-gce-alpha-features' will runs with
 				// features gate enabled, which includes Evented PLEG, but uses the
 				// runtime without Evented PLEG support.
-				logger.V(4).Info("Runtime does not set pod status timestamp", "pod", klog.KObj(pod))
-				containerStatuses, activeContainerStatuses, err = m.getPodContainerStatuses(ctx, uid, name, namespace, activePodSandboxID)
+				logger.V(4).Info("Runtime does not set pod status timestamp")
+				containerStatuses, activeContainerStatuses, err = m.getPodContainerStatuses(ctx, pod, activePodSandboxID)
 				if err != nil {
 					if m.logReduction.ShouldMessageBePrinted(err.Error(), podFullName) {
-						logger.Error(err, "getPodContainerStatuses for pod failed", "pod", klog.KObj(pod))
+						logger.Error(err, "getPodContainerStatuses for pod failed")
 					}
 					return nil, err
 				}
@@ -2018,7 +2010,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 				// timestamp from sandboxStatus.
 				timestamp = time.Unix(0, resp.Timestamp)
 				for _, cs := range resp.ContainersStatuses {
-					cStatus := m.convertToKubeContainerStatus(ctx, uid, cs)
+					cStatus := m.convertToKubeContainerStatus(ctx, pod.ID, cs)
 					containerStatuses = append(containerStatuses, cStatus)
 				}
 			}
@@ -2027,10 +2019,11 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
 		// Get statuses of all containers visible in the pod.
-		containerStatuses, activeContainerStatuses, err = m.getPodContainerStatuses(ctx, uid, name, namespace, activePodSandboxID)
+		var err error
+		containerStatuses, activeContainerStatuses, err = m.getPodContainerStatuses(ctx, pod, activePodSandboxID)
 		if err != nil {
 			if m.logReduction.ShouldMessageBePrinted(err.Error(), podFullName) {
-				logger.Error(err, "getPodContainerStatuses for pod failed", "pod", klog.KObj(pod))
+				logger.Error(err, "getPodContainerStatuses for pod failed")
 			}
 			return nil, err
 		}
@@ -2038,9 +2031,9 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 
 	m.logReduction.ClearID(podFullName)
 	return &kubecontainer.PodStatus{
-		ID:                      uid,
-		Name:                    name,
-		Namespace:               namespace,
+		ID:                      pod.ID,
+		Name:                    pod.Name,
+		Namespace:               pod.Namespace,
 		IPs:                     podIPs,
 		SandboxStatuses:         sandboxStatuses,
 		ContainerStatuses:       containerStatuses,

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -477,13 +477,15 @@ func TestGetPods(t *testing.T) {
 	for i := range containers {
 		fakeContainer := fakeContainers[i]
 		c, err := m.toKubeContainer(tCtx, &runtimeapi.Container{
-			Id:          fakeContainer.Id,
-			Metadata:    fakeContainer.Metadata,
-			State:       fakeContainer.State,
-			Image:       fakeContainer.Image,
-			ImageRef:    fakeContainer.ImageRef,
-			Labels:      fakeContainer.Labels,
-			Annotations: fakeContainer.Annotations,
+			Id:           fakeContainer.Id,
+			Metadata:     fakeContainer.Metadata,
+			State:        fakeContainer.State,
+			Image:        fakeContainer.Image,
+			ImageRef:     fakeContainer.ImageRef,
+			Labels:       fakeContainer.Labels,
+			Annotations:  fakeContainer.Annotations,
+			PodSandboxId: fakeContainer.SandboxID,
+			CreatedAt:    fakeContainer.CreatedAt,
 		})
 		if err != nil {
 			t.Fatalf("unexpected error %v", err)
@@ -503,23 +505,29 @@ func TestGetPods(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	expected := []*kubecontainer.Pod{
-		{
-			ID:         types.UID("12345678"),
-			Name:       "foo",
-			Namespace:  "new",
-			CreatedAt:  uint64(fakeSandbox.CreatedAt),
-			Containers: []*kubecontainer.Container{containers[0], containers[1]},
-			Sandboxes:  []*kubecontainer.Container{sandbox},
-		},
+	expectedPod := &kubecontainer.Pod{
+		ID:         types.UID("12345678"),
+		Name:       "foo",
+		Namespace:  "new",
+		CreatedAt:  uint64(fakeSandbox.CreatedAt),
+		Containers: []*kubecontainer.Container{containers[0], containers[1]},
+		Sandboxes:  []*kubecontainer.Container{sandbox},
 	}
+	expected := []*kubecontainer.Pod{expectedPod}
 
 	actual, err := m.GetPods(tCtx, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	if !verifyPods(expected, actual) {
 		t.Errorf("expected %#v, got %#v", expected, actual)
 	}
+
+	actualPod, err := m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	assert.Equal(t, expectedPod, actualPod)
+
+	_, err = m.GetPod(tCtx, "non-existent-uid")
+	assert.ErrorIs(t, err, kubecontainer.ErrPodNotFound)
 }
 
 func TestGetPodsSorted(t *testing.T) {
@@ -828,7 +836,7 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 
 	// 3. should create all app containers because init container finished.
 	// Stop init container instance 0.
-	sandboxIDs, err := m.getSandboxIDByPodUID(tCtx, pod.UID, nil)
+	sandboxIDs, err := m.getSandboxIDByPodUID(tCtx, pod.UID)
 	require.NoError(t, err)
 	sandboxID := sandboxIDs[0]
 	initID0, err := fakeRuntime.GetContainerID(sandboxID, initContainers[0].Name, 0)
@@ -933,7 +941,7 @@ func TestSyncPodWithRestartAllContainers(t *testing.T) {
 
 	// 2. should run all app containers because init container finished.
 	// Stop init container instance 0.
-	sandboxIDs, err := m.getSandboxIDByPodUID(tCtx, pod.UID, nil)
+	sandboxIDs, err := m.getSandboxIDByPodUID(tCtx, pod.UID)
 	require.NoError(t, err)
 	sandboxID := sandboxIDs[0]
 	initID0, err := fakeRuntime.GetContainerID(sandboxID, initContainers[0].Name, 0)
@@ -954,7 +962,7 @@ func TestSyncPodWithRestartAllContainers(t *testing.T) {
 
 	// 3. Exits the container foo2 with code 42, the pod should be marked for RestartAllContainers, and
 	// should remove all containers.
-	sandboxIDs, err = m.getSandboxIDByPodUID(tCtx, pod.UID, nil)
+	sandboxIDs, err = m.getSandboxIDByPodUID(tCtx, pod.UID)
 	require.NoError(t, err)
 	sandboxID = sandboxIDs[0]
 	foo2ID, err := fakeRuntime.GetContainerID(sandboxID, containers[1].Name, 0)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -358,8 +358,10 @@ func TestGetPodStatus(t *testing.T) {
 	// Set fake sandbox and faked containers to fakeRuntime.
 	makeAndSetFakePod(t, m, fakeRuntime, pod)
 
-	podStatus, err := m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
-	assert.NoError(t, err)
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err := m.GetPodStatus(tCtx, runtimePod)
+	require.NoError(t, err)
 	assert.Equal(t, pod.UID, podStatus.ID)
 	assert.Equal(t, pod.Name, podStatus.Name)
 	assert.Equal(t, pod.Namespace, podStatus.Namespace)
@@ -397,7 +399,9 @@ func TestStopContainerWithNotFoundError(t *testing.T) {
 	// Set fake sandbox and faked containers to fakeRuntime.
 	makeAndSetFakePod(t, m, fakeRuntime, pod)
 	fakeRuntime.InjectError("StopContainer", status.Error(codes.NotFound, "No such container"))
-	podStatus, err := m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err := m.GetPodStatus(tCtx, runtimePod)
 	require.NoError(t, err)
 	p := kubecontainer.ConvertPodStatusToRunningPod("", podStatus)
 	gracePeriod := int64(1)
@@ -436,7 +440,9 @@ func TestGetPodStatusWithNotFoundError(t *testing.T) {
 	// Set fake sandbox and faked containers to fakeRuntime.
 	makeAndSetFakePod(t, m, fakeRuntime, pod)
 	fakeRuntime.InjectError("ContainerStatus", status.Error(codes.NotFound, "No such container"))
-	podStatus, err := m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err := m.GetPodStatus(tCtx, runtimePod)
 	require.NoError(t, err)
 	require.Equal(t, pod.UID, podStatus.ID)
 	require.Equal(t, pod.Name, podStatus.Name)
@@ -447,7 +453,7 @@ func TestGetPodStatusWithNotFoundError(t *testing.T) {
 func TestGetPods(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -482,10 +488,11 @@ func TestGetPods(t *testing.T) {
 			State:        fakeContainer.State,
 			Image:        fakeContainer.Image,
 			ImageRef:     fakeContainer.ImageRef,
+			ImageId:      fakeContainer.ImageId,
 			Labels:       fakeContainer.Labels,
 			Annotations:  fakeContainer.Annotations,
-			PodSandboxId: fakeContainer.SandboxID,
-			CreatedAt:    fakeContainer.CreatedAt,
+			PodSandboxId: fakeSandbox.Id,
+			CreatedAt:    fakeCreatedAt,
 		})
 		if err != nil {
 			t.Fatalf("unexpected error %v", err)
@@ -769,8 +776,10 @@ func TestPruneInitContainers(t *testing.T) {
 	}
 	fakes := makeFakeContainers(t, m, templates)
 	fakeRuntime.SetFakeContainers(fakes)
-	podStatus, err := m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
-	assert.NoError(t, err)
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err := m.GetPodStatus(tCtx, runtimePod)
+	require.NoError(t, err)
 
 	m.pruneInitContainersBeforeStart(tCtx, pod, podStatus)
 	expectedContainers := sets.New[string](fakes[0].Id, fakes[2].Id)
@@ -818,20 +827,30 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
 
 	// 1. should only create the init container.
-	podStatus, err := m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
-	assert.NoError(t, err)
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	if err != nil {
+		runtimePod = &kubecontainer.Pod{
+			ID:        pod.UID,
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		}
+	}
+	podStatus, err := m.GetPodStatus(tCtx, runtimePod)
+	require.NoError(t, err)
 	result := m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
-	assert.NoError(t, result.Error())
+	require.NoError(t, result.Error())
 	expected := []*cRecord{
 		{name: initContainers[0].Name, attempt: 0, state: runtimeapi.ContainerState_CONTAINER_RUNNING},
 	}
 	verifyContainerStatuses(t, fakeRuntime, expected, "start only the init container")
 
 	// 2. should not create app container because init container is still running.
-	podStatus, err = m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
-	assert.NoError(t, err)
+	runtimePod, err = m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err = m.GetPodStatus(tCtx, runtimePod)
+	require.NoError(t, err)
 	result = m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
-	assert.NoError(t, result.Error())
+	require.NoError(t, result.Error())
 	verifyContainerStatuses(t, fakeRuntime, expected, "init container still running; do nothing")
 
 	// 3. should create all app containers because init container finished.
@@ -844,10 +863,12 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	err = fakeRuntime.StopContainer(tCtx, initID0, 0)
 	require.NoError(t, err)
 	// Sync again.
-	podStatus, err = m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
-	assert.NoError(t, err)
+	runtimePod, err = m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err = m.GetPodStatus(tCtx, runtimePod)
+	require.NoError(t, err)
 	result = m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
-	assert.NoError(t, result.Error())
+	require.NoError(t, result.Error())
 	expected = []*cRecord{
 		{name: initContainers[0].Name, attempt: 0, state: runtimeapi.ContainerState_CONTAINER_EXITED},
 		{name: containers[0].Name, attempt: 0, state: runtimeapi.ContainerState_CONTAINER_RUNNING},
@@ -860,10 +881,12 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	err = fakeRuntime.StopPodSandbox(tCtx, sandboxID)
 	require.NoError(t, err)
 	// Sync again.
-	podStatus, err = m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
-	assert.NoError(t, err)
+	runtimePod, err = m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err = m.GetPodStatus(tCtx, runtimePod)
+	require.NoError(t, err)
 	result = m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
-	assert.NoError(t, result.Error())
+	require.NoError(t, result.Error())
 	expected = []*cRecord{
 		// The first init container instance is purged and no longer visible.
 		// The second (attempt == 1) instance has been started and is running.
@@ -930,7 +953,15 @@ func TestSyncPodWithRestartAllContainers(t *testing.T) {
 	backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
 
 	// 1. Run the pod first. First SyncPod should execute the init container.
-	podStatus, err := m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	if err != nil {
+		runtimePod = &kubecontainer.Pod{
+			ID:        pod.UID,
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		}
+	}
+	podStatus, err := m.GetPodStatus(tCtx, runtimePod)
 	require.NoError(t, err)
 	result := m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
 	require.NoError(t, result.Error())
@@ -949,7 +980,9 @@ func TestSyncPodWithRestartAllContainers(t *testing.T) {
 	err = fakeRuntime.StopContainer(tCtx, initID0, 0)
 	require.NoError(t, err)
 	// Sync again.
-	podStatus, err = m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
+	runtimePod, err = m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err = m.GetPodStatus(tCtx, runtimePod)
 	require.NoError(t, err)
 	result = m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
 	require.NoError(t, result.Error())
@@ -972,7 +1005,9 @@ func TestSyncPodWithRestartAllContainers(t *testing.T) {
 	failedFoo2.ExitCode = 42
 	fakeRuntime.Containers[foo2ID] = failedFoo2
 
-	podStatus, err = m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
+	runtimePod, err = m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err = m.GetPodStatus(tCtx, runtimePod)
 	require.NoError(t, err)
 	result = m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, true)
 	require.NoError(t, result.Error())
@@ -980,7 +1015,9 @@ func TestSyncPodWithRestartAllContainers(t *testing.T) {
 	verifyContainerStatuses(t, fakeRuntime, expected, "kill all containers")
 
 	// 4. Unmark the pod. Now it should start the init container first.
-	podStatus, err = m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
+	runtimePod, err = m.GetPod(tCtx, pod.UID)
+	require.NoError(t, err)
+	podStatus, err = m.GetPodStatus(tCtx, runtimePod)
 	require.NoError(t, err)
 	result = m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
 	require.NoError(t, result.Error())
@@ -2746,11 +2783,19 @@ func TestSyncPodWithSandboxAndDeletedPod(t *testing.T) {
 	// GetPodStatus and the following SyncPod will not return errors in the
 	// case where the pod has been deleted. We are not adding any pods into
 	// the fakePodProvider so they are 'deleted'.
-	podStatus, err := m.GetPodStatus(tCtx, pod.UID, pod.Name, pod.Namespace)
-	assert.NoError(t, err)
+	runtimePod, err := m.GetPod(tCtx, pod.UID)
+	if err != nil {
+		runtimePod = &kubecontainer.Pod{
+			ID:        pod.UID,
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		}
+	}
+	podStatus, err := m.GetPodStatus(tCtx, runtimePod)
+	require.NoError(t, err)
 	result := m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
 	// This will return an error if the pod has _not_ been deleted.
-	assert.NoError(t, result.Error())
+	require.NoError(t, result.Error())
 }
 
 func makeBasePodAndStatusWithInitAndEphemeralContainers() (*v1.Pod, *kubecontainer.PodStatus) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -27,7 +27,6 @@ import (
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/kubelet/pkg/types"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	runtimeutil "k8s.io/kubernetes/pkg/kubelet/kuberuntime/util"
 	"k8s.io/kubernetes/pkg/kubelet/util"
@@ -279,28 +278,6 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxWindowsConfig(pod *v1.Pod)
 	return wc, nil
 }
 
-// getKubeletSandboxes lists all (or just the running) sandboxes managed by kubelet.
-func (m *kubeGenericRuntimeManager) getKubeletSandboxes(ctx context.Context, all bool) ([]*runtimeapi.PodSandbox, error) {
-	logger := klog.FromContext(ctx)
-	var filter *runtimeapi.PodSandboxFilter
-	if !all {
-		readyState := runtimeapi.PodSandboxState_SANDBOX_READY
-		filter = &runtimeapi.PodSandboxFilter{
-			State: &runtimeapi.PodSandboxStateValue{
-				State: readyState,
-			},
-		}
-	}
-
-	resp, err := m.runtimeService.ListPodSandbox(ctx, filter)
-	if err != nil {
-		logger.Error(err, "Failed to list pod sandboxes")
-		return nil, err
-	}
-
-	return resp, nil
-}
-
 // determinePodSandboxIP determines the IP addresses of the given pod sandbox.
 func (m *kubeGenericRuntimeManager) determinePodSandboxIPs(ctx context.Context, podNamespace, podName string, podSandbox *runtimeapi.PodSandboxStatus) []string {
 	logger := klog.FromContext(ctx)
@@ -334,19 +311,11 @@ func (m *kubeGenericRuntimeManager) determinePodSandboxIPs(ctx context.Context, 
 	return podIPs
 }
 
-// getPodSandboxID gets the sandbox id by podUID and returns ([]sandboxID, error).
+// getPodSandboxIDByPodUID gets the sandbox id by podUID and returns ([]sandboxID, error).
 // Param state could be nil in order to get all sandboxes belonging to same pod.
-func (m *kubeGenericRuntimeManager) getSandboxIDByPodUID(ctx context.Context, podUID kubetypes.UID, state *runtimeapi.PodSandboxState) ([]string, error) {
+func (m *kubeGenericRuntimeManager) getSandboxIDByPodUID(ctx context.Context, podUID kubetypes.UID) ([]string, error) {
 	logger := klog.FromContext(ctx)
-	filter := &runtimeapi.PodSandboxFilter{
-		LabelSelector: map[string]string{types.KubernetesPodUIDLabel: string(podUID)},
-	}
-	if state != nil {
-		filter.State = &runtimeapi.PodSandboxStateValue{
-			State: *state,
-		}
-	}
-	sandboxes, err := m.runtimeService.ListPodSandbox(ctx, filter)
+	sandboxes, err := m.getSandboxes(ctx, listOptions{podUID: podUID})
 	if err != nil {
 		logger.Error(err, "Failed to list sandboxes for pod", "podUID", podUID)
 		return nil, err
@@ -368,7 +337,7 @@ func (m *kubeGenericRuntimeManager) getSandboxIDByPodUID(ctx context.Context, po
 
 // GetPortForward gets the endpoint the runtime will serve the port-forward request from.
 func (m *kubeGenericRuntimeManager) GetPortForward(ctx context.Context, podName, podNamespace string, podUID kubetypes.UID, ports []int32) (*url.URL, error) {
-	sandboxIDs, err := m.getSandboxIDByPodUID(ctx, podUID, nil)
+	sandboxIDs, err := m.getSandboxIDByPodUID(ctx, podUID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sandboxID for pod %s: %v", format.PodDesc(podName, podNamespace, podUID), err)
 	}

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -60,7 +60,8 @@ type handlerRunner struct {
 }
 
 type podStatusProvider interface {
-	GetPodStatus(ctx context.Context, uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error)
+	GetPod(ctx context.Context, podUID types.UID) (*kubecontainer.Pod, error)
+	GetPodStatus(ctx context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error)
 }
 
 // NewHandlerRunner returns a configured lifecycle handler for a container.
@@ -129,10 +130,13 @@ func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, contai
 	host := handler.HTTPGet.Host
 	podIP := host
 	if len(host) == 0 {
-		status, err := hr.containerManager.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
+		runtimePod, err := hr.containerManager.GetPod(ctx, pod.UID)
 		if err != nil {
-			logger.Error(err, "Unable to get pod info, event handlers may be invalid.", "pod", klog.KObj(pod))
-			return err
+			return fmt.Errorf("unable to get pod, event handlers may be invalid: %w", err)
+		}
+		status, err := hr.containerManager.GetPodStatus(ctx, runtimePod)
+		if err != nil {
+			return fmt.Errorf("unable to get pod status, event handlers may be invalid: %w", err)
 		}
 		if len(status.IPs) == 0 {
 			return fmt.Errorf("failed to find networking container: %v", status)

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -61,20 +61,22 @@ func (f *fakeContainerCommandRunner) RunInContainer(_ context.Context, id kubeco
 }
 
 func stubPodStatusProvider(podIP string) podStatusProvider {
-	return podStatusProviderFunc(func(uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
-		return &kubecontainer.PodStatus{
-			ID:        uid,
-			Name:      name,
-			Namespace: namespace,
-			IPs:       []string{podIP},
-		}, nil
-	})
+	return &fakePodStatusProvider{podIP: podIP}
 }
 
-type podStatusProviderFunc func(uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error)
+type fakePodStatusProvider struct {
+	podIP string
+}
 
-func (f podStatusProviderFunc) GetPodStatus(_ context.Context, uid types.UID, name, namespace string) (*kubecontainer.PodStatus, error) {
-	return f(uid, name, namespace)
+func (f *fakePodStatusProvider) GetPod(_ context.Context, uid types.UID) (*kubecontainer.Pod, error) {
+	return &kubecontainer.Pod{ID: uid}, nil
+}
+
+func (f *fakePodStatusProvider) GetPodStatus(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
+	return &kubecontainer.PodStatus{
+		ID:  pod.ID,
+		IPs: []string{f.podIP},
+	}, nil
 }
 
 func TestRunHandlerExec(t *testing.T) {

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -419,7 +419,7 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 
 	timestamp := g.clock.Now()
 
-	status, err := g.runtime.GetPodStatus(ctx, pod.ID, pod.Name, pod.Namespace)
+	status, err := g.runtime.GetPodStatus(ctx, pod)
 	if err != nil {
 		// nolint:logcheck // Not using the result of klog.V inside the
 		// if branch is okay, we just use it to determine whether the

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -363,10 +363,10 @@ func TestRelistWithCache(t *testing.T) {
 
 	pods, statuses, events := createTestPodsStatusesAndEvents(2)
 	runtimeMock.EXPECT().GetPods(ctx, true).Return(pods, nil).Maybe()
-	runtimeMock.EXPECT().GetPodStatus(ctx, pods[0].ID, "", "").Return(statuses[0], nil).Times(1)
+	runtimeMock.EXPECT().GetPodStatus(ctx, pods[0]).Return(statuses[0], nil).Times(1)
 	// Inject an error when querying runtime for the pod status for pods[1].
 	statusErr := fmt.Errorf("unable to get status")
-	runtimeMock.EXPECT().GetPodStatus(ctx, pods[1].ID, "", "").Return(&kubecontainer.PodStatus{}, statusErr).Times(1)
+	runtimeMock.EXPECT().GetPodStatus(ctx, pods[1]).Return(&kubecontainer.PodStatus{}, statusErr).Times(1)
 
 	pleg.Relist()
 	actualEvents := getEventsFromChannel(ch)
@@ -388,7 +388,7 @@ func TestRelistWithCache(t *testing.T) {
 	assert.Exactly(t, []*PodLifecycleEvent{events[0]}, actualEvents)
 
 	// Return normal status for pods[1].
-	runtimeMock.EXPECT().GetPodStatus(ctx, pods[1].ID, "", "").Return(statuses[1], nil).Times(1)
+	runtimeMock.EXPECT().GetPodStatus(ctx, pods[1]).Return(statuses[1], nil).Times(1)
 	pleg.Relist()
 	actualEvents = getEventsFromChannel(ch)
 	cases = []struct {
@@ -416,7 +416,7 @@ func TestRemoveCacheEntry(t *testing.T) {
 
 	pods, statuses, _ := createTestPodsStatusesAndEvents(1)
 	runtimeMock.EXPECT().GetPods(ctx, true).Return(pods, nil).Times(1)
-	runtimeMock.EXPECT().GetPodStatus(ctx, pods[0].ID, "", "").Return(statuses[0], nil).Times(1)
+	runtimeMock.EXPECT().GetPodStatus(ctx, pods[0]).Return(statuses[0], nil).Times(1)
 	// Does a relist to populate the cache.
 	pleg.Relist()
 	// Delete the pod from runtime. Verify that the cache entry has been
@@ -585,7 +585,7 @@ func TestReinspect(t *testing.T) {
 				if tc.podDeleted {
 					// updateCache(ctx, nil, podID) will be called, it doesn't call GetPodStatus
 				} else {
-					runtimeMock.EXPECT().GetPodStatus(ctx, podID, "name", "ns").Return(expectedStatus, tc.updateCacheError)
+					runtimeMock.EXPECT().GetPodStatus(ctx, pod).Return(expectedStatus, tc.updateCacheError)
 				}
 			}
 
@@ -729,7 +729,7 @@ func TestRelistIPChange(t *testing.T) {
 		event := &PodLifecycleEvent{ID: pod.ID, Type: ContainerStarted, Data: container.ID.ID}
 
 		runtimeMock.EXPECT().GetPods(ctx, true).Return([]*kubecontainer.Pod{pod}, nil).Times(1)
-		runtimeMock.EXPECT().GetPodStatus(ctx, pod.ID, "", "").Return(status, nil).Times(1)
+		runtimeMock.EXPECT().GetPodStatus(ctx, pod).Return(status, nil).Times(1)
 
 		pleg.Relist()
 		actualEvents := getEventsFromChannel(ch)
@@ -750,7 +750,7 @@ func TestRelistIPChange(t *testing.T) {
 		}
 		event = &PodLifecycleEvent{ID: pod.ID, Type: ContainerDied, Data: container.ID.ID}
 		runtimeMock.EXPECT().GetPods(ctx, true).Return([]*kubecontainer.Pod{pod}, nil).Times(1)
-		runtimeMock.EXPECT().GetPodStatus(ctx, pod.ID, "", "").Return(status, nil).Times(1)
+		runtimeMock.EXPECT().GetPodStatus(ctx, pod).Return(status, nil).Times(1)
 
 		pleg.Relist()
 		actualEvents = getEventsFromChannel(ch)

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -19,6 +19,7 @@ package kubelet
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -1309,7 +1310,7 @@ func (p *podWorkers) podWorkerLoop(parentCtx context.Context, podUID types.UID, 
 
 		var phaseTransition bool
 		switch {
-		case err == context.Canceled:
+		case errors.Is(err, context.Canceled):
 			// when the context is cancelled we expect an update to already be queued
 			logger.V(2).Info("Sync exited with context cancellation error", "pod", podRef, "podUID", podUID, "updateType", update.WorkType)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Today, the generic PLEG works like this:

1. Get all pods (`runtime.GetPods`)
    1. Get all sandboxes
    2. Get all containers
    3. group containers & sandboxes into pods (`kubecontainer.Pod`)
2. Compare this new state to the previous state. If there are changes:
3. For each pod that changed, get an updated status (`runtime.GetPodStatus`)
    1. Get the pod sandboxes
    2. Get the pod containers
    3. For each sandbox, get its status
    4. For each container, get its status
    5. Combine into `kubecontainer.PodStatus` object

Steps 3.1 and 3.2 are redundant with 1.1 and 1.2.

This PR:
1. Refactors GetPodStatus to take a `kubecontainer.Pod` (from step 1.3), so it can skip the repeated runtime calls.
2. Adds a new `runtime.GetPod` function that is the singular equivalent of `runtime.GetPods`. Also includes some refactoring within kuberuntime to avoid code duplication for the new GetPod function.

#### Special notes for your reviewer:

This PR is a prerequisite for https://github.com/kubernetes/kubernetes/pull/137362

I couldn't help but clean up some places where we were logging & returning an error. LMK if I should move those to a separate PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon