### PR TITLE
WIP: e2e: add support for detecting panics in logs

### DIFF
--- a/test/e2e/invariants/logcheck/logcheck.go
+++ b/test/e2e/invariants/logcheck/logcheck.go
@@ -129,13 +129,15 @@ type logCheck struct {
 
 	// dataRaces enables checking for "DATA RACE" reports.
 	dataRaces bool
+	// panics enabled checking for go panics
+	panics bool
 	// More checks may get added in the future.
 }
 
 // any returns true if any log output check is enabled.
 func (c logCheck) any() bool {
 	// Needs to be extended when adding new checks.
-	return c.dataRaces
+	return c.dataRaces || c.panics
 }
 
 // regexpValue implements flag.Value for a regular expression.
@@ -161,6 +163,7 @@ func (r *regexpValue) Set(expr string) error {
 // RegisterFlags adds command line flags for configuring the package to the given flag set.
 // They have "logcheck" as prefix.
 func RegisterFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&enabledLogChecks.panics, "logcheck-panics", false, "enables checking logs for panics")
 	fs.BoolVar(&enabledLogChecks.dataRaces, "logcheck-data-races", false, "enables checking logs for DATA RACE warnings")
 	fs.Var(&enabledLogChecks.namespaces, "logcheck-namespaces-regexp", "all namespaces matching this regular expressions get checked")
 	fs.Var(&enabledLogChecks.nodes, "logcheck-nodes-regexp", "all kubelets on nodes matching this regular expressions get checked")
@@ -256,6 +259,7 @@ func newLogChecker(ctx context.Context, client kubernetes.Interface, check logCh
 		logDir:    logDir,
 		logFile:   logFile,
 		dataRaces: make(map[string][][]string),
+		panics:    make(map[string][][]string),
 	}, nil
 }
 
@@ -280,6 +284,15 @@ type logChecker struct {
 	// Only entities for which at least some output was received get added here,
 	// therefore also the "<entity>: okay" part of the report only appears for those.
 	dataRaces map[string][][]string
+
+	// All panics detected so far, indexed by "<namespace>/<pod name>/<container name>"
+	// or "kubelet/<node name>".
+	//
+	// The last entry is initially empty while waiting for the next panic.
+	//
+	// Only entities for which at least some output was received get added here,
+	// therefore also the "<entity>: okay" part of the report only appears for those.
+	panics map[string][][]string
 }
 
 // stop cancels pod monitoring, waits until that is shut down, and then produces text for a failure message (ideally empty) and stdout.
