### PR TITLE
KEP-5832: Add podGroup Status

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -528,9 +528,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		utilruntime.HandleErrorWithContext(ctx, podGroupResult.status.AsError(), "Error scheduling pod group", "podGroup", klog.KObj(podGroupInfo), "errorPods", len(podGroupInfo.QueuedPodInfos))
 		metrics.PodGroupScheduleError(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 	}
-	if condition != nil {
-		sched.updatePodGroupScheduledCondition(ctx, podGroupInfo, condition)
-	}
+	sched.updatePodGroupScheduledCondition(ctx, podGroupInfo, condition)
 }
 
 // updatePodGroupScheduledCondition patches the given condition on a PodGroup.

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -502,6 +502,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		}
 		logger.V(2).Info("Successfully scheduled a pod group", "podGroup", klog.KObj(podGroupInfo), "scheduledPods", scheduledPods, "unschedulablePods", unschedulablePods)
 		metrics.PodGroupScheduled(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
+
 	case podGroupResult.status.IsRejected():
 		condition = &metav1.Condition{
 			Type:    schedulingapi.PodGroupScheduled,
@@ -510,14 +511,13 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			Message: podGroupResult.status.Message(),
 		}
 		if podGroupResult.waitingOnPreemption {
-			condition.Message = "waiting for preemption to complete"
-
 			logger.V(2).Info("Pod group is waiting for preemption", "podGroup", klog.KObj(podGroupInfo), "unschedulablePods", unschedulablePods)
 			metrics.PodGroupWaitingOnPreemption(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 		} else {
 			logger.V(2).Info("Unable to schedule a pod group", "podGroup", klog.KObj(podGroupInfo), "unschedulablePods", unschedulablePods)
 			metrics.PodGroupUnschedulable(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 		}
+
 	default:
 		condition = &metav1.Condition{
 			Type:    schedulingapi.PodGroupScheduled,
@@ -528,17 +528,22 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		utilruntime.HandleErrorWithContext(ctx, podGroupResult.status.AsError(), "Error scheduling pod group", "podGroup", klog.KObj(podGroupInfo), "errorPods", len(podGroupInfo.QueuedPodInfos))
 		metrics.PodGroupScheduleError(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 	}
-	sched.updatePodGroupScheduledCondition(ctx, podGroupInfo, condition)
+	sched.updatePodGroupCondition(ctx, podGroupInfo, condition)
 }
 
-// updatePodGroupScheduledCondition patches the given condition on a PodGroup.
-func (sched *Scheduler) updatePodGroupScheduledCondition(ctx context.Context,
+// updatePodGroupCondition patches the given condition on a PodGroup.
+func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 	podGroupInfo *framework.QueuedPodGroupInfo, condition *metav1.Condition) {
 	logger := klog.FromContext(ctx)
 
 	pg, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name)
 	if err != nil {
 		utilruntime.HandleErrorWithLogger(logger, err, "Failed to get PodGroup for status update", "podGroup", klog.KObj(podGroupInfo))
+		return
+	}
+
+	existing := apimeta.FindStatusCondition(pg.Status.Conditions, condition.Type)
+	if existing != nil && existing.Status == metav1.ConditionTrue && condition.Status != metav1.ConditionTrue {
 		return
 	}
 

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -412,6 +412,8 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 // If the preemption is required for this pod group, all pods are moved back to the scheduling queue
 // and require the next pod group scheduling cycle to verify the preemption outcome.
 func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, schedFwk framework.Framework, podGroupInfo *framework.QueuedPodGroupInfo, podGroupResult podGroupAlgorithmResult, start time.Time) {
+	logger := klog.FromContext(ctx)
+
 	var scheduledPods, unschedulablePods int
 	for i, pInfo := range podGroupInfo.QueuedPodInfos {
 		var podResult algorithmResult
@@ -490,15 +492,6 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			unschedulablePods++
 		}
 	}
-	logger := klog.FromContext(ctx)
-
-	// If the PodGroup was already successfully scheduled, don't regress the
-	// condition back to False on a subsequent cycle for extra pods.
-	alreadyScheduled := false
-	if pg, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name); err == nil {
-		existing := apimeta.FindStatusCondition(pg.Status.Conditions, schedulingapi.PodGroupScheduled)
-		alreadyScheduled = existing != nil && existing.Status == metav1.ConditionTrue
-	}
 
 	var condition *metav1.Condition
 	switch {
@@ -513,13 +506,11 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		metrics.PodGroupScheduled(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 
 	case podGroupResult.status.IsRejected():
-		if !alreadyScheduled {
-			condition = &metav1.Condition{
-				Type:    schedulingapi.PodGroupScheduled,
-				Status:  metav1.ConditionFalse,
-				Reason:  schedulingapi.PodGroupReasonUnschedulable,
-				Message: podGroupResult.status.Message(),
-			}
+		condition = &metav1.Condition{
+			Type:    schedulingapi.PodGroupScheduled,
+			Status:  metav1.ConditionFalse,
+			Reason:  schedulingapi.PodGroupReasonUnschedulable,
+			Message: podGroupResult.status.Message(),
 		}
 		if podGroupResult.waitingOnPreemption {
 			logger.V(2).Info("Pod group is waiting for preemption", "podGroup", klog.KObj(podGroupInfo), "unschedulablePods", unschedulablePods)
@@ -530,20 +521,16 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		}
 
 	default:
-		if !alreadyScheduled {
-			condition = &metav1.Condition{
-				Type:    schedulingapi.PodGroupScheduled,
-				Status:  metav1.ConditionFalse,
-				Reason:  schedulingapi.PodGroupReasonSchedulerError,
-				Message: podGroupResult.status.AsError().Error(),
-			}
+		condition = &metav1.Condition{
+			Type:    schedulingapi.PodGroupScheduled,
+			Status:  metav1.ConditionFalse,
+			Reason:  schedulingapi.PodGroupReasonSchedulerError,
+			Message: podGroupResult.status.AsError().Error(),
 		}
 		utilruntime.HandleErrorWithContext(ctx, podGroupResult.status.AsError(), "Error scheduling pod group", "podGroup", klog.KObj(podGroupInfo), "errorPods", len(podGroupInfo.QueuedPodInfos))
 		metrics.PodGroupScheduleError(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 	}
-	if condition != nil {
-		sched.updatePodGroupCondition(ctx, podGroupInfo, condition)
-	}
+	sched.updatePodGroupCondition(ctx, podGroupInfo, condition)
 }
 
 // updatePodGroupCondition patches the given condition on a PodGroup.
@@ -551,6 +538,8 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 	podGroupInfo *framework.QueuedPodGroupInfo, condition *metav1.Condition) {
 	logger := klog.FromContext(ctx)
 
+	// If the PodGroup was already successfully scheduled, don't regress the
+	// condition back to False on a subsequent cycle for extra pods.
 	pg, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name)
 	if err != nil {
 		utilruntime.HandleErrorWithLogger(logger, err, "Failed to get PodGroup for status update", "podGroup", klog.KObj(podGroupInfo))

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -24,14 +24,18 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
+	schedulingapi "k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/kubernetes/pkg/scheduler/util"
 	"k8s.io/utils/ptr"
 )
 
@@ -487,12 +491,27 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		}
 	}
 	logger := klog.FromContext(ctx)
+	var condition *metav1.Condition
 	switch {
 	case podGroupResult.status.IsSuccess():
+		condition = &metav1.Condition{
+			Type:    schedulingapi.PodGroupScheduled,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Scheduled",
+			Message: podGroupResult.status.Message(),
+		}
 		logger.V(2).Info("Successfully scheduled a pod group", "podGroup", klog.KObj(podGroupInfo), "scheduledPods", scheduledPods, "unschedulablePods", unschedulablePods)
 		metrics.PodGroupScheduled(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 	case podGroupResult.status.IsRejected():
+		condition = &metav1.Condition{
+			Type:    schedulingapi.PodGroupScheduled,
+			Status:  metav1.ConditionFalse,
+			Reason:  schedulingapi.PodGroupReasonUnschedulable,
+			Message: podGroupResult.status.Message(),
+		}
 		if podGroupResult.waitingOnPreemption {
+			condition.Message = "waiting for preemption to complete"
+
 			logger.V(2).Info("Pod group is waiting for preemption", "podGroup", klog.KObj(podGroupInfo), "unschedulablePods", unschedulablePods)
 			metrics.PodGroupWaitingOnPreemption(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 		} else {
@@ -500,8 +519,39 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			metrics.PodGroupUnschedulable(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 		}
 	default:
+		condition = &metav1.Condition{
+			Type:    schedulingapi.PodGroupScheduled,
+			Status:  metav1.ConditionFalse,
+			Reason:  schedulingapi.PodGroupReasonSchedulerError,
+			Message: podGroupResult.status.AsError().Error(),
+		}
 		utilruntime.HandleErrorWithContext(ctx, podGroupResult.status.AsError(), "Error scheduling pod group", "podGroup", klog.KObj(podGroupInfo), "errorPods", len(podGroupInfo.QueuedPodInfos))
 		metrics.PodGroupScheduleError(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
+	}
+	if condition != nil {
+		sched.updatePodGroupScheduledCondition(ctx, podGroupInfo, condition)
+	}
+}
+
+// updatePodGroupScheduledCondition patches the given condition on a PodGroup.
+func (sched *Scheduler) updatePodGroupScheduledCondition(ctx context.Context,
+	podGroupInfo *framework.QueuedPodGroupInfo, condition *metav1.Condition) {
+	logger := klog.FromContext(ctx)
+
+	pg, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name)
+	if err != nil {
+		utilruntime.HandleErrorWithLogger(logger, err, "Failed to get PodGroup for status update", "podGroup", klog.KObj(podGroupInfo))
+		return
+	}
+
+	condition.ObservedGeneration = pg.Generation
+	newStatus := pg.Status.DeepCopy()
+	if !apimeta.SetStatusCondition(&newStatus.Conditions, *condition) {
+		return
+	}
+
+	if err := util.PatchPodGroupStatus(ctx, sched.client, podGroupInfo.Name, podGroupInfo.Namespace, &pg.Status, newStatus); err != nil {
+		utilruntime.HandleErrorWithLogger(logger, err, "Failed to update PodGroup status", "podGroup", klog.KObj(podGroupInfo))
 	}
 }
 

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -491,6 +491,15 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		}
 	}
 	logger := klog.FromContext(ctx)
+
+	// If the PodGroup was already successfully scheduled, don't regress the
+	// condition back to False on a subsequent cycle for extra pods.
+	alreadyScheduled := false
+	if pg, err := sched.podGroupLister.PodGroups(podGroupInfo.Namespace).Get(podGroupInfo.Name); err == nil {
+		existing := apimeta.FindStatusCondition(pg.Status.Conditions, schedulingapi.PodGroupScheduled)
+		alreadyScheduled = existing != nil && existing.Status == metav1.ConditionTrue
+	}
+
 	var condition *metav1.Condition
 	switch {
 	case podGroupResult.status.IsSuccess():
@@ -504,11 +513,13 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		metrics.PodGroupScheduled(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 
 	case podGroupResult.status.IsRejected():
-		condition = &metav1.Condition{
-			Type:    schedulingapi.PodGroupScheduled,
-			Status:  metav1.ConditionFalse,
-			Reason:  schedulingapi.PodGroupReasonUnschedulable,
-			Message: podGroupResult.status.Message(),
+		if !alreadyScheduled {
+			condition = &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: podGroupResult.status.Message(),
+			}
 		}
 		if podGroupResult.waitingOnPreemption {
 			logger.V(2).Info("Pod group is waiting for preemption", "podGroup", klog.KObj(podGroupInfo), "unschedulablePods", unschedulablePods)
@@ -519,16 +530,20 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		}
 
 	default:
-		condition = &metav1.Condition{
-			Type:    schedulingapi.PodGroupScheduled,
-			Status:  metav1.ConditionFalse,
-			Reason:  schedulingapi.PodGroupReasonSchedulerError,
-			Message: podGroupResult.status.AsError().Error(),
+		if !alreadyScheduled {
+			condition = &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonSchedulerError,
+				Message: podGroupResult.status.AsError().Error(),
+			}
 		}
 		utilruntime.HandleErrorWithContext(ctx, podGroupResult.status.AsError(), "Error scheduling pod group", "podGroup", klog.KObj(podGroupInfo), "errorPods", len(podGroupInfo.QueuedPodInfos))
 		metrics.PodGroupScheduleError(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
 	}
-	sched.updatePodGroupCondition(ctx, podGroupInfo, condition)
+	if condition != nil {
+		sched.updatePodGroupCondition(ctx, podGroupInfo, condition)
+	}
 }
 
 // updatePodGroupCondition patches the given condition on a PodGroup.

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -335,9 +335,15 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 
+	testPG := &schedulingv1alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
+	}
+
 	pgInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2},
 		PodGroupInfo: &framework.PodGroupInfo{
+			Name:            "pg",
+			Namespace:       "default",
 			UnscheduledPods: []*v1.Pod{p1, p2},
 		},
 	}
@@ -374,15 +380,22 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 		},
 	}
 
