### PR TITLE
Promote webhook x509 warning metrics to beta stability

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/metrics.go
@@ -30,7 +30,7 @@ var x509MissingSANCounter = metrics.NewCounter(
 			"in their serving certificate OR the number of connection failures " +
 			"due to the lack of x509 certificate SAN extension missing " +
 			"(either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 
@@ -42,7 +42,7 @@ var x509InsecureSHA1Counter = metrics.NewCounter(
 		Help: "Counts the number of requests to servers with insecure SHA1 signatures " +
 			"in their serving certificate OR the number of connection failures " +
 			"due to the insecure SHA1 signatures (either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
@@ -30,7 +30,7 @@ var x509MissingSANCounter = metrics.NewCounter(
 			"in their serving certificate OR the number of connection failures " +
 			"due to the lack of x509 certificate SAN extension missing " +
 			"(either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 
@@ -42,7 +42,7 @@ var x509InsecureSHA1Counter = metrics.NewCounter(
 		Help: "Counts the number of requests to servers with insecure SHA1 signatures " +
 			"in their serving certificate OR the number of connection failures " +
 			"due to the insecure SHA1 signatures (either/or, based on the runtime environment)",
-		StabilityLevel: metrics.ALPHA,
+		StabilityLevel: metrics.BETA,
 	},
 )
 

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -132,6 +132,22 @@
   - 10
   - 15
   - 30
+- name: x509_insecure_sha1_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers with insecure SHA1 signatures in
+    their serving certificate OR the number of connection failures due to the insecure
+    SHA1 signatures (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
+- name: x509_missing_san_total
+  subsystem: kube_aggregator
+  namespace: apiserver
+  help: Counts the number of requests to servers missing SAN extension in their serving
+    certificate OR the number of connection failures due to the lack of x509 certificate
+    SAN extension missing (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
 - name: check_duration_seconds
   subsystem: validating_admission_policy
   namespace: apiserver
@@ -204,6 +220,22 @@
   - 30
   - 45
   - 60
+- name: x509_insecure_sha1_total
+  subsystem: webhooks
+  namespace: apiserver
+  help: Counts the number of requests to servers with insecure SHA1 signatures in
+    their serving certificate OR the number of connection failures due to the insecure
+    SHA1 signatures (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
+- name: x509_missing_san_total
+  subsystem: webhooks
+  namespace: apiserver
+  help: Counts the number of requests to servers missing SAN extension in their serving
+    certificate OR the number of connection failures due to the lack of x509 certificate
+    SAN extension missing (either/or, based on the runtime environment)
+  type: Counter
+  stabilityLevel: BETA
 - name: disabled_metrics_total
   help: The count of disabled metrics.
   type: Counter


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes webhook x509 certificate warning metrics in kube-apiserver and kube-aggregator from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304.

This PR is intentionally scoped to these webhook x509 metrics only, to make review and approval easier across SIGs. Beta graduation provides stronger compatibility guarantees for metric consumers, specifically that existing metric names and label sets are not removed while in Beta.

#### Which issue(s) this PR is related to:
Part of #136304

#### Special notes for your reviewer:
- Scoped split from [#137067] for easier review.
- Includes only webhook x509 metric stability-level promotions in:
  - `staging/src/k8s.io/apiserver/pkg/util/webhook/metrics.go`
  - `staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go`
- Includes corresponding `stable-metrics-list.yaml` regeneration.
- No functional behavior changes.

#### Does this PR introduce a user-facing change?
Yes. The webhook x509 warning metrics promoted in this PR are now Beta, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted webhook x509 warning metrics in kube-apiserver and kube-aggregator to Beta stability. These metrics now provide stronger compatibility guarantees, including stability of existing label sets while in Beta.
```