### PR TITLE
kubelet: fix eviction-max-pod-grace-period=-1 sending SIGKILL

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -428,11 +428,14 @@ func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfo
 				// Previously, min(negative, podGracePeriod) always returned the negative value,
 				// causing the CRI runtime to receive -1 and immediately SIGKILL the container.
 				// See https://github.com/kubernetes/kubernetes/issues/118172
-				// Note: TerminationGracePeriodSeconds is defaulted to 30s by the API server,
-				// so it should never be nil for pods admitted through the API.
-				gracePeriodOverride = *pod.Spec.TerminationGracePeriodSeconds
+				if pod.Spec.TerminationGracePeriodSeconds != nil {
+					gracePeriodOverride = *pod.Spec.TerminationGracePeriodSeconds
+				}
 			} else {
-				gracePeriodOverride = min(m.config.MaxPodGracePeriodSeconds, *pod.Spec.TerminationGracePeriodSeconds)
+				gracePeriodOverride = m.config.MaxPodGracePeriodSeconds
+				if pod.Spec.TerminationGracePeriodSeconds != nil {
+					gracePeriodOverride = min(m.config.MaxPodGracePeriodSeconds, *pod.Spec.TerminationGracePeriodSeconds)
+				}
 			}
 		}
 

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -432,10 +432,7 @@ func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfo
 				// so it should never be nil for pods admitted through the API.
 				gracePeriodOverride = *pod.Spec.TerminationGracePeriodSeconds
 			} else {
-				gracePeriodOverride = m.config.MaxPodGracePeriodSeconds
-				if pod.Spec.TerminationGracePeriodSeconds != nil {
-					gracePeriodOverride = min(m.config.MaxPodGracePeriodSeconds, *pod.Spec.TerminationGracePeriodSeconds)
-				}
+				gracePeriodOverride = min(m.config.MaxPodGracePeriodSeconds, *pod.Spec.TerminationGracePeriodSeconds)
 			}
 		}
 

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -428,11 +428,9 @@ func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfo
 				// Previously, min(negative, podGracePeriod) always returned the negative value,
 				// causing the CRI runtime to receive -1 and immediately SIGKILL the container.
 				// See https://github.com/kubernetes/kubernetes/issues/118172