+	client := clientsetfake.NewClientset(testPG)
+	pgIndexer := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, toolscache.Indexers{toolscache.NamespaceIndex: toolscache.MetaNamespaceIndexFunc})
+	if err := pgIndexer.Add(testPG); err != nil {
+		t.Fatalf("Failed to add PodGroup to indexer: %v", err)
+	}
+
 	var failureHandlerCalled bool
 	sched := &Scheduler{
 		Profiles:        profile.Map{"test-scheduler": schedFwk},
 		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 		Cache:           cache,
-		client:          clientsetfake.NewClientset(),
+		client:          client,
+		podGroupLister:  schedulinglisters.NewPodGroupLister(pgIndexer),
 		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 			failureHandlerCalled = true
-			if cmp.Equal(updateSnapshotErr.Error(), status.AsError()) {
+			if updateSnapshotErr.Error() != status.AsError().Error() {
 				t.Errorf("Expected status error %q, got %q", updateSnapshotErr, status.AsError())
 			}
 		},
@@ -1318,7 +1331,9 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			cache.AddNode(klog.FromContext(ctx), testNode)
 
 			pgIndexer := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, toolscache.Indexers{toolscache.NamespaceIndex: toolscache.MetaNamespaceIndexFunc})
-			pgIndexer.Add(testPG)
+			if err := pgIndexer.Add(testPG); err != nil {
+				t.Fatalf("Failed to add PodGroup to indexer: %v", err)
+			}
 
 			sched := &Scheduler{
 				client:          client,
@@ -1482,7 +1497,9 @@ func TestUpdatePodGroupScheduledCondition(t *testing.T) {
 			pgIndexer := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, toolscache.Indexers{toolscache.NamespaceIndex: toolscache.MetaNamespaceIndexFunc})
 			if tt.existingPG != nil {
 				client = clientsetfake.NewClientset(tt.existingPG)
-				pgIndexer.Add(tt.existingPG)
+				if err := pgIndexer.Add(tt.existingPG); err != nil {
+					t.Fatalf("Failed to add PodGroup to indexer: %v", err)
+				}
 			} else {
 				client = clientsetfake.NewClientset()
 			}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -24,7 +24,11 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -32,12 +36,15 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha2"
 	clienttesting "k8s.io/client-go/testing"
+	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
+	schedulingapi "k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
@@ -372,6 +379,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 		Profiles:        profile.Map{"test-scheduler": schedFwk},
 		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 		Cache:           cache,
+		client:          clientsetfake.NewClientset(),
 		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 			failureHandlerCalled = true
 			if cmp.Equal(updateSnapshotErr.Error(), status.AsError()) {
@@ -897,9 +905,15 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
 
+	testPG := &schedulingv1alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
+	}
+
 	pgInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3},
 		PodGroupInfo: &framework.PodGroupInfo{
+			Name:            "pg",
+			Namespace:       "default",
 			UnscheduledPods: []*v1.Pod{p1, p2, p3},
 		},
 	}
@@ -910,6 +924,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 		expectBound      sets.Set[string]
 		expectPreempting sets.Set[string]
 		expectFailed     sets.Set[string]
+		expectCondition  *metav1.Condition
 	}{
 		{
 			name: "All pods feasible",
@@ -930,11 +945,16 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				}},
 			},
 			expectBound: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:   schedulingapi.PodGroupScheduled,
+				Status: metav1.ConditionTrue,
+				Reason: "Scheduled",
+			},
 		},
 		{
 			name: "All pods feasible, but all waiting",
 			algorithmResult: podGroupAlgorithmResult{
-				status: fwk.NewStatus(fwk.Unschedulable),
+				status: fwk.NewStatus(fwk.Unschedulable, "not enough capacity for the gang"),
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
@@ -950,6 +970,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				}},
 			},
 			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "not enough capacity for the gang",
+			},
 		},
 		{
 			name: "All pods feasible, but last waiting",
@@ -970,6 +996,11 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				}},
 			},
 			expectBound: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:   schedulingapi.PodGroupScheduled,
+				Status: metav1.ConditionTrue,
+				Reason: "Scheduled",
+			},
 		},
 		{
 			name: "All pods feasible, one waiting, one unschedulable",
@@ -990,6 +1021,11 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 			expectBound:  sets.New("p1", "p3"),
 			expectFailed: sets.New("p2"),
+			expectCondition: &metav1.Condition{
+				Type:   schedulingapi.PodGroupScheduled,
+				Status: metav1.ConditionTrue,
+				Reason: "Scheduled",
+			},
 		},
 		{
 			name: "All pods require preemption",
@@ -1023,11 +1059,17 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				}},
 			},
 			expectPreempting: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "waiting for preemption to complete",
+			},
 		},
 		{
 			name: "All pods require preemption, but waiting",
 			algorithmResult: podGroupAlgorithmResult{
-				status: fwk.NewStatus(fwk.Unschedulable),
+				status: fwk.NewStatus(fwk.Unschedulable, "preemption required but not feasible"),
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{
 						SuggestedHost:  "node1",
@@ -1055,6 +1097,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				}},
 			},
 			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "preemption required but not feasible",
+			},
 		},
 		{
 			name: "One pod requires preemption, but waiting, two are feasible",
@@ -1080,6 +1128,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				}},
 			},
 			expectPreempting: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "waiting for preemption to complete",
+			},
 		},
 		{
 			name: "One pod unschedulable, one requires preemption, one feasible",
@@ -1104,11 +1158,17 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 			expectPreempting: sets.New("p1", "p3"),
 			expectFailed:     sets.New("p2"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "waiting for preemption to complete",
+			},
 		},
 		{
 			name: "All pods unschedulable",
 			algorithmResult: podGroupAlgorithmResult{
-				status: fwk.NewStatus(fwk.Unschedulable),
+				status: fwk.NewStatus(fwk.Unschedulable, "0/3 nodes are available: insufficient cpu"),
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
 					status:         fwk.NewStatus(fwk.Unschedulable),
@@ -1122,11 +1182,17 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "0/3 nodes are available: insufficient cpu",
+			},
 		},
 		{
 			name: "All pods unschedulable with nil nominatingInfo",
 			algorithmResult: podGroupAlgorithmResult{
-				status: fwk.NewStatus(fwk.Unschedulable),
+				status: fwk.NewStatus(fwk.Unschedulable, "0/3 nodes are available: insufficient cpu"),
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: nil},
 					status:         fwk.NewStatus(fwk.Unschedulable),
@@ -1140,15 +1206,27 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "0/3 nodes are available: insufficient cpu",
+			},
 		},
 		{
 			name: "Unschedulable for the entire pod group",
 			algorithmResult: podGroupAlgorithmResult{
-				status:     fwk.NewStatus(fwk.Unschedulable),
+				status:     fwk.NewStatus(fwk.Unschedulable, "node affinity mismatch"),
 				podResults: []algorithmResult{},
 			},
 			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "node affinity mismatch",
+			},
 		},
 		{
 			name: "Error for one pod",
@@ -1197,7 +1275,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			preemptingPods := sets.New[string]()
 			failedPods := sets.New[string]()
 
-			client := clientsetfake.NewClientset(testNode)
+			client := clientsetfake.NewClientset(testNode, testPG)
 			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 				if action.GetSubresource() != "binding" {
 					return false, nil, nil
@@ -1239,7 +1317,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			cache := internalcache.New(ctx, nil, true)
 			cache.AddNode(klog.FromContext(ctx), testNode)
 
+			pgIndexer := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, toolscache.Indexers{toolscache.NamespaceIndex: toolscache.MetaNamespaceIndexFunc})
+			pgIndexer.Add(testPG)
+
 			sched := &Scheduler{
+				client:          client,
+				podGroupLister:  schedulinglisters.NewPodGroupLister(pgIndexer),
 				Cache:           cache,
 				Profiles:        profile.Map{"test-scheduler": schedFwk},
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
@@ -1278,6 +1361,163 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			}
 			if !tt.expectFailed.Equal(failedPods) {
 				t.Errorf("Expected failed pods: %v, but got: %v", tt.expectFailed, failedPods)
+			}
+
+			updatedPG, err := client.SchedulingV1alpha2().PodGroups("default").Get(ctx, "pg", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get PodGroup: %v", err)
+			}
+			cond := apimeta.FindStatusCondition(updatedPG.Status.Conditions, schedulingapi.PodGroupScheduled)
+			if tt.expectCondition != nil {
+				if cond == nil {
+					t.Fatalf("Expected PodGroupScheduled condition to be set, but it was not found")
+				}
+				if diff := cmp.Diff(*tt.expectCondition, *cond, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
+					t.Errorf("Unexpected PodGroupScheduled condition (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdatePodGroupScheduledCondition(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingPG      *schedulingv1alpha2.PodGroup
+		namespace       string
+		pgName          string
+		condition       *metav1.Condition
+		expectCondition bool
+	}{
+		{
+			name: "set Scheduled condition to True on empty status",
+			existingPG: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "ns1"},
+			},
+			namespace: "ns1",
+			pgName:    "pg1",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "SomeReason",
+				Message: "All required pods have been successfully scheduled",
+			},
+			expectCondition: true,
+		},
+		{
+			name: "set Scheduled condition to False with Unschedulable reason",
+			existingPG: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg2", Namespace: "ns1"},
+			},
+			namespace: "ns1",
+			pgName:    "pg2",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "0/3 nodes are available: insufficient cpu",
+			},
+			expectCondition: true,
+		},
+		{
+			name: "set Scheduled condition to False with SchedulerError reason",
+			existingPG: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg3", Namespace: "ns1"},
+			},
+			namespace: "ns1",
+			pgName:    "pg3",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonSchedulerError,
+				Message: "Internal scheduling error",
+			},
+			expectCondition: true,
+		},
+		{
+			name: "transition from Unschedulable to Scheduled",
+			existingPG: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg4", Namespace: "ns1"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               schedulingapi.PodGroupScheduled,
+							Status:             metav1.ConditionFalse,
+							Reason:             schedulingapi.PodGroupReasonUnschedulable,
+							Message:            "previously unschedulable",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			namespace: "ns1",
+			pgName:    "pg4",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "SomeReason",
+				Message: "All required pods have been successfully scheduled",
+			},
+			expectCondition: true,
+		},
+		{
+			name:      "PodGroup not found does not panic",
+			namespace: "ns1",
+			pgName:    "nonexistent",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "SomeReason",
+				Message: "test",
+			},
+			expectCondition: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+
+			var client *clientsetfake.Clientset
+			pgIndexer := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, toolscache.Indexers{toolscache.NamespaceIndex: toolscache.MetaNamespaceIndexFunc})
+			if tt.existingPG != nil {
+				client = clientsetfake.NewClientset(tt.existingPG)
+				pgIndexer.Add(tt.existingPG)
+			} else {
+				client = clientsetfake.NewClientset()
+			}
+			sched := &Scheduler{client: client, podGroupLister: schedulinglisters.NewPodGroupLister(pgIndexer)}
+
+			pgInfo := &framework.QueuedPodGroupInfo{
+				PodGroupInfo: &framework.PodGroupInfo{
+					Namespace: tt.namespace,
+					Name:      tt.pgName,
+				},
+			}
+			sched.updatePodGroupScheduledCondition(ctx, pgInfo, tt.condition)
+
+			if !tt.expectCondition {
+				return
+			}
+
+			updatedPG, err := client.SchedulingV1alpha2().PodGroups(tt.namespace).Get(ctx, tt.pgName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get PodGroup: %v", err)
+			}
+
+			cond := apimeta.FindStatusCondition(updatedPG.Status.Conditions, tt.condition.Type)
+			if cond == nil {
+				t.Fatalf("Expected %s condition to be set, but it was not found", tt.condition.Type)
+			}
+
+			if cond.Status != tt.condition.Status {
+				t.Errorf("Condition status: got %v, want %v", cond.Status, tt.condition.Status)
+			}
+			if cond.Reason != tt.condition.Reason {
+				t.Errorf("Condition reason: got %v, want %v", cond.Reason, tt.condition.Reason)
+			}
+			if cond.Message != tt.condition.Message {
+				t.Errorf("Condition message: got %v, want %v", cond.Message, tt.condition.Message)
 			}
 		})
 	}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -36,9 +36,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha2"
 	clienttesting "k8s.io/client-go/testing"
-	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
@@ -247,8 +245,8 @@ func TestFrameworkForPodGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sched := &Scheduler{Profiles: tt.profiles}
-			pgInfo := &framework.QueuedPodGroupInfo{QueuedPodInfos: tt.pods}
-			_, err := sched.frameworkForPodGroup(pgInfo)
+			podGroupInfo := &framework.QueuedPodGroupInfo{QueuedPodInfos: tt.pods}
+			_, err := sched.frameworkForPodGroup(podGroupInfo)
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("Expected error, but got nil")
@@ -271,7 +269,7 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
 
-	pgInfo := &framework.QueuedPodGroupInfo{
+	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3},
 		PodGroupInfo: &framework.PodGroupInfo{
 			UnscheduledPods: []*v1.Pod{p1, p2, p3},
@@ -313,19 +311,19 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 		t.Fatalf("Failed to assume pod p3: %v", err)
 	}
 
-	sched.skipPodGroupPodSchedule(ctx, schedFwk, pgInfo)
+	sched.skipPodGroupPodSchedule(ctx, schedFwk, podGroupInfo)
 
