### PR TITLE
Integrate TAS logic into the pod group scheduling cycle

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -233,6 +233,8 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 
 // algorithmResult stores the scheduling result and status for a scheduling attempt of a single pod.
 type algorithmResult struct {
+	// pod is the pod the result applies to.
+	pod *v1.Pod
 	// scheduleResult is a scheduling algorithm result.
 	scheduleResult ScheduleResult
 	// podCtx is a specific pod scheduling context used for the scheduling algorithm.
@@ -246,6 +248,14 @@ type algorithmResult struct {
 	// permitStatus is a status of the permit check.
 	// This is only set when the `status` is success or the `requiresPreemption` is true.
 	permitStatus *fwk.Status
+}
+
+func (ar *algorithmResult) GetPod() *v1.Pod {
+	return ar.pod
+}
+
+func (ar *algorithmResult) GetNodeName() string {
+	return ar.scheduleResult.SuggestedHost
 }
 
 // podGroupAlgorithmResult stores the scheduling pod scheduling results for a pod group
@@ -348,6 +358,7 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 		} else {
 			// In case of pod being just unschedulable or having an error, just return now.
 			return algorithmResult{
+				pod:                pod,
 				scheduleResult:     scheduleResult,
 				podCtx:             podCtx,
 				schedulingDuration: time.Since(start),
@@ -358,6 +369,7 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 	assumedPodInfo, assumeStatus := sched.assumeAndReserve(ctx, podCtx.state, schedFwk, podInfo, scheduleResult)
 	if !assumeStatus.IsSuccess() {
 		return algorithmResult{
+			pod:                pod,
 			scheduleResult:     ScheduleResult{nominatingInfo: clearNominatedNode},
 			podCtx:             podCtx,
 			schedulingDuration: time.Since(start),
@@ -388,6 +400,7 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 			permitStatus = fwk.NewStatus(permitStatus.Code()).WithError(fitErr)
 		}
 		return algorithmResult{
+			pod:                pod,
 			scheduleResult:     ScheduleResult{nominatingInfo: clearNominatedNode},
 			podCtx:             podCtx,
 			schedulingDuration: time.Since(start),
@@ -396,6 +409,7 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 	}
 
 	return algorithmResult{
+		pod:                pod,
 		scheduleResult:     scheduleResult,
 		podCtx:             podCtx,
 		schedulingDuration: time.Since(start),
@@ -562,13 +576,6 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 	}
 }
 
-// placementResult associates pod group algorithm result with the placement.
-// The placement information can be used by the placement score plugins.
-type placementResult struct {
-	podGroupAlgorithmResult
-	placement *fwk.Placement
-}
-
 // podGroupSchedulingPlacementAlgorithm tries several different combinations for scheduling the pod group and selects the best one.
 // First it runs placement generator plugins to create a list of placements.
 // Placement is a set of nodes that will be considered when scheduling a pod group.
@@ -583,17 +590,20 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 		}
 	}
 
-	// TODO: kubernetes/enhancements#5732 - run placement generator plugins to get the set of placements
-	placements := []*fwk.Placement{
-		{
-			Nodes: allNodes,
-		},
+	podGroupCycleState := framework.NewCycleState()
+	// For now, always record plugin metrics until we understand its impact on performance.
+	podGroupCycleState.SetRecordPluginMetrics(true)
+	placements, status := schedFwk.RunPlacementGeneratePlugins(ctx, podGroupCycleState, podGroupInfo.PodGroupInfo, allNodes)
+	if !status.IsSuccess() {
+		return podGroupAlgorithmResult{
+			status: status,
+		}
 	}
 
-	results := make([]placementResult, len(placements))
-	successfulResults := make([]placementResult, 0, len(placements))
+	var anyResult *podGroupAlgorithmResult
+	successfulResults := make(map[*fwk.Placement]*podGroupAlgorithmResult)
 
-	for i, placement := range placements {
+	for _, placement := range placements {
 		logger.V(4).Info("Assuming placement in snapshot", "placement", placement.Name)
 		err := sched.nodeInfoSnapshot.AssumePlacement(placement)
 		if err != nil {
@@ -607,24 +617,87 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 			return result
 		}
 
-		results[i] = placementResult{
-			podGroupAlgorithmResult: result,
-			placement:               placement,
+		if anyResult == nil {
+			anyResult = &result
 		}
 
 		if result.status.IsSuccess() || result.waitingOnPreemption {
-			successfulResults = append(successfulResults, results[i])
+			successfulResults[placement] = &result
 		}
 	}
 
 	if len(successfulResults) == 0 {
 		// We need to send events and set the status for pods in case all simulations were infeasible.
 		// The selection of which simulation we report is arbitrary for now, but may change in the future.
-		return results[0].podGroupAlgorithmResult
+		anyResult.status = fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("0/%d placements are available, first placement status: %v", len(placements), anyResult.status.AsError()))
+		return *anyResult
 	}
 
-	// TODO: kubernetes/enhancements#5732 - run placement scorer plugins to select the best placement
-	return successfulResults[0].podGroupAlgorithmResult
+	if len(successfulResults) == 1 {
+		for _, result := range successfulResults {
+			return *result
+		}
+	}
+
+	bestPlacement, status := sched.findBestPlacement(ctx, schedFwk, podGroupCycleState, podGroupInfo, successfulResults)
+	if !status.IsSuccess() {
+		return podGroupAlgorithmResult{
+			status: status,
+		}
+	}
+
+	return *successfulResults[bestPlacement]
+}
+
+// findBestPlacement uses PlacementScore plugins to determine the best placement based on the scheduling results.
+func (sched *Scheduler) findBestPlacement(ctx context.Context, schedFwk framework.Framework, podGroupCycleState fwk.PodGroupCycleState, podGroupInfo *framework.QueuedPodGroupInfo, successfulResults map[*fwk.Placement]*podGroupAlgorithmResult) (*fwk.Placement, *fwk.Status) {
+	placementPodGroupAssignments := makePodGroupAssignments(successfulResults)
+
+	scores, status := schedFwk.RunPlacementScorePlugins(ctx, podGroupCycleState, podGroupInfo, placementPodGroupAssignments)
+	if !status.IsSuccess() {
+		return nil, status
+	}
+
+	for i := range scores {
+		scores[i].Randomizer = rand.Int()
+	}
+
+	loggerVTen := klog.FromContext(ctx).V(10)
+	if loggerVTen.Enabled() {
+		for _, score := range scores {
+			for _, pluginScore := range score.Scores {
+				loggerVTen.Info("Plugin scored placement for podGroup", "podGroup", klog.KObj(podGroupInfo), "plugin", pluginScore.Name, "placement", score.Placement.Name, "score", pluginScore.Score)
+			}
+			loggerVTen.Info("Calculated placement's final score for podGroup", "podGroup", klog.KObj(podGroupInfo), "placement", score.Placement.Name, "score", score.TotalScore)
+		}
+	}
+
+	bestScore := &scores[0]
+	for _, score := range scores[1:] {
+		if score.TotalScore > bestScore.TotalScore ||
+			score.TotalScore == bestScore.TotalScore &&
+				score.Randomizer > bestScore.Randomizer {
+			bestScore = &score
+		}
+	}
+	return bestScore.Placement, nil
+}
+
+func makePodGroupAssignments(successfulResults map[*fwk.Placement]*podGroupAlgorithmResult) []*fwk.PodGroupAssignments {
+	placementPodGroupAssignments := make([]*fwk.PodGroupAssignments, 0, len(successfulResults))
+	for placement, result := range successfulResults {
+		proposedAssignments := make([]fwk.ProposedAssignment, 0)
+		for _, algorithmResult := range result.podResults {
+			if algorithmResult.GetNodeName() != "" {
+				proposedAssignments = append(proposedAssignments, &algorithmResult)
+			}
+		}
+		placementPodGroupAssignments = append(placementPodGroupAssignments, &fwk.PodGroupAssignments{
+			Placement:           placement,
+			ProposedAssignments: proposedAssignments,
+		})
+	}
+	return placementPodGroupAssignments
 }
 
 // podGroupSchedulingAlgorithm attempts to schedule pods in the pod group according to the policy and constraints and returns the scheduling result for each pod in the pod group.

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -1902,3 +1902,453 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		})
 	}
 }
