### PR TITLE
Fix potential double-locking of RWMutex in device manager podDevices

### DIFF
--- a/pkg/kubelet/cm/devicemanager/pod_devices.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices.go
@@ -104,7 +104,7 @@ func (pdev *podDevices) podDevices(podUID, resource string) sets.Set[string] {
 
 	ret := sets.New[string]()
 	for contName := range pdev.devs[podUID] {
-		ret = ret.Union(pdev.containerDevices(podUID, contName, resource))
+		ret = ret.Union(pdev.containerDevicesLocked(podUID, contName, resource))
 	}
 	return ret
 }
@@ -114,6 +114,11 @@ func (pdev *podDevices) podDevices(podUID, resource string) sets.Set[string] {
 func (pdev *podDevices) containerDevices(podUID, contName, resource string) sets.Set[string] {
 	pdev.RLock()
 	defer pdev.RUnlock()
+	return pdev.containerDevicesLocked(podUID, contName, resource)
+}
+
+// containerDevicesLocked does the work of containerDevices but assumes pdev.RLock is already held.
+func (pdev *podDevices) containerDevicesLocked(podUID, contName, resource string) sets.Set[string] {
 	if _, podExists := pdev.devs[podUID]; !podExists {
 		return nil
 	}

--- a/pkg/kubelet/cm/devicemanager/pod_devices_test.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices_test.go
@@ -254,6 +254,34 @@ func TestDeviceRunContainerOptions(t *testing.T) {
 	}
 }
 
+func TestPodDevicesDoesNotDoubleLock(t *testing.T) {
+	pdev := newPodDevices()
+	resourceName := "domain1.com/resource1"
+	podID := "pod1"
+
+	pdev.insert(podID, "con1", resourceName,
+		checkpoint.DevicesPerNUMA{0: []string{"dev1"}},
+		newContainerAllocateResponse(),
+	)
+	pdev.insert(podID, "con2", resourceName,
+		checkpoint.DevicesPerNUMA{0: []string{"dev2"}},
+		newContainerAllocateResponse(),
+	)
+
+	// podDevices() previously called containerDevices() while holding RLock,
+	// which would deadlock if a writer was waiting. Verify it returns correct
+	// results now that the double-lock is fixed.
+	devs := pdev.podDevices(podID, resourceName)
+	assert.True(t, devs.Has("dev1"))
+	assert.True(t, devs.Has("dev2"))
+	assert.Equal(t, 2, devs.Len())
+
+	// containerDevices() still works independently.
+	cdevs := pdev.containerDevices(podID, "con1", resourceName)
+	assert.True(t, cdevs.Has("dev1"))
+	assert.Equal(t, 1, cdevs.Len())
+}
+
 func TestGetPodAndContainerForDevice(t *testing.T) {
 	podDevices := newPodDevices()
 	resourceName1 := "domain1.com/resource1"


### PR DESCRIPTION
Fixes #127826

`podDevices()` acquires `RLock` then calls `containerDevices()` which also acquires `RLock` on the same mutex. With Go `sync.RWMutex`, a second `RLock` can deadlock if a writer is waiting between the two calls.

This extracts the inner logic into `containerDevicesLocked()` which assumes the lock is already held, and has both `podDevices()` and `containerDevices()` use it.