### PR TITLE
apiextensions-apiserver: forbid CR create/apply while CRD is deleting

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -295,7 +295,7 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	terminating := apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Terminating)
+	terminating := !crd.DeletionTimestamp.IsZero() || apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Terminating)
 
 	crdInfo, err := r.getOrCreateServingInfoFor(crd.UID, crd.Name)
 	if apierrors.IsNotFound(err) {


### PR DESCRIPTION
#### What type of PR is this?
/kind flake


#### What this PR does / why we need it:
I can reproduce it using stress: https://gist.github.com/liggitt/6a3a2217fa5f846b52519acfc0ffece0.

```
15m20s: 363 runs so far, 1 failures (0.28%), 2 active

--- FAIL: TestApplyCRDuringCRDFinalization (3.94s)
    testserver.go:302: Resolved testserver package path to: "/Users/pacoxu/git/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing"
    testserver.go:186: runtime-config=map[api/all:true]
    testserver.go:187: Starting apiextensions-apiserver on port 63019...
    testserver.go:213: Waiting for /healthz to be ok...
    finalization_test.go:210: 
                Error Trace:    /Users/pacoxu/git/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go:210
                Error:          An error is expected but got nil.
                Test:           TestApplyCRDuringCRDFinalization
FAIL

```
with this fix, add the result later
```
25m40s: 608 runs so far, 0 failures, 2 active
```



#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/137603


#### Special notes for your reviewer:

 A CRD is considered terminating from the moment its deletion timestamp is set until it is fully removed.
With the finalizer, the condition may be set back or changed.

#### Does this PR introduce a user-facing change?

```release-note
None
```
