### PR TITLE
dra: add CEL selector mismatch error message for better diagnostics

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -975,6 +975,30 @@ func TestAllocator(t *testing.T,
 	}{
 
 		"empty": {},
+		// Verify that when a CEL selector on a request does not match any
+		// available device, the error message includes the claim name and
+		// the failing expression so users can diagnose the mismatch.
+		"cel-selector-no-match": {
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				nil,
+				request(req0, classA, 1, resourceapi.DeviceSelector{
+					CEL: &resourceapi.CELDeviceSelector{
+						// This expression checks for boolAttribute==true, but the
+						// device has boolAttribute==false, so it compiles but evaluates to false.
+						Expression: fmt.Sprintf(`device.attributes["%s"].boolAttribute == true`, driverA),
+					},
+				}),
+			)),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					resourceapi.QualifiedName("boolAttribute"): {BoolValue: ptr.To(false)},
+				}),
+			)),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring(claim0)),
+		},
 		"simple": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -993,7 +993,7 @@ func TestAllocator(t *testing.T,
 			classes: objects(class(classA, driverA)),
 			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-					resourceapi.QualifiedName("boolAttribute"): {BoolValue: ptr.To(false)},
+					resourceapi.QualifiedName("boolAttribute"): {BoolValue: new(bool)},
 				}),
 			)),
 			node:        node(node1, region1),

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -361,6 +361,11 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 				return nil, fmt.Errorf("invalid resource pools were encountered%w", internal.ErrFailedAllocationOnNode)
 			}
 		}
+		// If a CEL selector mismatch was recorded, surface it as a
+		// per-node failure reason so users know why no device matched.
+		if alloc.noMatchReason != "" {
+			return nil, fmt.Errorf("%s%w", alloc.noMatchReason, internal.ErrFailedAllocationOnNode)
+		}
 		return nil, nil
 	}
 
@@ -632,6 +637,11 @@ type allocator struct {
 	// requested by all allocations targeting that device.
 	allocatingCapacity ConsumedCapacityCollection
 	result             []internalAllocationResult
+	// noMatchReason records the first CEL selector expression that did not
+	// match any device, together with the claim or class name. It is only
+	// set once (the first mismatch wins) and is surfaced as the failure
+	// reason when Allocate() finds no solution.
+	noMatchReason string
 }
 
 // counterSets is a map with the name of counter sets to the counters in
@@ -1282,6 +1292,14 @@ func (alloc *allocator) selectorsMatch(r requestIndices, device *draapi.Device, 
 			return false, fmt.Errorf("claim %s: selector #%d: CEL runtime error: %w", klog.KObj(alloc.claimsToAllocate[r.claimIndex]), i, err)
 		}
 		if !matches {
+			// Record the first mismatch reason so it can be surfaced if no
+			// device ever matches. We only record claim-level (user-written)
+			// selectors, not class selectors — class selectors filtering out
+			// devices from other drivers is expected infrastructure behavior.
+			if class == nil && alloc.noMatchReason == "" {
+				alloc.noMatchReason = fmt.Sprintf("claim %s, selector #%d: expression %q did not match",
+					klog.KObj(alloc.claimsToAllocate[r.claimIndex]), i, selector.CEL.Expression)
+			}
 			return false, nil
 		}
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -361,6 +361,11 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 				return nil, fmt.Errorf("invalid resource pools were encountered%w", internal.ErrFailedAllocationOnNode)
 			}
 		}
+		// If a CEL selector mismatch was recorded, surface it as a
+		// per-node failure reason so users know why no device matched.
+		if alloc.noMatchReason != "" {
+			return nil, fmt.Errorf("%s%w", alloc.noMatchReason, internal.ErrFailedAllocationOnNode)
+		}
 		return nil, nil
 	}
 
@@ -632,6 +637,11 @@ type allocator struct {
 	// requested by all allocations targeting that device.
 	allocatingCapacity ConsumedCapacityCollection
 	result             []internalAllocationResult
+	// noMatchReason records the first CEL selector expression that did not
+	// match any device, together with the claim or class name. It is only
+	// set once (the first mismatch wins) and is surfaced as the failure
+	// reason when Allocate() finds no solution.
+	noMatchReason string
 }
 
 // counterSets is a map with the name of counter sets to the counters in
