### PR TITLE
scheduler: wait for DeviceClass sync in dynamicresources tests

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -3019,13 +3019,16 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 	// manager, but it is close enough because the assume cache
 	// uses a single boolean for "is synced" for all handlers.
 	registeredHandler := claimsCache.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+	doneCheckers := []cache.DoneChecker{registeredHandler.HasSyncedChecker(), resourceSliceTracker.HasSyncedChecker()}
 
 	tc.draManager = NewDRAManager(tCtx, claimsCache, resourceSliceTracker, tc.informerFactory)
 	if features.EnableDRAExtendedResource {
 		cache := tc.draManager.DeviceClassResolver().(*extendedresourcecache.ExtendedResourceCache)
-		if _, err := tc.informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(cache); err != nil {
+		handle, err := tc.informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(cache)
+		if err != nil {
 			tCtx.Logger().Error(err, "failed to add device class informer event handler")
 		}
+		doneCheckers = append(doneCheckers, handle.HasSyncedChecker())
 	}
 
 	opts := []runtime.Option{
@@ -3068,11 +3071,11 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 	})
 
 	tc.informerFactory.WaitForCacheSync(tCtx.Done())
-	// The above does not tell us if the registered handler (from NewAssumeCache)
-	// is synced, we need to wait until HasSynced of the handler returns
-	// true, this ensures that the assume cache is in sync with the informer's
+	// The above does not tell us if the registered handlers (e.g. from NewAssumeCache)
+	// are synced, we need to wait until the event handlers confirm that they are synced.
+	// This ensures that the assume cache is in sync with the informer's
 	// store which has been informed by at least one full LIST of the underlying storage.
-	cache.WaitForNamedCacheSyncWithContext(tCtx, registeredHandler.HasSynced, resourceSliceTracker.HasSynced)
+	cache.WaitFor(tCtx, "event handlers", doneCheckers...)
 
 	for _, node := range nodes {
 		nodeInfo := framework.NewNodeInfo()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

When DRAExtendedResource is enabled, the dynamicresources test setup registers an event handler for DeviceClasses but was not waiting for it to sync. This can lead to flaky tests where the cache is not fully populated when the test starts.

This change captures the event handler registration and includes its DoneChecker in a WaitFor call.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/137113 (not closed yet, waiting for clean CI signal)

#### Special notes for your reviewer:

Replaces https://github.com/kubernetes/kubernetes/pull/137475

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @yliaog
/cc @troychiu
