### PR TITLE
Promote audit metrics to beta stability

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -240,35 +240,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: error_total
-  subsystem: apiserver_audit
-  help: Counter of audit events that failed to be audited properly. Plugin identifies
-    the plugin affected by the error.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - plugin
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: event_total
-  subsystem: apiserver_audit
-  help: Counter of audit events generated and sent to the audit backend.
-  type: Counter
-  stabilityLevel: ALPHA
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: level_total
-  subsystem: apiserver_audit
-  help: Counter of policy levels for audit events (1 per request).
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - level
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: requests_rejected_total
   subsystem: apiserver_audit
   help: Counter of apiserver requests rejected due to an error in audit logging backend.
@@ -7022,6 +6993,35 @@
   labels:
   - group
   - resource
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: error_total
+  subsystem: apiserver_audit
+  help: Counter of audit events that failed to be audited properly. Plugin identifies
+    the plugin affected by the error.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - plugin
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: event_total
+  subsystem: apiserver_audit
+  help: Counter of audit events generated and sent to the audit backend.
+  type: Counter
+  stabilityLevel: BETA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: level_total
+  subsystem: apiserver_audit
+  help: Counter of policy levels for audit events (1 per request).
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - level
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -1,3 +1,23 @@
+- name: error_total
+  subsystem: apiserver_audit
+  help: Counter of audit events that failed to be audited properly. Plugin identifies
+    the plugin affected by the error.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - plugin
+- name: event_total
+  subsystem: apiserver_audit
+  help: Counter of audit events generated and sent to the audit backend.
+  type: Counter
+  stabilityLevel: BETA
+- name: level_total
+  subsystem: apiserver_audit
+  help: Counter of policy levels for audit events (1 per request).
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - level
 - name: automatic_reload_last_timestamp_seconds
   subsystem: authentication_config_controller
   namespace: apiserver

--- a/staging/src/k8s.io/apiserver/pkg/audit/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/metrics.go
@@ -44,7 +44,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "event_total",
 			Help:           "Counter of audit events generated and sent to the audit backend.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		})
 	errorCounter = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -52,7 +52,7 @@ var (
 			Name:      "error_total",
 			Help: "Counter of audit events that failed to be audited properly. " +
 				"Plugin identifies the plugin affected by the error.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"plugin"},
 	)
