### PR TITLE
Lint: Activate modernize/forvar rule in golangci-lint.

### DIFF
--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -542,11 +542,6 @@ linters:
         # should only be updated in old code
         # where it really matters.
         - fmtappendf
-        # Remove redundant re-declaration of loop variables.
-        #
-        # A useful hint that this is no longer necessary with
-        # the Go version that Kubernetes depends on.
-        - forvar
         # Replace explicit loops over maps with calls to maps package.
         #
         # Completely disabled because the benefit

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -297,11 +297,6 @@ linters:
         # should only be updated in old code
         # where it really matters.
         - fmtappendf
-        # Remove redundant re-declaration of loop variables.
-        #
-        # A useful hint that this is no longer necessary with
-        # the Go version that Kubernetes depends on.
-        - forvar
         # Replace explicit loops over maps with calls to maps package.
         #
         # Completely disabled because the benefit

--- a/pkg/scheduler/util/assumecache/assume_cache.go
+++ b/pkg/scheduler/util/assumecache/assume_cache.go
@@ -314,7 +314,6 @@ func (c *AssumeCache) delete(obj interface{}) {
 // An update has both as non-nil.
 func (c *AssumeCache) pushEvent(oldObj, newObj interface{}) {
 	for _, handler := range c.eventHandlers {
-		handler := handler
 		if oldObj == nil {
 			c.eventQueue.WriteOne(func() {
 				handler.OnAdd(newObj, false)

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -1417,7 +1417,6 @@ func TestAdmitBelowVolumeAttributesClassQuotaLimitWhenPVCScopeUpdated(t *testing
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.desc, func(t *testing.T) {
 			stopCh := make(chan struct{})
 			defer close(stopCh)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
@@ -1235,12 +1235,9 @@ func TestCelCostStability(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			for validRule, expectedCost := range tt.expectCost {
-				validRule := validRule
-				expectedCost := expectedCost
 				testName := validRule
 				if len(testName) > 127 {
 					testName = testName[:127]
@@ -2093,12 +2090,9 @@ func TestCelEstimatedCostStability(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			for validRule, expectedCost := range tt.expectCost {
-				validRule := validRule
-				expectedCost := expectedCost
 				testName := validRule
 				if len(testName) > 127 {
 					testName = testName[:127]

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/adaptor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/adaptor.go
@@ -229,7 +229,6 @@ func (s *Structural) XListMapKeys() []string {
 func (s *Structural) AllOf() []common.Schema {
 	var res []common.Schema
 	for _, subSchema := range s.Structural.ValueValidation.AllOf {
-		subSchema := subSchema
 		res = append(res, nestedValueValidationToStructural(&subSchema))
 	}
 	return res
@@ -238,7 +237,6 @@ func (s *Structural) AllOf() []common.Schema {
 func (s *Structural) AnyOf() []common.Schema {
 	var res []common.Schema
 	for _, subSchema := range s.Structural.ValueValidation.AnyOf {
-		subSchema := subSchema
 		res = append(res, nestedValueValidationToStructural(&subSchema))
 	}
 	return res
@@ -247,7 +245,6 @@ func (s *Structural) AnyOf() []common.Schema {
 func (s *Structural) OneOf() []common.Schema {
 	var res []common.Schema
 	for _, subSchema := range s.Structural.ValueValidation.OneOf {
-		subSchema := subSchema
 		res = append(res, nestedValueValidationToStructural(&subSchema))
 	}
 	return res

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -2196,7 +2196,6 @@ func TestValidationExpressions(t *testing.T) {
 	}
 
 	for i := range tests {
-		i := i
 		t.Run(tests[i].name, func(t *testing.T) {
 			t.Parallel()
 			tt := tests[i]
@@ -2918,7 +2917,6 @@ func TestValidationExpressionsAtSchemaLevels(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.TODO()
@@ -4593,7 +4591,6 @@ func TestOptionalOldSelf(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		tp := true
 		for i := range tt.schema.XValidations {
 			tt.schema.XValidations[i].OptionalOldSelf = &tp
@@ -4749,7 +4746,6 @@ func TestOptionalOldSelfCheckForNull(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		tp := true
 		for i := range tt.schema.XValidations {
 			tt.schema.XValidations[i].OptionalOldSelf = &tp

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/test/cel.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/test/cel.go
@@ -116,7 +116,6 @@ func findCEL(t *testing.T, s *schema.Structural, root bool, pth *field.Path) (ma
 	}
 
 	for k, v := range s.Properties {
-		v := v
 		sub, err := findCEL(t, &v, false, pth.Child("properties").Child(k))
 		if err != nil {
 			return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/test/pattern.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/test/pattern.go
@@ -69,7 +69,6 @@ func findPattern(t *testing.T, s *schema.Structural, pth *field.Path) (map[strin
 	}
 
 	for k, v := range s.Properties {
-		v := v
 		sub, err := findPattern(t, &v, pth.Child("properties").Child(k))
 		if err != nil {
 			return nil, err

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -964,7 +964,6 @@ func TestCustomToUnstructured(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.Data, func(t *testing.T) {
 			t.Parallel()
 			result, err := runtime.NewTestUnstructuredConverter(simpleEquality).ToUnstructured(&G{
@@ -989,7 +988,6 @@ func TestCustomToUnstructuredTopLevel(t *testing.T) {
 	}
 	expected := map[string]interface{}{"a": int64(1)}
 	for i, obj := range topLevelCases {
-		obj := obj
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			result, err := runtime.NewTestUnstructuredConverter(simpleEquality).ToUnstructured(obj)

--- a/staging/src/k8s.io/apimachinery/pkg/test/apis_meta_v1_unstructed_unstructure_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/test/apis_meta_v1_unstructed_unstructure_test.go
@@ -370,7 +370,6 @@ func TestOwnerReferences(t *testing.T) {
 		},
 	}
 	for i, ref := range refs {
-		ref := ref
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			u1 := unstructured.Unstructured{

--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
@@ -55,7 +55,6 @@ func HandleCrash(additionalHandlers ...func(interface{})) {
 	if r := recover(); r != nil {
 		additionalHandlersWithContext := make([]func(context.Context, interface{}), len(additionalHandlers))
 		for i, handler := range additionalHandlers {
-			handler := handler // capture loop variable
 			additionalHandlersWithContext[i] = func(_ context.Context, r interface{}) {
 				handler(r)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/audit/union.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/union.go
@@ -48,7 +48,6 @@ func (u union) ProcessEvents(events ...*auditinternal.Event) bool {
 func (u union) Run(stopCh <-chan struct{}) error {
 	var funcs []func() error
 	for _, backend := range u.backends {
-		backend := backend
 		funcs = append(funcs, func() error {
 			return backend.Run(stopCh)
 		})

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/adaptor.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/adaptor.go
@@ -156,7 +156,6 @@ func (s *Schema) Nullable() bool {
 func (s *Schema) AllOf() []common.Schema {
 	var res []common.Schema
 	for _, nestedSchema := range s.Schema.AllOf {
-		nestedSchema := nestedSchema
 		res = append(res, &Schema{&nestedSchema})
 	}
 	return res
@@ -165,7 +164,6 @@ func (s *Schema) AllOf() []common.Schema {
 func (s *Schema) AnyOf() []common.Schema {
 	var res []common.Schema
 	for _, nestedSchema := range s.Schema.AnyOf {
-		nestedSchema := nestedSchema
 		res = append(res, &Schema{&nestedSchema})
 	}
 	return res
@@ -174,7 +172,6 @@ func (s *Schema) AnyOf() []common.Schema {
 func (s *Schema) OneOf() []common.Schema {
 	var res []common.Schema
 	for _, nestedSchema := range s.Schema.OneOf {
-		nestedSchema := nestedSchema
 		res = append(res, &Schema{&nestedSchema})
 	}
 	return res

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -282,8 +282,6 @@ func getTransformerOverridesAndKMSPluginProbes(ctx context.Context, config *apis
 
 	// For each entry in the configuration
 	for _, resourceConfig := range config.Resources {
-		resourceConfig := resourceConfig
-
 		transformers, p, used, err := prefixTransformersAndProbes(ctx, resourceConfig, apiServerID)
 		if err != nil {
 			return nil, nil, nil, err
@@ -292,7 +290,6 @@ func getTransformerOverridesAndKMSPluginProbes(ctx context.Context, config *apis
 
 		// For each resource, create a list of providers to use
 		for _, resource := range resourceConfig.Resources {
-			resource := resource
 			gr := schema.ParseGroupResource(resource)
 
 			// check if resource is masked by *.group rule
@@ -317,8 +314,6 @@ func getTransformerOverridesAndKMSPluginProbes(ctx context.Context, config *apis
 
 	transformers := make(map[schema.GroupResource]storagevalue.Transformer, len(resourceToPrefixTransformer))
 	for gr, transList := range resourceToPrefixTransformer {
-		gr := gr
-		transList := transList
 		transformers[gr] = storagevalue.NewPrefixTransformers(fmt.Errorf("no matching prefix found"), transList...)
 	}
 
@@ -567,7 +562,6 @@ func prefixTransformersAndProbes(ctx context.Context, config apiserver.ResourceC
 	var kmsUsed kmsState
 
 	for _, provider := range config.Providers {
-		provider := provider
 		var (
 			transformer    storagevalue.PrefixTransformer
 			transformerErr error
@@ -624,7 +618,6 @@ func aesPrefixTransformer(config *apiserver.AESConfiguration, fn blockTransforme
 		return result, fmt.Errorf("aes provider has no valid keys")
 	}
 	for _, key := range config.Keys {
-		key := key
 		if key.Name == "" {
 			return result, fmt.Errorf("key with invalid name provided")
 		}
@@ -636,7 +629,6 @@ func aesPrefixTransformer(config *apiserver.AESConfiguration, fn blockTransforme
 	keyTransformers := []storagevalue.PrefixTransformer{}
 
 	for _, keyData := range config.Keys {
-		keyData := keyData
 		key, err := base64.StdEncoding.DecodeString(keyData.Secret)
 		if err != nil {
 			return result, fmt.Errorf("could not obtain secret for named key %s: %w", keyData.Name, err)
@@ -677,7 +669,6 @@ func secretboxPrefixTransformer(config *apiserver.SecretboxConfiguration) (stora
 		return result, fmt.Errorf("secretbox provider has no valid keys")
 	}
 	for _, key := range config.Keys {
-		key := key
 		if key.Name == "" {
 			return result, fmt.Errorf("key with invalid name provided")
 		}
@@ -689,7 +680,6 @@ func secretboxPrefixTransformer(config *apiserver.SecretboxConfiguration) (stora
 	keyTransformers := []storagevalue.PrefixTransformer{}
 
 	for _, keyData := range config.Keys {
-		keyData := keyData
 		key, err := base64.StdEncoding.DecodeString(keyData.Secret)
 		if err != nil {
 			return result, fmt.Errorf("could not obtain secret for named key %s: %s", keyData.Name, err)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -2229,7 +2229,6 @@ func TestGetEncryptionConfigHash(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces_test.go
@@ -173,7 +173,6 @@ func TestValidateListOptions(t *testing.T) {
 		},
 	}
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			withRev, continueKey, err := ValidateListOptions("", APIObjectVersioner{}, tt.opts)
 			if len(tt.expectedError) > 0 {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -206,7 +206,6 @@ func RunTestGet(ctx context.Context, t *testing.T, store storage.Interface) {
 	}}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// For some asynchronous implementations of storage interface (in particular watchcache),
 			// certain requests may impact result of further requests. As an example, if we first
@@ -2263,7 +2262,6 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// For some asynchronous implementations of storage interface (in particular watchcache),
 			// certain requests may impact result of further requests. As an example, if we first
@@ -2689,7 +2687,6 @@ func RunTestGetListNonRecursive(ctx context.Context, t *testing.T, increaseRV In
 	}}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// For some asynchronous implementations of storage interface (in particular watchcache),
 			// certain requests may impact result of further requests. As an example, if we first
@@ -2817,10 +2814,8 @@ func RunTestGetListRecursivePrefix(ctx context.Context, t *testing.T, store stor
 	}
 
 	for _, listType := range listTypes {
-		listType := listType
 		t.Run(listType.name, func(t *testing.T) {
 			for _, tt := range tests {
-				tt := tt
 				t.Run(tt.name, func(t *testing.T) {
 					out := &example.PodList{}
 					storageOpts := storage.ListOptions{

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes_test.go
@@ -502,7 +502,6 @@ func BenchmarkGCMRead(b *testing.B) {
 		name := fmt.Sprintf("%vKeyLength/%vValueLength/%vExpectStale", t.keyLength, t.valueLength, t.expectStale)
 		b.Run(name, func(b *testing.B) {
 			for _, n := range gcmBenchmarks {
-				n := n
 				if t.keyLength == 16 && n.name == "gcm-extended-nonce" {
 					continue // gcm-extended-nonce requires 32 byte keys
 				}
@@ -528,7 +527,6 @@ func BenchmarkGCMWrite(b *testing.B) {
 		name := fmt.Sprintf("%vKeyLength/%vValueLength", t.keyLength, t.valueLength)
 		b.Run(name, func(b *testing.B) {
 			for _, n := range gcmBenchmarks {
-				n := n
 				if t.keyLength == 16 && n.name == "gcm-extended-nonce" {
 					continue // gcm-extended-nonce requires 32 byte keys
 				}

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/cache_test.go
@@ -110,7 +110,6 @@ func Test_simpleCache(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			clock := clocktesting.NewFakeClock(time.Now())

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
@@ -111,7 +111,6 @@ func TestTimeouts(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 			var (

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go
@@ -523,7 +523,6 @@ func generateCacheKey(encryptedDEKSourceType kmstypes.EncryptedDEKSourceType, en
 	// Sort the annotations by key.
 	keys := make([]string, 0, len(annotations))
 	for k := range annotations {
-		k := k
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
@@ -314,7 +314,6 @@ func TestEnvelopeTransformerStaleness(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -512,7 +511,6 @@ func TestTransformToStorageError(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -658,7 +656,6 @@ func TestValidateAnnotations(t *testing.T) {
 	}
 	t.Run("success", func(t *testing.T) {
 		for i := range successCases {
-			i := i
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 				t.Parallel()
 				if err := validateAnnotations(successCases[i]); err != nil {
@@ -696,7 +693,6 @@ func TestValidateAnnotations(t *testing.T) {
 
 	t.Run("name error", func(t *testing.T) {
 		for i := range annotationsNameErrorCases {
-			i := i
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 				t.Parallel()
 				err := validateAnnotations(annotationsNameErrorCases[i].annotations)
@@ -724,7 +720,6 @@ func TestValidateAnnotations(t *testing.T) {
 	}
 	t.Run("size error", func(t *testing.T) {
 		for i := range annotationsSizeErrorCases {
-			i := i
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 				t.Parallel()
 				err := validateAnnotations(annotationsSizeErrorCases[i].annotations)
@@ -769,7 +764,6 @@ func TestValidateKeyID(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			errCode, err := ValidateKeyID(tt.keyID)
@@ -822,7 +816,6 @@ func TestValidateEncryptedDEKSource(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateEncryptedDEKSource(tt.encryptedDEKSource)
@@ -1028,7 +1021,6 @@ func TestEnvelopeLogging(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			var buf bytes.Buffer
 			klog.SetOutput(&buf)
@@ -1170,9 +1162,7 @@ func TestGenerateCacheKey(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		for _, tc2 := range testCases {
-			tc2 := tc2
 			t.Run(fmt.Sprintf("%+v-%+v", tc, tc2), func(t *testing.T) {
 				key1, err1 := generateCacheKey(tc.encryptedDEKSourceType, tc.encryptedDEKSource, tc.keyID, tc.annotations)
 				key2, err2 := generateCacheKey(tc2.encryptedDEKSourceType, tc2.encryptedDEKSource, tc2.keyID, tc2.annotations)
@@ -1240,7 +1230,6 @@ func TestGenerateTransformer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service_unix_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service_unix_test.go
@@ -117,7 +117,6 @@ func TestTimeouts(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 			var (

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate_test.go
@@ -70,7 +70,6 @@ func TestTruncatingEvents(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -122,7 +121,6 @@ func TestSplittingBatches(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -220,7 +220,6 @@ func (l ConcurrentVisitorList) Visit(fn VisitorFunc) error {
 	g.SetLimit(concurrency)
 
 	for i := range l.visitors {
-		i := i
 		g.Go(func() error {
 			return l.visitors[i].Visit(fn)
 		})

--- a/staging/src/k8s.io/client-go/rest/exec_test.go
+++ b/staging/src/k8s.io/client-go/rest/exec_test.go
@@ -192,7 +192,6 @@ func TestConfigToExecCluster(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			out, err := ConfigToExecCluster(&test.in)
 			if test.wantErrorPrefix != "" {

--- a/staging/src/k8s.io/client-go/rest/transport_test.go
+++ b/staging/src/k8s.io/client-go/rest/transport_test.go
@@ -128,7 +128,6 @@ uml0obOEy+ON91k+SWTJ3ggmF/U=
 	var wg sync.WaitGroup
 
 	for _, tt := range configurations {
-		tt := tt
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/staging/src/k8s.io/client-go/tools/auth/exec/exec_test.go
+++ b/staging/src/k8s.io/client-go/tools/auth/exec/exec_test.go
@@ -254,7 +254,6 @@ func TestLoadExecCredential(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/staging/src/k8s.io/client-go/tools/auth/exec/types_test.go
+++ b/staging/src/k8s.io/client-go/tools/auth/exec/types_test.go
@@ -35,7 +35,6 @@ func TestClientAuthenticationClusterTypesAreSynced(t *testing.T) {
 		clientauthenticationv1beta1.Cluster{},
 		clientauthenticationv1.Cluster{},
 	} {
-		cluster := cluster
 		t.Run(fmt.Sprintf("%T", cluster), func(t *testing.T) {
 			t.Parallel()
 			testClientAuthenticationClusterTypesAreSynced(t, cluster)

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
@@ -278,8 +278,6 @@ func TestDeltaFIFOW_ReplaceMakesDeletionsForObjectsOnlyInQueue(t *testing.T) {
 		},
 	}
 	for _, tt := range table {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			// Test with a DeltaFIFO with a backing KnownObjects
 			fWithKnownObjects := NewDeltaFIFOWithOptions(DeltaFIFOOptions{

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
@@ -246,8 +246,6 @@ func TestRealFIFOW_ReplaceMakesDeletionsForObjectsOnlyInQueue(t *testing.T) {
 		},
 	}
 	for _, tt := range table {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			// Test with a RealFIFO with a backing KnownObjects
 			fWithKnownObjects := NewRealFIFO(
@@ -1394,8 +1392,6 @@ func TestRealFIFO_ReplaceAtomic(t *testing.T) {
 		},
 	}
 	for _, tt := range table {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			// Test with a RealFIFO with a backing KnownObjects
 			f := NewRealFIFO(

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/defaults_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/defaults_test.go
@@ -72,7 +72,6 @@ func TestSetDefaults_Config(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			gotOut := test.in.DeepCopy()
 			SetDefaults_ExecConfig(gotOut)

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -548,7 +548,6 @@ func TestRetryWatcher(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			t.Parallel()

--- a/staging/src/k8s.io/component-base/metrics/opts_test.go
+++ b/staging/src/k8s.io/component-base/metrics/opts_test.go
@@ -53,7 +53,6 @@ func TestDefaultStabilityLevel(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var stability = tc.inputValue
 

--- a/staging/src/k8s.io/component-helpers/storage/volume/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/helpers_test.go
@@ -250,7 +250,6 @@ func TestPersistentVolumeClaimHasClass(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got := PersistentVolumeClaimHasClass(tc.pvc)
 			if got != tc.want {

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -357,7 +357,6 @@ func (t *Tracker) pushEvent(oldObj, newObj any) {
 	t.rwMutex.Lock()
 	defer t.rwMutex.Unlock()
 	for _, handler := range t.eventHandlers {
-		handler := handler
 		if oldObj == nil {
 			t.eventQueue.WriteOne(func() {
 				handler.OnAdd(newObj, false)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -612,7 +612,6 @@ func TestMasker(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			m, err := NewMasker(tc.input.from, tc.input.to)

--- a/staging/src/k8s.io/kubectl/pkg/drain/default_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default_test.go
@@ -54,7 +54,6 @@ func TestRunCordonOrUncordon(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			err := RunCordonOrUncordon(test.drainer, test.node, test.desired)
 			if test.expectedError == nil {

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -3016,8 +3016,6 @@ func benchPostPod(client clientset.Interface, pod v1.Pod, parallel int) func(*te
 		for i := 0; i < b.N; i++ {
 			c := make(chan error)
 			for j := range parallel {
-				j := j
-				i := i
 				go func(pod v1.Pod) {
 					pod.Name = fmt.Sprintf("post%d-%d-%d-%d", parallel, b.N, j, i)
 					_, err := client.CoreV1().RESTClient().Post().


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The [forvar](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_forvar) has already been applied under `test` and `pkg` in two previous PRs by me. I suggest that this rule from modernize is activated. The pattern is mostly in the test-files, although one match in a non-test file was found.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

Changes can be reproduced with:

```sh
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -forvar -fix -test ./...
```

And then I found one `i := i` in the second for-loop that I think looks weird. It was removed with post-editing.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```