### PR TITLE
Explicitly allow GET and POST methods for NodeLogQuery handler

### DIFF
--- a/pkg/kubelet/kubelet_server_journal.go
+++ b/pkg/kubelet/kubelet_server_journal.go
@@ -63,6 +63,11 @@ type journalServer struct{}
 // to journalctl on the current system. It supports content-encoding of
 // gzip to reduce total content size.
 func (journalServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet && req.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	var out io.Writer = w
 
 	nlq, errs := newNodeLogQuery(req.URL.Query())


### PR DESCRIPTION
Fixes #137503. The NodeLogQuery handler did not explicitly check HTTP methods, causing POST requests to fail after the Go 1.26 upgrade. This change explicitly allows GET and POST methods and returns 405 Method Not Allowed for other methods.