### PR TITLE
Fix: kubectl drain --disable-eviction --dry-run=server hanging indefinitely

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -390,6 +390,9 @@ func (d *Helper) deletePods(pods []corev1.Pod, getPodFn func(namespace, name str
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
+		if d.DryRunStrategy == cmdutil.DryRunServer {
+			continue
+		}
 		if d.OnPodDeletionOrEvictionStarted != nil {
 			d.OnPodDeletionOrEvictionStarted(&pod, false)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -394,6 +394,11 @@ func (d *Helper) deletePods(pods []corev1.Pod, getPodFn func(namespace, name str
 			d.OnPodDeletionOrEvictionStarted(&pod, false)
 		}
 	}
+
+	if d.DryRunStrategy == cmdutil.DryRunServer {
+		return nil
+	}
+
 	ctx := d.getContext()
 	params := waitForDeleteParams{
 		ctx:                             ctx,

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"testing"
@@ -508,10 +509,8 @@ func TestDeleteOrEvictWithDryRunServer(t *testing.T) {
 			// removing the object, simulating real API server dry-run behavior.
 			k.PrependReactor("delete", "pods", func(actions ktest.Action) (bool, runtime.Object, error) {
 				deleteAction := actions.(ktest.DeleteAction)
-				for _, v := range deleteAction.GetDeleteOptions().DryRun {
-					if v == metav1.DryRunAll {
-						return true, nil, nil
-					}
+				if slices.Contains(deleteAction.GetDeleteOptions().DryRun, metav1.DryRunAll) {
+					return true, nil, nil
 				}
 				return false, nil, nil
 			})

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package drain
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	ktest "k8s.io/client-go/testing"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 func TestDeletePods(t *testing.T) {
@@ -456,6 +458,69 @@ func TestDeleteOrEvict(t *testing.T) {
 			})
 			if !reflect.DeepEqual(actualEvictions, expectedEvictions) {
 				t.Errorf("%s: unexpected evictions; actual\n\t%v\nexpected\n\t%v", tc.description, actualEvictions, expectedEvictions)
+			}
+		})
+	}
+}
+
+func TestDeleteOrEvictWithDryRunServer(t *testing.T) {
+	testCases := []struct {
+		description     string
+		disableEviction bool
+	}{
+		{
+			description:     "Eviction enabled with server dry-run",
+			disableEviction: false,
+		},
+		{
+			description:     "Eviction disabled with server dry-run",
+			disableEviction: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := &Helper{
+				Out:                &buf,
+				GracePeriodSeconds: 10,
+				DisableEviction:    tc.disableEviction,
+				DryRunStrategy:     cmdutil.DryRunServer,
+			}
+
+			var allPods []runtime.Object
+			var podsToDelete []corev1.Pod
+
+			for i := 1; i <= 4; i++ {
+				pod := corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("mypod-%d", i),
+						Namespace: "default",
+					},
+				}
+				allPods = append(allPods, &pod)
+				if i <= 2 {
+					podsToDelete = append(podsToDelete, pod)
+				}
+			}
+
+			k := fake.NewSimpleClientset(allPods...)
+
+			// fake clientset will actually delete objects from the in-memory store.
+			// This reactor intercepts delete requests with DryRun set and returns success without
+			// removing the object, simulating real API server dry-run behavior.
+			k.PrependReactor("delete", "pods", func(actions ktest.Action) (bool, runtime.Object, error) {
+				deleteAction := actions.(ktest.DeleteAction)
+				if len(deleteAction.GetDeleteOptions().DryRun) > 0 {
+					return true, nil, nil
+				}
+				return false, nil, nil
+			})
+			addEvictionSupport(t, k, "v1")
+			h.Client = k
+
+			if err := h.DeleteOrEvictPods(podsToDelete); err != nil {
+				t.Fatalf("error from DeleteOrEvictPods: %v", err)
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -491,7 +491,7 @@ func TestDeleteOrEvictWithDryRunServer(t *testing.T) {
 			var allPods []runtime.Object
 			var podsToDelete []corev1.Pod
 
-			for i := 1; i <= 4; i++ {
+			for i := 1; i <= 2; i++ {
 				pod := corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("mypod-%d", i),
@@ -499,20 +499,19 @@ func TestDeleteOrEvictWithDryRunServer(t *testing.T) {
 					},
 				}
 				allPods = append(allPods, &pod)
-				if i <= 2 {
-					podsToDelete = append(podsToDelete, pod)
-				}
+				podsToDelete = append(podsToDelete, pod)
 			}
 
 			k := fake.NewSimpleClientset(allPods...)
 
-			// fake clientset will actually delete objects from the in-memory store.
 			// This reactor intercepts delete requests with DryRun set and returns success without
 			// removing the object, simulating real API server dry-run behavior.
 			k.PrependReactor("delete", "pods", func(actions ktest.Action) (bool, runtime.Object, error) {
 				deleteAction := actions.(ktest.DeleteAction)
-				if len(deleteAction.GetDeleteOptions().DryRun) > 0 {
-					return true, nil, nil
+				for _, v := range deleteAction.GetDeleteOptions().DryRun {
+					if v == metav1.DryRunAll {
+						return true, nil, nil
+					}
 				}
 				return false, nil, nil
 			})

--- a/test/cmd/node-management.sh
+++ b/test/cmd/node-management.sh
@@ -193,6 +193,10 @@ run_cluster_management_tests() {
    kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/v1/nodes?labelSelector=test%3Dlabel&limit=500" status="200 OK"'
    kube::test::if_has_string "${output_message}" '"Response" verb="GET" url=".*/v1/pods?fieldSelector=spec.nodeName%3D127.0.0.1&limit=500" status="200 OK"'
 
+   ### kubectl drain with --disable-eviction --dry-run=server completes successfully
+   kubectl drain "127.0.0.1" --force --disable-eviction --dry-run=server
+   kube::test::get_object_assert "pods" "{{range .items}}{{.metadata.name}},{{end}}" 'test-pod-1,test-pod-2,'
+
   ### kubectl cordon command fails when no arguments are passed
   # Pre-condition: node exists
   response=$(! kubectl cordon 2>&1)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

Fixes `kubectl drain --disable-eviction --dry-run=server` hanging indefinitely.

The `evictPods` path skips `waitForDelete` when `DryRunStrategy == DryRunServer`, but the `deletePods` path (used when `--disable-eviction` is set) lacks this check, causing the command to wait for pods that are never actually removed.

**Which issue(s) this PR fixes:**

Fixes #https://github.com/kubernetes/kubectl/issues/1830

**Does this PR introduce a user-facing change?**

```release-note
Fixed a bug where `kubectl drain --disable-eviction --dry-run=server` hangs indefinitely.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancements Proposals), usage docs, etc.:**

The added test may appear trivial since it only asserts that `DeleteOrEvictPods` returns without error. However, it verifies that the command completes under the `DisableEviction` + `DryRunServer`. Without the fix, this test hangs indefinitely, which has been confirmed against the original implementation.

/sig cli
/area kubectl