### PR TITLE
fix uncore cache alignment with odd integer CPUs when SMT enabled

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -568,7 +568,7 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 
 	// determine the N number of free cores (physical cpus) within the UncoreCache, then
 	// determine the M number of free cpus (virtual cpus) that correspond with the free cores
-	freeCores := a.details.CoresNeededInUncoreCache(numCoresNeeded, uncoreID)
+	freeCores := a.details.CoresNeededInUncoreCache(numCoresNeeded, a.topo.CPUsPerCore(), uncoreID)
 	freeCPUs := a.details.CPUsInCores(freeCores.UnsortedList()...)
 
 	// when SMT/hyperthread is enabled and remaining cpu requirement is an odd integer value:

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -571,19 +571,19 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 	freeCores := a.details.CoresNeededInUncoreCache(numCoresNeeded, a.topo.CPUsPerCore(), uncoreID)
 	freeCPUs := a.details.CPUsInCores(freeCores.UnsortedList()...)
 
-	// when SMT/hyperthread is enabled and remaining cpu requirement is an odd integer value:
+	// when SMT/hyperthread is enabled and remaining cpu requirement is not a multiple of CPUsPerCore:
 	// sort the free CPUs that were determined based on the cores that have available cpus.
-	// if the amount of free cpus is greather than the cpus needed, we can drop the last cpu
-	// since the odd integer request will only require one out of the two free cpus that
+	// if the amount of free cpus is greater than the cpus needed, we can trim to the exact
+	// number needed since the request will only require some (not all) of the free cpus that
 	// correspond to the last core
-	if a.numCPUsNeeded%2 != 0 && a.topo.CPUsPerCore() > 1 {
+	if a.numCPUsNeeded%a.topo.CPUsPerCore() != 0 && a.topo.CPUsPerCore() > 1 {
 		// we sort freeCPUs to ensure we pack virtual cpu allocations, meaning we allocate
 		// whole core's worth of cpus as much as possible to reduce smt-misalignment
 		sortFreeCPUs := freeCPUs.List()
 		if len(sortFreeCPUs) > a.numCPUsNeeded {
 			// if we are in takePartialUncore, the accumulator is not satisfied after
-			// takeFullUncore, so freeCPUs.Size() can't be < 1
-			sortFreeCPUs = sortFreeCPUs[:freeCPUs.Size()-1]
+			// takeFullUncore, so freeCPUs.Size() can't be < numCPUsNeeded
+			sortFreeCPUs = sortFreeCPUs[:a.numCPUsNeeded]
 		}
 		freeCPUs = cpuset.New(sortFreeCPUs...)
 	}

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -1856,7 +1856,7 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 				"with-single-container",
 			),
 			expCPUAlloc: true,
-			expCSet:     cpuset.New(2, 65, 66),
+			expCSet:     cpuset.New(2, 3, 66),
 		},
 		{
 			// even integer requested on smt-enabled processor with odd integer available cpus on uncore
@@ -1880,7 +1880,7 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 				"with-single-container",
 			),
 			expCPUAlloc: true,
-			expCSet:     cpuset.New(4, 5, 68, 69),
+			expCSet:     cpuset.New(2, 3, 66, 67),
 		},
 		{
 			// large odd integer cpu required on smt-enabled
@@ -1903,7 +1903,84 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 				"with-single-container",
 			),
 			expCPUAlloc: true,
