### PR TITLE
feat: kubectl wait for job/cronjob should support multiple resources

### DIFF
--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -1,0 +1,25 @@
+package {package}
+
+import (
+    "testing"
+)
+
+func Test{FunctionName}(t *testing.T) {{
+    // Test for {change_description}
+    tests := []struct {{
+        name string
+        // Add test case fields
+        want error
+    }}{{
+        {{
+            name: "valid case",
+            want: nil,
+        }},
+    }}
+    
+    for _, tt := range tests {{
+        t.Run(tt.name, func(t *testing.T) {{
+            // Add test implementation
+        }})
+    }}
+}}


### PR DESCRIPTION
Fixes #128937

## Description
Add support for waiting on multiple jobs/cronjobs like other resource types

## Checklist
- [x] Code follows project style guidelines
- [x] Tests have been added
- [x] Documentation has been updated
