### PR TITLE
Register sample-device-plugin image in manifest

### DIFF
--- a/test/images/.permitted-images
+++ b/test/images/.permitted-images
@@ -28,6 +28,7 @@ registry.k8s.io/e2e-test-images/perl
 registry.k8s.io/e2e-test-images/regression-issue-74839
 registry.k8s.io/e2e-test-images/resource-consumer
 registry.k8s.io/e2e-test-images/sample-apiserver
+registry.k8s.io/e2e-test-images/sample-device-plugin
 registry.k8s.io/e2e-test-images/volume/iscsi
 registry.k8s.io/e2e-test-images/volume/nfs
 registry.k8s.io/etcd

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -204,6 +204,8 @@ const (
 	VolumeNFSServer
 	// VolumeISCSIServer image
 	VolumeISCSIServer
+	// SampleDevicePlugin image
+	SampleDevicePlugin
 )
 
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
@@ -236,6 +238,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[ResourceConsumer] = Config{list.PromoterE2eRegistry, "resource-consumer", "1.14"}
 	configs[VolumeNFSServer] = Config{list.PromoterE2eRegistry, "volume/nfs", "1.6.0"}
 	configs[VolumeISCSIServer] = Config{list.PromoterE2eRegistry, "volume/iscsi", "2.7"}
+	configs[SampleDevicePlugin] = Config{list.PromoterE2eRegistry, "sample-device-plugin", "1.7"}
 
 	// This adds more config entries. Those have no pre-defined ImageID number,
 	// but will be used via ReplaceRegistryInImageURL when deploying


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- Registers the `sample-device-plugin:1.7` image in the central e2e image manifest (`test/utils/image/manifest.go`) with a new `SampleDevicePlugin` ImageID and config.
- Adds `registry.k8s.io/e2e-test-images/sample-device-plugin` to `test/images/.permitted-images` so `hack/verify-e2e-images.sh` passes.
- The image is already used by DaemonSet manifests under `test/e2e/testing-manifests/sample-device-plugin/` but was missing from the manifest, which is inconsistent with other e2e test images.
- Downstream and air-gapped setups rely on the manifest to pre-provision or mirror images; without this entry they cannot discover or mirror this image.

#### Which issue(s) this PR is related to:

Fixes #137520

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```

