### PR TITLE
KEP-2570: setMemoryQoS clears memory.min when requests 0

### DIFF
--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -288,6 +288,14 @@ func (m *qosContainerManagerImpl) retrySetMemoryReserve(logger klog.Logger, conf
 // setMemoryQoS sums the memory requests of all pods in the Burstable class,
 // and set the sum memory as the memory.min in the Unified field of CgroupConfig.
 func (m *qosContainerManagerImpl) setMemoryQoS(logger klog.Logger, configs map[v1.PodQOSClass]*CgroupConfig) {
+	setMemoryMin := func(qos v1.PodQOSClass, memoryMin int64) {
+		if configs[qos].ResourceParameters.Unified == nil {
+			configs[qos].ResourceParameters.Unified = make(map[string]string)
+		}
+		configs[qos].ResourceParameters.Unified[Cgroup2MemoryMin] = strconv.FormatInt(memoryMin, 10)
+		logger.V(4).Info("MemoryQoS config for qos", "qos", qos, "memoryMin", memoryMin)
+	}
+
 	qosMemoryRequests := m.getQoSMemoryRequests()
 
 	// Calculate the memory.min:
@@ -296,21 +304,9 @@ func (m *qosContainerManagerImpl) setMemoryQoS(logger klog.Logger, configs map[v
 	burstableMin := qosMemoryRequests[v1.PodQOSBurstable]
 	guaranteedMin := qosMemoryRequests[v1.PodQOSGuaranteed] + burstableMin
 
-	if burstableMin > 0 {
-		if configs[v1.PodQOSBurstable].ResourceParameters.Unified == nil {
-			configs[v1.PodQOSBurstable].ResourceParameters.Unified = make(map[string]string)
-		}
-		configs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryMin] = strconv.FormatInt(burstableMin, 10)
-		logger.V(4).Info("MemoryQoS config for qos", "qos", v1.PodQOSBurstable, "memoryMin", burstableMin)
-	}
-
-	if guaranteedMin > 0 {
-		if configs[v1.PodQOSGuaranteed].ResourceParameters.Unified == nil {
-			configs[v1.PodQOSGuaranteed].ResourceParameters.Unified = make(map[string]string)
-		}
-		configs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin] = strconv.FormatInt(guaranteedMin, 10)
-		logger.V(4).Info("MemoryQoS config for qos", "qos", v1.PodQOSGuaranteed, "memoryMin", guaranteedMin)
-	}
+	// Always set memory.min, even when it is 0, because omitted Unified keys are not cleared by the cgroup manager.
+	setMemoryMin(v1.PodQOSBurstable, burstableMin)
+	setMemoryMin(v1.PodQOSGuaranteed, guaranteedMin)
 }
 
 func (m *qosContainerManagerImpl) UpdateCgroups(logger logr.Logger) error {

--- a/pkg/kubelet/cm/qos_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux_test.go
@@ -21,7 +21,14 @@ package cm
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,11 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
-	"strconv"
-	"strings"
-	"sync"
-	"testing"
-	"time"
 )
 
 func activeTestPods() []*v1.Pod {
@@ -134,31 +136,112 @@ func createTestQOSContainerManager(logger klog.Logger) (*qosContainerManagerImpl
 }
 
 func TestQoSContainerCgroup(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
-	m, err := createTestQOSContainerManager(logger)
-	assert.NoError(t, err)
+	burstableMin := resource.MustParse("384Mi")
+	guaranteedMin := resource.MustParse("128Mi")
 
-	qosConfigs := map[v1.PodQOSClass]*CgroupConfig{
-		v1.PodQOSGuaranteed: {
-			Name:               m.qosContainersInfo.Guaranteed,
-			ResourceParameters: &ResourceConfig{},
+	tests := []struct {
+		name               string
+		pods               []*v1.Pod
+		initialGuaranteed  string
+		initialBurstable   string
+		expectedGuaranteed string
+		expectedBurstable  string
+	}{
+		{
+			name:               "writes aggregated memory min",
+			pods:               activeTestPods(),
+			initialGuaranteed:  "",
+			initialBurstable:   "",
+			expectedGuaranteed: strconv.FormatInt(burstableMin.Value()+guaranteedMin.Value(), 10),
+			expectedBurstable:  strconv.FormatInt(burstableMin.Value(), 10),
 		},
-		v1.PodQOSBurstable: {
-			Name:               m.qosContainersInfo.Burstable,
-			ResourceParameters: &ResourceConfig{},
+		{
+			name: "writes zero memory min for best effort pod",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{UID: "99999999", Name: "besteffort-pod", Namespace: "test"},
+					Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "foo", Image: "busybox"}}},
+				},
+			},
+			initialGuaranteed:  "",
+			initialBurstable:   "",
+			expectedGuaranteed: "0",
+			expectedBurstable:  "0",
 		},
-		v1.PodQOSBestEffort: {
-			Name:               m.qosContainersInfo.BestEffort,
-			ResourceParameters: &ResourceConfig{},
+		{
+			name: "writes zero memory min for burstable pod without memory request",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{UID: "88888888", Name: "burstable-pod-no-memory-request", Namespace: "test"},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "foo",
+								Image: "busybox",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+								},
+							},
+						},
+					},
+				},
+			},
+			initialGuaranteed:  "",
+			initialBurstable:   "",
+			expectedGuaranteed: "0",
+			expectedBurstable:  "0",
+		},
+		{
+			name:               "clears stale memory min when all pods removed",
+			pods:               nil,
+			initialGuaranteed:  "1234",
+			initialBurstable:   "5678",
+			expectedGuaranteed: "0",
+			expectedBurstable:  "0",
 		},
 	}
 
