### PR TITLE
kubectl: improve command suggestions for describe and get

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
@@ -157,6 +157,7 @@ func NewCmdDescribe(parent string, f cmdutil.Factory, streams genericiooptions.I
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
+		SuggestFor: []string{"inspect"},
 	}
 
 	flags.AddFlags(cmd)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -173,7 +173,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericiooptions.IOStre
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run(f, args))
 		},
-		SuggestFor: []string{"list", "ps"},
+		SuggestFor: []string{"list", "ls"},
 	}
 
 	o.PrintFlags.AddFlags(cmd)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it: 
This PR improves CLI usability by adding additional command suggestions using Cobra's SuggestFor field.

Changes:
- Add `inspect` as a suggestion for `kubectl describe`
- Add `ls` to suggestions for `kubectl get` (instead of `ps`)

These aliases reflect common Unix and Docker command patterns and help guide users to the appropriate kubectl commands.


<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:  
[comment](https://github.com/kubernetes/kubectl/issues/1825#issuecomment-3960746257): as discussed from the last bug scrub meeting about SuggestFor, I think these changes also make sense. Would request reviewers to give their thoughts.

<!--