-				if pod.Spec.TerminationGracePeriodSeconds != nil {
-					gracePeriodOverride = *pod.Spec.TerminationGracePeriodSeconds
-				} else {
-					gracePeriodOverride = int64(v1.DefaultTerminationGracePeriodSeconds)
-				}
+				// Note: TerminationGracePeriodSeconds is defaulted to 30s by the API server,
+				// so it should never be nil for pods admitted through the API.
+				gracePeriodOverride = *pod.Spec.TerminationGracePeriodSeconds
 			} else {
 				gracePeriodOverride = m.config.MaxPodGracePeriodSeconds
 				if pod.Spec.TerminationGracePeriodSeconds != nil {

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -422,9 +422,22 @@ func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfo
 		pod := activePods[i]
 		gracePeriodOverride := int64(immediateEvictionGracePeriodSeconds)
 		if !isHardEvictionThreshold(thresholdToReclaim) {
-			gracePeriodOverride = m.config.MaxPodGracePeriodSeconds
-			if pod.Spec.TerminationGracePeriodSeconds != nil {
-				gracePeriodOverride = min(m.config.MaxPodGracePeriodSeconds, *pod.Spec.TerminationGracePeriodSeconds)
+			if m.config.MaxPodGracePeriodSeconds < 0 {
+				// A negative value means "defer to the pod's own TerminationGracePeriodSeconds",
+				// as documented in the --eviction-max-pod-grace-period flag.
+				// Previously, min(negative, podGracePeriod) always returned the negative value,
+				// causing the CRI runtime to receive -1 and immediately SIGKILL the container.
+				// See https://github.com/kubernetes/kubernetes/issues/118172
+				if pod.Spec.TerminationGracePeriodSeconds != nil {
+					gracePeriodOverride = *pod.Spec.TerminationGracePeriodSeconds
+				} else {
+					gracePeriodOverride = int64(v1.DefaultTerminationGracePeriodSeconds)
+				}
+			} else {
+				gracePeriodOverride = m.config.MaxPodGracePeriodSeconds
+				if pod.Spec.TerminationGracePeriodSeconds != nil {
+					gracePeriodOverride = min(m.config.MaxPodGracePeriodSeconds, *pod.Spec.TerminationGracePeriodSeconds)
+				}
 			}
 		}
 

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -898,6 +898,114 @@ func makeContainersByQOS(class v1.PodQOSClass) []v1.Container {
 	}
 }
 
+
+// TestSoftEvictionNegativeMaxPodGracePeriod is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/118172
+//
+// When --eviction-max-pod-grace-period is set to a negative value the flag
+// documents: "If negative, defer to pod specified value."
+// The bug: min(-1, podGracePeriod) always evaluates to -1, so the CRI
+// runtime receives -1 and immediately SIGKILLs the container (exit 137).
+func TestSoftEvictionNegativeMaxPodGracePeriod(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	podMaker := makePodWithMemoryStats
+	summaryStatsMaker := makeMemoryStats
+
+	podTermGracePeriod := int64(60) // pod requests a 60s graceful shutdown
+
+	podsToMake := []podToMake{
+		{name: "evict-me", priority: lowPriority, requests: newResourceList("100m", "1Gi", ""), limits: newResourceList("100m", "1Gi", ""), memoryWorkingSet: "900Mi"},
+	}
+	pods := []*v1.Pod{}
+	podStats := map[*v1.Pod]statsapi.PodStats{}
+	for _, podToMake := range podsToMake {
+		pod, podStat := podMaker(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.memoryWorkingSet)
+		pod.Spec.TerminationGracePeriodSeconds = &podTermGracePeriod
+		pods = append(pods, pod)
+		podStats[pod] = podStat
+	}
+	podToEvict := pods[0]
+	activePodsFunc := func() []*v1.Pod { return pods }
+
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	podKiller := &mockPodKiller{}
+	diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: ptr.To(false)}
+	diskGC := &mockDiskGC{err: nil}
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+
+	config := Config{
+		MaxPodGracePeriodSeconds: -1, // negative = defer to pod's own grace period
+		PressureTransitionPeriod: time.Minute * 5,
+		Thresholds: []evictionapi.Threshold{
+			{
+				Signal:   evictionapi.SignalMemoryAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+				GracePeriod: time.Minute * 2,
+			},
+		},
+	}
+	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("2Gi", podStats)}
+	manager := &managerImpl{
+		clock:                        fakeClock,
+		killPodFunc:                  podKiller.killPodNow,
+		imageGC:                      diskGC,
+		containerGC:                  diskGC,
+		config:                       config,
+		recorder:                     &record.FakeRecorder{},
+		summaryProvider:              summaryProvider,
+		nodeRef:                      nodeRef,
+		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
+		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+	}
+
+	// Induce memory pressure below threshold
+	fakeClock.Step(1 * time.Minute)
+	summaryProvider.result = summaryStatsMaker("500Mi", podStats)
+	_, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+	if err != nil {
+		t.Fatalf("Manager expects no error but got %v", err)
+	}
+	if manager.IsUnderMemoryPressure() {
+		t.Errorf("Manager should report memory pressure")
+	}
+	// No eviction yet — grace period hasn't elapsed
+	if podKiller.pod != nil {
+		t.Errorf("Manager should not have killed a pod yet, but killed: %v", podKiller.pod.Name)
+	}
+
+	// Advance past the soft eviction grace period
+	fakeClock.Step(3 * time.Minute)
+	summaryProvider.result = summaryStatsMaker("500Mi", podStats)
+	_, err = manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+	if err != nil {
+		t.Fatalf("Manager expects no error but got %v", err)
+	}
+
+	// Verify the right pod was evicted
+	if podKiller.pod != podToEvict {
+		t.Fatalf("Manager chose to kill pod %v, but should have chosen %v", podKiller.pod, podToEvict.Name)
+	}
+	if podKiller.gracePeriodOverride == nil {
+		t.Fatalf("Manager killed pod but gracePeriodOverride was nil")
+	}
+
+	// KEY assertion: grace period must equal the pod's TerminationGracePeriodSeconds (60),
+	// NOT the raw -1 that was passed as MaxPodGracePeriodSeconds.
+	// Sending -1 to the CRI causes immediate SIGKILL (exit code 137).
+	observedGracePeriod := *podKiller.gracePeriodOverride
+	if observedGracePeriod != podTermGracePeriod {
+		t.Errorf(
+			"eviction-max-pod-grace-period=-1 should defer to pod's grace period (%ds), got %ds. "+
+				"Passing -1 to the CRI causes immediate SIGKILL. See issue #118172.",
+			podTermGracePeriod, observedGracePeriod,
+		)
+	}
+}
+
+
 func TestPIDPressure(t *testing.T) {
 	testCases := []struct {
 		name                               string

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -935,22 +935,11 @@ func TestSoftEvictionGracePeriod(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
-			podMaker := makePodWithMemoryStats
-			summaryStatsMaker := makeMemoryStats
 
-			podsToMake := []podToMake{
-				{name: "evict-me", priority: lowPriority, requests: newResourceList("100m", "1Gi", ""), limits: newResourceList("100m", "1Gi", ""), memoryWorkingSet: "900Mi"},
-			}
-			pods := []*v1.Pod{}
-			podStats := map[*v1.Pod]statsapi.PodStats{}
-			for _, ptm := range podsToMake {
-				pod, podStat := podMaker(ptm.name, ptm.priority, ptm.requests, ptm.limits, ptm.memoryWorkingSet)
-				pod.Spec.TerminationGracePeriodSeconds = &podTermGracePeriod
-				pods = append(pods, pod)
-				podStats[pod] = podStat
-			}
-			podToEvict := pods[0]
-			activePodsFunc := func() []*v1.Pod { return pods }
+			podToEvict, podStat := makePodWithMemoryStats("evict-me", lowPriority, newResourceList("100m", "1Gi", ""), newResourceList("100m", "1Gi", ""), "900Mi")
+			podToEvict.Spec.TerminationGracePeriodSeconds = &podTermGracePeriod
+			podStats := map[*v1.Pod]statsapi.PodStats{podToEvict: podStat}
+			activePodsFunc := func() []*v1.Pod { return []*v1.Pod{podToEvict} }
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			podKiller := &mockPodKiller{}
@@ -972,7 +961,7 @@ func TestSoftEvictionGracePeriod(t *testing.T) {
 					},
 				},
 			}
-			summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("2Gi", podStats)}
+			summaryProvider := &fakeSummaryProvider{result: makeMemoryStats("2Gi", podStats)}
 			manager := &managerImpl{
 				clock:                        fakeClock,
 				killPodFunc:                  podKiller.killPodNow,
@@ -988,7 +977,7 @@ func TestSoftEvictionGracePeriod(t *testing.T) {
 
 			// Induce memory pressure below threshold
 			fakeClock.Step(1 * time.Minute)
-			summaryProvider.result = summaryStatsMaker("500Mi", podStats)
+			summaryProvider.result = makeMemoryStats("500Mi", podStats)
 			_, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
 			if err != nil {
 				t.Fatalf("Manager expects no error but got %v", err)
@@ -1003,7 +992,7 @@ func TestSoftEvictionGracePeriod(t *testing.T) {
 
 			// Advance past the soft eviction grace period
 			fakeClock.Step(3 * time.Minute)
-			summaryProvider.result = summaryStatsMaker("500Mi", podStats)
+			summaryProvider.result = makeMemoryStats("500Mi", podStats)
 			_, err = manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
 			if err != nil {
 				t.Fatalf("Manager expects no error but got %v", err)

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -899,109 +899,133 @@ func makeContainersByQOS(class v1.PodQOSClass) []v1.Container {
 }
 
 
-// TestSoftEvictionNegativeMaxPodGracePeriod is a regression test for
+// TestSoftEvictionGracePeriod is a table-driven test covering various
+// MaxPodGracePeriodSeconds behaviors during soft eviction.
+// The negative-value case is a regression test for
 // https://github.com/kubernetes/kubernetes/issues/118172
-//
-// When --eviction-max-pod-grace-period is set to a negative value the flag
-// documents: "If negative, defer to pod specified value."
-// The bug: min(-1, podGracePeriod) always evaluates to -1, so the CRI
-// runtime receives -1 and immediately SIGKILLs the container (exit 137).
-func TestSoftEvictionNegativeMaxPodGracePeriod(t *testing.T) {
-	tCtx := ktesting.Init(t)
-	podMaker := makePodWithMemoryStats
-	summaryStatsMaker := makeMemoryStats
-
+func TestSoftEvictionGracePeriod(t *testing.T) {
 	podTermGracePeriod := int64(60) // pod requests a 60s graceful shutdown
 
-	podsToMake := []podToMake{
-		{name: "evict-me", priority: lowPriority, requests: newResourceList("100m", "1Gi", ""), limits: newResourceList("100m", "1Gi", ""), memoryWorkingSet: "900Mi"},
-	}
-	pods := []*v1.Pod{}
-	podStats := map[*v1.Pod]statsapi.PodStats{}
-	for _, podToMake := range podsToMake {
-		pod, podStat := podMaker(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.memoryWorkingSet)
-		pod.Spec.TerminationGracePeriodSeconds = &podTermGracePeriod
-		pods = append(pods, pod)
-		podStats[pod] = podStat
-	}
-	podToEvict := pods[0]
-	activePodsFunc := func() []*v1.Pod { return pods }
-
-	fakeClock := testingclock.NewFakeClock(time.Now())
-	podKiller := &mockPodKiller{}
-	diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: ptr.To(false)}
-	diskGC := &mockDiskGC{err: nil}
-	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
-
-	config := Config{
-		MaxPodGracePeriodSeconds: -1, // negative = defer to pod's own grace period
-		PressureTransitionPeriod: time.Minute * 5,
-		Thresholds: []evictionapi.Threshold{
-			{
-				Signal:   evictionapi.SignalMemoryAvailable,
-				Operator: evictionapi.OpLessThan,
-				Value: evictionapi.ThresholdValue{
-					Quantity: quantityMustParse("1Gi"),
-				},
-				GracePeriod: time.Minute * 2,
-			},
+	testCases := []struct {
+		name                    string
+		maxPodGracePeriod       int64
+		expectedGracePeriod     int64
+	}{
+		{
+			name:                "negative value defers to pod grace period",
+			maxPodGracePeriod:   -1,
+			expectedGracePeriod: 60, // pod's own TerminationGracePeriodSeconds
+		},
+		{
+			name:                "zero means immediate graceful termination",
+			maxPodGracePeriod:   0,
+			expectedGracePeriod: 0,
+		},
+		{
+			name:                "positive lower than pod caps to max",
+			maxPodGracePeriod:   30,
+			expectedGracePeriod: 30, // min(30, 60) = 30
+		},
+		{
+			name:                "positive higher than pod uses pod value",
+			maxPodGracePeriod:   120,
+			expectedGracePeriod: 60, // min(120, 60) = 60
 		},
 	}
-	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("2Gi", podStats)}
-	manager := &managerImpl{
-		clock:                        fakeClock,
-		killPodFunc:                  podKiller.killPodNow,
-		imageGC:                      diskGC,
-		containerGC:                  diskGC,
-		config:                       config,
-		recorder:                     &record.FakeRecorder{},
-		summaryProvider:              summaryProvider,
-		nodeRef:                      nodeRef,
-		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
-		thresholdsFirstObservedAt:    thresholdsObservedAt{},
-	}
 
-	// Induce memory pressure below threshold
-	fakeClock.Step(1 * time.Minute)
-	summaryProvider.result = summaryStatsMaker("500Mi", podStats)
-	_, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
-	if err != nil {
-		t.Fatalf("Manager expects no error but got %v", err)
-	}
-	if manager.IsUnderMemoryPressure() {
-		t.Errorf("Manager should report memory pressure")
-	}
-	// No eviction yet — grace period hasn't elapsed
-	if podKiller.pod != nil {
-		t.Errorf("Manager should not have killed a pod yet, but killed: %v", podKiller.pod.Name)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			podMaker := makePodWithMemoryStats
+			summaryStatsMaker := makeMemoryStats
 
-	// Advance past the soft eviction grace period
-	fakeClock.Step(3 * time.Minute)
-	summaryProvider.result = summaryStatsMaker("500Mi", podStats)
-	_, err = manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
-	if err != nil {
-		t.Fatalf("Manager expects no error but got %v", err)
-	}
+			podsToMake := []podToMake{
+				{name: "evict-me", priority: lowPriority, requests: newResourceList("100m", "1Gi", ""), limits: newResourceList("100m", "1Gi", ""), memoryWorkingSet: "900Mi"},
+			}
+			pods := []*v1.Pod{}
+			podStats := map[*v1.Pod]statsapi.PodStats{}
+			for _, ptm := range podsToMake {
+				pod, podStat := podMaker(ptm.name, ptm.priority, ptm.requests, ptm.limits, ptm.memoryWorkingSet)
+				pod.Spec.TerminationGracePeriodSeconds = &podTermGracePeriod
+				pods = append(pods, pod)
+				podStats[pod] = podStat
+			}
+			podToEvict := pods[0]
+			activePodsFunc := func() []*v1.Pod { return pods }
 
-	// Verify the right pod was evicted
-	if podKiller.pod != podToEvict {
-		t.Fatalf("Manager chose to kill pod %v, but should have chosen %v", podKiller.pod, podToEvict.Name)
-	}
-	if podKiller.gracePeriodOverride == nil {
-		t.Fatalf("Manager killed pod but gracePeriodOverride was nil")
-	}
+			fakeClock := testingclock.NewFakeClock(time.Now())
+			podKiller := &mockPodKiller{}
+			diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: ptr.To(false)}
+			diskGC := &mockDiskGC{err: nil}
+			nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
 
-	// KEY assertion: grace period must equal the pod's TerminationGracePeriodSeconds (60),
-	// NOT the raw -1 that was passed as MaxPodGracePeriodSeconds.
-	// Sending -1 to the CRI causes immediate SIGKILL (exit code 137).
-	observedGracePeriod := *podKiller.gracePeriodOverride
-	if observedGracePeriod != podTermGracePeriod {
-		t.Errorf(
-			"eviction-max-pod-grace-period=-1 should defer to pod's grace period (%ds), got %ds. "+
-				"Passing -1 to the CRI causes immediate SIGKILL. See issue #118172.",
-			podTermGracePeriod, observedGracePeriod,
-		)
+			config := Config{
+				MaxPodGracePeriodSeconds: tc.maxPodGracePeriod,
+				PressureTransitionPeriod: time.Minute * 5,
+				Thresholds: []evictionapi.Threshold{
+					{
+						Signal:   evictionapi.SignalMemoryAvailable,
+						Operator: evictionapi.OpLessThan,
+						Value: evictionapi.ThresholdValue{
+							Quantity: quantityMustParse("1Gi"),
+						},
+						GracePeriod: time.Minute * 2,
+					},
+				},
+			}
+			summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("2Gi", podStats)}
+			manager := &managerImpl{
+				clock:                        fakeClock,
+				killPodFunc:                  podKiller.killPodNow,
+				imageGC:                      diskGC,
+				containerGC:                  diskGC,
+				config:                       config,
+				recorder:                     &record.FakeRecorder{},
+				summaryProvider:              summaryProvider,
+				nodeRef:                      nodeRef,
+				nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
+				thresholdsFirstObservedAt:    thresholdsObservedAt{},
+			}
+
+			// Induce memory pressure below threshold
+			fakeClock.Step(1 * time.Minute)
+			summaryProvider.result = summaryStatsMaker("500Mi", podStats)
+			_, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+			if err != nil {
+				t.Fatalf("Manager expects no error but got %v", err)
+			}
+			if !manager.IsUnderMemoryPressure() {
+				t.Errorf("Manager should report memory pressure")
+			}
+			// No eviction yet — grace period hasn't elapsed
+			if podKiller.pod != nil {
+				t.Errorf("Manager should not have killed a pod yet, but killed: %v", podKiller.pod.Name)
+			}
+
+			// Advance past the soft eviction grace period
+			fakeClock.Step(3 * time.Minute)
+			summaryProvider.result = summaryStatsMaker("500Mi", podStats)
+			_, err = manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+			if err != nil {
+				t.Fatalf("Manager expects no error but got %v", err)
+			}
+
+			// Verify the right pod was evicted
+			if podKiller.pod != podToEvict {
+				t.Fatalf("Manager chose to kill pod %v, but should have chosen %v", podKiller.pod, podToEvict.Name)
+			}
+			if podKiller.gracePeriodOverride == nil {
+				t.Fatalf("Manager killed pod but gracePeriodOverride was nil")
+			}
+
+			observedGracePeriod := *podKiller.gracePeriodOverride
+			if observedGracePeriod != tc.expectedGracePeriod {
+				t.Errorf(
+					"MaxPodGracePeriodSeconds=%d: expected grace period %ds, got %ds",
+					tc.maxPodGracePeriod, tc.expectedGracePeriod, observedGracePeriod,
+				)
+			}
+		})
 	}
 }
 

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -898,7 +898,6 @@ func makeContainersByQOS(class v1.PodQOSClass) []v1.Container {
 	}
 }
 
-
 // TestSoftEvictionGracePeriod is a table-driven test covering various
 // MaxPodGracePeriodSeconds behaviors during soft eviction.
 // The negative-value case is a regression test for
@@ -907,9 +906,9 @@ func TestSoftEvictionGracePeriod(t *testing.T) {
 	podTermGracePeriod := int64(60) // pod requests a 60s graceful shutdown
 
 	testCases := []struct {
-		name                    string
-		maxPodGracePeriod       int64
-		expectedGracePeriod     int64
+		name                string
+		maxPodGracePeriod   int64
+		expectedGracePeriod int64
 	}{
 		{
 			name:                "negative value defers to pod grace period",
@@ -1028,7 +1027,6 @@ func TestSoftEvictionGracePeriod(t *testing.T) {
 		})
 	}
 }
-
 
 func TestPIDPressure(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
Negative `--eviction-max-pod-grace-period` should defer to the pod's own
`TerminationGracePeriodSeconds`. The bug: `min(-1, podGracePeriod)` always
returned `-1`, which the CRI interpreted as immediate SIGKILL (exit 137).

Fixes #118172

**What changed:**
In `pkg/kubelet/eviction/eviction_manager.go`, the grace period override
logic now checks for a negative `MaxPodGracePeriodSeconds` first and, when
negative, falls back to the pod's own `TerminationGracePeriodSeconds` (or
the default 30s if unset), matching the documented flag behavior.

**Test:**
Added `TestSoftEvictionNegativeMaxPodGracePeriod` to
`pkg/kubelet/eviction/eviction_manager_test.go` as a regression test.

```release-note
kubelet: Fixed --eviction-max-pod-grace-period behavior for negative values.
Negative values now correctly defer to the pod's TerminationGracePeriodSeconds
during soft eviction, as documented. Previously, negative values were passed
directly to the CRI, causing immediate SIGKILL (exit code 137).
```