### PR TITLE
Promote client certificate expiration metric to beta stability

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -523,31 +523,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: certificate_expiration_seconds
-  subsystem: client
-  namespace: apiserver
-  help: Distribution of the remaining lifetime on the certificate used to authenticate
-    a request.
-  type: Histogram
-  stabilityLevel: ALPHA
-  buckets:
-  - 0
-  - 1800
-  - 3600
-  - 7200
-  - 21600
-  - 43200
-  - 86400
-  - 172800
-  - 345600
-  - 604800
-  - 2.592e+06
-  - 7.776e+06
-  - 1.5552e+07
-  - 3.1104e+07
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: ip_errors_total
   subsystem: clusterip_repair
   namespace: apiserver
@@ -7154,6 +7129,31 @@
   help: CEL evaluation time in seconds.
   type: Histogram
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: certificate_expiration_seconds
+  subsystem: client
+  namespace: apiserver
+  help: Distribution of the remaining lifetime on the certificate used to authenticate
+    a request.
+  type: Histogram
+  stabilityLevel: BETA
+  buckets:
+  - 0
+  - 1800
+  - 3600
+  - 7200
+  - 21600
+  - 43200
+  - 86400
+  - 172800
+  - 345600
+  - 604800
+  - 2.592e+06
+  - 7.776e+06
+  - 1.5552e+07
+  - 3.1104e+07
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -50,6 +50,28 @@
   help: CEL evaluation time in seconds.
   type: Histogram
   stabilityLevel: BETA
