### PR TITLE
Promote flowcontrol metrics to beta stability

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
@@ -118,7 +118,7 @@ var (
 			// Buckets for both 0.99 and 1.0 mean PromQL's histogram_quantile will reveal saturation
 			Buckets:        []float64{0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1},
 			ConstLabels:    map[string]string{phase: "executing"},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		priorityLevel,
 	)
@@ -132,7 +132,7 @@ var (
 			// For executing: the denominator will be seats, so this metric will skew low.
 			// For waiting: total queue capacity is generally quite generous, so this metric will skew low.
 			Buckets:        []float64{0, 0.001, 0.003, 0.01, 0.03, 0.1, 0.25, 0.5, 0.75, 1},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		LabelNamePhase, priorityLevel,
 	)
@@ -239,7 +239,7 @@ var (
 			Help:      "Nominal number of execution seats configured for each priority level",
 			// Remove this metric once all suppported releases have the equal nominal_limit_seats metric
 			DeprecatedVersion: "1.30.0",
-			StabilityLevel:    compbasemetrics.ALPHA,
+			StabilityLevel:    compbasemetrics.BETA,
 		},
 		[]string{priorityLevel},
 	)
@@ -271,7 +271,7 @@ var (
 			Help:      "Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem",
 			// Remove this metric once all suppported releases have the equal current_executing_seats metric
 			DeprecatedVersion: "1.31.0",
-			StabilityLevel:    compbasemetrics.ALPHA,
+			StabilityLevel:    compbasemetrics.BETA,
 		},
 		[]string{priorityLevel, flowSchema},
 	)
@@ -293,7 +293,7 @@ var (
 			Name:           "request_execution_seconds",
 			Help:           "Duration of initial stage (for a WATCH) or any (for a non-WATCH) stage of request execution in the API Priority and Fairness subsystem",
 			Buckets:        requestDurationSecondsBuckets,
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{priorityLevel, flowSchema, "type"},
 	)
@@ -327,7 +327,7 @@ var (
 			// the upper bound comes from the maximum number of seats a request
 			// can occupy which is currently set at 10.
 			Buckets:        []float64{1, 2, 4, 8, 16, 32, 64, 100},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{priorityLevel, flowSchema},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
@@ -239,7 +239,7 @@ var (
 			Help:      "Nominal number of execution seats configured for each priority level",
 			// Remove this metric once all suppported releases have the equal nominal_limit_seats metric
 			DeprecatedVersion: "1.30.0",
-			StabilityLevel:    compbasemetrics.BETA,
+			StabilityLevel:    compbasemetrics.ALPHA,
 		},
 		[]string{priorityLevel},
 	)
@@ -271,7 +271,7 @@ var (
 			Help:      "Concurrency (number of seats) occupied by the currently executing (initial stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness subsystem",
 			// Remove this metric once all suppported releases have the equal current_executing_seats metric
 			DeprecatedVersion: "1.31.0",
-			StabilityLevel:    compbasemetrics.BETA,
+			StabilityLevel:    compbasemetrics.ALPHA,
 		},
 		[]string{priorityLevel, flowSchema},
 	)

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -155,27 +155,6 @@
   - flow_schema
   - priority_level
   - reason