-	if len(pgInfo.QueuedPodInfos) != 1 {
-		t.Errorf("Expected 1 queued pod left, got %d", len(pgInfo.QueuedPodInfos))
+	if len(podGroupInfo.QueuedPodInfos) != 1 {
+		t.Errorf("Expected 1 queued pod left, got %d", len(podGroupInfo.QueuedPodInfos))
 	}
-	if pgInfo.QueuedPodInfos[0].Pod.Name != "p1" {
-		t.Errorf("Expected p1 to be left in queued pods, got %s", pgInfo.QueuedPodInfos[0].Pod.Name)
+	if podGroupInfo.QueuedPodInfos[0].Pod.Name != "p1" {
+		t.Errorf("Expected p1 to be left in queued pods, got %s", podGroupInfo.QueuedPodInfos[0].Pod.Name)
 	}
-	if len(pgInfo.UnscheduledPods) != 1 {
-		t.Errorf("Expected 1 unscheduled pod left, got %d", len(pgInfo.UnscheduledPods))
+	if len(podGroupInfo.UnscheduledPods) != 1 {
+		t.Errorf("Expected 1 unscheduled pod left, got %d", len(podGroupInfo.UnscheduledPods))
 	}
-	if pgInfo.UnscheduledPods[0].Name != "p1" {
-		t.Errorf("Expected p1 to be left in unscheduled pods, got %s", pgInfo.UnscheduledPods[0].Name)
+	if podGroupInfo.UnscheduledPods[0].Name != "p1" {
+		t.Errorf("Expected p1 to be left in unscheduled pods, got %s", podGroupInfo.UnscheduledPods[0].Name)
 	}
 }
 
@@ -335,11 +333,11 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 
-	testPG := &schedulingv1alpha2.PodGroup{
+	testPodGroup := &schedulingv1alpha2.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 	}
 
-	pgInfo := &framework.QueuedPodGroupInfo{
+	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
@@ -380,10 +378,10 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 		},
 	}
 
-	client := clientsetfake.NewClientset(testPG)
-	pgIndexer := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, toolscache.Indexers{toolscache.NamespaceIndex: toolscache.MetaNamespaceIndexFunc})
-	if err := pgIndexer.Add(testPG); err != nil {
-		t.Fatalf("Failed to add PodGroup to indexer: %v", err)
+	client := clientsetfake.NewClientset(testPodGroup)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	if err := informerFactory.Scheduling().V1alpha2().PodGroups().Informer().GetStore().Add(testPodGroup); err != nil {
+		t.Fatalf("Failed to add PodGroup to informer store: %v", err)
 	}
 
 	var failureHandlerCalled bool
@@ -392,7 +390,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 		Cache:           cache,
 		client:          client,
-		podGroupLister:  schedulinglisters.NewPodGroupLister(pgIndexer),
+		podGroupLister:  informerFactory.Scheduling().V1alpha2().PodGroups().Lister(),
 		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 			failureHandlerCalled = true
 			if updateSnapshotErr.Error() != status.AsError().Error() {
@@ -401,7 +399,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 		},
 	}
 
-	sched.podGroupCycle(ctx, schedFwk, pgInfo)
+	sched.podGroupCycle(ctx, schedFwk, podGroupInfo)
 
 	if !failureHandlerCalled {
 		t.Errorf("Expected FailureHandler to be called after UpdateSnapshot failed")
@@ -419,7 +417,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
 
-	pgInfo := &framework.QueuedPodGroupInfo{
+	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
@@ -859,7 +857,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					t.Fatalf("Failed to update snapshot: %v", err)
 				}
 
-				result := sched.podGroupSchedulingAlgorithm(ctx, schedFwk, pgInfo)
+				result := sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupInfo)
 
 				if result.status.Code() != tt.expectedGroupStatusCode {
 					t.Errorf("Expected group status code: %v, got: %v", tt.expectedGroupStatusCode, result.status.Code())
@@ -871,7 +869,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					t.Errorf("Expected %d pod results, got %d", len(tt.expectedPodStatus), len(result.podResults))
 				}
 				for i, podResult := range result.podResults {
-					podName := pgInfo.QueuedPodInfos[i].Pod.Name
+					podName := podGroupInfo.QueuedPodInfos[i].Pod.Name
 					if expected, ok := tt.expectedPodStatus[podName]; ok {
 						if podResult.status.Code() != expected.Code() {
 							t.Errorf("Expected pod %s status code: %v, got: %v", podName, expected.Code(), podResult.status.Code())
@@ -918,11 +916,11 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
 
-	testPG := &schedulingv1alpha2.PodGroup{
+	testPodGroup := &schedulingv1alpha2.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 	}
 
-	pgInfo := &framework.QueuedPodGroupInfo{
+	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
@@ -1043,7 +1041,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 		{
 			name: "All pods require preemption",
 			algorithmResult: podGroupAlgorithmResult{
-				status:              fwk.NewStatus(fwk.Unschedulable),
+				status:              fwk.NewStatus(fwk.Unschedulable, "waiting for preemption to complete"),
 				waitingOnPreemption: true,
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{
@@ -1120,7 +1118,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 		{
 			name: "One pod requires preemption, but waiting, two are feasible",
 			algorithmResult: podGroupAlgorithmResult{
-				status:              fwk.NewStatus(fwk.Unschedulable),
+				status:              fwk.NewStatus(fwk.Unschedulable, "waiting for preemption to complete"),
 				waitingOnPreemption: true,
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{
@@ -1151,7 +1149,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 		{
 			name: "One pod unschedulable, one requires preemption, one feasible",
 			algorithmResult: podGroupAlgorithmResult{
-				status:              fwk.NewStatus(fwk.Unschedulable),
+				status:              fwk.NewStatus(fwk.Unschedulable, "waiting for preemption to complete"),
 				waitingOnPreemption: true,
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{
@@ -1256,6 +1254,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonSchedulerError,
+				Message: "",
+			},
 		},
 		{
 			name: "Error for one pod while waiting on preemption",
@@ -1276,6 +1280,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonSchedulerError,
+				Message: "",
+			},
 		},
 	}
 
@@ -1288,7 +1298,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			preemptingPods := sets.New[string]()
 			failedPods := sets.New[string]()
 
-			client := clientsetfake.NewClientset(testNode, testPG)
+			client := clientsetfake.NewClientset(testNode, testPodGroup)
 			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 				if action.GetSubresource() != "binding" {
 					return false, nil, nil
@@ -1330,14 +1340,14 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			cache := internalcache.New(ctx, nil, true)
 			cache.AddNode(klog.FromContext(ctx), testNode)
 
-			pgIndexer := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, toolscache.Indexers{toolscache.NamespaceIndex: toolscache.MetaNamespaceIndexFunc})
-			if err := pgIndexer.Add(testPG); err != nil {
-				t.Fatalf("Failed to add PodGroup to indexer: %v", err)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			if err := informerFactory.Scheduling().V1alpha2().PodGroups().Informer().GetStore().Add(testPodGroup); err != nil {
+				t.Fatalf("Failed to add PodGroup to informer store: %v", err)
 			}
 
 			sched := &Scheduler{
 				client:          client,
-				podGroupLister:  schedulinglisters.NewPodGroupLister(pgIndexer),
+				podGroupLister:  informerFactory.Scheduling().V1alpha2().PodGroups().Lister(),
 				Cache:           cache,
 				Profiles:        profile.Map{"test-scheduler": schedFwk},
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
@@ -1353,17 +1363,17 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			}
 
 			for i := range tt.algorithmResult.podResults {
-				pod := pgInfo.QueuedPodInfos[i].Pod
+				pod := podGroupInfo.QueuedPodInfos[i].Pod
 				podCtx := initPodSchedulingContext(ctx, pod)
 				tt.algorithmResult.podResults[i].podCtx = podCtx
 			}
 
-			sched.submitPodGroupAlgorithmResult(ctx, schedFwk, pgInfo, tt.algorithmResult, time.Now())
+			sched.submitPodGroupAlgorithmResult(ctx, schedFwk, podGroupInfo, tt.algorithmResult, time.Now())
 
 			if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				lock.Lock()
 				defer lock.Unlock()
-				return len(boundPods)+len(preemptingPods)+len(failedPods) == len(pgInfo.QueuedPodInfos), nil
+				return len(boundPods)+len(preemptingPods)+len(failedPods) == len(podGroupInfo.QueuedPodInfos), nil
 			}); err != nil {
 				t.Errorf("Failed waiting for all pods to be either bound or failed")
 			}
@@ -1378,11 +1388,11 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				t.Errorf("Expected failed pods: %v, but got: %v", tt.expectFailed, failedPods)
 			}
 
-			updatedPG, err := client.SchedulingV1alpha2().PodGroups("default").Get(ctx, "pg", metav1.GetOptions{})
+			updatedPodGroup, err := client.SchedulingV1alpha2().PodGroups("default").Get(ctx, "pg", metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get PodGroup: %v", err)
 			}
-			cond := apimeta.FindStatusCondition(updatedPG.Status.Conditions, schedulingapi.PodGroupScheduled)
+			cond := apimeta.FindStatusCondition(updatedPodGroup.Status.Conditions, schedulingapi.PodGroupScheduled)
 			if tt.expectCondition != nil {
 				if cond == nil {
 					t.Fatalf("Expected PodGroupScheduled condition to be set, but it was not found")
@@ -1395,63 +1405,78 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 	}
 }
 
-func TestUpdatePodGroupScheduledCondition(t *testing.T) {
+func TestUpdatePodGroupCondition(t *testing.T) {
 	tests := []struct {
-		name            string
-		existingPG      *schedulingv1alpha2.PodGroup
-		namespace       string
-		pgName          string
-		condition       *metav1.Condition
-		expectCondition bool
+		name             string
+		existingPodGroup *schedulingv1alpha2.PodGroup
+		namespace        string
+		podGroupName     string
+		condition        *metav1.Condition
+		expectCondition  *metav1.Condition
 	}{
 		{
 			name: "set Scheduled condition to True on empty status",
-			existingPG: &schedulingv1alpha2.PodGroup{
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "ns1"},
 			},
-			namespace: "ns1",
-			pgName:    "pg1",
+			namespace:    "ns1",
+			podGroupName: "pg1",
 			condition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupScheduled,
 				Status:  metav1.ConditionTrue,
 				Reason:  "SomeReason",
 				Message: "All required pods have been successfully scheduled",
 			},
-			expectCondition: true,
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "SomeReason",
+				Message: "All required pods have been successfully scheduled",
+			},
 		},
 		{
 			name: "set Scheduled condition to False with Unschedulable reason",
-			existingPG: &schedulingv1alpha2.PodGroup{
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg2", Namespace: "ns1"},
 			},
-			namespace: "ns1",
-			pgName:    "pg2",
+			namespace:    "ns1",
+			podGroupName: "pg2",
 			condition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupScheduled,
 				Status:  metav1.ConditionFalse,
 				Reason:  schedulingapi.PodGroupReasonUnschedulable,
 				Message: "0/3 nodes are available: insufficient cpu",
 			},
-			expectCondition: true,
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "0/3 nodes are available: insufficient cpu",
+			},
 		},
 		{
 			name: "set Scheduled condition to False with SchedulerError reason",
-			existingPG: &schedulingv1alpha2.PodGroup{
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg3", Namespace: "ns1"},
 			},
-			namespace: "ns1",
-			pgName:    "pg3",
+			namespace:    "ns1",
+			podGroupName: "pg3",
 			condition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupScheduled,
 				Status:  metav1.ConditionFalse,
 				Reason:  schedulingapi.PodGroupReasonSchedulerError,
 				Message: "Internal scheduling error",
 			},
-			expectCondition: true,
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonSchedulerError,
+				Message: "Internal scheduling error",
+			},
 		},
 		{
 			name: "transition from Unschedulable to Scheduled",
-			existingPG: &schedulingv1alpha2.PodGroup{
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg4", Namespace: "ns1"},
 				Status: schedulingv1alpha2.PodGroupStatus{
 					Conditions: []metav1.Condition{
@@ -1465,27 +1490,223 @@ func TestUpdatePodGroupScheduledCondition(t *testing.T) {
 					},
 				},
 			},
-			namespace: "ns1",
-			pgName:    "pg4",
+			namespace:    "ns1",
+			podGroupName: "pg4",
 			condition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupScheduled,
 				Status:  metav1.ConditionTrue,
-				Reason:  "SomeReason",
+				Reason:  "Scheduled",
 				Message: "All required pods have been successfully scheduled",
 			},
-			expectCondition: true,
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All required pods have been successfully scheduled",
+			},
 		},
 		{
-			name:      "PodGroup not found does not panic",
-			namespace: "ns1",
-			pgName:    "nonexistent",
+			name: "transition from SchedulerError to Scheduled",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg-se-to-true", Namespace: "ns1"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               schedulingapi.PodGroupScheduled,
+							Status:             metav1.ConditionFalse,
+							Reason:             schedulingapi.PodGroupReasonSchedulerError,
+							Message:            "internal error",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			namespace:    "ns1",
+			podGroupName: "pg-se-to-true",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All required pods have been successfully scheduled",
+			},
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All required pods have been successfully scheduled",
+			},
+		},
+		{
+			name: "do not regress Scheduled to Unschedulable",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg-true-to-unsched", Namespace: "ns1"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               schedulingapi.PodGroupScheduled,
+							Status:             metav1.ConditionTrue,
+							Reason:             "Scheduled",
+							Message:            "All pods scheduled",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			namespace:    "ns1",
+			podGroupName: "pg-true-to-unsched",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "extra pods could not be placed",
+			},
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All pods scheduled",
+			},
+		},
+		{
+			name: "do not regress Scheduled to SchedulerError",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg-true-to-se", Namespace: "ns1"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               schedulingapi.PodGroupScheduled,
+							Status:             metav1.ConditionTrue,
+							Reason:             "Scheduled",
+							Message:            "All pods scheduled",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			namespace:    "ns1",
+			podGroupName: "pg-true-to-se",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonSchedulerError,
+				Message: "internal error",
+			},
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All pods scheduled",
+			},
+		},
+		{
+			name: "transition from Unschedulable to SchedulerError",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg-unsched-to-se", Namespace: "ns1"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               schedulingapi.PodGroupScheduled,
+							Status:             metav1.ConditionFalse,
+							Reason:             schedulingapi.PodGroupReasonUnschedulable,
+							Message:            "not enough resources",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			namespace:    "ns1",
+			podGroupName: "pg-unsched-to-se",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonSchedulerError,
+				Message: "internal error",
+			},
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonSchedulerError,
+				Message: "internal error",
+			},
+		},
+		{
+			name: "transition from SchedulerError to Unschedulable",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg-se-to-unsched", Namespace: "ns1"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               schedulingapi.PodGroupScheduled,
+							Status:             metav1.ConditionFalse,
+							Reason:             schedulingapi.PodGroupReasonSchedulerError,
+							Message:            "internal error",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			namespace:    "ns1",
+			podGroupName: "pg-se-to-unsched",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "not enough resources",
+			},
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "not enough resources",
+			},
+		},
+		{
+			name: "Scheduled to Scheduled is a no-op",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg-true-to-true", Namespace: "ns1"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               schedulingapi.PodGroupScheduled,
+							Status:             metav1.ConditionTrue,
+							Reason:             "Scheduled",
+							Message:            "All pods scheduled",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			namespace:    "ns1",
+			podGroupName: "pg-true-to-true",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All pods scheduled",
+			},
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All pods scheduled",
+			},
+		},
+		{
+			name:         "PodGroup not found does not panic",
+			namespace:    "ns1",
+			podGroupName: "nonexistent",
 			condition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupScheduled,
 				Status:  metav1.ConditionTrue,
 				Reason:  "SomeReason",
 				Message: "test",
 			},