+
+// fakePlacementPlugin simulates Filter, PlacementGenerate and PlacementScore behaviors for PodGroup placement scheduling testing.
+type fakePlacementPlugin struct {
+	name                     string
+	filterStatus             map[string]*fwk.Status
+	generatePlacementsResult map[string][]string
+	generatePlacementsStatus *fwk.Status
+	scorePlacementsResult    map[string]int64
+	scorePlacementsStatus    map[string]*fwk.Status
+}
+
+var _ fwk.FilterPlugin = &fakePlacementPlugin{}
+var _ fwk.PlacementGeneratePlugin = &fakePlacementPlugin{}
+var _ fwk.PlacementScorePlugin = &fakePlacementPlugin{}
+
+func (mp *fakePlacementPlugin) Name() string { return mp.name }
+
+func (mp *fakePlacementPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+	return mp.filterStatus[nodeInfo.Node().Name]
+}
+
+func (mp *fakePlacementPlugin) PlacementScoreExtensions() fwk.PlacementScoreExtensions {
+	return nil
+}
+
+func (mp *fakePlacementPlugin) ScorePlacement(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, placement *fwk.PodGroupAssignments) (int64, *fwk.Status) {
+	return mp.scorePlacementsResult[placement.Name], mp.scorePlacementsStatus[placement.Name]
+}
+
+func (mp *fakePlacementPlugin) GeneratePlacements(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, parentPlacement *fwk.Placement) (*fwk.GeneratePlacementsResult, *fwk.Status) {
+	parentNodes := map[string]fwk.NodeInfo{}
+	for _, node := range parentPlacement.Nodes {
+		parentNodes[node.Node().Name] = node
+	}
+
+	placements := make([]*fwk.Placement, 0, len(mp.generatePlacementsResult))
+	for placementName, nodeNames := range mp.generatePlacementsResult {
+		placement := &fwk.Placement{Name: placementName}
+		for _, nodeName := range nodeNames {
+			placement.Nodes = append(placement.Nodes, parentNodes[nodeName])
+		}
+		placements = append(placements, placement)
+	}
+	return &fwk.GeneratePlacementsResult{Placements: placements}, mp.generatePlacementsStatus
+}
+
+var statusCmpOpt = cmp.Comparer(func(s1 *fwk.Status, s2 *fwk.Status) bool {
+	if s1 == nil || s2 == nil {
+		return s1.IsSuccess() && s2.IsSuccess()
+	}
+	if s1.Code() == fwk.Error {
+		return s1.AsError().Error() == s2.AsError().Error()
+	}
+	return s1.Code() == s2.Code() && s1.Plugin() == s2.Plugin() && s1.Message() == s2.Message()
+})
+
+func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.TopologyAwareWorkloadScheduling: true,
+		features.GenericWorkload:                 true,
+	})
+
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+	}
+	podGroupPod := st.MakePod().Name("foo").UID("foo").PodGroupName("pg").Obj()
+
+	tests := map[string]struct {
+		placementPlugin fakePlacementPlugin
+		expectedResult  podGroupAlgorithmResult
+	}{
+		"respects higher score of placement1": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string][]string{
+					"placement1": {nodes[0].Name},
+					"placement2": {nodes[1].Name},
+				},
+				scorePlacementsResult: map[string]int64{
+					"placement1": 2,
+					"placement2": 1,
+				},
+			},
+			expectedResult: podGroupAlgorithmResult{
+				podResults: []algorithmResult{
+					{
+						pod: podGroupPod,
+						scheduleResult: ScheduleResult{
+							SuggestedHost:  nodes[0].Name,
+							EvaluatedNodes: 1,
+							FeasibleNodes:  1,
+						},
+					},
+				},
+				status: nil,
+			},
+		},
+		"respects higher score of placement2": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string][]string{
+					"placement1": {nodes[0].Name},
+					"placement2": {nodes[1].Name},
+				},
+				scorePlacementsResult: map[string]int64{
+					"placement1": 1,
+					"placement2": 2,
+				},
+			},
+			expectedResult: podGroupAlgorithmResult{
+				podResults: []algorithmResult{
+					{
+						pod: podGroupPod,
+						scheduleResult: ScheduleResult{
+							SuggestedHost:  nodes[1].Name,
+							EvaluatedNodes: 1,
+							FeasibleNodes:  1,
+						},
+					},
+				},
+				status: nil,
+			},
+		},
+		"when no placements are generated, returns unschedulable": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string][]string{},
+			},
+			expectedResult: podGroupAlgorithmResult{
+				status: fwk.NewStatus(fwk.Unschedulable, "no feasible placements found").WithPlugin("FakePlacementPlugin"),
+			},
+		},
+		"when all placements are infeasible, returns unschedulable": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string][]string{
+					"placement1": {nodes[0].Name},
+					"placement2": {nodes[1].Name},
+				},
+				scorePlacementsResult: map[string]int64{
+					"placement1": 1,
+					"placement2": 2,
+				},
+				filterStatus: map[string]*fwk.Status{
+					nodes[0].Name: fwk.NewStatus(fwk.Unschedulable),
+					nodes[1].Name: fwk.NewStatus(fwk.Unschedulable),
+				},
+			},
+			expectedResult: podGroupAlgorithmResult{
+				podResults: []algorithmResult{
+					{
+						pod: podGroupPod,
+						scheduleResult: ScheduleResult{
+							EvaluatedNodes: 0,
+							FeasibleNodes:  0,
+							nominatingInfo: &fwk.NominatingInfo{NominatingMode: fwk.ModeOverride},
+						},
+						status: fwk.NewStatus(fwk.Unschedulable, "0/1 nodes are available:"),
+					},
+				},
+				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: pod group is unschedulable"),
+			},
+		},
+		"filters out infeasible placements": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string][]string{
+					"placement1": {nodes[0].Name},
+					"placement2": {nodes[1].Name},
+				},
+				scorePlacementsResult: map[string]int64{
+					"placement1": 1,
+				},
+				filterStatus: map[string]*fwk.Status{
+					nodes[1].Name: fwk.NewStatus(fwk.Unschedulable),
+				},
+			},
+			expectedResult: podGroupAlgorithmResult{
+				podResults: []algorithmResult{
+					{
+						pod: podGroupPod,
+						scheduleResult: ScheduleResult{
+							SuggestedHost:  nodes[0].Name,
+							EvaluatedNodes: 1,
+							FeasibleNodes:  1,
+						},
+					},
+				},
+				status: nil,
+			},
+		},
+		"when generate plugin fails, returns error": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsStatus: fwk.NewStatus(fwk.Error, "error for test"),
+			},
+			expectedResult: podGroupAlgorithmResult{
+				status: fwk.NewStatus(fwk.Error, "error for test").WithPlugin("FakePlacementPlugin"),
+			},
+		},
+		"when score plugin fails, returns error": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string][]string{
+					"placement1": {nodes[0].Name},
+					"placement2": {nodes[1].Name},
+				},
+				scorePlacementsResult: map[string]int64{
+					"placement1": 1,
+				},
+				scorePlacementsStatus: map[string]*fwk.Status{
+					"placement2": fwk.NewStatus(fwk.Error, "error for test"),
+				},
+			},
+			expectedResult: podGroupAlgorithmResult{
+				status: fwk.NewStatus(fwk.Error, "running PlacementScore plugins: plugin \"FakePlacementPlugin\" failed with: error for test").WithPlugin("FakePlacementPlugin"),
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(), 0)
+			queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+
+			tt.placementPlugin.name = "FakePlacementPlugin"
+
+			registry := []tf.RegisterPluginFunc{
+				tf.RegisterPlacementGeneratePlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &tt.placementPlugin, nil
+				}),
+				tf.RegisterPlacementScorePlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &tt.placementPlugin, nil
+				}, 1),
+				tf.RegisterFilterPlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &tt.placementPlugin, nil
+				}),
+			}
+
+			snapshot := internalcache.NewEmptySnapshot()
+
+			schedFwk, err := tf.NewFramework(ctx,
+				append(registry,
+					tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+					tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				),
+				"test-scheduler",
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create new framework: %v", err)
+			}
+
+			cache := internalcache.New(ctx, nil, true)
+			for _, node := range nodes {
+				cache.AddNode(logger, node)
+			}
+
+			sched := &Scheduler{
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
+				SchedulingQueue:  queue,
+				Profiles:         profile.Map{"test-scheduler": schedFwk},
+			}
+			sched.SchedulePod = sched.schedulePod
+
+			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			pgInfo := &framework.QueuedPodGroupInfo{
+				QueuedPodInfos: []*framework.QueuedPodInfo{
+					{
+						PodInfo: &framework.PodInfo{Pod: podGroupPod},
+					},
+				},
+				PodGroupInfo: &framework.PodGroupInfo{
+					UnscheduledPods: []*v1.Pod{podGroupPod},
+				},
+			}
+
+			result := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, pgInfo)
+
+			opts := cmp.Options{
+				cmp.AllowUnexported(
+					podGroupAlgorithmResult{},
+					algorithmResult{},
+					ScheduleResult{},
+					fwk.Status{}),
+				cmpopts.IgnoreFields(algorithmResult{}, "podCtx", "schedulingDuration"),
+				statusCmpOpt,
+			}
+
+			if diff := cmp.Diff(tt.expectedResult, result, opts...); diff != "" {
+				t.Fatalf("Unexpected algorithm result (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.TopologyAwareWorkloadScheduling: true,
+		features.GenericWorkload:                 true,
+	})
+
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+	}
+	placements := map[string][]string{
+		"placement1": {nodes[0].Name},
+		"placement2": {nodes[1].Name},
+	}
+	podGroupPod := st.MakePod().Name("foo").UID("foo").PodGroupName("pg").Obj()
+
+	type pluginData struct {
+		weight               int32
+		scorePlacementResult map[string]int64
+		scorePlacementStatus map[string]*fwk.Status
+	}
+
+	tests := map[string]struct {
+		pluginData        []pluginData
+		expectedPlacement string
+	}{
+		"respects higher score of placement1": {
+			pluginData: []pluginData{
+				{
+					weight: 1,
+					scorePlacementResult: map[string]int64{
+						"placement1": 50,
+						"placement2": 75,
+					},
+				},
+				{
+					weight: 2,
+					scorePlacementResult: map[string]int64{
+						"placement1": 25,
+						"placement2": 10,
+					},
+				},
+			},
+			expectedPlacement: "placement1",
+		},
+		"respects higher score of placement2": {
+			pluginData: []pluginData{
+				{
+					weight: 1,
+					scorePlacementResult: map[string]int64{
+						"placement1": 75,
+						"placement2": 50,
+					},
+				},
+				{
+					weight: 2,
+					scorePlacementResult: map[string]int64{
+						"placement1": 10,
+						"placement2": 25,
+					},
+				},
+			},
+			expectedPlacement: "placement2",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(), 0)
+			queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+
+			placementPlugin := fakePlacementPlugin{
+				name:                     "FakeGeneratorPlugin",
+				generatePlacementsResult: placements,
+			}
+
+			registry := []tf.RegisterPluginFunc{
+				tf.RegisterPlacementGeneratePlugin(placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &placementPlugin, nil
+				}),
+				tf.RegisterFilterPlugin(placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &placementPlugin, nil
+				}),
+			}
+
+			for i, placementScorePluginData := range tt.pluginData {
+				plugin := fakePlacementPlugin{
+					name:                  fmt.Sprintf("FakeScorePlugin[%d]", i),
+					scorePlacementsResult: placementScorePluginData.scorePlacementResult,
+					scorePlacementsStatus: placementScorePluginData.scorePlacementStatus,
+				}
+
+				registry = append(registry, tf.RegisterPlacementScorePlugin(plugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &plugin, nil
+				}, placementScorePluginData.weight))
+			}
+
+			snapshot := internalcache.NewEmptySnapshot()
+
+			schedFwk, err := tf.NewFramework(ctx,
+				append(registry,
+					tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+					tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				),
+				"test-scheduler",
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create new framework: %v", err)
+			}
+
+			cache := internalcache.New(ctx, nil, true)
+			for _, node := range nodes {
+				cache.AddNode(logger, node)
+			}
+
+			sched := &Scheduler{
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
+				SchedulingQueue:  queue,
+				Profiles:         profile.Map{"test-scheduler": schedFwk},
+			}
+			sched.SchedulePod = sched.schedulePod
+
+			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			pgInfo := &framework.QueuedPodGroupInfo{
+				QueuedPodInfos: []*framework.QueuedPodInfo{
+					{
+						PodInfo: &framework.PodInfo{Pod: podGroupPod},
+					},
+				},
+				PodGroupInfo: &framework.PodGroupInfo{
+					UnscheduledPods: []*v1.Pod{podGroupPod},
+				},
+			}
+
+			result := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, pgInfo)
+
+			expectedHost := placements[tt.expectedPlacement][0]
+			actualHost := result.podResults[0].scheduleResult.SuggestedHost
+			if expectedHost != actualHost {
+				t.Fatalf("Unexpected algorithm result, expected placement %s with node %s, got node %s", tt.expectedPlacement, expectedHost, actualHost)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/testing/framework/framework_helpers.go
+++ b/pkg/scheduler/testing/framework/framework_helpers.go
@@ -98,6 +98,16 @@ func RegisterBindPlugin(pluginName string, pluginNewFunc runtime.PluginFactory) 
 	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "Bind")
 }
 
