### PR TITLE
client-go: make Reflector backoff and watch timeout configurable via SharedInformerFactory

### DIFF
--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -56,6 +56,10 @@ import (
 // SharedInformerOption defines the functional option type for SharedInformerFactory.
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
+// ReflectorConfig holds configuration for the underlying Reflector's backoff and timeout behavior.
+// It is an alias for cache.ReflectorConfig.
+type ReflectorConfig = cache.ReflectorConfig
+
 type sharedInformerFactory struct {
 	client           kubernetes.Interface
 	namespace        string
@@ -65,6 +69,7 @@ type sharedInformerFactory struct {
 	customResync     map[reflect.Type]time.Duration
 	transform        cache.TransformFunc
 	informerName     *cache.InformerName
+	reflectorConfig  ReflectorConfig
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -125,6 +130,16 @@ func WithInformerName(informerName *cache.InformerName) SharedInformerOption {
 func (f *sharedInformerFactory) InformerName() *cache.InformerName {
 	return f.informerName
 }
+
+// WithReflectorConfig sets custom reflector configuration for all informers created by the factory.
+// This controls backoff behavior and watch request timeouts for the underlying reflectors.
+func WithReflectorConfig(config ReflectorConfig) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.reflectorConfig = config
+		return factory
+	}
+}
+
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client kubernetes.Interface, defaultResync time.Duration) SharedInformerFactory {
@@ -259,6 +274,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if f.transform != nil {
 		informer.SetTransform(f.transform)
 	}
+	informer.SetReflectorConfig(f.reflectorConfig)
 	f.informers[informerType] = informer
 
 	return informer

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -20,6 +20,7 @@ package informers
 
 import (
 	context "context"
+	"fmt"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -57,15 +58,15 @@ import (
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
 type sharedInformerFactory struct {
-	client           kubernetes.Interface
-	namespace        string
-	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	lock             sync.Mutex
-	defaultResync    time.Duration
-	customResync     map[reflect.Type]time.Duration
-	transform        cache.TransformFunc
-	informerName     *cache.InformerName
-	reflectionOptions  cache.ReflectionOptions
+	client            kubernetes.Interface
+	namespace         string
+	tweakListOptions  internalinterfaces.TweakListOptionsFunc
+	lock              sync.Mutex
+	defaultResync     time.Duration
+	customResync      map[reflect.Type]time.Duration
+	transform         cache.TransformFunc
+	informerName      *cache.InformerName
+	reflectionOptions cache.ReflectionOptions
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -135,7 +136,6 @@ func WithReflectionOptions(config cache.ReflectionOptions) SharedInformerOption 
 		return factory
 	}
 }
-
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client kubernetes.Interface, defaultResync time.Duration) SharedInformerFactory {
@@ -270,7 +270,11 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if f.transform != nil {
 		informer.SetTransform(f.transform)
 	}
-	informer.SetReflectionOptions(f.reflectionOptions)
+	if setter, ok := informer.(cache.ReflectionOptionsSetter); ok {
+		if err := setter.SetReflectionOptions(f.reflectionOptions); err != nil {
+			panic(fmt.Sprintf("SetReflectionOptions called on already-started informer: %v", err))
+		}
+	}
 	f.informers[informerType] = informer
 
 	return informer

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -56,10 +56,6 @@ import (
 // SharedInformerOption defines the functional option type for SharedInformerFactory.
 type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
 
-// ReflectorConfig holds configuration for the underlying Reflector's backoff and timeout behavior.
-// It is an alias for cache.ReflectorConfig.
-type ReflectorConfig = cache.ReflectorConfig
-
 type sharedInformerFactory struct {
 	client           kubernetes.Interface
 	namespace        string
@@ -69,7 +65,7 @@ type sharedInformerFactory struct {
 	customResync     map[reflect.Type]time.Duration
 	transform        cache.TransformFunc
 	informerName     *cache.InformerName
-	reflectorConfig  ReflectorConfig
+	reflectionOptions  cache.ReflectionOptions
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -131,11 +127,11 @@ func (f *sharedInformerFactory) InformerName() *cache.InformerName {
 	return f.informerName
 }
 
-// WithReflectorConfig sets custom reflector configuration for all informers created by the factory.
+// WithReflectionOptions sets custom reflector configuration for all informers created by the factory.
 // This controls backoff behavior and watch request timeouts for the underlying reflectors.
-func WithReflectorConfig(config ReflectorConfig) SharedInformerOption {
+func WithReflectionOptions(config cache.ReflectionOptions) SharedInformerOption {
 	return func(factory *sharedInformerFactory) *sharedInformerFactory {
-		factory.reflectorConfig = config
+		factory.reflectionOptions = config
 		return factory
 	}
 }
@@ -274,7 +270,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if f.transform != nil {
 		informer.SetTransform(f.transform)
 	}
-	informer.SetReflectorConfig(f.reflectorConfig)
+	informer.SetReflectionOptions(f.reflectionOptions)
 	f.informers[informerType] = informer
 
 	return informer

--- a/staging/src/k8s.io/client-go/informers/factory_test.go
+++ b/staging/src/k8s.io/client-go/informers/factory_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestWithReflectorConfigSetsFactory(t *testing.T) {
+	client := fake.NewClientset()
+
+	backoff := &wait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   2.0,
+		Jitter:   1.0,
+		Steps:    10,
+		Cap:      30 * time.Second,
+	}
+	cfg := ReflectorConfig{
+		Backoff:              backoff,
+		BackoffResetDuration: 2 * time.Minute,
+		MinWatchTimeout:      6 * time.Minute,
+		MaxWatchTimeout:      12 * time.Minute,
+	}
+
+	factory := NewSharedInformerFactoryWithOptions(client, 0, WithReflectorConfig(cfg))
+	f := factory.(*sharedInformerFactory)
+
+	if f.reflectorConfig.Backoff == nil {
+		t.Error("expected Backoff to be set on factory")
+	}
+	if f.reflectorConfig.MinWatchTimeout != 6*time.Minute {
+		t.Errorf("expected MinWatchTimeout=6m, got %v", f.reflectorConfig.MinWatchTimeout)
+	}
+	if f.reflectorConfig.MaxWatchTimeout != 12*time.Minute {
+		t.Errorf("expected MaxWatchTimeout=12m, got %v", f.reflectorConfig.MaxWatchTimeout)
+	}
+	if f.reflectorConfig.BackoffResetDuration != 2*time.Minute {
+		t.Errorf("expected BackoffResetDuration=2m, got %v", f.reflectorConfig.BackoffResetDuration)
+	}
+}
+
+
+func TestReflectorConfigIsTypeAliasForCacheReflectorConfig(t *testing.T) {
+	// Verify that informers.ReflectorConfig is the same type as cache.ReflectorConfig.
+	// This is tested at compile time by the type alias declaration.
+	var cfg ReflectorConfig
+	var cacheCfg cache.ReflectorConfig
+	cacheCfg = cfg
+	cfg = cacheCfg
+	_ = cfg
+}

--- a/staging/src/k8s.io/client-go/informers/factory_test.go
+++ b/staging/src/k8s.io/client-go/informers/factory_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func TestWithReflectorConfigSetsFactory(t *testing.T) {
+func TestWithReflectionOptionsSetsFactory(t *testing.T) {
 	client := fake.NewClientset()
 
 	backoff := &wait.Backoff{
@@ -35,37 +35,27 @@ func TestWithReflectorConfigSetsFactory(t *testing.T) {
 		Steps:    10,
 		Cap:      30 * time.Second,
 	}
-	cfg := ReflectorConfig{
+	cfg := cache.ReflectionOptions{
 		Backoff:              backoff,
 		BackoffResetDuration: 2 * time.Minute,
 		MinWatchTimeout:      6 * time.Minute,
 		MaxWatchTimeout:      12 * time.Minute,
 	}
 
-	factory := NewSharedInformerFactoryWithOptions(client, 0, WithReflectorConfig(cfg))
+	factory := NewSharedInformerFactoryWithOptions(client, 0, WithReflectionOptions(cfg))
 	f := factory.(*sharedInformerFactory)
 
-	if f.reflectorConfig.Backoff == nil {
+	if f.reflectionOptions.Backoff == nil {
 		t.Error("expected Backoff to be set on factory")
 	}
-	if f.reflectorConfig.MinWatchTimeout != 6*time.Minute {
-		t.Errorf("expected MinWatchTimeout=6m, got %v", f.reflectorConfig.MinWatchTimeout)
+	if f.reflectionOptions.MinWatchTimeout != 6*time.Minute {
+		t.Errorf("expected MinWatchTimeout=6m, got %v", f.reflectionOptions.MinWatchTimeout)
 	}
-	if f.reflectorConfig.MaxWatchTimeout != 12*time.Minute {
-		t.Errorf("expected MaxWatchTimeout=12m, got %v", f.reflectorConfig.MaxWatchTimeout)
+	if f.reflectionOptions.MaxWatchTimeout != 12*time.Minute {
+		t.Errorf("expected MaxWatchTimeout=12m, got %v", f.reflectionOptions.MaxWatchTimeout)
 	}
-	if f.reflectorConfig.BackoffResetDuration != 2*time.Minute {
-		t.Errorf("expected BackoffResetDuration=2m, got %v", f.reflectorConfig.BackoffResetDuration)
+	if f.reflectionOptions.BackoffResetDuration != 2*time.Minute {
+		t.Errorf("expected BackoffResetDuration=2m, got %v", f.reflectionOptions.BackoffResetDuration)
 	}
 }
 
-
-func TestReflectorConfigIsTypeAliasForCacheReflectorConfig(t *testing.T) {
-	// Verify that informers.ReflectorConfig is the same type as cache.ReflectorConfig.
-	// This is tested at compile time by the type alias declaration.
-	var cfg ReflectorConfig
-	var cacheCfg cache.ReflectorConfig
-	cacheCfg = cfg
-	cfg = cacheCfg
-	_ = cfg
-}

--- a/staging/src/k8s.io/client-go/informers/factory_test.go
+++ b/staging/src/k8s.io/client-go/informers/factory_test.go
@@ -28,15 +28,14 @@ import (
 func TestWithReflectionOptionsSetsFactory(t *testing.T) {
 	client := fake.NewClientset()
 
-	backoff := &wait.Backoff{
-		Duration: 500 * time.Millisecond,
-		Factor:   2.0,
-		Jitter:   1.0,
-		Steps:    10,
-		Cap:      30 * time.Second,
-	}
 	cfg := cache.ReflectionOptions{
-		Backoff:              backoff,
+		Backoff: wait.Backoff{
+			Duration: 500 * time.Millisecond,
+			Factor:   2.0,
+			Jitter:   1.0,
+			Steps:    10,
+			Cap:      30 * time.Second,
+		},
 		BackoffResetDuration: 2 * time.Minute,
 		MinWatchTimeout:      6 * time.Minute,
 		MaxWatchTimeout:      12 * time.Minute,
@@ -45,7 +44,7 @@ func TestWithReflectionOptionsSetsFactory(t *testing.T) {
 	factory := NewSharedInformerFactoryWithOptions(client, 0, WithReflectionOptions(cfg))
 	f := factory.(*sharedInformerFactory)
 
-	if f.reflectionOptions.Backoff == nil {
+	if f.reflectionOptions.Backoff == (wait.Backoff{}) {
 		t.Error("expected Backoff to be set on factory")
 	}
 	if f.reflectionOptions.MinWatchTimeout != 6*time.Minute {

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -80,6 +80,20 @@ type Config struct {
 	// Optional - if unset a default value of 5m will be used.
 	MinWatchTimeout time.Duration
 
+	// MaxWatchTimeout, if non-zero, defines the maximum timeout for watch requests.
+	// Actual timeout is chosen randomly in [MinWatchTimeout, MaxWatchTimeout].
+	// If zero, defaults to 2*MinWatchTimeout.
+	MaxWatchTimeout time.Duration
+
+	// Backoff, if non-nil, configures the backoff strategy for retrying list/watch errors.
+	// If nil, the default exponential backoff is used.
+	Backoff *wait.Backoff
+
+	// BackoffResetDuration is how long without backoff activity before the backoff delay is
+	// reset to its initial value. Only used when Backoff is non-nil.
+	// If zero, defaults to 2 minutes.
+	BackoffResetDuration time.Duration
+
 	// ShouldResync is periodically used by the reflector to determine
 	// whether to Resync the Queue. If ShouldResync is `nil` or
 	// returns true, it means the reflector should proceed with the
@@ -179,11 +193,14 @@ func (c *controller) RunWithContext(ctx context.Context) {
 		c.config.ObjectType,
 		c.config.Queue,
 		ReflectorOptions{
-			Logger:          &logger,
-			ResyncPeriod:    c.config.FullResyncPeriod,
-			MinWatchTimeout: c.config.MinWatchTimeout,
-			TypeDescription: c.config.ObjectDescription,
-			Clock:           c.clock,
+			Logger:               &logger,
+			ResyncPeriod:         c.config.FullResyncPeriod,
+			MinWatchTimeout:      c.config.MinWatchTimeout,
+			MaxWatchTimeout:      c.config.MaxWatchTimeout,
+			Backoff:              c.config.Backoff,
+			BackoffResetDuration: c.config.BackoffResetDuration,
+			TypeDescription:      c.config.ObjectDescription,
+			Clock:                c.clock,
 		},
 	)
 	r.ShouldResync = c.config.ShouldResync

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -53,7 +53,8 @@ const defaultExpectedTypeName = "<unspecified>"
 
 var (
 	// We try to spread the load on apiserver by setting timeouts for
-	// watch requests - it is random in [minWatchTimeout, 2*minWatchTimeout].
+	// watch requests - it is random in [minWatchTimeout, maxWatchTimeout] where
+	// maxWatchTimeout defaults to 2*minWatchTimeout.
 	defaultMinWatchTimeout = 5 * time.Minute
 	defaultMaxWatchTimeout = 2 * defaultMinWatchTimeout
 	// We used to make the call every 1sec (1 QPS), the goal here is to achieve ~98% traffic reduction when
@@ -174,6 +175,16 @@ func (r *Reflector) Name() string {
 	return r.name
 }
 
+// watchTimeoutSeconds computes a random watch timeout in [minWatchTimeout, maxWatchTimeout].
+// maxWatchTimeout defaults to 2*minWatchTimeout when not set.
+func (r *Reflector) watchTimeoutSeconds() float64 {
+	maxTimeout := r.minWatchTimeout * 2
+	if r.maxWatchTimeout > r.minWatchTimeout {
+		maxTimeout = r.maxWatchTimeout
+	}
+	return r.minWatchTimeout.Seconds() + rand.Float64()*(maxTimeout-r.minWatchTimeout).Seconds()
+}
+
 func (r *Reflector) TypeDescription() string {
 	return r.typeDescription
 }
@@ -273,14 +284,22 @@ type ReflectorOptions struct {
 	// However, values lower than 5m will not be honored to avoid negative performance impact on controlplane.
 	MinWatchTimeout time.Duration
 
+	// MaxWatchTimeout, if non-zero, defines the maximum timeout for watch requests send to kube-apiserver.
+	// Actual timeout is chosen randomly in [MinWatchTimeout, MaxWatchTimeout].
+	// If zero, defaults to 2*MinWatchTimeout.
+	MaxWatchTimeout time.Duration
+
+	// Backoff, if non-nil, configures the backoff strategy for retrying list/watch errors.
+	// If nil, the default exponential backoff is used.
+	Backoff *wait.Backoff
+
+	// BackoffResetDuration is how long without backoff activity before the backoff delay is
+	// reset to its initial value. Only used when Backoff is non-nil.
+	// If zero, defaults to 2 minutes.
+	BackoffResetDuration time.Duration
+
 	// Clock allows tests to control time. If unset defaults to clock.RealClock{}
 	Clock clock.Clock
-
-	// Backoff is an optional custom backoff configuration.
-	// If set, it will be used instead of the default exponential backoff.
-	// DelayWithReset(clock, resetDuration) will be called on it to create the delay function.
-	// TODO(#136943): Expose this configuration through SharedInformerFactory.
-	Backoff *wait.Backoff
 }
 
 // NewReflectorWithOptions creates a new Reflector object which will keep the
@@ -305,6 +324,9 @@ func NewReflectorWithOptions(lw ListerWatcher, expectedType interface{}, store R
 		minWatchTimeout = options.MinWatchTimeout
 		maxWatchTimeout = 2 * minWatchTimeout
 	}
+	if options.MaxWatchTimeout > minWatchTimeout {
+		maxWatchTimeout = options.MaxWatchTimeout
+	}
 	if maxWatchTimeout < minWatchTimeout {
 		klog.TODO().V(3).Info(
 			"maxWatchTimeout was less than minWatchTimeout, overriding to minWatchTimeout. Watch timeout randomization is disabled.",
@@ -324,16 +346,20 @@ func NewReflectorWithOptions(lw ListerWatcher, expectedType interface{}, store R
 			Jitter:   defaultBackoffJitter,
 		}
 	}
+	resetDuration := defaultBackoffReset
+	if options.BackoffResetDuration > 0 {
+		resetDuration = options.BackoffResetDuration
+	}
 
 	r := &Reflector{
-		name:              options.Name,
-		resyncPeriod:      options.ResyncPeriod,
-		minWatchTimeout:   minWatchTimeout,
-		maxWatchTimeout:   maxWatchTimeout,
-		typeDescription:   options.TypeDescription,
-		listerWatcher:     ToListerWatcherWithContext(lw),
-		store:             store,
-		delayHandler:      backoff.DelayWithReset(reflectorClock, defaultBackoffReset),
+		name:            options.Name,
+		resyncPeriod:    options.ResyncPeriod,
+		minWatchTimeout: minWatchTimeout,
+		maxWatchTimeout: maxWatchTimeout,
+		typeDescription: options.TypeDescription,
+		listerWatcher:   ToListerWatcherWithContext(lw),
+		store:           store,
+		delayHandler:    backoff.DelayWithReset(reflectorClock, resetDuration),
 		clock:             reflectorClock,
 		watchErrorHandler: WatchErrorHandlerWithContext(DefaultWatchErrorHandler),
 		expectedType:      reflect.TypeOf(expectedType),
@@ -369,6 +395,7 @@ func NewReflectorWithOptions(lw ListerWatcher, expectedType interface{}, store R
 
 	return r
 }
+
 
 func getTypeDescriptionFromObject(expectedType interface{}) string {
 	if expectedType == nil {
@@ -585,7 +612,7 @@ func (r *Reflector) watch(ctx context.Context, w watch.Interface, resyncerrc cha
 		// if w is already initialized, it must be past any synthetic non-rv-ordered added events
 		propagateRVFromStart := true
 		if w == nil {
-			timeoutSeconds := int64(r.minWatchTimeout.Seconds() + rand.Float64()*(r.maxWatchTimeout.Seconds()-r.minWatchTimeout.Seconds()))
+			timeoutSeconds := int64(r.watchTimeoutSeconds())
 			options := metav1.ListOptions{
 				ResourceVersion: r.LastSyncResourceVersion(),
 				// We want to avoid situations of hanging watchers. Stop any watchers that do not
@@ -850,7 +877,7 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 		// TODO(#115478): large "list", slow clients, slow network, p&f
 		//  might slow down streaming and eventually fail.
 		//  maybe in such a case we should retry with an increased timeout?
-		timeoutSeconds := int64(r.minWatchTimeout.Seconds() + rand.Float64()*(r.maxWatchTimeout.Seconds()-r.minWatchTimeout.Seconds()))
+		timeoutSeconds := int64(r.watchTimeoutSeconds())
 		options := metav1.ListOptions{
 			ResourceVersion:      lastKnownRV,
 			AllowWatchBookmarks:  true,

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -176,13 +176,8 @@ func (r *Reflector) Name() string {
 }
 
 // watchTimeoutSeconds computes a random watch timeout in [minWatchTimeout, maxWatchTimeout].
-// maxWatchTimeout defaults to 2*minWatchTimeout when not set.
 func (r *Reflector) watchTimeoutSeconds() float64 {
-	maxTimeout := r.minWatchTimeout * 2
-	if r.maxWatchTimeout > r.minWatchTimeout {
-		maxTimeout = r.maxWatchTimeout
-	}
-	return r.minWatchTimeout.Seconds() + rand.Float64()*(maxTimeout-r.minWatchTimeout).Seconds()
+	return r.minWatchTimeout.Seconds() + rand.Float64()*(r.maxWatchTimeout-r.minWatchTimeout).Seconds()
 }
 
 func (r *Reflector) TypeDescription() string {

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -2532,3 +2532,124 @@ func TestIsUnsupportedTableObject(t *testing.T) {
 		})
 	}
 }
+
+func TestReflectorOptionsCustomBackoff(t *testing.T) {
+	lw := &ListWatch{
+		ListFunc:  func(_ metav1.ListOptions) (runtime.Object, error) { return &v1.PodList{}, nil },
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) { return watch.NewFake(), nil },
+	}
+	store := NewStore(MetaNamespaceKeyFunc)
+
+	t.Run("nil Backoff produces non-nil delay handler", func(t *testing.T) {
+		r := NewReflectorWithOptions(lw, &v1.Pod{}, store, ReflectorOptions{})
+		if r.delayHandler == nil {
+			t.Error("expected non-nil delayHandler with default options")
+		}
+	})
+
+	t.Run("custom Backoff initial duration is used", func(t *testing.T) {
+		fakeClock := testingclock.NewFakeClock(time.Now())
+		r := NewReflectorWithOptions(lw, &v1.Pod{}, store, ReflectorOptions{
+			Backoff: &wait.Backoff{
+				Duration: 100 * time.Millisecond,
+				Factor:   2.0,
+				Jitter:   0, // no jitter so result is deterministic
+				Steps:    1000,
+				Cap:      10 * time.Second,
+			},
+			BackoffResetDuration: 5 * time.Minute,
+			Clock:                fakeClock,
+		})
+
+		got := r.delayHandler()
+		if got != 100*time.Millisecond {
+			t.Errorf("expected initial delay of 100ms, got %v", got)
+		}
+	})
+
+	t.Run("zero BackoffResetDuration defaults to 2 minutes", func(t *testing.T) {
+		fakeClock := testingclock.NewFakeClock(time.Now())
+		r := NewReflectorWithOptions(lw, &v1.Pod{}, store, ReflectorOptions{
+			Backoff: &wait.Backoff{
+				Duration: 100 * time.Millisecond,
+				Factor:   2.0,
+				Jitter:   0,
+				Steps:    1000,
+				Cap:      10 * time.Second,
+			},
+			// BackoffResetDuration zero should default to 2 minutes.
+			Clock: fakeClock,
+		})
+
+		// First call: 100ms.
+		if d := r.delayHandler(); d != 100*time.Millisecond {
+			t.Fatalf("first delay expected 100ms, got %v", d)
+		}
+
+		// Advance 1.5 minutes — still under the 2-minute reset threshold.
+		fakeClock.Step(90 * time.Second)
+
+		// Second call should be 200ms (doubled), not 100ms (which would mean a reset occurred).
+		if d := r.delayHandler(); d != 200*time.Millisecond {
+			t.Errorf("expected 200ms after 1.5m (no reset), got %v", d)
+		}
+
+		// Advance 2.5 more minutes — now over the 2-minute reset threshold.
+		fakeClock.Step(150 * time.Second)
+
+		// Third call should reset to 100ms.
+		if d := r.delayHandler(); d != 100*time.Millisecond {
+			t.Errorf("expected reset to 100ms after 2.5m, got %v", d)
+		}
+	})
+}
+
+func TestReflectorOptionsWatchTimeout(t *testing.T) {
+	lw := &ListWatch{
+		ListFunc:  func(_ metav1.ListOptions) (runtime.Object, error) { return &v1.PodList{}, nil },
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) { return watch.NewFake(), nil },
+	}
+	store := NewStore(MetaNamespaceKeyFunc)
+
+	tests := []struct {
+		name           string
+		opts           ReflectorOptions
+		wantMinTimeout float64
+		wantMaxTimeout float64
+	}{
+		{
+			name:           "default timeouts use 5m to 10m range",
+			opts:           ReflectorOptions{},
+			wantMinTimeout: defaultMinWatchTimeout.Seconds(),
+			wantMaxTimeout: (2 * defaultMinWatchTimeout).Seconds(),
+		},
+		{
+			name:           "custom MinWatchTimeout expands range",
+			opts:           ReflectorOptions{MinWatchTimeout: 10 * time.Minute},
+			wantMinTimeout: (10 * time.Minute).Seconds(),
+			wantMaxTimeout: (20 * time.Minute).Seconds(),
+		},
+		{
+			name:           "custom MaxWatchTimeout limits upper bound",
+			opts:           ReflectorOptions{MinWatchTimeout: 10 * time.Minute, MaxWatchTimeout: 15 * time.Minute},
+			wantMinTimeout: (10 * time.Minute).Seconds(),
+			wantMaxTimeout: (15 * time.Minute).Seconds(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewReflectorWithOptions(lw, &v1.Pod{}, store, tt.opts)
+			// Run watchTimeoutSeconds many times and check the range.
+			for i := 0; i < 100; i++ {
+				got := r.watchTimeoutSeconds()
+				if got < tt.wantMinTimeout {
+					t.Errorf("iteration %d: timeout %v < min %v", i, got, tt.wantMinTimeout)
+				}
+				if got > tt.wantMaxTimeout {
+					t.Errorf("iteration %d: timeout %v > max %v", i, got, tt.wantMaxTimeout)
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -243,10 +243,38 @@ type SharedInformer interface {
 	// Please see the comment on TransformFunc for more details.
 	SetTransform(handler TransformFunc) error
 
+	// SetReflectorConfig configures backoff and watch timeout behavior for the
+	// underlying reflector. Must be called before the informer is started.
+	// Calling after start returns an error.
+	SetReflectorConfig(config ReflectorConfig) error
+
 	// IsStopped reports whether the informer has already been stopped.
 	// Adding event handlers to already stopped informers is not possible.
 	// An informer already stopped will never be started again.
 	IsStopped() bool
+}
+
+// ReflectorConfig holds optional configuration for a SharedInformer's underlying Reflector.
+// All fields are optional; zero values select appropriate defaults.
+type ReflectorConfig struct {
+	// Backoff configures the backoff strategy for retrying list/watch errors.
+	// If nil, the default exponential backoff is used (initial: 800ms, cap: 30s, factor: 2.0, jitter: 1.0).
+	Backoff *wait.Backoff
+
+	// BackoffResetDuration is how long without backoff activity before the backoff delay is
+	// reset to its initial value. Only used when Backoff is non-nil.
+	// If zero, defaults to 2 minutes.
+	BackoffResetDuration time.Duration
+
+	// MinWatchTimeout defines the minimum timeout for watch requests sent to kube-apiserver.
+	// Values lower than 5m will not be honored to avoid negative performance impact on the controlplane.
+	// If zero, defaults to 5 minutes.
+	MinWatchTimeout time.Duration
+
+	// MaxWatchTimeout defines the maximum timeout for watch requests.
+	// Actual timeout is chosen randomly in [MinWatchTimeout, MaxWatchTimeout].
+	// If zero, defaults to 2*MinWatchTimeout.
+	MaxWatchTimeout time.Duration
 }
 
 // Opaque interface representing the registration of ResourceEventHandler for
@@ -635,6 +663,9 @@ type sharedIndexInformer struct {
 
 	// keyFunc is called when processing deltas by the underlying process function.
 	keyFunc KeyFunc
+
+	// reflectorConfig holds optional backoff and timeout configuration for the underlying Reflector.
+	reflectorConfig ReflectorConfig
 }
 
 // dummyController hides the fact that a SharedInformer is different from a dedicated one
@@ -712,6 +743,18 @@ func (s *sharedIndexInformer) SetTransform(handler TransformFunc) error {
 	return nil
 }
 
+func (s *sharedIndexInformer) SetReflectorConfig(config ReflectorConfig) error {
+	s.startedLock.Lock()
+	defer s.startedLock.Unlock()
+
+	if s.started {
+		return fmt.Errorf("informer has already started")
+	}
+
+	s.reflectorConfig = config
+	return nil
+}
+
 func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 	s.RunWithContext(wait.ContextForChannel(stopCh))
 }
@@ -738,6 +781,11 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 			ObjectDescription: s.objectDescription,
 			FullResyncPeriod:  s.resyncCheckPeriod,
 			ShouldResync:      s.processor.shouldResync,
+
+			MinWatchTimeout:      s.reflectorConfig.MinWatchTimeout,
+			MaxWatchTimeout:      s.reflectorConfig.MaxWatchTimeout,
+			Backoff:              s.reflectorConfig.Backoff,
+			BackoffResetDuration: s.reflectorConfig.BackoffResetDuration,
 
 			Process: func(obj interface{}, isInInitialList bool) error {
 				return s.handleDeltas(logger, obj, isInInitialList)

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -258,11 +258,11 @@ type SharedInformer interface {
 // All fields are optional; zero values select appropriate defaults.
 type ReflectionOptions struct {
 	// Backoff configures the backoff strategy for retrying list/watch errors.
-	// If zero (Duration == 0), the default exponential backoff is used (initial: 800ms, cap: 30s, factor: 2.0, jitter: 1.0).
+	// If zero, the default exponential backoff is used (initial: 800ms, cap: 30s, factor: 2.0, jitter: 1.0).
 	Backoff wait.Backoff
 
 	// BackoffResetDuration is how long without backoff activity before the backoff delay is
-	// reset to its initial value. Only used when Backoff.Duration is non-zero.
+	// reset to its initial value. Only used when Backoff is non-zero.
 	// If zero, defaults to 2 minutes.
 	BackoffResetDuration time.Duration
 
@@ -774,6 +774,12 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 
 		logger, fifo := newQueueFIFO(logger, s.objectType, s.indexer, s.transform, s.identifier, s.fifoMetricsProvider)
 
+		var backoff *wait.Backoff
+		if s.reflectionOptions.Backoff != (wait.Backoff{}) {
+			b := s.reflectionOptions.Backoff
+			backoff = &b
+		}
+
 		cfg := &Config{
 			Queue:             fifo,
 			ListerWatcher:     s.listerWatcher,
@@ -784,7 +790,7 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 
 			MinWatchTimeout:      s.reflectionOptions.MinWatchTimeout,
 			MaxWatchTimeout:      s.reflectionOptions.MaxWatchTimeout,
-			Backoff:              s.reflectionOptions.Backoff,
+			Backoff:              backoff,
 			BackoffResetDuration: s.reflectionOptions.BackoffResetDuration,
 
 			Process: func(obj interface{}, isInInitialList bool) error {

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -243,15 +243,18 @@ type SharedInformer interface {
 	// Please see the comment on TransformFunc for more details.
 	SetTransform(handler TransformFunc) error
 
-	// SetReflectionOptions configures backoff and watch timeout behavior for the
-	// underlying reflector. Must be called before the informer is started.
-	// Calling after start returns an error.
-	SetReflectionOptions(config ReflectionOptions) error
-
 	// IsStopped reports whether the informer has already been stopped.
 	// Adding event handlers to already stopped informers is not possible.
 	// An informer already stopped will never be started again.
 	IsStopped() bool
+}
+
+// ReflectionOptionsSetter is an optional interface for SharedInformer implementations if they also should set Reflection Options
+type ReflectionOptionsSetter interface {
+	// SetReflectionOptions configures backoff and watch timeout behavior for the
+	// underlying reflector. Must be called before the informer is started.
+	// Calling after start returns an error.
+	SetReflectionOptions(config ReflectionOptions) error
 }
 
 // ReflectionOptions holds optional configuration for a SharedInformer's underlying Reflector.

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -243,10 +243,10 @@ type SharedInformer interface {
 	// Please see the comment on TransformFunc for more details.
 	SetTransform(handler TransformFunc) error
 
-	// SetReflectorConfig configures backoff and watch timeout behavior for the
+	// SetReflectionOptions configures backoff and watch timeout behavior for the
 	// underlying reflector. Must be called before the informer is started.
 	// Calling after start returns an error.
-	SetReflectorConfig(config ReflectorConfig) error
+	SetReflectionOptions(config ReflectionOptions) error
 
 	// IsStopped reports whether the informer has already been stopped.
 	// Adding event handlers to already stopped informers is not possible.
@@ -254,15 +254,15 @@ type SharedInformer interface {
 	IsStopped() bool
 }
 
-// ReflectorConfig holds optional configuration for a SharedInformer's underlying Reflector.
+// ReflectionOptions holds optional configuration for a SharedInformer's underlying Reflector.
 // All fields are optional; zero values select appropriate defaults.
-type ReflectorConfig struct {
+type ReflectionOptions struct {
 	// Backoff configures the backoff strategy for retrying list/watch errors.
-	// If nil, the default exponential backoff is used (initial: 800ms, cap: 30s, factor: 2.0, jitter: 1.0).
-	Backoff *wait.Backoff
+	// If zero (Duration == 0), the default exponential backoff is used (initial: 800ms, cap: 30s, factor: 2.0, jitter: 1.0).
+	Backoff wait.Backoff
 
 	// BackoffResetDuration is how long without backoff activity before the backoff delay is
-	// reset to its initial value. Only used when Backoff is non-nil.
+	// reset to its initial value. Only used when Backoff.Duration is non-zero.
 	// If zero, defaults to 2 minutes.
 	BackoffResetDuration time.Duration
 
@@ -664,8 +664,8 @@ type sharedIndexInformer struct {
 	// keyFunc is called when processing deltas by the underlying process function.
 	keyFunc KeyFunc
 
-	// reflectorConfig holds optional backoff and timeout configuration for the underlying Reflector.
-	reflectorConfig ReflectorConfig
+	// reflectionOptions holds optional backoff and timeout configuration for the underlying Reflector.
+	reflectionOptions ReflectionOptions
 }
 
 // dummyController hides the fact that a SharedInformer is different from a dedicated one
@@ -743,7 +743,7 @@ func (s *sharedIndexInformer) SetTransform(handler TransformFunc) error {
 	return nil
 }
 
-func (s *sharedIndexInformer) SetReflectorConfig(config ReflectorConfig) error {
+func (s *sharedIndexInformer) SetReflectionOptions(config ReflectionOptions) error {
 	s.startedLock.Lock()
 	defer s.startedLock.Unlock()
 
@@ -751,7 +751,7 @@ func (s *sharedIndexInformer) SetReflectorConfig(config ReflectorConfig) error {
 		return fmt.Errorf("informer has already started")
 	}
 
-	s.reflectorConfig = config
+	s.reflectionOptions = config
 	return nil
 }
 
@@ -782,10 +782,10 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 			FullResyncPeriod:  s.resyncCheckPeriod,
 			ShouldResync:      s.processor.shouldResync,
 
-			MinWatchTimeout:      s.reflectorConfig.MinWatchTimeout,
-			MaxWatchTimeout:      s.reflectorConfig.MaxWatchTimeout,
-			Backoff:              s.reflectorConfig.Backoff,
-			BackoffResetDuration: s.reflectorConfig.BackoffResetDuration,
+			MinWatchTimeout:      s.reflectionOptions.MinWatchTimeout,
+			MaxWatchTimeout:      s.reflectionOptions.MaxWatchTimeout,
+			Backoff:              s.reflectionOptions.Backoff,
+			BackoffResetDuration: s.reflectionOptions.BackoffResetDuration,
 
 			Process: func(obj interface{}, isInInitialList bool) error {
 				return s.handleDeltas(logger, obj, isInInitialList)

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -1385,3 +1385,54 @@ func numOccurrences(hay, needle string) int {
 		hay = hay[index+len(needle):]
 	}
 }
+
+func TestSetReflectorConfigBeforeStart(t *testing.T) {
+	lw := &fcache.FakeControllerSource{}
+	informer := NewSharedIndexInformer(lw, &v1.Pod{}, 0, Indexers{})
+
+	cfg := ReflectorConfig{
+		MinWatchTimeout: 10 * time.Minute,
+		MaxWatchTimeout: 20 * time.Minute,
+		Backoff: &wait.Backoff{
+			Duration: 500 * time.Millisecond,
+			Factor:   2.0,
+			Jitter:   1.0,
+			Steps:    10,
+			Cap:      30 * time.Second,
+		},
+		BackoffResetDuration: 1 * time.Minute,
+	}
+
+	if err := informer.SetReflectorConfig(cfg); err != nil {
+		t.Fatalf("expected no error setting reflector config before start, got: %v", err)
+	}
+
+	si := informer.(*sharedIndexInformer)
+	if si.reflectorConfig.MinWatchTimeout != 10*time.Minute {
+		t.Errorf("MinWatchTimeout not set: got %v", si.reflectorConfig.MinWatchTimeout)
+	}
+	if si.reflectorConfig.MaxWatchTimeout != 20*time.Minute {
+		t.Errorf("MaxWatchTimeout not set: got %v", si.reflectorConfig.MaxWatchTimeout)
+	}
+	if si.reflectorConfig.Backoff == nil {
+		t.Error("Backoff not set")
+	}
+	if si.reflectorConfig.BackoffResetDuration != 1*time.Minute {
+		t.Errorf("BackoffResetDuration not set: got %v", si.reflectorConfig.BackoffResetDuration)
+	}
+}
+
+func TestSetReflectorConfigAfterStartReturnsError(t *testing.T) {
+	lw := &fcache.FakeControllerSource{}
+	informer := NewSharedIndexInformer(lw, &v1.Pod{}, 0, Indexers{})
+
+	// Simulate informer having been started by directly setting the started flag.
+	si := informer.(*sharedIndexInformer)
+	si.startedLock.Lock()
+	si.started = true
+	si.startedLock.Unlock()
+
+	if err := informer.SetReflectorConfig(ReflectorConfig{}); err == nil {
+		t.Error("expected error when setting reflector config after start, got nil")
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -1403,7 +1403,7 @@ func TestSetReflectionOptionsBeforeStart(t *testing.T) {
 		BackoffResetDuration: 1 * time.Minute,
 	}
 
-	if err := informer.SetReflectionOptions(cfg); err != nil {
+	if err := informer.(ReflectionOptionsSetter).SetReflectionOptions(cfg); err != nil {
 		t.Fatalf("expected no error setting reflector config before start, got: %v", err)
 	}
 
@@ -1432,7 +1432,7 @@ func TestSetReflectionOptionsAfterStartReturnsError(t *testing.T) {
 	si.started = true
 	si.startedLock.Unlock()
 
-	if err := informer.SetReflectionOptions(ReflectionOptions{}); err == nil {
+	if err := informer.(ReflectionOptionsSetter).SetReflectionOptions(ReflectionOptions{}); err == nil {
 		t.Error("expected error when setting reflector config after start, got nil")
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -1393,7 +1393,7 @@ func TestSetReflectionOptionsBeforeStart(t *testing.T) {
 	cfg := ReflectionOptions{
 		MinWatchTimeout: 10 * time.Minute,
 		MaxWatchTimeout: 20 * time.Minute,
-		Backoff: &wait.Backoff{
+		Backoff: wait.Backoff{
 			Duration: 500 * time.Millisecond,
 			Factor:   2.0,
 			Jitter:   1.0,
@@ -1414,7 +1414,7 @@ func TestSetReflectionOptionsBeforeStart(t *testing.T) {
 	if si.reflectionOptions.MaxWatchTimeout != 20*time.Minute {
 		t.Errorf("MaxWatchTimeout not set: got %v", si.reflectionOptions.MaxWatchTimeout)
 	}
-	if si.reflectionOptions.Backoff == nil {
+	if si.reflectionOptions.Backoff == (wait.Backoff{}) {
 		t.Error("Backoff not set")
 	}
 	if si.reflectionOptions.BackoffResetDuration != 1*time.Minute {

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -1386,11 +1386,11 @@ func numOccurrences(hay, needle string) int {
 	}
 }
 
-func TestSetReflectorConfigBeforeStart(t *testing.T) {
+func TestSetReflectionOptionsBeforeStart(t *testing.T) {
 	lw := &fcache.FakeControllerSource{}
 	informer := NewSharedIndexInformer(lw, &v1.Pod{}, 0, Indexers{})
 
-	cfg := ReflectorConfig{
+	cfg := ReflectionOptions{
 		MinWatchTimeout: 10 * time.Minute,
 		MaxWatchTimeout: 20 * time.Minute,
 		Backoff: &wait.Backoff{
@@ -1403,26 +1403,26 @@ func TestSetReflectorConfigBeforeStart(t *testing.T) {
 		BackoffResetDuration: 1 * time.Minute,
 	}
 
-	if err := informer.SetReflectorConfig(cfg); err != nil {
+	if err := informer.SetReflectionOptions(cfg); err != nil {
 		t.Fatalf("expected no error setting reflector config before start, got: %v", err)
 	}
 
 	si := informer.(*sharedIndexInformer)
-	if si.reflectorConfig.MinWatchTimeout != 10*time.Minute {
-		t.Errorf("MinWatchTimeout not set: got %v", si.reflectorConfig.MinWatchTimeout)
+	if si.reflectionOptions.MinWatchTimeout != 10*time.Minute {
+		t.Errorf("MinWatchTimeout not set: got %v", si.reflectionOptions.MinWatchTimeout)
 	}
-	if si.reflectorConfig.MaxWatchTimeout != 20*time.Minute {
-		t.Errorf("MaxWatchTimeout not set: got %v", si.reflectorConfig.MaxWatchTimeout)
+	if si.reflectionOptions.MaxWatchTimeout != 20*time.Minute {
+		t.Errorf("MaxWatchTimeout not set: got %v", si.reflectionOptions.MaxWatchTimeout)
 	}
-	if si.reflectorConfig.Backoff == nil {
+	if si.reflectionOptions.Backoff == nil {
 		t.Error("Backoff not set")
 	}
-	if si.reflectorConfig.BackoffResetDuration != 1*time.Minute {
-		t.Errorf("BackoffResetDuration not set: got %v", si.reflectorConfig.BackoffResetDuration)
+	if si.reflectionOptions.BackoffResetDuration != 1*time.Minute {
+		t.Errorf("BackoffResetDuration not set: got %v", si.reflectionOptions.BackoffResetDuration)
 	}
 }
 
-func TestSetReflectorConfigAfterStartReturnsError(t *testing.T) {
+func TestSetReflectionOptionsAfterStartReturnsError(t *testing.T) {
 	lw := &fcache.FakeControllerSource{}
 	informer := NewSharedIndexInformer(lw, &v1.Pod{}, 0, Indexers{})
 
@@ -1432,7 +1432,7 @@ func TestSetReflectorConfigAfterStartReturnsError(t *testing.T) {
 	si.started = true
 	si.startedLock.Unlock()
 
-	if err := informer.SetReflectorConfig(ReflectorConfig{}); err == nil {
+	if err := informer.SetReflectionOptions(ReflectionOptions{}); err == nil {
 		t.Error("expected error when setting reflector config after start, got nil")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR makes the Reflector's backoff and watch timeout behavior fully configurable, threading the configuration from the low-level Reflector all the way up to SharedInformerFactory.

#### Which issue(s) this PR is related to: Fixes #136943
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