+- name: certificate_expiration_seconds
+  subsystem: client
+  namespace: apiserver
+  help: Distribution of the remaining lifetime on the certificate used to authenticate
+    a request.
+  type: Histogram
+  stabilityLevel: BETA
+  buckets:
+  - 0
+  - 1800
+  - 3600
+  - 7200
+  - 21600
+  - 43200
+  - 86400
+  - 172800
+  - 345600
+  - 604800
+  - 2.592e+06
+  - 7.776e+06
+  - 1.5552e+07
+  - 3.1104e+07
 - name: current_executing_requests
   subsystem: flowcontrol
   namespace: apiserver

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -69,7 +69,7 @@ var clientCertificateExpirationHistogram = metrics.NewHistogram(
 			15552000, // 6 months
 			31104000, // 1 year
 		},
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
@@ -23,10 +23,13 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +42,8 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 )
 
 const (
@@ -1277,4 +1282,79 @@ func TestCertificateIdentifier(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientCertificateExpirationSeconds(t *testing.T) {
+	clientCertificateExpirationHistogram.Reset()
+	defer clientCertificateExpirationHistogram.Reset()
+
+	certs := getCerts(t, clientCNCert)
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req.TLS = &tls.ConnectionState{PeerCertificates: certs}
+
+	a := New(getDefaultVerifyOptions(t), CommonNameUserConversion)
+	if _, ok, err := a.AuthenticateRequest(req); err != nil || !ok {
+		t.Fatalf("AuthenticateRequest() = ok=%v err=%v", ok, err)
+	}
+
+	remaining, err := histogramSampleSum("apiserver_client_certificate_expiration_seconds")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := certificateExpirationMetricWant(remaining)
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_client_certificate_expiration_seconds"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func histogramSampleSum(name string) (float64, error) {
+	metricFamilies, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		return 0, err
+	}
+	for _, mf := range metricFamilies {
+		if mf.GetName() != name {
+			continue
+		}
+		if len(mf.Metric) != 1 {
+			return 0, fmt.Errorf("expected one sample for %s, got %d", name, len(mf.Metric))
+		}
+		return mf.Metric[0].GetHistogram().GetSampleSum(), nil
+	}
+	return 0, fmt.Errorf("metric %s not found", name)
+}
+
+func certificateExpirationMetricWant(remaining float64) string {
+	buckets := []float64{0, 1800, 3600, 7200, 21600, 43200, 86400, 172800, 345600, 604800, 2592000, 7776000, 15552000, 31104000}
+	var b strings.Builder
+	b.WriteString("# HELP apiserver_client_certificate_expiration_seconds [BETA] Distribution of the remaining lifetime on the certificate used to authenticate a request.\n")
+	b.WriteString("# TYPE apiserver_client_certificate_expiration_seconds histogram\n")
+	for _, le := range buckets {
+		count := 0
+		if remaining <= le {
+			count = 1
+		}
+		b.WriteString("apiserver_client_certificate_expiration_seconds_bucket{le=\"")
+		b.WriteString(formatHistogramBucketLE(le))
+		b.WriteString("\"} ")
+		b.WriteString(strconv.Itoa(count))
+		b.WriteString("\n")
+	}
+	b.WriteString("apiserver_client_certificate_expiration_seconds_bucket{le=\"+Inf\"} 1\n")
+	b.WriteString("apiserver_client_certificate_expiration_seconds_sum ")
+	b.WriteString(strconv.FormatFloat(remaining, 'f', -1, 64))
+	b.WriteString("\n")
+	b.WriteString("apiserver_client_certificate_expiration_seconds_count 1\n")
+	return b.String()
+}
+
+func formatHistogramBucketLE(le float64) string {
+	if le == 0 {
+		return "0"
+	}
+	return strconv.FormatFloat(le, 'f', -1, 64)
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
@@ -39,6 +39,8 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 )
 
 const (
@@ -1277,4 +1279,64 @@ func TestCertificateIdentifier(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientCertificateExpirationSeconds(t *testing.T) {
+	clientCerts := getCerts(t, clientCNCert)
+	clientCert := clientCerts[0]
+
+	authenticator := New(getDefaultVerifyOptions(t), CommonNameUserConversion)
+
+	beforeSum, err := testutil.GetHistogramMetricValue(clientCertificateExpirationHistogram.ObserverMetric)
+	if err != nil {
+		t.Fatalf("unexpected error reading metric sum before auth: %v", err)
+	}
+	beforeCount, err := testutil.GetHistogramMetricCount(clientCertificateExpirationHistogram.ObserverMetric)
+	if err != nil {
+		t.Fatalf("unexpected error reading metric count before auth: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req.TLS = &tls.ConnectionState{PeerCertificates: clientCerts}
+
+	if _, ok, err := authenticator.AuthenticateRequest(req); err != nil || !ok {
+		t.Fatalf("AuthenticateRequest() = ok=%v err=%v", ok, err)
+	}
+
+	afterSum, err := testutil.GetHistogramMetricValue(clientCertificateExpirationHistogram.ObserverMetric)
+	if err != nil {
+		t.Fatalf("unexpected error reading metric sum after auth: %v", err)
+	}
+	afterCount, err := testutil.GetHistogramMetricCount(clientCertificateExpirationHistogram.ObserverMetric)
+	if err != nil {
+		t.Fatalf("unexpected error reading metric count after auth: %v", err)
+	}
+	if afterCount != beforeCount+1 {
+		t.Fatalf("expected histogram count to increase by 1, before=%d after=%d", beforeCount, afterCount)
+	}
+
+	observedRemaining := afterSum - beforeSum
+	wantRemaining := time.Until(clientCert.NotAfter).Seconds()
+	const allowedDriftSeconds = 5.0
+	if observedRemaining < wantRemaining-allowedDriftSeconds || observedRemaining > wantRemaining+allowedDriftSeconds {
+		t.Fatalf("observed remaining lifetime %f, want within [%f, %f]", observedRemaining, wantRemaining-allowedDriftSeconds, wantRemaining+allowedDriftSeconds)
+	}
+
+	metricFamilies, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("unexpected error gathering metrics: %v", err)
+	}
+	for _, mf := range metricFamilies {
+		if mf.GetName() != "apiserver_client_certificate_expiration_seconds" {
+			continue
+		}
+		if wantHelp := "[BETA] Distribution of the remaining lifetime on the certificate used to authenticate a request."; mf.GetHelp() != wantHelp {
+			t.Fatalf("unexpected help for apiserver_client_certificate_expiration_seconds: got %q, want %q", mf.GetHelp(), wantHelp)
+		}
+		return
+	}
+	t.Fatal("metric apiserver_client_certificate_expiration_seconds not found")
 }

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -88,6 +88,14 @@ func (h *Histogram) DeprecatedVersion() *semver.Version {
 	return parseSemver(h.HistogramOpts.DeprecatedVersion)
 }
 
+// Reset resets the underlying prometheus Histogram to start counting from 0 again
+func (h *Histogram) Reset() {
+	if !h.IsCreated() {
+		return
+	}
+	h.setPrometheusHistogram(prometheus.NewHistogram(h.HistogramOpts.toPromHistogramOpts()))
+}
+
 // initializeMetric invokes the actual prometheus.Histogram object instantiation
 // and stores a reference to it
 func (h *Histogram) initializeMetric() {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes the kube-apiserver client certificate expiration metric from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304.

This PR is intentionally scoped to this metric only, to make review and approval easier across SIGs. Beta graduation provides stronger compatibility guarantees for metric consumers, specifically that existing metric names and label sets are not removed while in Beta.

#### Which issue(s) this PR is related to:
Part of #136304

#### Special notes for your reviewer:
- Scoped split from [#137067] for easier review.
- Includes only this metric stability-level promotion:
  - `apiserver_client_certificate_expiration_seconds`
- Includes corresponding `stable-metrics-list.yaml` regeneration.
- No functional behavior changes.

#### Does this PR introduce a user-facing change?
Yes. The metric listed above is now Beta, meaning its existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted apiserver client certificate expiration metric to Beta stability. This metric now provides stronger compatibility guarantees, including stability of existing label sets while in Beta.
```