### PR TITLE
Add feature-gate ClientConcurrentWatchObjectDecode

### DIFF
--- a/staging/src/k8s.io/client-go/features/known_features.go
+++ b/staging/src/k8s.io/client-go/features/known_features.go
@@ -48,6 +48,12 @@ const (
 	// "application/json" or "application/apply-patch+yaml", respectively.
 	ClientsAllowCBOR Feature = "ClientsAllowCBOR"
 
+	// owner: @chenk008
+	// alpha: 1.36
+	//
+	// If enabled, the client will decode watch stream events concurrently.
+	ClientsConcurrentWatchObjectDecode = "ClientsConcurrentWatchObjectDecode"
+
 	// owner: @benluddy
 	// kep: https://kep.k8s.io/4222
 	// alpha: 1.32
@@ -100,6 +106,9 @@ var defaultVersionedKubernetesFeatureGates = map[Feature]VersionedSpecs{
 	},
 	ClientsAllowCBOR: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: Alpha},
+	},
+	ClientsConcurrentWatchObjectDecode: {
+		{Version: version.MustParse("1.36"), Default: true, PreRelease: Alpha},
 	},
 	ClientsPreferCBOR: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: Alpha},

--- a/staging/src/k8s.io/client-go/rest/watch/decoder.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder.go
@@ -18,12 +18,22 @@ package watch
 
 import (
 	"fmt"
+	"io"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/watch"
+	clientfeatures "k8s.io/client-go/features"
 )
+
+const processEventConcurrency = 10
+
+type eventData struct {
+	action string
+	object runtime.Object
+	err    error
+}
 
 // Decoder implements the watch.Decoder interface for io.ReadClosers that
 // have contents which consist of a series of watchEvent objects encoded
