### PR TITLE
Promote endpoint metrics to beta stability

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -130,7 +130,7 @@ var (
 			// dependant on user configuration.
 			Buckets: []float64{0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
 				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
 	)
@@ -172,7 +172,7 @@ var (
 			Subsystem:      APIServerComponent,
 			Name:           "watch_events_total",
 			Help:           "Number of events sent in watch clients",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "version", "resource"},
 	)
@@ -182,7 +182,7 @@ var (
 			Name:           "watch_events_sizes",
 			Help:           "Watch event size distribution in bytes",
 			Buckets:        compbasemetrics.ExponentialBuckets(1024, 2.0, 8), // 1K, 2K, 4K, 8K, ..., 128K.
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "version", "resource"},
 	)
@@ -233,7 +233,7 @@ var (
 			Name:           "request_filter_duration_seconds",
 			Help:           "Request filter latency distribution in seconds, for each filter type",
 			Buckets:        []float64{0.0001, 0.0003, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 5.0, 10.0, 15.0, 30.0},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"filter"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -527,3 +527,119 @@ func TestCleanListScope(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestFilterDurationSecondsIsBeta(t *testing.T) {
+	Register()
+	requestFilterDuration.Reset()
+	defer requestFilterDuration.Reset()
+
+	want := `
+		# HELP apiserver_request_filter_duration_seconds [BETA] Request filter latency distribution in seconds, for each filter type
+		# TYPE apiserver_request_filter_duration_seconds histogram
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.0001"} 0
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.0003"} 0
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.001"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.003"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.01"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.03"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.1"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="0.3"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="1"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="5"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="10"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="15"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="30"} 1
+		apiserver_request_filter_duration_seconds_bucket{filter="test-filter",le="+Inf"} 1
+		apiserver_request_filter_duration_seconds_sum{filter="test-filter"} 0.001
+		apiserver_request_filter_duration_seconds_count{filter="test-filter"} 1
+	`
+
+	requestFilterDuration.WithLabelValues("test-filter").Observe(0.001)
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_request_filter_duration_seconds"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRequestSLIDurationSecondsIsBeta(t *testing.T) {
+	Register()
+	requestSliLatencies.Reset()
+	defer requestSliLatencies.Reset()
+
+	want := `
+		# HELP apiserver_request_sli_duration_seconds [BETA] Response latency distribution (not counting webhook duration and priority & fairness queue wait times) in seconds for each verb, group, version, resource, subresource, scope and component.
+		# TYPE apiserver_request_sli_duration_seconds histogram
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="0.05"} 0
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="0.1"} 0
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="0.2"} 1
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="0.4"} 1
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="0.6"} 1
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="0.8"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="1"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="1.25"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="1.5"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="2"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="3"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="4"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="5"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="6"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="8"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="10"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="15"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="20"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="30"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="45"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="60"} 2
+		apiserver_request_sli_duration_seconds_bucket{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v",le="+Inf"} 2
+		apiserver_request_sli_duration_seconds_sum{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v"} 1
+		apiserver_request_sli_duration_seconds_count{component="apiserver",group="g",resource="r",scope="cluster",subresource="s",verb="GET",version="v"} 2
+	`
+
+	requestSliLatencies.WithLabelValues("GET", "g", "v", "r", "s", "cluster", "apiserver").Observe(0.2)
+	requestSliLatencies.WithLabelValues("GET", "g", "v", "r", "s", "cluster", "apiserver").Observe(0.8)
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_request_sli_duration_seconds"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWatchEventsMetricsAreBeta(t *testing.T) {
+	Register()
+
+	WatchEvents.Reset()
+	defer WatchEvents.Reset()
+	WatchEventsSizes.Reset()
+	defer WatchEventsSizes.Reset()
+
+	wantSizes := `
+		# HELP apiserver_watch_events_sizes [BETA] Watch event size distribution in bytes
+		# TYPE apiserver_watch_events_sizes histogram
+		apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="1024"} 0
+		apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="2048"} 0
+		apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="4096"} 1
+		apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="8192"} 1
+		apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="16384"} 1
+		apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="32768"} 1
+		apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="65536"} 1
+		apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="131072"} 1
+		apiserver_watch_events_sizes_bucket{group="group",resource="resource",version="version",le="+Inf"} 1
+		apiserver_watch_events_sizes_sum{group="group",resource="resource",version="version"} 4096
+		apiserver_watch_events_sizes_count{group="group",resource="resource",version="version"} 1
+	`
+
+	wantTotal := `
+		# HELP apiserver_watch_events_total [BETA] Number of events sent in watch clients
+		# TYPE apiserver_watch_events_total counter
+		apiserver_watch_events_total{group="group",resource="resource",version="version"} 1
+	`
+
+	WatchEventsSizes.WithLabelValues("group", "version", "resource").Observe(4096.0)
+	WatchEvents.WithLabelValues("group", "version", "resource").Inc()
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantSizes), "apiserver_watch_events_sizes"); err != nil {
+		t.Fatal(err)
+	}
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantTotal), "apiserver_watch_events_total"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -4987,7 +4987,7 @@
   subsystem: apiserver
   help: Request filter latency distribution in seconds, for each filter type
   type: Histogram
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - filter
   buckets:
