### PR TITLE
kubectl: only print default cotnainer if there are multi containers

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
@@ -78,7 +78,7 @@ func FindOrDefaultContainerByName(pod *v1.Pod, name string, quiet bool, warn io.
 
 	// fallback to pick the first container to maintain existing behavior
 	container := &pod.Spec.Containers[0]
-	if !quiet {
+	if !quiet && (len(pod.Spec.Containers) > 1 || len(pod.Spec.InitContainers) > 0 || len(pod.Spec.EphemeralContainers) > 0) {
 		fmt.Fprintf(warn, "Defaulted container %q out of: %s\n", container.Name, AllContainerNames(pod)) // nolint:errcheck
 	}
 	klog.V(4).Infof("Using the first container in a pod: %s", container.Name)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/137399/changes#diff-bb643003d7e8335c1645fb2db8cdc6e403dd514cfc948a5ecee36f34c760cb68R82


#### Which issue(s) this PR is related to:

Fixes #137532


#### Special notes for your reviewer:

/cc @neolit123 @soltysh @BenTheElder 

#### Does this PR introduce a user-facing change?

```release-note
None
```
