### PR TITLE
Fix node lifecycle controller to mark pods not ready on False->Unknown transition

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -734,7 +734,7 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 
 			_, needsRetry := nc.nodesToRetry.Load(node.Name)
 			switch {
-			case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue:
+			case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status != currentReadyCondition.Status:
 				// Report node event only once when status changed.
 				controllerutil.RecordNodeStatusChange(logger, nc.recorder, node, "NodeNotReady")
 				fallthrough

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -1933,6 +1933,54 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 			},
 			expectedPodStatusUpdate: true,
 		},
+		// Node state transitions from False to Unknown (grace period exceeded).
+		// This tests the fix for issue #112733.
+		// Expect pods status updated when node becomes Unknown.
+		{
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:   v1.NodeReady,
+									Status: v1.ConditionFalse, // Node is already NotReady
+									// Node status hasn't been updated for 1hr.
+									LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+								},
+							},
+							Capacity: v1.ResourceList{
+								v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+								v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+			},
+			timeToPass: 1 * time.Minute,
+			newNodeStatus: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionFalse, // Status will change to Unknown
+						// Node status hasn't been updated for 1hr + 1min.
+						LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+					},
+				},
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+				},
+			},
+			expectedPodStatusUpdate: true, // Should mark pods not ready
+		},
 	}
 
 	tCtx := ktesting.Init(t)


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

This PR fixes a bug in the Node Lifecycle Controller where `MarkPodsNotReady` was not being triggered when a node's Ready condition transitions from `False` to `Unknown`.

### Bug Scenario

**Current behavior:**
1. Node's containerd fails → NodeReady condition = `False`
2. Node's kubelet loses connection → NodeReady condition = `Unknown`
3. `MarkPodsNotReady` is **NOT** triggered
4. Pods incorrectly remain in `Ready` status

**Root cause:**
The condition check only triggered when `observedReadyCondition.Status == v1.ConditionTrue`:
```go
case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue:
```

This misses the transition from `False` to `Unknown`.

### Fix

Changed the condition to detect **any status change** when the current status is not `True`:
```go
case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status != currentReadyCondition.Status:
```

This now correctly handles:
- `True` → `False` ✅ (already worked)
- `True` → `Unknown` ✅ (already worked)
- `False` → `Unknown` ✅ (BUG FIX)

## Which issue(s) this PR fixes:

Fixes #112733

## Special notes for your reviewer:

### Testing
- Added a test case to verify pods are marked NotReady when node transitions from `False` to `Unknown`
- All existing tests pass
- New test passes

### Impact
This is a critical bug fix that prevents pods from incorrectly remaining in `Ready` status when a node becomes unreachable after already being in a not-ready state.

## Testing

### Unit Tests
```bash
go test ./pkg/controller/nodelifecycle/... -v
```

All tests pass, including new test case for `False` → `Unknown` transition.

## Release Notes

```release-note
Fix Node Lifecycle Controller to correctly mark pods as NotReady when node transitions from False to Unknown condition.
```