### PR TITLE
DRA integration: fix test isolation of extended resource test

### DIFF
--- a/test/integration/dra/helpers_test.go
+++ b/test/integration/dra/helpers_test.go
@@ -97,13 +97,16 @@ func createTestClassWithSpec(tCtx ktesting.TContext, namespace string, spec *res
 	driverName := namespace + driverNameSuffix
 	class := class.DeepCopy()
 	class.Name = namespace + classNameSuffix
-	class.Spec.Selectors = []resourceapi.DeviceSelector{{
-		CEL: &resourceapi.CELDeviceSelector{
-			Expression: fmt.Sprintf("device.driver == %q", driverName),
-		},
-	}}
 	if spec != nil {
 		class.Spec = *spec
+	}
+	// If the caller didn't supply a selector, we add the one which selects by driver name.
+	if len(class.Spec.Selectors) == 0 {
+		class.Spec.Selectors = []resourceapi.DeviceSelector{{
+			CEL: &resourceapi.CELDeviceSelector{
+				Expression: fmt.Sprintf("device.driver == %q", driverName),
+			},
+		}}
 	}
 	class, err := tCtx.Client().ResourceV1().DeviceClasses().Create(tCtx, class, metav1.CreateOptions{})
 	tCtx.ExpectNoError(err, "create class")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

The testExtendedResource caller supplies a spec without selector and thus allocated devices from whatever slice some other test might have created. This caused random test flakes, typically in UsesAllResources because it cannot allocate all its claims.

This could be fixed in the caller, but as the function exists and might also be called incorrectly in other, future tests, the function itself gets changed to add the selector if the caller didn't provide one.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/137618

#### Special notes for your reviewer:

I'll add more changes to prevent this from happening again later in a different PR. For now let's fix the root cause that I found with that additional code:
```
        	Claim all-explicitextendedresource-7brph/my-pod-extended-resources-bmd9d has allocated device v1.DeviceRequestAllocationResult{Request:"container-0-request-0", Driver:"driver-all-evictclusterwithslices-8nqps", Pool:"cluster", Device:"device-950", AdminAccess:(*bool)(nil), Tolerations:[]v1.DeviceToleration(nil), BindingConditions:[]string(nil), BindingFailureConditions:[]string(nil), ShareID:(*types.UID)(nil), ConsumedCapacity:map[v1.QualifiedName]resource.Quantity(nil)} from a driver in some other test (driver-all-evictclusterwithslices-8nqps): [...]
```

/assign @mortent @yliaog 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
