### PR TITLE
Promote authorization webhook metrics to beta stability

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -413,54 +413,6 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
-- name: webhook_duration_seconds
-  subsystem: authorization
-  namespace: apiserver
-  help: Request latency in seconds.
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - name
-  - result
-  buckets:
-  - 0.005
-  - 0.01
-  - 0.025
-  - 0.05
-  - 0.1
-  - 0.25
-  - 0.5
-  - 1
-  - 2.5
-  - 5
-  - 10
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: webhook_evaluations_fail_open_total
-  subsystem: authorization
-  namespace: apiserver
-  help: NoOpinion results due to webhook timeout or error.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - name
-  - result
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
-- name: webhook_evaluations_total
-  subsystem: authorization
-  namespace: apiserver
-  help: Round-trips to authorization webhooks.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - name
-  - result
-  componentEndpoints:
-  - component: kube-apiserver
-    endpoint: /metrics
 - name: cache_list_fetched_objects_total
   namespace: apiserver
   help: Number of objects read from watch cache in the course of serving a LIST request
@@ -7136,6 +7088,54 @@
   labels:
   - apiserver_id_hash
   - status
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: webhook_duration_seconds
+  subsystem: authorization
+  namespace: apiserver
+  help: Request latency in seconds.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
+  buckets:
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: webhook_evaluations_fail_open_total
+  subsystem: authorization
+  namespace: apiserver
+  help: NoOpinion results due to webhook timeout or error.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
+- name: webhook_evaluations_total
+  subsystem: authorization
+  namespace: apiserver
+  help: Round-trips to authorization webhooks.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -38,6 +38,45 @@
   labels:
   - apiserver_id_hash
   - status
+- name: webhook_duration_seconds
+  subsystem: authorization
+  namespace: apiserver
+  help: Request latency in seconds.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
+  buckets:
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  - 10
+- name: webhook_evaluations_fail_open_total
+  subsystem: authorization
+  namespace: apiserver
+  help: NoOpinion results due to webhook timeout or error.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
+- name: webhook_evaluations_total
+  subsystem: authorization
+  namespace: apiserver
+  help: Round-trips to authorization webhooks.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+  - result
 - name: compilation_duration_seconds
   subsystem: cel
   namespace: apiserver

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics.go
@@ -113,7 +113,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "webhook_evaluations_total",
 			Help:           "Round-trips to authorization webhooks.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"name", "result"},
 	)
@@ -125,7 +125,7 @@ var (
 			Name:           "webhook_duration_seconds",
 			Help:           "Request latency in seconds.",
 			Buckets:        compbasemetrics.DefBuckets,
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"name", "result"},
 	)
@@ -136,7 +136,7 @@ var (
 			Subsystem:      subsystem,
 			Name:           "webhook_evaluations_fail_open_total",
 			Help:           "NoOpinion results due to webhook timeout or error.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		[]string{"name", "result"},
 	)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics_test.go
@@ -45,7 +45,7 @@ func TestRecordWebhookMetrics(t *testing.T) {
 			result:   "timeout",
 			duration: 1.5,
 			want: `
-			# HELP apiserver_authorization_webhook_duration_seconds [ALPHA] Request latency in seconds.
+			# HELP apiserver_authorization_webhook_duration_seconds [BETA] Request latency in seconds.
 			# TYPE apiserver_authorization_webhook_duration_seconds histogram
             apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.005"} 0
             apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.01"} 0
@@ -61,10 +61,10 @@ func TestRecordWebhookMetrics(t *testing.T) {
             apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="+Inf"} 1
             apiserver_authorization_webhook_duration_seconds_sum{name="wh1.example.com",result="timeout"} 1.5
             apiserver_authorization_webhook_duration_seconds_count{name="wh1.example.com",result="timeout"} 1
-            # HELP apiserver_authorization_webhook_evaluations_fail_open_total [ALPHA] NoOpinion results due to webhook timeout or error.
+            # HELP apiserver_authorization_webhook_evaluations_fail_open_total [BETA] NoOpinion results due to webhook timeout or error.
             # TYPE apiserver_authorization_webhook_evaluations_fail_open_total counter
             apiserver_authorization_webhook_evaluations_fail_open_total{name="wh1.example.com",result="timeout"} 1
-            # HELP apiserver_authorization_webhook_evaluations_total [ALPHA] Round-trips to authorization webhooks.
+            # HELP apiserver_authorization_webhook_evaluations_total [BETA] Round-trips to authorization webhooks.
             # TYPE apiserver_authorization_webhook_evaluations_total counter
             apiserver_authorization_webhook_evaluations_total{name="wh1.example.com",result="timeout"} 1
             `,

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics/metrics_test.go
@@ -25,62 +25,69 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 )
 
