### PR TITLE
test/e2e_node: wait for CRI ImageStatus after private image pull

### DIFF
--- a/test/e2e_node/image_credential_pulls.go
+++ b/test/e2e_node/image_credential_pulls.go
@@ -19,6 +19,7 @@ package e2enode
 import (
 	"context"
 	"path"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -74,6 +75,10 @@ var _ = SIGDescribe("Ensure Credential Pulled Images", func() {
 			testNode = registryNodeNames[0]
 			origPod := e2ecommonnode.ImagePullTest(ctx, f, testImage, v1.PullIfNotPresent, testSecret, testNode, v1.PodRunning, false)
 			gomega.Expect(origPod.Spec.NodeName).To(gomega.Equal(testNode), "pod should be scheduled on the expected node")
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
+				status, err := is.ImageStatus(ctx, &runtimeapi.ImageSpec{Image: testImage}, false)
+				return err == nil && status != nil && status.Image != nil
+			}, time.Minute, time.Second).Should(gomega.BeTrue(), "image %q should become visible in CRI after first pull", testImage)
 		})
 
 		for _, pullPolicy := range []v1.PullPolicy{v1.PullIfNotPresent, v1.PullNever} {

--- a/test/e2e_node/image_credential_pulls.go
+++ b/test/e2e_node/image_credential_pulls.go
@@ -38,7 +38,10 @@ import (
 )
 
 var _ = SIGDescribe("Ensure Credential Pulled Images", func() {
-	f := framework.NewDefaultFramework("ensure-credential-pulled-images")
+	f := framework.NewFramework("ensure-credential-pulled-images", framework.Options{
+		ClientQPS:   50,
+		ClientBurst: 100,
+	}, nil)
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	var is internalapi.ImageManagerService
 

--- a/test/e2e_node/image_credential_pulls.go
+++ b/test/e2e_node/image_credential_pulls.go
@@ -19,7 +19,6 @@ package e2enode
 import (
 	"context"
 	"path"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -78,10 +77,10 @@ var _ = SIGDescribe("Ensure Credential Pulled Images", func() {
 			testNode = registryNodeNames[0]
 			origPod := e2ecommonnode.ImagePullTest(ctx, f, testImage, v1.PullIfNotPresent, testSecret, testNode, v1.PodRunning, false)
 			gomega.Expect(origPod.Spec.NodeName).To(gomega.Equal(testNode), "pod should be scheduled on the expected node")
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				status, err := is.ImageStatus(ctx, &runtimeapi.ImageSpec{Image: testImage}, false)
-				return err == nil && status != nil && status.Image != nil
-			}, time.Minute, time.Second).Should(gomega.BeTrue(), "image %q should become visible in CRI after first pull", testImage)
+			status, err := is.ImageStatus(ctx, &runtimeapi.ImageSpec{Image: testImage}, false)
+			framework.ExpectNoError(err)
+			gomega.Expect(status).NotTo(gomega.BeNil(), "image should be visible in CRI immediately after pull")
+			gomega.Expect(status.Image).NotTo(gomega.BeNil(), "image should have image data in CRI immediately after pull")
 		})
 
 		for _, pullPolicy := range []v1.PullPolicy{v1.PullIfNotPresent, v1.PullNever} {


### PR DESCRIPTION
#### What type of PR is this?
/kind flake


#### What this PR does / why we need it:
https://testgrid.k8s.io/sig-node-cri-o#ci-node-crio-swap-serial

#### Which issue(s) this PR is related to:

xref #137004


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
