### PR TITLE
Update Docker installation links in README.md to current URLs:

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -6,11 +6,11 @@ Building Kubernetes is easy if you take advantage of the containerized build env
 
 1. Docker, using one of the following configurations:
   * **macOS** Install Docker for Mac. See installation instructions [here](https://docs.docker.com/desktop/install/mac-install/).
-     **Note**: You will want to set the Docker VM to have at least 8GB of initial memory or building will likely fail. (See: [#11852]( http://issue.k8s.io/11852)).
-  * **Linux with local Docker**  Install Docker according to the [instructions](https://docs.docker.com/installation/#installation) for your OS.
-  * **Windows with Docker Desktop WSL2 backend**  Install Docker according to the [instructions](https://docs.docker.com/docker-for-windows/wsl-tech-preview/). Be sure to store your sources in the local Linux file system, not the Windows remote mount at `/mnt/c`.
+     **Note**: You will want to set the Docker VM to have at least 8GB of initial memory or building will likely fail. (See: [#11852](http://issue.k8s.io/11852)).
+  * **Linux with local Docker**  Install Docker according to the [instructions](https://docs.docker.com/engine/install/) for your OS.
+  * **Windows with Docker Desktop WSL2 backend**  Install Docker according to the [instructions](https://docs.docker.com/desktop/features/wsl/). Be sure to store your sources in the local Linux file system, not the Windows remote mount at `/mnt/c`.
   
-  **Note**: You will need to check if Docker CLI plugin buildx is properly installed (`docker-buildx` file should be present in `~/.docker/cli-plugins`). You can install buildx according to the [instructions](https://github.com/docker/buildx/blob/master/README.md#installing).
+  **Note**: You will need to check if Docker CLI plugin buildx is properly installed (`docker-buildx` file should be present in `~/.docker/cli-plugins`). You can install buildx according to the [instructions](https://github.com/docker/buildx#installing).
 
 2. **Optional** [Google Cloud SDK](https://developers.google.com/cloud/sdk/)
 
@@ -58,7 +58,7 @@ You can specify a different registry/name and version for `kube-cross` by settin
 All Docker names are suffixed with a hash derived from the file path (to allow concurrent usage on things like CI machines) and a version number.  When the version number changes all state is cleared and clean build is started.  This allows the build infrastructure to be changed and signal to CI systems that old artifacts need to be deleted.
 
 ## Build artifacts
-The build system output all its products to a top level directory in the source repository named `_output`.
+The build system outputs all its products to a top level directory in the source repository named `_output`.
 These include the binary compiled packages (e.g. kubectl, kube-scheduler etc.) and archived Docker images.
 If you intend to run a component with a docker image you will need to load it from this directory with
 the appropriate command, e.g.

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -303,7 +303,7 @@ function kube::release::create_docker_images_for_server() {
     mkdir -p "${images_dir}"
 
     # registry.k8s.io is the constant tag in the docker archives, this is also the default for config scripts in GKE.
-    # We can use KUBE_DOCKER_REGISTRY to include and extra registry in the docker archive.
+    # We can use KUBE_DOCKER_REGISTRY to include an extra registry in the docker archive.
     # If we use KUBE_DOCKER_REGISTRY="registry.k8s.io", then the extra tag (same) is ignored, see release_docker_image_tag below.
     local -r docker_registry="registry.k8s.io"
     # Docker tags cannot contain '+'

--- a/build/release-images.sh
+++ b/build/release-images.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build Kubernetes release images. This will build the server target binaries,
-# and create wrap them in Docker images, see `make release` for full releases
+# and wrap them in Docker images, see `make release` for full releases
 
 set -o errexit
 set -o nounset


### PR DESCRIPTION
  Linux: docs.docker.com/engine/install/
  Windows WSL2: docs.docker.com/desktop/features/wsl/
  buildx: github.com/docker/buildx#installing


/kind cleanup
/kind documentation

```release-note
NONE
```

```docs
NONE
```
