### PR TITLE
Canonically parse int/bool tag payloads in validation-gen

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util.go
@@ -137,3 +137,19 @@ func ParseInt(val string) (int, error) {
 
 	return intVal, nil
 }
+
+// ParseBool strictly parses a bool from a string input,
+// ensuring that when converted back to a string via strconv.FormatBool,
+// the resulting string and the input string match.
+// Only the canonical forms "true" and "false" are accepted.
+func ParseBool(val string) (bool, error) {
+	b, err := strconv.ParseBool(val)
+	if err != nil {
+		return false, fmt.Errorf("parsing %q as bool: %w", val, err)
+	}
+	// Reject non-canonical forms: FormatBool(true)=="true", FormatBool(false)=="false"
+	if strconv.FormatBool(b) != val {
+		return false, fmt.Errorf("parsing %q as bool: only canonical forms %q and %q are accepted", val, "true", "false")
+	}
+	return b, nil
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util_test.go
@@ -504,3 +504,67 @@ func TestParseInt(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBool(t *testing.T) {
+	type testcase struct {
+		name          string
+		in            string
+		expectedOut   bool
+		expectedError bool
+	}
+
+	testcases := []testcase{
+		{
+			name:          "canonical true",
+			in:            "true",
+			expectedOut:   true,
+			expectedError: false,
+		},
+		{
+			name:          "canonical false",
+			in:            "false",
+			expectedOut:   false,
+			expectedError: false,
+		},
+		{
+			name:          "non-canonical 1",
+			in:            "1",
+			expectedOut:   false,
+			expectedError: true,
+		},
+		{
+			name:          "non-canonical 0",
+			in:            "0",
+			expectedOut:   false,
+			expectedError: true,
+		},
+		{
+			name:          "non-canonical True",
+			in:            "True",
+			expectedOut:   false,
+			expectedError: true,
+		},
+		{
+			name:          "invalid",
+			in:            "notabool",
+			expectedOut:   false,
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := ParseBool(tc.in)
+			switch {
+			case tc.expectedError && err == nil:
+				t.Error("expected an error but did not receive one")
+			case !tc.expectedError && err != nil:
+				t.Errorf("received an unexpected error: %v", err)
+			}
+
+			if out != tc.expectedOut {
+				t.Errorf("expected an output value of %v but got %v", tc.expectedOut, out)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/discriminator.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/discriminator.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
-	"strconv"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/code-generator/cmd/validation-gen/util"
@@ -451,18 +450,18 @@ func convertDiscriminatorValue(val string, discType *types.Type) (any, error) {
 	case "string":
 		return val, nil
 	case "bool":
-		b, err := strconv.ParseBool(val)
+		b, err := util.ParseBool(val)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse %q as bool: %w", val, err)
 		}
 		return b, nil
 	default:
 		if types.IsInteger(nt) {
-			i, err := strconv.ParseInt(val, 10, 64)
+			i, err := util.ParseInt(val)
 			if err != nil {
 				return nil, fmt.Errorf("cannot parse %q as integer: %w", val, err)
 			}
-			return int(i), nil
+			return i, nil
 		}
 		return nil, fmt.Errorf("unsupported discriminator type: %s", nt.Name.Name)
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/equality.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/equality.go
@@ -18,7 +18,6 @@ package validators
 
 import (
 	"fmt"
-	"strconv"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/code-generator/cmd/validation-gen/util"
@@ -75,7 +74,7 @@ func (v neqTagValidator) GetValidations(context Context, tag codetags.Tag) (Vali
 		if tag.ValueType != codetags.ValueTypeBool {
 			return Validations{}, fmt.Errorf("type mismatch: field is a bool, but payload is of type %s", tag.ValueType)
 		}
-		disallowedValue, err = strconv.ParseBool(tag.Value)
+		disallowedValue, err = util.ParseBool(tag.Value)
 		if err != nil {
 			return Validations{}, fmt.Errorf("invalid bool value for payload: %w", err)
 		}
@@ -83,7 +82,7 @@ func (v neqTagValidator) GetValidations(context Context, tag codetags.Tag) (Vali
 		if tag.ValueType != codetags.ValueTypeInt {
 			return Validations{}, fmt.Errorf("type mismatch: field is an integer, but payload is of type %s", tag.ValueType)
 		}
-		disallowedValue, err = strconv.Atoi(tag.Value)
+		disallowedValue, err = util.ParseInt(tag.Value)
 		if err != nil {
 			return Validations{}, fmt.Errorf("invalid integer value for payload: %w", err)
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/item.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/item.go
@@ -18,7 +18,6 @@ package validators
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -231,13 +230,13 @@ func parseTypedValue(value string, argType codetags.ArgType) (any, codetags.Valu
 	case codetags.ArgTypeString:
 		return value, codetags.ValueTypeString, nil
 	case codetags.ArgTypeInt:
-		intVal, err := strconv.Atoi(value)
+		intVal, err := util.ParseInt(value)
 		if err != nil {
 			return nil, "", fmt.Errorf("invalid integer: %w", err)
 		}
 		return intVal, codetags.ValueTypeInt, nil
 	case codetags.ArgTypeBool:
-		boolVal, err := strconv.ParseBool(value)
+		boolVal, err := util.ParseBool(value)
 		if err != nil {
 			return nil, "", fmt.Errorf("invalid boolean: %w", err)
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -18,7 +18,6 @@ package validators
 
 import (
 	"fmt"
-	"strconv"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/code-generator/cmd/validation-gen/util"
@@ -175,7 +174,7 @@ func (maxItemsTagValidator) GetValidations(context Context, tag codetags.Tag) (V
 		return Validations{}, fmt.Errorf("can only be used on list types (%s)", rootTypeString(context.Type, t))
 	}
 
-	intVal, err := strconv.Atoi(tag.Value)
+	intVal, err := util.ParseInt(tag.Value)
 	if err != nil {
 		return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
 	}
@@ -227,7 +226,7 @@ func (minimumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 		return result, fmt.Errorf("can only be used on integer types (%s)", rootTypeString(context.Type, t))
 	}
 
-	intVal, err := strconv.Atoi(tag.Value)
+	intVal, err := util.ParseInt(tag.Value)
 	if err != nil {
 		return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Declarative validation (validation-gen) was parsing integer and boolean tag payloads in a non-canonical way. This change:

- Adds `util.ParseBool`, which accepts only `"true"` and `"false"` so that parsing and then formatting back to string matches the original input. Values like `"1"`, `"0"`, `"True"` are no longer accepted.
- Replaces all direct `strconv.Atoi` / `strconv.ParseInt` usage for tag payloads with `util.ParseInt` (equality, limits, item, discriminator).
- Replaces all `strconv.ParseBool` usage for tag payloads with `util.ParseBool` (equality, item, discriminator).

So tag payloads are parsed canonically and round-trip correctly.

#### Which issue(s) this PR is related to:
Fixes #137406

#### Special notes for your reviewer:

No behavioral change for valid inputs (canonical integers and `"true"`/`"false"`). Non-canonical payloads (e.g. `k8s:neq=1` for a bool field, or `k8s:maxLength=0100`) will now fail at codegen with a clear error instead of being accepted.

#### Does this PR introduce a user-facing change?
No

```release-note
NONE
```

