### PR TITLE
fix: resource.MustParse handles additional quantity formats

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
@@ -25,7 +25,7 @@ import (
 const (
 	// maxInt64Factors is the highest value that will be checked when removing factors of 10 from an int64.
 	// It is also the maximum decimal digits that can be represented with an int64.
-	maxInt64Factors = 18
+	maxInt64Factors = 19
 )
 
 var (

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -384,6 +384,12 @@ func TestQuantityParse(t *testing.T) {
 		{"0.05Gi", decQuantity(536870912, -1, BinarySI)},
 		{"0.025Ti", decQuantity(274877906944, -1, BinarySI)},
 
+		// Test parsing of MaxInt64
+		{strconv.FormatInt(math.MaxInt64, 10), intQuantity(math.MaxInt64, 0, DecimalSI)},
+
+		// Test parsing of MinInt64
+		{strconv.FormatInt(math.MinInt64, 10), intQuantity(math.MinInt64, 0, DecimalSI)},
+
 		// Things written by trolls
 		{"0.000000000001Ki", decQuantity(2, -9, DecimalSI)}, // rounds up, changes format
 		{".001", decQuantity(1, -3, DecimalSI)},


### PR DESCRIPTION
Fixes quantity parsing edge cases as described in #135487.