### PR TITLE
Promote storage cacher metrics to beta stability

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -92,7 +92,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "events_dispatched_total",
 			Help:           "Counter of events dispatched in watch cache broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -102,7 +102,7 @@ var (
 			Namespace:      namespace,
 			Name:           "terminated_watchers_total",
 			Help:           "Counter of watchers closed due to unresponsiveness broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -113,7 +113,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "resource_version",
 			Help:           "Current resource version of watch cache broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -143,7 +143,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "capacity",
 			Help:           "Total capacity of watch cache broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -154,7 +154,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "initializations_total",
 			Help:           "Counter of watch cache initializations broken by resource type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"group", "resource"},
 	)
@@ -165,7 +165,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "read_wait_seconds",
 			Help:           "Histogram of time spent waiting for a watch cache to become fresh.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 			Buckets:        []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3},
 		}, []string{"group", "resource"})
 
@@ -175,7 +175,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "consistent_read_total",
 			Help:           "Counter for consistent reads from cache.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		}, []string{"group", "resource", "success", "fallback"})
 
 	StorageConsistencyCheckTotal = compbasemetrics.NewCounterVec(

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -132,6 +132,14 @@
   - 10
   - 15
   - 30
+- name: terminated_watchers_total
+  namespace: apiserver
+  help: Counter of watchers closed due to unresponsiveness broken by resource type.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
 - name: check_duration_seconds
   subsystem: validating_admission_policy
   namespace: apiserver
@@ -175,6 +183,67 @@
   help: Number of times declarative validation has panicked during validation.
   type: Counter
   stabilityLevel: BETA
+- name: consistent_read_total
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Counter for consistent reads from cache.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - fallback
+  - group
+  - resource
+  - success
+- name: events_dispatched_total
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Counter of events dispatched in watch cache broken by resource type.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+- name: initializations_total
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Counter of watch cache initializations broken by resource type.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+- name: read_wait_seconds
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Histogram of time spent waiting for a watch cache to become fresh.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.4
+  - 0.6
+  - 0.8
+  - 1
+  - 1.25
+  - 1.5
+  - 2
+  - 3
+- name: resource_version
+  subsystem: watch_cache
+  namespace: apiserver
+  help: Current resource version of watch cache broken by resource type.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
 - name: watch_list_duration_seconds
   subsystem: apiserver
   help: Response latency distribution in seconds for watch list requests broken by
@@ -372,6 +441,14 @@
   - 1310.72
   - 2621.44
   - 5242.88
+- name: capacity
+  subsystem: watch_cache
+  help: Total capacity of watch cache broken by resource type.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - group
+  - resource
 - name: adds_total
   subsystem: workqueue
   help: Total number of adds handled by workqueue


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes kube-apiserver storage cacher metrics from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304.

This PR is intentionally scoped to storage cacher metrics only, to make review and approval easier across SIGs. Beta graduation provides stronger compatibility guarantees for metric consumers, specifically that existing metric names and label sets are not removed while in Beta.

#### Which issue(s) this PR is related to:
Part of #136304

#### Special notes for your reviewer:
- Scoped split from [#137067] for easier review.
- Includes only storage cacher metric stability-level promotions:
  - `apiserver_watch_cache_events_dispatched_total`
  - `apiserver_terminated_watchers_total`
  - `apiserver_watch_cache_resource_version`
  - `apiserver_watch_cache_capacity`
  - `apiserver_watch_cache_initializations_total`
  - `apiserver_watch_cache_read_wait_seconds`
  - `apiserver_watch_cache_consistent_read_total`
- Includes corresponding `stable-metrics-list.yaml` regeneration.
- No functional behavior changes.

#### Does this PR introduce a user-facing change?
Yes. The storage cacher metrics listed above are now Beta, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted apiserver storage cacher metrics to Beta stability. These metrics now provide stronger compatibility guarantees, including stability of existing label sets while in Beta.
```