### PR TITLE
Extract preemption executor into Framework

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -289,6 +289,9 @@ type Framework interface {
 	// SetAPICacher sets the APICacher
 	SetAPICacher(apiCacher fwk.APICacher)
 
+	// SetPreemptionExecutor sets the PreemptionExecutor
+	SetPreemptionExecutor(executor fwk.PreemptionExecutor)
+
 	// Close calls Close method of each plugin.
 	Close() error
 }

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -103,7 +103,7 @@ func New(_ context.Context, dpArgs runtime.Object, fh fwk.Handle, fts feature.Fe
 		fts:  fts,
 		args: *args,
 	}
-	pl.Evaluator = preemption.NewEvaluator(Name, fh, &pl, fts.EnableAsyncPreemption)
+	pl.Evaluator = preemption.NewEvaluator(Name, fh, &pl)
 
 	// Default behavior: No additional filtering, beyond the internal requirement that the victim pod
 	// have lower priority than the preemptor pod.
@@ -135,7 +135,11 @@ func (pl *DefaultPreemption) PreEnqueue(ctx context.Context, p *v1.Pod) *fwk.Sta
 	if !pl.fts.EnableAsyncPreemption {
 		return nil
 	}
-	if pl.Evaluator.IsPodRunningPreemption(p.GetUID()) {
+	executor := pl.fh.PreemptionExecutor()
+	if executor == nil {
+		return nil
+	}
+	if executor.IsPodRunningPreemption(p.GetUID()) {
 		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for the preemption for this pod to be finished")
 	}
 	return nil

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -52,12 +52,12 @@ import (
 	apipod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	configv1 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1"
-	"k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
-	"k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
+	apicache "k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
+	apidispatcher "k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
+	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -459,7 +459,7 @@ func TestPostFilter(t *testing.T) {
 					cache := internalcache.New(ctx, apiDispatcher, false)
 					f.SetAPICacher(apicache.New(nil, cache))
 				}
-
+				f.SetPreemptionExecutor(preemption.NewExecutor(f, feature.Features{}))
 				p, err := New(ctx, getDefaultDefaultPreemptionArgs(), f, feature.Features{})
 				if err != nil {
 					t.Fatal(err)
@@ -2247,10 +2247,10 @@ func TestPreempt(t *testing.T) {
 					if _, s, _ := schedFramework.RunPreFilterPlugins(ctx, state, testPod); !s.IsSuccess() {
 						t.Errorf("Unexpected preFilterStatus: %v", s)
 					}
-					// Call preempt and check the expected results.
 					features := feature.Features{
 						EnableAsyncPreemption: asyncPreemptionEnabled,
 					}
+					schedFramework.SetPreemptionExecutor(preemption.NewExecutor(schedFramework, features))
 					pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), schedFramework, features)
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -29,12 +29,13 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
+	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
 	apipod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
 )
@@ -50,7 +51,7 @@ type Executor struct {
 	mu sync.RWMutex
 	fh fwk.Handle
 
-	podLister corelisters.PodLister
+	fts feature.Features
 
 	// preempting is a set that records the pods that are currently triggering preemption asynchronously,
 	// which is used to prevent the pods from entering the scheduling cycle meanwhile.
@@ -64,13 +65,13 @@ type Executor struct {
 	PreemptPod func(ctx context.Context, c Candidate, preemptor, victim *v1.Pod, pluginName string) error
 }
 
-// newExecutor creates a new preemption executor.
-func newExecutor(fh fwk.Handle) *Executor {
+// NewExecutor creates a new preemption executor.
+func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 	e := &Executor{
 		fh:                           fh,
-		podLister:                    fh.SharedInformerFactory().Core().V1().Pods().Lister(),
 		preempting:                   sets.New[types.UID](),
 		lastVictimsPendingPreemption: make(map[types.UID]pendingVictim),
+		fts:                          fts,
 	}
 
 	e.PreemptPod = func(ctx context.Context, c Candidate, preemptor, victim *v1.Pod, pluginName string) error {
@@ -133,6 +134,25 @@ func newExecutor(fh fwk.Handle) *Executor {
 	}
 
 	return e
+}
+
+// ActuatePreemption actuates the preemption given preemptorPod to be scheduled on targetNode and a list of
+// victims to be evicted.
+func (e *Executor) ActuatePreemption(ctx context.Context, targetNode string, victims *extenderv1.Victims, preemptorPod *v1.Pod, pluginName string) *fwk.Status {
+	candidate := candidate{
+		victims: victims,
+		name:    targetNode,
+	}
+
+	if e.fts.EnableAsyncPreemption {
+		e.prepareCandidateAsync(&candidate, preemptorPod, pluginName)
+	} else {
+		if status := e.prepareCandidate(ctx, &candidate, preemptorPod, pluginName); !status.IsSuccess() {
+			return status
+		}
+	}
+
+	return fwk.NewStatus(fwk.Success)
 }
 
 // prepareCandidateAsync triggers a goroutine for some preparation work:
@@ -302,8 +322,9 @@ func (e *Executor) IsPodRunningPreemption(podUID types.UID) bool {
 		// Since pod is in `preempting` but last victim is not registered yet, the async preemption is pending.
 		return true
 	}
+	podLister := e.fh.SharedInformerFactory().Core().V1().Pods().Lister()
 	// Pod is waiting for preemption of one last victim. We can check if the victim has already been deleted.
-	victimPod, err := e.podLister.Pods(victim.namespace).Get(victim.name)
+	victimPod, err := podLister.Pods(victim.namespace).Get(victim.name)
 	if err != nil {
 		// Victim already deleted, preemption is done.
 		return false

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
@@ -50,6 +49,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
@@ -57,45 +57,28 @@ import (
 	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
 )
 
-// fakePodLister helps test IsPodRunningPreemption logic without worrying about cache synchronization issues.
-// Current list of pods is set using field pods.
-type fakePodLister struct {
-	corelisters.PodLister
-	pods map[string]*v1.Pod
+type fakeHandleForLister struct {
+	fwk.Handle
+	informerFactory informers.SharedInformerFactory
 }
 
-func (m *fakePodLister) Pods(namespace string) corelisters.PodNamespaceLister {
-	return &fakePodNamespaceLister{pods: m.pods}
-}
-
-// fakePodNamespaceLister helps test IsPodRunningPreemption logic without worrying about cache synchronization issues.
-// Current list of pods is set using field pods.
-type fakePodNamespaceLister struct {
-	corelisters.PodNamespaceLister
-	pods map[string]*v1.Pod
-}
-
-func (m *fakePodNamespaceLister) Get(name string) (*v1.Pod, error) {
-	if pod, ok := m.pods[name]; ok {
-		return pod, nil
-	}
-	// Important: Return the standard IsNotFound error for a fake cache miss.
-	return nil, apierrors.NewNotFound(v1.Resource("pods"), name)
+func (f *fakeHandleForLister) SharedInformerFactory() informers.SharedInformerFactory {
+	return f.informerFactory
 }
 
 func TestIsPodRunningPreemption(t *testing.T) {
 	var (
-		victim1 = st.MakePod().Name("victim1").UID("victim1").
+		victim1 = st.MakePod().Namespace("ns").Name("victim1").UID("victim1").
 			Node("node").SchedulerName("sch").Priority(midPriority).
 			Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
 			Obj()
 
-		victim2 = st.MakePod().Name("victim2").UID("victim2").
+		victim2 = st.MakePod().Namespace("ns").Name("victim2").UID("victim2").
 			Node("node").SchedulerName("sch").Priority(midPriority).
 			Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
 			Obj()
 
-		victimWithDeletionTimestamp = st.MakePod().Name("victim-deleted").UID("victim-deleted").
+		victimWithDeletionTimestamp = st.MakePod().Namespace("ns").Name("victim-deleted").UID("victim-deleted").
 						Node("node").SchedulerName("sch").Priority(midPriority).
 						Terminating().
 						Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
@@ -191,11 +174,16 @@ func TestIsPodRunningPreemption(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%v", tt.name), func(t *testing.T) {
 
-			fakeLister := &fakePodLister{
-				pods: tt.podsInPodLister,
+			client := clientsetfake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			for _, pod := range tt.podsInPodLister {
+				e := informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
+				if e != nil {
+					t.Errorf("Failed to add pod %v to indexer: %v", pod, e)
+				}
 			}
 			a := &Executor{
-				podLister:                    fakeLister,
+				fh:                           &fakeHandleForLister{informerFactory: informerFactory},
 				preempting:                   tt.preemptingSet,
 				lastVictimsPendingPreemption: tt.lastVictimSet,
 			}
@@ -606,7 +594,7 @@ func TestPrepareCandidate(t *testing.T) {
 						fwk.SetAPICacher(apicache.New(nil, cache))
 					}
 
-					executor := newExecutor(fwk)
+					executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: asyncPreemptionEnabled})
 
 					if asyncPreemptionEnabled {
 						executor.prepareCandidateAsync(tt.candidate, tt.preemptor, "test-plugin")
@@ -833,7 +821,7 @@ func TestPrepareCandidateAsyncSetsPreemptingSets(t *testing.T) {
 					fwk.SetAPICacher(apicache.New(nil, cache))
 				}
 
-				executor := newExecutor(fwk)
+				executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: true})
 				// preemptPodCallsCounter helps verify if the last victim pod gets preempted after other victims.
 				preemptPodCallsCounter := 0
 				preemptFunc := executor.PreemptPod
@@ -1066,7 +1054,7 @@ func TestAsyncPreemptionFailure(t *testing.T) {
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
 
-			executor := newExecutor(fwk)
+			executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: true})
 
 			// Run the actual preemption.
 			executor.prepareCandidateAsync(candidate, preemptor, "test-plugin")
@@ -1272,7 +1260,7 @@ func TestPreemptPod(t *testing.T) {
 				}
 				fwk.AddWaitingPod(victimPod, pluginsWaitTime)
 			}
-			pe := NewEvaluator("FakePreemptionScorePostFilter", fwk, &FakePreemptionScorePostFilterPlugin{}, false)
+			pe := NewExecutor(fwk, feature.Features{})
 
 			err = pe.PreemptPod(ctx, &candidate{}, preemptorPod, victimPod, "test-plugin")
 			if err != nil {

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -60,27 +60,24 @@ type Interface interface {
 	OrderedScoreFuncs(ctx context.Context, nodesToVictims map[string]*extenderv1.Victims) []func(node string) int64
 }
 
+// Evaluator is a preemption evaluator. It runs preemption logic with a given Interface.
 type Evaluator struct {
 	PluginName string
 	Handler    fwk.Handle
 	PodLister  corelisters.PodLister
 	PdbLister  policylisters.PodDisruptionBudgetLister
 
-	enableAsyncPreemption bool
-
-	*Executor
 	Interface
 }
 
-func NewEvaluator(pluginName string, fh fwk.Handle, i Interface, enableAsyncPreemption bool) *Evaluator {
+// NewEvaluator create a new Evaluator.
+func NewEvaluator(pluginName string, fh fwk.Handle, i Interface) *Evaluator {
 	return &Evaluator{
-		PluginName:            pluginName,
-		Handler:               fh,
-		PodLister:             fh.SharedInformerFactory().Core().V1().Pods().Lister(),
-		PdbLister:             fh.SharedInformerFactory().Policy().V1().PodDisruptionBudgets().Lister(),
-		enableAsyncPreemption: enableAsyncPreemption,
-		Executor:              newExecutor(fh),
-		Interface:             i,
+		PluginName: pluginName,
+		Handler:    fh,
+		PodLister:  fh.SharedInformerFactory().Core().V1().Pods().Lister(),
+		PdbLister:  fh.SharedInformerFactory().Policy().V1().PodDisruptionBudgets().Lister(),
+		Interface:  i,
 	}
 }
 
@@ -161,13 +158,16 @@ func (ev *Evaluator) Preempt(ctx context.Context, state fwk.CycleState, pod *v1.
 
 	logger.V(2).Info("the target node for the preemption is determined", "node", bestCandidate.Name(), "pod", klog.KObj(pod))
 
-	// 5) Perform preparation work before nominating the selected candidate.
-	if ev.enableAsyncPreemption {
-		ev.prepareCandidateAsync(bestCandidate, pod, ev.PluginName)
-	} else {
-		if status := ev.prepareCandidate(ctx, bestCandidate, pod, ev.PluginName); !status.IsSuccess() {
+	// 5) Actuate the preemption.
+	executor := ev.Handler.PreemptionExecutor()
+	if executor != nil {
+		if status := executor.ActuatePreemption(ctx, bestCandidate.Name(), bestCandidate.Victims(), pod, ev.PluginName); !status.IsSuccess() {
 			return nil, status
 		}
+	} else {
+		// This should not happen outside of tests.
+		logger.Error(errors.New("preemption executor is not set"), "Cannot actuate preemption", "pod", klog.KObj(pod))
+		return nil, fwk.NewStatus(fwk.Error, "preemption executor is not set")
 	}
 
 	return framework.NewPostFilterResultWithNominatedNode(bestCandidate.Name()), fwk.NewStatus(fwk.Success)

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -82,13 +82,14 @@ type frameworkImpl struct {
 	// pluginsMap contains all plugins, by name.
 	pluginsMap map[string]fwk.Plugin
 
-	clientSet        clientset.Interface
-	kubeConfig       *restclient.Config
-	eventRecorder    events.EventRecorder
-	informerFactory  informers.SharedInformerFactory
-	sharedDRAManager fwk.SharedDRAManager
-	podGroupManager  fwk.PodGroupManager
-	logger           klog.Logger
+	clientSet          clientset.Interface
+	kubeConfig         *restclient.Config
+	eventRecorder      events.EventRecorder
+	informerFactory    informers.SharedInformerFactory
+	sharedDRAManager   fwk.SharedDRAManager
+	podGroupManager    fwk.PodGroupManager
+	logger             klog.Logger
+	preemptionExecutor fwk.PreemptionExecutor
 
 	sharedCSIManager fwk.CSIManager
 
@@ -539,6 +540,14 @@ func (f *frameworkImpl) SetPodActivator(a fwk.PodActivator) {
 
 func (f *frameworkImpl) SetAPICacher(c fwk.APICacher) {
 	f.apiCacher = c
+}
+
+func (f *frameworkImpl) SetPreemptionExecutor(executor fwk.PreemptionExecutor) {
+	f.preemptionExecutor = executor
+}
+
+func (f *frameworkImpl) PreemptionExecutor() fwk.PreemptionExecutor {
+	return f.preemptionExecutor
 }
 
 // Close closes each plugin, when they implement io.Closer interface.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -50,8 +50,10 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
+	plfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits"
+	"k8s.io/kubernetes/pkg/scheduler/framework/preemption"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
@@ -374,6 +376,10 @@ func New(ctx context.Context,
 
 	if len(profiles) == 0 {
 		return nil, errors.New("at least one profile is required")
+	}
+
+	for _, fwk := range profiles {
+		fwk.SetPreemptionExecutor(preemption.NewExecutor(fwk, plfeature.NewSchedulerFeaturesFromGates(feature.DefaultFeatureGate)))
 	}
 
 	preEnqueuePluginMap := make(map[string]map[string]fwk.PreEnqueuePlugin)

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 )
 
 // Code is the Status code/type which is returned from plugins.
@@ -887,6 +888,9 @@ type Handle interface {
 
 	// SignPod creates a PodSignature for a pod.
 	SignPod(ctx context.Context, pod *v1.Pod) PodSignature
+
+	// PreemptionExecutor returns the PreemptionExecutor.
+	PreemptionExecutor() PreemptionExecutor
 }
 
 // Parallelizer helps run scheduling operations in parallel chunks where possible, to improve performance and CPU utilization.
@@ -946,4 +950,16 @@ type PluginsRunner interface {
 	// PreFilter plugins. It returns directly if any of the plugins return any
 	// status other than Success.
 	RunPreFilterExtensionRemovePod(ctx context.Context, state CycleState, podToSchedule *v1.Pod, podInfoToRemove PodInfo, nodeInfo NodeInfo) *Status
+}
+
+// PreemptionExecutor knows how to perform preemption of victims for selected Pods. It also keeps track
+// of all in progress preemption operations.
+type PreemptionExecutor interface {
+	// ActuatePreemption actuates the preemption given preemptorPod to be scheduled on targetNode and a list of
+	// victims to be evicted.
+	// Preemption can happen asynchronously in which case the preemption can be tracked via IsPodRunningPreemption method.
+	ActuatePreemption(ctx context.Context, targetNode string, victims *extenderv1.Victims, preemptorPod *v1.Pod, source string) *Status
+
+	// IsPodRunningPreemption returns true if the pod triggered an asynchronous preemption that has not yet completed.
+	IsPodRunningPreemption(podUID types.UID) bool
 }

--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -491,18 +491,6 @@ func TestPreemptionAndNominatedNodeNameScenarios(t *testing.T) {
 							return nil, fmt.Errorf("unexpected plugin type %T", p)
 						}
 
-						preemptPodFn := preemptionPlugin.Evaluator.PreemptPod
-						preemptionPlugin.Evaluator.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor, victim *v1.Pod, pluginName string) error {
-							// block the preemption goroutine to complete until the test case allows it to proceed.
-							lock.Lock()
-							ch, ok := preemptionDoneChannels[preemptor.Name]
-							lock.Unlock()
-							if ok {
-								<-ch
-							}
-							return preemptPodFn(ctx, c, preemptor, victim, pluginName)
-						}
-
 						return preemptionPlugin, nil
 					})
 					if err != nil {
@@ -541,6 +529,27 @@ func TestPreemptionAndNominatedNodeNameScenarios(t *testing.T) {
 
 					if preemptionPlugin == nil {
 						t.Fatalf("the preemption plugin should be initialized")
+					}
+
+					v, ok := testCtx.Scheduler.Profiles[v1.DefaultSchedulerName]
+					if !ok {
+						t.Fatalf("unexpected profile type %T", testCtx.Scheduler.Profiles[v1.DefaultSchedulerName])
+					}
+					executor, ok := v.PreemptionExecutor().(*preemption.Executor)
+					if !ok {
+						t.Fatalf("unexpected executor type %T", v.PreemptionExecutor())
+					}
+
+					preemptPodFn := executor.PreemptPod
+					executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor, victim *v1.Pod, pluginName string) error {
+						// block the preemption goroutine to complete until the test case allows it to proceed.
+						lock.Lock()
+						ch, ok := preemptionDoneChannels[preemptor.Name]
+						lock.Unlock()
+						if ok {
+							<-ch
+						}
+						return preemptPodFn(ctx, c, preemptor, victim, pluginName)
 					}
 
 					logger, _ := ktesting.NewTestContext(t)

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1247,18 +1247,6 @@ func TestAsyncPreemption(t *testing.T) {
 						return nil, fmt.Errorf("unexpected plugin type %T", p)
 					}
 
-					preemptPodFn := preemptionPlugin.Evaluator.PreemptPod
-					preemptionPlugin.Evaluator.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor, victim *v1.Pod, pluginName string) error {
-						// block the preemption goroutine to complete until the test case allows it to proceed.
-						lock.Lock()
-						ch, ok := preemptionDoneChannels[preemptor.Name]
-						lock.Unlock()
-						if ok {
-							<-ch
-						}
-						return preemptPodFn(ctx, c, preemptor, victim, pluginName)
-					}
-
 					return preemptionPlugin, nil
 				})
 				if err != nil {
@@ -1334,6 +1322,27 @@ func TestAsyncPreemption(t *testing.T) {
 
 				if preemptionPlugin == nil {
 					t.Fatalf("the preemption plugin should be initialized")
+				}
+
+				v, ok := testCtx.Scheduler.Profiles[v1.DefaultSchedulerName]
+				if !ok {
+					t.Fatalf("unexpected profile type %T", testCtx.Scheduler.Profiles[v1.DefaultSchedulerName])
+				}
+				executor, ok := v.PreemptionExecutor().(*preemption.Executor)
+				if !ok {
+					t.Fatalf("unexpected executor type %T", v.PreemptionExecutor())
+				}
+
+				preemptPodFn := executor.PreemptPod
+				executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor, victim *v1.Pod, pluginName string) error {
+					// block the preemption goroutine to complete until the test case allows it to proceed.
+					lock.Lock()
+					ch, ok := preemptionDoneChannels[preemptor.Name]
+					lock.Unlock()
+					if ok {
+						<-ch
+					}
+					return preemptPodFn(ctx, c, preemptor, victim, pluginName)
 				}
 
 				logger, _ := ktesting.NewTestContext(t)
@@ -1449,7 +1458,7 @@ func TestAsyncPreemption(t *testing.T) {
 						}
 					case scenario.podRunningPreemption != nil:
 						if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-							return preemptionPlugin.Evaluator.IsPodRunningPreemption(createdPods[*scenario.podRunningPreemption].GetUID()), nil
+							return executor.IsPodRunningPreemption(createdPods[*scenario.podRunningPreemption].GetUID()), nil
 						}); err != nil {
 							t.Fatalf("Expected the pod %s to be running preemption", createdPods[*scenario.podRunningPreemption].Name)
 						}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR is a prework for two other features: Workload Aware Preeemption from [KEP-5710](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5710-workload-aware-preemption) and delayed preemption from [KEP-4671](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4671-gang-scheduling). With that we make preemption a first class citizen in the scheduler framework, which will allow us to call the executor outside of the default preemption plugin.

#### Which issue(s) this PR is related to:

- [KEP-5710](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5710-workload-aware-preemption) 
- [KEP-4671](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4671-gang-scheduling)

#### Special notes for your reviewer:

For now, the Preempt from preemption.go still actuates the preemptions if the Evaluator has the Executor set. In the future we should get rid of that completely and rely only on external Executor to actuate preemptions but I wanted to minimize the changes. This should result in no user-facing changes.

#### Does this PR introduce a user-facing change?

```release-note
Preemption Executor is extracted out of preemption Evaluator. Authors of out of tree custom preemption plugins can pass Executor to Evaluator to keep the current behavior, or preferably call the Executor to actuate preemptions after Evaluator calculates them.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
