### PR TITLE
Promote egress selector dial metrics to beta stability

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -701,54 +701,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: dial_duration_seconds
-  subsystem: egress_dialer
-  namespace: apiserver
-  help: Dial latency histogram in seconds, labeled by the protocol (http-connect or
-    grpc), transport (tcp or uds)
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - protocol
-  - transport
-  buckets:
-  - 0.005
-  - 0.025
-  - 0.1
-  - 0.5
-  - 2.5
-  - 12.5
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: dial_failure_count
-  subsystem: egress_dialer
-  namespace: apiserver
-  help: Dial failure count, labeled by the protocol (http-connect or grpc), transport
-    (tcp or uds), and stage (connect or proxy). The stage indicates at which stage
-    the dial failed
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - protocol
-  - stage
-  - transport
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: dial_start_total
-  subsystem: egress_dialer
-  namespace: apiserver
-  help: Dial starts, labeled by the protocol (http-connect or grpc) and transport
-    (tcp or uds).
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - protocol
-  - transport
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: automatic_reload_last_timestamp_seconds
   subsystem: encryption_config_controller
   namespace: apiserver
@@ -7092,6 +7044,54 @@
   help: CEL evaluation time in seconds.
   type: Histogram
   stabilityLevel: BETA
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: dial_duration_seconds
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial latency histogram in seconds, labeled by the protocol (http-connect or
+    grpc), transport (tcp or uds)
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - transport
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.5
+  - 2.5
+  - 12.5
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: dial_failures_total
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial failure count, labeled by the protocol (http-connect or grpc), transport
+    (tcp or uds), and stage (connect or proxy). The stage indicates at which stage
+    the dial failed
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - stage
+  - transport
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: dial_start_total
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial starts, labeled by the protocol (http-connect or grpc) and transport
+    (tcp or uds).
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - transport
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics

--- a/hack/tools/instrumentation/documentation/documentation.md
+++ b/hack/tools/instrumentation/documentation/documentation.md
@@ -1082,7 +1082,7 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">protocol</span><span class="metric_label">transport</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">apiserver_egress_dialer_dial_failure_count</div>
+	<div class="metric_name">apiserver_egress_dialer_dial_failures_total</div>
 	<div class="metric_help">Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -50,6 +50,45 @@
   help: CEL evaluation time in seconds.
   type: Histogram
   stabilityLevel: BETA