-			expectCondition: false,
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "SomeReason",
+				Message: "test",
+			},
 		},
 	}
 
@@ -1493,48 +1714,45 @@ func TestUpdatePodGroupScheduledCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 
-			var client *clientsetfake.Clientset
-			pgIndexer := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, toolscache.Indexers{toolscache.NamespaceIndex: toolscache.MetaNamespaceIndexFunc})
-			if tt.existingPG != nil {
-				client = clientsetfake.NewClientset(tt.existingPG)
-				if err := pgIndexer.Add(tt.existingPG); err != nil {
-					t.Fatalf("Failed to add PodGroup to indexer: %v", err)
-				}
-			} else {
-				client = clientsetfake.NewClientset()
+			var objects []runtime.Object
+			if tt.existingPodGroup != nil {
+				objects = append(objects, tt.existingPodGroup)
 			}
-			sched := &Scheduler{client: client, podGroupLister: schedulinglisters.NewPodGroupLister(pgIndexer)}
+			client := clientsetfake.NewClientset(objects...)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			if tt.existingPodGroup != nil {
+				if err := informerFactory.Scheduling().V1alpha2().PodGroups().Informer().GetStore().Add(tt.existingPodGroup); err != nil {
+					t.Fatalf("Failed to add PodGroup to informer store: %v", err)
+				}
+			}
+			sched := &Scheduler{client: client, podGroupLister: informerFactory.Scheduling().V1alpha2().PodGroups().Lister()}
 
-			pgInfo := &framework.QueuedPodGroupInfo{
+			podGroupInfo := &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
 					Namespace: tt.namespace,
-					Name:      tt.pgName,
+					Name:      tt.podGroupName,
 				},
 			}
-			sched.updatePodGroupScheduledCondition(ctx, pgInfo, tt.condition)
+			sched.updatePodGroupCondition(ctx, podGroupInfo, tt.condition)
 
-			if !tt.expectCondition {
+			updatedPodGroup, err := client.SchedulingV1alpha2().PodGroups(tt.namespace).Get(ctx, tt.podGroupName, metav1.GetOptions{})
+			if tt.existingPodGroup == nil {
+				if err == nil {
+					t.Fatalf("Expected PodGroup to not be found, but got: %v", updatedPodGroup)
+				}
 				return
 			}
-
-			updatedPG, err := client.SchedulingV1alpha2().PodGroups(tt.namespace).Get(ctx, tt.pgName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get PodGroup: %v", err)
 			}
 
-			cond := apimeta.FindStatusCondition(updatedPG.Status.Conditions, tt.condition.Type)
+			cond := apimeta.FindStatusCondition(updatedPodGroup.Status.Conditions, tt.expectCondition.Type)
 			if cond == nil {
-				t.Fatalf("Expected %s condition to be set, but it was not found", tt.condition.Type)
+				t.Fatalf("Expected %s condition to be set, but it was not found", tt.expectCondition.Type)
 			}
 
-			if cond.Status != tt.condition.Status {
-				t.Errorf("Condition status: got %v, want %v", cond.Status, tt.condition.Status)
-			}
-			if cond.Reason != tt.condition.Reason {
-				t.Errorf("Condition reason: got %v, want %v", cond.Reason, tt.condition.Reason)
-			}
-			if cond.Message != tt.condition.Message {
-				t.Errorf("Condition message: got %v, want %v", cond.Message, tt.condition.Message)
+			if diff := cmp.Diff(*tt.expectCondition, *cond, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
+				t.Errorf("Unexpected PodGroupScheduled condition (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -347,6 +347,9 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	}
 
 	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	registry := frameworkruntime.Registry{
 		queuesort.Name:     queuesort.New,
 		defaultbinder.Name: defaultbinder.New,
@@ -380,9 +383,9 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 
 	client := clientsetfake.NewClientset(testPodGroup)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	if err := informerFactory.Scheduling().V1alpha2().PodGroups().Informer().GetStore().Add(testPodGroup); err != nil {
-		t.Fatalf("Failed to add PodGroup to informer store: %v", err)
-	}
+	podGroupLister := informerFactory.Scheduling().V1alpha2().PodGroups().Lister()
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
 
 	var failureHandlerCalled bool
 	sched := &Scheduler{
@@ -390,7 +393,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 		Cache:           cache,
 		client:          client,
-		podGroupLister:  informerFactory.Scheduling().V1alpha2().PodGroups().Lister(),
+		podGroupLister:  podGroupLister,
 		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 			failureHandlerCalled = true
 			if updateSnapshotErr.Error() != status.AsError().Error() {
@@ -1243,14 +1246,14 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 		{
 			name: "Error for one pod",
 			algorithmResult: podGroupAlgorithmResult{
-				status: fwk.NewStatus(fwk.Error),
+				status: fwk.NewStatus(fwk.Error, "plugin returned error"),
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
 					permitStatus:   nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
-					status:         fwk.NewStatus(fwk.Error),
+					status:         fwk.NewStatus(fwk.Error, "plugin returned error"),
 				}},
 			},
 			expectBound:  sets.New[string](),
@@ -1259,13 +1262,13 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				Type:    schedulingapi.PodGroupScheduled,
 				Status:  metav1.ConditionFalse,
 				Reason:  schedulingapi.PodGroupReasonSchedulerError,
-				Message: "",
+				Message: "plugin returned error",
 			},
 		},
 		{
 			name: "Error for one pod while waiting on preemption",
 			algorithmResult: podGroupAlgorithmResult{
-				status: fwk.NewStatus(fwk.Error),
+				status: fwk.NewStatus(fwk.Error, "internal failure"),
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{
 						SuggestedHost:  "node1",
@@ -1276,7 +1279,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					permitStatus:       nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
-					status:         fwk.NewStatus(fwk.Error),
+					status:         fwk.NewStatus(fwk.Error, "internal failure"),
 				}},
 			},
 			expectBound:  sets.New[string](),
@@ -1285,7 +1288,44 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				Type:    schedulingapi.PodGroupScheduled,
 				Status:  metav1.ConditionFalse,
 				Reason:  schedulingapi.PodGroupReasonSchedulerError,
-				Message: "",
+				Message: "internal failure",
+			},
+		},
+		{
+			name: "Already Scheduled, successful cycle keeps condition",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{{
+						Type:               schedulingapi.PodGroupScheduled,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Scheduled",
+						Message:            "All pods scheduled",
+						LastTransitionTime: metav1.Now(),
+					}},
+				},
+			},
+			algorithmResult: podGroupAlgorithmResult{
+				status: nil,
+				podResults: []algorithmResult{{
+					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
+					status:         nil,
+					permitStatus:   nil,
+				}, {
+					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
+					status:         nil,
+					permitStatus:   nil,
+				}, {
+					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
+					status:         nil,
+					permitStatus:   nil,
+				}},
+			},
+			expectBound: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:   schedulingapi.PodGroupScheduled,
+				Status: metav1.ConditionTrue,
+				Reason: "Scheduled",
 			},
 		},
 		{
@@ -1415,13 +1455,13 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			cache.AddNode(klog.FromContext(ctx), testNode)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			if err := informerFactory.Scheduling().V1alpha2().PodGroups().Informer().GetStore().Add(pg); err != nil {
-				t.Fatalf("Failed to add PodGroup to informer store: %v", err)
-			}
+			podGroupLister := informerFactory.Scheduling().V1alpha2().PodGroups().Lister()
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
 
 			sched := &Scheduler{
 				client:          client,
-				podGroupLister:  informerFactory.Scheduling().V1alpha2().PodGroups().Lister(),
+				podGroupLister:  podGroupLister,
 				Cache:           cache,
 				Profiles:        profile.Map{"test-scheduler": schedFwk},
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
@@ -1467,13 +1507,8 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				t.Fatalf("Failed to get PodGroup: %v", err)
 			}
 			cond := apimeta.FindStatusCondition(updatedPodGroup.Status.Conditions, schedulingapi.PodGroupScheduled)
-			if tt.expectCondition != nil {
-				if cond == nil {
-					t.Fatalf("Expected PodGroupScheduled condition to be set, but it was not found")
-				}
-				if diff := cmp.Diff(*tt.expectCondition, *cond, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
-					t.Errorf("Unexpected PodGroupScheduled condition (-want +got):\n%s", diff)
-				}
+			if diff := cmp.Diff(tt.expectCondition, cond, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
+				t.Errorf("Unexpected PodGroupScheduled condition (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1487,6 +1522,9 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		podGroupName     string
 		condition        *metav1.Condition
 		expectCondition  *metav1.Condition
+		// expectLastTransitionTimeUnchanged, when true, verifies that LastTransitionTime
+		// is preserved from the existing condition.
+		expectLastTransitionTimeUnchanged bool
 	}{
 		{
 			name: "set Scheduled condition to True on empty status",
@@ -1640,6 +1678,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 				Reason:  "Scheduled",
 				Message: "All pods scheduled",
 			},
+			expectLastTransitionTimeUnchanged: true,
 		},
 		{
 			name: "do not regress Scheduled to SchedulerError",
@@ -1671,9 +1710,10 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 				Reason:  "Scheduled",
 				Message: "All pods scheduled",
 			},
+			expectLastTransitionTimeUnchanged: true,
 		},
 		{
-			name: "transition from Unschedulable to SchedulerError",
+			name: "transition from Unschedulable to SchedulerError preserves LastTransitionTime",
 			existingPodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-unsched-to-se", Namespace: "ns1"},
 				Status: schedulingv1alpha2.PodGroupStatus{
@@ -1702,9 +1742,10 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 				Reason:  schedulingapi.PodGroupReasonSchedulerError,
 				Message: "internal error",
 			},
+			expectLastTransitionTimeUnchanged: true,
 		},
 		{
-			name: "transition from SchedulerError to Unschedulable",
+			name: "transition from SchedulerError to Unschedulable preserves LastTransitionTime",
 			existingPodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-se-to-unsched", Namespace: "ns1"},
 				Status: schedulingv1alpha2.PodGroupStatus{
@@ -1733,6 +1774,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 				Reason:  schedulingapi.PodGroupReasonUnschedulable,
 				Message: "not enough resources",
 			},
+			expectLastTransitionTimeUnchanged: true,
 		},
 		{
 			name: "Scheduled to Scheduled is a no-op",
@@ -1764,6 +1806,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 				Reason:  "Scheduled",
 				Message: "All pods scheduled",
 			},
+			expectLastTransitionTimeUnchanged: true,
 		},
 		{
 			name:         "PodGroup not found does not panic",
@@ -1782,6 +1825,27 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 				Message: "test",
 			},
 		},
