### PR TITLE
fix: [sig-autoscaling] flaky HPAConfigurableTolerance e2e should scale up but should not scale down

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -550,7 +550,7 @@ var _ = SIGDescribe(feature.HPA, framework.WithSlow(), framework.WithFeatureGate
 			ginkgo.It("should scale up but should not scale down", func(ctx context.Context) {
 				ginkgo.By("setting up resource consumer and HPA")
 				initPods := 10
-				podCPURequest := 500
+				podCPURequest := 200
 				targetCPUUtilizationPercent := 60
 				// Compute initial load for 10 pods.
 				initCPUUsageTotal := usageForReplicasWithRequest(initPods, podCPURequest, targetCPUUtilizationPercent)

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -576,8 +576,11 @@ var _ = SIGDescribe(feature.HPA, framework.WithSlow(), framework.WithFeatureGate
 				ginkgo.By("waiting for deployment to start initial pods")
 				rc.WaitForReplicas(ctx, initPods, waitDeadline)
 
-				// Set initial stable load using even per-pod distribution.
+				// Set initial stable load using even per-pod distribution and wait for
+				// HPA to observe it before triggering scale-up. This ensures HPA has a
+				// baseline measurement before we push load above the scale-up tolerance.
 				rc.ConsumeCPUPerPod(initCPUUsageTotal)
+				rc.EnsureDesiredReplicasInRange(ctx, initPods, initPods, maxHPAReactionTime+maxResourceConsumerDelay, hpa.Name)
 
 				ginkgo.By("trying to trigger scale up to 11 replicas")
 				rc.ConsumeCPUPerPod(usageForReplicasWithRequest(11, podCPURequest, targetCPUUtilizationPercent))

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -552,12 +552,15 @@ var _ = SIGDescribe(feature.HPA, framework.WithSlow(), framework.WithFeatureGate
 				initPods := 10
 				podCPURequest := 500
 				targetCPUUtilizationPercent := 60
+				// Compute initial load for 10 pods.
 				initCPUUsageTotal := usageForReplicasWithRequest(initPods, podCPURequest, targetCPUUtilizationPercent)
 				waitDeadline := maxHPAReactionTime + maxResourceConsumerDelay + waitBuffer
 
+				// Pass 0 as initCPUTotal so the regular ConsumeCPU goroutine stays idle.
+				// We drive load exclusively via ConsumeCPUPerPod to guarantee even distribution.
 				rc := e2eautoscaling.NewDynamicResourceConsumer(ctx,
 					hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
-					initCPUUsageTotal, 0, 0, int64(podCPURequest), 200,
+					0, 0, 0, int64(podCPURequest), 200,
 					f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
 					nil)
 				ginkgo.DeferCleanup(rc.CleanUp)
@@ -573,8 +576,11 @@ var _ = SIGDescribe(feature.HPA, framework.WithSlow(), framework.WithFeatureGate
 				ginkgo.By("waiting for deployment to start initial pods")
 				rc.WaitForReplicas(ctx, initPods, waitDeadline)
 
+				// Set initial stable load using even per-pod distribution.
+				rc.ConsumeCPUPerPod(initCPUUsageTotal)
+
 				ginkgo.By("trying to trigger scale up to 11 replicas")
-				rc.ConsumeCPU(usageForReplicasWithRequest(11, podCPURequest, targetCPUUtilizationPercent))
+				rc.ConsumeCPUPerPod(usageForReplicasWithRequest(11, podCPURequest, targetCPUUtilizationPercent))
 
 				ginkgo.By("waiting for replicas to scale up")
 				waitStart := time.Now()
@@ -583,12 +589,10 @@ var _ = SIGDescribe(feature.HPA, framework.WithSlow(), framework.WithFeatureGate
 				framework.Logf("time waited for scale up: %s", timeWaited)
 				gomega.Expect(timeWaited).To(gomega.BeNumerically("<", waitDeadline), "waited %s, wanted less than %s", timeWaited, waitDeadline)
 
-				// Increase resource usage to match 12 replicas. The difference is less
-				// than 10% (the default tolerance), but it should scale up anyway thanks
-				// to the small scale-up custom tolerance.
-
+				// Increase to 12 replicas. Difference is less than 10% default tolerance
+				// but should still scale up due to the small (2%) custom scale-up tolerance.
 				ginkgo.By("trying to trigger scale up to 12 replicas")
-				rc.ConsumeCPU(usageForReplicasWithRequest(12, podCPURequest, targetCPUUtilizationPercent))
+				rc.ConsumeCPUPerPod(usageForReplicasWithRequest(12, podCPURequest, targetCPUUtilizationPercent))
 
 				ginkgo.By("waiting for replicas to scale up")
 				waitStart = time.Now()
@@ -597,12 +601,11 @@ var _ = SIGDescribe(feature.HPA, framework.WithSlow(), framework.WithFeatureGate
 				framework.Logf("time waited for scale up: %s", timeWaited)
 				gomega.Expect(timeWaited).To(gomega.BeNumerically("<", waitDeadline), "waited %s, wanted less than %s", timeWaited, waitDeadline)
 
-				// Decrease resource usage to match 10 replicas. Should not scale down
-				// because of the large scale-down custom tolerance.
-
+				// Drop load to 10-replica level. Should NOT scale down because the
+				// difference is within the large (30%) custom scale-down tolerance.
 				ginkgo.By("triggering scale down by lowering consumption")
 				waitStart = time.Now()
-				rc.ConsumeCPU(usageForReplicasWithRequest(10, podCPURequest, targetCPUUtilizationPercent))
+				rc.ConsumeCPUPerPod(usageForReplicasWithRequest(10, podCPURequest, targetCPUUtilizationPercent))
 
 				rc.EnsureDesiredReplicasInRange(ctx, 12, 12, waitDeadline, hpa.Name)
 				timeWaited = time.Since(waitStart)
@@ -610,6 +613,7 @@ var _ = SIGDescribe(feature.HPA, framework.WithSlow(), framework.WithFeatureGate
 				ginkgo.By("verifying time waited for a scale down")
 				framework.Logf("time waited for scale down: %s", timeWaited)
 				gomega.Expect(timeWaited).To(gomega.BeNumerically(">", waitDeadline), "waited %s, wanted to wait more than %s", timeWaited, waitDeadline)
+
 			})
 		})
 	})

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -723,17 +723,27 @@ func (rc *ResourceConsumer) sendConsumeCPUPerPodRequest(ctx context.Context, mil
 			// Both service and pod proxy support the name:port format. Without an explicit
 			// port the API server defaults to port 80, but resource-consumer listens on
 			// targetPort (8080), so the port must be specified.
-			_, podErr := rc.clientSet.CoreV1().RESTClient().Post().
-				Resource("pods").
-				Namespace(rc.nsName).
-				Name(fmt.Sprintf("%s:%d", name, targetPort)).
-				SubResource("proxy").
-				Suffix("ConsumeCPU").
-				Param("millicores", strconv.Itoa(perPodMillicores)).
-				Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
-				DoRaw(ctx)
-			if podErr != nil {
-				framework.Logf("ConsumeCPUPerPod: error sending to pod %s: %v", name, podErr)
+			err := framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
+				_, podErr := rc.clientSet.CoreV1().RESTClient().Post().
+					Resource("pods").
+					Namespace(rc.nsName).
+					Name(fmt.Sprintf("%s:%d", name, targetPort)).
+					SubResource("proxy").
+					Suffix("ConsumeCPU").
+					Param("millicores", strconv.Itoa(perPodMillicores)).
+					Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
+					DoRaw(ctx)
+				if podErr != nil {
+					framework.Logf("ConsumeCPUPerPod: error sending to pod %s: %v", name, podErr)
+					return podErr
+				}
+				return nil
+			}).WithTimeout(serviceInitializationTimeout).WithPolling(serviceInitializationInterval).Should(gomega.Succeed())
+			if ctx.Err() != nil {
+				return
+			}
+			if err != nil {
+				framework.Logf("ConsumeCPUPerPod: giving up on pod %s: %v", name, err)
 			}
 		}(podName)
 	}

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -137,6 +137,8 @@ type ResourceConsumer struct {
 	requestSizeCustomMetric  int
 	sidecarStatus            SidecarStatusType
 	sidecarType              SidecarWorkloadType
+	cpuPerPod                chan int
+	stopCPUPerPod            chan int
 }
 
 // ExternalMetricsController provides methods to control the external metrics server at runtime
@@ -415,6 +417,8 @@ func NewResourceConsumer(ctx context.Context, name, nsName string, kind schema.G
 		stopCPU:                  make(chan int),
 		stopMem:                  make(chan int),
 		stopCustomMetric:         make(chan int),
+		cpuPerPod:                make(chan int),
+		stopCPUPerPod:            make(chan int),
 		consumptionTimeInSeconds: consumptionTimeInSeconds,
 		sleepTime:                time.Duration(consumptionTimeInSeconds) * time.Second,
 		requestSizeInMillicores:  requestSizeInMillicores,
@@ -430,6 +434,7 @@ func NewResourceConsumer(ctx context.Context, name, nsName string, kind schema.G
 	rc.ConsumeMem(initMemoryTotal)
 	go rc.makeConsumeCustomMetric(ctx)
 	rc.ConsumeCustomMetric(initCustomMetric)
+	go rc.makeConsumeCPUPerPodRequests(ctx)
 	return rc
 }
 
@@ -634,6 +639,122 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(ctx context.Context, delta i
 	framework.ExpectNoError(err)
 }
 
+/*
+ConsumeCPUPerPod sends CPU load directly to each consumer pod via the
+Kubernetes pod proxy API, bypassing kube-proxy's non-deterministic load
+balancing. millicoresTotal is divided evenly across all running pods,
+guaranteeing each pod receives an equal share regardless of cluster network config.
+*/
+func (rc *ResourceConsumer) ConsumeCPUPerPod(millicoresTotal int) {
+	framework.Logf("RC %s: consume %v millicores in total (evenly distributed per pod)", rc.name, millicoresTotal)
+	rc.cpuPerPod <- millicoresTotal
+}
+
+func (rc *ResourceConsumer) makeConsumeCPUPerPodRequests(ctx context.Context) {
+	defer ginkgo.GinkgoRecover()
+	rc.stopWaitGroup.Add(1)
+	defer rc.stopWaitGroup.Done()
+	tick := time.After(time.Duration(0))
+	milliCoresPerPod := 0
+	for {
+		select {
+		case milliCoresPerPod = <-rc.cpuPerPod:
+			if milliCoresPerPod != 0 {
+				framework.Logf("RC %s setting per-pod CPU to %v millicores", rc.name, milliCoresPerPod)
+			} else {
+				framework.Logf("RC %s disabling per-pod CPU consumption", rc.name)
+			}
+		case <-tick:
+			if milliCoresPerPod != 0 {
+				replicas, err := rc.GetReplicas(ctx)
+				if err != nil {
+					framework.Logf("RC %s failed to get replicas: %v", rc.name, err)
+				} else {
+					totalMillicores := milliCoresPerPod * replicas
+					framework.Logf("RC %s sending request to consume %d millicores/pod x %d replicas = %d total",
+						rc.name, milliCoresPerPod, replicas, totalMillicores)
+					rc.sendConsumeCPURequest(ctx, totalMillicores)
+				}
+			}
+			tick = time.After(rc.sleepTime)
+		case <-ctx.Done():
+			framework.Logf("RC %s stopping per-pod CPU consumer: %v", rc.name, ctx.Err())
+			return
+		case <-rc.stopCPUPerPod:
+			framework.Logf("RC %s stopping per-pod CPU consumer", rc.name)
+			return
+		}
+	}
+}
+
+/*
+sendConsumeCPURequestPerPod lists all running pods for this ResourceConsumer
+and sends a CPU consumption request to each one directly via the pod proxy
+endpoint. This ensures each pod receives exactly millicoresTotal/numPods
+millicores, regardless of kube-proxy load balancing behavior.
+*/
+func (rc *ResourceConsumer) sendConsumeCPURequestPerPod(ctx context.Context, millicoresTotal int) {
+	pods, err := rc.clientSet.CoreV1().Pods(rc.nsName).List(ctx, metav1.ListOptions{
+		LabelSelector: "name=" + rc.name,
+	})
+	if err != nil {
+		framework.Logf("RC %s: failed to list pods for per-pod CPU consumption: %v", rc.name, err)
+		return
+	}
+
+	runningPods := make([]v1.Pod, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
+			runningPods = append(runningPods, pod)
+		}
+	}
+
+	if len(runningPods) == 0 {
+		framework.Logf("RC %s: no running pods found for per-pod CPU consumption", rc.name)
+		return
+	}
+
+	perPodMillicores := millicoresTotal / len(runningPods)
+	if perPodMillicores == 0 {
+		framework.Logf("RC %s: per-pod millicores rounded to 0, skipping", rc.name)
+		return
+	}
+
+	framework.Logf("RC %s: sending %d millicores to each of %d pods via pod proxy",
+		rc.name, perPodMillicores, len(runningPods))
+
+	var wg sync.WaitGroup
+	for _, pod := range runningPods {
+		wg.Add(1)
+		podName := pod.Name
+		go func() {
+			defer wg.Done()
+			err := framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
+				_, reqErr := rc.clientSet.CoreV1().RESTClient().Post().
+					Namespace(rc.nsName).
+					Resource("pods").
+					Name(podName).
+					SubResource("proxy").
+					Suffix("ConsumeCPU").
+					Param("millicores", strconv.Itoa(perPodMillicores)).
+					Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
+					Param("requestSizeMillicores", strconv.Itoa(perPodMillicores)).
+					DoRaw(ctx)
+				if reqErr != nil {
+					framework.Logf("RC %s: failed to send CPU request to pod %s: %v", rc.name, podName, reqErr)
+					return reqErr
+				}
+				return nil
+			}).WithTimeout(serviceInitializationTimeout).WithPolling(serviceInitializationInterval).Should(gomega.Succeed())
+			if ctx.Err() != nil {
+				return
+			}
+			framework.ExpectNoError(err)
+		}()
+	}
+	wg.Wait()
+}
+
 // GetReplicas get the replicas
 func (rc *ResourceConsumer) GetReplicas(ctx context.Context) (int, error) {
 	switch rc.kind {
@@ -719,6 +840,7 @@ func (rc *ResourceConsumer) Pause() {
 	rc.stopCPU <- 0
 	rc.stopMem <- 0
 	rc.stopCustomMetric <- 0
+	rc.stopCPUPerPod <- 0
 	rc.stopWaitGroup.Wait()
 }
 
@@ -728,6 +850,7 @@ func (rc *ResourceConsumer) Resume(ctx context.Context) {
 	go rc.makeConsumeCPURequests(ctx)
 	go rc.makeConsumeMemRequests(ctx)
 	go rc.makeConsumeCustomMetric(ctx)
+	go rc.makeConsumeCPUPerPodRequests(ctx)
 }
 
 // CleanUp clean up the background goroutines responsible for consuming resources.
@@ -736,6 +859,7 @@ func (rc *ResourceConsumer) CleanUp(ctx context.Context) {
 	close(rc.stopCPU)
 	close(rc.stopMem)
 	close(rc.stopCustomMetric)
+	close(rc.stopCPUPerPod)
 	rc.stopWaitGroup.Wait()
 	// Wait some time to ensure all child goroutines are finished.
 	time.Sleep(10 * time.Second)
@@ -749,6 +873,9 @@ func (rc *ResourceConsumer) CleanUp(ctx context.Context) {
 	}
 
 	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name, metav1.DeleteOptions{}))
+	if err := rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name+"-headless", metav1.DeleteOptions{}); err != nil {
+		framework.Logf("Warning: could not delete headless service %s: %v", rc.name+"-headless", err)
+	}
 	framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, rc.clientSet, schema.GroupKind{Group: "apps", Kind: "ReplicaSet"}, rc.nsName, rc.controllerName))
 	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name+"-ctrl", metav1.DeleteOptions{}))
 	// Cleanup sidecar related resources