+- name: dial_duration_seconds
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial latency histogram in seconds, labeled by the protocol (http-connect or
+    grpc), transport (tcp or uds)
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - transport
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.5
+  - 2.5
+  - 12.5
+- name: dial_failures_total
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial failure count, labeled by the protocol (http-connect or grpc), transport
+    (tcp or uds), and stage (connect or proxy). The stage indicates at which stage
+    the dial failed
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - stage
+  - transport
+- name: dial_start_total
+  subsystem: egress_dialer
+  namespace: apiserver
+  help: Dial starts, labeled by the protocol (http-connect or grpc) and transport
+    (tcp or uds).
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - protocol
+  - transport
 - name: current_executing_requests
   subsystem: flowcontrol
   namespace: apiserver

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -213,7 +213,7 @@ func TestMetrics(t *testing.T) {
 			proxierErr:   true,
 			metrics:      []string{"apiserver_egress_dialer_dial_start_total"},
 			want: `
-	# HELP apiserver_egress_dialer_dial_start_total [ALPHA] Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).
+	# HELP apiserver_egress_dialer_dial_start_total [BETA] Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).
 	# TYPE apiserver_egress_dialer_dial_start_total counter
 	apiserver_egress_dialer_dial_start_total{protocol="fake_protocol",transport="fake_transport"} 1
 `,
@@ -221,21 +221,21 @@ func TestMetrics(t *testing.T) {
 		"connect to proxy server error": {
 			connectorErr: true,
 			proxierErr:   false,
-			metrics:      []string{"apiserver_egress_dialer_dial_failure_count"},
+			metrics:      []string{"apiserver_egress_dialer_dial_failures_total"},
 			want: `
-	# HELP apiserver_egress_dialer_dial_failure_count [ALPHA] Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed
-	# TYPE apiserver_egress_dialer_dial_failure_count counter
-	apiserver_egress_dialer_dial_failure_count{protocol="fake_protocol",stage="connect",transport="fake_transport"} 1
+	# HELP apiserver_egress_dialer_dial_failures_total [BETA] Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed
+	# TYPE apiserver_egress_dialer_dial_failures_total counter
+	apiserver_egress_dialer_dial_failures_total{protocol="fake_protocol",stage="connect",transport="fake_transport"} 1
 `,
 		},
 		"connect succeeded, proxy failed": {
 			connectorErr: false,
 			proxierErr:   true,
-			metrics:      []string{"apiserver_egress_dialer_dial_failure_count"},
+			metrics:      []string{"apiserver_egress_dialer_dial_failures_total"},
 			want: `
-	# HELP apiserver_egress_dialer_dial_failure_count [ALPHA] Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed
-	# TYPE apiserver_egress_dialer_dial_failure_count counter
-	apiserver_egress_dialer_dial_failure_count{protocol="fake_protocol",stage="proxy",transport="fake_transport"} 1
+	# HELP apiserver_egress_dialer_dial_failures_total [BETA] Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed
+	# TYPE apiserver_egress_dialer_dial_failures_total counter
+	apiserver_egress_dialer_dial_failures_total{protocol="fake_protocol",stage="proxy",transport="fake_transport"} 1
 `,
 		},
 		"successful": {
@@ -243,7 +243,7 @@ func TestMetrics(t *testing.T) {
 			proxierErr:   false,
 			metrics:      []string{"apiserver_egress_dialer_dial_duration_seconds"},
 			want: `
-            # HELP apiserver_egress_dialer_dial_duration_seconds [ALPHA] Dial latency histogram in seconds, labeled by the protocol (http-connect or grpc), transport (tcp or uds)
+            # HELP apiserver_egress_dialer_dial_duration_seconds [BETA] Dial latency histogram in seconds, labeled by the protocol (http-connect or grpc), transport (tcp or uds)
             # TYPE apiserver_egress_dialer_dial_duration_seconds histogram
             apiserver_egress_dialer_dial_duration_seconds_bucket{protocol="fake_protocol",transport="fake_transport",le="0.005"} 1
             apiserver_egress_dialer_dial_duration_seconds_bucket{protocol="fake_protocol",transport="fake_transport",le="0.025"} 1

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/metrics/metrics.go
@@ -66,7 +66,7 @@ func newDialMetrics() *DialMetrics {
 			Subsystem:      subsystem,
 			Name:           "dial_start_total",
 			Help:           "Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"protocol", "transport"},
 	)
@@ -78,7 +78,7 @@ func newDialMetrics() *DialMetrics {
 			Name:           "dial_duration_seconds",
 			Help:           "Dial latency histogram in seconds, labeled by the protocol (http-connect or grpc), transport (tcp or uds)",
 			Buckets:        latencyBuckets,
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"protocol", "transport"},
 	)
@@ -87,9 +87,9 @@ func newDialMetrics() *DialMetrics {
 		&metrics.CounterOpts{
 			Namespace:      namespace,
 			Subsystem:      subsystem,
-			Name:           "dial_failure_count",
+			Name:           "dial_failures_total",
 			Help:           "Dial failure count, labeled by the protocol (http-connect or grpc), transport (tcp or uds), and stage (connect or proxy). The stage indicates at which stage the dial failed",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"protocol", "transport", "stage"},
 	)

--- a/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
@@ -30,9 +30,6 @@ import (
 // We setup this list for allow and not fail on the current violations.
 // Generally speaking, you need to fix the problem for a new metric rather than add it into the list.
 var exceptionMetrics = []string{
-	// k8s.io/apiserver/pkg/server/egressselector
-	"apiserver_egress_dialer_dial_failure_count", // counter metrics should have "_total" suffix
-
 	// k8s.io/apiserver/pkg/endpoints/filters
 	"authenticated_user_requests", // counter metrics should have "_total" suffix
 	"authentication_attempts",     // counter metrics should have "_total" suffix


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes kube-apiserver egress selector dial metrics from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304.

This PR is intentionally scoped to egress selector dial metrics only, to make review and approval easier across SIGs. Beta graduation provides stronger compatibility guarantees for metric consumers, specifically that existing metric names and label sets are not removed while in Beta.

#### Which issue(s) this PR is related to:
Part of #136304

#### Special notes for your reviewer:
- Scoped split from [#137067 for easier review.
- Includes only egress selector dial metric stability-level promotions:
  - `apiserver_egress_selector_dial_start_total`
  - `apiserver_egress_selector_dial_duration_seconds`
  - `apiserver_egress_selector_dial_failure_count`
- Includes corresponding `stable-metrics-list.yaml` regeneration.
- No functional behavior changes.

#### Does this PR introduce a user-facing change?
Yes. The egress selector dial metrics listed above are now Beta, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted apiserver egress selector dial metrics to Beta stability. These metrics now provide stronger compatibility guarantees, including stability of existing label sets while in Beta.
```