### PR TITLE
Make DialerStopCh a config rather than a global var

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -54,7 +54,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	clientgotransport "k8s.io/client-go/transport"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
 	basecompatibility "k8s.io/component-base/compatibility"
@@ -393,14 +392,14 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	}
 	utilfeature.DefaultMutableFeatureGate.AddMetrics()
 
+	// dialerStopCh controls the lifecycle of cert-reloading dialer goroutines.
+	dialerCtx, dialerCancel := context.WithTimeout(context.Background(), time.Hour)
+	t.Cleanup(dialerCancel)
+	dialerStopCh := dialerCtx.Done()
+	s.DialerStopCh = dialerStopCh
+
 	if instanceOptions.EnableCertAuth {
 		if featureGate.Enabled(genericfeatures.UnknownVersionInteroperabilityProxy) {
-			// TODO: set up a general clean up for testserver
-			if clientgotransport.DialerStopCh == wait.NeverStop {
-				ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
-				t.Cleanup(cancel)
-				clientgotransport.DialerStopCh = ctx.Done()
-			}
 			s.PeerCAFile = filepath.Join(s.SecureServing.ServerCert.CertDirectory, s.SecureServing.ServerCert.PairName+".crt")
 		}
 	}

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -143,6 +143,7 @@ func BuildGenericConfig(
 	// Disable compression for self-communication, since we are going to be
 	// on a fast local network
 	genericConfig.LoopbackClientConfig.DisableCompression = true
+	genericConfig.LoopbackClientConfig.DialerStopCh = s.DialerStopCh
 
 	kubeClientConfig := genericConfig.LoopbackClientConfig
 	clientgoExternalClient, err := clientgoclientset.NewForConfig(kubeClientConfig)
@@ -332,6 +333,7 @@ func CreateConfig(
 				config.Extra.PeerEndpointLeaseReconciler,
 				config.Generic.Serializer,
 				config.Generic.EgressSelector,
+				opts.DialerStopCh,
 			)
 			if err != nil {
 				return nil, nil, err

--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -96,6 +96,12 @@ type Options struct {
 	CoordinatedLeadershipLeaseDuration time.Duration
 	CoordinatedLeadershipRenewDeadline time.Duration
 	CoordinatedLeadershipRetryPeriod   time.Duration
+
+	// DialerStopCh is an optional stop channel for cert-reloading dialer goroutines.
+	// If set, it controls the lifecycle of background goroutines that handle
+	// certificate rotation for transport configs using file-based TLS.
+	// This is primarily useful in tests to prevent goroutine leaks.
+	DialerStopCh <-chan struct{}
 }
 
 // completedServerRunOptions is a private wrapper that enforces a call of Complete() before Run can be invoked.

--- a/pkg/controlplane/apiserver/peer.go
+++ b/pkg/controlplane/apiserver/peer.go
@@ -55,6 +55,7 @@ func BuildPeerProxy(
 	reconciler reconcilers.PeerEndpointLeaseReconciler,
 	serializer runtime.NegotiatedSerializer,
 	es *egressselector.EgressSelector,
+	dialerStopCh <-chan struct{},
 ) (utilpeerproxy.Interface, error) {
 	if proxyClientCertFile == "" {
 		return nil, fmt.Errorf("error building peer proxy handler, proxy-cert-file not specified")
@@ -70,7 +71,9 @@ func BuildPeerProxy(
 			KeyFile:    proxyClientKeyFile,
 			CAFile:     peerCAFile,
 			ServerName: "kubernetes.default.svc",
-		}}
+		},
+		DialerStopCh: dialerStopCh,
+	}
 
 	if es != nil {
 		egressDialer, err := es.Lookup(egressselector.ControlPlane.AsNetworkContext())

--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -50,6 +50,10 @@ type KubeletClientConfig struct {
 
 	// Lookup will give us a dialer if the egress selector is configured for it
 	Lookup egressselector.Lookup
+
+	// DialerStopCh is an optional stop channel for the cert-reloading dialer goroutine.
+	// If nil, the dialer goroutine will run for the lifetime of the process.
+	DialerStopCh <-chan struct{}
 }
 
 type KubeletTLSConfig struct {
@@ -121,6 +125,7 @@ func (c *KubeletClientConfig) transportConfig() *transport.Config {
 			// it is clearer to set it explicitly here so we remember that this is happening
 			ReloadTLSFiles: true,
 		},
+		DialerStopCh: c.DialerStopCh,
 	}
 	if !cfg.HasCA() {
 		cfg.TLS.Insecure = true

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -159,6 +159,10 @@ type Config struct {
 	// socks5 proxying does not currently support spdy streaming endpoints.
 	Proxy func(*http.Request) (*url.URL, error)
 
+	// DialerStopCh is an optional stop channel for the cert-reloading dialer goroutine.
+	// If nil, the dialer goroutine will run for the lifetime of the process.
+	DialerStopCh <-chan struct{}
+
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?
 	// Version string
@@ -653,6 +657,7 @@ func AnonymousClientConfig(config *Config) *Config {
 		Timeout:                   config.Timeout,
 		Dial:                      config.Dial,
 		Proxy:                     config.Proxy,
+		DialerStopCh:              config.DialerStopCh,
 	}
 }
 
@@ -698,6 +703,7 @@ func CopyConfig(config *Config) *Config {
 		Timeout:                   config.Timeout,
 		Dial:                      config.Dial,
 		Proxy:                     config.Proxy,
+		DialerStopCh:              config.DialerStopCh,
 	}
 	if config.ExecProvider != nil && config.ExecProvider.Config != nil {
 		c.ExecProvider.Config = config.ExecProvider.Config.DeepCopyObject()

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -358,6 +358,7 @@ func TestAnonymousAuthConfig(t *testing.T) {
 		func(r *func(*http.Request) (*url.URL, error), f randfill.Continue) {
 			*r = fakeProxyFunc
 		},
+		func(r *<-chan struct{}, f randfill.Continue) {},
 		func(r *runtime.Object, f randfill.Continue) {
 			unknown := &runtime.Unknown{}
 			f.Fill(unknown)
@@ -457,6 +458,7 @@ func TestCopyConfig(t *testing.T) {
 		func(r *func(*http.Request) (*url.URL, error), f randfill.Continue) {
 			*r = fakeProxyFunc
 		},
+		func(r *<-chan struct{}, f randfill.Continue) {},
 		func(r *runtime.Object, f randfill.Continue) {
 			unknown := &runtime.Unknown{}
 			f.Fill(unknown)
@@ -652,7 +654,7 @@ func TestConfigSprint(t *testing.T) {
 		Proxy:                     fakeProxyFunc,
 	}
 	want := fmt.Sprintf(
-		`&rest.Config{Host:"localhost:8080", APIPath:"v1", ContentConfig:rest.ContentConfig{AcceptContentTypes:"application/json", ContentType:"application/json", GroupVersion:(*schema.GroupVersion)(nil), NegotiatedSerializer:runtime.NegotiatedSerializer(nil)}, Username:"gopher", Password:"--- REDACTED ---", BearerToken:"--- REDACTED ---", BearerTokenFile:"", Impersonate:rest.ImpersonationConfig{UserName:"gopher2", UID:"uid123", Groups:[]string(nil), Extra:map[string][]string(nil)}, AuthProvider:api.AuthProviderConfig{Name: "gopher", Config: map[string]string{--- REDACTED ---}}, AuthConfigPersister:rest.AuthProviderConfigPersister(--- REDACTED ---), ExecProvider:api.ExecConfig{Command: "sudo", Args: []string{"--- REDACTED ---"}, Env: []ExecEnvVar{--- REDACTED ---}, APIVersion: "", ProvideClusterInfo: true, Config: runtime.Object(--- REDACTED ---), StdinUnavailable: false}, TLSClientConfig:rest.sanitizedTLSClientConfig{Insecure:false, ServerName:"", CertFile:"a.crt", KeyFile:"a.key", CAFile:"", CertData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x54, 0x52, 0x55, 0x4e, 0x43, 0x41, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, KeyData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x52, 0x45, 0x44, 0x41, 0x43, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, CAData:[]uint8(nil), NextProtos:[]string{"h2", "http/1.1"}}, UserAgent:"gobot", DisableCompression:false, Transport:(*rest.fakeRoundTripper)(%p), WrapTransport:(transport.WrapperFunc)(%p), QPS:1, Burst:2, RateLimiter:(*rest.fakeLimiter)(%p), WarningHandler:rest.fakeWarningHandler{}, WarningHandlerWithContext:rest.fakeWarningHandlerWithContext{}, Timeout:3000000000, Dial:(func(context.Context, string, string) (net.Conn, error))(%p), Proxy:(func(*http.Request) (*url.URL, error))(%p)}`,
+		`&rest.Config{Host:"localhost:8080", APIPath:"v1", ContentConfig:rest.ContentConfig{AcceptContentTypes:"application/json", ContentType:"application/json", GroupVersion:(*schema.GroupVersion)(nil), NegotiatedSerializer:runtime.NegotiatedSerializer(nil)}, Username:"gopher", Password:"--- REDACTED ---", BearerToken:"--- REDACTED ---", BearerTokenFile:"", Impersonate:rest.ImpersonationConfig{UserName:"gopher2", UID:"uid123", Groups:[]string(nil), Extra:map[string][]string(nil)}, AuthProvider:api.AuthProviderConfig{Name: "gopher", Config: map[string]string{--- REDACTED ---}}, AuthConfigPersister:rest.AuthProviderConfigPersister(--- REDACTED ---), ExecProvider:api.ExecConfig{Command: "sudo", Args: []string{"--- REDACTED ---"}, Env: []ExecEnvVar{--- REDACTED ---}, APIVersion: "", ProvideClusterInfo: true, Config: runtime.Object(--- REDACTED ---), StdinUnavailable: false}, TLSClientConfig:rest.sanitizedTLSClientConfig{Insecure:false, ServerName:"", CertFile:"a.crt", KeyFile:"a.key", CAFile:"", CertData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x54, 0x52, 0x55, 0x4e, 0x43, 0x41, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, KeyData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x52, 0x45, 0x44, 0x41, 0x43, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, CAData:[]uint8(nil), NextProtos:[]string{"h2", "http/1.1"}}, UserAgent:"gobot", DisableCompression:false, Transport:(*rest.fakeRoundTripper)(%p), WrapTransport:(transport.WrapperFunc)(%p), QPS:1, Burst:2, RateLimiter:(*rest.fakeLimiter)(%p), WarningHandler:rest.fakeWarningHandler{}, WarningHandlerWithContext:rest.fakeWarningHandlerWithContext{}, Timeout:3000000000, Dial:(func(context.Context, string, string) (net.Conn, error))(%p), Proxy:(func(*http.Request) (*url.URL, error))(%p), DialerStopCh:(<-chan struct {})(nil)}`,
 		c.Transport, fakeWrapperFunc, c.RateLimiter, fakeDialFunc, fakeProxyFunc,
 	)
 

--- a/staging/src/k8s.io/client-go/rest/exec_test.go
+++ b/staging/src/k8s.io/client-go/rest/exec_test.go
@@ -256,6 +256,7 @@ func TestConfigToExecClusterRoundtrip(t *testing.T) {
 		func(r *func(*http.Request) (*url.URL, error), f randfill.Continue) {
 			*r = fakeProxyFunc
 		},
+		func(r *<-chan struct{}, f randfill.Continue) {},
 		func(r *runtime.Object, f randfill.Continue) {
 			unknown := &runtime.Unknown{}
 			f.Fill(unknown)
@@ -295,6 +296,7 @@ func TestConfigToExecClusterRoundtrip(t *testing.T) {
 		expected.WarningHandlerWithContext = nil
 		expected.Timeout = 0
 		expected.Dial = nil
+		expected.DialerStopCh = nil
 
 		// Manually set URLs so we don't get an error when parsing these during the roundtrip.
 		if expected.Host != "" {

--- a/staging/src/k8s.io/client-go/rest/transport.go
+++ b/staging/src/k8s.io/client-go/rest/transport.go
@@ -108,7 +108,8 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			Groups:   c.Impersonate.Groups,
 			Extra:    c.Impersonate.Extra,
 		},
-		Proxy: c.Proxy,
+		Proxy:        c.Proxy,
+		DialerStopCh: c.DialerStopCh,
 	}
 
 	if c.Dial != nil {

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -39,9 +39,10 @@ type tlsTransportCache struct {
 	transports map[tlsCacheKey]*http.Transport
 }
 
-// DialerStopCh is stop channel that is passed down to dynamic cert dialer.
-// It's exposed as variable for testing purposes to avoid testing for goroutine
-// leakages.
+// DialerStopCh is a global stop channel for the cert-reloading dialer.
+//
+// Deprecated: This variable is no longer used internally. Use Config.DialerStopCh
+// instead to control the lifecycle of cert-reloading dialers per-client.
 var DialerStopCh = wait.NeverStop
 
 const idleConnsPerHost = 25
@@ -123,7 +124,11 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 		dynamicCertDialer := certRotatingDialer(logger, tlsConfig.GetClientCertificate, dial)
 		tlsConfig.GetClientCertificate = dynamicCertDialer.GetClientCertificate
 		dial = dynamicCertDialer.connDialer.DialContext
-		go dynamicCertDialer.run(DialerStopCh)
+		stopCh := config.DialerStopCh
+		if stopCh == nil {
+			stopCh = wait.NeverStop
+		}
+		go dynamicCertDialer.run(stopCh)
 	}
 
 	proxy := http.ProxyFromEnvironment

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -77,6 +77,10 @@ type Config struct {
 	//
 	// socks5 proxying does not currently support spdy streaming endpoints.
 	Proxy func(*http.Request) (*url.URL, error)
+
+	// DialerStopCh is an optional stop channel for the cert-reloading dialer goroutine.
+	// If nil, the dialer goroutine will run for the lifetime of the process.
+	DialerStopCh <-chan struct{}
 }
 
 // DialHolder is used to make the wrapped function comparable so that it can be used as a map key.

--- a/test/integration/apiserver/peerproxy/peer_proxy_test.go
+++ b/test/integration/apiserver/peerproxy/peer_proxy_test.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apiserver/pkg/server"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/cert"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
@@ -53,13 +52,6 @@ import (
 
 func TestPeerProxiedRequest(t *testing.T) {
 	ktesting.SetDefaultVerbosity(1)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer func() {
-		t.Cleanup(cancel) // register context cancellation last so it is cleaned up before servers
-	}()
-
-	// ensure to stop cert reloading after shutdown
-	transport.DialerStopCh = ctx.Done()
 
 	// enable feature flags
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
@@ -120,9 +112,6 @@ func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
 	defer func() {
 		t.Cleanup(cancel) // register context cancellation last so it is cleaned up before servers
 	}()
-
-	// ensure to stop cert reloading after shutdown
-	transport.DialerStopCh = ctx.Done()
 
 	// enable feature flags
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{

--- a/test/integration/apiserver/podlogs/podlogs_test.go
+++ b/test/integration/apiserver/podlogs/podlogs_test.go
@@ -202,12 +202,9 @@ func TestPodLogsKubeletClientCertReload(t *testing.T) {
 	t.Cleanup(cancel)
 
 	origCertCallbackRefreshDuration := transport.CertCallbackRefreshDuration
-	origDialerStopCh := transport.DialerStopCh
 	transport.CertCallbackRefreshDuration = time.Second // make client cert reloading fast
-	transport.DialerStopCh = ctx.Done()
 	t.Cleanup(func() {
 		transport.CertCallbackRefreshDuration = origCertCallbackRefreshDuration
-		transport.DialerStopCh = origDialerStopCh
 	})
 
 	// create a CA to sign the API server's kubelet client cert
@@ -258,6 +255,7 @@ func TestPodLogsKubeletClientCertReload(t *testing.T) {
 			opts.KubeletConfig.TLSClientConfig.CAFile = kubeletCA
 			opts.KubeletConfig.TLSClientConfig.CertFile = startingCerts.clientCertFile
 			opts.KubeletConfig.TLSClientConfig.KeyFile = startingCerts.clientCertKeyFile
+			opts.KubeletConfig.DialerStopCh = ctx.Done()
 		},
 	})
 	t.Cleanup(tearDownFn)

--- a/test/integration/client/cert_rotation_test.go
+++ b/test/integration/client/cert_rotation_test.go
@@ -42,11 +42,7 @@ import (
 )
 
 func TestCertRotation(t *testing.T) {
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	transport.CertCallbackRefreshDuration = 1 * time.Second
-	transport.DialerStopCh = stopCh
 
 	certDir := os.TempDir()
 	clientCAFilename, clientSigningCert, clientSigningKey := writeCACertFiles(t, certDir)
@@ -100,11 +96,7 @@ func TestCertRotation(t *testing.T) {
 }
 
 func TestCertRotationContinuousRequests(t *testing.T) {
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	transport.CertCallbackRefreshDuration = 1 * time.Second
-	transport.DialerStopCh = stopCh
 
 	certDir := os.TempDir()
 	clientCAFilename, clientSigningCert, clientSigningKey := writeCACertFiles(t, certDir)

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -235,6 +235,9 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 	kubeAPIServerClientConfig.CAFile = path.Join(certDir, "apiserver.crt")
 	kubeAPIServerClientConfig.CAData = nil
 	kubeAPIServerClientConfig.ServerName = ""
+	// Set DialerStopCh to stop cert-reloading dialer goroutines when the test ends.
+	// This prevents goroutine leaks since CAFile triggers file-based TLS reloading.
+	kubeAPIServerClientConfig.DialerStopCh = ctx.Done()
 
 	// wait for health
 	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

#### What this PR does / why we need it:
Adds DialerStopCh field to transport.Config and rest.Config (instead of using the global transport.DialerStopCh variable) which causes data races when multiple tests run in parallel. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Issue: https://github.com/kubernetes/kubernetes/issues/137407

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