@@ -321,15 +334,17 @@ func (l *logChecker) stop(logger klog.Logger) (failure, stdout string) {
 	slices.Sort(keys)
 	for _, k := range keys {
 		races := l.dataRaces[k]
+		panics := l.panics[k]
 		buffer := &failureBuffer
-		if len(races) == 0 {
+		noIssues := len(races) == 0 && len(panics) == 0
+		if noIssues {
 			buffer = &stdoutBuffer
 		}
 		if buffer.Len() > 0 {
 			buffer.WriteString("\n")
 		}
 		buffer.WriteString("#### " + k + "\n")
-		if len(races) == 0 {
+		if noIssues {
 			buffer.WriteString("\nOkay.\n")
 			continue
 		}
@@ -380,6 +395,12 @@ func (l *logChecker) stop(logger klog.Logger) (failure, stdout string) {
 				backtrace = append(backtrace, line)
 			}
 			dumpBacktrace()
+		}
+		for _, panic := range panics {
+			buffer.WriteString("\n")
+			for _, line := range panic {
+				buffer.WriteString(line)
+			}
 		}
 	}
 
@@ -471,7 +492,7 @@ const journaldHeader = `... .. ..:..:......... \S+ kubelet\[\d+\]: `
 var logQueryLineHeaderRE = regexp.MustCompile(`^(?:` + journaldHeader + `)`)
 
 func (l *logChecker) logOpen(logger klog.Logger, names ...string) io.Writer {
-	if !l.check.dataRaces {
+	if !l.check.any() {
 		return nil
 	}
 
@@ -480,7 +501,7 @@ func (l *logChecker) logOpen(logger klog.Logger, names ...string) io.Writer {
 	}
 
 	k := strings.Join(names, "/")
-	logger.Info("Starting to check for data races", "container", k)
+	logger.Info("Starting to check logs", "container", k)
 	return &logOutputChecker{logger: logger, k: k, l: l}
 }
 
@@ -510,7 +531,17 @@ type logOutputChecker struct {
 	k          string
 	l          *logChecker
 	inDataRace bool
+	panicState panicMatchState
 }
+
+type panicMatchState uint8
+
+const (
+	notInPanic  panicMatchState = 0
+	inPanic     panicMatchState = 1
+	firstBlank  panicMatchState = 2
+	restOfPanic panicMatchState = 3
+)
 
 var (
 	_ io.Writer = &logOutputChecker{}
@@ -526,7 +557,25 @@ func (p *logOutputChecker) Write(l []byte) (int, error) {
 	defer p.l.mutex.Unlock()
 
 	races := p.l.dataRaces[p.k]
+	panics := p.l.panics[p.k]
+
 	switch {
+	// panic state machine
+	case p.panicState == notInPanic && strings.HasPrefix(line, "panic: "):
+		p.panicState = inPanic
+		panics = append(panics, nil)
+		p.logger.Info("Started new panic", "containerd", p.k, "count", len(panics))
+	case p.panicState == inPanic: // consume first blank line after a panic
+		p.panicState = firstBlank
+		panics[len(panics)-1] = append(panics[len(panics)-1], line)
+	case p.panicState == firstBlank: // there will be at least one goroutine log line after the first blank
+		p.panicState = restOfPanic
+		panics[len(panics)-1] = append(panics[len(panics)-1], line)
+	case p.panicState == restOfPanic && line == "\n": // panic ends with blank line
+		p.panicState = notInPanic
+		p.logger.Info("Completed panic", "container", p.k, "count", len(panics), "panic", strings.Join(panics[len(panics)-1], ""))
+
+	// data race state machine
 	case p.inDataRace && line != dataRaceEnd:
 		races[len(races)-1] = append(races[len(races)-1], line)
 	case p.inDataRace && line == dataRaceEnd:
@@ -538,17 +587,20 @@ func (p *logOutputChecker) Write(l []byte) (int, error) {
 		p.inDataRace = true
 		races = append(races, nil)
 		p.logger.Info("Started new data race", "container", p.k, "count", len(races))
+
 	default:
 		// Some other log output.
 	}
+
 	p.l.dataRaces[p.k] = races
+	p.l.panics[p.k] = panics
 
 	return len(l), nil
 }
 
 // Close gets called once all output is processed.
 func (p *logOutputChecker) Close() error {
-	p.logger.Info("Done checking for data races", "container", p.k)
+	p.logger.Info("Done checking logs", "container", p.k)
 	p.l.wg.done()
 	return nil
 }

--- a/test/e2e/invariants/logcheck/logcheck_test.go
+++ b/test/e2e/invariants/logcheck/logcheck_test.go
@@ -84,14 +84,14 @@ DATA RACE:
       scheduleHandler()
 `,
 			expectStdout: `<log header>] "Watching" namespace="kube-system"
-<log header>] "Starting to check for data races" container="kube-system/pod/container"
+<log header>] "Starting to check logs" container="kube-system/pod/container"
 <log header>] "Started new data race" container="kube-system/pod/container" count=1
 <log header>] "Completed data race" container="kube-system/pod/container" count=1 dataRace=<
 	Write at ...
 	Goroutine created at:
 	  scheduleHandler()
  >
-<log header>] "Done checking for data races" container="kube-system/pod/container"
+<log header>] "Done checking logs" container="kube-system/pod/container"
 `,
 		},
 		"disabled-data-race": {
@@ -182,7 +182,7 @@ Goroutine created at:
         otherScheduleHandler()
 `,
 			expectStdout: `<log header>] "Watching" namespace="kube-system"
-<log header>] "Starting to check for data races" container="kube-system/pod/container"
+<log header>] "Starting to check logs" container="kube-system/pod/container"
 <log header>] "Started new data race" container="kube-system/pod/container" count=1
 <log header>] "Completed data race" container="kube-system/pod/container" count=1 dataRace=<
 	Write at ...
@@ -195,7 +195,7 @@ Goroutine created at:
 	Goroutine created at:
 	  otherScheduleHandler()
  >
-<log header>] "Done checking for data races" container="kube-system/pod/container"
+<log header>] "Done checking logs" container="kube-system/pod/container"
 `,
 		},
 		"both": {
@@ -216,14 +216,14 @@ DATA RACE:
       scheduleHandler()
 `,
 			expectStdout: `<log header>] "Watching" namespace="kube-system"