+// RegisterPlacementGeneratePlugin returns a function to register a PlacementGenerate Plugin to a given registry.
+func RegisterPlacementGeneratePlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
+	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "PlacementGenerate")
+}
+
+// RegisterPlacementScorePlugin returns a function to register a PlacementScore Plugin to a given registry.
+func RegisterPlacementScorePlugin(pluginName string, pluginNewFunc runtime.PluginFactory, weight int32) RegisterPluginFunc {
+	return RegisterPluginAsExtensionsWithWeight(pluginName, weight, pluginNewFunc, "PlacementScore")
+}
+
 // RegisterPluginAsExtensions returns a function to register a Plugin as given extensionPoints to a given registry.
 func RegisterPluginAsExtensions(pluginName string, pluginNewFunc runtime.PluginFactory, extensions ...string) RegisterPluginFunc {
 	return RegisterPluginAsExtensionsWithWeight(pluginName, 1, pluginNewFunc, extensions...)
@@ -150,6 +160,10 @@ func getPluginSetByExtension(plugins *schedulerapi.Plugins, extension string) *s
 		return &plugins.PreBind
 	case "PostBind":
 		return &plugins.PostBind
+	case "PlacementGenerate":
+		return &plugins.PlacementGenerate
+	case "PlacementScore":
+		return &plugins.PlacementScore
 	default:
 		return nil
 	}

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -1619,6 +1619,18 @@ func (wrapper *PodGroupWrapper) TemplateRef(templateName, workloadName string) *
 	return wrapper
 }
 