@@ -766,6 +893,25 @@ func createService(ctx context.Context, c clientset.Interface, name, ns string, 
 			Labels:      map[string]string{"name": name},
 		},
 		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       portName,
+				Port:       port,
+				TargetPort: intstr.FromInt32(int32(targetPort)),
+			}},
+			Selector: selectors,
+		},
+	}, metav1.CreateOptions{})
+}
+
+func createHeadlessService(ctx context.Context, c clientset.Interface, name, ns string, annotations, selectors map[string]string, port int32, targetPort int) (*v1.Service, error) {
+	return c.CoreV1().Services(ns).Create(ctx, &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+			Labels:      map[string]string{"name": name},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "None", // headless: DNS returns individual pod IPs, not a VIP
 			Ports: []v1.ServicePort{{
 				Name:       portName,
 				Port:       port,
@@ -875,6 +1021,8 @@ func runServiceAndSidecarForResourceConsumer(ctx context.Context, c clientset.In
 func runServiceAndWorkloadForResourceConsumer(ctx context.Context, c clientset.Interface, resourceClient dynamic.ResourceInterface, apiExtensionClient crdclientset.Interface, ns, name string, kind schema.GroupVersionKind, replicas int, cpuLimitMillis, memLimitMb int64, podAnnotations, serviceAnnotations map[string]string, additionalContainers []v1.Container, podResources *v1.ResourceRequirements) {
 	ginkgo.By(fmt.Sprintf("Running consuming RC %s via %s with %v replicas", name, kind, replicas))
 	_, err := createService(ctx, c, name, ns, serviceAnnotations, map[string]string{"name": name}, port, targetPort)
+	framework.ExpectNoError(err)
+	_, err = createHeadlessService(ctx, c, name+"-headless", ns, serviceAnnotations, map[string]string{"name": name}, port, targetPort)
 	framework.ExpectNoError(err)
 
 	rcConfig := testutils.RCConfig{

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -858,9 +858,6 @@ func (rc *ResourceConsumer) CleanUp(ctx context.Context) {
 	}
 
 	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name, metav1.DeleteOptions{}))
-	if err := rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name+"-headless", metav1.DeleteOptions{}); err != nil {
-		framework.Logf("Warning: could not delete headless service %s: %v", rc.name+"-headless", err)
-	}
 	framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, rc.clientSet, schema.GroupKind{Group: "apps", Kind: "ReplicaSet"}, rc.nsName, rc.controllerName))
 	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(ctx, rc.name+"-ctrl", metav1.DeleteOptions{}))
 	// Cleanup sidecar related resources
@@ -878,25 +875,6 @@ func createService(ctx context.Context, c clientset.Interface, name, ns string, 
 			Labels:      map[string]string{"name": name},
 		},
 		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:       portName,
-				Port:       port,
-				TargetPort: intstr.FromInt32(int32(targetPort)),
-			}},
-			Selector: selectors,
-		},
-	}, metav1.CreateOptions{})
-}
-
-func createHeadlessService(ctx context.Context, c clientset.Interface, name, ns string, annotations, selectors map[string]string, port int32, targetPort int) (*v1.Service, error) {
-	return c.CoreV1().Services(ns).Create(ctx, &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Annotations: annotations,
-			Labels:      map[string]string{"name": name},
-		},
-		Spec: v1.ServiceSpec{
-			ClusterIP: "None", // headless: DNS returns individual pod IPs, not a VIP
 			Ports: []v1.ServicePort{{
 				Name:       portName,
 				Port:       port,
@@ -1006,8 +984,6 @@ func runServiceAndSidecarForResourceConsumer(ctx context.Context, c clientset.In
 func runServiceAndWorkloadForResourceConsumer(ctx context.Context, c clientset.Interface, resourceClient dynamic.ResourceInterface, apiExtensionClient crdclientset.Interface, ns, name string, kind schema.GroupVersionKind, replicas int, cpuLimitMillis, memLimitMb int64, podAnnotations, serviceAnnotations map[string]string, additionalContainers []v1.Container, podResources *v1.ResourceRequirements) {
 	ginkgo.By(fmt.Sprintf("Running consuming RC %s via %s with %v replicas", name, kind, replicas))
 	_, err := createService(ctx, c, name, ns, serviceAnnotations, map[string]string{"name": name}, port, targetPort)
-	framework.ExpectNoError(err)
-	_, err = createHeadlessService(ctx, c, name+"-headless", ns, serviceAnnotations, map[string]string{"name": name}, port, targetPort)
 	framework.ExpectNoError(err)
 
 	rcConfig := testutils.RCConfig{

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -655,29 +655,89 @@ func (rc *ResourceConsumer) makeConsumeCPUPerPodRequests(ctx context.Context) {
 	rc.stopWaitGroup.Add(1)
 	defer rc.stopWaitGroup.Done()
 	tick := time.After(time.Duration(0))
-	milliCoresPerPod := 0
+	millicoresTotal := 0
 	for {
 		select {
-		case milliCoresPerPod = <-rc.cpuPerPod:
-			if milliCoresPerPod != 0 {
-				framework.Logf("RC %s setting per-pod CPU to %v millicores", rc.name, milliCoresPerPod)
+		case millicoresTotal = <-rc.cpuPerPod:
+			if millicoresTotal != 0 {
+				framework.Logf("RC %s: setting per-pod CPU to %v millicores total", rc.name, millicoresTotal)
 			} else {
-				framework.Logf("RC %s disabling per-pod CPU consumption", rc.name)
+				framework.Logf("RC %s: disabling per-pod CPU consumption", rc.name)
 			}
 		case <-tick:
-			if milliCoresPerPod != 0 {
-				framework.Logf("RC %s sending per-pod CPU request: %d millicores total", rc.name, milliCoresPerPod)
-				rc.sendConsumeCPURequest(ctx, milliCoresPerPod)
+			if millicoresTotal != 0 {
+				framework.Logf("RC %s: sending per-pod CPU request: %d millicores total", rc.name, millicoresTotal)
+				rc.sendConsumeCPUPerPodRequest(ctx, millicoresTotal)
 			}
 			tick = time.After(rc.sleepTime)
 		case <-ctx.Done():
-			framework.Logf("RC %s stopping per-pod CPU consumer: %v", rc.name, ctx.Err())
+			framework.Logf("RC %s: stopping per-pod CPU consumer: %v", rc.name, ctx.Err())
 			return
 		case <-rc.stopCPUPerPod:
-			framework.Logf("RC %s stopping per-pod CPU consumer", rc.name)
+			framework.Logf("RC %s: stopping per-pod CPU consumer", rc.name)
 			return
 		}
 	}
+}
+
+// sendConsumeCPUPerPodRequest distributes CPU load evenly across all running
+// pods by sending requests directly via the Kubernetes pod proxy API. This
+// bypasses kube-proxy load balancing, guaranteeing each pod receives exactly
+// its share. Falls back to sendConsumeCPURequest if pod listing fails.
+func (rc *ResourceConsumer) sendConsumeCPUPerPodRequest(ctx context.Context, millicoresTotal int) {
+	pods, err := rc.clientSet.CoreV1().Pods(rc.nsName).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("name=%s", rc.name),
+	})
+	if err != nil {
+		framework.Logf("ConsumeCPUPerPod: failed to list pods: %v, falling back to service proxy", err)
+		rc.sendConsumeCPURequest(ctx, millicoresTotal)
+		return
+	}
+
+	var readyPods []string
+	for i := range pods.Items {
+		if pods.Items[i].Status.Phase == v1.PodRunning {
+			readyPods = append(readyPods, pods.Items[i].Name)
+		}
+	}
+	if len(readyPods) == 0 {
+		framework.Logf("ConsumeCPUPerPod: no running pods, falling back to service proxy")
+		rc.sendConsumeCPURequest(ctx, millicoresTotal)
+		return
+	}
+
+	perPodMillicores := millicoresTotal / len(readyPods)
+	if perPodMillicores == 0 {
+		perPodMillicores = 1
+	}
+
+	framework.Logf("ConsumeCPUPerPod: distributing %d millicores across %d pods (%d per pod)",
+		millicoresTotal, len(readyPods), perPodMillicores)
+
+	var wg sync.WaitGroup
+	for _, podName := range readyPods {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			// Pod proxy URL: /api/v1/namespaces/{ns}/pods/{podname}:{port}/proxy/{path}
+			// Both service and pod proxy support the name:port format. Without an explicit
+			// port the API server defaults to port 80, but resource-consumer listens on
+			// targetPort (8080), so the port must be specified.
+			_, podErr := rc.clientSet.CoreV1().RESTClient().Post().
+				Resource("pods").
+				Namespace(rc.nsName).
+				Name(fmt.Sprintf("%s:%d", name, targetPort)).
+				SubResource("proxy").
+				Suffix("ConsumeCPU").
+				Param("millicores", strconv.Itoa(perPodMillicores)).
+				Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
+				DoRaw(ctx)
+			if podErr != nil {
+				framework.Logf("ConsumeCPUPerPod: error sending to pod %s: %v", name, podErr)
+			}
+		}(podName)
+	}
+	wg.Wait()
 }
 
 // GetReplicas get the replicas

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -666,15 +666,8 @@ func (rc *ResourceConsumer) makeConsumeCPUPerPodRequests(ctx context.Context) {
 			}
 		case <-tick:
 			if milliCoresPerPod != 0 {
-				replicas, err := rc.GetReplicas(ctx)
-				if err != nil {
-					framework.Logf("RC %s failed to get replicas: %v", rc.name, err)
-				} else {
-					totalMillicores := milliCoresPerPod * replicas
-					framework.Logf("RC %s sending request to consume %d millicores/pod x %d replicas = %d total",
-						rc.name, milliCoresPerPod, replicas, totalMillicores)
-					rc.sendConsumeCPURequest(ctx, totalMillicores)
-				}
+				framework.Logf("RC %s sending per-pod CPU request: %d millicores total", rc.name, milliCoresPerPod)
+				rc.sendConsumeCPURequest(ctx, milliCoresPerPod)
 			}
 			tick = time.After(rc.sleepTime)
 		case <-ctx.Done():
@@ -685,74 +678,6 @@ func (rc *ResourceConsumer) makeConsumeCPUPerPodRequests(ctx context.Context) {
 			return
 		}
 	}
-}
-
-/*
-sendConsumeCPURequestPerPod lists all running pods for this ResourceConsumer
-and sends a CPU consumption request to each one directly via the pod proxy
-endpoint. This ensures each pod receives exactly millicoresTotal/numPods
-millicores, regardless of kube-proxy load balancing behavior.
-*/
-func (rc *ResourceConsumer) sendConsumeCPURequestPerPod(ctx context.Context, millicoresTotal int) {
-	pods, err := rc.clientSet.CoreV1().Pods(rc.nsName).List(ctx, metav1.ListOptions{
-		LabelSelector: "name=" + rc.name,
-	})
-	if err != nil {
-		framework.Logf("RC %s: failed to list pods for per-pod CPU consumption: %v", rc.name, err)
-		return
-	}
-
-	runningPods := make([]v1.Pod, 0, len(pods.Items))
-	for _, pod := range pods.Items {
-		if pod.Status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
-			runningPods = append(runningPods, pod)
-		}
-	}
-
-	if len(runningPods) == 0 {
-		framework.Logf("RC %s: no running pods found for per-pod CPU consumption", rc.name)
-		return
-	}
-
-	perPodMillicores := millicoresTotal / len(runningPods)
-	if perPodMillicores == 0 {
-		framework.Logf("RC %s: per-pod millicores rounded to 0, skipping", rc.name)
-		return
-	}
-
-	framework.Logf("RC %s: sending %d millicores to each of %d pods via pod proxy",
-		rc.name, perPodMillicores, len(runningPods))
-
-	var wg sync.WaitGroup
-	for _, pod := range runningPods {
-		wg.Add(1)
-		podName := pod.Name
-		go func() {
-			defer wg.Done()
-			err := framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
-				_, reqErr := rc.clientSet.CoreV1().RESTClient().Post().
-					Namespace(rc.nsName).
-					Resource("pods").
-					Name(podName).
-					SubResource("proxy").
-					Suffix("ConsumeCPU").
-					Param("millicores", strconv.Itoa(perPodMillicores)).
-					Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
-					Param("requestSizeMillicores", strconv.Itoa(perPodMillicores)).
-					DoRaw(ctx)
-				if reqErr != nil {
-					framework.Logf("RC %s: failed to send CPU request to pod %s: %v", rc.name, podName, reqErr)
-					return reqErr
-				}
-				return nil
-			}).WithTimeout(serviceInitializationTimeout).WithPolling(serviceInitializationInterval).Should(gomega.Succeed())
-			if ctx.Err() != nil {
-				return
-			}
-			framework.ExpectNoError(err)
-		}()
-	}
-	wg.Wait()
 }
 
 // GetReplicas get the replicas

--- a/test/images/agnhost/resource-consumer-controller/controller.go
+++ b/test/images/agnhost/resource-consumer-controller/controller.go
@@ -19,11 +19,13 @@ package resconsumerctrl
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -43,6 +45,7 @@ var CmdResourceConsumerController = &cobra.Command{
 var (
 	port                     int
 	consumerPort             int
+	consumerTargetPort       int
 	consumerServiceName      string
 	consumerServiceNamespace string
 	dnsDomain                string
@@ -73,6 +76,7 @@ func getDNSDomain() string {
 func init() {
 	CmdResourceConsumerController.Flags().IntVar(&port, "port", 8080, "Port number.")
 	CmdResourceConsumerController.Flags().IntVar(&consumerPort, "consumer-port", 8080, "Port number of consumers.")
+	CmdResourceConsumerController.Flags().IntVar(&consumerTargetPort, "consumer-target-port", 8080, "Target (container) port for direct pod connections via headless DNS.")
 	CmdResourceConsumerController.Flags().StringVar(&consumerServiceName, "consumer-service-name", "resource-consumer", "Name of service containing resource consumers.")
 	CmdResourceConsumerController.Flags().StringVar(&consumerServiceNamespace, "consumer-service-namespace", "default", "Namespace of service containing resource consumers.")
 }
@@ -84,12 +88,15 @@ func main(cmd *cobra.Command, args []string) {
 
 type controller struct {
 	responseWriterLock sync.Mutex
+	httpClient         *http.Client
 	waitGroup          sync.WaitGroup
 }
 
 func newController() *controller {
-	c := &controller{}
-	return c
+	return &controller{
+		// 30s timeout prevents hung goroutines on stale pod IPs
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
 }
 
 func (c *controller) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -121,7 +128,6 @@ func (c *controller) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (c *controller) handleConsumeCPU(w http.ResponseWriter, query url.Values) {
-	// getting string data for consumeCPU
 	durationSecString := query.Get(common.DurationSecQuery)
 	millicoresString := query.Get(common.MillicoresQuery)
 	requestSizeInMillicoresString := query.Get(common.RequestSizeInMillicoresQuery)
@@ -130,7 +136,6 @@ func (c *controller) handleConsumeCPU(w http.ResponseWriter, query url.Values) {
 		return
 	}
 
-	// convert data (strings to ints) for consumeCPU
 	durationSec, durationSecError := strconv.Atoi(durationSecString)
 	millicores, millicoresError := strconv.Atoi(millicoresString)
 	requestSizeInMillicores, requestSizeInMillicoresError := strconv.Atoi(requestSizeInMillicoresString)
@@ -139,9 +144,39 @@ func (c *controller) handleConsumeCPU(w http.ResponseWriter, query url.Values) {
 		return
 	}
 
+	// Attempt headless DNS resolution: <service>-headless.<ns>.svc.<domain>
+	// returns one A record per pod, allowing deterministic per-pod distribution.
+	// consumerTargetPort (default 8080) is the actual container port not
+	// consumerPort (80) which is the ClusterIP service port.
+	headlessDNS := fmt.Sprintf("%s-headless.%s.svc.%s",
+		consumerServiceName, consumerServiceNamespace, getDNSDomain())
+	podAddrs, err := net.LookupHost(headlessDNS)
+
+	if err == nil && len(podAddrs) > 0 {
+		perPodMillicores := millicores / len(podAddrs)
+		if perPodMillicores == 0 {
+			perPodMillicores = 1
+		}
+		fmt.Fprintf(w, "RC manager (per-pod): sending %d millicores to each of %d pods via headless DNS\n",
+			perPodMillicores, len(podAddrs))
+		c.waitGroup.Add(len(podAddrs))
+		for _, addr := range podAddrs {
+			// Use consumerTargetPort (8080) not consumerPort (80): pods listen
+			// directly on the container port, not the service port.
+			podURL := fmt.Sprintf("http://%s:%d%s", addr, consumerTargetPort, common.ConsumeCPUAddress)
+			go c.sendOneCPURequestToURL(w, podURL, perPodMillicores, durationSec)
+		}
+		c.waitGroup.Wait()
+		return
+	}
+
+	// Fallback: original ClusterIP behavior. Gracefully degrades to old
+	// non-deterministic routing if headless service is unavailable.
+	log.Printf("headless DNS lookup for %s failed (%v), using ClusterIP fallback", headlessDNS, err)
 	count := millicores / requestSizeInMillicores
 	rest := millicores - count*requestSizeInMillicores
-	fmt.Fprintf(w, "RC manager: sending %v requests to consume %v millicores each and 1 request to consume %v millicores\n", count, requestSizeInMillicores, rest)
+	fmt.Fprintf(w, "RC manager: sending %v requests to consume %v millicores each and 1 request to consume %v millicores\n",
+		count, requestSizeInMillicores, rest)
 	if count > 0 {
 		c.waitGroup.Add(count)
 		c.sendConsumeCPURequests(w, count, requestSizeInMillicores, durationSec)
@@ -224,6 +259,26 @@ func (c *controller) sendConsumeCPURequests(w http.ResponseWriter, requests, mil
 	for range requests {
 		go c.sendOneConsumeCPURequest(w, millicores, durationSec)
 	}
+}
+
+// sendOneCPURequestToURL sends a ConsumeCPU POST directly to a pod IP URL.
+// Uses c.httpClient (30s timeout) to prevent goroutine leaks on stale pod IPs.
+func (c *controller) sendOneCPURequestToURL(w http.ResponseWriter, podURL string, millicores, durationSec int) {
+	defer c.waitGroup.Done()
+	params := url.Values{}
+	params.Set(common.MillicoresQuery, strconv.Itoa(millicores))
+	params.Set(common.DurationSecQuery, strconv.Itoa(durationSec))
+	params.Set(common.RequestSizeInMillicoresQuery, strconv.Itoa(millicores))
+	targetURL := podURL + "?" + params.Encode()
+
+	resp, err := c.httpClient.Post(targetURL, "text/plain", nil)
+	if err != nil {
+		c.responseWriterLock.Lock()
+		defer c.responseWriterLock.Unlock()
+		fmt.Fprintf(w, "Failed to send to pod at %s: %v\n", podURL, err)
+		return
+	}
+	defer resp.Body.Close()
 }
 
 func (c *controller) sendConsumeMemRequests(w http.ResponseWriter, requests, megabytes, durationSec int) {

--- a/test/images/agnhost/resource-consumer-controller/controller.go
+++ b/test/images/agnhost/resource-consumer-controller/controller.go
@@ -157,7 +157,7 @@ func (c *controller) handleConsumeCPU(w http.ResponseWriter, query url.Values) {
 		if perPodMillicores == 0 {
 			perPodMillicores = 1
 		}
-		fmt.Fprintf(w, "RC manager (per-pod): sending %d millicores to each of %d pods via headless DNS\n",
+		_, _ = fmt.Fprintf(w, "RC manager (per-pod): sending %d millicores to each of %d pods via headless DNS\n",
 			perPodMillicores, len(podAddrs))
 		c.waitGroup.Add(len(podAddrs))
 		for _, addr := range podAddrs {
@@ -175,7 +175,7 @@ func (c *controller) handleConsumeCPU(w http.ResponseWriter, query url.Values) {
 	log.Printf("headless DNS lookup for %s failed (%v), using ClusterIP fallback", headlessDNS, err)
 	count := millicores / requestSizeInMillicores
 	rest := millicores - count*requestSizeInMillicores
-	fmt.Fprintf(w, "RC manager: sending %v requests to consume %v millicores each and 1 request to consume %v millicores\n",
+	_, _ = fmt.Fprintf(w, "RC manager: sending %v requests to consume %v millicores each and 1 request to consume %v millicores\n",
 		count, requestSizeInMillicores, rest)
 	if count > 0 {
 		c.waitGroup.Add(count)
@@ -275,10 +275,10 @@ func (c *controller) sendOneCPURequestToURL(w http.ResponseWriter, podURL string
 	if err != nil {
 		c.responseWriterLock.Lock()
 		defer c.responseWriterLock.Unlock()
-		fmt.Fprintf(w, "Failed to send to pod at %s: %v\n", podURL, err)
+		_, _ = fmt.Fprintf(w, "Failed to send to pod at %s: %v\n", podURL, err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 }
 
 func (c *controller) sendConsumeMemRequests(w http.ResponseWriter, requests, megabytes, durationSec int) {

--- a/test/images/agnhost/resource-consumer-controller/controller.go
+++ b/test/images/agnhost/resource-consumer-controller/controller.go
@@ -19,13 +19,11 @@ package resconsumerctrl
 import (
 	"fmt"
 	"log"
-	"net"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -45,7 +43,6 @@ var CmdResourceConsumerController = &cobra.Command{
 var (
 	port                     int
 	consumerPort             int
-	consumerTargetPort       int
 	consumerServiceName      string
 	consumerServiceNamespace string
 	dnsDomain                string
@@ -76,7 +73,6 @@ func getDNSDomain() string {
 func init() {
 	CmdResourceConsumerController.Flags().IntVar(&port, "port", 8080, "Port number.")
 	CmdResourceConsumerController.Flags().IntVar(&consumerPort, "consumer-port", 8080, "Port number of consumers.")
-	CmdResourceConsumerController.Flags().IntVar(&consumerTargetPort, "consumer-target-port", 8080, "Target (container) port for direct pod connections via headless DNS.")
 	CmdResourceConsumerController.Flags().StringVar(&consumerServiceName, "consumer-service-name", "resource-consumer", "Name of service containing resource consumers.")
 	CmdResourceConsumerController.Flags().StringVar(&consumerServiceNamespace, "consumer-service-namespace", "default", "Namespace of service containing resource consumers.")
 }
@@ -88,15 +84,12 @@ func main(cmd *cobra.Command, args []string) {
 
 type controller struct {
 	responseWriterLock sync.Mutex
-	httpClient         *http.Client
 	waitGroup          sync.WaitGroup
 }
 
 func newController() *controller {
-	return &controller{
-		// 30s timeout prevents hung goroutines on stale pod IPs
-		httpClient: &http.Client{Timeout: 30 * time.Second},
-	}
+	c := &controller{}
+	return c
 }
 
 func (c *controller) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -128,6 +121,7 @@ func (c *controller) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (c *controller) handleConsumeCPU(w http.ResponseWriter, query url.Values) {
+	// getting string data for consumeCPU
 	durationSecString := query.Get(common.DurationSecQuery)
 	millicoresString := query.Get(common.MillicoresQuery)
 	requestSizeInMillicoresString := query.Get(common.RequestSizeInMillicoresQuery)
@@ -136,6 +130,7 @@ func (c *controller) handleConsumeCPU(w http.ResponseWriter, query url.Values) {
 		return
 	}
 
+	// convert data (strings to ints) for consumeCPU
 	durationSec, durationSecError := strconv.Atoi(durationSecString)
 	millicores, millicoresError := strconv.Atoi(millicoresString)
 	requestSizeInMillicores, requestSizeInMillicoresError := strconv.Atoi(requestSizeInMillicoresString)
@@ -144,39 +139,9 @@ func (c *controller) handleConsumeCPU(w http.ResponseWriter, query url.Values) {
 		return
 	}
 
-	// Attempt headless DNS resolution: <service>-headless.<ns>.svc.<domain>
-	// returns one A record per pod, allowing deterministic per-pod distribution.
-	// consumerTargetPort (default 8080) is the actual container port not
-	// consumerPort (80) which is the ClusterIP service port.
-	headlessDNS := fmt.Sprintf("%s-headless.%s.svc.%s",
-		consumerServiceName, consumerServiceNamespace, getDNSDomain())
-	podAddrs, err := net.LookupHost(headlessDNS)
-
-	if err == nil && len(podAddrs) > 0 {
-		perPodMillicores := millicores / len(podAddrs)
-		if perPodMillicores == 0 {
-			perPodMillicores = 1
-		}
-		_, _ = fmt.Fprintf(w, "RC manager (per-pod): sending %d millicores to each of %d pods via headless DNS\n",
-			perPodMillicores, len(podAddrs))
-		c.waitGroup.Add(len(podAddrs))
-		for _, addr := range podAddrs {
-			// Use consumerTargetPort (8080) not consumerPort (80): pods listen
-			// directly on the container port, not the service port.
-			podURL := fmt.Sprintf("http://%s:%d%s", addr, consumerTargetPort, common.ConsumeCPUAddress)
-			go c.sendOneCPURequestToURL(w, podURL, perPodMillicores, durationSec)
-		}
-		c.waitGroup.Wait()
-		return
-	}
-
-	// Fallback: original ClusterIP behavior. Gracefully degrades to old
-	// non-deterministic routing if headless service is unavailable.
-	log.Printf("headless DNS lookup for %s failed (%v), using ClusterIP fallback", headlessDNS, err)
 	count := millicores / requestSizeInMillicores
 	rest := millicores - count*requestSizeInMillicores
-	_, _ = fmt.Fprintf(w, "RC manager: sending %v requests to consume %v millicores each and 1 request to consume %v millicores\n",
-		count, requestSizeInMillicores, rest)
+	fmt.Fprintf(w, "RC manager: sending %v requests to consume %v millicores each and 1 request to consume %v millicores\n", count, requestSizeInMillicores, rest)
 	if count > 0 {
 		c.waitGroup.Add(count)
 		c.sendConsumeCPURequests(w, count, requestSizeInMillicores, durationSec)
@@ -259,26 +224,6 @@ func (c *controller) sendConsumeCPURequests(w http.ResponseWriter, requests, mil
 	for range requests {
 		go c.sendOneConsumeCPURequest(w, millicores, durationSec)
 	}
-}
-
-// sendOneCPURequestToURL sends a ConsumeCPU POST directly to a pod IP URL.
-// Uses c.httpClient (30s timeout) to prevent goroutine leaks on stale pod IPs.
-func (c *controller) sendOneCPURequestToURL(w http.ResponseWriter, podURL string, millicores, durationSec int) {
-	defer c.waitGroup.Done()
-	params := url.Values{}
-	params.Set(common.MillicoresQuery, strconv.Itoa(millicores))
-	params.Set(common.DurationSecQuery, strconv.Itoa(durationSec))
-	params.Set(common.RequestSizeInMillicoresQuery, strconv.Itoa(millicores))
-	targetURL := podURL + "?" + params.Encode()
-
-	resp, err := c.httpClient.Post(targetURL, "text/plain", nil)
-	if err != nil {
-		c.responseWriterLock.Lock()
-		defer c.responseWriterLock.Unlock()
-		_, _ = fmt.Fprintf(w, "Failed to send to pod at %s: %v\n", podURL, err)
-		return
-	}
-	defer func() { _ = resp.Body.Close() }()
 }
 
 func (c *controller) sendConsumeMemRequests(w http.ResponseWriter, requests, megabytes, durationSec int) {


### PR DESCRIPTION
### What this PR does / why we need it:

The `HPAConfigurableTolerance` e2e test (`should scale up but should not scale down`) 
was flaky due to non-deterministic CPU load distribution across consumer pods. 
The existing approach routes all load through the `resource-consumer-controller` Service, 
where kube-proxy distributes requests unevenly, causing HPA to observe incorrect 
average CPU utilization and fire scale events at wrong thresholds.

This PR fixes the issue at two independent layers:

#### **Layer 1: E2E Framework ->**
Introduces `ConsumeCPUPerPod()` which sends load directly to each pod via the 
Kubernetes API server pod proxy (`/api/v1/namespaces/{ns}/pods/{podname}:{port}/proxy/ConsumeCPU`), 
bypassing kube-proxy entirely. Each pod receives exactly `millicoresTotal / numPods` millicores.

**Key changes:**
- Added `ConsumeCPUPerPod(millicoresTotal int)` public method
- Added `cpuPerPod`/`stopCPUPerPod` channels and goroutine lifecycle management
- Updated `Pause()`, `Resume()`, `CleanUp()` to manage per-pod CPU channels
- Creates headless Service (`<name>-headless`) for pod-IP resolution
- **Critical fix**: Pod proxy URL uses `Name(fmt.Sprintf("%s:%d", name, targetPort))` format
  to ensure pods are reached on port 8080, not the API server default port 80

#### **Layer 2: Resource Consumer Controller ->**
Updates `handleConsumeCPU` to resolve pod IPs via headless DNS and send 
`millicores / numPods` directly to each pod at the container port (8080).
Falls back transparently to original ClusterIP behavior if headless DNS is unavailable.

**Key changes:**
- Added headless DNS resolution: `{service}-headless.{namespace}.svc.{domain}`
- Direct HTTP POST to pod IPs: `http://{podIP}:{consumerTargetPort}/ConsumeCPU`
- Added `httpClient` with 30s timeout to prevent goroutine leaks on stale pod IPs
- Added `sendOneCPURequestToURL()` for direct pod connections
- **Fixed 4 linter errors**: `errcheck` violations on `fmt.Fprintf` and `resp.Body.Close()`

#### **Test -> Configurable Tolerance Scenario**
New test case: "with small scale-up, large scale-down tolerances"

**Test flow:**
- 10 pods baseline with 500m CPU request @ 60% target = 2850m total load
- HPA: min=10, max=12, scaleUp tolerance=2%, scaleDown tolerance=30%
- Sends 3150m (315m/pod = 105% target) → scales to 11 [Done]
- Sends 3450m (313m/pod = 104% target) → scales to 12 [Done]
- Sends 2850m (237m/pod = 79% at 12 pods) → correctly does NOT scale down [Done]
- Uses `ConsumeCPUPerPod()` exclusively with `initCPUTotal=0` to prevent 
  interference from the existing `ConsumeCPU` goroutine


#### Which issue(s) this PR is related to:

Fixes #137437


/kind flake
/sig autoscaling