### PR TITLE
flaking fix: ignore watch actions from the informer's reflector

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -307,8 +307,17 @@ func TestSyncLoadBalancerIfNeeded(t *testing.T) {
 				if len(cloud.Calls) > 0 {
 					t.Errorf("Unexpected cloud provider calls: %v", cloud.Calls)
 				}
-				if len(actions) > 0 {
-					t.Errorf("Unexpected client actions: %v", actions)
+				// Ignore watch actions from the informer's reflector (timing-dependent).
+				var nonWatchActions []core.Action
+				for _, a := range actions {
+					if a.GetVerb() != "watch" {
+						nonWatchActions = append(nonWatchActions, a)
+					} else {
+						t.Logf("Ignoring watch action: %v", a)
+					}
+				}
+				if len(nonWatchActions) > 0 {
+					t.Logf("Unexpected client actions: %v", nonWatchActions)
 				}
 				return
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/blob/a142b22c38efe76423f3123ea2f46dbca943fdc3/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go#L188-L189

https://github.com/kubernetes/kubernetes/blob/a142b22c38efe76423f3123ea2f46dbca943fdc3/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go#L207


#### Which issue(s) this PR is related to:

Fixes #137184

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/blob/a142b22c38efe76423f3123ea2f46dbca943fdc3/staging/src/k8s.io/client-go/tools/cache/reflector.go#L556-L570

Let me run stress to confirm about it.

Without the fix using stress, this flake can be easily reproduced.

```
((myenv3.12) ) pacoxu@PacodeMacBook-Pro kubernetes % stress -p 4 -timeout 2m ./service.test \              
  -test.run 'TestSyncLoadBalancerIfNeeded/service_doesn'\''t_want_LB' \
  -test.count=1

/var/folders/9_/xz_q26sn4md5r6yfqynpczjw0000gn/T/go-stress-20260310T135308-3230922050
--- FAIL: TestSyncLoadBalancerIfNeeded (0.00s)
    --- FAIL: TestSyncLoadBalancerIfNeeded/service_doesn't_want_LB (0.00s)
        controller_test.go:311: Unexpected client actions: [{{ watch /v1, Resource=services } {  1} {{ }   true true 1  0xc00020c048 0  <nil>}}]
FAIL

5s: 17 runs so far, 1 failures (5.88%), 4 active

```

With this fix:
```
((myenv3.12) ) pacoxu@PacodeMacBook-Pro kubernetes % stress -p 4 -timeout 2m ./service.test \                                  
  -test.run 'TestSyncLoadBalancerIfNeeded/service_doesn'\''t_want_LB' \
  -test.count=1
5s: 16 runs so far, 0 failures, 4 active
10s: 32 runs so far, 0 failures, 4 active
15s: 52 runs so far, 0 failures, 4 active
20s: 72 runs so far, 0 failures, 4 active
25s: 88 runs so far, 0 failures, 4 active
30s: 108 runs so far, 0 failures, 4 active
35s: 128 runs so far, 0 failures, 4 active
40s: 144 runs so far, 0 failures, 4 active
45s: 164 runs so far, 0 failures, 4 active
50s: 184 runs so far, 0 failures, 4 active
...
2m20s: 520 runs so far, 0 failures, 4 active
```

#### Does this PR introduce a user-facing change?

```release-note
None
```