-			expCSet:     cpuset.New(2, 65, 66, 4, 5, 6, 7, 68, 69, 70, 71), // full uncore 1 and partial uncore 0
+			expCSet:     cpuset.New(2, 3, 66, 4, 5, 6, 7, 68, 69, 70, 71), // partial uncore 0 and full uncore 1
+		},
+		{
+			// avoid SMT misalignment and align to uncore cache
+			description:     "avoid SMT misalignment and align to uncore cache",
+			topo:            topoUncoreSingleSocketSMT, // 8 cpus per uncore
+			numReservedCPUs: 6,
+			reserved:        cpuset.New(0, 1, 2, 8, 9, 10), // first 6 cpus taken from uncore 0
+			cpuPolicyOptions: map[string]string{
+				PreferAlignByUnCoreCacheOption: "true",
+			},
+			stAssignments: state.ContainerCPUAssignments{},
+			stDefaultCPUSet: topoUncoreSingleSocketSMT.CPUDetails.CPUs().Difference(
+				cpuset.New(4, 6),
+			),
+			pod: WithPodUID(
+				makeMultiContainerPod(
+					[]struct{ request, limit string }{}, // init container
+					[]struct{ request, limit string }{ // app container
+						{"4000m", "4000m"},
+					},
+				),
+				"with-single-container",
+			),
+			expCPUAlloc: true,
+			expCSet:     cpuset.New(5, 13, 7, 15), // avoids SMT misalignment
+		},
+		{
+			// unable to avoid SMT misalignment of odd-integer cpu container and defaults to packed allocation
+			description:     "unable to avoid SMT misalignment of odd-integer cpu container and defaults to packed allocation",
+			topo:            topoUncoreSingleSocketSMT, // 8 cpus per uncore
+			numReservedCPUs: 6,
+			reserved:        cpuset.New(0, 1, 2, 8, 9, 10), // first 6 cpus taken from uncore 0
+			cpuPolicyOptions: map[string]string{
+				PreferAlignByUnCoreCacheOption: "true",
+			},
+			stAssignments: state.ContainerCPUAssignments{},
+			stDefaultCPUSet: topoUncoreSingleSocketSMT.CPUDetails.CPUs().Difference(
+				cpuset.New(4, 6, 13),
+			),
+			pod: WithPodUID(
+				makeMultiContainerPod(
+					[]struct{ request, limit string }{}, // init container
+					[]struct{ request, limit string }{ // app container
+						{"3000m", "3000m"},
+					},
+				),
+				"with-single-container",
+			),
+			expCPUAlloc: true,
+			// uncore cache alignment is not forced at the cost of SMT misalignment
+			// prefer-align-cpus-by-uncore-cache will fall back to default packed allocation
+			expCSet: cpuset.New(3, 11, 12),
+		},
+		{
+			// unable to avoid SMT misalignment of even-integer cpu container and defaults to packed allocation
+			description:     "unable to avoid SMT misalignment of even-integer cpu container and defaults to packed allocation",
+			topo:            topoUncoreSingleSocketSMT, // 8 cpus per uncore
+			numReservedCPUs: 6,
+			reserved:        cpuset.New(0, 1, 2, 8, 9, 10), // first 6 cpus taken from uncore 0
+			cpuPolicyOptions: map[string]string{
+				PreferAlignByUnCoreCacheOption: "true",
+			},
+			stAssignments: state.ContainerCPUAssignments{},
+			stDefaultCPUSet: topoUncoreSingleSocketSMT.CPUDetails.CPUs().Difference(
+				cpuset.New(4, 6, 13),
+			),
+			pod: WithPodUID(
+				makeMultiContainerPod(
+					[]struct{ request, limit string }{}, // init container
+					[]struct{ request, limit string }{ // app container
+						{"4000m", "4000m"},
+					},
+				),
+				"with-single-container",
+			),
+			expCPUAlloc: true,
+			expCSet:     cpuset.New(3, 7, 11, 15), // default static policy will call takeFullCores to avoid SMT misalignment
 		},
 		{
 			// odd integer cpu required on hyperthread-enabled and monolithic uncore cache
@@ -1915,7 +1992,7 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 				PreferAlignByUnCoreCacheOption: "true",
 			},
 			stAssignments:   state.ContainerCPUAssignments{},
