### PR TITLE
Add sample-device-plugin:1.7 to test image manifest

### DIFF
--- a/test/images/.permitted-images
+++ b/test/images/.permitted-images
@@ -28,6 +28,7 @@ registry.k8s.io/e2e-test-images/perl
 registry.k8s.io/e2e-test-images/regression-issue-74839
 registry.k8s.io/e2e-test-images/resource-consumer
 registry.k8s.io/e2e-test-images/sample-apiserver
+registry.k8s.io/e2e-test-images/sample-device-plugin
 registry.k8s.io/e2e-test-images/volume/iscsi
 registry.k8s.io/e2e-test-images/volume/nfs
 registry.k8s.io/etcd

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -204,6 +204,8 @@ const (
 	VolumeNFSServer
 	// VolumeISCSIServer image
 	VolumeISCSIServer
+	// SampleDevicePlugin image
+	SampleDevicePlugin
 )
 
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
@@ -236,6 +238,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[ResourceConsumer] = Config{list.PromoterE2eRegistry, "resource-consumer", "1.14"}
 	configs[VolumeNFSServer] = Config{list.PromoterE2eRegistry, "volume/nfs", "1.6.0"}
 	configs[VolumeISCSIServer] = Config{list.PromoterE2eRegistry, "volume/iscsi", "2.7"}
+	configs[SampleDevicePlugin] = Config{list.PromoterE2eRegistry, "sample-device-plugin", "1.7"}
 
 	// This adds more config entries. Those have no pre-defined ImageID number,
 	// but will be used via ReplaceRegistryInImageURL when deploying


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
Adds the missing sample-device-plugin:1.7 image entry to test/utils/image/manifest.go and updates test/images/.permitted-images to keep the e2e image allowlist in sync. Without these entries, tests referencing this image version fail to resolve.

**Which issue(s) this PR fixes:**
Fixes #137520

**Special notes for your reviewer:**
Two-file change in the test image manifest plumbing. Validation ran with `go test ./test/utils/image` and `hack/verify-e2e-images.sh`.

**Does this PR introduce a user-facing change?**
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancements Proposals), usage docs, etc.:**
N/A

```release-note
Add sample-device-plugin:1.7 to the e2e test image manifest
```
