### PR TITLE
KEP-3926: Ensure corruption at latest revision for "unsafe delete" path.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -69,8 +69,7 @@ func TestWebhookConverterWithoutWatchCache(t *testing.T) {
 func TestWebhookNotCalledForUnusedVersions(t *testing.T) {
 	ctx := context.Background()
 
-	etcd3watcher.TestOnlySetFatalOnDecodeError(false)
-	defer etcd3watcher.TestOnlySetFatalOnDecodeError(true)
+	etcd3watcher.TestOnlySetFatalOnDecodeError(t, false)
 
 	tearDown, config, options, err := fixtures.StartDefaultServer(t, "--watch-cache=true")
 	if err != nil {
@@ -268,8 +267,7 @@ func testWebhookConverter(t *testing.T, watchCache bool) {
 	// TODO: Added for integration testing of conversion webhooks, where decode errors due to conversion webhook failures need to be tested.
 	// Maybe we should identify conversion webhook related errors in decoding to avoid triggering this? Or maybe having this special casing
 	// of test cases in production code should be removed?
-	etcd3watcher.TestOnlySetFatalOnDecodeError(false)
-	defer etcd3watcher.TestOnlySetFatalOnDecodeError(true)
+	etcd3watcher.TestOnlySetFatalOnDecodeError(t, false)
 
 	// To avoid the high cost of restarting the API server for every test case, we start
 	// the infrastructure (API Server + Webhook Server) ONCE at the beginning of the test.

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter.go
@@ -19,13 +19,10 @@ package registry
 import (
 	"context"
 	"errors"
-	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
@@ -38,13 +35,12 @@ import (
 // the corrupt object deleter has the same interface as rest.GracefulDeleter
 var _ rest.GracefulDeleter = &corruptObjectDeleter{}
 
-// NewCorruptObjectDeleter returns a deleter that can perform unsafe deletion
-// of corrupt objects, it makes an attempt to perform a normal deletion flow
-// first, and if the normal deletion flow fails with a corrupt object error
-// then it performs the unsafe delete of the object.
+// NewCorruptObjectDeleter returns a deleter that can perform unsafe deletion of corrupt
+// objects. The deletion will be rejected if the object turns out to be decodable (i.e. not actually
+// corrupt).
 //
-// NOTE: it skips precondition checks, finalizer constraints, and any
-// post deletion hook defined in 'AfterDelete' of the registry.
+// NOTE: it skips precondition checks, finalizer constraints, and any post deletion hook defined in
+// 'AfterDelete' of the registry.
 //
 // WARNING: This may break the cluster if the resource being deleted has dependencies.
 func NewCorruptObjectDeleter(store *Store) rest.GracefulDeleter {
@@ -72,41 +68,12 @@ func (d *corruptObjectDeleter) Delete(ctx context.Context, name string, deleteVa
 	if err != nil {
 		return nil, false, err
 	}
-	obj := d.store.NewFunc()
 	qualifiedResource := d.store.qualifiedResourceFromContext(ctx)
 	// use the storage implementation directly, bypass the dryRun layer
 	storageBackend := d.store.Storage.Storage
-	// we leave ResourceVersion as empty in the GetOptions so the
-	// object is retrieved from the underlying storage directly
-	err = storageBackend.Get(ctx, key, storage.GetOptions{}, obj)
-	if err == nil || !storage.IsCorruptObject(err) {
-		// TODO: The Invalid error should have a field for Resource.
-		// After that field is added, we should fill the Resource and
-		// leave the Kind field empty. See the discussion in #18526.
-		qualifiedKind := schema.GroupKind{Group: qualifiedResource.Group, Kind: qualifiedResource.Resource}
-		fieldErrList := field.ErrorList{
-			field.Invalid(field.NewPath("ignoreStoreReadErrorWithClusterBreakingPotential"), true, "is exclusively used to delete corrupt object(s), try again by removing this option"),
-		}
-		return nil, false, apierrors.NewInvalid(qualifiedKind, name, fieldErrList)
-	}
-
-	// try normal deletion anyway, it is expected to fail
-	obj, deleted, err := d.store.Delete(ctx, name, deleteValidation, opts)
-	if err == nil {
-		return obj, deleted, err
-	}
-	// TODO: unfortunately we can't do storage.IsCorruptObject(err),
-	// conversion to API error drops the inner error chain
-	if !strings.Contains(err.Error(), "corrupt object") {
-		return obj, deleted, err
-	}
-
-	// TODO: at this instant, some actor may have a) managed to recreate this
-	// object by doing a delete+create, or b) the underlying error has resolved
-	// since the last time we checked, and the object is readable now.
 	klog.FromContext(ctx).V(1).Info("Going to perform unsafe object deletion", "object", klog.KRef(genericapirequest.NamespaceValue(ctx), name))
 	out := d.store.NewFunc()
-	storageOpts := storage.DeleteOptions{IgnoreStoreReadError: true}
+	storageOpts := storage.DeleteOptions{ExpectTransformOrDecodeError: true}
 	// we don't have the old object in the cache, neither can it be
 	// retrieved from the storage and decoded into an object
 	// successfully, so we do the following:
@@ -115,14 +82,9 @@ func (d *corruptObjectDeleter) Delete(ctx context.Context, name string, deleteVa
 	var nilPreconditions *storage.Preconditions = nil
 	var nilCachedExistingObject runtime.Object = nil
 	if err := storageBackend.Delete(ctx, key, out, nilPreconditions, rest.ValidateAllObjectFunc, nilCachedExistingObject, storageOpts); err != nil {
-		if storage.IsNotFound(err) {
-			// the DELETE succeeded, but we don't have the object since it's
-			// not retrievable from the storage, so we send a nil object
-			return nil, false, nil
-		}
 		return nil, false, storeerr.InterpretDeleteError(err, qualifiedResource, name)
 	}
-	// the DELETE succeeded, but we don't have the object sine it's
-	// not retrievable from the storage, so we send a nil objct
+	// the DELETE succeeded, but we don't have the object since it's
+	// not retrievable from the storage, so we send a nil object
 	return nil, true, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter_test.go
@@ -19,314 +19,138 @@ package registry
 import (
 	"context"
 	"fmt"
-	"strings"
+	"path"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/apis/example"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
-
 	"k8s.io/utils/ptr"
 )
 
-type result struct {
-	deleted bool
-	err     error
+// fakeStorage is a test double for storage.Interface that intercepts Delete calls, records the
+// arguments, and returns a pre-configured error.
+type fakeStorage struct {
+	storage.Interface
+	deleteErr error
+
+	deleteCalled            bool
+	key                     string
+	expectTransformOrDecode bool
+	preconditions           *storage.Preconditions
+	cachedExistingObject    runtime.Object
 }
 
-type deleteWant struct {
-	deleted  bool
-	checkErr func(err error) bool
+func (s *fakeStorage) Delete(ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions, deleteValidation storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions) error {
+	s.deleteCalled = true
+	s.key = key
+	s.expectTransformOrDecode = opts.ExpectTransformOrDecodeError
+	s.preconditions = preconditions
+	s.cachedExistingObject = cachedExistingObject
+	return s.deleteErr
 }
 
-var (
-	wantNoError     = func(err error) bool { return err == nil }
-	wantErrContains = func(shouldContain string) func(error) bool {
-		return func(err error) bool {
-			return err != nil && strings.Contains(err.Error(), shouldContain)
-		}
-	}
-)
-
-func (w deleteWant) verify(t *testing.T, got result) {
-	t.Helper()
-
-	if !w.checkErr(got.err) {
-		t.Errorf("Unexpected failure with the deletion operation, got: %v", got.err)
-	}
-	if w.deleted != got.deleted {
-		t.Errorf("Expected deleted to be: %t, but got: %t", w.deleted, got.deleted)
-	}
-
-}
-
-func TestUnsafeDeletePrecondition(t *testing.T) {
-	option := func(enabled bool) *metav1.DeleteOptions {
-		return &metav1.DeleteOptions{
-			IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To[bool](enabled),
-		}
-	}
-
-	const (
-		unsafeDeleteNotAllowed = "ignoreStoreReadErrorWithClusterBreakingPotential: Invalid value: true: is exclusively used to delete corrupt object(s), try again by removing this option"
-		internalErr            = "Internal error occurred: initialization error, expected normal deletion flow to be used"
-	)
-
-	tests := []struct {
-		name    string
-		err     error
-		opts    *metav1.DeleteOptions
-		invoked int
-		want    deleteWant
+func TestCorruptObjectDeleterDelete(t *testing.T) {
+	for _, test := range []struct {
+		name               string
+		deleteErr          error
+		opts               *metav1.DeleteOptions
+		expectDeleteCalled bool
+		wantDeleted        bool
+		wantErr            func(error) bool
 	}{
 		{
-			name: "option nil, should throw internal error",
-			opts: nil,
-			want: deleteWant{checkErr: wantErrContains(internalErr)},
+			name:    "options nil, should return internal error",
+			opts:    nil,
+			wantErr: errors.IsInternalError,
 		},
 		{
-			name: "option empty, should throw internal error",
-			opts: &metav1.DeleteOptions{},
-			want: deleteWant{checkErr: wantErrContains(internalErr)},
+			name:    "options empty, should return internal error",
+			opts:    &metav1.DeleteOptions{},
+			wantErr: errors.IsInternalError,
 		},
 		{
-			name: "option false, should throw internal error",
-			opts: option(false),
-			want: deleteWant{checkErr: wantErrContains(internalErr)},
+			name:    "option false, should return internal error",
+			opts:    &metav1.DeleteOptions{IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To(false)},
+			wantErr: errors.IsInternalError,
 		},
 		{
-			name: "option true, object readable, should throw invalid error",
-			opts: option(true),
-			want: deleteWant{
-				checkErr: wantErrContains(unsafeDeleteNotAllowed),
-			},
+			name:               "option true, object decodable, store returns InvalidObj",
+			opts:               &metav1.DeleteOptions{IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To(true)},
+			deleteErr:          storage.NewInvalidObjError("/pods/foo", "object is decodable"),
+			expectDeleteCalled: true,
+			wantErr:            errors.IsConflict,
 		},
 		{
-			name: "option true, object not readable with unexpected error, should throw invalid error",
-			opts: option(true),
-			err:  fmt.Errorf("unexpected error"),
-			want: deleteWant{
-				checkErr: wantErrContains(unsafeDeleteNotAllowed),
-			},
+			name:               "option true, object not decodable, delete succeeds",
+			opts:               &metav1.DeleteOptions{IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To(true)},
+			deleteErr:          nil,
+			expectDeleteCalled: true,
+			wantDeleted:        true,
+			wantErr:            func(err error) bool { return err == nil },
 		},
 		{
-			name: "option true, object not readable with storage internal error, should throw invalid error",
-			opts: option(true),
-			err:  storage.NewInternalError(fmt.Errorf("unexpected error")),
-			want: deleteWant{
-				checkErr: wantErrContains(unsafeDeleteNotAllowed),
-			},
+			name:               "option true, object not found, store returns NotFound",
+			opts:               &metav1.DeleteOptions{IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To(true)},
+			deleteErr:          storage.NewKeyNotFoundError("/pods/foo", 0),
+			expectDeleteCalled: true,
+			wantErr:            errors.IsNotFound,
 		},
-		{
-			name: "option true, object not readable with corrupt object error, unsafe-delete should trigger",
-			opts: option(true),
-			err:  storage.NewCorruptObjError("foo", fmt.Errorf("object not decodable")),
-			want: deleteWant{
-				deleted:  true,
-				checkErr: wantNoError,
-			},
-			invoked: 1,
-		},
-	}
-
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
-			destroyFunc, registry := NewTestGenericStoreRegistry(t)
-			defer destroyFunc()
-
-			object := &example.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec:       example.PodSpec{NodeName: "machine"},
+			fs := &fakeStorage{deleteErr: test.deleteErr}
+			const podPrefix = "/pods/"
+			store := &Store{
+				NewFunc:                   func() runtime.Object { return &example.Pod{} },
+				DefaultQualifiedResource:  schema.GroupResource{Resource: "pods"},
+				SingularQualifiedResource: schema.GroupResource{Resource: "pod"},
+				KeyRootFunc:               func(ctx context.Context) string { return podPrefix },
+				KeyFunc: func(ctx context.Context, name string) (string, error) {
+					if _, ok := genericapirequest.NamespaceFrom(ctx); !ok {
+						return "", fmt.Errorf("namespace is required")
+					}
+					return path.Join(podPrefix, name), nil
+				},
+				Storage: DryRunnableStorage{Storage: fs},
 			}
-			_, err := registry.Create(ctx, object, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
-			if err != nil {
-				t.Fatalf("Unexpected error from Create: %v", err)
+			deleter := NewCorruptObjectDeleter(store)
+
+			obj, deleted, err := deleter.Delete(ctx, "foo", func(context.Context, runtime.Object) error {
+				t.Fatal("caller-provided admission was invoked")
+				return nil
+			}, test.opts)
+
+			if obj != nil {
+				t.Errorf("Expected nil object, but got %v", obj)
 			}
-
-			// wrap the storage so it returns the expected error
-			cs := &corruptStorage{
-				Interface: registry.Storage.Storage,
-				err:       test.err,
+			if !test.wantErr(err) {
+				t.Errorf("Unexpected error: %v", err)
 			}
-			registry.Storage.Storage = cs
-			deleter := NewCorruptObjectDeleter(registry)
-
-			_, deleted, err := deleter.Delete(ctx, "foo", rest.ValidateAllObjectFunc, test.opts)
-
-			got := result{deleted: deleted, err: err}
-			test.want.verify(t, got)
-			if want, got := test.invoked, cs.unsafeDeleteInvoked; want != got {
-				t.Errorf("Expected unsafe-delete to be invoked %d time(s), but got: %d", want, got)
+			if test.wantDeleted != deleted {
+				t.Errorf("Expected deleted to be %t, but got %t", test.wantDeleted, deleted)
+			}
+			if test.expectDeleteCalled != fs.deleteCalled {
+				t.Errorf("Expected storage Delete called=%t, but got %t", test.expectDeleteCalled, fs.deleteCalled)
+			}
+			if fs.deleteCalled {
+				if want, got := "/pods/foo", fs.key; want != got {
+					t.Errorf("Expected storage Delete to be called with key %q, but got %q", want, got)
+				}
+				if !fs.expectTransformOrDecode {
+					t.Error("Expected storage Delete to be called with ExpectTransformOrDecodeError=true")
+				}
+				if fs.preconditions != nil {
+					t.Error("Expected storage Delete to be called with nil preconditions")
+				}
+				if fs.cachedExistingObject != nil {
+					t.Error("Expected storage Delete to be called with nil cachedExistingObject")
+				}
 			}
 		})
 	}
-}
-
-func TestUnsafeDeleteWithCorruptObject(t *testing.T) {
-	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
-	destroyFunc, registry := NewTestGenericStoreRegistry(t)
-	defer destroyFunc()
-
-	object := &example.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec:       example.PodSpec{NodeName: "machine"},
-	}
-	// a) prerequisite: try deleting the object, we expect a not found error
-	_, _, err := registry.Delete(ctx, object.Name, rest.ValidateAllObjectFunc, nil)
-	if !errors.IsNotFound(err) {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	// b) create the target object
-	_, err = registry.Create(ctx, object, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	// c) wrap the storage to return corrupt object error
-	cs := &corruptStorage{
-		Interface: registry.Storage.Storage,
-		err:       storage.NewCorruptObjError("key", fmt.Errorf("untransformable")),
-	}
-	registry.Storage.Storage = cs
-
-	got := result{}
-	// d) try deleting the traget object
-	_, got.deleted, got.err = registry.Delete(ctx, object.Name, rest.ValidateAllObjectFunc, nil)
-	want := deleteWant{checkErr: errors.IsInternalError}
-	want.verify(t, got)
-
-	// e) set up an unsafe-deleter
-	deleter := NewCorruptObjectDeleter(registry)
-
-	// f) try to delete the object, but don't set the delete option just yet
-	_, got.deleted, got.err = deleter.Delete(ctx, object.Name, rest.ValidateAllObjectFunc, nil)
-	want.verify(t, got)
-
-	// g) this time, set the delete option to ignore store read error
-	_, got.deleted, got.err = deleter.Delete(ctx, object.Name, rest.ValidateAllObjectFunc, &metav1.DeleteOptions{
-		IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To[bool](true),
-	})
-	want = deleteWant{
-		deleted:  true,
-		checkErr: wantNoError,
-	}
-	want.verify(t, got)
-	if want, got := 1, cs.unsafeDeleteInvoked; want != got {
-		t.Errorf("Expected unsafe-delete to be invoked %d time(s), but got: %d", want, got)
-	}
-}
-
-func TestUnsafeDeleteWithUnexpectedError(t *testing.T) {
-	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
-	// TODO: inject a corrupt transformer
-	destroyFunc, registry := NewTestGenericStoreRegistry(t)
-	defer destroyFunc()
-
-	object := &example.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec:       example.PodSpec{NodeName: "machine"},
-	}
-	// a) create the target object
-	_, err := registry.Create(ctx, object, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	// b) wrap the storage to return corrupt object error
-	cs := &corruptStorage{
-		Interface: registry.Storage.Storage,
-		err:       storage.NewInternalError(fmt.Errorf("unexpected error")),
-	}
-	registry.Storage.Storage = cs
-
-	// c) try deleting the object using normal deletion flow
-	got := result{}
-	_, got.deleted, got.err = registry.Delete(ctx, object.Name, rest.ValidateAllObjectFunc, nil)
-	want := deleteWant{checkErr: errors.IsInternalError}
-	want.verify(t, got)
-
-	// d) set up a corrupt object deleter for the registry
-	deleter := NewCorruptObjectDeleter(registry)
-
-	// e) try deleting with unsafe-delete
-	_, got.deleted, got.err = deleter.Delete(ctx, object.Name, rest.ValidateAllObjectFunc, &metav1.DeleteOptions{
-		IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To[bool](true),
-	})
-	want = deleteWant{
-		checkErr: wantErrContains("is exclusively used to delete corrupt object(s), try again by removing this option"),
-	}
-	want.verify(t, got)
-	if want, got := 0, cs.unsafeDeleteInvoked; want != got {
-		t.Errorf("Expected unsafe-delete to be invoked %d time(s), but got: %d", want, got)
-	}
-}
-
-func TestUnsafeDeleteWithAdmissionShouldBeSkipped(t *testing.T) {
-	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
-	destroyFunc, registry := NewTestGenericStoreRegistry(t)
-	defer destroyFunc()
-
-	// a) create the target object
-	object := &example.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec:       example.PodSpec{NodeName: "machine"},
-	}
-	_, err := registry.Create(ctx, object, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	// b) wrap the storage layer to return corrupt object error
-	registry.Storage.Storage = &corruptStorage{
-		Interface: registry.Storage.Storage,
-		err:       storage.NewCorruptObjError("key", fmt.Errorf("untransformable")),
-	}
-
-	// c) set up a corrupt object deleter for the registry
-	deleter := NewCorruptObjectDeleter(registry)
-
-	// d) try unsafe delete, but pass a validation that always fails
-	var admissionInvoked int
-	_, deleted, err := deleter.Delete(ctx, object.Name, func(_ context.Context, _ runtime.Object) error {
-		admissionInvoked++
-		return fmt.Errorf("admission was not skipped")
-	}, &metav1.DeleteOptions{
-		IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To[bool](true),
-	})
-
-	if err != nil {
-		t.Errorf("Unexpected error from Delete: %v", err)
-	}
-	if want, got := true, deleted; want != got {
-		t.Errorf("Expected deleted: %t, but got: %t", want, got)
-	}
-	if want, got := 0, admissionInvoked; want != got {
-		t.Errorf("Expected admission to be invoked %d time(s), but got: %d", want, got)
-	}
-}
-
-type corruptStorage struct {
-	storage.Interface
-	err                 error
-	unsafeDeleteInvoked int
-}
-
-func (s *corruptStorage) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
-	if s.err != nil {
-		return s.err
-	}
-	return s.Interface.Get(ctx, key, opts, objPtr)
-}
-
-func (s *corruptStorage) Delete(ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions, deleteValidation storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions) error {
-	if opts.IgnoreStoreReadError {
-		s.unsafeDeleteInvoked++
-	}
-	return s.Interface.Delete(ctx, key, out, preconditions, deleteValidation, cachedExistingObject, opts)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -18,12 +18,15 @@ package cacher
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 
+	"k8s.io/apimachinery/pkg/api/apitesting"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -37,8 +40,10 @@ import (
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/etcd3"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
+	"k8s.io/apiserver/pkg/storage/value"
 	"k8s.io/apiserver/pkg/storage/value/encrypt/identity"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientfeatures "k8s.io/client-go/features"
@@ -159,6 +164,79 @@ func TestDeleteWithConflict(t *testing.T) {
 	ctx, cacher, terminate := testSetup(t)
 	t.Cleanup(terminate)
 	storagetesting.RunTestDeleteWithConflict(ctx, t, cacher)
+}
+
+type testTransformer struct {
+	value.Transformer
+	fail atomic.Bool
+}
+
+func (tt *testTransformer) setFailing(c bool) {
+	tt.fail.Store(c)
+}
+
+func (tt *testTransformer) TransformFromStorage(ctx context.Context, data []byte, dataCtx value.Context) (out []byte, stale bool, err error) {
+	if tt.fail.Load() {
+		return nil, false, errors.New("synthetic error")
+	}
+	return tt.Transformer.TransformFromStorage(ctx, data, dataCtx)
+}
+
+type testCodec struct {
+	runtime.Codec
+	fail atomic.Bool
+}
+
+func (tc *testCodec) setFailing(c bool) {
+	tc.fail.Store(c)
+}
+
+func (tc *testCodec) Decode(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	if tc.fail.Load() {
+		return nil, nil, errors.New("synthetic error")
+	}
+	return tc.Codec.Decode(data, defaults, into)
+}
+
+func TestDeleteWithConflictAndMissingExpectedTransformOrDecodeError(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
+
+	transformer := &testTransformer{Transformer: identity.NewEncryptCheckTransformer()}
+	ctx, s, _ := testSetup(t, withTransformer(transformer))
+
+	storagetesting.RunTestDeleteWithConflictAndMissingExpectedTransformOrDecodeError(ctx, t, s, transformer.setFailing)
+}
+
+func TestDeleteWithConflictAndExpectedTransformError(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
+
+	transformer := &testTransformer{Transformer: identity.NewEncryptCheckTransformer()}
+	ctx, cacher, terminate := testSetup(t, withTransformer(transformer))
+	t.Cleanup(terminate)
+
+	storagetesting.RunTestDeleteExpectedTransformOrDecodeError(ctx, t, cacher, transformer.setFailing)
+}
+
+func TestDeleteWithConflictAndExpectedDecodeError(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
+
+	// Decode errors cause a panic when they occur during tests. Disable for this particular
+	// test since it is deliberately exercising a case where the stored bytes cannot be decoded.
+	etcd3.TestOnlySetFatalOnDecodeError(t, false)
+
+	codec := &testCodec{Codec: apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)}
+	ctx, cacher, terminate := testSetup(t, withCodec(codec))
+	t.Cleanup(terminate)
+
+	storagetesting.RunTestDeleteExpectedTransformOrDecodeError(ctx, t, cacher, codec.setFailing)
+}
+
+func TestDeleteWithSuggestionAndMissingExpectedTransformOrDecodeError(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
+
+	ctx, cacher, terminate := testSetup(t)
+	t.Cleanup(terminate)
+	storagetesting.RunTestDeleteWithSuggestionAndMissingExpectedTransformOrDecodeError(ctx, t, cacher)
 }
 
 func TestPreconditionalDeleteWithSuggestion(t *testing.T) {
@@ -493,6 +571,7 @@ type setupOptions struct {
 	indexers       cache.Indexers
 	clock          clock.WithTicker
 	codec          runtime.Codec
+	transformer    value.Transformer
 }
 
 type setupOption func(*setupOptions)
@@ -504,6 +583,7 @@ func withDefaults(options *setupOptions) {
 	options.keyFunc = func(obj runtime.Object) (string, error) { return storage.NamespaceKeyFunc(prefix, obj) }
 	options.clock = clock.RealClock{}
 	options.codec = examplev1ProtoCodec
+	options.transformer = identity.NewEncryptCheckTransformer()
 }
 
 func withClusterScopedKeyFunc(options *setupOptions) {
@@ -535,6 +615,18 @@ func withNodeNameAndNamespaceIndex(options *setupOptions) {
 	}
 }
 
+func withCodec(codec runtime.Codec) setupOption {
+	return func(options *setupOptions) {
+		options.codec = codec
+	}
+}
+
+func withTransformer(transformer value.Transformer) setupOption {
+	return func(options *setupOptions) {
+		options.transformer = transformer
+	}
+}
+
 func testSetup(t *testing.T, opts ...setupOption) (context.Context, *CacheDelegator, tearDownFunc) {
 	ctx, cacher, _, tearDown := testSetupWithEtcdServer(t, opts...)
 	return ctx, cacher, tearDown
@@ -547,7 +639,7 @@ func testSetupWithEtcdServer(t testing.TB, opts ...setupOption) (context.Context
 		opt(&setupOpts)
 	}
 
-	server, etcdStorage := newEtcdTestStorageWithCodec(t, etcd3testing.PathPrefix(), setupOpts.codec)
+	server, etcdStorage := newEtcdTestStorageWithOptions(t, etcd3testing.PathPrefix(), setupOpts.codec, setupOpts.transformer)
 	// Inject one list error to make sure we test the relist case.
 	listErrors := 1
 	if clientfeatures.FeatureGates().Enabled(clientfeatures.WatchListClient) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -41,6 +41,7 @@ import (
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
+	"k8s.io/apiserver/pkg/storage/value"
 	"k8s.io/apiserver/pkg/storage/value/encrypt/identity"
 	"k8s.io/utils/clock"
 )
@@ -77,6 +78,10 @@ func newEtcdTestStorage(t testing.TB, prefix string) (*etcd3testing.EtcdTestServ
 }
 
 func newEtcdTestStorageWithCodec(t testing.TB, prefix string, codec runtime.Codec) (*etcd3testing.EtcdTestServer, storage.Interface) {
+	return newEtcdTestStorageWithOptions(t, prefix, codec, identity.NewEncryptCheckTransformer())
+}
+
+func newEtcdTestStorageWithOptions(t testing.TB, prefix string, codec runtime.Codec, transformer value.Transformer) (*etcd3testing.EtcdTestServer, storage.Interface) {
 	server, _ := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	versioner := storage.APIObjectVersioner{}
 	compactor := etcd3.NewCompactor(server.V3Client.Client, 0, clock.RealClock{}, nil)
@@ -90,7 +95,7 @@ func newEtcdTestStorageWithCodec(t testing.TB, prefix string, codec runtime.Code
 		prefix,
 		"/pods/",
 		schema.GroupResource{Resource: "pods"},
-		identity.NewEncryptCheckTransformer(),
+		transformer,
 		etcd3.NewDefaultLeaseManagerConfig(),
 		etcd3.NewDefaultDecoder(codec, versioner),
 		versioner)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -346,22 +346,22 @@ func (s *store) Delete(
 		return fmt.Errorf("unable to convert output object to pointer: %v", err)
 	}
 
-	skipTransformDecode := false
+	expectTransformOrDecodeError := false
 	if utilfeature.DefaultFeatureGate.Enabled(features.AllowUnsafeMalformedObjectDeletion) {
-		skipTransformDecode = opts.IgnoreStoreReadError
+		expectTransformOrDecodeError = opts.ExpectTransformOrDecodeError
 	}
-	return s.conditionalDelete(ctx, preparedKey, out, v, preconditions, validateDeletion, cachedExistingObject, skipTransformDecode)
+	return s.conditionalDelete(ctx, preparedKey, out, v, preconditions, validateDeletion, cachedExistingObject, expectTransformOrDecodeError)
 }
 
 func (s *store) conditionalDelete(
 	ctx context.Context, key string, out runtime.Object, v reflect.Value, preconditions *storage.Preconditions,
-	validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, skipTransformDecode bool) error {
-	getCurrentState := s.getCurrentState(ctx, key, v, false, skipTransformDecode)
+	validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, expectTransformOrDecodeError bool) error {
+	getCurrentState := s.getCurrentState(ctx, key, v, false, expectTransformOrDecodeError)
 
 	var origState *objState
 	var err error
 	var origStateIsCurrent bool
-	if cachedExistingObject != nil {
+	if cachedExistingObject != nil && !expectTransformOrDecodeError {
 		origState, err = s.getStateFromObject(cachedExistingObject)
 	} else {
 		origState, err = getCurrentState()
@@ -435,7 +435,7 @@ func (s *store) conditionalDelete(
 		}
 		if !txnResp.Succeeded {
 			klog.V(4).Infof("deletion of %s failed because of a conflict, going to retry", key)
-			origState, err = s.getState(ctx, txnResp.KV, key, v, false, skipTransformDecode)
+			origState, err = s.getState(ctx, txnResp.KV, key, v, false, expectTransformOrDecodeError)
 			if err != nil {
 				return err
 			}
@@ -443,7 +443,7 @@ func (s *store) conditionalDelete(
 			continue
 		}
 
-		if !skipTransformDecode {
+		if !expectTransformOrDecodeError {
 			err = s.decoder.Decode(origState.data, out, txnResp.Revision)
 			if err != nil {
 				recordDecodeError(s.groupResource, key)
@@ -475,8 +475,7 @@ func (s *store) GuaranteedUpdate(
 		return fmt.Errorf("unable to convert output object to pointer: %v", err)
 	}
 
-	skipTransformDecode := false
-	getCurrentState := s.getCurrentState(ctx, preparedKey, v, ignoreNotFound, skipTransformDecode)
+	getCurrentState := s.getCurrentState(ctx, preparedKey, v, ignoreNotFound, false)
 
 	var origState *objState
 	var origStateIsCurrent bool
@@ -602,7 +601,7 @@ func (s *store) GuaranteedUpdate(
 		span.AddEvent("Transaction committed")
 		if !txnResp.Succeeded {
 			klog.V(4).Infof("GuaranteedUpdate of %s failed because of a conflict, going to retry", preparedKey)
-			origState, err = s.getState(ctx, txnResp.KV, preparedKey, v, ignoreNotFound, skipTransformDecode)
+			origState, err = s.getState(ctx, txnResp.KV, preparedKey, v, ignoreNotFound, false)
 			if err != nil {
 				return err
 			}
@@ -986,7 +985,7 @@ func (s *store) watchContext(ctx context.Context) context.Context {
 	return clientv3.WithRequireLeader(ctx)
 }
 
-func (s *store) getCurrentState(ctx context.Context, key string, v reflect.Value, ignoreNotFound bool, skipTransformDecode bool) func() (*objState, error) {
+func (s *store) getCurrentState(ctx context.Context, key string, v reflect.Value, ignoreNotFound bool, expectTransformOrDecodeError bool) func() (*objState, error) {
 	return func() (*objState, error) {
 		startTime := time.Now()
 		getResp, err := s.client.Kubernetes.Get(ctx, key, kubernetes.GetOptions{})
@@ -994,17 +993,15 @@ func (s *store) getCurrentState(ctx context.Context, key string, v reflect.Value
 		if err != nil {
 			return nil, err
 		}
-		return s.getState(ctx, getResp.KV, key, v, ignoreNotFound, skipTransformDecode)
+		return s.getState(ctx, getResp.KV, key, v, ignoreNotFound, expectTransformOrDecodeError)
 	}
 }
 
-// getState constructs a new objState from the given response from the storage.
-// skipTransformDecode: if true, the function will neither transform the data
-// from the storage nor decode it into an object; otherwise, data from the
-// storage will be transformed and decoded.
-// NOTE: when skipTransformDecode is true, the 'data', and the 'obj' fields
-// of the objState will be nil, and 'stale' will be set to true.
-func (s *store) getState(ctx context.Context, kv *mvccpb.KeyValue, key string, v reflect.Value, ignoreNotFound bool, skipTransformDecode bool) (*objState, error) {
+// getState constructs a new objState from the given response from the storage. If
+// expectTransformOrDecodeError is true and neither transformation nor decode fails, returns an
+// InvalidObj error; if either fails, the returned error and the 'obj' field of the returned
+// objState will both be nil.
+func (s *store) getState(ctx context.Context, kv *mvccpb.KeyValue, key string, v reflect.Value, ignoreNotFound bool, expectTransformOrDecodeError bool) (*objState, error) {
 	state := &objState{
 		meta: &storage.ResponseMeta{},
 	}
@@ -1022,30 +1019,42 @@ func (s *store) getState(ctx context.Context, kv *mvccpb.KeyValue, key string, v
 		if err := runtime.SetZeroValue(state.obj); err != nil {
 			return nil, err
 		}
-	} else {
-		state.rev = kv.ModRevision
-		state.meta.ResourceVersion = uint64(state.rev)
+		return state, nil
+	}
 
-		if skipTransformDecode {
-			// be explicit that we don't have the object
-			state.obj = nil
-			state.stale = true // this seems a more sane value here
-			return state, nil
-		}
+	state.rev = kv.ModRevision
+	state.meta.ResourceVersion = uint64(state.rev)
 
-		data, stale, err := s.transformer.TransformFromStorage(ctx, kv.Value, authenticatedDataString(key))
-		if err != nil {
+	data, stale, err := s.transformer.TransformFromStorage(ctx, kv.Value, authenticatedDataString(key))
+	if err != nil {
+		if !expectTransformOrDecodeError {
 			return nil, storage.NewInternalError(err)
 		}
 
-		state.data = data
-		state.stale = stale
+		// be explicit that we don't have the object
+		state.obj = nil
+		state.stale = true // this seems a more sane value here
+		return state, nil
+	}
 
-		if err := s.decoder.Decode(state.data, state.obj, state.rev); err != nil {
+	state.data = data
+	state.stale = stale
+
+	if err := s.decoder.Decode(state.data, state.obj, state.rev); err != nil {
+		if !expectTransformOrDecodeError {
 			recordDecodeError(s.groupResource, key)
 			return nil, err
 		}
+
+		// be explicit that we don't have the object
+		state.obj = nil
+		return state, nil
 	}
+
+	if expectTransformOrDecodeError {
+		return nil, storage.NewInvalidObjError(key, "unsafe deletion is not allowed because the object is decodable from storage")
+	}
+
 	return state, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -19,11 +19,13 @@ package etcd3
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -158,6 +160,72 @@ func TestValidateDeletionWithOnlySuggestionValid(t *testing.T) {
 func TestDeleteWithConflict(t *testing.T) {
 	ctx, store, _ := testSetup(t)
 	storagetesting.RunTestDeleteWithConflict(ctx, t, store)
+}
+
+type testTransformer struct {
+	value.Transformer
+	fail atomic.Bool
+}
+
+func (tt *testTransformer) setFailing(c bool) {
+	tt.fail.Store(c)
+}
+
+func (tt *testTransformer) TransformFromStorage(ctx context.Context, data []byte, dataCtx value.Context) (out []byte, stale bool, err error) {
+	if tt.fail.Load() {
+		return nil, false, errors.New("synthetic error")
+	}
+	return tt.Transformer.TransformFromStorage(ctx, data, dataCtx)
+}
+
+type testCodec struct {
+	runtime.Codec
+	fail atomic.Bool
+}
+
+func (tc *testCodec) setFailing(c bool) {
+	tc.fail.Store(c)
+}
+
+func (tc *testCodec) Decode(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	if tc.fail.Load() {
+		return nil, nil, errors.New("synthetic error")
+	}
+	return tc.Codec.Decode(data, defaults, into)
+}
+
+func TestDeleteWithConflictAndMissingExpectedTransformOrDecodeError(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
+
+	codec := &testCodec{Codec: apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)}
+	ctx, s, _ := testSetup(t, withCodec(codec))
+
+	storagetesting.RunTestDeleteWithConflictAndMissingExpectedTransformOrDecodeError(ctx, t, s, codec.setFailing)
+}
+
+func TestDeleteWithConflictAndExpectedTransformError(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
+
+	transformer := &testTransformer{Transformer: newTestTransformer()}
+	ctx, s, _ := testSetup(t, withTransformer(transformer))
+
+	storagetesting.RunTestDeleteExpectedTransformOrDecodeError(ctx, t, s, transformer.setFailing)
+}
+
+func TestDeleteWithConflictAndExpectedDecodeError(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
+
+	codec := &testCodec{Codec: apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)}
+	ctx, s, _ := testSetup(t, withCodec(codec))
+
+	storagetesting.RunTestDeleteExpectedTransformOrDecodeError(ctx, t, s, codec.setFailing)
+}
+
+func TestDeleteWithSuggestionAndMissingExpectedTransformOrDecodeFailure(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
+
+	ctx, store, _ := testSetup(t)
+	storagetesting.RunTestDeleteWithSuggestionAndMissingExpectedTransformOrDecodeError(ctx, t, store)
 }
 
 func TestPreconditionalDeleteWithSuggestion(t *testing.T) {
@@ -609,6 +677,18 @@ func withResourcePrefix(prefix string) setupOption {
 func withLeaseConfig(leaseConfig LeaseManagerConfig) setupOption {
 	return func(options *setupOptions) {
 		options.leaseConfig = leaseConfig
+	}
+}
+
+func withTransformer(transformer value.Transformer) setupOption {
+	return func(options *setupOptions) {
+		options.transformer = transformer
+	}
+}
+
+func withCodec(codec runtime.Codec) setupOption {
+	return func(options *setupOptions) {
+		options.codec = codec
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -65,12 +65,23 @@ var fatalOnDecodeError atomic.Bool
 func init() {
 	// check to see if we are running in a test environment
 	b, _ := strconv.ParseBool(os.Getenv("KUBE_PANIC_WATCH_DECODE_ERROR"))
-	TestOnlySetFatalOnDecodeError(b)
+	fatalOnDecodeError.Store(b)
+}
+
+// TestingTB is the subset of testing.TB required by TestOnlySetFatalOnDecodeError. Avoids importing
+// the testing package.
+type TestingTB interface {
+	Helper()
+	Cleanup(func())
 }
 
 // TestOnlySetFatalOnDecodeError should only be used for cases where decode errors are expected and need to be tested. e.g. conversion webhooks.
-func TestOnlySetFatalOnDecodeError(b bool) {
-	fatalOnDecodeError.Store(b)
+func TestOnlySetFatalOnDecodeError(tb TestingTB, b bool) {
+	tb.Helper()
+	old := fatalOnDecodeError.Swap(b)
+	tb.Cleanup(func() {
+		fatalOnDecodeError.Store(old)
+	})
 }
 
 type watcher struct {

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -334,13 +334,12 @@ type ListOptions struct {
 
 // DeleteOptions provides the options that may be provided for storage delete operations.
 type DeleteOptions struct {
-	// IgnoreStoreReadError, if enabled, will ignore store read error
-	// such as transformation or decode failure and go ahead with the
-	// deletion of the object.
+	// ExpectTransformOrDecodeError, if enabled, will return an error if the object can be
+	// transformed and decoded.
 	// NOTE: for normal deletion flow it should always be false, it may be
 	// enabled by the caller only to facilitate unsafe deletion of corrupt
 	// object which otherwise can not be deleted using the normal flow
-	IgnoreStoreReadError bool
+	ExpectTransformOrDecodeError bool
 }
 
 func ValidateListOptions(keyPrefix string, versioner Versioner, opts ListOptions) (withRev int64, continueKey string, err error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -2265,6 +2265,87 @@ func ExpectContinueMatches(t *testing.T, expect, got string) {
 	t.Errorf("expected continue token: %s, got: %s", expectDecoded, gotDecoded)
 }
 
+// RunTestDeleteWithConflictAndMissingExpectedTransformOrDecodeError verifies that, when
+// ExpectTransformOrDecodeError is true, the delete will fail if a concurrent write makes it
+// possible to decode the object.
+func RunTestDeleteWithConflictAndMissingExpectedTransformOrDecodeError(ctx context.Context, t testing.TB, store storage.Interface, setFailing func(bool)) {
+	obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test-ns"}}
+	key := computePodKey(obj)
+	out := &example.Pod{}
+	if err := store.Create(ctx, key, obj, out, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// During validation (immediately before executing the optimistic delete transaction),
+	// simulate a concurrent update that both increases the current revision and allows the next
+	// TransformFromStorage/Decode to succeed.
+	validateCount := 0
+	injectUpdate := func(_ context.Context, _ runtime.Object) error {
+		validateCount++
+		if validateCount > 1 {
+			return nil
+		}
+
+		setFailing(false)
+
+		return store.GuaranteedUpdate(ctx, key, &example.Pod{}, false, nil,
+			storage.SimpleUpdate(func(obj runtime.Object) (runtime.Object, error) {
+				pod := obj.(*example.Pod)
+				pod.Labels = map[string]string{"updated": "true"}
+				return pod, nil
+			}), nil)
+	}
+
+	// Initially, TransformFromStorage or Decode should fail.
+	setFailing(true)
+
+	err := store.Delete(ctx, key, &example.Pod{}, nil, injectUpdate, nil,
+		storage.DeleteOptions{ExpectTransformOrDecodeError: true})
+	if !storage.IsInvalidObj(err) {
+		t.Fatalf("Expected Delete to return an 'Invalid Object' error: %v", err)
+	}
+}
+
+// RunTestDeleteExpectedTransformOrDecodeError tests that an object that cannot be transformed or
+// decoded from storage can be deleted using the ExpectTransformOrDecodeError option.
+func RunTestDeleteExpectedTransformOrDecodeError(ctx context.Context, t testing.TB, store storage.Interface, setFailing func(bool)) {
+	obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test-ns"}}
+	key := computePodKey(obj)
+	out := &example.Pod{}
+	if err := store.Create(ctx, key, obj, out, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	setFailing(true)
+	err := store.Delete(ctx, key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, nil,
+		storage.DeleteOptions{ExpectTransformOrDecodeError: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Get(ctx, key, storage.GetOptions{}, &example.Pod{}); !storage.IsNotFound(err) {
+		t.Errorf("Unexpected error on reading object: %v", err)
+	}
+}
+
+// RunTestDeleteWithSuggestionAndMissingExpectedTransformOrDecodeError verifies that, when
+// ExpectTransformOrDecodeError is true, passing a suggested object does not bypass transformation
+// or decoding of the serialized object in storage.
+func RunTestDeleteWithSuggestionAndMissingExpectedTransformOrDecodeError(ctx context.Context, t testing.TB, store storage.Interface) {
+	obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test-ns"}}
+	key := computePodKey(obj)
+	out := &example.Pod{}
+	if err := store.Create(ctx, key, obj, out, 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	err := store.Delete(ctx, key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, out,
+		storage.DeleteOptions{ExpectTransformOrDecodeError: true})
+	if !storage.IsInvalidObj(err) {
+		t.Fatalf("Expected Delete to return an 'Invalid Object' error: %v", err)
+	}
+}
+
 func RunTestConsistentList(ctx context.Context, t *testing.T, store storage.Interface, increaseRV IncreaseRVFunc, cacheEnabled, consistentReadsSupported, listFromCacheSnapshot bool) {
 	outPod := &example.Pod{}
 	inPod := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "foo"}}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -446,7 +446,7 @@ func RunTestWatchWithUnsafeDelete(ctx context.Context, t *testing.T, store Inter
 	if err := store.Delete(ctx, key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, nil, storage.DeleteOptions{}); err == nil {
 		t.Fatalf("Expected normal Delete to fail")
 	}
-	if err := store.Delete(ctx, key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, nil, storage.DeleteOptions{IgnoreStoreReadError: true}); err != nil {
+	if err := store.Delete(ctx, key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, nil, storage.DeleteOptions{ExpectTransformOrDecodeError: true}); err != nil {
 		t.Fatalf("Expected unsafe Delete to succeed, but got: %v", err)
 	}
 

--- a/test/integration/storageversionmigrator/storageversionmigrator_test.go
+++ b/test/integration/storageversionmigrator/storageversionmigrator_test.go
@@ -158,8 +158,7 @@ func TestStorageVersionMigrationWithCRD(t *testing.T) {
 		extensionfeatures.CRDObservedGenerationTracking:                  true,
 	})
 	// decode errors are expected when using conversation webhooks
-	etcd3watcher.TestOnlySetFatalOnDecodeError(false)
-	t.Cleanup(func() { etcd3watcher.TestOnlySetFatalOnDecodeError(true) })
+	etcd3watcher.TestOnlySetFatalOnDecodeError(t, false)
 	framework.GoleakCheck(t, // block test clean up and let any lingering watches complete before making decode errors fatal again
 		goleak.IgnoreTopFunction("k8s.io/kubernetes/vendor/gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This addresses an edge case that could have allowed admission and finalizers to be bypassed using the corrupt object deletion mechanism.

The original option (IgnoreStoreReadError) would skip transform/decode entirely, relying on the caller to ensure that the stored object is corrupt at the time of deletion. The new implementation (ExpectTransformOrDecodeError) always attempts to transform and decode, and only proceeds with the delete if that attempt fails. If the object turns out to be successfully decodable (e.g., a concurrent write fixed the corruption), the delete is rejected with an InvalidObj error.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

KEP: https://github.com/kubernetes/enhancements/issues/3926

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removed an edge case that could allow malformed object deletion to bypass admission and graceful deletion of well-formed objects.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