+// TopologyKey sets appropriate TopologyKey field in the SchedulingConstraints of the inner PodGroup.
+func (wrapper *PodGroupWrapper) TopologyKey(topologyKey string) *PodGroupWrapper {
+	wrapper.PodGroup.Spec.SchedulingConstraints = &schedulingapi.PodGroupSchedulingConstraints{
+		Topology: []schedulingapi.TopologyConstraint{
+			{
+				Key: topologyKey,
+			},
+		},
+	}
+	return wrapper
+}
+
 // WorkloadWrapper wraps a Workload inside.
 type WorkloadWrapper struct{ schedulingapi.Workload }
 

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -309,6 +309,9 @@ type PlacementPluginScores struct {
 	Scores []PluginScore
 	// TotalScore is the total score in Scores.
 	TotalScore int64
+	// Randomizer is used to provide randomness
+	// when randomizing placements within a common score.
+	Randomizer int
 }
 
 const (

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -18,6 +18,7 @@ package podgroup
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -114,8 +115,10 @@ func TestPodGroupScheduling(t *testing.T) {
 	}
 
 	tests := []struct {
-		name  string
-		steps []step
+		name string
+		// Enabling TAS disables preemption, therefore tests verifying preemption logic need to be run with TAS disabled.
+		disableTopologyAwareScheduling bool
+		steps                          []step
 	}{
 		{
 			name: "gang schedules when pod group and resources are available",
@@ -308,7 +311,8 @@ func TestPodGroupScheduling(t *testing.T) {
 			},
 		},
 		{
-			name: "gang schedules with preemption",
+			name:                           "gang schedules with preemption",
+			disableTopologyAwareScheduling: true,
 			steps: []step{
 				{
 					name:       "Create a low priority pod taking all resources",
@@ -407,7 +411,8 @@ func TestPodGroupScheduling(t *testing.T) {
 			},
 		},
 		{
-			name: "basic group schedules with preemption",
+			name:                           "basic group schedules with preemption",
+			disableTopologyAwareScheduling: true,
 			steps: []step{
 				{
 					name:       "Create a low priority pod taking all resources",
@@ -434,135 +439,142 @@ func TestPodGroupScheduling(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-				features.GenericWorkload: true,
-				features.GangScheduling:  true,
-			})
+		runWithTasFlagSettings := []bool{true, false}
+		if tt.disableTopologyAwareScheduling {
+			runWithTasFlagSettings = []bool{false}
+		}
+		for _, tasEnabled := range runWithTasFlagSettings {
+			t.Run(fmt.Sprintf("%s (TopologyAwareWorkloadScheduling enabled: %v)", tt.name, tasEnabled), func(t *testing.T) {
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.GenericWorkload:                 true,
+					features.GangScheduling:                  true,
+					features.TopologyAwareWorkloadScheduling: tasEnabled,
+				})
 
-			testCtx := testutils.InitTestSchedulerWithNS(t, "podgroup-scheduling",
-				// disable backoff
-				scheduler.WithPodMaxBackoffSeconds(0),
-				scheduler.WithPodInitialBackoffSeconds(0))
+				testCtx := testutils.InitTestSchedulerWithNS(t, "podgroup-scheduling",
+					// disable backoff
+					scheduler.WithPodMaxBackoffSeconds(0),
+					scheduler.WithPodInitialBackoffSeconds(0))
 
-			cs, ns := testCtx.ClientSet, testCtx.NS.Name
+				cs, ns := testCtx.ClientSet, testCtx.NS.Name
 
-			_, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
-			if err != nil {
-				t.Fatalf("Failed to create node: %v", err)
-			}
-
-			for _, w := range []*schedulingapi.Workload{workload, otherWorkload} {
-				wCopy := w.DeepCopy()
-				wCopy.Namespace = ns
-				if _, err := cs.SchedulingV1alpha2().Workloads(ns).Create(testCtx.Ctx, wCopy, metav1.CreateOptions{}); err != nil {
-					t.Fatalf("Failed to create workload %s: %v", wCopy.Name, err)
+				_, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Failed to create node: %v", err)
 				}
-			}
 
-			for i, step := range tt.steps {
-				t.Logf("Executing step %d: %s", i, step.name)
-				switch {
-				case step.createPods != nil:
-					for _, pod := range step.createPods {
-						p := pod.DeepCopy()
-						p.Namespace = ns
-						if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, p, metav1.CreateOptions{}); err != nil {
-							t.Fatalf("Step %d: Failed to create pod %s: %v", i, p.Name, err)
-						}
+				for _, w := range []*schedulingapi.Workload{workload, otherWorkload} {
+					wCopy := w.DeepCopy()
+					wCopy.Namespace = ns
+					if _, err := cs.SchedulingV1alpha2().Workloads(ns).Create(testCtx.Ctx, wCopy, metav1.CreateOptions{}); err != nil {
+						t.Fatalf("Failed to create workload %s: %v", wCopy.Name, err)
 					}
-				case step.createPodGroup != nil:
-					w := step.createPodGroup.DeepCopy()
-					w.Namespace = ns
-					if _, err := cs.SchedulingV1alpha2().PodGroups(ns).Create(testCtx.Ctx, w, metav1.CreateOptions{}); err != nil {
-						t.Fatalf("Step %d: Failed to create pod group %s: %v", i, w.Name, err)
-					}
-					// Ensure all next steps will see this pod group.
-					err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
-						func(_ context.Context) (bool, error) {
-							_, err := testCtx.InformerFactory.Scheduling().V1alpha2().PodGroups().Lister().PodGroups(ns).Get(w.Name)
-							if err != nil {
-								if apierrors.IsNotFound(err) {
-									return false, nil
-								}
-								return false, err
+				}
+
+				for i, step := range tt.steps {
+					t.Logf("Executing step %d: %s", i, step.name)
+					switch {
+					case step.createPods != nil:
+						for _, pod := range step.createPods {
+							p := pod.DeepCopy()
+							p.Namespace = ns
+							if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, p, metav1.CreateOptions{}); err != nil {
+								t.Fatalf("Step %d: Failed to create pod %s: %v", i, p.Name, err)
 							}
-							return true, nil
-						},
-					)
-					if err != nil {
-						t.Fatalf("Step %d: Failed to wait for pod group %s to be discoverable by scheduler: %v", i, w.Name, err)
-					}
-				case step.deletePods != nil:
-					for _, podName := range step.deletePods {
-						if err := cs.CoreV1().Pods(ns).Delete(testCtx.Ctx, podName, metav1.DeleteOptions{}); err != nil {
-							t.Fatalf("Step %d: Failed to delete pod %s: %v", i, podName, err)
 						}
-					}
-				case step.waitForPodsGatedOnPreEnqueue != nil:
-					for _, podName := range step.waitForPodsGatedOnPreEnqueue {
+					case step.createPodGroup != nil:
+						w := step.createPodGroup.DeepCopy()
+						w.Namespace = ns
+						if _, err := cs.SchedulingV1alpha2().PodGroups(ns).Create(testCtx.Ctx, w, metav1.CreateOptions{}); err != nil {
+							t.Fatalf("Step %d: Failed to create pod group %s: %v", i, w.Name, err)
+						}
+						// Ensure all next steps will see this pod group.
 						err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
 							func(_ context.Context) (bool, error) {
-								return podInUnschedulablePods(t, testCtx.Scheduler.SchedulingQueue, podName), nil
+								_, err := testCtx.InformerFactory.Scheduling().V1alpha2().PodGroups().Lister().PodGroups(ns).Get(w.Name)
+								if err != nil {
+									if apierrors.IsNotFound(err) {
+										return false, nil
+									}
+									return false, err
+								}
+								return true, nil
 							},
 						)
 						if err != nil {
-							t.Fatalf("Step %d: Failed to wait for pod %s to be in unschedulable pods pool: %v", i, podName, err)
+							t.Fatalf("Step %d: Failed to wait for pod group %s to be discoverable by scheduler: %v", i, w.Name, err)
 						}
-					}
-				case step.waitForPodsUnschedulable != nil:
-					for _, podName := range step.waitForPodsUnschedulable {
-						err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
-							testutils.PodUnschedulable(cs, ns, podName))
-						if err != nil {
-							t.Fatalf("Step %d: Failed to wait for pod %s to be unschedulable: %v", i, podName, err)
-						}
-					}
-				case step.waitForPodsScheduled != nil:
-					for _, podName := range step.waitForPodsScheduled {
-						err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
-							testutils.PodScheduled(cs, ns, podName))
-						if err != nil {
-							t.Fatalf("Step %d: Failed to wait for pod %s to be scheduled: %v", i, podName, err)
-						}
-					}
-				case step.waitForAnyPodsScheduled != nil:
-					err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
-						func(ctx context.Context) (bool, error) {
-							scheduledCount := 0
-							unschedulableCount := 0
-							for _, pod := range step.waitForAnyPodsScheduled.pods {
-								if ok, err := testutils.PodScheduled(cs, ns, pod.Name)(ctx); err != nil {
-									return false, err
-								} else if ok {
-									scheduledCount++
-									continue
-								}
-								if ok, err := testutils.PodUnschedulable(cs, ns, pod.Name)(ctx); err != nil {
-									return false, err
-								} else if ok {
-									unschedulableCount++
-								}
+					case step.deletePods != nil:
+						for _, podName := range step.deletePods {
+							if err := cs.CoreV1().Pods(ns).Delete(testCtx.Ctx, podName, metav1.DeleteOptions{}); err != nil {
+								t.Fatalf("Step %d: Failed to delete pod %s: %v", i, podName, err)
 							}
-							t.Logf("Step %d: Waiting for %d pods to be scheduled and %d to be unschedulable, got %d scheduled and %d unschedulable",
-								i, step.waitForAnyPodsScheduled.numScheduled, step.waitForAnyPodsScheduled.numUnschedulable, scheduledCount, unschedulableCount)
-							return scheduledCount == step.waitForAnyPodsScheduled.numScheduled && unschedulableCount == step.waitForAnyPodsScheduled.numUnschedulable, nil
-						},
-					)
-					if err != nil {
-						t.Fatalf("Step %d: Failed to wait for pods to be scheduled or unschedulable: %v", i, err)
-					}
-				case step.waitForPodGroupCondition != nil:
-					check := step.waitForPodGroupCondition
-					err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
-						podGroupHasScheduledCondition(cs, ns, check.podGroupName, check.conditionStatus, check.reason))
-					if err != nil {
-						t.Fatalf("Step %d: Failed to wait for PodGroup %s condition (status=%s, reason=%s): %v",
-							i, check.podGroupName, check.conditionStatus, check.reason, err)
+						}
+					case step.waitForPodsGatedOnPreEnqueue != nil:
+						for _, podName := range step.waitForPodsGatedOnPreEnqueue {
+							err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+								func(_ context.Context) (bool, error) {
+									return podInUnschedulablePods(t, testCtx.Scheduler.SchedulingQueue, podName), nil
+								},
+							)
+							if err != nil {
+								t.Fatalf("Step %d: Failed to wait for pod %s to be in unschedulable pods pool: %v", i, podName, err)
+							}
+						}
+					case step.waitForPodsUnschedulable != nil:
+						for _, podName := range step.waitForPodsUnschedulable {
+							err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+								testutils.PodUnschedulable(cs, ns, podName))
+							if err != nil {
+								t.Fatalf("Step %d: Failed to wait for pod %s to be unschedulable: %v", i, podName, err)
+							}
+						}
+					case step.waitForPodsScheduled != nil:
+						for _, podName := range step.waitForPodsScheduled {
+							err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+								testutils.PodScheduled(cs, ns, podName))
+							if err != nil {
+								t.Fatalf("Step %d: Failed to wait for pod %s to be scheduled: %v", i, podName, err)
+							}
+						}
+					case step.waitForAnyPodsScheduled != nil:
+						err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+							func(ctx context.Context) (bool, error) {
+								scheduledCount := 0
+								unschedulableCount := 0
+								for _, pod := range step.waitForAnyPodsScheduled.pods {
+									if ok, err := testutils.PodScheduled(cs, ns, pod.Name)(ctx); err != nil {
+										return false, err
+									} else if ok {
+										scheduledCount++
+										continue
+									}
+									if ok, err := testutils.PodUnschedulable(cs, ns, pod.Name)(ctx); err != nil {
+										return false, err
+									} else if ok {
+										unschedulableCount++
+									}
+								}
+								t.Logf("Step %d: Waiting for %d pods to be scheduled and %d to be unschedulable, got %d scheduled and %d unschedulable",
+									i, step.waitForAnyPodsScheduled.numScheduled, step.waitForAnyPodsScheduled.numUnschedulable, scheduledCount, unschedulableCount)
+								return scheduledCount == step.waitForAnyPodsScheduled.numScheduled && unschedulableCount == step.waitForAnyPodsScheduled.numUnschedulable, nil
+							},
+						)
+						if err != nil {
+							t.Fatalf("Step %d: Failed to wait for pods to be scheduled or unschedulable: %v", i, err)
+						}
+					case step.waitForPodGroupCondition != nil:
+						check := step.waitForPodGroupCondition
+						err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+							podGroupHasScheduledCondition(cs, ns, check.podGroupName, check.conditionStatus, check.reason))
+						if err != nil {
+							t.Fatalf("Step %d: Failed to wait for PodGroup %s condition (status=%s, reason=%s): %v",
+								i, check.podGroupName, check.conditionStatus, check.reason, err)
+						}
 					}
 				}
-			}
-		})
+			})
+		}
 	}
 }
 

