### PR TITLE
Fix deterministic scope list output for DV tags (#137405)

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package validators
 
 import (
+	"cmp"
+	"slices"
 	"strings"
 	"testing"
 
 	"k8s.io/gengo/v2/codetags"
+	"k8s.io/gengo/v2/generator"
 )
 
 func TestTypeCheck(t *testing.T) {
@@ -215,5 +218,18 @@ func TestTypeCheck(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestTagDocScopesAreSorted ensures that all registered tag validators return
+// sorted scope lists from Docs().Scopes. This guarantees deterministic output
+// when generating validation code and docs (see kubernetes/kubernetes#137405).
+func TestTagDocScopesAreSorted(t *testing.T) {
+	validator := InitGlobalValidator(&generator.Context{}, nil)
+	docs := validator.Docs()
+	for _, d := range docs {
+		if !slices.IsSortedFunc(d.Scopes, func(a, b Scope) int { return cmp.Compare(string(a), string(b)) }) {
+			t.Errorf("tag %q: Docs().Scopes is not sorted (got %v); use sets.List() for deterministic output", d.Tag, d.Scopes)
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Makes DV tag scope lists deterministic by using `sets.List()` instead of `UnsortedList()` when building `TagDoc.Scopes` in all tag validators. `UnsortedList()` relies on map iteration order, which is not guaranteed in Go, so generated validation code and docs could change between runs and cause noisy diffs. `sets.List()` returns a sorted slice so the same set always produces the same order.

- Replaced `ValidScopes().UnsortedList()` with `sets.List(ValidScopes())` in every tag validator’s `Docs()` under `cmd/validation-gen/validators`.
- Added `TestTagDocScopesAreSorted` to ensure all registered tags return sorted `Docs().Scopes` and prevent regressions.

#### Which issue(s) this PR is related to:

Fixes #137405

#### Special notes for your reviewer:

Scope is limited to DV tag **scopes** only (per issue). Update-tag constraint lists, `supportedSubresources`, and `testFixtureTagValues` were not changed.

#### Does this PR introduce a user-facing change?
No

```release-note
NONE
```