-func TestRecordWebhookMetrics(t *testing.T) {
-	testCases := []struct {
-		desc     string
-		metrics  []string
-		name     string
-		result   string
-		duration float64
-		want     string
-	}{
-		{
-			desc: "evaluation failure total",
-			metrics: []string{
-				"apiserver_authorization_webhook_duration_seconds",
-				"apiserver_authorization_webhook_evaluations_total",
-				"apiserver_authorization_webhook_evaluations_fail_open_total",
-			},
-			name:     "wh1.example.com",
-			result:   "timeout",
-			duration: 1.5,
-			want: `
-			# HELP apiserver_authorization_webhook_duration_seconds [ALPHA] Request latency in seconds.
-			# TYPE apiserver_authorization_webhook_duration_seconds histogram
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.005"} 0
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.01"} 0
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.025"} 0
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.05"} 0
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.1"} 0
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.25"} 0
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="0.5"} 0
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="1"} 0
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="2.5"} 1
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="5"} 1
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="10"} 1
-            apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="timeout",le="+Inf"} 1
-            apiserver_authorization_webhook_duration_seconds_sum{name="wh1.example.com",result="timeout"} 1.5
-            apiserver_authorization_webhook_duration_seconds_count{name="wh1.example.com",result="timeout"} 1
-            # HELP apiserver_authorization_webhook_evaluations_fail_open_total [ALPHA] NoOpinion results due to webhook timeout or error.
-            # TYPE apiserver_authorization_webhook_evaluations_fail_open_total counter
-            apiserver_authorization_webhook_evaluations_fail_open_total{name="wh1.example.com",result="timeout"} 1
-            # HELP apiserver_authorization_webhook_evaluations_total [ALPHA] Round-trips to authorization webhooks.
-            # TYPE apiserver_authorization_webhook_evaluations_total counter
-            apiserver_authorization_webhook_evaluations_total{name="wh1.example.com",result="timeout"} 1
-            `,
-		},
-	}
+func TestAuthorizationWebhookEvaluationsTotal(t *testing.T) {
+	ResetWebhookMetricsForTest()
+	defer ResetWebhookMetricsForTest()
 
-	for _, tt := range testCases {
-		t.Run(tt.desc, func(t *testing.T) {
-			ResetWebhookMetricsForTest()
-			m := NewWebhookMetrics()
-			m.RecordWebhookDuration(context.Background(), tt.name, tt.result, tt.duration)
-			m.RecordWebhookEvaluation(context.Background(), tt.name, tt.result)
-			m.RecordWebhookFailOpen(context.Background(), tt.name, tt.result)
-			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tt.want), tt.metrics...); err != nil {
-				t.Fatal(err)
-			}
-		})
+	want := `
+		# HELP apiserver_authorization_webhook_evaluations_total [BETA] Round-trips to authorization webhooks.
+		# TYPE apiserver_authorization_webhook_evaluations_total counter
+		apiserver_authorization_webhook_evaluations_total{name="wh1.example.com",result="success"} 1
+	`
+
+	m := NewWebhookMetrics()
+	m.RecordWebhookEvaluation(context.Background(), "wh1.example.com", "success")
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_authorization_webhook_evaluations_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuthorizationWebhookDurationSeconds(t *testing.T) {
+	ResetWebhookMetricsForTest()
+	defer ResetWebhookMetricsForTest()
+
+	want := `
+		# HELP apiserver_authorization_webhook_duration_seconds [BETA] Request latency in seconds.
+		# TYPE apiserver_authorization_webhook_duration_seconds histogram
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="0.005"} 0
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="0.01"} 0
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="0.025"} 0
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="0.05"} 0
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="0.1"} 0
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="0.25"} 1
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="0.5"} 1
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="1"} 1
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="2.5"} 1
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="5"} 1
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="10"} 1
+		apiserver_authorization_webhook_duration_seconds_bucket{name="wh1.example.com",result="success",le="+Inf"} 1
+		apiserver_authorization_webhook_duration_seconds_sum{name="wh1.example.com",result="success"} 0.2
+		apiserver_authorization_webhook_duration_seconds_count{name="wh1.example.com",result="success"} 1
+	`
+
+	m := NewWebhookMetrics()
+	m.RecordWebhookDuration(context.Background(), "wh1.example.com", "success", 0.2)
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_authorization_webhook_duration_seconds"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuthorizationWebhookEvaluationsFailOpenTotal(t *testing.T) {
+	ResetWebhookMetricsForTest()
+	defer ResetWebhookMetricsForTest()
+
+	want := `
+		# HELP apiserver_authorization_webhook_evaluations_fail_open_total [BETA] NoOpinion results due to webhook timeout or error.
+		# TYPE apiserver_authorization_webhook_evaluations_fail_open_total counter
+		apiserver_authorization_webhook_evaluations_fail_open_total{name="wh1.example.com",result="timeout"} 1
+	`
+
+	m := NewWebhookMetrics()
+	m.RecordWebhookFailOpen(context.Background(), "wh1.example.com", "timeout")
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "apiserver_authorization_webhook_evaluations_fail_open_total"); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Promotes kube-apiserver authorization webhook metrics from Alpha to Beta stability as part of the metrics graduation effort tracked in #136304.

This PR is intentionally scoped to authorization webhook metrics only, to make review and approval easier across SIGs. Beta graduation provides stronger compatibility guarantees for metric consumers, specifically that existing metric names and label sets are not removed while in Beta.

#### Which issue(s) this PR is related to:
Part of #136304

#### Special notes for your reviewer:
- Scoped split from [#137067] for easier review.
- Includes only authorization webhook metric stability-level promotions:
  - `apiserver_authorization_webhook_evaluations_total`
  - `apiserver_authorization_webhook_duration_seconds`
  - `apiserver_authorization_webhook_evaluations_fail_open_total`
- Includes focused unit test updates for expected stability labels/values.
- Includes corresponding `stable-metrics-list.yaml` regeneration.
- No functional behavior changes.

#### Does this PR introduce a user-facing change?
Yes. The authorization webhook metrics listed above are now Beta, meaning their existing labels are guaranteed not to be removed while in Beta.

```release-note
Promoted apiserver authorization webhook metrics to Beta stability. These metrics now provide stronger compatibility guarantees, including stability of existing label sets while in Beta.
```