### PR TITLE
e2e: update snapshotmetadataservice crd to v1beta1

### DIFF
--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -409,7 +409,7 @@ var (
 	// Tests marked with this feature require:
 	// - A CSI driver that supports the snapshot metadata service (e.g., CSI hostpath driver with --enable-snapshot-metadata)
 	// - The external-snapshot-metadata sidecar deployed alongside the CSI driver
-	// - The SnapshotMetadataService CRD (cbt.storage.k8s.io/v1alpha1) installed
+	// - The SnapshotMetadataService CRD (cbt.storage.k8s.io/v1beta1) installed
 	// - A storage driver that implements the CapSnapshotMetadata capability
 	SnapshotMetadata = framework.WithFeature(framework.ValidFeatures.Add("SnapshotMetadata"))
 

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -411,7 +411,7 @@ var (
 	// - The external-snapshot-metadata sidecar deployed alongside the CSI driver
 	// - The SnapshotMetadataService CRD (cbt.storage.k8s.io/v1beta1) installed
 	// - A storage driver that implements the CapSnapshotMetadata capability
-	SnapshotMetadata = framework.WithFeature(framework.ValidFeatures.Add("SnapshotMetadata"))
+	SnapshotMetadata = framework.WithFeature(framework.ValidFeatures.Add("snapshotmetadata"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	StackdriverAcceleratorMonitoring = framework.WithFeature(framework.ValidFeatures.Add("StackdriverAcceleratorMonitoring"))

--- a/test/e2e/storage/utils/snapshot-metadata.go
+++ b/test/e2e/storage/utils/snapshot-metadata.go
@@ -51,7 +51,7 @@ const (
 
 	// SnapshotMetadataService API constants
 	SnapshotMetadataServiceGroup      = "cbt.storage.k8s.io"
-	SnapshotMetadataServiceVersion    = "v1alpha1"
+	SnapshotMetadataServiceVersion    = "v1beta1"
 	SnapshotMetadataServiceAPIVersion = SnapshotMetadataServiceGroup + "/" + SnapshotMetadataServiceVersion
 	SnapshotMetadataServiceKind       = "SnapshotMetadataService"
 	SnapshotMetadataServiceResource   = "snapshotmetadataservices"

--- a/test/e2e/testing-manifests/storage-csi/external-snapshot-metadata/cbt.storage.k8s.io_snapshotmetadataservices.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshot-metadata/cbt.storage.k8s.io_snapshotmetadataservices.yaml
@@ -17,7 +17,7 @@ spec:
     singular: snapshotmetadataservice
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - name: v1beta1
     schema:
       openAPIV3Schema:
         description: |-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

- Align e2e tests with upstream external-snapshot-metadata change
(https://github.com/kubernetes-csi/external-snapshot-metadata/pull/215) which promotes the
SnapshotMetadataService API to v1beta1.

- Change the feature label from "SnapshotMetadata" to "snapshotmetadata"
so it matches the [Feature:snapshotmetadata] [focus filter](https://github.com/kubernetes/test-infra/blob/1d8f9214bed2fbc64187b95db84d659eba946af7/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml#L468-L469) used in test-infra,
which was causing the e2e tests to be skipped.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`SnapshotMetadataService` is now available in v1beta1 version. The support for the v1alpha1 version have been removed. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
