### PR TITLE
kubelet: deduplicate CPU conversion helper functions

### DIFF
--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -347,7 +347,7 @@ func GetKubeletContainer(logger klog.Logger, kubeletCgroups string) (string, err
 func CPURequestsFromConfig(podConfig *ResourceConfig) *resource.Quantity {
 	var cpuRequest *resource.Quantity
 	if podConfig != nil && *podConfig.CPUShares > 0 {
-		milliCPU := sharesToMilliCPU(int64(*podConfig.CPUShares))
+		milliCPU := SharesToMilliCPU(int64(*podConfig.CPUShares))
 		if milliCPU > 0 {
 			cpuRequest = resource.NewMilliQuantity(milliCPU, resource.DecimalSI)
 		}
@@ -360,7 +360,7 @@ func CPULimitsFromConfig(podConfig *ResourceConfig) *resource.Quantity {
 	var cpuLimit *resource.Quantity
 
 	if podConfig != nil && *podConfig.CPUPeriod > 0 {
-		milliCPU := quotaToMilliCPU(*podConfig.CPUQuota, int64(*podConfig.CPUPeriod))
+		milliCPU := QuotaToMilliCPU(*podConfig.CPUQuota, int64(*podConfig.CPUPeriod))
 		if milliCPU > 0 {
 			cpuLimit = resource.NewMilliQuantity(milliCPU, resource.DecimalSI)
 		}
@@ -378,9 +378,8 @@ func MemoryLimitsFromConfig(podConfig *ResourceConfig) *resource.Quantity {
 	return memLimit
 }
 
-// sharesToMilliCPU converts CpuShares (cpu.shares) to milli-CPU value
-// TODO - dedup sharesToMilliCPU with sharesToMilliCPU in pkg/kubelet/kuberuntime/helpers_linux.go
-func sharesToMilliCPU(shares int64) int64 {
+// SharesToMilliCPU converts CpuShares (cpu.shares) to milli-CPU value
+func SharesToMilliCPU(shares int64) int64 {
 	milliCPU := int64(0)
 	if shares >= int64(MinShares) {
 		milliCPU = int64(math.Ceil(float64(shares*MilliCPUToCPU) / float64(SharesPerCPU)))
@@ -388,10 +387,8 @@ func sharesToMilliCPU(shares int64) int64 {
 	return milliCPU
 }
 
-// quotaToMilliCPU converts cpu.cfs_quota_us and cpu.cfs_period_us to milli-CPU
-// value
-// TODO - dedup quotaToMilliCPU with sharesToMilliCPU in pkg/kubelet/kuberuntime/helpers_linux.go
-func quotaToMilliCPU(quota int64, period int64) int64 {
+// QuotaToMilliCPU converts cpu.cfs_quota_us and cpu.cfs_period_us to milli-CPU value
+func QuotaToMilliCPU(quota int64, period int64) int64 {
 	if quota == -1 {
 		return int64(0)
 	}

--- a/pkg/kubelet/kuberuntime/helpers_linux.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux.go
@@ -19,28 +19,9 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"math"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 )
-
-// sharesToMilliCPU converts CpuShares (cpu.shares) to milli-CPU value
-func sharesToMilliCPU(shares int64) int64 {
-	milliCPU := int64(0)
-	if shares >= int64(cm.MinShares) {
-		milliCPU = int64(math.Ceil(float64(shares*cm.MilliCPUToCPU) / float64(cm.SharesPerCPU)))
-	}
-	return milliCPU
-}
-
-// quotaToMilliCPU converts cpu.cfs_quota_us and cpu.cfs_period_us to milli-CPU value
-func quotaToMilliCPU(quota int64, period int64) int64 {
-	if quota == -1 {
-		return int64(0)
-	}
-	return (quota * cm.MilliCPUToCPU) / period
-}
 
 func subtractOverheadFromResourceConfig(resCfg *cm.ResourceConfig, pod *v1.Pod) *cm.ResourceConfig {
 	if resCfg == nil {
@@ -58,7 +39,7 @@ func subtractOverheadFromResourceConfig(resCfg *cm.ResourceConfig, pod *v1.Pod) 
 			}
 
 			if rc.CPUShares != nil {
-				totalCPUMilli := sharesToMilliCPU(int64(*rc.CPUShares))
+				totalCPUMilli := cm.SharesToMilliCPU(int64(*rc.CPUShares))
 				cpuShares := cm.MilliCPUToShares(totalCPUMilli - cpu.MilliValue())
 				rc.CPUShares = &cpuShares
 			}

--- a/pkg/kubelet/kuberuntime/helpers_linux_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux_test.go
@@ -267,7 +267,7 @@ func TestSharesToMilliCPU(t *testing.T) {
 			if testMilliCPU < 2 {
 				expectedMilliCPU = 2
 			}
-			milliCPU := sharesToMilliCPU(shares)
+			milliCPU := cm.SharesToMilliCPU(shares)
 			if milliCPU != expectedMilliCPU {
 				t.Errorf("Test sharesToMilliCPU: Input shares %v, expected milliCPU %v, but got %v", shares, expectedMilliCPU, milliCPU)
 			}
@@ -307,7 +307,7 @@ func TestQuotaToMilliCPU(t *testing.T) {
 			expected: int64(1500),
 		}} {
 		t.Run(tc.name, func(t *testing.T) {
-			milliCPU := quotaToMilliCPU(tc.quota, tc.period)
+			milliCPU := cm.QuotaToMilliCPU(tc.quota, tc.period)
 			if milliCPU != tc.expected {
 				t.Errorf("Test %s: Input quota %v and period %v, expected milliCPU %v, but got %v", tc.name, tc.quota, tc.period, tc.expected, milliCPU)
 			}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -386,13 +386,13 @@ func toKubeContainerResources(statusResources *runtimeapi.ContainerResources) *k
 	if runtimeStatusResources != nil {
 		var cpuLimit, memLimit, cpuRequest *resource.Quantity
 		if runtimeStatusResources.CpuPeriod > 0 {
-			milliCPU := quotaToMilliCPU(runtimeStatusResources.CpuQuota, runtimeStatusResources.CpuPeriod)
+			milliCPU := cm.QuotaToMilliCPU(runtimeStatusResources.CpuQuota, runtimeStatusResources.CpuPeriod)
 			if milliCPU > 0 {
 				cpuLimit = resource.NewMilliQuantity(milliCPU, resource.DecimalSI)
 			}
 		}
 		if runtimeStatusResources.CpuShares > 0 {
-			milliCPU := sharesToMilliCPU(runtimeStatusResources.CpuShares)
+			milliCPU := cm.SharesToMilliCPU(runtimeStatusResources.CpuShares)
 			if milliCPU > 0 {
 				cpuRequest = resource.NewMilliQuantity(milliCPU, resource.DecimalSI)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig node

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Consolidates duplicate CPU conversion functions by exporting them from the `cm` package and removing duplicates from the `kuberuntime` package.

The functions `sharesToMilliCPU` and `quotaToMilliCPU` had identical implementations in both:
- `pkg/kubelet/cm/helpers_linux.go`
- `pkg/kubelet/kuberuntime/helpers_linux.go`

**Changes:**
- Exported `sharesToMilliCPU` → `SharesToMilliCPU` in cm package
- Exported `quotaToMilliCPU` → `QuotaToMilliCPU` in cm package
- Removed duplicate functions from kuberuntime package
- Updated all call sites to use `cm.SharesToMilliCPU` and `cm.QuotaToMilliCPU`


#### Which issue(s) this PR is related to:

Resolves TODOs in:
- `pkg/kubelet/cm/helpers_linux.go

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
- Pure refactoring with no functional changes
- The kuberuntime package already imports the cm package, so no new dependencies


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