-			stDefaultCPUSet: topoSingleSocketSingleNumaPerSocketSMTSmallUncore.CPUDetails.CPUs(),
+			stDefaultCPUSet: topoDualSocketSubNumaPerSocketHTMonolithicUncore.CPUDetails.CPUs(),
 			pod: WithPodUID(
 				makeMultiContainerPod(
 					[]struct{ request, limit string }{}, // init container
@@ -1926,7 +2003,7 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 				"with-single-container",
 			),
 			expCPUAlloc: true,
-			expCSet:     cpuset.New(2, 3, 121, 122, 123),
+			expCSet:     cpuset.New(2, 3, 4, 122, 123),
 		},
 		{
 			// even integer cpu required on hyperthread-enabled and monolithic uncore cache
@@ -1938,7 +2015,7 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 				PreferAlignByUnCoreCacheOption: "true",
 			},
 			stAssignments:   state.ContainerCPUAssignments{},
-			stDefaultCPUSet: topoSingleSocketSingleNumaPerSocketSMTSmallUncore.CPUDetails.CPUs(),
+			stDefaultCPUSet: topoDualSocketSubNumaPerSocketHTMonolithicUncore.CPUDetails.CPUs(),
 			pod: WithPodUID(
 				makeMultiContainerPod(
 					[]struct{ request, limit string }{}, // init container

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -2110,6 +2110,11 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 					t.Errorf("StaticPolicy Allocate() error (%v). expected CPUSet %v but got %v",
 						testCase.description, testCase.expCSet, cset)
 				}
+				// Verify SMT alignment
+				if err := verifySMTAlignment(cset, testCase.topo); err != nil {
+					t.Errorf("StaticPolicy Allocate() error (%v). SMT misalignment: %v",
+						testCase.description, err)
+				}
 				return
 			}
 
