### PR TITLE
Improve stability by sorting containers by create time and ID in kubeGenericRuntimeManager.GetPods() and GetPod()

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -42,20 +42,28 @@ func (b podsByID) Len() int           { return len(b) }
 func (b podsByID) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 func (b podsByID) Less(i, j int) bool { return b[i].ID < b[j].ID }
 
-type containersByID []*kubecontainer.Container
+type containerByCreatedThenID []*runtimeapi.Container
 
-func (b containersByID) Len() int           { return len(b) }
-func (b containersByID) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
-func (b containersByID) Less(i, j int) bool { return b[i].ID.ID < b[j].ID.ID }
+func (b containerByCreatedThenID) Len() int      { return len(b) }
+func (b containerByCreatedThenID) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b containerByCreatedThenID) Less(i, j int) bool {
+	if b[i].CreatedAt != b[j].CreatedAt {
+		return b[i].CreatedAt > (b[j].CreatedAt)
+	}
+	return b[i].Id < b[j].Id
+}
 
 // Newest first.
-type podSandboxByCreated []*runtimeapi.PodSandbox
+type podSandboxByCreatedThenID []*runtimeapi.PodSandbox
 
-func (p podSandboxByCreated) Len() int      { return len(p) }
-func (p podSandboxByCreated) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
-func (p podSandboxByCreated) Less(i, j int) bool {
-	if p[i].Metadata == nil || p[j].Metadata == nil {
-		return p[i].CreatedAt > p[j].CreatedAt
+func (p podSandboxByCreatedThenID) Len() int      { return len(p) }
+func (p podSandboxByCreatedThenID) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p podSandboxByCreatedThenID) Less(i, j int) bool {
+	if p[i].Metadata == nil || p[j].Metadata == nil || (p[i].Metadata.Attempt == p[j].Metadata.Attempt) {
+		if p[i].CreatedAt != p[j].CreatedAt {
+			return p[i].CreatedAt > p[j].CreatedAt
+		}
+		return p[i].Id < p[j].Id
 	}
 	return p[i].Metadata.Attempt > p[j].Metadata.Attempt
 }

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -19,7 +19,9 @@ package kuberuntime
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -599,4 +601,219 @@ func TestConvertResourceConfigToLinuxContainerResources(t *testing.T) {
 	assert.Equal(t, int64(*resCfg.CPUShares), lcr.CpuShares)
 	assert.Equal(t, *resCfg.Memory, lcr.MemoryLimitInBytes)
 	assert.Equal(t, resCfg.Unified, lcr.Unified)
+}
+
+func TestContainerByCreatedThenID(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		input    []*runtimeapi.Container
+		expected []*runtimeapi.Container
+	}{
+		{
+			name: "different CreatedAt sort by time desc (newest first)",
+			input: []*runtimeapi.Container{
+				{Id: "c1", CreatedAt: now.Add(-30 * time.Minute).Unix()},
+				{Id: "c2", CreatedAt: now.Unix()},
+				{Id: "c3", CreatedAt: now.Add(-10 * time.Minute).Unix()},
+			},
+			expected: []*runtimeapi.Container{
+				{Id: "c2"}, // newest
+				{Id: "c3"},
+				{Id: "c1"}, // oldest
+			},
+		},
+		{
+			name: "same CreatedAt sort by ID asc",
+			input: []*runtimeapi.Container{
+				{Id: "container-zzz", CreatedAt: now.Unix()},
+				{Id: "container-aaa", CreatedAt: now.Unix()},
+				{Id: "container-mmm", CreatedAt: now.Unix()},
+			},
+			expected: []*runtimeapi.Container{
+				{Id: "container-aaa"},
+				{Id: "container-mmm"},
+				{Id: "container-zzz"},
+			},
+		},
+		{
+			name: "mixed: some same time, some different",
+			input: []*runtimeapi.Container{
+				{Id: "c-old-2", CreatedAt: now.Add(-1 * time.Hour).Unix()},
+				{Id: "c-new-1", CreatedAt: now.Unix()},
+				{Id: "c-group-b", CreatedAt: now.Unix()},
+				{Id: "c-group-a", CreatedAt: now.Unix()},
+				{Id: "c-old-1", CreatedAt: now.Add(-1 * time.Hour).Unix()},
+			},
+			expected: []*runtimeapi.Container{
+				{Id: "c-group-a"},
+				{Id: "c-group-b"},
+				{Id: "c-new-1"},
+				{Id: "c-old-1"},
+				{Id: "c-old-2"},
+			},
+		},
+		{
+			name:     "empty slice",
+			input:    []*runtimeapi.Container{},
+			expected: []*runtimeapi.Container{},
+		},
+		{
+			name: "single element",
+			input: []*runtimeapi.Container{
+				{Id: "only-one", CreatedAt: now.Add(-5 * time.Minute).Unix()},
+			},
+			expected: []*runtimeapi.Container{
+				{Id: "only-one"},
+			},
+		},
+		{
+			name: "all CreatedAt same, IDs already sorted should remain stable",
+			input: []*runtimeapi.Container{
+				{Id: "id-001", CreatedAt: now.Unix()},
+				{Id: "id-002", CreatedAt: now.Unix()},
+				{Id: "id-003", CreatedAt: now.Unix()},
+			},
+			expected: []*runtimeapi.Container{
+				{Id: "id-001"},
+				{Id: "id-002"},
+				{Id: "id-003"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			containers := make([]*runtimeapi.Container, len(tt.input))
+			copy(containers, tt.input)
+
+			sort.Sort(containerByCreatedThenID(containers))
+
+			assert.Len(t, containers, len(tt.expected), "length mismatch")
+
+			for i := range tt.expected {
+				assert.Equal(t, tt.expected[i].Id, containers[i].Id, "ID mismatch at index %d", i)
+			}
+		})
+	}
+}
+
+func TestPodSandboxByCreatedThenID(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		input    []*runtimeapi.PodSandbox
+		expected []string
+	}{
+		{
+			name: "different Attempt higher Attempt first",
+			input: []*runtimeapi.PodSandbox{
+				{
+					Id:        "sandbox-c",
+					CreatedAt: now.UnixNano(),
+					Metadata:  &runtimeapi.PodSandboxMetadata{Attempt: 0},
+				},
+				{
+					Id:        "sandbox-a",
+					CreatedAt: now.UnixNano(),
+					Metadata:  &runtimeapi.PodSandboxMetadata{Attempt: 2},
+				},
+				{
+					Id:        "sandbox-b",
+					CreatedAt: now.UnixNano(),
+					Metadata:  &runtimeapi.PodSandboxMetadata{Attempt: 1},
+				},
+			},
+			expected: []string{"sandbox-a", "sandbox-b", "sandbox-c"},
+		},
+		{
+			name: "same Attempt newer CreatedAt first",
+			input: []*runtimeapi.PodSandbox{
+				{
+					Id:        "old",
+					CreatedAt: now.Add(-10 * time.Minute).UnixNano(),
+					Metadata:  &runtimeapi.PodSandboxMetadata{Attempt: 5},
+				},
+				{
+					Id:        "newest",
+					CreatedAt: now.UnixNano(),
+					Metadata:  &runtimeapi.PodSandboxMetadata{Attempt: 5},
+				},
+				{
+					Id:        "medium",
+					CreatedAt: now.Add(-5 * time.Minute).UnixNano(),
+					Metadata:  &runtimeapi.PodSandboxMetadata{Attempt: 5},
+				},
+			},
+			expected: []string{"newest", "medium", "old"},
+		},
+		{
+			name: "same Attempt and CreatedAt sort by Id ascending",
+			input: []*runtimeapi.PodSandbox{
+				{Id: "zzz-3", CreatedAt: now.UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 1}},
+				{Id: "aaa-1", CreatedAt: now.UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 1}},
+				{Id: "mmm-2", CreatedAt: now.UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 1}},
+			},
+			expected: []string{"aaa-1", "mmm-2", "zzz-3"},
+		},
+		{
+			name: "mixed: Attempt CreatedAt + Id",
+			input: []*runtimeapi.PodSandbox{
+				{Id: "c1", CreatedAt: now.UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 0}},
+				{Id: "a2", CreatedAt: now.Add(-20 * time.Minute).UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 2}},
+				{Id: "b3", CreatedAt: now.UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 1}},
+				{Id: "group-b", CreatedAt: now.UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 1}},
+				{Id: "group-a", CreatedAt: now.UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 1}},
+			},
+			expected: []string{
+				"a2",
+				"b3",
+				"group-a",
+				"group-b",
+				"c1",
+			},
+		},
+		{
+			name:     "empty slice",
+			input:    []*runtimeapi.PodSandbox{},
+			expected: []string{},
+		},
+		{
+			name: "single sandbox",
+			input: []*runtimeapi.PodSandbox{
+				{Id: "single", CreatedAt: now.UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 3}},
+			},
+			expected: []string{"single"},
+		},
+		{
+			name: "Metadata nil fallback only CreatedAt then Id",
+			input: []*runtimeapi.PodSandbox{
+				{Id: "nil-b", CreatedAt: now.UnixNano(), Metadata: nil},
+				{Id: "nil-a", CreatedAt: now.UnixNano(), Metadata: nil},
+				{Id: "with-meta", CreatedAt: now.UnixNano(), Metadata: &runtimeapi.PodSandboxMetadata{Attempt: 0}},
+			},
+			expected: []string{"nil-a", "nil-b", "with-meta"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandboxes := make([]*runtimeapi.PodSandbox, len(tt.input))
+			copy(sandboxes, tt.input)
+
+			sort.Sort(podSandboxByCreatedThenID(sandboxes))
+
+			assert.Len(t, sandboxes, len(tt.expected), "length mismatch")
+
+			actualIDs := make([]string, len(sandboxes))
+			for i, s := range sandboxes {
+				actualIDs[i] = s.Id
+			}
+
+			assert.Equal(t, tt.expected, actualIDs, "sorting order mismatch")
+		})
+	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -472,7 +472,7 @@ func (m *kubeGenericRuntimeManager) getPods(ctx context.Context, opts listOption
 		return nil, err
 	}
 	// Sort sandboxes by creation time, newest first.