-	m.setMemoryQoS(logger, qosConfigs)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			m, err := createTestQOSContainerManager(logger)
+			require.NoError(t, err)
+			m.activePods = func() []*v1.Pod { return tc.pods }
 
-	burstableMin := resource.MustParse("384Mi")
-	guaranteedMin := resource.MustParse("128Mi")
-	assert.Equal(t, qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified["memory.min"], strconv.FormatInt(burstableMin.Value()+guaranteedMin.Value(), 10))
-	assert.Equal(t, qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified["memory.min"], strconv.FormatInt(burstableMin.Value(), 10))
+			guaranteedUnified := map[string]string{}
+			if tc.initialGuaranteed != "" {
+				guaranteedUnified[Cgroup2MemoryMin] = tc.initialGuaranteed
+			}
+			burstableUnified := map[string]string{}
+			if tc.initialBurstable != "" {
+				burstableUnified[Cgroup2MemoryMin] = tc.initialBurstable
+			}
+
+			qosConfigs := map[v1.PodQOSClass]*CgroupConfig{
+				v1.PodQOSGuaranteed: {
+					Name: m.qosContainersInfo.Guaranteed,
+					ResourceParameters: &ResourceConfig{
+						Unified: guaranteedUnified,
+					},
+				},
+				v1.PodQOSBurstable: {
+					Name: m.qosContainersInfo.Burstable,
+					ResourceParameters: &ResourceConfig{
+						Unified: burstableUnified,
+					},
+				},
+				v1.PodQOSBestEffort: {
+					Name:               m.qosContainersInfo.BestEffort,
+					ResourceParameters: &ResourceConfig{},
+				},
+			}
+
+			m.setMemoryQoS(logger, qosConfigs)
+
+			assert.Equal(t, tc.expectedGuaranteed, qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin])
+			assert.Equal(t, tc.expectedBurstable, qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryMin])
+		})
+	}
 }
 
 // fakeCgroupManager is used because Start() requires a functional


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Always write memory.min, including "0". The cgroup manager only applies keys present in Unified and does not clear omitted keys, so skipping memory.min would leave any previously written value in place.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/2570

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This blocks feature PR: https://github.com/kubernetes/kubernetes/pull/137584

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Explicitly writes memory.min=0 for QoS cgroups when the calculated requests are zero
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2570-memory-qos/README.md
```