+		{
+			name: "ObservedGeneration is set from PodGroup generation",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg-gen", Namespace: "ns1", Generation: 7},
+			},
+			namespace:    "ns1",
+			podGroupName: "pg-gen",
+			condition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All pods scheduled",
+			},
+			expectCondition: &metav1.Condition{
+				Type:               schedulingapi.PodGroupScheduled,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Scheduled",
+				Message:            "All pods scheduled",
+				ObservedGeneration: 7,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1794,12 +1858,17 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			}
 			client := clientsetfake.NewClientset(objects...)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			podGroupLister := informerFactory.Scheduling().V1alpha2().PodGroups().Lister()
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+			sched := &Scheduler{client: client, podGroupLister: podGroupLister}
+
+			var existingLTT metav1.Time
 			if tt.existingPodGroup != nil {
-				if err := informerFactory.Scheduling().V1alpha2().PodGroups().Informer().GetStore().Add(tt.existingPodGroup); err != nil {
-					t.Fatalf("Failed to add PodGroup to informer store: %v", err)
+				if existing := apimeta.FindStatusCondition(tt.existingPodGroup.Status.Conditions, schedulingapi.PodGroupScheduled); existing != nil {
+					existingLTT = existing.LastTransitionTime
 				}
 			}
-			sched := &Scheduler{client: client, podGroupLister: informerFactory.Scheduling().V1alpha2().PodGroups().Lister()}
 
 			podGroupInfo := &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
@@ -1821,12 +1890,14 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			}
 
 			cond := apimeta.FindStatusCondition(updatedPodGroup.Status.Conditions, tt.expectCondition.Type)
-			if cond == nil {
-				t.Fatalf("Expected %s condition to be set, but it was not found", tt.expectCondition.Type)
+			if diff := cmp.Diff(tt.expectCondition, cond, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
+				t.Errorf("Unexpected PodGroupScheduled condition (-want +got):\n%s", diff)
 			}
 
-			if diff := cmp.Diff(*tt.expectCondition, *cond, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
-				t.Errorf("Unexpected PodGroupScheduled condition (-want +got):\n%s", diff)
+			if tt.expectLastTransitionTimeUnchanged {
+				if !cond.LastTransitionTime.Time.Truncate(time.Second).Equal(existingLTT.Time.Truncate(time.Second)) {
+					t.Errorf("Expected LastTransitionTime to be preserved as %v, got %v", existingLTT, cond.LastTransitionTime)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -1777,7 +1777,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			expectLastTransitionTimeUnchanged: true,
 		},
 		{
-			name: "Scheduled to Scheduled is a no-op",
+			name: "Scheduled to Scheduled preserves LastTransitionTime",
 			existingPodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-true-to-true", Namespace: "ns1"},
 				Status: schedulingv1alpha2.PodGroupStatus{
@@ -1798,13 +1798,13 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 				Type:    schedulingapi.PodGroupScheduled,
 				Status:  metav1.ConditionTrue,
 				Reason:  "Scheduled",
-				Message: "All pods scheduled",
+				Message: "New condition message",
 			},
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupScheduled,
 				Status:  metav1.ConditionTrue,
 				Reason:  "Scheduled",
-				Message: "All pods scheduled",
+				Message: "New condition message",
 			},
 			expectLastTransitionTimeUnchanged: true,
 		},

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -931,6 +931,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		existingPodGroup *schedulingv1alpha2.PodGroup
 		algorithmResult  podGroupAlgorithmResult
 		expectBound      sets.Set[string]
 		expectPreempting sets.Set[string]
@@ -1287,6 +1288,75 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				Message: "",
 			},
 		},
+		{
+			name: "Already Scheduled, rejected cycle does not regress condition",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{{
+						Type:               schedulingapi.PodGroupScheduled,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Scheduled",
+						Message:            "All pods scheduled",
+						LastTransitionTime: metav1.Now(),
+					}},
+				},
+			},
+			algorithmResult: podGroupAlgorithmResult{
+				status: fwk.NewStatus(fwk.Unschedulable, "extra pods could not be placed"),
+				podResults: []algorithmResult{{
+					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
+					status:         fwk.NewStatus(fwk.Unschedulable),
+				}, {
+					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
+					status:         fwk.NewStatus(fwk.Unschedulable),
+				}, {
+					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
+					status:         fwk.NewStatus(fwk.Unschedulable),
+				}},
+			},
+			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All pods scheduled",
+			},
+		},
+		{
+			name: "Already Scheduled, error cycle does not regress condition",
+			existingPodGroup: &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{{
+						Type:               schedulingapi.PodGroupScheduled,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Scheduled",
+						Message:            "All pods scheduled",
+						LastTransitionTime: metav1.Now(),
+					}},
+				},
+			},
+			algorithmResult: podGroupAlgorithmResult{
+				status: fwk.NewStatus(fwk.Error),
+				podResults: []algorithmResult{{
+					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
+					status:         nil,
+					permitStatus:   nil,
+				}, {
+					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
+					status:         fwk.NewStatus(fwk.Error),
+				}},
+			},
+			expectBound:  sets.New[string](),
+			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupScheduled,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Scheduled",
+				Message: "All pods scheduled",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1298,7 +1368,11 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			preemptingPods := sets.New[string]()
 			failedPods := sets.New[string]()
 
-			client := clientsetfake.NewClientset(testNode, testPodGroup)
+			pg := testPodGroup
+			if tt.existingPodGroup != nil {
+				pg = tt.existingPodGroup
+			}
+			client := clientsetfake.NewClientset(testNode, pg)
 			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 				if action.GetSubresource() != "binding" {
 					return false, nil, nil
@@ -1341,7 +1415,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			cache.AddNode(klog.FromContext(ctx), testNode)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			if err := informerFactory.Scheduling().V1alpha2().PodGroups().Informer().GetStore().Add(testPodGroup); err != nil {
+			if err := informerFactory.Scheduling().V1alpha2().PodGroups().Informer().GetStore().Add(pg); err != nil {
 				t.Fatalf("Failed to add PodGroup to informer store: %v", err)
 			}
 

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1041,16 +1041,15 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			item.sendPod = withSchedulingGroup(item.sendPod, group)
 			item.expectErrorPod = withSchedulingGroup(item.expectErrorPod, group)
 			item.expectPodInBackoffQ = withSchedulingGroup(item.expectPodInBackoffQ, group)
-			item.expectPodInUnschedulable = withSchedulingGroup(item.expectPodInUnschedulable, group)
+			if item.expectPodInUnschedulable != nil {
+				// Pods from a pod group skip unschedulablePods structure and land directly in the backoffQ.
+				item.expectPodInBackoffQ = withSchedulingGroup(item.expectPodInUnschedulable, group)
+				item.expectPodInUnschedulable = nil
+			}
 
 			testPG := &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: item.sendPod.Namespace},
 			}
-			pgIndexer := clientcache.NewIndexer(clientcache.MetaNamespaceKeyFunc, clientcache.Indexers{clientcache.NamespaceIndex: clientcache.MetaNamespaceIndexFunc})
-			if err := pgIndexer.Add(testPG); err != nil {
-				t.Fatalf("Failed to add PodGroup to indexer: %v", err)
-			}
-			podGroupLister = schedulinglisters.NewPodGroupLister(pgIndexer)
 			clientObjs = []runtime.Object{item.sendPod, testPG}
 		} else {
 			clientObjs = []runtime.Object{item.sendPod}
@@ -1075,6 +1074,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		internalCache := internalcache.New(ctx, apiDispatcher, scheduleAsPodGroup)
 
 		if scheduleAsPodGroup {
+			podGroupLister = informerFactory.Scheduling().V1alpha2().PodGroups().Lister()
 			internalCache.AddPodGroupMember(item.sendPod)
 		}
 		cache := &fakecache.Cache{

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -38,6 +38,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
+	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,6 +51,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha2"
 	clienttesting "k8s.io/client-go/testing"
 	clientcache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
@@ -1029,6 +1031,9 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		var gotBinding *v1.Binding
 		var gotNominatingInfo *fwk.NominatingInfo
 
+		var pgm podgroupmanager.PodGroupManager
+		var podGroupLister schedulinglisters.PodGroupLister
+
 		if scheduleAsPodGroup {
 			group := &v1.PodSchedulingGroup{
 				PodGroupName: new("pg"),
@@ -1044,7 +1049,35 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			}
 		}
 
-		client := clientsetfake.NewClientset(item.sendPod)
+		if scheduleAsPodGroup {
+			group := &v1.PodSchedulingGroup{
+				PodGroupName: ptr.To("pg"),
+			}
+			// When scheduling a pod as a pod group, set scheduling group to all relevant pods.
+			item.sendPod = withSchedulingGroup(item.sendPod, group)
+			item.expectErrorPod = withSchedulingGroup(item.expectErrorPod, group)
+			item.expectPodInBackoffQ = withSchedulingGroup(item.expectPodInBackoffQ, group)
+			item.expectPodInUnschedulable = withSchedulingGroup(item.expectPodInUnschedulable, group)
+			pgm = podgroupmanager.New(logger)
+			pgm.AddPod(item.sendPod)
+
+			testPG := &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: item.sendPod.Namespace},
+			}
+			pgIndexer := clientcache.NewIndexer(clientcache.MetaNamespaceKeyFunc, clientcache.Indexers{clientcache.NamespaceIndex: clientcache.MetaNamespaceIndexFunc})
+			if err := pgIndexer.Add(testPG); err != nil {
+				t.Fatalf("Failed to add PodGroup to indexer: %v", err)
+			}
+			podGroupLister = schedulinglisters.NewPodGroupLister(pgIndexer)
+		}
+
+		clientObjs := []runtime.Object{item.sendPod}
+		if scheduleAsPodGroup {
+			clientObjs = append(clientObjs, &schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: item.sendPod.Namespace},
+			})
+		}
+		client := clientsetfake.NewClientset(clientObjs...)
 		informerFactory := informers.NewSharedInformerFactory(client, 0)
 		client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 			if action.GetSubresource() != "binding" {
@@ -1141,6 +1174,8 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			SchedulingQueue:                        queue,
 			Profiles:                               profile.Map{testSchedulerName: schedFramework},
 			APIDispatcher:                          apiDispatcher,
+			PodGroupManager:                        pgm,
+			podGroupLister:                         podGroupLister,
 			nominatedNodeNameForExpectationEnabled: features.nominatedNodeNameForExpectationEnabled,
 		}
 		queue.Add(ctx, item.sendPod)

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1031,9 +1031,8 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		var gotBinding *v1.Binding
 		var gotNominatingInfo *fwk.NominatingInfo
 
-		var pgm podgroupmanager.PodGroupManager
 		var podGroupLister schedulinglisters.PodGroupLister
-
+		var clientObjs []runtime.Object
 		if scheduleAsPodGroup {
 			group := &v1.PodSchedulingGroup{
 				PodGroupName: new("pg"),
@@ -1042,24 +1041,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			item.sendPod = withSchedulingGroup(item.sendPod, group)
 			item.expectErrorPod = withSchedulingGroup(item.expectErrorPod, group)
 			item.expectPodInBackoffQ = withSchedulingGroup(item.expectPodInBackoffQ, group)
-			if item.expectPodInUnschedulable != nil {
-				// Pods from a pod group skip unschedulablePods structure and land directly in the backoffQ.
-				item.expectPodInBackoffQ = withSchedulingGroup(item.expectPodInUnschedulable, group)
-				item.expectPodInUnschedulable = nil
-			}
-		}
-
-		if scheduleAsPodGroup {
-			group := &v1.PodSchedulingGroup{
-				PodGroupName: ptr.To("pg"),
-			}
-			// When scheduling a pod as a pod group, set scheduling group to all relevant pods.
-			item.sendPod = withSchedulingGroup(item.sendPod, group)
-			item.expectErrorPod = withSchedulingGroup(item.expectErrorPod, group)
-			item.expectPodInBackoffQ = withSchedulingGroup(item.expectPodInBackoffQ, group)
 			item.expectPodInUnschedulable = withSchedulingGroup(item.expectPodInUnschedulable, group)
-			pgm = podgroupmanager.New(logger)
-			pgm.AddPod(item.sendPod)
 
 			testPG := &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: item.sendPod.Namespace},
@@ -1069,13 +1051,9 @@ func TestSchedulerScheduleOne(t *testing.T) {
 				t.Fatalf("Failed to add PodGroup to indexer: %v", err)
 			}
 			podGroupLister = schedulinglisters.NewPodGroupLister(pgIndexer)
-		}
-
-		clientObjs := []runtime.Object{item.sendPod}
-		if scheduleAsPodGroup {
-			clientObjs = append(clientObjs, &schedulingv1alpha2.PodGroup{
-				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: item.sendPod.Namespace},
-			})
+			clientObjs = []runtime.Object{item.sendPod, testPG}
+		} else {
+			clientObjs = []runtime.Object{item.sendPod}
 		}
 		client := clientsetfake.NewClientset(clientObjs...)
 		informerFactory := informers.NewSharedInformerFactory(client, 0)
@@ -1174,7 +1152,6 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			SchedulingQueue:                        queue,
 			Profiles:                               profile.Map{testSchedulerName: schedFramework},
 			APIDispatcher:                          apiDispatcher,
