### PR TITLE
golangci-lint: disable newexpr hint

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -511,6 +511,10 @@ linters:
         # consistency with existing code
         # and it's just syntactic sugar.
         - any
+        # simplify code by using go1.26's new(expr)
+        # should only be updated in old code where it really matters (= always disable in base)
+        # and needs to remain disabled as hint until Go 1.26 is also available for backported code (https://github.com/kubernetes/kubernetes/issues/137595)
+        - newexpr
         # Suggest replacing omitempty with omitzero for struct fields.
         #
         # Disabled because might interfere

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -552,7 +552,8 @@ linters:
         # A useful hint for new code.
         - minmax
         # simplify code by using go1.26's new(expr)
-        # should only be updated in old code where it really matters.
+        # should only be updated in old code where it really matters (= always disable in base)
+        # and needs to remain disabled as hint until Go 1.26 is also available for backported code (https://github.com/kubernetes/kubernetes/issues/137595)
         - newexpr
         # use iterators instead of Len/At-style APIs
         # should only be updated in old code where it really matters.

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -306,9 +306,12 @@ linters:
         #
         # A useful hint for new code.
         - minmax
+        {{- end }}
         # simplify code by using go1.26's new(expr)
-        # should only be updated in old code where it really matters.
+        # should only be updated in old code where it really matters (= always disable in base)
+        # and needs to remain disabled as hint until Go 1.26 is also available for backported code (https://github.com/kubernetes/kubernetes/issues/137595)
         - newexpr
+        {{- if .Base }}
         # use iterators instead of Len/At-style APIs
         # should only be updated in old code where it really matters.
         - stditerators


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When updating master to Go 1.26, the hint in the modernize linter got enabled automatically. We want to be more conservative to avoid issues when new code needs to be backported. Currently older release branches do not have Go 1.26 yet.


#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/137595

#### Special notes for your reviewer:

See policy in https://github.com/kubernetes/community/pull/8897

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @dims
