### PR TITLE
Add explicit forbid for `omitzero` usage on optional fields

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -161,22 +161,19 @@ linters:
         path: "staging/src/k8s.io/api/events/(v1|v1beta1)/types.go"
       - text: 'notimestamp: naming convention "notimestamp": field AllocationResult.AllocationTimestamp: prefer use of the term ''time'' over ''timestamp'''
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
+      
+      
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
         path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
-      - text: "optionalfields: field StorageVersionCondition.ObservedGeneration should be a pointer."
+      
+      # optionalfields - Ignore existing issues for apiserverinternal API group
+      - text: "optionalfields: field StorageVersionCondition.(ObservedGeneration|LastTransitionTime) should be a pointer."
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersion.Spec should be a pointer."
+      - text: "optionalfields: field StorageVersion.(Spec|Status) should (?:be a pointer|have the omitempty tag)\\."
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersion.Status should be a pointer."
-        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersionCondition.LastTransitionTime should be a pointer."
-        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersion.Spec should have the omitempty tag."
-        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersion.Status should have the omitempty tag."
-        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.
       # This is incorrect, but cannot be changed without breaking changes.

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -424,14 +424,14 @@ linters:
             #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
             # nomaps:
             #   policy: AllowStringToStringMaps # Determines how the linter should handle maps of basic types. Maps of objects are always disallowed.
-            # optionalFields:
-            #  pointers:
-            #    preference: Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
-            #    policy: SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
-            #  omitempty:
-            #      policy: SuggestFix | Warn | Ignore # The policy for omitempty in optional fields. Defaults to `SuggestFix`.
-            #  omitzero:
-            #      policy: SuggestFix | Warn | Forbid # The policy for omitzero in optional fields. Defaults to `SuggestFix`.
+            optionalFields:
+             pointers:
+               preference: Always # Whether to always require pointers, or only when required. Defaults to `Always`.
+               policy: SuggestFix # The policy for pointers in optional fields. Defaults to `SuggestFix`.
+             omitempty:
+                 policy: SuggestFix # The policy for omitempty in optional fields. Defaults to `SuggestFix`.
+             omitzero:
+                 policy: Forbid # The policy for omitzero in optional fields. Defaults to `SuggestFix`.
             # optionalOrRequired:
             #   preferredOptionalMarker: optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
             #   preferredRequiredMarker: required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`. 

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -176,22 +176,19 @@ linters:
         path: "staging/src/k8s.io/api/events/(v1|v1beta1)/types.go"
       - text: 'notimestamp: naming convention "notimestamp": field AllocationResult.AllocationTimestamp: prefer use of the term ''time'' over ''timestamp'''
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
+      
+      
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
         path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
-      - text: "optionalfields: field StorageVersionCondition.ObservedGeneration should be a pointer."
+      
+      # optionalfields - Ignore existing issues for apiserverinternal API group
+      - text: "optionalfields: field StorageVersionCondition.(ObservedGeneration|LastTransitionTime) should be a pointer."
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersion.Spec should be a pointer."
+      - text: "optionalfields: field StorageVersion.(Spec|Status) should (?:be a pointer|have the omitempty tag)\\."
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersion.Status should be a pointer."
-        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersionCondition.LastTransitionTime should be a pointer."
-        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersion.Spec should have the omitempty tag."
-        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      - text: "optionalfields: field StorageVersion.Status should have the omitempty tag."
-        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.
       # This is incorrect, but cannot be changed without breaking changes.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -437,14 +437,14 @@ linters:
             #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
             # nomaps:
             #   policy: AllowStringToStringMaps # Determines how the linter should handle maps of basic types. Maps of objects are always disallowed.
-            # optionalFields:
-            #  pointers:
-            #    preference: Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
-            #    policy: SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
-            #  omitempty:
-            #      policy: SuggestFix | Warn | Ignore # The policy for omitempty in optional fields. Defaults to `SuggestFix`.
-            #  omitzero:
-            #      policy: SuggestFix | Warn | Forbid # The policy for omitzero in optional fields. Defaults to `SuggestFix`.
+            optionalFields:
+             pointers:
+               preference: Always # Whether to always require pointers, or only when required. Defaults to `Always`.
+               policy: SuggestFix # The policy for pointers in optional fields. Defaults to `SuggestFix`.
+             omitempty:
+                 policy: SuggestFix # The policy for omitempty in optional fields. Defaults to `SuggestFix`.
+             omitzero:
+                 policy: Forbid # The policy for omitzero in optional fields. Defaults to `SuggestFix`.
             # optionalOrRequired:
             #   preferredOptionalMarker: optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
             #   preferredRequiredMarker: required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`. 

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -37,22 +37,19 @@
   path: "staging/src/k8s.io/api/events/(v1|v1beta1)/types.go"
 - text: 'notimestamp: naming convention "notimestamp": field AllocationResult.AllocationTimestamp: prefer use of the term ''time'' over ''timestamp'''
   path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
+
+
 # optionalfields - Ignore optionalfields issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
   path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
-- text: "optionalfields: field StorageVersionCondition.ObservedGeneration should be a pointer."
+
+# optionalfields - Ignore existing issues for apiserverinternal API group
+- text: "optionalfields: field StorageVersionCondition.(ObservedGeneration|LastTransitionTime) should be a pointer."
   path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-- text: "optionalfields: field StorageVersion.Spec should be a pointer."
+- text: "optionalfields: field StorageVersion.(Spec|Status) should (?:be a pointer|have the omitempty tag)\\."
   path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-- text: "optionalfields: field StorageVersion.Status should be a pointer."
-  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-- text: "optionalfields: field StorageVersionCondition.LastTransitionTime should be a pointer."
-  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-- text: "optionalfields: field StorageVersion.Spec should have the omitempty tag."
-  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-- text: "optionalfields: field StorageVersion.Status should have the omitempty tag."
-  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+
 # Pre-existing issues from the conflictmarkers linter
 # The Error field in some older API types is marked as both optional and required.
 # This is incorrect, but cannot be changed without breaking changes.

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -51,14 +51,14 @@ lintersConfig:
   #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
   # nomaps:
   #   policy: AllowStringToStringMaps # Determines how the linter should handle maps of basic types. Maps of objects are always disallowed.
-  # optionalFields:
-  #  pointers:
-  #    preference: Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
-  #    policy: SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
-  #  omitempty:
-  #      policy: SuggestFix | Warn | Ignore # The policy for omitempty in optional fields. Defaults to `SuggestFix`.
-  #  omitzero:
-  #      policy: SuggestFix | Warn | Forbid # The policy for omitzero in optional fields. Defaults to `SuggestFix`.
+  optionalFields:
+   pointers:
+     preference: Always # Whether to always require pointers, or only when required. Defaults to `Always`.
+     policy: SuggestFix # The policy for pointers in optional fields. Defaults to `SuggestFix`.
+   omitempty:
+       policy: SuggestFix # The policy for omitempty in optional fields. Defaults to `SuggestFix`.
+   omitzero:
+       policy: Forbid # The policy for omitzero in optional fields. Defaults to `SuggestFix`.
   # optionalOrRequired:
   #   preferredOptionalMarker: optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
   #   preferredRequiredMarker: required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`. 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR is enabling the `Forbid` policy for the `optionalfields` linter so that any field marked `+optional` may not set `omitzero`. We currently aren't allowing use of `omitzero` on our types while we understand the impact of using it.

CC @liggitt since you mentioned this would be helpful

Also condenses the existing linter exceptions for the optionalfields linter as an example of a good pattern for enabling the pointer and omitempty exceptions on future API groups

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
