### PR TITLE
feature: add ServiceName, PodManagementPolicy, and PersistentVolumeClaimRetentionPolicy to kubectl describe statefulset output

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -3643,6 +3643,12 @@ func describeStatefulSet(ps *appsv1.StatefulSet, selector labels.Selector, event
 		w.Write(LEVEL_0, "Selector:\t%s\n", selector)
 		printLabelsMultiline(w, "Labels", ps.Labels)
 		printAnnotationsMultiline(w, "Annotations", ps.Annotations)
+		if len(ps.Spec.ServiceName) > 0 {
+			w.Write(LEVEL_0, "Service Name:\t%s\n", ps.Spec.ServiceName)
+		}
+		if len(ps.Spec.PodManagementPolicy) > 0 {
+			w.Write(LEVEL_0, "Pod Management Policy:\t%s\n", ps.Spec.PodManagementPolicy)
+		}
 		w.Write(LEVEL_0, "Replicas:\t%d desired | %d total\n", *ps.Spec.Replicas, ps.Status.Replicas)
 		w.Write(LEVEL_0, "Update Strategy:\t%s\n", ps.Spec.UpdateStrategy.Type)
 		if ps.Spec.UpdateStrategy.RollingUpdate != nil {
@@ -3654,7 +3660,11 @@ func describeStatefulSet(ps *appsv1.StatefulSet, selector labels.Selector, event
 				}
 			}
 		}
-
+		if ps.Spec.PersistentVolumeClaimRetentionPolicy != nil {
+			w.Write(LEVEL_0, "Persistent Volume Claim Retention Policy:\n")
+			w.Write(LEVEL_1, "WhenDeleted:\t%s\n", ps.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
+			w.Write(LEVEL_1, "WhenScaled:\t%s\n", ps.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
+		}
 		w.Write(LEVEL_0, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
 		DescribePodTemplate(&ps.Spec.Template, w)
 		describeVolumeClaimTemplates(ps.Spec.VolumeClaimTemplates, w)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -6694,10 +6694,8 @@ func TestDescribeStatefulSet(t *testing.T) {
 	var replicas int32 = 1
 	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "bar",
-			Namespace:   "foo",
-			Labels:      map[string]string{"app": "mytest"},
-			Annotations: map[string]string{"annotation1": "value1"},
+			Name:      "bar",
+			Namespace: "foo",
 		},
 		Spec: appsv1.StatefulSetSpec{
 			PodManagementPolicy: appsv1.ParallelPodManagement,
@@ -6709,7 +6707,7 @@ func TestDescribeStatefulSet(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "metest",
+							Name:  "mytest",
 							Image: "mytest-image:latest",
 						},
 					},
@@ -6739,8 +6737,6 @@ func TestDescribeStatefulSet(t *testing.T) {
 		"Namespace:              foo",
 		"CreationTimestamp:      Mon, 01 Jan 0001 00:00:00 +0000",
 		"Selector:               app=mytest",
-		"Labels:                 app=mytest",
-		"Annotations:            annotation1: value1",
 		"Service Name:           test-service",
 		"Pod Management Policy:  Parallel",
 		"Replicas:               1 desired | 0 total",

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -6694,18 +6694,31 @@ func TestDescribeStatefulSet(t *testing.T) {
 	var replicas int32 = 1
 	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "bar",
-			Namespace: "foo",
+			Name:        "bar",
+			Namespace:   "foo",
+			Labels:      map[string]string{"app": "mytest"},
+			Annotations: map[string]string{"annotation1": "value1"},
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{},
+			PodManagementPolicy: appsv1.ParallelPodManagement,
+			Replicas:            &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "mytest"},
+			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
-						{Image: "mytest-image:latest"},
+						{
+							Name:  "metest",
+							Image: "mytest-image:latest",
+						},
 					},
 				},
+			},
+			ServiceName: "test-service",
+			PersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
 			},
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
@@ -6722,7 +6735,20 @@ func TestDescribeStatefulSet(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	expectedOutputs := []string{
-		"bar", "foo", "Containers:", "mytest-image:latest", "Update Strategy", "RollingUpdate", "Partition", "2672",
+		"Name:                   bar",
+		"Namespace:              foo",
+		"CreationTimestamp:      Mon, 01 Jan 0001 00:00:00 +0000",
+		"Selector:               app=mytest",
+		"Labels:                 app=mytest",
+		"Annotations:            annotation1: value1",
+		"Service Name:           test-service",
+		"Pod Management Policy:  Parallel",
+		"Replicas:               1 desired | 0 total",
+		"Update Strategy:        RollingUpdate",
+		"  Partition:            2672",
+		"Persistent Volume Claim Retention Policy:",
+		"  WhenDeleted:  Delete",
+		"  WhenScaled:   Retain",
 	}
 	for _, o := range expectedOutputs {
 		if !strings.Contains(out, o) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add `ServiceName`, `PodManagementPolicy`, and `PersistentVolumeClaimRetentionPolicy` to `kubectl describe statefulset` output.

#### Which issue(s) this PR is related to:

Fixes #https://github.com/kubernetes/kubectl/issues/1831

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Added ServiceName, PodManagementPolicy, and PersistentVolumeClaimRetentionPolicy to `kubectl describe statefulset` output.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```

/sig cli
/area kubectl