### PR TITLE
apiserver: replace btree-based snapshotter with slice and binary search

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
@@ -25,6 +25,19 @@ import (
 	"k8s.io/utils/third_party/forked/golang/btree"
 )
 
+type Snapshotter interface {
+	Reset()
+	GetLessOrEqual(rv uint64) (OrderedLister, bool)
+	Add(rv uint64, indexer OrderedLister)
+	RemoveLess(rv uint64)
+	Len() int
+}
+
+type rvSnapshot struct {
+	resourceVersion uint64
+	snapshot        OrderedLister
+}
+
 // newThreadedBtreeStoreIndexer returns a storage for cacher by adding locking over the two 2 data structures:
 // * btree based storage for efficient LIST operation on prefix
 // * map based indexer for retrieving values by index.
@@ -393,113 +406,3 @@ func (i *indexer) delete(key, value string, index map[string]map[string]*Element
 	}
 }
 
-// newStoreSnapshotter returns a storeSnapshotter that stores snapshots for
-// serving read requests with exact resource versions (RV) and pagination.
-//
-// Snapshots are created by calling Clone method on orderedLister, which is
-// expected to be fast and efficient thanks to usage of B-trees.
-// B-trees can create a lazy copy of the tree structure, minimizing overhead.
-//
-// Assuming the watch cache observes all events and snapshots cache after each of them,
-// requests for a specific resource version can be served by retrieving
-// the snapshot with the greatest RV less than or equal to the requested RV.
-// To make snapshot retrivial efficient we need an ordered data structure, such as tree.
-//
-// The initial implementation uses a B-tree to achieve the following performance characteristics (n - number of snapshots stored):
-//   - `Add`: Adds a new snapshot.
-//     Complexity: O(log n).
-//     Executed for each watch event observed by the cache.
-//   - `GetLessOrEqual`: Retrieves the snapshot with the greatest RV less than or equal to the requested RV.
-//     Complexity: O(log n).
-//     Executed for each LIST request with match=Exact or continuation.
-//   - `RemoveLess`: Cleans up snapshots outside the watch history window.
-//     Complexity: O(k log n), k - number of snapshots to remove, usually only one if watch capacity was not reduced.
-//     Executed per watch event observed when the cache is full.
-//   - `Reset`: Cleans up all snapshots.
-//     Complexity: O(1).
-//     Executed when the watch cache is reinitialized.
-//
-// Further optimization is possible by leveraging the property that adds always
-// increase the maximum RV and deletes only increase the minimum RV.
-// For example, a binary search on a cyclic buffer of (RV, snapshot)
-// should reduce number of allocations and improve removal complexity.
-// However, this solution is more complex and is deferred for future implementation.
-//
-// TODO: Rewrite to use a cyclic buffer
-func NewSnapshotter() Snapshotter {
-	s := &storeSnapshotter{
-		snapshots: btree.New(btreeDegree, func(a, b rvSnapshot) bool {
-			return a.resourceVersion < b.resourceVersion
-		}),
-	}
-	return s
-}
-
-var _ Snapshotter = (*storeSnapshotter)(nil)
-
-type Snapshotter interface {
-	Reset()
-	GetLessOrEqual(rv uint64) (OrderedLister, bool)
-	Add(rv uint64, indexer OrderedLister)
-	RemoveLess(rv uint64)
-	Len() int
-}
-
-type storeSnapshotter struct {
-	mux       sync.RWMutex
-	snapshots *btree.BTree[rvSnapshot]
-}
-
-type rvSnapshot struct {
-	resourceVersion uint64
-	snapshot        OrderedLister
-}
-
-func (s *storeSnapshotter) Reset() {
-	s.mux.Lock()
-	defer s.mux.Unlock()
-	s.snapshots.Clear(false)
-}
-
-func (s *storeSnapshotter) GetLessOrEqual(rv uint64) (OrderedLister, bool) {
-	s.mux.RLock()
-	defer s.mux.RUnlock()
-
-	var result *rvSnapshot
-	s.snapshots.DescendLessOrEqual(rvSnapshot{resourceVersion: rv}, func(rvs rvSnapshot) bool {
-		result = &rvs
-		return false
-	})
-	if result == nil {
-		return nil, false
-	}
-	return result.snapshot, true
-}
-
-func (s *storeSnapshotter) Add(rv uint64, indexer OrderedLister) {
-	s.mux.Lock()
-	defer s.mux.Unlock()
-	s.snapshots.ReplaceOrInsert(rvSnapshot{resourceVersion: rv, snapshot: indexer.Clone()})
-}
-
-func (s *storeSnapshotter) RemoveLess(rv uint64) {
-	s.mux.Lock()
-	defer s.mux.Unlock()
-	for s.snapshots.Len() > 0 {
-		oldest, ok := s.snapshots.Min()
-		if !ok {
-			break
-		}
-		if rv <= oldest.resourceVersion {
-			break
-		}
-		s.snapshots.DeleteMin()
-	}
-}
-
-func (s *storeSnapshotter) Len() int {
-	s.mux.RLock()
-	defer s.mux.RUnlock()
-
-	return s.snapshots.Len()
-}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package store
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -155,4 +156,122 @@ func (f *fakeSnapshotter) Add(rv uint64, indexer OrderedLister) {}
 func (f *fakeSnapshotter) RemoveLess(rv uint64)                 {}
 func (f *fakeSnapshotter) Len() int {
 	return 0
+}
+
+func TestSliceSnapshotterCompaction(t *testing.T) {
+	cache := NewSnapshotter()
+	// Add 100 entries.
+	for i := uint64(1); i <= 100; i++ {
+		cache.Add(i, fakeOrderedLister{rv: int(i)})
+	}
+	assert.Equal(t, 100, cache.Len())
+
+	// Remove the first 80 entries (rv < 81).
+	cache.RemoveLess(81)
+	assert.Equal(t, 20, cache.Len())
+
+	// Verify that lookups still work correctly after compaction.
+	_, found := cache.GetLessOrEqual(80)
+	assert.False(t, found)
+
+	snapshot, found := cache.GetLessOrEqual(81)
+	assert.True(t, found)
+	assert.Equal(t, 81, snapshot.(fakeOrderedLister).rv)
+
+	snapshot, found = cache.GetLessOrEqual(100)
+	assert.True(t, found)
+	assert.Equal(t, 100, snapshot.(fakeOrderedLister).rv)
+
+	snapshot, found = cache.GetLessOrEqual(200)
+	assert.True(t, found)
+	assert.Equal(t, 100, snapshot.(fakeOrderedLister).rv)
+}
+
+func TestSliceSnapshotterEdgeCases(t *testing.T) {
+	cache := NewSnapshotter()
+
+	t.Log("Empty snapshotter: GetLessOrEqual returns not found")
+	_, found := cache.GetLessOrEqual(10)
+	assert.False(t, found)
+
+	t.Log("Empty snapshotter: RemoveLess is a no-op")
+	cache.RemoveLess(10) // should not panic
+	assert.Equal(t, 0, cache.Len())
+
+	t.Log("Single element")
+	cache.Add(5, fakeOrderedLister{rv: 5})
+	assert.Equal(t, 1, cache.Len())
+
+	_, found = cache.GetLessOrEqual(4)
+	assert.False(t, found)
+
+	snapshot, found := cache.GetLessOrEqual(5)
+	assert.True(t, found)
+	assert.Equal(t, 5, snapshot.(fakeOrderedLister).rv)
+
+	snapshot, found = cache.GetLessOrEqual(100)
+	assert.True(t, found)
+	assert.Equal(t, 5, snapshot.(fakeOrderedLister).rv)
+
+	t.Log("RemoveLess with rv beyond all entries removes everything")
+	cache.RemoveLess(1000)
+	assert.Equal(t, 0, cache.Len())
+	_, found = cache.GetLessOrEqual(5)
+	assert.False(t, found)
+
+	t.Log("Reset on empty snapshotter is a no-op")
+	cache.Reset()
+	assert.Equal(t, 0, cache.Len())
+
+	t.Log("GetLessOrEqual on exact boundary")
+	cache.Add(10, fakeOrderedLister{rv: 10})
+	cache.Add(20, fakeOrderedLister{rv: 20})
+	snapshot, found = cache.GetLessOrEqual(10)
+	assert.True(t, found)
+	assert.Equal(t, 10, snapshot.(fakeOrderedLister).rv)
+
+	snapshot, found = cache.GetLessOrEqual(20)
+	assert.True(t, found)
+	assert.Equal(t, 20, snapshot.(fakeOrderedLister).rv)
+}
+
+func TestSliceSnapshotterConcurrent(t *testing.T) {
+	cache := NewSnapshotter()
+	const goroutines = 10
+	const ops = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 3)
+
+	// Writers
+	for g := 0; g < goroutines; g++ {
+		go func(offset int) {
+			defer wg.Done()
+			for i := 0; i < ops; i++ {
+				cache.Add(uint64(offset*ops+i), fakeOrderedLister{rv: offset*ops + i})
+			}
+		}(g)
+	}
+
+	// Readers
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < ops; i++ {
+				cache.GetLessOrEqual(uint64(i))
+			}
+		}()
+	}
+
+	// Removers
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < ops; i++ {
+				cache.RemoveLess(uint64(i))
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_snapshotter.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_snapshotter.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"sort"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+// NewSnapshotter returns a Snapshotter that stores snapshots for serving read
+// requests with exact resource versions (RV) and pagination.
+//
+// Snapshots are created by calling Clone on an OrderedLister, which is expected
+// to be fast and efficient thanks to the copy-on-write semantics of B-trees.
+//
+// The implementation uses a sorted slice with binary search, leveraging the
+// monotonic-append property: Add always appends to the end (increasing RV) and
+// RemoveLess only removes from the front (increasing minimum RV). This gives:
+//   - Add:            O(1) amortized (slice append)
+//   - GetLessOrEqual: O(log n) (binary search)
+//   - RemoveLess:     O(log n + k) where k = removed entries (binary search + head advance)
+//   - Reset:          O(1)
+//   - Len:            O(1)
+func NewSnapshotter() Snapshotter {
+	return &sliceSnapshotter{}
+}
+
+var _ Snapshotter = (*sliceSnapshotter)(nil)
+
+type sliceSnapshotter struct {
+	mux       sync.RWMutex
+	snapshots []rvSnapshot
+	head      int // index of first live element
+}
+
+func (s *sliceSnapshotter) Add(rv uint64, indexer OrderedLister) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	if live := len(s.snapshots) - s.head; live > 0 {
+		last := s.snapshots[len(s.snapshots)-1]
+		if rv <= last.resourceVersion {
+			klog.Warningf("snapshotter: Add called with rv %d <= last rv %d; snapshots must be added in increasing order", rv, last.resourceVersion)
+		}
+	}
+	s.snapshots = append(s.snapshots, rvSnapshot{resourceVersion: rv, snapshot: indexer.Clone()})
+}
+
+func (s *sliceSnapshotter) GetLessOrEqual(rv uint64) (OrderedLister, bool) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	live := s.snapshots[s.head:]
+	if len(live) == 0 {
+		return nil, false
+	}
+	// Find the first entry with RV > rv.
+	i := sort.Search(len(live), func(i int) bool {
+		return live[i].resourceVersion > rv
+	})
+	// The entry at i-1 has the greatest RV <= rv.
+	if i == 0 {
+		return nil, false
+	}
+	return live[i-1].snapshot, true
+}
+
+func (s *sliceSnapshotter) RemoveLess(rv uint64) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	live := s.snapshots[s.head:]
+	if len(live) == 0 {
+		return
+	}
+	// Find the first entry with RV >= rv.
+	i := sort.Search(len(live), func(i int) bool {
+		return live[i].resourceVersion >= rv
+	})
+	// Nil out removed entries so GC can collect the snapshots.
+	for j := 0; j < i; j++ {
+		s.snapshots[s.head+j] = rvSnapshot{}
+	}
+	s.head += i
+	s.compact()
+}
+
+// compact copies live entries to the front of the slice when the dead prefix
+// (head) occupies at least half the capacity. This keeps amortized cost O(1)
+// per removal.
+func (s *sliceSnapshotter) compact() {
+	if s.head > 0 && s.head >= len(s.snapshots)/2 {
+		live := s.snapshots[s.head:]
+		n := copy(s.snapshots, live)
+		// Zero trailing slots for GC.
+		for i := n; i < len(s.snapshots); i++ {
+			s.snapshots[i] = rvSnapshot{}
+		}
+		s.snapshots = s.snapshots[:n]
+		s.head = 0
+	}
+}
+
+func (s *sliceSnapshotter) Reset() {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.snapshots = nil
+	s.head = 0
+}
+
+func (s *sliceSnapshotter) Len() int {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	return len(s.snapshots) - s.head
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_snapshotter_benchmark_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_snapshotter_benchmark_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkSnapshotterAdd(b *testing.B) {
+	cache := NewSnapshotter()
+	lister := fakeOrderedLister{rv: 1}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Add(uint64(i), lister)
+	}
+}
+
+func BenchmarkSnapshotterGetLessOrEqual(b *testing.B) {
+	cache := NewSnapshotter()
+	const size = 10000
+	for i := uint64(0); i < size; i++ {
+		cache.Add(i, fakeOrderedLister{rv: int(i)})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.GetLessOrEqual(uint64(rand.Intn(size + 1000)))
+	}
+}
+
+func BenchmarkSnapshotterSteadyState(b *testing.B) {
+	cache := NewSnapshotter()
+	// Pre-fill to simulate a warm cache.
+	const warmup = 1000
+	for i := uint64(0); i < warmup; i++ {
+		cache.Add(i, fakeOrderedLister{rv: int(i)})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rv := uint64(warmup + i)
+		cache.Add(rv, fakeOrderedLister{rv: int(rv)})
+		cache.RemoveLess(rv - warmup + 1)
+		cache.GetLessOrEqual(rv - uint64(rand.Intn(warmup)))
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replaces the btree-backed `storeSnapshotter` with a slice-based implementation using binary search, addressing the TODO comment in `store_btree.go:396-428`:

> Further optimization is possible by leveraging the property that adds always increase the maximum RV and deletes only increase the minimum RV. For example, a binary search on a cyclic buffer of (RV, snapshot) should reduce number of allocations and improve removal complexity.

The new `sliceSnapshotter` leverages the monotonic-append property of resource versions (Add always appends with increasing RV, RemoveLess only removes from the front) to achieve better algorithmic complexity:

| Operation | btree (before) | slice (after) |
|---|---|---|
| `Add` | O(log n) | O(1) amortized |
| `GetLessOrEqual` | O(log n) | O(log n) |
| `RemoveLess` | O(k log n) | O(log n + k) |
| `Reset` | O(1) | O(1) |
| `Len` | O(1) | O(1) |

The `Snapshotter` interface is unchanged — this is a drop-in replacement that only affects the `ListFromCacheSnapshot` code path. No changes to `watch_cache.go` or any consumer.

**Benchmark comparison (10 runs, `-benchmem`, same machine):**

btree (before):
```
BenchmarkSnapshotterAdd-14                4042725        363.6 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14                4145930        323.2 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14                4232169        333.0 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14                4183873        313.5 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14                4270672        314.1 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14                4162510        307.9 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14                4291929        326.9 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14                4012586        301.2 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14                3470888        306.9 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14                4395835        320.2 ns/op       91 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3275263        361.8 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3691923        338.4 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3543507        342.1 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3326710        345.1 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3662905        334.7 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3584206        339.0 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3373743        363.3 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3368295        367.2 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3395512        348.9 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14     3372064        377.5 ns/op       24 B/op        1 allocs/op
BenchmarkSnapshotterSteadyState-14        2102211        597.7 ns/op       40 B/op        3 allocs/op
BenchmarkSnapshotterSteadyState-14        2176930        534.6 ns/op       40 B/op        3 allocs/op
BenchmarkSnapshotterSteadyState-14        1857340        554.4 ns/op       40 B/op        3 allocs/op
BenchmarkSnapshotterSteadyState-14        2301170        514.0 ns/op       40 B/op        3 allocs/op
BenchmarkSnapshotterSteadyState-14        2238788        571.4 ns/op       40 B/op        3 allocs/op
BenchmarkSnapshotterSteadyState-14        2284440        544.5 ns/op       40 B/op        3 allocs/op
BenchmarkSnapshotterSteadyState-14        2182171        566.2 ns/op       40 B/op        3 allocs/op
BenchmarkSnapshotterSteadyState-14        2264847        583.9 ns/op       40 B/op        3 allocs/op
BenchmarkSnapshotterSteadyState-14        2210248        526.7 ns/op       40 B/op        3 allocs/op
BenchmarkSnapshotterSteadyState-14        2401596        481.1 ns/op       40 B/op        3 allocs/op
```

slice + binary search (after):
```
BenchmarkSnapshotterAdd-14               16708138         64.64 ns/op     140 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14               22491079         63.74 ns/op     130 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14               21654054         54.93 ns/op     135 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14               23905016         50.93 ns/op     122 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14               24524742         56.74 ns/op     149 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14               21383169         58.16 ns/op     137 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14               22999556         52.18 ns/op     127 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14               19666650         57.03 ns/op     149 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14               23104237         52.59 ns/op     127 B/op        0 allocs/op
BenchmarkSnapshotterAdd-14               23606169         57.15 ns/op     124 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    11564893        112.1 ns/op        0 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    11449976        104.1 ns/op        0 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    11364087         92.62 ns/op       0 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    10797668        109.4 ns/op        0 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    10290500        105.2 ns/op        0 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    10807042        100.3 ns/op        0 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    12593757        103.6 ns/op        0 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    10609300        107.8 ns/op        0 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    12230931        100.0 ns/op        0 B/op        0 allocs/op
BenchmarkSnapshotterGetLessOrEqual-14    11935868        108.3 ns/op        0 B/op        0 allocs/op
BenchmarkSnapshotterSteadyState-14        7338062        162.0 ns/op       16 B/op        2 allocs/op
BenchmarkSnapshotterSteadyState-14        7389307        158.4 ns/op       16 B/op        2 allocs/op
BenchmarkSnapshotterSteadyState-14        7608902        157.9 ns/op       16 B/op        2 allocs/op
BenchmarkSnapshotterSteadyState-14        7226268        168.0 ns/op       16 B/op        2 allocs/op
BenchmarkSnapshotterSteadyState-14        7289054        170.5 ns/op       16 B/op        2 allocs/op
BenchmarkSnapshotterSteadyState-14        7512475        169.4 ns/op       16 B/op        2 allocs/op
BenchmarkSnapshotterSteadyState-14        7164602        165.1 ns/op       16 B/op        2 allocs/op
BenchmarkSnapshotterSteadyState-14        7534441        157.6 ns/op       16 B/op        2 allocs/op
BenchmarkSnapshotterSteadyState-14        8115757        181.7 ns/op       16 B/op        2 allocs/op
BenchmarkSnapshotterSteadyState-14        7376031        153.4 ns/op       16 B/op        2 allocs/op
```

Summary:

| Benchmark | btree (old) | slice (new) | Improvement |
|---|---|---|---|
| Add | ~321 ns/op, 91 B/op, 0 allocs | ~57 ns/op, 135 B/op, 0 allocs | ~5.6x faster |
| GetLessOrEqual | ~352 ns/op, 24 B/op, 1 alloc | ~104 ns/op, 0 B/op, 0 allocs | ~3.4x faster, zero allocs |
| SteadyState | ~547 ns/op, 40 B/op, 3 allocs | ~164 ns/op, 16 B/op, 2 allocs | ~3.3x faster, -60% memory, -33% allocs |

Key implementation details:
- GC safety: nil out snapshot references in removed entries before advancing head
- Compaction: when dead prefix >= half the slice, copy live entries to front (amortized O(1) per removal)
- Monotonicity guard: log warning if Add is called with non-increasing RV (should never happen in production)

#### Which issue(s) this PR is related to:

N/A (addresses inline TODO)

#### Special notes for your reviewer:

- The existing `TestStoreSnapshotter` passes unchanged against the new implementation
- New tests cover compaction, edge cases, and concurrent access
- Benchmarks included in `store_snapshotter_benchmark_test.go`
- Add uses slightly more B/op (135 vs 91) due to slice growth amortization, but the throughput improvement (~5.6x) far outweighs this

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