@@ -32,41 +42,164 @@ import (
 type Decoder struct {
 	decoder         streaming.Decoder
 	embeddedDecoder runtime.Decoder
+	getEvent        func() (watch.EventType, runtime.Object, error)
+	stopCh          chan struct{}
+	processing      concurrentOrderedEventProcessing
 }
 
 // NewDecoder creates an Decoder for the given writer and codec.
 func NewDecoder(decoder streaming.Decoder, embeddedDecoder runtime.Decoder) *Decoder {
-	return &Decoder{
+	d := &Decoder{
 		decoder:         decoder,
 		embeddedDecoder: embeddedDecoder,
+		stopCh:          make(chan struct{}),
 	}
+	d.getEvent = func() (watch.EventType, runtime.Object, error) {
+		var got metav1.WatchEvent
+		got, err := decodeWatchEvent(d.decoder)
+		if err != nil {
+			return "", nil, err
+		}
+
+		obj, err := runtime.Decode(d.embeddedDecoder, got.Object.Raw)
+		if err != nil {
+			return "", nil, fmt.Errorf("unable to decode watch event: %v", err)
+		}
+		return watch.EventType(got.Type), obj, nil
+	}
+	if clientfeatures.FeatureGates().Enabled(clientfeatures.ClientsConcurrentWatchObjectDecode) {
+		d.startConcurrentDecode()
+		d.getEvent = func() (watch.EventType, runtime.Object, error) {
+			select {
+			case <-d.stopCh:
+				return "", nil, io.EOF
+			case event, ok := <-d.processing.resultChan:
+				if !ok {
+					// should not happen. eventChan is closed after error, when got an error, getEvent loop will exit.
+					return "", nil, io.EOF
+				}
+				return watch.EventType(event.action), event.object, event.err
+			}
+		}
+	}
+	return d
 }
 
 // Decode blocks until it can return the next object in the reader. Returns an error
 // if the reader is closed or an object can't be decoded.
 func (d *Decoder) Decode() (watch.EventType, runtime.Object, error) {
+	return d.getEvent()
+}
+
+func decodeWatchEvent(decoder streaming.Decoder) (metav1.WatchEvent, error) {
 	var got metav1.WatchEvent
-	res, _, err := d.decoder.Decode(nil, &got)
+	res, _, err := decoder.Decode(nil, &got)
 	if err != nil {
-		return "", nil, err
+		return metav1.WatchEvent{}, err
 	}
 	if res != &got {
-		return "", nil, fmt.Errorf("unable to decode to metav1.WatchEvent")
+		return metav1.WatchEvent{}, fmt.Errorf("unable to decode to metav1.WatchEvent")
 	}
 	switch got.Type {
 	case string(watch.Added), string(watch.Modified), string(watch.Deleted), string(watch.Error), string(watch.Bookmark):
 	default:
-		return "", nil, fmt.Errorf("got invalid watch event type: %v", got.Type)
+		return metav1.WatchEvent{}, fmt.Errorf("got invalid watch event type: %v", got.Type)
 	}
+	return got, nil
+}
 
-	obj, err := runtime.Decode(d.embeddedDecoder, got.Object.Raw)
-	if err != nil {
-		return "", nil, fmt.Errorf("unable to decode watch event: %v", err)
+func (d *Decoder) startConcurrentDecode() {
+	d.processing = concurrentOrderedEventProcessing{
+		resultChan:      make(chan *eventData, processEventConcurrency-1),
+		processingQueue: make(chan chan *eventData, processEventConcurrency-1),
+		decoder:         d.decoder,
+		embeddedDecoder: d.embeddedDecoder,
 	}
-	return watch.EventType(got.Type), obj, nil
+	go func() {
+		d.processing.scheduleEventProcessing(d.stopCh)
+	}()
+	go func() {
+		d.processing.collectEventProcessing(d.stopCh)
+	}()
+
+}
+
+type concurrentOrderedEventProcessing struct {
+	resultChan      chan *eventData
+	processingQueue chan chan *eventData
+	decoder         streaming.Decoder
+	embeddedDecoder runtime.Decoder
+}
+
+func (p *concurrentOrderedEventProcessing) scheduleEventProcessing(stopCh <-chan struct{}) {
+	for {
+		got, err := decodeWatchEvent(p.decoder)
+		processingResponse := make(chan *eventData, 1)
+		select {
+		case <-stopCh:
+			return
+		case p.processingQueue <- processingResponse:
+		}
+
+		go func(watchEvent *metav1.WatchEvent, err error, response chan<- *eventData) {
+			pr := &eventData{
+				action: watchEvent.Type,
+			}
+			if err != nil {
+				pr.err = err
+			} else {
+				obj, err := runtime.Decode(p.embeddedDecoder, got.Object.Raw)
+				if err != nil {
+					pr.err = fmt.Errorf("unable to decode watch event: %v", err)
+				} else {
+					pr.object = obj
+				}
+			}
+			response <- pr
+		}(&got, err, processingResponse)
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (p *concurrentOrderedEventProcessing) collectEventProcessing(stopCh <-chan struct{}) {
+	defer close(p.resultChan)
+	for {
+		var processingResponse chan *eventData
+		var ok bool
+		select {
+		case <-stopCh:
+			return
+		case processingResponse, ok = <-p.processingQueue:
+			if !ok {
+				return
+			}
+		}
+
+		var r *eventData
+		select {
+		case <-stopCh:
+			return
+		case r, ok = <-processingResponse:
+			if !ok {
+				return
+			}
+		}
+
+		select {
+		case <-stopCh:
+			return
+		case p.resultChan <- r:
+			if r.err != nil {
+				return
+			}
+		}
+	}
 }
 
 // Close closes the underlying r.
 func (d *Decoder) Close() {
 	d.decoder.Close()
+	close(d.stopCh)
 }

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -42,89 +44,176 @@ func getDecoder() runtime.Decoder {
 }
 
 func TestDecoder(t *testing.T) {
-	table := []watch.EventType{watch.Added, watch.Deleted, watch.Modified, watch.Error, watch.Bookmark}
+	tests := []struct {
+		name                               string
+		clientsConcurrentWatchObjectDecode bool
+	}{
+		{
+			name:                               "disable clientsConcurrentWatchObjectDecode",
+			clientsConcurrentWatchObjectDecode: false,
+		},
+		{
+			name:                               "enable clientsConcurrentWatchObjectDecode",
+			clientsConcurrentWatchObjectDecode: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsConcurrentWatchObjectDecode, test.clientsConcurrentWatchObjectDecode)
 
-	for _, eventType := range table {
-		out, in := io.Pipe()
+			table := []watch.EventType{watch.Added, watch.Deleted, watch.Modified, watch.Error, watch.Bookmark}
 
-		decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
-		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
-		encoder := json.NewEncoder(in)
-		eType := eventType
-		errc := make(chan error)
+			for _, eventType := range table {
+				out, in := io.Pipe()
 
-		go func() {
-			data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
-			if err != nil {
-				errc <- fmt.Errorf("Unexpected error %v", err)
-				return
-			}
-			event := metav1.WatchEvent{
-				Type:   string(eType),
-				Object: runtime.RawExtension{Raw: json.RawMessage(data)},
-			}
-			if err := encoder.Encode(&event); err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
-			in.Close()
-		}()
+				decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+				expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+				encoder := json.NewEncoder(in)
+				eType := eventType
+				errc := make(chan error)
 
-		done := make(chan struct{})
-		go func() {
-			action, got, err := decoder.Decode()
-			if err != nil {
-				errc <- fmt.Errorf("Unexpected error %v", err)
-				return
-			}
-			if e, a := eType, action; e != a {
-				t.Errorf("Expected %v, got %v", e, a)
-			}
-			if e, a := expect, got; !apiequality.Semantic.DeepDerivative(e, a) {
-				t.Errorf("Expected %v, got %v", e, a)
-			}
-			t.Logf("Exited read")
-			close(done)
-		}()
-		select {
-		case err := <-errc:
-			t.Fatal(err)
-		case <-done:
-		}
+				go func() {
+					data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
+					if err != nil {
+						errc <- fmt.Errorf("Unexpected error %v", err)
+						return
+					}
+					event := metav1.WatchEvent{
+						Type:   string(eType),
+						Object: runtime.RawExtension{Raw: json.RawMessage(data)},
+					}
+					if err := encoder.Encode(&event); err != nil {
+						t.Errorf("Unexpected error %v", err)
+					}
+					in.Close()
+				}()
 
-		done = make(chan struct{})
-		go func() {
-			_, _, err := decoder.Decode()
-			if err == nil {
-				t.Errorf("Unexpected nil error")
-			}
-			close(done)
-		}()
-		<-done
+				done := make(chan struct{})
+				go func() {
+					action, got, err := decoder.Decode()
+					if err != nil {
+						errc <- fmt.Errorf("Unexpected error %v", err)
+						return
+					}
+					if e, a := eType, action; e != a {
+						t.Errorf("Expected %v, got %v", e, a)
+					}
+					if e, a := expect, got; !apiequality.Semantic.DeepDerivative(e, a) {
+						t.Errorf("Expected %v, got %v", e, a)
+					}
+					t.Logf("Exited read")
+					close(done)
+				}()
+				select {
+				case err := <-errc:
+					t.Fatal(err)
+				case <-done:
+				}
 
-		decoder.Close()
+				done = make(chan struct{})
+				go func() {
+					_, _, err := decoder.Decode()
+					if err == nil {
+						t.Errorf("Unexpected nil error")
+					}
+					close(done)
+				}()
+				<-done
+
+				decoder.Close()
+			}
+		})
 	}
 }
 
 func TestDecoder_SourceClose(t *testing.T) {
-	out, in := io.Pipe()
-	decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+	tests := []struct {
+		name                               string
+		clientsConcurrentWatchObjectDecode bool
+	}{
+		{
+			name:                               "disable clientsConcurrentWatchObjectDecode",
+			clientsConcurrentWatchObjectDecode: false,
+		},
+		{
+			name:                               "enable clientsConcurrentWatchObjectDecode",
+			clientsConcurrentWatchObjectDecode: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsConcurrentWatchObjectDecode, test.clientsConcurrentWatchObjectDecode)
+			out, in := io.Pipe()
+			decoder := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
 
-	done := make(chan struct{})
+			done := make(chan struct{})
+
+			go func() {
+				_, _, err := decoder.Decode()
+				if err == nil {
+					t.Errorf("Unexpected nil error")
+				}
+				close(done)
+			}()
+
+			in.Close()
+
+			select {
+			case <-done:
+				break
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Error("Timeout")
+			}
+		})
+	}
+}
+
+func TestDecoder_ConcurrentDecode(t *testing.T) {
+	out, in := io.Pipe()
+	d := NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
+	encoder := json.NewEncoder(in)
+
+	table := []watch.EventType{watch.Added, watch.Deleted, watch.Modified, watch.Error, watch.Bookmark}
+	eventList := []metav1.WatchEvent{}
+	expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+	for _, eventType := range table {
+		data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+			return
+		}
+		eventList = append(eventList, metav1.WatchEvent{
+			Type:   string(eventType),
+			Object: runtime.RawExtension{Raw: json.RawMessage(data)},
+		})
+	}
 
 	go func() {
-		_, _, err := decoder.Decode()
-		if err == nil {
-			t.Errorf("Unexpected nil error")
+		for _, event := range eventList {
+			if err := encoder.Encode(&event); err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
 		}
-		close(done)
+		in.Close()
 	}()
 
-	in.Close()
+	gotActions := []watch.EventType{}
+	for {
+		action, got, err := d.Decode()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Errorf("Unexpected error %v", err)
+			return
+		}
+		gotActions = append(gotActions, action)
+		if !apiequality.Semantic.DeepDerivative(expect, got) {
+			t.Errorf("Expected %v, got %v", expect, got)
+		}
+	}
 
-	select {
-	case <-done:
-		break
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Error("Timeout")
+	if !apiequality.Semantic.DeepDerivative(table, gotActions) {
+		t.Errorf("Expected %v, got %v", table, gotActions)
 	}
 }

--- a/staging/src/k8s.io/client-go/rest/watch/main_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/main_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	// Bail out early when -help was given as parameter.
+	flag.Parse()
+
+	// Must be called *before* creating new goroutines.
+	goleakOpts := []goleak.Option{
+		goleak.IgnoreCurrent(),
+	}
+
+	result := m.Run()
+
+	if err := goleak.Find(goleakOpts...); err != nil {
+		fmt.Fprintf(os.Stderr, "leaked Goroutines: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(result)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

@serathius introduced the feature gate ConcurrentWatchObjectDecode, which helps mitigate watch cache starvation. . For example, `Fast watcher, slow processing. Probably caused by slow decoding, user not receiving fast, or other processing logic`.

We ran some watch benchmarks and found that performance was bottlenecked by network writes. Upon deeper analysis, we discovered that the client performs network reads and decoding sequentially, which causes blocking in event delivery.

This change introduces ClientConcurrentWatchObjectDecode, similar to ConcurrentWatchObjectDecode, which enables concurrent network reading and decoding. In our tests, it doubles the event delivery throughput and helps mitigate `watcher closed caused by unresponsiveness`.

https://gist.github.com/chenk008/df8775a885667b393b67ea8790ae2b1b is benchmark script.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc @serathius