### PR TITLE
hack/golangci.yaml.in: remove trailing whitespace

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -121,7 +121,7 @@ linters:
       - linters:
         - kubeapilinter
         path-except: staging/src/k8s.io/api/.*
-        
+
       # Exceptions for kube-api-linter.
       # Exceptions are used for kube-api-linter to ignore existing issues that cannot be fixed without breaking changes.
       
@@ -510,7 +510,7 @@ linters:
           pkg: ^k8s\.io/client-go/applyconfigurations/
           msg: should not be used because managedFields was removed
         - pattern: \.Add$
-          pkg: ^k8s\.io/component-base/featuregate$         
+          pkg: ^k8s\.io/component-base/featuregate$
           msg: should not use Add, use AddVersioned instead
         - pattern: \.(ReportBeforeSuite|ReportAfterSuite)
           pkg: ^github\.com/onsi/ginkgo/v2$

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -136,7 +136,7 @@ linters:
       - linters:
         - kubeapilinter
         path-except: staging/src/k8s.io/api/.*
-        
+
       # Exceptions for kube-api-linter.
       # Exceptions are used for kube-api-linter to ignore existing issues that cannot be fixed without breaking changes.
       
@@ -523,7 +523,7 @@ linters:
           pkg: ^k8s\.io/client-go/applyconfigurations/
           msg: should not be used because managedFields was removed
         - pattern: \.Add$
-          pkg: ^k8s\.io/component-base/featuregate$         
+          pkg: ^k8s\.io/component-base/featuregate$
           msg: should not use Add, use AddVersioned instead
         - pattern: \.(ReportBeforeSuite|ReportAfterSuite)
           pkg: ^github\.com/onsi/ginkgo/v2$

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -153,7 +153,7 @@ linters:
       - linters:
         - kubeapilinter
         path-except: staging/src/k8s.io/api/.*
-        
+
       {{include "hack/kube-api-linter/exceptions.yaml" | indent 6 | trim}}
 
       - linters:
@@ -239,7 +239,7 @@ linters:
           pkg: ^k8s\.io/client-go/applyconfigurations/
           msg: should not be used because managedFields was removed
         - pattern: \.Add$
-          pkg: ^k8s\.io/component-base/featuregate$         
+          pkg: ^k8s\.io/component-base/featuregate$
           msg: should not use Add, use AddVersioned instead
         - pattern: \.(ReportBeforeSuite|ReportAfterSuite)
           pkg: ^github\.com/onsi/ginkgo/v2$
@@ -251,7 +251,7 @@ linters:
           msg: "it does not produce a good failure message - use BeTrueBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"
         - pattern: ^gomega\.BeFalse$
           pkg: ^github.com/onsi/gomega$
-          msg: "it does not produce a good failure message - use BeFalseBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"        
+          msg: "it does not produce a good failure message - use BeFalseBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"
       {{- end}}
       {{- if .Base }}
     gocritic:


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove trailing whitespace on three lines in `hack/golangci.yaml.in`. No behavioral change.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

/cc @pohly

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```