--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/main_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologyawarescheduling
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}

--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
@@ -1,0 +1,1425 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologyawarescheduling
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler"
+
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	testutils "k8s.io/kubernetes/test/integration/util"
+)
+
+func makeGangPodGroup(podGroupName, topologyKey string, minCount int32) *schedulingapi.PodGroup {
+	return st.MakePodGroup().Name(podGroupName).TemplateRef("t1", "workload").TopologyKey(topologyKey).MinCount(minCount).Obj()
+}
+
+func makeBasicPodGroup(podGroupName, topologyKey string) *schedulingapi.PodGroup {
+	return st.MakePodGroup().Name(podGroupName).TemplateRef("t1", "workload").BasicPolicy().TopologyKey(topologyKey).Obj()
+}
+
+func makeNode(nodeName, rackLabel, zoneLabel string) *v1.Node {
+	return st.MakeNode().Name(nodeName).Label("rack", rackLabel).Label("zone", zoneLabel).Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj()
+}
+
+func makePod(podName, podGroupName string) *v1.Pod {
+	return st.MakePod().Name(podName).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").
+		PodGroupName(podGroupName).Priority(100).ZeroTerminationGracePeriod().Obj()
+}
+
+// makeAssignedPod creates a pre-existing pod assigned to a node in the cluster
+func makeAssignedPod(podName, nodeName, consumedCPU string) *v1.Pod {
+	return st.MakePod().Name(podName).Node(nodeName).Req(map[v1.ResourceName]string{v1.ResourceCPU: consumedCPU}).Container("image").Priority(100).ZeroTerminationGracePeriod().Obj()
+}
+
+// makeLargePod creates a pod that consumes all resources of a single node
+func makeLargePod(podName, podGroupName string) *v1.Pod {
+	return st.MakePod().Name(podName).Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").
+		PodGroupName(podGroupName).Priority(100).Obj()
+}
+
+// makeUnfittablePod creates a pod that requests more resources than available on a single node
+func makeUnfittablePod(podName, podGroupName string) *v1.Pod {
+	return st.MakePod().Name(podName).Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Container("image").
+		PodGroupName(podGroupName).Priority(100).Obj()
+}
+
+// step represents a single step in a test scenario.
+type step struct {
+	name                      string
+	createNodes               []*v1.Node
+	createPodGroup            *schedulingapi.PodGroup
+	createPods                []*v1.Pod
+	deletePods                []string
+	waitForPodsScheduled      []string
+	verifyAssignments         *verifyAssignments
+	verifyAssignedInOneDomain *verifyAssignedInOneDomain
+	waitForPodsUnschedulable  []string
+}
+
+type verifyAssignments struct {
+	pods  []string
+	nodes sets.Set[string]
+}
+
+type verifyAssignedInOneDomain struct {
+	pods        []string
+	topologyKey string
+}
+
+type scenario struct {
+	name  string
+	steps []step
+}
+
+func TestTopologyAwareSchedulingWithGangPolicy(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps []step
+	}{
+		{
+			name: "gang schedules on a single rack, when only one feasible rack is available",
+			steps: []step{
+				{
+					name: "Create nodes in multiple zones and racks. Racks 1 and 2 can fit 3 pods",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack1", "rack-1", "zone-1"),
+						makeNode("node4-rack2", "rack-2", "zone-1"),
+						makeNode("node5-rack2", "rack-2", "zone-1"),
+						makeNode("node6-zone2", "rack-3", "zone-2"),
+					},
+				},
+				{
+					name: "Create an assigned pod in rack2, making rack2 unable to fit 3 additional pods",
+					createPods: []*v1.Pod{
+						makeAssignedPod("existing1", "node4-rack2", "2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 3),
+				},
+				{
+					name: "Create all pods belonging to the podgroup",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Verify all pods scheduled on rack1",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3"},
+						nodes: sets.New("node1-rack1", "node2-rack1", "node3-rack1"),
+					},
+				},
+			},
+		},
+		{
+			name: "gang remains pending when no feasible resources are found",
+			steps: []step{
+				{
+					name: "Create nodes in multiple zones and racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack2", "rack-2", "zone-1"),
+						makeNode("node4-zone2", "rack-3", "zone-2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 3),
+				},
+				{
+					name: "Create all pods belonging to the podgroup, requesting more resources in total than available in any rack",
+					createPods: []*v1.Pod{
+						makeLargePod("p1", "pg1"),
+						makeLargePod("p2", "pg1"),
+						makeLargePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                     "Verify the entire gang becomes unschedulable",
+					waitForPodsUnschedulable: []string{"p1", "p2", "p3"},
+				},
+			},
+		},
+		{
+			name: "gang remains pending when resources are consumed by existing pods",
+			steps: []step{
+				{
+					name: "Create nodes in a rack",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack1", "rack-1", "zone-1"),
+					},
+				},
+				{
+					name: "Create assigned pods in rack1, making rack1 unable to fit 3 additional pods",
+					createPods: []*v1.Pod{
+						makeAssignedPod("existing1", "node1-rack1", "2"),
+						makeAssignedPod("existing2", "node3-rack1", "2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 3),
+				},
+				{
+					name: "Create all pods belonging to the podgroup, requesting more resources in total than available in any rack",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                     "Verify the entire gang becomes unschedulable",
+					waitForPodsUnschedulable: []string{"p1", "p2", "p3"},
+				},
+				{
+					name:       "Delete a pod in rack1 to free up resources",
+					deletePods: []string{"existing1"},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+			},
+		},
+		{
+			name: "gang schedules on a single rack, choosing placement with the highest score in default placement scoring algorithm",
+			steps: []step{
+				{
+					name: "Create nodes in multiple zones and racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack2", "rack-2", "zone-2"),
+						makeNode("node4-rack2", "rack-2", "zone-2"),
+						makeNode("node5-rack2", "rack-2", "zone-2"),
+						makeNode("node6-rack3", "rack-3", "zone-2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 3),
+				},
+				{
+					name: "Create all pods belonging to the podgroup. Pods won't fit on rack3, and will score higher on rack1 than rack2",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					// Scoring results: PodGroupPodsCount will score the same for rack1 and rack2,
+					// and NodeResourcesFit with default strategy MostAllocated will score higher on rack1.
+					name: "Verify all pods scheduled on rack1",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3"},
+						nodes: sets.New("node1-rack1", "node2-rack1"),
+					},
+				},
+			},
+		},
+		{
+			name: "gang schedules on a single rack, choosing placement with highest allocation percentage (default placement scoring algorithm) with pre-existing pods in cluster",
+			steps: []step{
+				{
+					name: "Create nodes in multiple zones and racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack2", "rack-2", "zone-2"),
+						makeNode("node4-rack2", "rack-2", "zone-2"),
+						makeNode("node5-rack2", "rack-2", "zone-2"),
+						makeNode("node6-rack3", "rack-3", "zone-2"),
+						makeNode("node7-rack3", "rack-3", "zone-2"),
+						makeNode("node8-rack3", "rack-3", "zone-2"),
+						makeNode("node9-rack4", "rack-4", "zone-2"),
+					},
+				},
+				{
+					name: "Create pre-existing nodes, which will be considered in the scoring algorithm",
+					createPods: []*v1.Pod{
+						makeAssignedPod("existing1", "node3-rack2", "2"),
+						makeAssignedPod("existing2", "node8-rack3", "1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 3),
+				},
+				{
+					name: "Create all pods belonging to the podgroup. Pods won't fit on rack4, and will score highest on rack2",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				// Each node has 2 CPUs, each of gang pods requests 1 CPU.
+				// The PodGroupPods count scoring plugin will score racks 1-3 the same, as they will all fit the entire podgroup.
+				// Allocation fractions in racks (for the default "most allocated" strategy the max allocation is picked):
+				// - rack1: (0 + 3)/4 = 0.75
+				// - rack2: (2 + 3)/6 = 0.83
+				// - rack3: (1 + 3)/6 = 0.67
+				// - rack4: unfeasible
+				{
+					name: "Verify all pods scheduled on rack2",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3"},
+						nodes: sets.New("node3-rack2", "node4-rack2", "node5-rack2"),
+					},
+				},
+			},
+		},
+		{
+			name: "two gangs schedule consecutively, each on a separate rack",
+			steps: []step{
+				{
+					name: "Create nodes in multiple racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack1", "rack-1", "zone-1"),
+						makeNode("node4-rack2", "rack-2", "zone-1"),
+						makeNode("node5-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 3),
+				},
+				{
+					name: "Create all pods belonging to gang pg1. Pods are large, pg1 will only fit on rack1",
+					createPods: []*v1.Pod{
+						makeLargePod("p1", "pg1"),
+						makeLargePod("p2", "pg1"),
+						makeLargePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang pg1 is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=2) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg2", "rack", 2),
+				},
+				{
+					name: "Create all pods belonging to gang pg2",
+					createPods: []*v1.Pod{
+						makePod("p4", "pg2"),
+						makePod("p5", "pg2"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang pg2 is now scheduled",
+					waitForPodsScheduled: []string{"p4", "p5"},
+				},
+				{
+					name: "Verify all pods in pg1 scheduled on rack1 (the only one fitting them)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3"},
+						nodes: sets.New("node1-rack1", "node2-rack1", "node3-rack1"),
+					},
+				},
+				{
+					name: "Verify all pods in pg2 scheduled on rack2 (the only one fitting them after pg1 is scheduled)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p4", "p5"},
+						nodes: sets.New("node4-rack2", "node5-rack2"),
+					},
+				},
+			},
+		},
+		{
+			name: "two gangs schedule consecutively, both on the same rack",
+			steps: []step{
+				{
+					name: "Create nodes in multiple racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack1", "rack-1", "zone-1"),
+						makeNode("node4-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=2) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 2),
+				},
+				{
+					name: "Create all pods belonging to gang pg1",
+					createPods: []*v1.Pod{
+						makeLargePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg2", "rack", 3),
+				},
+				{
+					name: "Create all pods belonging to gang pg2",
+					createPods: []*v1.Pod{
+						makePod("p3", "pg2"),
+						makePod("p4", "pg2"),
+						makePod("p5", "pg2"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang pg1 is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					name: "Verify all pods in pg1 scheduled on rack1 (the only one fitting them)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2"},
+						nodes: sets.New("node1-rack1", "node2-rack1", "node3-rack1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang pg2 is now scheduled",
+					waitForPodsScheduled: []string{"p3", "p4", "p5"},
+				},
+				{
+					name: "Verify all pods in pg2 scheduled also on rack1 (the only one fitting them)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p3", "p4", "p5"},
+						nodes: sets.New("node1-rack1", "node2-rack1", "node3-rack1"),
+					},
+				},
+			},
+		},
+		{
+			name: "two gangs schedule consecutively, different topology keys",
+			steps: []step{
+				{
+					name: "Create nodes in multiple zones and racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack2", "rack-2", "zone-1"),
+						makeNode("node4-zone2", "rack-3", "zone-2"),
+						makeNode("node5-zone2", "rack-3", "zone-2"),
+						makeNode("node6-zone2", "rack-3", "zone-2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 3),
+				},
+				{
+					name: "Create all pods belonging to gang pg1",
+					createPods: []*v1.Pod{
+						makeLargePod("p1", "pg1"),
+						makeLargePod("p2", "pg1"),
+						makeLargePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang pg1 is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled in one zone",
+					createPodGroup: makeGangPodGroup("pg2", "zone", 3),
+				},
+				{
+					name: "Create all pods belonging to gang pg2",
+					createPods: []*v1.Pod{
+						makeLargePod("p4", "pg2"),
+						makeLargePod("p5", "pg2"),
+						makeLargePod("p6", "pg2"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang pg2 is now scheduled",
+					waitForPodsScheduled: []string{"p4", "p5", "p6"},
+				},
+				{
+					name: "Verify all pods in pg1 scheduled on rack3 (the only one fitting them)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3"},
+						nodes: sets.New("node4-zone2", "node5-zone2", "node6-zone2"),
+					},
+				},
+				{
+					name: "Verify all pods in pg2 scheduled in zone1 (the only one fitting them)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p4", "p5", "p6"},
+						nodes: sets.New("node1-rack1", "node2-rack1", "node3-rack2"),
+					},
+				},
+			},
+		},
+		{
+			name: "two gangs schedule consecutively, only one fits in the cluster",
+			steps: []step{
+				{
+					name: "Create nodes in one rack",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 3),
+				},
+				{
+					name: "Create all pods belonging to gang pg1",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang pg1 is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=2) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg2", "rack", 2),
+				},
+				{
+					name: "Create all pods belonging to gang pg2",
+					createPods: []*v1.Pod{
+						makePod("p4", "pg2"),
+						makePod("p5", "pg2"),
+					},
+				},
+				{
+					name: "Verify all pods in pg1 scheduled on rack1",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3"},
+						nodes: sets.New("node1-rack1", "node2-rack1"),
+					},
+				},
+				{
+					name:                     "Verify the entire second gang becomes unschedulable due to insufficient resources",
+					waitForPodsUnschedulable: []string{"p4", "p5"},
+				},
+			},
+		},
+		{
+			name: "gang with minCount < pod count schedules on a single rack",
+			steps: []step{
+				{
+					name: "Create nodes in two racks, each rack can fit 3 pods",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack2", "rack-2", "zone-1"),
+						makeNode("node4-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=2) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 2),
+				},
+				{
+					name: "Create 3 pods (more than minCount) belonging to the podgroup",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Verify all pods scheduled on a single rack",
+					verifyAssignedInOneDomain: &verifyAssignedInOneDomain{
+						pods:        []string{"p1", "p2", "p3"},
+						topologyKey: "rack",
+					},
+				},
+			},
+		},
+		{
+			// TODO: Add a test scenario where minCount < pod count and when entering the scheduling cycle, scheduler sees more than minCount pods in queue.
+			name: "gang with minCount < pod count schedules on a single rack, choosing smaller rack",
+			steps: []step{
+				{
+					name: "Create nodes in multiple racks, one can fit 4 pods, second can fit 6 pods, last is too small",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack1", "rack-1", "zone-1"),
+						makeNode("node4-rack2", "rack-2", "zone-1"),
+						makeNode("node5-rack2", "rack-2", "zone-1"),
+						makeNode("node6-rack3", "rack-3", "zone-2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object (Gang with minCount=3) that should be scheduled on one rack",
+					createPodGroup: makeGangPodGroup("pg1", "rack", 3),
+				},
+				{
+					name: "Create 3 pods (=minCount) belonging to the gang",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Create an additional pod (pod count > minCount) belonging to the gang",
+					createPods: []*v1.Pod{
+						makePod("p4", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the the new pods gets scheduled",
+					waitForPodsScheduled: []string{"p4"},
+				},
+				{
+					name: "Verify all pods in pg1 scheduled on rack2, which scored higher in the default placement scoring algorithm",
+					// Scoring details:
+					// At the time of scoring pg1 contained 3 pods. Racks 1 and 2 both fit all 3 pods, and were scored equally by PodGroupPodsCount.
+					// NodeResourcesFit with the default mostAllocated strategy scored rack2 higher than rack1.
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3", "p4"},
+						nodes: sets.New("node4-rack2", "node5-rack2"),
+					},
+				},
+				{
+					name: "Create one more pod belonging to the gang",
+					createPods: []*v1.Pod{
+						makePod("p5", "pg1"),
+					},
+				},
+				{
+					name:                     "Verify the last pod becomes unschedulable due to insufficient resources in the rack",
+					waitForPodsUnschedulable: []string{"p5"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runTestScenario(t, tt, true /* gangSchedulingEnabled */)
+		})
+	}
+}
+
+func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
+	tests := []scenario{
+		{
+			name: "basic podgroup schedules on the only rack in the cluster",
+			steps: []step{
+				{
+					name: "Create nodes in only one rack",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to the podgroup",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire podgroup is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Verify all pods scheduled on rack1",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3"},
+						nodes: sets.New("node1-rack1", "node2-rack1"),
+					},
+				},
+			},
+		},
+		{
+			name: "basic podgroup schedules all pods on a single rack, when there are multiple racks fitting in the cluster",
+			steps: []step{
+				{
+					name: "Create nodes in multiple racks and zones, each rack enough to fit 3 pods",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack2", "rack-2", "zone-1"),
+						makeNode("node4-rack2", "rack-2", "zone-1"),
+						makeNode("node5-zone2", "rack-3", "zone-2"),
+						makeNode("node6-zone2", "rack-3", "zone-2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to the podgroup",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Verify all pods scheduled the same rack",
+					verifyAssignedInOneDomain: &verifyAssignedInOneDomain{
+						pods:        []string{"p1", "p2", "p3"},
+						topologyKey: "rack",
+					},
+				},
+			},
+		},
+		{
+			name: "basic podgroup cannot fit on a single rack, no pods get scheduled on a different rack",
+			steps: []step{
+				{
+					name: "Create nodes in 2 racks, each rack enough to fit 2 pods",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to the podgroup, more than fitting in a single rack",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify that 2 pods got scheduled",
+					waitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					name:                     "Verify that the last pod becomes unschedulable due to insufficient resources in the rack",
+					waitForPodsUnschedulable: []string{"p3"},
+				},
+				{
+					name: "Verify both pods scheduled on the same rack",
+					verifyAssignedInOneDomain: &verifyAssignedInOneDomain{
+						pods:        []string{"p1", "p2"},
+						topologyKey: "rack",
+					},
+				},
+			},
+		},
+		{
+			name: "basic podgroup does not schedule at all when no pods fit",
+			steps: []step{
+				{
+					name: "Create nodes in 2 racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to the podgroup, each pod not fitting any nodes in the cluster",
+					createPods: []*v1.Pod{
+						makeUnfittablePod("p1", "pg1"),
+						makeUnfittablePod("p2", "pg1"),
+					},
+				},
+				{
+					name:                     "Verify no pods are scheduled due to insufficient resources in the rack",
+					waitForPodsUnschedulable: []string{"p1", "p2"},
+				},
+			},
+		},
+		{
+			name: "basic podgroup schedules only some pods when others don't fit on any node",
+			steps: []step{
+				{
+					name: "Create nodes in 2 racks, each rack enough to fit 2 regular pods",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to the podgroup, some of them not fitting any nodes in the cluster",
+					createPods: []*v1.Pod{
+						makeUnfittablePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify that the smaller pod got scheduled",
+					waitForPodsScheduled: []string{"p2"},
+				},
+				{
+					name:                     "Verify that the big pod is not scheduled due to insufficient resources in the rack",
+					waitForPodsUnschedulable: []string{"p1"},
+				},
+			},
+		},
+		{
+			name: "basic podgroup schedules on a single rack, choosing placement with highest allocation percentage (default placement scoring algorithm)",
+			steps: []step{
+				{
+					name: "Create nodes in multiple zones and racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack2", "rack-2", "zone-2"),
+						makeNode("node4-rack2", "rack-2", "zone-2"),
+						makeNode("node5-rack2", "rack-2", "zone-2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to the podgroup",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				// Each node has 2 CPUs, each of gang pods requests 1 CPU.
+				// Scores are first calculated when scheduling the first pod, without the knowledge how many pods would be in the podgroup.
+				// PodGroupPodsCount will score the same for each rack (because both racks can fit the first pod).
+				// NodeResourcesFit will compute allocation fractions in racks (for the default "most allocated" strategy the highest allocation is picked):
+				// - rack1: 1/4 = 0.25
+				// - rack2: 1/6 = 0.17
+				{
+					name: "Verify all pods scheduled on rack1",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3"},
+						nodes: sets.New("node1-rack1", "node2-rack1"),
+					},
+				},
+			},
+		},
+		{
+			name: "basic podgroup schedules on a single rack, choosing placement with highest allocation percentage with pre-existing pods",
+			steps: []step{
+				{
+					name: "Create nodes in multiple zones and racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack1", "rack-1", "zone-1"),
+						makeNode("node4-rack2", "rack-2", "zone-2"),
+						makeNode("node5-rack2", "rack-2", "zone-2"),
+						makeNode("node6-rack2", "rack-2", "zone-2"),
+						makeNode("node7-rack3", "rack-3", "zone-2"),
+						makeNode("node8-rack3", "rack-3", "zone-2"),
+						makeNode("node9-rack3", "rack-3", "zone-2"),
+						makeNode("node10-rack3", "rack-3", "zone-2"),
+					},
+				},
+				{
+					name: "Create all pods belonging to the podgroup",
+					createPods: []*v1.Pod{
+						makeAssignedPod("existing1", "node1-rack1", "1"),
+						makeAssignedPod("existing2", "node5-rack2", "1"),
+						makeAssignedPod("existing3", "node6-rack2", "1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to the podgroup",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the entire podgroup is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				// Each node has 2 CPUs, each of podgroup pods requests 1 CPU.
+				// Scores are first calculated when scheduling the first pod, without the knowledge how many pods would be in the podgroup.
+				// PodGroupPodsCount will score the same for each rack (because both racks can fit the first pod).
+				// NodeResourcesFit will compute allocation fractions in racks (for the default "most allocated" strategy the highest allocation is picked):
+				// - rack1: 2/6 = 0.33
+				// - rack2: 3/6 = 0.5
+				// - rack3: 1/8 = 0.125
+				{
+					name: "Verify all pods scheduled on rack2",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2", "p3"},
+						nodes: sets.New("node4-rack2", "node5-rack2", "node6-rack2"),
+					},
+				},
+			},
+		},
+		{
+			name: "basic podgroup schedules on a single rack, choosing best scoring placement that will not fit all podgroup",
+			steps: []step{
+				{
+					name: "Create nodes in multiple racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack1", "rack-1", "zone-1"),
+						makeNode("node4-rack1", "rack-1", "zone-1"),
+						makeNode("node5-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name: "Create pods in rack1, consuming 25% of its resources",
+					createPods: []*v1.Pod{
+						makeAssignedPod("existing1", "node1-rack1", "2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to the podgroup",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				// Each node has 2 CPUs, podgroup pods request 1 or 2 CPUs.
+				// Scores are first calculated when scheduling the first pod, without the knowledge how many pods would be in the podgroup.
+				// PodGroupPodsCount will score the same for each rack (because both racks can fit the first pod).
+				// NodeResourcesFit will compute allocation fractions in racks (for the default "most allocated" strategy the highest allocation is picked):
+				// - rack1: 3/8 = 0.375
+				// - rack2: 1/2 = 0.5
+				{
+					name:                 "Verify that the first two pods are now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					name: "Verify pod scheduled on rack2",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2"},
+						nodes: sets.New("node5-rack2"),
+					},
+				},
+				{
+					name:                     "Verify that third pod is not scheduled due to insufficient resources in rack2",
+					waitForPodsUnschedulable: []string{"p3"},
+				},
+			},
+		},
+		{
+			name: "two basic podgroups schedule consecutively, each on a single rack",
+			steps: []step{
+				{
+					name: "Create nodes in multiple racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack1", "rack-1", "zone-1"),
+						makeNode("node4-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to podgroup pg1",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg2", "rack"),
+				},
+				{
+					name: "Create all pods belonging to podgroup pg2",
+					createPods: []*v1.Pod{
+						makePod("p3", "pg2"),
+						makePod("p4", "pg2"),
+					},
+				},
+				{
+					name:                 "Verify the entire podgroup pg1 is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2"},
+				},
+				// Each node has 2 CPUs, podgroup pods request 1 or 2 CPUs.
+				// Scores are first calculated when scheduling the first pod, without the knowledge how many pods would be in the podgroup.
+				// PodGroupPodsCount will score the same for each rack (because both racks can fit the first pod).
+				// Allocation fractions in racks (for the default "most allocated" strategy the highest allocation is picked):
+				// - rack1: 1/6 = 0.17
+				// - rack2: 1/2 = 0.5
+				{
+					name: "Verify all pods in pg1 scheduled on rack2 (which scored most allocation)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2"},
+						nodes: sets.New("node4-rack2"),
+					},
+				},
+				{
+					name:                 "Verify the entire podgroup pg2 is now scheduled",
+					waitForPodsScheduled: []string{"p3", "p4"},
+				},
+				{
+					name: "Verify all pods in pg2 scheduled on rack1 (because rack2 is full)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p3", "p4"},
+						nodes: sets.New("node1-rack1", "node2-rack1", "node3-rack1"),
+					},
+				},
+			},
+		},
+		{
+			name: "two basic podgroups schedule consecutively on the only rack",
+			steps: []step{
+				{
+					name: "Create nodes in one rack",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack1", "rack-1", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to podgroup pg1",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg2", "rack"),
+				},
+				{
+					name: "Create all pods belonging to podgroup pg2",
+					createPods: []*v1.Pod{
+						makePod("p3", "pg2"),
+						makePod("p4", "pg2"),
+						makePod("p5", "pg2"),
+					},
+				},
+				{
+					name:                 "Verify all pods scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3", "p4", "p5"},
+				},
+			},
+		},
+		{
+			name: "two basic podgroups schedule consecutively, different topology keys",
+			steps: []step{
+				{
+					name: "Create nodes in multiple zones and racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-zone2", "rack-2", "zone-2"),
+						makeNode("node3-zone2", "rack-2", "zone-2"),
+						makeNode("node4-zone2", "rack-3", "zone-2"),
+						makeNode("node5-zone2", "rack-3", "zone-2"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to podgroup pg1",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled in one zone",
+					createPodGroup: makeBasicPodGroup("pg2", "zone"),
+				},
+				{
+					name: "Create all pods belonging to podgroup pg2. Large pods, each consumes CPU of an entire node",
+					createPods: []*v1.Pod{
+						makeLargePod("p3", "pg2"),
+						makeLargePod("p4", "pg2"),
+						makeLargePod("p5", "pg2"),
+					},
+				},
+				{
+					name:                 "Verify all pods scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3", "p4", "p5"},
+				},
+				{
+					name: "Verify all pods in pg1 scheduled on rack1 (the smallest rack, scoring highest allocation fraction)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2"},
+						nodes: sets.New("node1-rack1"),
+					},
+				},
+				{
+					name: "Verify all pods in pg2 scheduled in zone2 (because zone1 is full)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p3", "p4", "p5"},
+						nodes: sets.New("node2-zone2", "node3-zone2", "node4-zone2", "node5-zone2"),
+					},
+				},
+			},
+		},
+		{
+			name: "two basic podgroups schedule consecutively, one does not fit in the assigned rack",
+			steps: []step{
+				{
+					name: "Create nodes in multiple racks",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack1", "rack-1", "zone-1"),
+						makeNode("node3-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to podgroup pg1",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg2", "rack"),
+				},
+				{
+					name: "Create all pods belonging to podgroup pg2",
+					createPods: []*v1.Pod{
+						makePod("p4", "pg2"),
+						makePod("p5", "pg2"),
+						makePod("p6", "pg2"),
+					},
+				},
+				// Each node has 2 CPUs, each of gang pods requests 1 CPU.
+				// Scores are first calculated when scheduling the first pod, without the knowledge how many pods would be in the podgroup.
+				// PodGroupPodsCount will score the same for each rack (because both racks can fit the first pod).
+				// Allocation fractions in racks (for the default "most allocated" strategy the highest allocation is picked):
+				// - rack1: 1/4 = 0.25
+				// - rack2: 1/2 = 0.5
+				{
+					name:                 "Verify part of podgroup p1 is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					name: "Verify all pods in pg1 scheduled on rack2 (which scored higher allocation)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2"},
+						nodes: sets.New("node3-rack2"),
+					},
+				},
+				{
+					name:                     "Verify the last pod becomes unschedulable due to insufficient resources",
+					waitForPodsUnschedulable: []string{"p3"},
+				},
+				{
+					name:                 "Verify the entire podgroup pg2 is now scheduled",
+					waitForPodsScheduled: []string{"p4", "p5", "p6"},
+				},
+				{
+					name: "Verify pods in pg2 scheduled on rack1 (because rack2 is full)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p4", "p5", "p6"},
+						nodes: sets.New("node1-rack1", "node2-rack1"),
+					},
+				},
+			},
+		},
+		{
+			name: "basic podgroup continues to schedule pods when more resources become available",
+			steps: []step{
+				{
+					name: "Create nodes in 2 racks, each rack enough to fit 2 pods",
+					createNodes: []*v1.Node{
+						makeNode("node1-rack1", "rack-1", "zone-1"),
+						makeNode("node2-rack2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					name: "Create blocker pod in rack1",
+					createPods: []*v1.Pod{
+						makeAssignedPod("existing1", "node1-rack1", "1"),
+					},
+				},
+				{
+					name:           "Create the PodGroup object that should be scheduled on one rack",
+					createPodGroup: makeBasicPodGroup("pg1", "rack"),
+				},
+				{
+					name: "Create all pods belonging to the podgroup, more than fitting in rack1",
+					createPods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify that 1 pod got scheduled",
+					waitForPodsScheduled: []string{"p1"},
+				},
+				{
+					name: "Verify that p1 got scheduled on rack1, which scored higher in mostAllocated strategy",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1"},
+						nodes: sets.New("node1-rack1"),
+					},
+				},
+				{
+					name:                     "Verify that the last pod becomes unschedulable due to insufficient resources in the rack",
+					waitForPodsUnschedulable: []string{"p2"},
+				},
+				{
+					name:       "Remove the blocker pod",
+					deletePods: []string{"existing1"},
+				},
+				{
+					name:                 "Verify that both pods got scheduled",
+					waitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					name: "Verify that both are on the same rack",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2"},
+						nodes: sets.New("node1-rack1"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, gangSchedulingEnabled := range []bool{true, false} {
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%s (GangScheduling enabled: %v)", tt.name, gangSchedulingEnabled), func(t *testing.T) {
+				runTestScenario(t, tt, gangSchedulingEnabled)
+			})
+		}
+	}
+}
+
+func runTestScenario(t *testing.T, tt scenario, gangSchedulingEnabled bool) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload:                 true,
+		features.GangScheduling:                  gangSchedulingEnabled,
+		features.TopologyAwareWorkloadScheduling: true,
+	})
+
+	// TODO: Add tests for at least one non-default scoring strategy.
+	testCtx := testutils.InitTestSchedulerWithNS(t, "tas",
+		// Disable backoff - it doesn't impact the end scheduling result.
+		scheduler.WithPodMaxBackoffSeconds(0),
+		scheduler.WithPodInitialBackoffSeconds(0))
+	cs, ns := testCtx.ClientSet, testCtx.NS.Name
+
+	for i, step := range tt.steps {
+		t.Logf("Executing step %d: %s", i, step.name)
+		switch {
+		case step.createNodes != nil:
+			for _, node := range step.createNodes {
+				n := node.DeepCopy()
+				if _, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, n, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Step %d: Failed to create node %s: %v", i, n.Name, err)
+				}
+			}
+		case step.createPods != nil:
+			for _, pod := range step.createPods {
+				p := pod.DeepCopy()
+				p.Namespace = ns
+				if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, p, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Step %d: Failed to create pod %s: %v", i, p.Name, err)
+				}
+			}
+		case step.createPodGroup != nil:
+			w := step.createPodGroup.DeepCopy()
+			w.Namespace = ns
+			if _, err := cs.SchedulingV1alpha2().PodGroups(ns).Create(testCtx.Ctx, w, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Step %d: Failed to create pod group %s: %v", i, w.Name, err)
+			}
+			// Ensure all next steps will see this pod group.
+			err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+				func(_ context.Context) (bool, error) {
+					_, err := testCtx.InformerFactory.Scheduling().V1alpha2().PodGroups().Lister().PodGroups(ns).Get(w.Name)
+					if err != nil {
+						if apierrors.IsNotFound(err) {
+							return false, nil
+						}
+						return false, err
+					}
+					return true, nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("Step %d: Failed to wait for pod group %s to be discoverable by scheduler: %v", i, w.Name, err)
+			}
+		case step.deletePods != nil:
+			for _, podName := range step.deletePods {
+				if err := cs.CoreV1().Pods(ns).Delete(testCtx.Ctx, podName, metav1.DeleteOptions{}); err != nil {
+					t.Fatalf("Step %d: Failed to delete pod %s: %v", i, podName, err)
+				}
+				// Ensure all next steps will not see the deleted pod.
+				err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+					func(_ context.Context) (bool, error) {
+						_, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, podName, metav1.GetOptions{})
+						if err != nil {
+							if apierrors.IsNotFound(err) {
+								return true, nil
+							}
+							return false, err
+						}
+						return false, nil
+					},
+				)
+				if err != nil {
+					t.Fatalf("Step %d: Failed to wait for pod %s to be no longer visible in scheduler: %v", i, podName, err)
+				}
+			}
+		case step.verifyAssignments != nil:
+			for _, podName := range step.verifyAssignments.pods {
+				assignedPod, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, podName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Step %d: Failed to retrieve assigned pod %s: %v", i, podName, err)
+				}
+				nodeName := assignedPod.Spec.NodeName
+				if nodeName == "" {
+					t.Errorf("Step %d: Pod %s is not assigned", i, podName)
+				}
+				if !step.verifyAssignments.nodes.Has(nodeName) {
+					t.Errorf("Step %d: Wanted pod %s scheduled on node within %v but got assignment to %s. Error %v", i, podName, step.verifyAssignments.nodes, nodeName, err)
+				}
+			}
+		case step.verifyAssignedInOneDomain != nil:
+			expectedDomain := ""
+			for _, podName := range step.verifyAssignedInOneDomain.pods {
+				assignedPod, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, podName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Step %d: Failed to retrieve assigned pod %s: %v", i, podName, err)
+				}
+				nodeName := assignedPod.Spec.NodeName
+				if nodeName == "" {
+					t.Errorf("Step %d: Pod %s is not assigned", i, podName)
+				}
+				node, err := cs.CoreV1().Nodes().Get(testCtx.Ctx, nodeName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Step %d: Failed to retrieve node %s: %v", i, nodeName, err)
+				}
+				domain := node.Labels[step.verifyAssignedInOneDomain.topologyKey]
+				if domain == "" {
+					t.Fatalf("Step %d: Invalid domain value \"\" in node %s", i, nodeName)
+				}
+
+				if expectedDomain == "" {
+					expectedDomain = domain
+				} else if expectedDomain != domain {
+					t.Errorf("Step %d: Pod %s assigned to a different domain than other pods in the podgroup. Expected %s but got %s", i, podName, expectedDomain, domain)
+				}
+			}
+		case step.waitForPodsUnschedulable != nil:
+			for _, podName := range step.waitForPodsUnschedulable {
+				err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+					testutils.PodUnschedulable(cs, ns, podName))
+				if err != nil {
+					t.Fatalf("Step %d: Failed to wait for pod %s to be unschedulable: %v", i, podName, err)
+				}
+			}
+		case step.waitForPodsScheduled != nil:
+			for _, podName := range step.waitForPodsScheduled {
+				err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+					testutils.PodScheduled(cs, ns, podName))
+				if err != nil {
+					t.Fatalf("Step %d: Failed to wait for pod %s to be scheduled: %v", i, podName, err)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR integrates TAS logic described in KEP-5732.

When considering scheduling for a pod group we first run PlacementGenerate (TopologyPlacementPlugin) plugin to determine the groups of nodes with matching topologies.

Afterwards, for each group we run the normal scheduling algorithm to get the scheduling results.

Finally, we choose the best scheduling result by running the PlacementScore plugins.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/5732

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added TAS logic to the pod group scheduling cycle behind TopologyAwareWorkloadScheduling feature gate. This feature supports scheduling pod groups on nodes with matching topology domains.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/241bce5f83b9234e290e5b845e59c16d1212f0a4/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md?plain=1#L486
```