@@ -3016,6 +3021,43 @@ func TestValidatePodScopeResources(t *testing.T) {
 func newCPUSetPtr(cpus ...int) *cpuset.CPUSet {
 	ret := cpuset.New(cpus...)
 	return &ret
+}
+
+// verifySMTAlignment checks that a cpuset has no SMT/hyperthreading misalignment.
+// When SMT is enabled (CPUsPerCore > 1), the allocation should prefer whole cores.
+// Returns an error if there is more than one partially-allocated core,
+// or if the partial allocation is unnecessary given the request size.
+func verifySMTAlignment(cset cpuset.CPUSet, topo *topology.CPUTopology) error {
+	cpusPerCore := topo.CPUsPerCore()
+	if cpusPerCore == 1 {
+		// SMT disabled, no alignment concerns
+		return nil
+	}
+
+	coreIDs := topo.CPUDetails.KeepOnly(cset).Cores()
+	partialCores := 0
+	for _, coreID := range coreIDs.List() {
+		// Get all CPUs that belong to this core and check how many are allocated
+		cpusInCore := topo.CPUDetails.CPUsInCores(coreID)
+		allocatedFromCore := cpusInCore.Intersection(cset)
+		if allocatedFromCore.Size() != cpusPerCore {
+			partialCores++
+		}
+	}
+
+	// We should have at most one partial core (when request is not divisible by CPUsPerCore)
+	if partialCores > 1 {
+		return fmt.Errorf("SMT misalignment detected: %d partial cores (expected at most 1)",
+			partialCores)
+	}
+
+	// If we have a partial core, verify it's necessary
+	if partialCores == 1 && cset.Size()%cpusPerCore == 0 {
+		return fmt.Errorf("SMT misalignment: partial core present but request size %d is divisible by CPUsPerCore %d",
+			cset.Size(), cpusPerCore)
+	}
+
+	return nil
 }
 
 func getPodUncoreCacheIDs(s state.Reader, topo *topology.CPUTopology, pod *v1.Pod) ([]int, error) {

--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -167,24 +167,25 @@ func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, cpusPerCore int
 // If SMT/hyperthreading is enabled, only fully available cores are returned
 // to prevent any possible SMT/hyperthreading misalignment
 func (d CPUDetails) coresInUncoreCache(cpusPerCore int, ids ...int) cpuset.CPUSet {
-	var coreIDs []int
-	for _, id := range ids {
-		for _, info := range d {
-			if info.UncoreCacheID == id {
-				if cpusPerCore == 1 {
-					// SMT/hyperthreading disabled case, return the available cores
-					coreIDs = append(coreIDs, info.CoreID)
-				} else {
-					// SMT/hyperthreading enabled case, return only the cores that have all their cpus available
-					cpusInCore := d.CPUsInCores(info.CoreID)
-					if cpusInCore.Size() == cpusPerCore {
-						coreIDs = append(coreIDs, info.CoreID)
-					}
-				}
-			}
+	// Get all CPUs in the requested uncore caches using existing helper
+	cpusInUncore := d.CPUsInUncoreCaches(ids...)
+
+	// Get unique cores from those CPUs
+	coresInUncore := d.KeepOnly(cpusInUncore).Cores()
+
+	if cpusPerCore == 1 {
+		// SMT/hyperthreading disabled case, return all cores
+		return coresInUncore
+	}
+
+	// return only cores that have all CPUs available when SMT/hyperthreading enabled
+	var fullCores []int
+	for _, coreID := range coresInUncore.List() {
+		if d.CPUsInCores(coreID).Size() == cpusPerCore {
+			fullCores = append(fullCores, coreID)
 		}
 	}
-	return cpuset.New(coreIDs...)
+	return cpuset.New(fullCores...)
 }
 
 // CPUsInUncoreCaches returns all the logical CPU IDs associated with the given

--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -154,8 +154,8 @@ func (d CPUDetails) UncoreInNUMANodes(ids ...int) cpuset.CPUSet {
 
 // CoresNeededInUncoreCache returns either the full list of all available unique core IDs associated with the given
 // UnCoreCache IDs in this CPUDetails or subset that matches the ask.
-func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpuset.CPUSet {
-	coreIDs := d.coresInUncoreCache(ids...)
+func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, cpusPerCore int, ids ...int) cpuset.CPUSet {
+	coreIDs := d.coresInUncoreCache(cpusPerCore, ids...)
 	if coreIDs.Size() <= numCoresNeeded {
 		return coreIDs
 	}
@@ -163,13 +163,24 @@ func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpu
 	return cpuset.New(tmpCoreIDs[:numCoresNeeded]...)
 }
 
-// Helper function that just gets the cores
-func (d CPUDetails) coresInUncoreCache(ids ...int) cpuset.CPUSet {
+// Helper function that gets the available cores based on the uncore cache ID.
+// If SMT/hyperthreading is enabled, only fully available cores are returned
+// to prevent any possible SMT/hyperthreading misalignment
+func (d CPUDetails) coresInUncoreCache(cpusPerCore int, ids ...int) cpuset.CPUSet {
 	var coreIDs []int
 	for _, id := range ids {
 		for _, info := range d {
 			if info.UncoreCacheID == id {
-				coreIDs = append(coreIDs, info.CoreID)
+				if cpusPerCore == 1 {
+					// SMT/hyperthreading disabled case, return the available cores
+					coreIDs = append(coreIDs, info.CoreID)
+				} else {
+					// SMT/hyperthreading enabled case, return only the cores that have all their cpus available
+					cpusInCore := d.CPUsInCores(info.CoreID)
+					if cpusInCore.Size() == cpusPerCore {
+						coreIDs = append(coreIDs, info.CoreID)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR addresses an edge case where uncore cache is possible on SMT/hyperthread enabled topologies, but the current implementation fails to recognize it. (See added test cases).
This PR also improves SMT alignment as the preference for `prefer-align-cpus-by-uncore-cache`

#### Which issue(s) this PR is related to:
Fixes #137315
KEP: https://github.com/kubernetes/enhancements/issues/4800
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improvements made to prefer-align-cpus-by-uncore-cache on SMT enabled systems
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: <https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4800-cpumanager-split-uncorecache/README.md>
```
