### PR TITLE
scheduler: add metric to measure pod preemption wait time

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -558,6 +558,11 @@ type QueuedPodInfo struct {
 	// or doesn't belong to any pod group.
 	// This field can only be set to true when GenericWorkload feature flag is enabled.
 	NeedsPodGroupScheduling bool
+	// NominationTimestamp is the time when the pod was first nominated to a node via
+	// a PostFilter plugin (e.g. preemption). It's used to measure how long the pod
+	// waited for victims to be evicted before it was successfully bound.
+	// It shouldn't be updated once initialized.
+	NominationTimestamp *time.Time
 }
 
 func (pqi *QueuedPodInfo) GetPodInfo() fwk.PodInfo {
@@ -619,6 +624,7 @@ func (pqi *QueuedPodInfo) DeepCopy() *QueuedPodInfo {
 		InitialAttemptTimestamp: pqi.InitialAttemptTimestamp,
 		UnschedulablePlugins:    pqi.UnschedulablePlugins.Clone(),
 		BackoffExpiration:       pqi.BackoffExpiration,
+		NominationTimestamp:     pqi.NominationTimestamp,
 		GatingPlugin:            pqi.GatingPlugin,
 		GatingPluginEvents:      slices.Clone(pqi.GatingPluginEvents),
 		PendingPlugins:          pqi.PendingPlugins.Clone(),

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -113,12 +113,13 @@ const (
 	BatchFlushPodNotBatchable = "pod_not_batchable"
 )
 
-// All the histogram based metrics have 1ms as size for the smallest bucket.
+// All the histogram based metrics have 1ms as size for the smallest bucket (except NominationToBindingDuration duration).
 var (
 	scheduleAttempts             *metrics.CounterVec
 	EventHandlingLatency         *metrics.HistogramVec
 	schedulingLatency            *metrics.HistogramVec
 	SchedulingAlgorithmLatency   *metrics.Histogram
+	NominationToBindingDuration  *metrics.Histogram
 	PreemptionVictims            *metrics.Histogram
 	PreemptionAttempts           *metrics.Counter
 	pendingPods                  *metrics.GaugeVec
@@ -236,6 +237,14 @@ func InitMetrics() {
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+	NominationToBindingDuration = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "nomination_to_binding_duration_seconds",
+			Help:           "Duration in seconds from when a pod is first nominated to a node via a PostFilter plugin to when it is successfully bound.",
+			Buckets:        metrics.ExponentialBuckets(1, 2, 10),
+			StabilityLevel: metrics.ALPHA,
+		})
 	PreemptionVictims = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
@@ -503,6 +512,7 @@ func InitMetrics() {
 		schedulingLatency,
 		SchedulingAlgorithmLatency,
 		EventHandlingLatency,
+		NominationToBindingDuration,
 		PreemptionVictims,
 		PreemptionAttempts,
 		pendingPods,

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/utils/clock"
 	utiltrace "k8s.io/utils/trace"
 )
 
@@ -482,6 +483,11 @@ func (sched *Scheduler) bindingCycle(
 	metrics.PodSchedulingAttempts.Observe(float64(assumedPodInfo.Attempts))
 	if assumedPodInfo.InitialAttemptTimestamp != nil {
 		metrics.PodSchedulingSLIDuration.WithLabelValues(getAttemptsLabel(assumedPodInfo)).Observe(metrics.SinceInSeconds(*assumedPodInfo.InitialAttemptTimestamp))
+	}
+	if assumedPodInfo.NominationTimestamp != nil {
+		nominationToBindingSecs := metrics.SinceInSeconds(*assumedPodInfo.NominationTimestamp)
+		logger.V(4).Info("nomination to binding duration", "pod", klog.KObj(assumedPod), "nominationToBindingDurationSecs", nominationToBindingSecs)
+		metrics.NominationToBindingDuration.Observe(nominationToBindingSecs)
 	}
 	// Count pods scheduled after being flushed from unschedulablePods
 	if assumedPodInfo.WasFlushedFromUnschedulable {
@@ -1249,6 +1255,7 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 			// and we can't fix the validation for backwards compatibility.
 			podInfo.PodInfo, _ = framework.NewPodInfo(cachedPod.DeepCopy())
 			pod = podInfo.Pod
+			maybeSetNominationTimestamp(podInfo, nominatingInfo, clock.RealClock{})
 			if err := sched.SchedulingQueue.AddUnschedulableIfNotPresent(logger, podInfo, sched.SchedulingQueue.SchedulingCycle()); err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred")
 			}
@@ -1320,4 +1327,16 @@ func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.AP
 		podStatusCopy.NominatedNodeName = nominatingInfo.NominatedNodeName
 	}
 	return util.PatchPodStatus(ctx, client, pod.Name, pod.Namespace, &pod.Status, podStatusCopy)
+}
+
+// maybeSetNominationTimestamp records the time a pod was first nominated to a node via a PostFilter plugin.
+// It is a no-op if the nomination didn't succeed or the timestamp was already set.
+func maybeSetNominationTimestamp(podInfo *framework.QueuedPodInfo, nominatingInfo *fwk.NominatingInfo, clk clock.Clock) {
+	if podInfo.NominationTimestamp == nil &&
+		nominatingInfo != nil &&
+		nominatingInfo.Mode() == fwk.ModeOverride &&
+		nominatingInfo.NominatedNodeName != "" {
+		now := clk.Now()
+		podInfo.NominationTimestamp = &now
+	}
 }

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -83,6 +83,7 @@ import (
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
+	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -4825,6 +4826,65 @@ func TestEvaluateNominatedNode(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.wantNodeList, gotNodeNames, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Unexpected nodes (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMaybeSetNominationTimestamp(t *testing.T) {
+	existingTimestamp := time.Now().Add(-time.Minute)
+	fakeNow := time.Now()
+
+	tests := []struct {
+		name              string
+		existingTimestamp *time.Time
+		nominatingInfo    *fwk.NominatingInfo
+		expectedTimestamp *time.Time
+	}{
+		{
+			name:           "nil nominatingInfo does not set timestamp",
+			nominatingInfo: nil,
+		},
+		{
+			name:           "ModeNoop does not set timestamp",
+			nominatingInfo: &fwk.NominatingInfo{NominatingMode: fwk.ModeNoop},
+		},
+		{
+			name: "ModeOverride with empty NominatedNodeName does not set timestamp",
+			nominatingInfo: &fwk.NominatingInfo{
+				NominatingMode:    fwk.ModeOverride,
+				NominatedNodeName: "",
+			},
+		},
+		{
+			name: "ModeOverride with non-empty NominatedNodeName sets timestamp",
+			nominatingInfo: &fwk.NominatingInfo{
+				NominatingMode:    fwk.ModeOverride,
+				NominatedNodeName: "node1",
+			},
+			expectedTimestamp: &fakeNow,
+		},
+		{
+			name:              "existing timestamp is not overwritten on re-nomination",
+			existingTimestamp: &existingTimestamp,
+			nominatingInfo: &fwk.NominatingInfo{
+				NominatingMode:    fwk.ModeOverride,
+				NominatedNodeName: "node1",
+			},
+			expectedTimestamp: &existingTimestamp,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podInfo := &framework.QueuedPodInfo{
+				PodInfo:             mustNewPodInfo(t, st.MakePod().Name("p").Namespace("ns").UID("p").Obj()),
+				NominationTimestamp: tt.existingTimestamp,
+			}
+
+			maybeSetNominationTimestamp(podInfo, tt.nominatingInfo, testingclock.NewFakeClock(fakeNow))
+			if diff := cmp.Diff(tt.expectedTimestamp, podInfo.NominationTimestamp, cmpopts.EquateApproxTime(0)); diff != "" {
+				t.Errorf("unexpected NominationTimestamp (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR instruments a new histogram metric in the scheduler that records the duration from the time a pod first has a `nominatedNode` set to the time the binding cycle successfully completes, e.g.

```
nomination_to_binding_duration_seconds = time of successful bind - time of first successful nomination
```

More details in https://github.com/kubernetes/kubernetes/issues/137440 for motivation, but essentially we have clusters that rely very heavily on preemption and need some way to quantify impact of increasing usage of lower priority pods. Our clusters are multi-tenanted, so the log line helps us qualify the impact by tenant.

I decided to call it `nomination_to_binding` instead of `preemption_to_binding` since technically it's what the metric is recording, and there could be out-of-tree plugins that nominate a node.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/137440

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
scheduler: add metric to measure pod preemption wait time
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
