### PR TITLE
Fix maskTrailingDash replacing two characters instead of one

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go
@@ -79,7 +79,7 @@ var ValidateServiceAccountName = NameIsDNSSubdomain
 // for more info.
 func maskTrailingDash(name string) string {
 	if len(name) > 1 && strings.HasSuffix(name, "-") {
-		return name[:len(name)-2] + "a"
+		return name[:len(name)-1] + "a"
 	}
 	return name
 }


### PR DESCRIPTION
Fixes #137491

## What type of PR is this?
/kind bug

## What this PR does / why we need it
`maskTrailingDash` uses `name[:len(name)-2]` which removes the last **two** characters instead of just the trailing dash. For example, `"foo-"` becomes `"foa"` instead of the intended `"fooa"`.

This could allow invalid generateNames to pass validation. For example, `"a?-"` masked to `"aa"` passes DNS label validation, but the generated name `"a?-vwxyz"` would be invalid.

The fix changes `-2` to `-1` so only the trailing dash is replaced.

## Does this PR introduce a user-facing change?
Yes - names generated from `generateName` values ending in `-` will now correctly preserve all characters except the trailing dash, instead of losing two characters.