@@ -1282,6 +1292,14 @@ func (alloc *allocator) selectorsMatch(r requestIndices, device *draapi.Device, 
 			return false, fmt.Errorf("claim %s: selector #%d: CEL runtime error: %w", klog.KObj(alloc.claimsToAllocate[r.claimIndex]), i, err)
 		}
 		if !matches {
+			// Record the first mismatch reason so it can be surfaced if no
+			// device ever matches. We only record claim-level (user-written)
+			// selectors, not class selectors — class selectors filtering out
+			// devices from other drivers is expected infrastructure behavior.
+			if class == nil && alloc.noMatchReason == "" {
+				alloc.noMatchReason = fmt.Sprintf("claim %s, selector #%d: expression %q did not match",
+					klog.KObj(alloc.claimsToAllocate[r.claimIndex]), i, selector.CEL.Expression)
+			}
 			return false, nil
 		}
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -289,6 +289,11 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 				return nil, fmt.Errorf("invalid resource pools were encountered%w", internal.ErrFailedAllocationOnNode)
 			}
 		}
+		// If a CEL selector mismatch was recorded, surface it as a
+		// per-node failure reason so users know why no device matched.
+		if alloc.noMatchReason != "" {
+			return nil, fmt.Errorf("%s%w", alloc.noMatchReason, internal.ErrFailedAllocationOnNode)
+		}
 		return nil, nil
 	}
 
@@ -519,6 +524,11 @@ type allocator struct {
 	// Claims are identified by their index in claimsToAllocate.
 	allocatingDevices map[DeviceID]sets.Set[int]
 	result            []internalAllocationResult
+	// noMatchReason records the first CEL selector expression that did not
+	// match any device, together with the claim or class name. It is only
+	// set once (the first mismatch wins) and is surfaced as the failure
+	// reason when Allocate() finds no solution.
+	noMatchReason string
 }
 
 // counterSets is a map with the name of counter sets to the counters in
@@ -1083,6 +1093,14 @@ func (alloc *allocator) selectorsMatch(r requestIndices, device *draapi.Device, 
 			return false, fmt.Errorf("claim %s: selector #%d: CEL runtime error: %w", klog.KObj(alloc.claimsToAllocate[r.claimIndex]), i, err)
 		}
 		if !matches {
+			// Record the first mismatch reason so it can be surfaced if no
+			// device ever matches. We only record claim-level (user-written)
+			// selectors, not class selectors — class selectors filtering out
+			// devices from other drivers is expected infrastructure behavior.
+			if class == nil && alloc.noMatchReason == "" {
+				alloc.noMatchReason = fmt.Sprintf("claim %s, selector #%d: expression %q did not match",
+					klog.KObj(alloc.claimsToAllocate[r.claimIndex]), i, selector.CEL.Expression)
+			}
 			return false, nil
 		}
 	}


### PR DESCRIPTION
## Summary

When a CEL selector on a resource claim does not match any available device,
the allocation fails with a generic error message that doesn't help users
diagnose the problem. This makes it difficult to understand why their
selector isn't matching.

This change adds a new field `noMatchReason` to the allocator struct that
records the first claim-level CEL selector that doesn't match any device.
When allocation fails, this reason is surfaced in the error message along
with the claim name and the expression that didn't match.

## Changes

- **Added `noMatchReason` field** to allocator struct in all three implementations
  (stable, incubating, experimental)
- **Enhanced error reporting**: When CEL selector mismatch causes allocation
  failure, the error message now includes:
  - The claim name (e.g., "claim-0")
  - The selector number
  - The actual CEL expression that didn't match
- **Added test case**: `cel-selector-no-match` to verify the error message
  contains the claim name when a CEL selector fails to match
- **Scope**: Only records claim-level (user-written) selectors, not class
  selectors, since class selectors filtering out devices from other drivers
  is expected infrastructure behavior

## Test Results

All tests pass:
- ✅ experimental: PASS
- ✅ incubating: PASS  
- ✅ stable: PASS
- ✅ New test case `cel-selector-no-match`: PASS in all implementations

## Example

**Before:**
```
Error: failed allocation on node
```

**After:**
```
Error: claim claim-0, selector #0: expression "device.attributes[\"driver-a\"].boolAttribute == true" did not match: failed allocation on node
```

This makes it much easier for users to understand which CEL expression is
failing and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)