-			PodGroupManager:                        pgm,
 			podGroupLister:                         podGroupLister,
 			nominatedNodeNameForExpectationEnabled: features.nominatedNodeNameForExpectationEnabled,
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -452,7 +452,6 @@ func New(ctx context.Context,
 		logger:                                 logger,
 		APIDispatcher:                          apiDispatcher,
 		nominatedNodeNameForExpectationEnabled: feature.DefaultFeatureGate.Enabled(features.NominatedNodeNameForExpectation),
-		PodGroupManager:                        podGroupManager,
 		podGroupLister:                         podGroupLister,
 		genericWorkloadEnabled:                 feature.DefaultFeatureGate.Enabled(features.GenericWorkload),
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha2"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
@@ -112,6 +113,8 @@ type Scheduler struct {
 	// otherwise logging functions will access a nil sink and
 	// panic.
 	logger klog.Logger
+
+	podGroupLister schedulinglisters.PodGroupLister
 
 	// registeredHandlers contains the registrations of all handlers. It's used to check if all handlers have finished syncing before the scheduling cycles start.
 	registeredHandlers []cache.ResourceEventHandlerRegistration
@@ -309,6 +312,7 @@ func New(ctx context.Context,
 
 	podLister := informerFactory.Core().V1().Pods().Lister()
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
+	podGroupLister := informerFactory.Scheduling().V1alpha2().PodGroups().Lister()
 
 	snapshot := internalcache.NewEmptySnapshot()
 	metricsRecorder := metrics.NewMetricsAsyncRecorder(1000, time.Second, stopEverything)
@@ -445,6 +449,8 @@ func New(ctx context.Context,
 		logger:                                 logger,
 		APIDispatcher:                          apiDispatcher,
 		nominatedNodeNameForExpectationEnabled: feature.DefaultFeatureGate.Enabled(features.NominatedNodeNameForExpectation),
+		PodGroupManager:                        podGroupManager,
+		podGroupLister:                         podGroupLister,
 		genericWorkloadEnabled:                 feature.DefaultFeatureGate.Enabled(features.GenericWorkload),
 	}
 	sched.NextPod = podQueue.Pop

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -312,7 +312,10 @@ func New(ctx context.Context,
 
 	podLister := informerFactory.Core().V1().Pods().Lister()
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	podGroupLister := informerFactory.Scheduling().V1alpha2().PodGroups().Lister()
+	var podGroupLister schedulinglisters.PodGroupLister
+	if feature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
+		podGroupLister = informerFactory.Scheduling().V1alpha2().PodGroups().Lister()
+	}
 
 	snapshot := internalcache.NewEmptySnapshot()
 	metricsRecorder := metrics.NewMetricsAsyncRecorder(1000, time.Second, stopEverything)

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -1619,6 +1619,37 @@ func (wrapper *PodGroupWrapper) TemplateRef(templateName, workloadName string) *
 	return wrapper
 }
 
+// WorkloadWrapper wraps a Workload inside.
+type WorkloadWrapper struct{ schedulingapi.Workload }
+
+// MakeWorkload creates a Workload wrapper.
+func MakeWorkload() *WorkloadWrapper {
+	return &WorkloadWrapper{}
+}
+
+// Obj returns the inner Workload.
+func (wrapper *WorkloadWrapper) Obj() *schedulingapi.Workload {
+	return &wrapper.Workload
+}
+
+// Name sets `name` as the name of the inner Workload.
+func (wrapper *WorkloadWrapper) Name(name string) *WorkloadWrapper {
+	wrapper.Workload.Name = name
+	return wrapper
+}
+
+// Namespace sets `namespace` as the namespace of the inner Workload.
+func (wrapper *WorkloadWrapper) Namespace(namespace string) *WorkloadWrapper {
+	wrapper.Workload.Namespace = namespace
+	return wrapper
+}
+
+// PodGroupTemplate appends a PodGroupTemplate built from the given wrapper.
+func (wrapper *WorkloadWrapper) PodGroupTemplate(t *PodGroupTemplateWrapper) *WorkloadWrapper {
+	wrapper.Workload.Spec.PodGroupTemplates = append(wrapper.Workload.Spec.PodGroupTemplates, t.PodGroupTemplate)
+	return wrapper
+}
+
 // PodGroupTemplateWrapper wraps a PodGroupTemplate inside.
 type PodGroupTemplateWrapper struct{ schedulingapi.PodGroupTemplate }
 

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -1644,9 +1644,9 @@ func (wrapper *WorkloadWrapper) Namespace(namespace string) *WorkloadWrapper {
 	return wrapper
 }
 
-// PodGroupTemplate appends a PodGroupTemplate built from the given wrapper.
-func (wrapper *WorkloadWrapper) PodGroupTemplate(t *PodGroupTemplateWrapper) *WorkloadWrapper {
-	wrapper.Workload.Spec.PodGroupTemplates = append(wrapper.Workload.Spec.PodGroupTemplates, t.PodGroupTemplate)
+// PodGroupTemplate appends the given PodGroupTemplate to the Workload spec.
+func (wrapper *WorkloadWrapper) PodGroupTemplate(t *schedulingapi.PodGroupTemplate) *WorkloadWrapper {
+	wrapper.Workload.Spec.PodGroupTemplates = append(wrapper.Workload.Spec.PodGroupTemplates, *t)
 	return wrapper
 }
 

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -1645,8 +1645,8 @@ func (wrapper *WorkloadWrapper) Namespace(namespace string) *WorkloadWrapper {
 }
 
 // PodGroupTemplate appends the given PodGroupTemplate to the Workload spec.
-func (wrapper *WorkloadWrapper) PodGroupTemplate(t *schedulingapi.PodGroupTemplate) *WorkloadWrapper {
-	wrapper.Workload.Spec.PodGroupTemplates = append(wrapper.Workload.Spec.PodGroupTemplates, *t)
+func (wrapper *WorkloadWrapper) PodGroupTemplate(t schedulingapi.PodGroupTemplate) *WorkloadWrapper {
+	wrapper.Workload.Spec.PodGroupTemplates = append(wrapper.Workload.Spec.PodGroupTemplates, t)
 	return wrapper
 }
 
@@ -1659,8 +1659,8 @@ func MakePodGroupTemplate() *PodGroupTemplateWrapper {
 }
 
 // Obj returns the inner PodGroupTemplate.
-func (wrapper *PodGroupTemplateWrapper) Obj() *schedulingapi.PodGroupTemplate {
-	return &wrapper.PodGroupTemplate
+func (wrapper *PodGroupTemplateWrapper) Obj() schedulingapi.PodGroupTemplate {
+	return wrapper.PodGroupTemplate
 }
 
 // Name sets `name` as the name of the inner PodGroupTemplate.

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -98,7 +98,7 @@ func MoreImportantPod(pod1, pod2 *v1.Pod) bool {
 // Retriable defines the retriable errors during a scheduling cycle.
 func Retriable(err error) bool {
 	return apierrors.IsInternalError(err) || apierrors.IsServiceUnavailable(err) ||
-		net.IsConnectionRefused(err)
+		apierrors.IsConflict(err) || net.IsConnectionRefused(err)
 }
 
 // PatchPodStatus calculates the delta bytes change from <old.Status> to <newStatus>,

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -122,7 +122,7 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 		return fmt.Errorf("failed to create merge patch for pod %q/%q: %w", namespace, name, err)
 	}
 
-	if string(patchBytes) == "{}" {
+	if "{}" == string(patchBytes) {
 		return nil
 	}
 

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -127,6 +128,41 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 
 	patchFn := func() error {
 		_, err := cs.CoreV1().Pods(namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+		return err
+	}
+
+	return retry.OnError(retry.DefaultBackoff, Retriable, patchFn)
+}
+
+// PatchPodGroupStatus calculates the delta bytes change from <old.Status> to <newStatus>,
+// and then submits a request to API server to patch the PodGroup status changes.
+func PatchPodGroupStatus(ctx context.Context, cs kubernetes.Interface, name string,
+	namespace string, oldStatus *schedulingv1alpha2.PodGroupStatus,
+	newStatus *schedulingv1alpha2.PodGroupStatus) error {
+	if newStatus == nil {
+		return nil
+	}
+
+	oldData, err := json.Marshal(schedulingv1alpha2.PodGroup{Status: *oldStatus})
+	if err != nil {
+		return err
+	}
+
+	newData, err := json.Marshal(schedulingv1alpha2.PodGroup{Status: *newStatus})
+	if err != nil {
+		return err
+	}
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, &schedulingv1alpha2.PodGroup{})
+	if err != nil {
+		return fmt.Errorf("failed to create merge patch for podgroup %q/%q: %w", namespace, name, err)
+	}
+
+	if "{}" == string(patchBytes) {
+		return nil
+	}
+
+	patchFn := func() error {
+		_, err := cs.SchedulingV1alpha2().PodGroups(namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
 		return err
 	}
 

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -108,6 +108,10 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 		return nil
 	}
 
+	if oldStatus == nil {
+		oldStatus = &v1.PodStatus{}
+	}
+
 	oldData, err := json.Marshal(v1.Pod{Status: *oldStatus})
 	if err != nil {
 		return err
@@ -141,6 +145,10 @@ func PatchPodGroupStatus(ctx context.Context, cs kubernetes.Interface, name stri
 	newStatus *schedulingv1alpha2.PodGroupStatus) error {
 	if newStatus == nil {
 		return nil
+	}
+
+	if oldStatus == nil {
+		oldStatus = &schedulingv1alpha2.PodGroupStatus{}
 	}
 
 	oldData, err := json.Marshal(schedulingv1alpha2.PodGroup{Status: *oldStatus})

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -122,7 +122,7 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 		return fmt.Errorf("failed to create merge patch for pod %q/%q: %w", namespace, name, err)
 	}
 
-	if "{}" == string(patchBytes) {
+	if string(patchBytes) == "{}" {
 		return nil
 	}
 
@@ -157,7 +157,7 @@ func PatchPodGroupStatus(ctx context.Context, cs kubernetes.Interface, name stri
 		return fmt.Errorf("failed to create merge patch for podgroup %q/%q: %w", namespace, name, err)
 	}
 
-	if "{}" == string(patchBytes) {
+	if string(patchBytes) == "{}" {
 		return nil
 	}
 

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -174,6 +174,7 @@ func TestPatchPodStatus(t *testing.T) {
 		// (true means error is expected one.)
 		validateErr    func(goterr error) bool
 		statusToUpdate v1.PodStatus
+		nilOldStatus   bool
 	}{
 		{
 			name:   "Should update pod conditions successfully",
@@ -300,6 +301,25 @@ func TestPatchPodStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "nil oldStatus patches successfully",
+			client: clientsetfake.NewClientset(),
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pod1",
+				},
+			},
+			statusToUpdate: v1.PodStatus{
+				Conditions: []v1.PodCondition{
+					{
+						Type:   v1.PodScheduled,
+						Status: v1.ConditionFalse,
+					},
+				},
+			},
+			nilOldStatus: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -314,7 +334,11 @@ func TestPatchPodStatus(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = PatchPodStatus(ctx, client, tc.pod.Name, tc.pod.Namespace, &tc.pod.Status, &tc.statusToUpdate)
+			oldStatus := &tc.pod.Status
+			if tc.nilOldStatus {
+				oldStatus = nil
+			}
+			err = PatchPodStatus(ctx, client, tc.pod.Name, tc.pod.Namespace, oldStatus, &tc.statusToUpdate)
 			if err != nil && tc.validateErr == nil {
 				// shouldn't be error
 				t.Fatal(err)
@@ -349,6 +373,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 		// (true means error is expected one.)
 		validateErr    func(goterr error) bool
 		statusToUpdate *schedulingv1alpha2.PodGroupStatus
+		nilOldStatus   bool
 	}{
 		{
 			name:   "Should update podgroup conditions successfully",
@@ -526,6 +551,28 @@ func TestPatchPodGroupStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "nil oldStatus patches successfully",
+			client: clientsetfake.NewClientset(),
+			podGroup: schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pg1",
+				},
+			},
+			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               schedulingapi.PodGroupScheduled,
+						Status:             metav1.ConditionFalse,
+						Reason:             schedulingapi.PodGroupReasonUnschedulable,
+						Message:            "not enough capacity for the gang",
+						LastTransitionTime: now,
+					},
+				},
+			},
+			nilOldStatus: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -540,7 +587,11 @@ func TestPatchPodGroupStatus(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = PatchPodGroupStatus(ctx, client, tc.podGroup.Name, tc.podGroup.Namespace, &tc.podGroup.Status, tc.statusToUpdate)
+			oldStatus := &tc.podGroup.Status
+			if tc.nilOldStatus {
+				oldStatus = nil
+			}
+			err = PatchPodGroupStatus(ctx, client, tc.podGroup.Name, tc.podGroup.Namespace, oldStatus, tc.statusToUpdate)
 			if err != nil && tc.validateErr == nil {
 				t.Fatal(err)
 			}

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/net"
@@ -328,6 +329,195 @@ func TestPatchPodStatus(t *testing.T) {
 
 			if diff := cmp.Diff(tc.statusToUpdate, retrievedPod.Status); diff != "" {
 				t.Errorf("unexpected pod status (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPatchPodGroupStatus(t *testing.T) {
+	now := metav1.NewTime(time.Now().Truncate(time.Second))
+
+	tests := []struct {
+		name   string
+		pg     schedulingv1alpha2.PodGroup
+		client *clientsetfake.Clientset
+		// validateErr checks if error returned from PatchPodGroupStatus is expected one or not.
+		// (true means error is expected one.)
+		validateErr    func(goterr error) bool
+		statusToUpdate *schedulingv1alpha2.PodGroupStatus
+	}{
+		{
+			name:   "Should update podgroup conditions successfully",
+			client: clientsetfake.NewClientset(),
+			pg: schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pg1",
+				},
+			},
+			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "PodGroupScheduled",
+						Status:             metav1.ConditionFalse,
+						Reason:             "Unschedulable",
+						Message:            "not enough capacity for the gang",
+						LastTransitionTime: now,
+					},
+				},
+			},
+		},
+		{
+			name:   "no-op when status is unchanged",
+			client: clientsetfake.NewClientset(),
+			pg: schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pg1",
+				},
+				Status: schedulingv1alpha2.PodGroupStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "PodGroupScheduled",
+							Status:             metav1.ConditionFalse,
+							Reason:             "Unschedulable",
+							Message:            "not enough capacity",
+							LastTransitionTime: now,
+						},
+					},
+				},
+			},
+			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "PodGroupScheduled",
+						Status:             metav1.ConditionFalse,
+						Reason:             "Unschedulable",
+						Message:            "not enough capacity",
+						LastTransitionTime: now,
+					},
+				},
+			},
+		},
+		{
+			name:   "nil newStatus returns nil",
+			client: clientsetfake.NewClientset(),
+			pg: schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pg1",
+				},
+			},
+			statusToUpdate: nil,
+		},
+		{
+			name: "retry patch request when a 'connection refused' error is returned",
+			client: func() *clientsetfake.Clientset {
+				client := clientsetfake.NewClientset()
+
+				reqcount := 0
+				client.PrependReactor("patch", "podgroups", func(action clienttesting.Action) (bool, runtime.Object, error) {
+					defer func() { reqcount++ }()
+					if reqcount == 0 {
+						return true, &schedulingv1alpha2.PodGroup{}, fmt.Errorf("connection refused: %w", syscall.ECONNREFUSED)
+					}
+					if reqcount == 1 {
+						return false, &schedulingv1alpha2.PodGroup{}, nil
+					}
+					return true, nil, errors.New("requests comes in more than three times.")
+				})
+
+				return client
+			}(),
+			pg: schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pg1",
+				},
+			},
+			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "PodGroupScheduled",
+						Status:             metav1.ConditionFalse,
+						Reason:             "Unschedulable",
+						Message:            "not enough capacity for the gang",
+						LastTransitionTime: now,
+					},
+				},
+			},
+		},
+		{
+			name: "only 4 retries at most",
+			client: func() *clientsetfake.Clientset {
+				client := clientsetfake.NewClientset()
+
+				reqcount := 0
+				client.PrependReactor("patch", "podgroups", func(action clienttesting.Action) (bool, runtime.Object, error) {
+					defer func() { reqcount++ }()
+					if reqcount >= 4 {
+						return true, nil, errors.New("requests comes in more than four times.")
+					}
+					return true, &schedulingv1alpha2.PodGroup{}, fmt.Errorf("connection refused: %w", syscall.ECONNREFUSED)
+				})
+
+				return client
+			}(),
+			pg: schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pg1",
+				},
+			},
+			validateErr: net.IsConnectionRefused,
+			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "PodGroupScheduled",
+						Status:             metav1.ConditionFalse,
+						Reason:             "Unschedulable",
+						Message:            "not enough capacity for the gang",
+						LastTransitionTime: now,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := tc.client
+			_, err := client.SchedulingV1alpha2().PodGroups(tc.pg.Namespace).Create(context.TODO(), &tc.pg, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			err = PatchPodGroupStatus(ctx, client, tc.pg.Name, tc.pg.Namespace, &tc.pg.Status, tc.statusToUpdate)
+			if err != nil && tc.validateErr == nil {
+				t.Fatal(err)
+			}
+			if tc.validateErr != nil {
+				if !tc.validateErr(err) {
+					t.Fatalf("Returned unexpected error: %v", err)
+				}
+				return
+			}
+
+			retrievedPG, err := client.SchedulingV1alpha2().PodGroups(tc.pg.Namespace).Get(ctx, tc.pg.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			wantStatus := tc.pg.Status
+			if tc.statusToUpdate != nil {
+				wantStatus = *tc.statusToUpdate
+			}
+			if diff := cmp.Diff(wantStatus, retrievedPG.Status); diff != "" {
+				t.Errorf("unexpected podgroup status (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+	schedulingapi "k8s.io/kubernetes/pkg/apis/scheduling"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
@@ -338,9 +339,9 @@ func TestPatchPodGroupStatus(t *testing.T) {
 	now := metav1.NewTime(time.Now().Truncate(time.Second))
 
 	tests := []struct {
-		name   string
-		pg     schedulingv1alpha2.PodGroup
-		client *clientsetfake.Clientset
+		name     string
+		podGroup schedulingv1alpha2.PodGroup
+		client   *clientsetfake.Clientset
 		// validateErr checks if error returned from PatchPodGroupStatus is expected one or not.
 		// (true means error is expected one.)
 		validateErr    func(goterr error) bool
@@ -349,7 +350,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 		{
 			name:   "Should update podgroup conditions successfully",
 			client: clientsetfake.NewClientset(),
-			pg: schedulingv1alpha2.PodGroup{
+			podGroup: schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
@@ -358,9 +359,9 @@ func TestPatchPodGroupStatus(t *testing.T) {
 			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               "PodGroupScheduled",
+						Type:               schedulingapi.PodGroupScheduled,
 						Status:             metav1.ConditionFalse,
-						Reason:             "Unschedulable",
+						Reason:             schedulingapi.PodGroupReasonUnschedulable,
 						Message:            "not enough capacity for the gang",
 						LastTransitionTime: now,
 					},
@@ -370,7 +371,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 		{
 			name:   "no-op when status is unchanged",
 			client: clientsetfake.NewClientset(),
-			pg: schedulingv1alpha2.PodGroup{
+			podGroup: schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
@@ -378,9 +379,9 @@ func TestPatchPodGroupStatus(t *testing.T) {
 				Status: schedulingv1alpha2.PodGroupStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               "PodGroupScheduled",
+							Type:               schedulingapi.PodGroupScheduled,
 							Status:             metav1.ConditionFalse,
-							Reason:             "Unschedulable",
+							Reason:             schedulingapi.PodGroupReasonUnschedulable,
 							Message:            "not enough capacity",
 							LastTransitionTime: now,
 						},
@@ -390,9 +391,9 @@ func TestPatchPodGroupStatus(t *testing.T) {
 			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               "PodGroupScheduled",
+						Type:               schedulingapi.PodGroupScheduled,
 						Status:             metav1.ConditionFalse,
-						Reason:             "Unschedulable",
+						Reason:             schedulingapi.PodGroupReasonUnschedulable,
 						Message:            "not enough capacity",
 						LastTransitionTime: now,
 					},
@@ -402,7 +403,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 		{
 			name:   "nil newStatus returns nil",
 			client: clientsetfake.NewClientset(),
-			pg: schedulingv1alpha2.PodGroup{
+			podGroup: schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
@@ -429,7 +430,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 
 				return client
 			}(),
-			pg: schedulingv1alpha2.PodGroup{
+			podGroup: schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
@@ -438,9 +439,9 @@ func TestPatchPodGroupStatus(t *testing.T) {
 			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               "PodGroupScheduled",
+						Type:               schedulingapi.PodGroupScheduled,
 						Status:             metav1.ConditionFalse,
-						Reason:             "Unschedulable",
+						Reason:             schedulingapi.PodGroupReasonUnschedulable,
 						Message:            "not enough capacity for the gang",
 						LastTransitionTime: now,
 					},
@@ -463,7 +464,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 
 				return client
 			}(),
-			pg: schedulingv1alpha2.PodGroup{
+			podGroup: schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
@@ -473,9 +474,9 @@ func TestPatchPodGroupStatus(t *testing.T) {
 			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               "PodGroupScheduled",
+						Type:               schedulingapi.PodGroupScheduled,
 						Status:             metav1.ConditionFalse,
-						Reason:             "Unschedulable",
+						Reason:             schedulingapi.PodGroupReasonUnschedulable,
 						Message:            "not enough capacity for the gang",
 						LastTransitionTime: now,
 					},
@@ -486,17 +487,17 @@ func TestPatchPodGroupStatus(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+
 			client := tc.client
-			_, err := client.SchedulingV1alpha2().PodGroups(tc.pg.Namespace).Create(context.TODO(), &tc.pg, metav1.CreateOptions{})
+			_, err := client.SchedulingV1alpha2().PodGroups(tc.podGroup.Namespace).Create(ctx, &tc.podGroup, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			_, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			err = PatchPodGroupStatus(ctx, client, tc.pg.Name, tc.pg.Namespace, &tc.pg.Status, tc.statusToUpdate)
+			err = PatchPodGroupStatus(ctx, client, tc.podGroup.Name, tc.podGroup.Namespace, &tc.podGroup.Status, tc.statusToUpdate)
 			if err != nil && tc.validateErr == nil {
 				t.Fatal(err)
 			}
@@ -507,12 +508,12 @@ func TestPatchPodGroupStatus(t *testing.T) {
 				return
 			}
 
-			retrievedPG, err := client.SchedulingV1alpha2().PodGroups(tc.pg.Namespace).Get(ctx, tc.pg.Name, metav1.GetOptions{})
+			retrievedPG, err := client.SchedulingV1alpha2().PodGroups(tc.podGroup.Namespace).Get(ctx, tc.podGroup.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			wantStatus := tc.pg.Status
+			wantStatus := tc.podGroup.Status
 			if tc.statusToUpdate != nil {
 				wantStatus = *tc.statusToUpdate
 			}

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -28,8 +28,10 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/net"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -302,15 +304,16 @@ func TestPatchPodStatus(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
 			client := tc.client
 			_, err := client.CoreV1().Pods(tc.pod.Namespace).Create(context.TODO(), &tc.pod, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			_, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
 			err = PatchPodStatus(ctx, client, tc.pod.Name, tc.pod.Namespace, &tc.pod.Status, &tc.statusToUpdate)
 			if err != nil && tc.validateErr == nil {
 				// shouldn't be error
@@ -483,19 +486,59 @@ func TestPatchPodGroupStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "retry patch request when a conflict error is returned",
+			client: func() *clientsetfake.Clientset {
+				client := clientsetfake.NewClientset()
+
+				reqcount := 0
+				client.PrependReactor("patch", "podgroups", func(action clienttesting.Action) (bool, runtime.Object, error) {
+					defer func() { reqcount++ }()
+					if reqcount == 0 {
+						return true, &schedulingv1alpha2.PodGroup{},
+							apierrors.NewConflict(schema.GroupResource{
+								Resource: "podgroups"}, "pg1",
+								errors.New("the object has been modified"))
+					}
+					if reqcount == 1 {
+						return false, &schedulingv1alpha2.PodGroup{}, nil
+					}
+					return true, nil, errors.New("requests comes in more than three times.")
+				})
+
+				return client
+			}(),
+			podGroup: schedulingv1alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pg1",
+				},
+			},
+			statusToUpdate: &schedulingv1alpha2.PodGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               schedulingapi.PodGroupScheduled,
+						Status:             metav1.ConditionFalse,
+						Reason:             schedulingapi.PodGroupReasonUnschedulable,
+						Message:            "not enough capacity for the gang",
+						LastTransitionTime: now,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
 			client := tc.client
 			_, err := client.SchedulingV1alpha2().PodGroups(tc.podGroup.Namespace).Create(ctx, &tc.podGroup, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer cancel()
 
 			err = PatchPodGroupStatus(ctx, client, tc.podGroup.Name, tc.podGroup.Namespace, &tc.podGroup.Status, tc.statusToUpdate)
 			if err != nil && tc.validateErr == nil {

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -24,10 +24,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
@@ -85,6 +87,13 @@ func TestPodGroupScheduling(t *testing.T) {
 		numUnschedulable int
 	}
 
+	type waitForPodGroupCondition struct {
+		podGroupName    string
+		conditionType   string
+		conditionStatus metav1.ConditionStatus
+		reason          string
+	}
+
 	// step represents a single step in a test scenario.
 	type step struct {
 		name                         string
@@ -95,6 +104,7 @@ func TestPodGroupScheduling(t *testing.T) {
 		waitForPodsUnschedulable     []string
 		waitForPodsScheduled         []string
 		waitForAnyPodsScheduled      *waitForAnyPodsScheduled
+		waitForPodGroupCondition     *waitForPodGroupCondition
 	}
 
 	tests := []struct {
@@ -383,6 +393,83 @@ func TestPodGroupScheduling(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "gang PodGroup status set to Scheduled when all pods scheduled",
+			steps: []step{
+				{
+					name:           "Create the PodGroup object",
+					createPodGroup: gangPodGroup,
+				},
+				{
+					name:       "Create all pods belonging to the gang",
+					createPods: []*v1.Pod{p1, p2, p3},
+				},
+				{
+					name:                 "Verify all gang pods are scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Verify PodGroup condition is Scheduled",
+					waitForPodGroupCondition: &waitForPodGroupCondition{
+						podGroupName:    "pg1",
+						conditionType:   scheduling.PodGroupScheduled,
+						conditionStatus: metav1.ConditionTrue,
+						reason:          scheduling.PodGroupReasonScheduled,
+					},
+				},
+			},
+		},
+		{
+			name: "gang PodGroup status transitions from Unschedulable to Scheduled",
+			steps: []step{
+				{
+					name:       "Create the resource-blocking pod",
+					createPods: []*v1.Pod{blockerPod},
+				},
+				{
+					name:                 "Schedule the resource-blocking pod",
+					waitForPodsScheduled: []string{"blocker"},
+				},
+				{
+					name:           "Create the PodGroup object",
+					createPodGroup: gangPodGroup,
+				},
+				{
+					name:       "Create gang pods",
+					createPods: []*v1.Pod{p1, p2, p3},
+				},
+				{
+					name:                     "Verify pods become unschedulable",
+					waitForPodsUnschedulable: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Verify PodGroup condition is Unschedulable",
+					waitForPodGroupCondition: &waitForPodGroupCondition{
+						podGroupName:    "pg1",
+						conditionType:   scheduling.PodGroupScheduled,
+						conditionStatus: metav1.ConditionFalse,
+						reason:          scheduling.PodGroupReasonUnschedulable,
+					},
+				},
+				{
+					name:       "Delete the resource-blocking pod",
+					deletePods: []string{"blocker"},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Verify PodGroup condition transitions to Scheduled",
+					waitForPodGroupCondition: &waitForPodGroupCondition{
+						podGroupName:    "pg1",
+						conditionType:   scheduling.PodGroupScheduled,
+						conditionStatus: metav1.ConditionTrue,
+						reason:          scheduling.PodGroupReasonScheduled,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -495,6 +582,25 @@ func TestPodGroupScheduling(t *testing.T) {
 					)
 					if err != nil {
 						t.Fatalf("Step %d: Failed to wait for pods to be scheduled or unschedulable: %v", i, err)
+					}
+				case step.waitForPodGroupCondition != nil:
+					wc := step.waitForPodGroupCondition
+					err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false,
+						func(ctx context.Context) (bool, error) {
+							pg, err := cs.SchedulingV1alpha2().PodGroups(ns).Get(ctx, wc.podGroupName, metav1.GetOptions{})
+							if err != nil {
+								return false, err
+							}
+							cond := apimeta.FindStatusCondition(pg.Status.Conditions, wc.conditionType)
+							if cond == nil {
+								return false, nil
+							}
+							return cond.Status == wc.conditionStatus && (wc.reason == "" || cond.Reason == wc.reason), nil
+						},
+					)
+					if err != nil {
+						t.Fatalf("Step %d: Timed out waiting for PodGroup %s condition %s=%s reason=%s: %v",
+							i, wc.podGroupName, wc.conditionType, wc.conditionStatus, wc.reason, err)
 					}
 				}
 			}

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -52,11 +52,11 @@ func TestPodGroupScheduling(t *testing.T) {
 	node := st.MakeNode().Name("node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
 
 	workload := st.MakeWorkload().Name("workload").
-		PodGroupTemplate(st.MakePodGroupTemplate().Name("t1").MinCount(3)).
-		PodGroupTemplate(st.MakePodGroupTemplate().Name("t2").BasicPolicy()).
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t1").MinCount(3).Obj()).
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t2").BasicPolicy().Obj()).
 		Obj()
 	otherWorkload := st.MakeWorkload().Name("other-workload").
-		PodGroupTemplate(st.MakePodGroupTemplate().Name("t").MinCount(3)).
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t").MinCount(3).Obj()).
 		Obj()
 
 	gangPodGroup := st.MakePodGroup().Name("pg1").TemplateRef("t1", "workload").MinCount(3).Obj()
@@ -555,7 +555,7 @@ func TestPodGroupScheduling(t *testing.T) {
 				case step.waitForPodGroupCondition != nil:
 					check := step.waitForPodGroupCondition
 					err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
-						podGroupHasCondition(cs, ns, check.podGroupName, check.conditionStatus, check.reason))
+						podGroupHasScheduledCondition(cs, ns, check.podGroupName, check.conditionStatus, check.reason))
 					if err != nil {
 						t.Fatalf("Step %d: Failed to wait for PodGroup %s condition (status=%s, reason=%s): %v",
 							i, check.podGroupName, check.conditionStatus, check.reason, err)
@@ -566,7 +566,7 @@ func TestPodGroupScheduling(t *testing.T) {
 	}
 }
 
-func podGroupHasCondition(cs kubernetes.Interface, ns, name string, status metav1.ConditionStatus, reason string) wait.ConditionWithContextFunc {
+func podGroupHasScheduledCondition(cs kubernetes.Interface, ns, name string, status metav1.ConditionStatus, reason string) wait.ConditionWithContextFunc {
 	return func(ctx context.Context) (bool, error) {
 		pg, err := cs.SchedulingV1alpha2().PodGroups(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -24,12 +24,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/kubernetes"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
@@ -51,6 +50,14 @@ func podInUnschedulablePods(t *testing.T, queue queue.SchedulingQueue, podName s
 
 func TestPodGroupScheduling(t *testing.T) {
 	node := st.MakeNode().Name("node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
+
+	workload := st.MakeWorkload().Name("workload").
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t1").MinCount(3)).
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t2").BasicPolicy()).
+		Obj()
+	otherWorkload := st.MakeWorkload().Name("other-workload").
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t").MinCount(3)).
+		Obj()
 
 	gangPodGroup := st.MakePodGroup().Name("pg1").TemplateRef("t1", "workload").MinCount(3).Obj()
 
@@ -87,9 +94,8 @@ func TestPodGroupScheduling(t *testing.T) {
 		numUnschedulable int
 	}
 
-	type waitForPodGroupCondition struct {
+	type podGroupConditionCheck struct {
 		podGroupName    string
-		conditionType   string
 		conditionStatus metav1.ConditionStatus
 		reason          string
 	}
@@ -104,7 +110,7 @@ func TestPodGroupScheduling(t *testing.T) {
 		waitForPodsUnschedulable     []string
 		waitForPodsScheduled         []string
 		waitForAnyPodsScheduled      *waitForAnyPodsScheduled
-		waitForPodGroupCondition     *waitForPodGroupCondition
+		waitForPodGroupCondition     *podGroupConditionCheck
 	}
 
 	tests := []struct {
@@ -125,6 +131,14 @@ func TestPodGroupScheduling(t *testing.T) {
 				{
 					name:                 "Verify all gang pods are scheduled successfully",
 					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Verify PodGroup condition is set to Scheduled",
+					waitForPodGroupCondition: &podGroupConditionCheck{
+						podGroupName:    "pg1",
+						conditionStatus: metav1.ConditionTrue,
+						reason:          "Scheduled",
+					},
 				},
 			},
 		},
@@ -181,12 +195,28 @@ func TestPodGroupScheduling(t *testing.T) {
 					waitForPodsUnschedulable: []string{"p1", "p2", "p3"},
 				},
 				{
+					name: "Verify PodGroup condition is set to Unschedulable",
+					waitForPodGroupCondition: &podGroupConditionCheck{
+						podGroupName:    "pg1",
+						conditionStatus: metav1.ConditionFalse,
+						reason:          schedulingapi.PodGroupReasonUnschedulable,
+					},
+				},
+				{
 					name:       "Delete the resource-blocking pod",
 					deletePods: []string{"blocker"},
 				},
 				{
 					name:                 "Verify the entire gang is now scheduled",
 					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					name: "Verify PodGroup condition transitions to Scheduled",
+					waitForPodGroupCondition: &podGroupConditionCheck{
+						podGroupName:    "pg1",
+						conditionStatus: metav1.ConditionTrue,
+						reason:          "Scheduled",
+					},
 				},
 			},
 		},
@@ -300,6 +330,14 @@ func TestPodGroupScheduling(t *testing.T) {
 					name:                 "Verify all gang pods are scheduled successfully (after preemption)",
 					waitForPodsScheduled: []string{"p1", "p2", "p3", "p4"},
 				},
+				{
+					name: "Verify PodGroup condition is set to Scheduled after preemption completes",
+					waitForPodGroupCondition: &podGroupConditionCheck{
+						podGroupName:    "pg1",
+						conditionStatus: metav1.ConditionTrue,
+						reason:          "Scheduled",
+					},
+				},
 			},
 		},
 		{
@@ -393,83 +431,6 @@ func TestPodGroupScheduling(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "gang PodGroup status set to Scheduled when all pods scheduled",
-			steps: []step{
-				{
-					name:           "Create the PodGroup object",
-					createPodGroup: gangPodGroup,
-				},
-				{
-					name:       "Create all pods belonging to the gang",
-					createPods: []*v1.Pod{p1, p2, p3},
-				},
-				{
-					name:                 "Verify all gang pods are scheduled",
-					waitForPodsScheduled: []string{"p1", "p2", "p3"},
-				},
-				{
-					name: "Verify PodGroup condition is Scheduled",
-					waitForPodGroupCondition: &waitForPodGroupCondition{
-						podGroupName:    "pg1",
-						conditionType:   scheduling.PodGroupScheduled,
-						conditionStatus: metav1.ConditionTrue,
-						reason:          scheduling.PodGroupReasonScheduled,
-					},
-				},
-			},
-		},
-		{
-			name: "gang PodGroup status transitions from Unschedulable to Scheduled",
-			steps: []step{
-				{
-					name:       "Create the resource-blocking pod",
-					createPods: []*v1.Pod{blockerPod},
-				},
-				{
-					name:                 "Schedule the resource-blocking pod",
-					waitForPodsScheduled: []string{"blocker"},
-				},
-				{
-					name:           "Create the PodGroup object",
-					createPodGroup: gangPodGroup,
-				},
-				{
-					name:       "Create gang pods",
-					createPods: []*v1.Pod{p1, p2, p3},
-				},
-				{
-					name:                     "Verify pods become unschedulable",
-					waitForPodsUnschedulable: []string{"p1", "p2", "p3"},
-				},
-				{
-					name: "Verify PodGroup condition is Unschedulable",
-					waitForPodGroupCondition: &waitForPodGroupCondition{
-						podGroupName:    "pg1",
-						conditionType:   scheduling.PodGroupScheduled,
-						conditionStatus: metav1.ConditionFalse,
-						reason:          scheduling.PodGroupReasonUnschedulable,
-					},
-				},
-				{
-					name:       "Delete the resource-blocking pod",
-					deletePods: []string{"blocker"},
-				},
-				{
-					name:                 "Verify the entire gang is now scheduled",
-					waitForPodsScheduled: []string{"p1", "p2", "p3"},
-				},
-				{
-					name: "Verify PodGroup condition transitions to Scheduled",
-					waitForPodGroupCondition: &waitForPodGroupCondition{
-						podGroupName:    "pg1",
-						conditionType:   scheduling.PodGroupScheduled,
-						conditionStatus: metav1.ConditionTrue,
-						reason:          scheduling.PodGroupReasonScheduled,
-					},
-				},
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -489,6 +450,14 @@ func TestPodGroupScheduling(t *testing.T) {
 			_, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Failed to create node: %v", err)
+			}
+
+			for _, w := range []*schedulingapi.Workload{workload, otherWorkload} {
+				wCopy := w.DeepCopy()
+				wCopy.Namespace = ns
+				if _, err := cs.SchedulingV1alpha2().Workloads(ns).Create(testCtx.Ctx, wCopy, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create workload %s: %v", wCopy.Name, err)
+				}
 			}
 
 			for i, step := range tt.steps {
@@ -584,26 +553,34 @@ func TestPodGroupScheduling(t *testing.T) {
 						t.Fatalf("Step %d: Failed to wait for pods to be scheduled or unschedulable: %v", i, err)
 					}
 				case step.waitForPodGroupCondition != nil:
-					wc := step.waitForPodGroupCondition
-					err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false,
-						func(ctx context.Context) (bool, error) {
-							pg, err := cs.SchedulingV1alpha2().PodGroups(ns).Get(ctx, wc.podGroupName, metav1.GetOptions{})
-							if err != nil {
-								return false, err
-							}
-							cond := apimeta.FindStatusCondition(pg.Status.Conditions, wc.conditionType)
-							if cond == nil {
-								return false, nil
-							}
-							return cond.Status == wc.conditionStatus && (wc.reason == "" || cond.Reason == wc.reason), nil
-						},
-					)
+					check := step.waitForPodGroupCondition
+					err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+						podGroupHasCondition(cs, ns, check.podGroupName, check.conditionStatus, check.reason))
 					if err != nil {
-						t.Fatalf("Step %d: Timed out waiting for PodGroup %s condition %s=%s reason=%s: %v",
-							i, wc.podGroupName, wc.conditionType, wc.conditionStatus, wc.reason, err)
+						t.Fatalf("Step %d: Failed to wait for PodGroup %s condition (status=%s, reason=%s): %v",
+							i, check.podGroupName, check.conditionStatus, check.reason, err)
 					}
 				}
 			}
 		})
+	}
+}
+
+func podGroupHasCondition(cs kubernetes.Interface, ns, name string, status metav1.ConditionStatus, reason string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pg, err := cs.SchedulingV1alpha2().PodGroups(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		for _, c := range pg.Status.Conditions {
+			if c.Type == schedulingapi.PodGroupScheduled &&
+				c.Status == status && c.Reason == reason {
+				return true, nil
+			}
+		}
+		return false, nil
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling
/sig apps
/area workload-aware

#### What this PR does / why we need it:

This PR implements PodGroup status updates driven by kube-scheduler as part of KEP-5832. The scheduler now sets a PodGroupScheduled condition on PodGroup resources reflecting the outcome of PodGroup scheduling cycles:

- `PodGroupScheduled=True`: set when the PodGroup scheduling cycle succeeds.
- `PodGroupScheduled=False` with reason Unschedulable: set when the scheduling cycle fails to place the group. Once the group has been successfully scheduled, subsequent failed cycles for additional pods beyond minCount do not regress the condition back to False.

#### Which issue(s) this PR is related to:

- KEP-5832: [Decouple PodGroup API](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5832-decouple-podgroup-api) 
- Depends on: #137464 (PodGroup admission)
- Related: #137641 (PodGroup protection controller)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kube-scheduler now updates PodGroup status with a `PodGroupScheduled` condition reflecting whether the group was successfully scheduled or is unschedulable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
