### PR TITLE
Use request context when serving node logs

### DIFF
--- a/pkg/kubelet/kubelet_server_journal.go
+++ b/pkg/kubelet/kubelet_server_journal.go
@@ -85,7 +85,7 @@ func (journalServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		defer gz.Close()
 		out = gz
 	}
-	nlq.Copy(out)
+	nlq.Copy(req.Context(), out)
 }
 
 // nodeLogQuery encapsulates the log query request
@@ -265,9 +265,9 @@ func (n *nodeLogQuery) validate() field.ErrorList {
 
 // Copy streams the contents of the OS specific logging command executed  with the current args to the provided
 // writer. If an error occurs a line is written to the output.
-func (n *nodeLogQuery) Copy(w io.Writer) {
+func (n *nodeLogQuery) Copy(ctx context.Context, w io.Writer) {
 	// set the deadline to the maximum across both runs
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
 	defer cancel()
 	boot := 0
 	if n.Boot != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR makes kubelet node log queries honor request cancellation.

* `journalServer.ServeHTTP` now passes the HTTP request context into log copy execution.
* The 30s max deadline is still enforced, but now it is derived from the request context instead of `context.Background()`.

This prevents backend log collection work from continuing after the client request has been canceled or timed out.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
