### PR TITLE
Fix capitalization in hack README

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,20 +1,20 @@
-# Kubernetes hack GuideLines
+# Kubernetes hack Guidelines
 
 This document describes how you can use the scripts from [`hack`](.) directory 
 and gives a brief introduction and explanation of these scripts. 
 
 ## Overview
 
-The [`hack`](.) directory contains many scripts that ensure continuous development of kubernetes, 
+The [`hack`](.) directory contains many scripts that ensure continuous development of Kubernetes, 
 enhance the robustness of the code, improve development efficiency, etc. 
 The explanations and descriptions of these scripts are helpful for contributors. 
 For details, refer to the following guidelines.
 
 ## Key scripts
 
-* [`verify-all.sh`](verify-all.sh): This script is a vestigial redirection, Please do not add "real" logic. It is equivalent to `make verify`.
-* [`update-all.sh`](update-all.sh): This script is a vestigial redirection, Please do not add "real" logic. 
-The `true` target of this makerule is `hack/make-rules/update.sh`.It is equivalent to `make update`.
+* [`verify-all.sh`](verify-all.sh): This script is a vestigial redirection, please do not add "real" logic. It is equivalent to `make verify`.
+* [`update-all.sh`](update-all.sh): This script is a vestigial redirection, please do not add "real" logic. 
+The `true` target of this make rule is `hack/make-rules/update.sh`. It is equivalent to `make update`.
 
 ## Attention
 Note that all scripts must be run from the Kubernetes root directory. 


### PR DESCRIPTION
## Description

Fix capitalization issues in hack/README.md:

- "GuideLines" -> "Guidelines" (title case)
- "kubernetes" -> "Kubernetes" (proper capitalization)
- "Please" -> "please" (lowercase after comma)
- "makerule" -> "make rule" (two words)

Fixes #137519

## Type of PR

- Documentation fix