### PR TITLE
Promote admission webhook metrics to BETA

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -198,7 +198,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 			Subsystem:      subsystem,
 			Name:           "webhook_rejection_count",
 			Help:           "Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"name", "type", "operation", "error_type", "rejection_code"})
 
@@ -218,7 +218,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 			Subsystem:      subsystem,
 			Name:           "webhook_request_total",
 			Help:           "Admission webhook request total, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify whether the request was rejected or not and an HTTP status code. Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"name", "type", "operation", "code", "rejected"})
 

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -1,3 +1,36 @@
+- name: webhook_rejection_count
+  subsystem: admission
+  namespace: apiserver
+  help: Admission webhook rejection count, identified by name and broken out for each
+    admission type (validating or admit) and operation. Additional labels specify
+    an error type (calling_webhook_error or apiserver_internal_error if an error occurred;
+    no_error otherwise) and optionally a non-zero rejection code if the webhook rejects
+    the request with an HTTP status code (honored by the apiserver when the code is
+    greater or equal to 400). Codes greater than 600 are truncated to 600, to keep
+    the metrics cardinality bounded.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - error_type
+  - name
+  - operation
+  - rejection_code
+  - type
+- name: webhook_request_total
+  subsystem: admission
+  namespace: apiserver
+  help: Admission webhook request total, identified by name and broken out for each
+    admission type (validating or admit) and operation. Additional labels specify
+    whether the request was rejected or not and an HTTP status code. Codes greater
+    than 600 are truncated to 600, to keep the metrics cardinality bounded.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - code
+  - name
+  - operation
+  - rejected
+  - type
 - name: automatic_reload_last_timestamp_seconds
   subsystem: authentication_config_controller
   namespace: apiserver


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes the kube-apiserver admission webhook metrics from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304.

This PR is intentionally scoped to admission webhook metrics only, to make review and approval easier across SIGs. Beta graduation provides stronger compatibility guarantees for metric consumers, specifically that existing metric names and label sets are not removed while in Beta.

#### Which issue(s) this PR is related to:
Part of #136304

#### Special notes for your reviewer:
- Scoped split from [#137067] for easier review.
- Includes only admission webhook metric stability-level promotions:
  - `apiserver_admission_webhook_rejection_count`
  - `apiserver_admission_webhook_request_total`
- Includes corresponding `stable-metrics-list.yaml` regeneration.
- No functional behavior changes.

#### Does this PR introduce a user-facing change?
Yes. The admission webhook metrics listed above are now Beta, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted admission webhook metrics to Beta stability. These metrics now provide stronger compatibility guarantees, including stability of existing label sets while in Beta.
```

