### PR TITLE
feat: add build-tag type switching for FieldsV1 to string that uses unique.Handle[string] for interning and associated tests

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/fieldsv1_benchmark_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/fieldsv1_benchmark_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var benchmarkPayloads = []string{
+	// Small managed fields payload
+	`{"f:metadata":{"f:labels":{"f:app":{}},"f:annotations":{"f:revision":{}}},"f:spec":{"f:replicas":{},"f:template":{"f:metadata":{"f:labels":{"f:app":{}}},"f:spec":{"f:containers":{"k:{\"name\":\"nginx\"}":{".":{},"f:image":{},"f:name":{}}}}}}}`,
+	// Larger, deeply nested valid JSON payload (representing complex managedFields)
+	`{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}},"f:labels":{".":{},"f:app.kubernetes.io/name":{}}},"f:spec":{"f:replicas":{},"f:selector":{},"f:template":{"f:metadata":{"f:labels":{".":{},"f:app.kubernetes.io/name":{}}},"f:spec":{"f:containers":{"k:{\"name\":\"app\"}":{".":{},"f:image":{},"f:name":{},"f:ports":{".":{},"k:{\"containerPort\":8080,\"protocol\":\"TCP\"}":{".":{},"f:containerPort":{},"f:protocol":{}}},"f:resources":{".":{},"f:limits":{".":{},"f:cpu":{},"f:memory":{}},"f:requests":{".":{},"f:cpu":{},"f:memory":{}}}}}}}}}`,
+}
+
+// BenchmarkDecodeDuplicate measures the allocation and speed of unmarshaling
+// exactly identical payloads repeatedly, which is the most common case for
+// heavily replicated resources (DaemonSets, ReplicaSets) in the API server.
+func BenchmarkDecodeDuplicate(b *testing.B) {
+	for _, payload := range benchmarkPayloads {
+		b.Run(fmt.Sprintf("Size%d", len(payload)), func(b *testing.B) {
+			rawJSON := []byte(payload)
+			b.ResetTimer()
+			b.ReportAllocs()
+			var retained []metav1.FieldsV1
+			for j := 0; j < b.N; j++ {
+				var f metav1.FieldsV1
+				if err := json.Unmarshal(rawJSON, &f); err != nil {
+					b.Fatal(err)
+				}
+				retained = append(retained, f)
+			}
+			_ = retained
+		})
+	}
+}
+
+// BenchmarkDecodeUnique measures the allocation and speed of unmarshaling
+// completely unique payloads to measure the worst-case interning overhead.
+func BenchmarkDecodeUnique(b *testing.B) {
+	for _, payload := range benchmarkPayloads {
+		b.Run(fmt.Sprintf("Size%d", len(payload)), func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			var retained []metav1.FieldsV1
+			for j := 0; j < b.N; j++ {
+				// Inject the iteration counter to guarantee the string is unique
+				novelPayload := fmt.Appendf(nil, `{"f:iter":%d,%s`, j, payload[1:])
+				var f metav1.FieldsV1
+				if err := json.Unmarshal(novelPayload, &f); err != nil {
+					b.Fatal(err)
+				}
+				retained = append(retained, f)
+			}
+			_ = retained
+		})
+	}
+}
+
+// BenchmarkParallelDecode tests parallel deserialization of duplicate strings
+// to verify lock contention behavior in highly concurrent environments.
+func BenchmarkParallelDecode(b *testing.B) {
+	for _, payload := range benchmarkPayloads {
+		b.Run(fmt.Sprintf("Size%d", len(payload)), func(b *testing.B) {
+			rawJSON := []byte(payload)
+			b.ResetTimer()
+			b.ReportAllocs()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					var f metav1.FieldsV1
+					if err := json.Unmarshal(rawJSON, &f); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkEqual_Same measures the fast-path equality check for identical structs.
+func BenchmarkEqual_Same(b *testing.B) {
+	f1 := metav1.NewFieldsV1(benchmarkPayloads[1])
+	f2 := metav1.NewFieldsV1(benchmarkPayloads[1])
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = f1.Equal(*f2)
+	}
+}
+
+// BenchmarkEqual_Different measures the fallback-path equality check for differing structs.
+func BenchmarkEqual_Different(b *testing.B) {
+	f1 := metav1.NewFieldsV1(benchmarkPayloads[1])
+	f2 := metav1.NewFieldsV1(benchmarkPayloads[0])
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = f1.Equal(*f2)
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/fieldsv1_string.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/fieldsv1_string.go
@@ -1,4 +1,4 @@
-//go:build !fieldsv1string
+//go:build fieldsv1string
 
 /*
 Copyright The Kubernetes Authors.
@@ -19,7 +19,8 @@ limitations under the License.
 package v1
 
 import (
-	"bytes"
+	"strings"
+	"unique"
 )
 
 // FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.
@@ -37,25 +38,37 @@ import (
 // +protobuf.options.marshal=false
 // +protobuf.options.(gogoproto.goproto_stringer)=false
 type FieldsV1 struct {
-	// Raw is the underlying serialization of this object.
-	//
-	// Deprecated: Direct access to this field is deprecated. Use GetRawBytes, GetRawString, SetRawBytes, SetRawString, GetRawReader, NewFieldsV1 instead.
-	Raw []byte `json:"-" protobuf:"bytes,1,opt,name=Raw"`
+	// The zero value of a unique.Handle[string] has an uninitialized underlying pointer.
+	// Calling .Value() on it panics. We must explicitly check for this uninitialized
+	// state (f.handle == unique.Handle[string]{}) across accessors to safely support
+	// uninitialized metav1.FieldsV1{} objects.
+	// See ongoing golang discussion related to this here: https://github.com/golang/go/issues/73344
+	handle unique.Handle[string]
 }
 
 func (f FieldsV1) String() string {
-	return string(f.Raw)
+	if f.handle == (unique.Handle[string]{}) {
+		return ""
+	}
+	return f.handle.Value()
 }
 
 func (f FieldsV1) Equal(f2 FieldsV1) bool {
-	return bytes.Equal(f.Raw, f2.Raw)
+	if f.handle == f2.handle {
+		return true
+	}
+	// An uninitialized FieldsV1 compared to an explicitly empty
+	// FieldsV1 (unique.Make("") will fail the handle check above.
+	// Evaluate string contents directly as well to maintain parity with legacy
+	// bytes.Equal(nil, []byte{}) == true behavior.
+	return f.GetRawString() == f2.GetRawString()
 }
 
 func (f *FieldsV1) GetRawReader() FieldsV1Reader {
-	if f == nil || len(f.Raw) == 0 {
-		return bytes.NewReader(nil)
+	if f == nil || f.handle == (unique.Handle[string]{}) {
+		return strings.NewReader("")
 	}
-	return bytes.NewReader(f.Raw)
+	return strings.NewReader(f.handle.Value())
 }
 
 // GetRawBytes returns the raw bytes.
@@ -63,43 +76,38 @@ func (f *FieldsV1) GetRawReader() FieldsV1Reader {
 // If mutating the underlying bytes is desired, the returned bytes may be mutated and then passed to SetRawBytes().
 // If mutating the underlying bytes is not desired, make a copy of the returned bytes.
 func (f *FieldsV1) GetRawBytes() []byte {
-	if f == nil {
+	if f == nil || f.handle == (unique.Handle[string]{}) {
 		return nil
 	}
-	return f.Raw
+	return []byte(f.handle.Value())
 }
 
 // GetRawString returns the raw data as a string.
 func (f *FieldsV1) GetRawString() string {
-	if f == nil {
+	if f == nil || f.handle == (unique.Handle[string]{}) {
 		return ""
 	}
-	return string(f.Raw)
+	return f.handle.Value()
 }
 
 // SetRawBytes sets the raw bytes. It does not retain the passed-in byte slice.
 func (f *FieldsV1) SetRawBytes(b []byte) {
 	if f != nil {
-		f.Raw = bytes.Clone(b)
+		f.handle = unique.Make(string(b))
 	}
 }
 
 // SetRawString sets the raw data from a string.
 func (f *FieldsV1) SetRawString(s string) {
 	if f != nil {
-		f.Raw = []byte(s)
+		f.handle = unique.Make(s)
 	}
 }
 
 func NewFieldsV1(raw string) *FieldsV1 {
-	return &FieldsV1{Raw: []byte(raw)}
+	return &FieldsV1{handle: unique.Make(raw)}
 }
 
 func (f *FieldsV1) DeepCopyInto(out *FieldsV1) {
 	*out = *f
-	if f.Raw != nil {
-		in, out := &f.Raw, &out.Raw
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/fieldsv1_string_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/fieldsv1_string_test.go
@@ -1,0 +1,362 @@
+//go:build fieldsv1string
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+	"unsafe"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// requireInterned fails the test if the two strings do not point to the exact same memory address.
+func requireInterned(t *testing.T, a, b string) {
+	t.Helper()
+	ptrA := unsafe.StringData(a)
+	ptrB := unsafe.StringData(b)
+	if ptrA != ptrB {
+		t.Fatalf("Expected strings to be interned (same memory address) but pointers differ: %p != %p", ptrA, ptrB)
+	}
+}
+
+func TestFieldsV1_String(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		f        metav1.FieldsV1
+		expected string
+	}{
+		{
+			name:     "zero value handle",
+			f:        metav1.FieldsV1{},
+			expected: "",
+		},
+		{
+			name:     "initialized empty handle",
+			f:        *metav1.NewFieldsV1(""),
+			expected: "",
+		},
+		{
+			name:     "valid payload",
+			f:        *metav1.NewFieldsV1(`{"f:app":{}}`),
+			expected: `{"f:app":{}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.f.String(); got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestFieldsV1_Equal(t *testing.T) {
+	valid := *metav1.NewFieldsV1(`{"f:app":{}}`)
+	validClone := *metav1.NewFieldsV1(`{"f:app":{}}`)
+	different := *metav1.NewFieldsV1(`{"f:other":{}}`)
+
+	for _, tc := range []struct {
+		name     string
+		a        metav1.FieldsV1
+		b        metav1.FieldsV1
+		expected bool
+	}{
+		{"both zero value", metav1.FieldsV1{}, metav1.FieldsV1{}, true},
+		{"zero value and initialized empty handle", metav1.FieldsV1{}, *metav1.NewFieldsV1(""), true},
+		{"identical valid payloads", valid, validClone, true},
+		{"different payloads", valid, different, false},
+		{"zero value and valid payload", metav1.FieldsV1{}, valid, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.a.Equal(tc.b); got != tc.expected {
+				t.Errorf("expected Equal() to be %v, got %v", tc.expected, got)
+			}
+			// Commutative property
+			if got := tc.b.Equal(tc.a); got != tc.expected {
+				t.Errorf("expected Equal() commutative to be %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestFieldsV1_GetRawReader(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		f        *metav1.FieldsV1
+		expected []byte
+	}{
+		{"nil receiver", nil, []byte("")},
+		{"zero value handle", &metav1.FieldsV1{}, []byte("")},
+		{"initialized empty handle", metav1.NewFieldsV1(""), []byte("")},
+		{"valid payload", metav1.NewFieldsV1(`{"f:app":{}}`), []byte(`{"f:app":{}}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := tc.f.GetRawReader()
+			got, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatalf("unexpected error reading from RawReader: %v", err)
+			}
+			if !bytes.Equal(got, tc.expected) {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestFieldsV1_GetRawBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		f        *metav1.FieldsV1
+		expected []byte
+	}{
+		{"nil receiver", nil, nil},
+		{"zero value handle", &metav1.FieldsV1{}, nil},
+		{"initialized empty handle", metav1.NewFieldsV1(""), []byte{}},
+		{"valid payload", metav1.NewFieldsV1(`{"f:app":{}}`), []byte(`{"f:app":{}}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.f.GetRawBytes()
+			if !bytes.Equal(got, tc.expected) {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+			// Explicitly check for nil
+			if tc.expected == nil && got != nil {
+				t.Errorf("expected strict nil, got %v", got)
+			}
+		})
+	}
+
+	t.Run("mutation safety", func(t *testing.T) {
+		f := metav1.NewFieldsV1(`{"f:app":{}}`)
+		b := f.GetRawBytes()
+
+		// Mutate the returned bytes
+		b[2] = 'X'
+
+		// The original interned string must remain unchanged
+		if got := f.GetRawString(); got != `{"f:app":{}}` {
+			t.Errorf("GetRawBytes returned an unisolated slice! Mutating it corrupted the handle. Got: %s", got)
+		}
+	})
+}
+
+func TestFieldsV1_GetRawString(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		f        *metav1.FieldsV1
+		expected string
+	}{
+		{"nil receiver", nil, ""},
+		{"zero value handle", &metav1.FieldsV1{}, ""},
+		{"initialized empty handle", metav1.NewFieldsV1(""), ""},
+		{"valid payload", metav1.NewFieldsV1(`{"f:app":{}}`), `{"f:app":{}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.f.GetRawString(); got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestFieldsV1_SetRawBytes(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var f *metav1.FieldsV1        // nil
+		f.SetRawBytes([]byte("test")) // Should not panic
+	})
+
+	t.Run("empty slice input", func(t *testing.T) {
+		f := &metav1.FieldsV1{}
+		f.SetRawBytes([]byte{})
+		if f.GetRawString() != "" {
+			t.Errorf("Expected empty string, got %q", f.GetRawString())
+		}
+	})
+
+	t.Run("nil slice input", func(t *testing.T) {
+		f := &metav1.FieldsV1{}
+		f.SetRawBytes(nil)
+		if f.GetRawString() != "" {
+			t.Errorf("Expected empty string, got %q", f.GetRawString())
+		}
+	})
+
+	t.Run("interning behavior", func(t *testing.T) {
+		payload := []byte(`{"f:app":{}}`)
+
+		// Two distinct slices with identical content
+		b1 := append([]byte(nil), payload...)
+		b2 := append([]byte(nil), payload...)
+
+		f1 := &metav1.FieldsV1{}
+		f1.SetRawBytes(b1)
+
+		f2 := &metav1.FieldsV1{}
+		f2.SetRawBytes(b2)
+
+		if f1.GetRawString() != string(payload) {
+			t.Errorf("Expected GetRawString to match payload, got %q", f1.GetRawString())
+		}
+
+		requireInterned(t, f1.GetRawString(), f2.GetRawString())
+	})
+}
+
+func TestFieldsV1_SetRawString(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var f *metav1.FieldsV1 // nil
+		f.SetRawString("test") // Should not panic
+	})
+
+	t.Run("interning behavior", func(t *testing.T) {
+		payload := `{"f:app":{}}`
+
+		// Force string copy to avoid compiler static string optimization if possible
+		s1 := string(append([]byte(nil), payload...))
+		s2 := string(append([]byte(nil), payload...))
+
+		f1 := &metav1.FieldsV1{}
+		f1.SetRawString(s1)
+
+		f2 := &metav1.FieldsV1{}
+		f2.SetRawString(s2)
+
+		requireInterned(t, f1.GetRawString(), f2.GetRawString())
+	})
+}
+
+func TestFieldsV1_NewFieldsV1(t *testing.T) {
+	t.Run("interning behavior", func(t *testing.T) {
+		payload := `{"f:app":{}}`
+		s1 := string(append([]byte(nil), payload...))
+		s2 := string(append([]byte(nil), payload...))
+
+		f1 := metav1.NewFieldsV1(s1)
+		f2 := metav1.NewFieldsV1(s2)
+
+		requireInterned(t, f1.GetRawString(), f2.GetRawString())
+	})
+}
+
+func TestFieldsV1_DeepCopyInto(t *testing.T) {
+	t.Run("preserves interning", func(t *testing.T) {
+		orig := metav1.NewFieldsV1(`{"f:app":{}}`)
+		var clone metav1.FieldsV1
+		orig.DeepCopyInto(&clone)
+
+		if orig.GetRawString() != clone.GetRawString() {
+			t.Fatalf("Expected strings to match after DeepCopyInto, got %q and %q", orig.GetRawString(), clone.GetRawString())
+		}
+
+		requireInterned(t, orig.GetRawString(), clone.GetRawString())
+	})
+
+	t.Run("zero value deep copy", func(t *testing.T) {
+		var orig metav1.FieldsV1
+		var clone metav1.FieldsV1
+		orig.DeepCopyInto(&clone)
+
+		if clone.GetRawString() != "" {
+			t.Errorf("Expected empty string from cloned zero-value, got %q", clone.GetRawString())
+		}
+		if !orig.Equal(clone) {
+			t.Errorf("Expected original zero-value and its clone to be equal")
+		}
+	})
+
+	t.Run("independence after deep copy", func(t *testing.T) {
+		orig := metav1.NewFieldsV1(`{"f:app":{}}`)
+		var clone metav1.FieldsV1
+		orig.DeepCopyInto(&clone)
+
+		// Modify the clone
+		clone.SetRawString(`{"f:new":{}}`)
+
+		// The original should be completely untouched
+		if got := orig.GetRawString(); got != `{"f:app":{}}` {
+			t.Errorf("DeepCopyInto failed to isolate clone! Modifying clone corrupted original. Got: %s", got)
+		}
+	})
+}
+func TestFieldsV1_UnmarshalInterning(t *testing.T) {
+	jsonPayload := []byte(`{"f:metadata":{"f:labels":{"f:app":{}}}}`)
+	orig := metav1.NewFieldsV1(string(jsonPayload))
+
+	protoPayload, err := orig.Marshal()
+	if err != nil {
+		t.Fatalf("Failed to marshal protobuf payload during setup: %v", err)
+	}
+
+	cborPayload, err := orig.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("Failed to marshal CBOR payload during setup: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		payload   []byte
+		unmarshal func(t *testing.T, f *metav1.FieldsV1, payload []byte)
+	}{
+		{
+			name:    "json unmarshal",
+			payload: jsonPayload,
+			unmarshal: func(t *testing.T, f *metav1.FieldsV1, payload []byte) {
+				if err := json.Unmarshal(payload, f); err != nil {
+					t.Fatalf("JSON Unmarshal failed: %v", err)
+				}
+			},
+		},
+		{
+			name:    "protobuf unmarshal",
+			payload: protoPayload,
+			unmarshal: func(t *testing.T, f *metav1.FieldsV1, payload []byte) {
+				if err := f.Unmarshal(payload); err != nil {
+					t.Fatalf("Protobuf Unmarshal failed: %v", err)
+				}
+			},
+		},
+		{
+			name:    "cbor unmarshal",
+			payload: cborPayload,
+			unmarshal: func(t *testing.T, f *metav1.FieldsV1, payload []byte) {
+				if err := f.UnmarshalCBOR(payload); err != nil {
+					t.Fatalf("CBOR Unmarshal failed: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Ensure independent slice memory
+			b1 := append([]byte(nil), tc.payload...)
+			b2 := append([]byte(nil), tc.payload...)
+
+			var f1 metav1.FieldsV1
+			var f2 metav1.FieldsV1
+
+			tc.unmarshal(t, &f1, b1)
+			tc.unmarshal(t, &f2, b2)
+
+			requireInterned(t, f1.GetRawString(), f2.GetRawString())
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

From cluster profiling done in https://github.com/kubernetes/kubernetes/issues/137109, `managedFields` is a large factor in `kube-apiserver` memory bloat. In envs with highly replicated resources (ex: DaemonSets, ReplicaSets, StatefulSets, and Jobs), thousands of identical Pods are created. When held in the API Server WatchCache, their `managedFields` payloads are duplicated as distinct `[]byte` slices in memory, causing O(N) memory bloat for identical `managedFields` data.

Building on https://github.com/kubernetes/kubernetes/pull/137304 which encapsulated `metav1.FieldsV1` behind accessors, this PR introduces a native string interning backend for FieldsV1.Raw utilizing Go 1.23's `unique.Handle[string]`. This deduplicates `managedField` values across the API server, dropping the memory footprint of duplicated payloads from O(N) to O(1). 

This PR:
- Changes `FieldsV1` to be two files w/ different backing types toggled via build tags: `fieldsv1_byte.go` (the default `!fieldsv1string` legacy implementation) and `fieldsv1_string.go` (the opt-in `fieldsv1string` interning implementation). 
- Under the `fieldsv1string` tag, `SetRawBytes` casts payload data to `string` and registers the string in the global interning pool via `unique.Make()`.
- Has  against the Go 1.23 `unique.Handle{}` zero-value panic bug (tracked in golang/go#73344) to  support uninitialized `metav1.FieldsV1{}` structs natively.
- Adds  unit test (`fieldsv1_string_test.go`) to verify added methods, `unique.Handle` interning boundaries, zero-value fallback behavior, deep copy safety, and mutation isolation.

**A note on `Equal()`:** 
The `Equal` method in `fieldsv1_string.go` contains a fallback path for zero-value vs explicitly empty structs to  mirror the legacy `bytes.Equal(nil, []byte{})` behavior. This is documented and tested in the PR.

#### Which issue(s) this PR is related to:

Part of: https://github.com/kubernetes/kubernetes/issues/137109

#### Special notes for your reviewer:
##### CI Test PR
To make sure CI tests (and the added unit test) pass as expected using the `fieldsv1string` build tag, I submitted https://github.com/kubernetes/kubernetes/pull/137579 which has these same changes only a single additional commit which makes CI builds and tests use the `fieldsv1string` test.  Merging this PR is contingent on that PR having green.

##### CI Testing Setting the `fieldsv1string` build tag
Three manually trigger-able prow tests were added to test these changes (PR here: https://github.com/kubernetes/test-infra/pull/36627).  These can be triggered for this PR and on other PRs using the below Prow commands.

- /test pull-kubernetes-unit-fieldsv1string
- /test pull-kubernetes-integration-fieldsv1string
- /test pull-kubernetes-e2e-kind-fieldsv1string

When these are manually triggered, the tests become part of the presubmit CI in Github and the logs etc. will be linked as normal. The dashboard for all of the `fieldsv1string` prow tests is here. **THIS INCLUDES PERIODIC TESTS SO YOU CAN CHECK THE CURRENT HEALTH OF USING K8s WITH THIS ENABLED**
https://testgrid.k8s.io/sig-api-machinery-fieldsv1string

##### Local Testing Setting the `fieldsv1string` build tag
- compile k8s with the memory optimization in this PR:
  - `make all GOFLAGS="-tags=fieldsv1string"`
- run the unit test
  - `go test -tags fieldsv1string -run "^(TestFieldsV1_String|...)$" k8s.io/apimachinery/pkg/apis/meta/v1`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/sig api-machinery
/triage accepted