### PR TITLE
test: Replace hardcoded kubelet volume paths with TestContext.KubeletRootDir in node e2e tests

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -372,6 +372,13 @@ func updateTestContext(ctx context.Context) error {
 	setExtraEnvs()
 	updateImageAllowList(ctx)
 
+	// Set KubeletRootDir to match the kubelet configuration used in node e2e tests.
+	// This ensures tests that use framework.TestContext.KubeletRootDir (e.g., for HostPath volumes)
+	// use the correct path.
+	if framework.TestContext.KubeletRootDir == "" {
+		framework.TestContext.KubeletRootDir = services.KubeletRootDirectory
+	}
+
 	client, err := getAPIServerClient()
 	if err != nil {
 		return fmt.Errorf("failed to get apiserver client: %w", err)

--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -295,9 +296,7 @@ current-context: local-context
 					},
 				},
 			})
-			// TODO: remove hardcoded kubelet volume directory path
-			// framework.TestContext.KubeVolumeDir is currently not populated for node e2e
-			hostLogFile = "/var/lib/kubelet/pods/" + string(pod.UID) + "/volumes/kubernetes.io~empty-dir" + logFile
+			hostLogFile = filepath.Join(framework.TestContext.KubeletRootDir, "pods", string(pod.UID), "volumes/kubernetes.io~empty-dir") + logFile
 		})
 
 		ginkgo.It("should generate node condition and events for corresponding errors", func(ctx context.Context) {

--- a/test/e2e_node/quota_lsci_test.go
+++ b/test/e2e_node/quota_lsci_test.go
@@ -48,10 +48,8 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool, userNamespace
 	sizeLimit := resource.MustParse("100Mi")
 	useOverLimit := 101 /* Mb */
 	useUnderLimit := 99 /* Mb */
-	// TODO: remove hardcoded kubelet volume directory path
-	// framework.TestContext.KubeVolumeDir is currently not populated for node e2e
 	// As for why we do this: see comment below at isXfs.
-	if isXfs("/var/lib/kubelet") {
+	if isXfs(framework.TestContext.KubeletRootDir) {
 		useUnderLimit = 50 /* Mb */
 	}
 	priority := 0
@@ -61,12 +59,10 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool, userNamespace
 	ginkgo.Context(fmt.Sprintf(testContextFmt, fmt.Sprintf("use quotas for LSCI monitoring (quotas enabled: %v, userNamespacesEnabled: %v)", quotasRequested, userNamespacesEnabled)), func() {
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			defer withFeatureGate(LSCIQuotaFeature, quotasRequested)()
-			// TODO: remove hardcoded kubelet volume directory path
-			// framework.TestContext.KubeVolumeDir is currently not populated for node e2e
 			if !supportsUserNS(ctx, f) {
 				e2eskipper.Skipf("runtime does not support user namespaces")
 			}
-			if quotasRequested && !supportsQuotas("/var/lib/kubelet", userNamespacesEnabled) {
+			if quotasRequested && !supportsQuotas(framework.TestContext.KubeletRootDir, userNamespacesEnabled) {
 				// No point in running this as a positive test if quotas are not
 				// enabled on the underlying filesystem.
 				e2eskipper.Skipf("Cannot run LocalStorageCapacityIsolationFSQuotaMonitoring on filesystem without project quota enabled")

--- a/test/e2e_node/volume_manager_test.go
+++ b/test/e2e_node/volume_manager_test.go
@@ -18,6 +18,8 @@ package e2enode
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -26,8 +28,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	admissionapi "k8s.io/pod-security-admission/api"
-
-	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
 )
@@ -107,9 +107,7 @@ var _ = SIGDescribe("Kubelet Volume Manager", func() {
 									{
 										Name: "kubelet-pods",
 										VolumeSource: v1.VolumeSource{
-											// TODO: remove hardcoded kubelet volume directory path
-											// framework.TestContext.KubeVolumeDir is currently not populated for node e2e
-											HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/kubelet/pods"},
+											HostPath: &v1.HostPathVolumeSource{Path: filepath.Join(framework.TestContext.KubeletRootDir, "pods")},
 										},
 									},
 								},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig node
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Replaces hardcoded `/var/lib/kubelet` paths with `framework.TestContext.KubeletRootDir` in node e2e tests to make them portable across different kubelet configurations.

#### Which issue(s) this PR is related to:
Fixes TODOs in:
- test/e2e_node/quota_lsci_test.go
- test/e2e_node/volume_manager_test.go  
- test/e2e_node/node_problem_detector_linux.go

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