-<log header>] "Starting to check for data races" container="kube-system/pod/container"
+<log header>] "Starting to check logs" container="kube-system/pod/container"
 <log header>] "Started new data race" container="kube-system/pod/container" count=1
 <log header>] "Completed data race" container="kube-system/pod/container" count=1 dataRace=<
 	Write at ...
 	Goroutine created at:
 	  scheduleHandler()
  >
-<log header>] "Done checking for data races" container="kube-system/pod/container"
+<log header>] "Done checking logs" container="kube-system/pod/container"
 `,
 		},
 		"two-containers": {
@@ -239,16 +239,16 @@ Goroutine created at:
 			},
 			check: logCheck{dataRaces: true},
 			expectStdout: `<log header>] "Watching" namespace="kube-system"
-<log header>] "Starting to check for data races" container="kube-system/pod/container1"
-<log header>] "Done checking for data races" container="kube-system/pod/container1"
-<log header>] "Starting to check for data races" container="kube-system/pod/container2"
+<log header>] "Starting to check logs" container="kube-system/pod/container1"
+<log header>] "Done checking logs" container="kube-system/pod/container1"
+<log header>] "Starting to check logs" container="kube-system/pod/container2"
 <log header>] "Started new data race" container="kube-system/pod/container2" count=1
 <log header>] "Completed data race" container="kube-system/pod/container2" count=1 dataRace=<
 	Write at ...
 	Goroutine created at:
 	  scheduleHandler()
  >
-<log header>] "Done checking for data races" container="kube-system/pod/container2"
+<log header>] "Done checking logs" container="kube-system/pod/container2"
 
 #### kube-system/pod/container1
 
@@ -276,16 +276,16 @@ Goroutine created at:
 			},
 			check: logCheck{dataRaces: true},
 			expectStdout: `<log header>] "Watching" namespace="kube-system"
-<log header>] "Starting to check for data races" container="kube-system/pod1/container"
-<log header>] "Done checking for data races" container="kube-system/pod1/container"
-<log header>] "Starting to check for data races" container="kube-system/pod2/container"
+<log header>] "Starting to check logs" container="kube-system/pod1/container"
+<log header>] "Done checking logs" container="kube-system/pod1/container"
+<log header>] "Starting to check logs" container="kube-system/pod2/container"
 <log header>] "Started new data race" container="kube-system/pod2/container" count=1
 <log header>] "Completed data race" container="kube-system/pod2/container" count=1 dataRace=<
 	Write at ...
 	Goroutine created at:
 	  scheduleHandler()
  >
-<log header>] "Done checking for data races" container="kube-system/pod2/container"
+<log header>] "Done checking logs" container="kube-system/pod2/container"
 
 #### kube-system/pod1/container
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Extends logcheck e2e invariant from checking for data races to also panics.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This is heavily derived from the existing data race checking patterns.

The state machine is slightly different, as panics don't have a clear end-of-panic marker, instead we know
the number of blank lines, panics look like this:

```
panic: at the disco

goroutine 1 [running]:
main.main()
	/tmp/sandbox1256160218/prog.go:9 +0x59

```

Keep this in mind when reading the parsing logic.

It has been integrated so if both flags are enabled we can do so with the same log processing stream.

TODO: As of yet untested and unoptimized. This is an MVP inspired by the GOFIPS140 discussion in SIG Arch today.
(I expect that if we were to test enabling GOFIPS140=only, even once we got that to a probably working state, we have to watch for runtime panics, which may be masked by components restarting on error => let's see if we can detect panics)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
e2e.test now supports --logcheck-panics to check cluster logs for panics during the tests
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
