### PR TITLE
Use provided context in RunLogsContext

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -366,7 +366,7 @@ func (o LogsOptions) RunLogs() error {
 //
 // When a signal is received, streaming is stopped, then followed by os.Exit(1).
 func (o LogsOptions) RunLogsContext(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	intr := interrupt.New(nil, cancel)
 	return intr.Run(func() error {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
kubectl logs `RunLogsContext()` function accepts a context, but it doesn't use it and replaces it with a background context.  This PR changes it to use the provided context.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