@@ -61,7 +61,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "level_total",
 			Help:           "Counter of policy levels for audit events (1 per request).",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"level"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/audit/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/metrics_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestAuditEventTotalIsBeta(t *testing.T) {
+	eventCounter.Reset()
+	defer eventCounter.Reset()
+
+	want := `
+		# HELP apiserver_audit_event_total [BETA] Counter of audit events generated and sent to the audit backend.
+		# TYPE apiserver_audit_event_total counter
+		apiserver_audit_event_total 1
+	`
+
+	ObserveEvent(context.Background())
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_audit_event_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuditErrorTotalIsBeta(t *testing.T) {
+	errorCounter.Reset()
+	defer errorCounter.Reset()
+
+	want := `
+		# HELP apiserver_audit_error_total [BETA] Counter of audit events that failed to be audited properly. Plugin identifies the plugin affected by the error.
+		# TYPE apiserver_audit_error_total counter
+		apiserver_audit_error_total{plugin="test-plugin"} 1
+	`
+
+	HandlePluginError("test-plugin", errors.New("audit failed"), &auditinternal.Event{})
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_audit_error_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuditLevelTotalIsBeta(t *testing.T) {
+	levelCounter.Reset()
+	defer levelCounter.Reset()
+
+	want := `
+		# HELP apiserver_audit_level_total [BETA] Counter of policy levels for audit events (1 per request).
+		# TYPE apiserver_audit_level_total counter
+		apiserver_audit_level_total{level="Metadata"} 1
+	`
+
+	ObservePolicyLevel(context.Background(), auditinternal.LevelMetadata)
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_audit_level_total"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/audit/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/metrics_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 )
 
-func TestAuditEventTotalIsBeta(t *testing.T) {
+func TestAuditEventTotal(t *testing.T) {
 	eventCounter.Reset()
 	defer eventCounter.Reset()
 
@@ -44,7 +44,7 @@ func TestAuditEventTotalIsBeta(t *testing.T) {
 	}
 }
 
-func TestAuditErrorTotalIsBeta(t *testing.T) {
+func TestAuditErrorTotal(t *testing.T) {
 	errorCounter.Reset()
 	defer errorCounter.Reset()
 
@@ -61,7 +61,7 @@ func TestAuditErrorTotalIsBeta(t *testing.T) {
 	}
 }
 
-func TestAuditLevelTotalIsBeta(t *testing.T) {
+func TestAuditLevelTotal(t *testing.T) {
 	levelCounter.Reset()
 	defer levelCounter.Reset()
 

--- a/staging/src/k8s.io/apiserver/pkg/audit/request_log_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request_log_test.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 )
 
 func TestLogResponseObjectWithPod(t *testing.T) {
@@ -359,4 +361,28 @@ func (s *capturingAuditSink) ProcessEvents(events ...*auditinternal.Event) bool 
 		s.events = append(s.events, eventCopy)
 	}
 	return true
+}
+
+func TestProcessEventStageRecordsAuditEventMetric(t *testing.T) {
+	legacyregistry.Reset()
+	t.Cleanup(legacyregistry.Reset)
+
+	ctx := WithAuditContext(context.Background())
+	ac := AuditContextFrom(ctx)
+	captureSink := &capturingAuditSink{}
+	if err := ac.Init(RequestAuditConfig{Level: auditinternal.LevelRequestResponse}, captureSink); err != nil {
+		t.Fatalf("failed to initialize audit context: %v", err)
+	}
+	if !ac.ProcessEventStage(ctx, auditinternal.StageResponseComplete) {
+		t.Fatal("expected ProcessEventStage to succeed")
+	}
+
+	const expected = `
+# HELP apiserver_audit_event_total [BETA] Counter of audit events generated and sent to the audit backend.
+# TYPE apiserver_audit_event_total counter
+apiserver_audit_event_total 1
+`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "apiserver_audit_event_total"); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"reflect"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -50,6 +51,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 )
 
 type fakeAuditSink struct {
@@ -1032,5 +1035,33 @@ func TestAuditBackendRaceCondition(t *testing.T) {
 				<-serveFinished
 			}
 		})
+	}
+}
+
+func TestAuditPolicyLevelMetric(t *testing.T) {
+	legacyregistry.Reset()
+	t.Cleanup(legacyregistry.Reset)
+
+	ctx := t.Context()
+	sink := &fakeAuditSink{}
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelMetadata, nil)
+	handler = WithAudit(handler, sink, fakeRuleEvaluator, nil)
+	handler = WithAuditInit(handler)
+
+	req, _ := http.NewRequestWithContext(ctx, request.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	req.RemoteAddr = "127.0.0.1"
+	req = withTestContext(req, &user.DefaultInfo{Name: "admin"}, nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	const expected = `
+# HELP apiserver_audit_level_total [BETA] Counter of policy levels for audit events (1 per request).
+# TYPE apiserver_audit_level_total counter
+apiserver_audit_level_total{level="Metadata"} 1
+`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "apiserver_audit_level_total"); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +35,8 @@ import (
 	"k8s.io/apiserver/pkg/apis/audit/install"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 )
 
 func init() {
@@ -160,5 +163,26 @@ func TestLogEventsJson(t *testing.T) {
 				t.Errorf("The result event should be the same with the original one, \noriginal: \n%#v\n result: \n%#v, apiVersion: %s", event, result, version)
 			}
 		}
+	}
+}
+
+func TestProcessEventsIncrementsErrorMetricOnUnknownFormat(t *testing.T) {
+	legacyregistry.Reset()
+	t.Cleanup(legacyregistry.Reset)
+
+	var buf bytes.Buffer
+	backend := NewBackend(&buf, "invalid-format", auditv1.SchemeGroupVersion)
+	event := &auditinternal.Event{AuditID: types.UID(uuid.New().String())}
+	if backend.ProcessEvents(event) {
+		t.Fatal("expected ProcessEvents to fail for unknown format")
+	}
+
+	const expected = `
+# HELP apiserver_audit_error_total [BETA] Counter of audit events that failed to be audited properly. Plugin identifies the plugin affected by the error.
+# TYPE apiserver_audit_error_total counter
+apiserver_audit_error_total{plugin="log"} 1
+`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "apiserver_audit_error_total"); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes the kube-apiserver audit metrics from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304.

This PR is intentionally scoped to audit metrics only, to make review and approval easier across SIGs. Beta graduation provides stronger compatibility guarantees for metric consumers, specifically that existing metric names and label sets are not removed while in Beta.

#### Which issue(s) this PR is related to:
Part of #136304

#### Special notes for your reviewer:
- Scoped split from [#137067](https://github.com/kubernetes/kubernetes/pull/137067) for easier review.
- Includes only audit metric stability-level promotions:
  - `apiserver_audit_event_total`
  - `apiserver_audit_error_total`
  - `apiserver_audit_level_total`
- Includes corresponding `stable-metrics-list.yaml` regeneration.
- No functional behavior changes.

#### Does this PR introduce a user-facing change?
Yes. The audit metrics listed above are now Beta, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted audit metrics to Beta stability. These metrics now provide stronger compatibility guarantees, including stability of existing label sets while in Beta.
```