### PR TITLE
client-go: pass through restConfig dial function for websocket

### DIFF
--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
@@ -74,6 +74,9 @@ type RoundTripper struct {
 	// If Proxy is nil or returns a nil *URL, no proxy is used.
 	Proxier func(req *http.Request) (*url.URL, error)
 
+	// Dialer specifies the dial function for creating TCP connections
+	Dialer utilnet.DialFunc
+
 	// Conn holds the WebSocket connection after a round trip.
 	Conn *gwebsocket.Conn
 }
@@ -111,6 +114,7 @@ func (rt *RoundTripper) RoundTrip(request *http.Request) (retResp *http.Response
 	delete(request.Header, wsstream.WebSocketProtocolHeader)
 
 	dialer := gwebsocket.Dialer{
+		NetDialContext:  rt.Dialer,
 		Proxy:           rt.Proxier,
 		TLSClientConfig: rt.TLSConfig,
 		Subprotocols:    protocolVersions,
@@ -195,6 +199,7 @@ func RoundTripperFor(config *restclient.Config) (http.RoundTripper, ConnectionHo
 	}
 
 	upgradeRoundTripper := &RoundTripper{
+		Dialer:    config.Dial,
 		TLSConfig: tlsConfig,
 		Proxier:   proxy,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Pass through **Dial** function from [`rest.Config`](https://pkg.go.dev/k8s.io/client-go/rest#Config) in websocket implementation. This allows clients that e.g. setup a ssh session in their code to use that as their dialer for websockets. This comes in handy when using the websocket command executor.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:
I did not bother to implement this for SPDY transport as it's already possible to provide the rest.Config dialer as a custom transport:
```go
rt, err := rest.TransportFor(restConfig)
if err != nil {
	return nil, err
}
upgradeRoundTripper, err := httpstreamspdy.NewRoundTripperWithConfig(httpstreamspdy.RoundTripperConfig{
	UpgradeTransport: rt,
	PingPeriod:       time.Second * 5,
})
if err != nil {
	return nil, err
}
wrapper, err := rest.HTTPWrappersForConfig(restConfig, upgradeRoundTripper)
if err != nil {
	return nil, err
}
return remotecommand.NewSPDYExecutorForTransports(wrapper, upgradeRoundTripper, http.MethodPost, execReqURL)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
