### PR TITLE
sig-windows: Ensure HNS policies are cleaned up when endpoints are zero

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -874,46 +874,36 @@ func (svcInfo *serviceInfo) deleteLoadBalancerPolicy(mapStaleLoadbalancer map[st
 	if err := hns.deleteLoadBalancer(svcInfo.hnsID); err != nil {
 		mapStaleLoadbalancer[svcInfo.hnsID] = true
 		klog.V(1).ErrorS(err, "Error deleting Hns loadbalancer policy resource.", "hnsID", svcInfo.hnsID, "ClusterIP", svcInfo.ClusterIP())
-	} else {
-		// On successful delete, remove hnsId
-		svcInfo.hnsID = ""
 	}
+	svcInfo.hnsID = ""
 
 	if err := hns.deleteLoadBalancer(svcInfo.nodePorthnsID); err != nil {
 		mapStaleLoadbalancer[svcInfo.nodePorthnsID] = true
 		klog.V(1).ErrorS(err, "Error deleting Hns NodePort policy resource.", "hnsID", svcInfo.nodePorthnsID, "NodePort", svcInfo.NodePort())
-	} else {
-		// On successful delete, remove hnsId
-		svcInfo.nodePorthnsID = ""
 	}
+	svcInfo.nodePorthnsID = ""
 
 	for _, externalIP := range svcInfo.externalIPs {
 		mapStaleLoadbalancer[externalIP.hnsID] = true
 		if err := hns.deleteLoadBalancer(externalIP.hnsID); err != nil {
 			klog.V(1).ErrorS(err, "Error deleting Hns ExternalIP policy resource.", "hnsID", externalIP.hnsID, "IP", externalIP.ip)
-		} else {
-			// On successful delete, remove hnsId
-			externalIP.hnsID = ""
 		}
+		externalIP.hnsID = ""
 	}
 	for _, lbIngressIP := range svcInfo.loadBalancerIngressIPs {
 		klog.V(3).InfoS("Loadbalancer Hns LoadBalancer delete triggered for loadBalancer Ingress resources in cleanup", "lbIngressIP", lbIngressIP)
 		if err := hns.deleteLoadBalancer(lbIngressIP.hnsID); err != nil {
 			mapStaleLoadbalancer[lbIngressIP.hnsID] = true
 			klog.V(1).ErrorS(err, "Error deleting Hns IngressIP policy resource.", "hnsID", lbIngressIP.hnsID, "IP", lbIngressIP.ip)
-		} else {
-			// On successful delete, remove hnsId
-			lbIngressIP.hnsID = ""
 		}
+		lbIngressIP.hnsID = ""
 
 		if lbIngressIP.healthCheckHnsID != "" {
 			if err := hns.deleteLoadBalancer(lbIngressIP.healthCheckHnsID); err != nil {
 				mapStaleLoadbalancer[lbIngressIP.healthCheckHnsID] = true
 				klog.V(1).ErrorS(err, "Error deleting Hns IngressIP HealthCheck policy resource.", "hnsID", lbIngressIP.healthCheckHnsID, "IP", lbIngressIP.ip)
-			} else {
-				// On successful delete, remove hnsId
-				lbIngressIP.healthCheckHnsID = ""
 			}
+			lbIngressIP.healthCheckHnsID = ""
 		}
 	}
 }
@@ -1410,11 +1400,9 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		// In ETP:Cluster, if all endpoints are under termination,
 		// it will have serving and terminating, else only ready and serving
 		if len(hnsEndpoints) == 0 {
-			if svcInfo.winProxyOptimization {
-				// Deleting loadbalancers when there are no endpoints to serve.
-				klog.V(3).InfoS("Cleanup existing ", "endpointInfo", hnsEndpoints, "serviceName", svcName)
-				svcInfo.deleteLoadBalancerPolicy(proxier.mapStaleLoadbalancers)
-			}
+			// Deleting loadbalancers when there are no endpoints to serve.
+			klog.V(3).InfoS("Cleanup existing policies since there are no endpoints", "hnsEndpoints", hnsEndpoints, "serviceName", svcName)
+			svcInfo.deleteLoadBalancerPolicy(proxier.mapStaleLoadbalancers)
 			klog.ErrorS(nil, "Endpoint information not available for service, not applying any policy", "serviceName", svcName)
 			continue
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
This PR addresses two intertwined bugs in the Windows `kube-proxy` proxier that result in a fatal `0x803b0013` (Port already exists) crash loop due to orphaned Host Networking Service (HNS) LoadBalancer policies.

1. The Leak (Skipped Deletion): Previously, when a service's endpoints dropped to zero, the sync loop would skip explicit cleanup, leaving an orphaned, inactive LoadBalancer policy holding an exclusive TCP lock in the Windows kernel. Relying on Windows to implicitly clean up or forgive these orphaned locks is highly unpredictable; we have observed this causing hard port collisions (`0x803b0013`) across multiple environments, including GKE Windows node pools (OS build `17763.8027`) and newer Windows Server builds (e.g., `17763.8146`). Fix: Ensure `deleteLoadBalancerPolicy` is explicitly called when endpoints reach 0.

2. The Poisoned Cache (Crash Loop): When `kube-proxy` called the HNS API to delete a LoadBalancer and received an error (often due to the OS dropping the rule but leaking the TCP socket), it only cleared the cached `hnsID` inside a success `else` block. This left `kube-proxy` permanently stuck in a poisoned state, repeatedly trying to update a dead, invalid ID. Fix: Move `hnsID = ""` outside of the `else` block. This guarantees `kube-proxy` clears its internal cache and self-heals by cleanly recreating the LoadBalancer on the next sync loop.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/137577

#### Special notes for your reviewer:
**Environmental Impact**: We verified this behavior across different setups (bare metal and managed GKE without CNI). Because Windows HNS handling of orphaned endpoints is environment-dependent, explicit state management and cleanup in kube-proxy is a hard requirement to prevent permanent port exhaustion on Windows nodes.

**Workaround context**: Restarting the `kube-proxy` pod temporarily fixes the crash loop because the startup garbage collection explicitly clears the orphaned policies and resets the poisoned memory cache. This PR brings that correct, explicit deletion logic into the standard runtime loop.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug in Windows `kube-proxy` where scaling a LoadBalancer or NodePort service to 0 endpoints orphaned the HNS policy, leading to port exhaustion (`0x803b0013`) and proxy crash loops upon recreation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```
```
