### PR TITLE
Use contextual logging in leaderelection controller

### DIFF
--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
@@ -75,7 +75,7 @@ type Controller struct {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 	defer func() {
 		err := c.leaseInformer.Informer().RemoveEventHandler(c.leaseRegistration)
@@ -95,7 +95,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	// This controller is leader elected and may start after informers have already started. List on startup.
 	lcs, err := c.leaseCandidateInformer.Lister().List(labels.Everything())
 	if err != nil {
-		utilruntime.HandleError(err)
+		utilruntime.HandleErrorWithContext(ctx, err, "Failed to list lease candidates")
 		return
 	}
 	for _, lc := range lcs {
@@ -166,7 +166,7 @@ func (c *Controller) processNextElectionItem(ctx context.Context) bool {
 	}
 
 	intervalForRequeue, err := c.reconcileElectionStep(ctx, key)
-	utilruntime.HandleError(err)
+	utilruntime.HandleErrorWithContext(ctx, err, "Failed to reconcile election step")
 	if intervalForRequeue != noRequeue {
 		defer c.queue.AddAfter(key, intervalForRequeue)
 	}

--- a/pkg/controlplane/controller/leaderelection/leasecandidategc_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leasecandidategc_controller.go
@@ -18,7 +18,6 @@ package leaderelection
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -61,13 +60,13 @@ func NewLeaseCandidateGC(clientset kubernetes.Interface, gcCheckPeriod time.Dura
 
 // Run starts one worker.
 func (c *LeaseCandidateGCController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer klog.Infof("Shutting down apiserver leasecandidate garbage collector")
 
 	klog.Infof("Starting apiserver leasecandidate garbage collector")
 
-	if !cache.WaitForCacheSync(ctx.Done(), c.leaseCandidatesSynced) {
-		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.leaseCandidatesSynced) {
+		utilruntime.HandleErrorWithContext(ctx, nil, "Timed out waiting for caches to sync")
 		return
 	}
 

--- a/pkg/controlplane/controller/leaderelection/run_with_leaderelection.go
+++ b/pkg/controlplane/controller/leaderelection/run_with_leaderelection.go
@@ -50,7 +50,7 @@ func RunWithLeaderElection(ctx context.Context, config *rest.Config, newRunnerFn
 	}
 	identity := hostname + "_" + string(uuid.NewUUID())
 
-	wait.Until(func() {
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		callbacks := leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				var err error
@@ -94,5 +94,5 @@ func RunWithLeaderElection(ctx context.Context, config *rest.Config, newRunnerFn
 			return
 		}
 		le.Run(ctx)
-	}, timers.RetryPeriod, ctx.Done())
+	}, timers.RetryPeriod)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replace with their context-aware alternatives in pkg/controlplane/controller/leaderelection/:

- `utilruntime.HandleCrash` -> `HandleCrashWithContext`
- `utilruntime.HandleError` -> `HandleErrorWithContext`
- `cache.WaitForCacheSync` -> `WaitForNamedCacheSyncWithContext`
- `wait.Until` -> `wait.UntilWithContext`

#### Which issue(s) this PR is related to:

Related #126379

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