-- name: request_concurrency_in_use
-  subsystem: flowcontrol
-  namespace: apiserver
-  help: Concurrency (number of seats) occupied by the currently executing (initial
-    stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness
-    subsystem
-  type: Gauge
-  deprecatedVersion: 1.31.0
-  stabilityLevel: BETA
-  labels:
-  - flow_schema
-  - priority_level
-- name: request_concurrency_limit
-  subsystem: flowcontrol
-  namespace: apiserver
-  help: Nominal number of execution seats configured for each priority level
-  type: Gauge
-  deprecatedVersion: 1.30.0
-  stabilityLevel: BETA
-  labels:
-  - priority_level
 - name: request_execution_seconds
   subsystem: flowcontrol
   namespace: apiserver

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -98,6 +98,53 @@
   stabilityLevel: BETA
   labels:
   - priority_level
+- name: priority_level_request_utilization
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Observations, at the end of every nanosecond, of number of requests (as a
+    fraction of the relevant limit) waiting or in any stage of execution (but only
+    initial stage for WATCHes)
+  type: TimingRatioHistogram
+  stabilityLevel: BETA
+  labels:
+  - phase
+  - priority_level
+  buckets:
+  - 0
+  - 0.001
+  - 0.003
+  - 0.01
+  - 0.03
+  - 0.1
+  - 0.25
+  - 0.5
+  - 0.75
+  - 1
+- name: priority_level_seat_utilization
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Observations, at the end of every nanosecond, of utilization of seats for
+    any stage of execution (but only initial stage for WATCHes)
+  type: TimingRatioHistogram
+  stabilityLevel: BETA
+  labels:
+  - priority_level
+  buckets:
+  - 0
+  - 0.1
+  - 0.2
+  - 0.3
+  - 0.4
+  - 0.5
+  - 0.6
+  - 0.7
+  - 0.8
+  - 0.9
+  - 0.95
+  - 0.99
+  - 1
+  constLabels:
+    phase: executing
 - name: rejected_requests_total
   subsystem: flowcontrol
   namespace: apiserver
@@ -108,6 +155,52 @@
   - flow_schema
   - priority_level
   - reason
+- name: request_concurrency_in_use
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Concurrency (number of seats) occupied by the currently executing (initial
+    stage for a WATCH, any stage otherwise) requests in the API Priority and Fairness
+    subsystem
+  type: Gauge
+  deprecatedVersion: 1.31.0
+  stabilityLevel: BETA
+  labels:
+  - flow_schema
+  - priority_level
+- name: request_concurrency_limit
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Nominal number of execution seats configured for each priority level
+  type: Gauge
+  deprecatedVersion: 1.30.0
+  stabilityLevel: BETA
+  labels:
+  - priority_level
+- name: request_execution_seconds
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Duration of initial stage (for a WATCH) or any (for a non-WATCH) stage of
+    request execution in the API Priority and Fairness subsystem
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - flow_schema
+  - priority_level
+  - type
+  buckets:
+  - 0
+  - 0.005
+  - 0.02
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.5
+  - 1
+  - 2
+  - 5
+  - 10
+  - 15
+  - 30
 - name: request_wait_duration_seconds
   subsystem: flowcontrol
   namespace: apiserver
@@ -132,6 +225,25 @@
   - 10
   - 15
   - 30
+- name: work_estimated_seats
+  subsystem: flowcontrol
+  namespace: apiserver
+  help: Number of estimated seats (maximum of initial and final seats) associated
+    with requests in API Priority and Fairness
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - flow_schema
+  - priority_level
+  buckets:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 100
 - name: check_duration_seconds
   subsystem: validating_admission_policy
   namespace: apiserver


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes kube-apiserver API Priority and Fairness (flowcontrol) metrics from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304.

This PR is intentionally scoped to flowcontrol metrics only, to make review and approval easier across SIGs. Beta graduation provides stronger compatibility guarantees for metric consumers, specifically that existing metric names and label sets are not removed while in Beta.

#### Which issue(s) this PR is related to:
Part of #136304

#### Special notes for your reviewer:
- Scoped split from [#137067] for easier review.
- Includes only flowcontrol metric stability-level promotions:
  - `apiserver_flowcontrol_current_limit_seats`
  - `apiserver_flowcontrol_current_inqueue_requests`
  - `apiserver_flowcontrol_request_concurrency_limit`
  - `apiserver_flowcontrol_request_concurrency_in_use`
  - `apiserver_flowcontrol_request_execution_seconds`
  - `apiserver_flowcontrol_read_vs_write_request_count_samples`
- Includes corresponding `stable-metrics-list.yaml` regeneration.
- No functional behavior changes.

#### Does this PR introduce a user-facing change?
Yes. The flowcontrol metrics listed above are now Beta, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted apiserver flowcontrol metrics to Beta stability. These metrics now provide stronger compatibility guarantees, including stability of existing label sets while in Beta.
```