-	sort.Sort(podSandboxByCreated(sandboxes))
+	sort.Sort(podSandboxByCreatedThenID(sandboxes))
 	for i := range sandboxes {
 		s := sandboxes[i]
 		if s.Metadata == nil {
@@ -501,6 +501,13 @@ func (m *kubeGenericRuntimeManager) getPods(ctx context.Context, opts listOption
 	if err != nil {
 		return nil, err
 	}
+	// Sort containers: newest CreatedAt first, then by container ID for stability.
+	// There are scenarios where multiple pods are running in parallel having
+	// the same name, because one of them have not been fully terminated yet.
+	// To avoid unexpected behavior on container name based search (for example
+	// by calling *Kubelet.findContainer() without specifying a pod ID), we
+	// return the list of pods ordered by their creation time.
+	sort.Sort(containerByCreatedThenID(containers))
 	for i := range containers {
 		c := containers[i]
 		if c.Metadata == nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -251,14 +251,6 @@ func verifyPods(a, b []*kubecontainer.Pod) bool {
 		return false
 	}
 
-	// Sort the containers within a pod.
-	for i := range a {
-		sort.Sort(containersByID(a[i].Containers))
-	}
-	for i := range b {
-		sort.Sort(containersByID(b[i].Containers))
-	}
-
 	// Sort the pods by UID.
 	sort.Sort(podsByID(a))
 	sort.Sort(podsByID(b))

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -327,7 +327,7 @@ func (m *kubeGenericRuntimeManager) getSandboxIDByPodUID(ctx context.Context, po
 
 	// Sort with newest first.
 	sandboxIDs := make([]string, len(sandboxes))
-	sort.Sort(podSandboxByCreated(sandboxes))
+	sort.Sort(podSandboxByCreatedThenID(sandboxes))
 	for i, s := range sandboxes {
 		sandboxIDs[i] = s.Id
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix Flaking Test `TestGetPods`
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #137557
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improve stability by sorting containers by create time and ID in kubeGenericRuntimeManager.GetPods() and GetPod()
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