@@ -5025,7 +5025,7 @@
     & fairness queue wait times) in seconds for each verb, group, version, resource,
     subresource, scope and component.
   type: Histogram
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - component
   - group
@@ -5164,7 +5164,7 @@
   subsystem: apiserver
   help: Watch event size distribution in bytes
   type: Histogram
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - group
   - resource
@@ -5185,7 +5185,7 @@
   subsystem: apiserver
   help: Number of events sent in watch clients
   type: Counter
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - group
   - resource

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -132,6 +132,64 @@
   - 10
   - 15
   - 30
+- name: request_filter_duration_seconds
+  subsystem: apiserver
+  help: Request filter latency distribution in seconds, for each filter type
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - filter
+  buckets:
+  - 0.0001
+  - 0.0003
+  - 0.001
+  - 0.003
+  - 0.01
+  - 0.03
+  - 0.1
+  - 0.3
+  - 1
+  - 5
+  - 10
+  - 15
+  - 30
+- name: request_sli_duration_seconds
+  subsystem: apiserver
+  help: Response latency distribution (not counting webhook duration and priority
+    & fairness queue wait times) in seconds for each verb, group, version, resource,
+    subresource, scope and component.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - component
+  - group
+  - resource
+  - scope
+  - subresource
+  - verb
+  - version
+  buckets:
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.4
+  - 0.6
+  - 0.8
+  - 1
+  - 1.25
+  - 1.5
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 8
+  - 10
+  - 15
+  - 20
+  - 30
+  - 45
+  - 60
 - name: check_duration_seconds
   subsystem: validating_admission_policy
   namespace: apiserver
@@ -175,6 +233,33 @@
   help: Number of times declarative validation has panicked during validation.
   type: Counter
   stabilityLevel: BETA
+- name: watch_events_sizes
+  subsystem: apiserver
+  help: Watch event size distribution in bytes
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  - version
+  buckets:
+  - 1024
+  - 2048
+  - 4096
+  - 8192
+  - 16384
+  - 32768
+  - 65536
+  - 131072
+- name: watch_events_total
+  subsystem: apiserver
+  help: Number of events sent in watch clients
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  - version
 - name: watch_list_duration_seconds
   subsystem: apiserver
   help: Response latency distribution in seconds for watch list requests broken by


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes a focused set of kube-apiserver endpoint metrics from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304.

This PR is intentionally scoped to endpoint metrics only, to make review and approval easier across SIGs. Beta graduation provides stronger compatibility guarantees for metric consumers, specifically that existing metric names and label sets are not removed while in Beta.

#### Which issue(s) this PR is related to:
Part of #136304

#### Special notes for your reviewer:
- Scoped split from [#137067] for easier review.
- Includes only endpoint metric stability-level promotions:
  - `apiserver_request_sli_duration_seconds`
  - `apiserver_watch_events_total`
  - `apiserver_watch_events_sizes`
  - `apiserver_request_filter_duration_seconds`
- Includes corresponding `stable-metrics-list.yaml` regeneration.
- No functional behavior changes.

#### Does this PR introduce a user-facing change?
Yes. The endpoint metrics listed above are now Beta, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted selected apiserver endpoint metrics to Beta stability. These metrics now provide stronger compatibility guarantees, including stability of existing label sets while in Beta.
```