### PR TITLE
[release-1.35] cmd/kubeadm: ignore EINVAL error during unmount

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/reset/unmount_linux.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/unmount_linux.go
@@ -70,6 +70,12 @@ func unmountKubeletDirectory(kubeletRunDirectory string, flags []string) error {
 		}
 		klog.V(5).Infof("[reset] Unmounting %q", m[1])
 		if err := syscall.Unmount(m[1], flagsInt); err != nil {
+			// EINVAL is expected here if a duplicate mount entry
+			// was already unmounted via its shared peer.
+			if err == syscall.EINVAL {
+				klog.Warningf("[reset] Ignoring EINVAL error while unmounting %q", m[1])
+				continue
+			}
 			errList = append(errList, errors.WithMessagef(err, "failed to unmount %q", m[1]))
 		}
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If /var/lib/kubelet is MS_SHARED mountpoint, all the mountpoints under /var/lib/kubelet will have duplicate one. When `kubeadm reset -f` is executed, it will try to umount one path twice. However, they are in the peer group. Once we umount one path, the duplicate one will be umounted as well. So, in this case, we should ignore EINVAL error.


(cherry picked from commit 2634261c175cf1c5960a808708728fb51df9f8ed)

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: ignore EINVAL when unmounting /var/lib/kubelet peer mounts during reset
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
