### PR TITLE
Fix kubectl --request-timeout breaking in-cluster config

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/homedir"
 	"k8s.io/utils/ptr"
 )
@@ -159,9 +160,6 @@ func (f *ConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 
 func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	// use the standard defaults for this client command
-	// DEPRECATED: remove and replace with something more accurate
-	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 
 	if f.KubeConfig != nil {
 		loadingRules.ExplicitPath = *f.KubeConfig
@@ -245,6 +243,8 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	if f.Timeout != nil {
 		overrides.Timeout = *f.Timeout
 	}
+
+	loadingRules.DefaultClientConfig = clientcmd.NewDefaultClientConfig(*clientcmdapi.NewConfig(), overrides)
 
 	// we only have an interactive prompt when a password is allowed
 	if f.Password == nil {

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestConfigFlagsBuildsDefaultClientConfigWithOverrides(t *testing.T) {
+	flags := NewConfigFlags(false)
+	*flags.Timeout = "30s"
+	*flags.Impersonate = "alice"
+	*flags.ImpersonateGroup = []string{"team-a", "team-b"}
+
+	loader, ok := flags.ToRawKubeConfigLoader().(*clientConfig)
+	if !ok {
+		t.Fatalf("unexpected loader type %T", flags.ToRawKubeConfigLoader())
+	}
+
+	loadingRules, ok := loader.ConfigAccess().(*clientcmd.ClientConfigLoadingRules)
+	if !ok {
+		t.Fatalf("unexpected config access type %T", loader.ConfigAccess())
+	}
+
+	defaultConfig, err := loadingRules.DefaultClientConfig.ClientConfig()
+	if err != nil {
+		t.Fatalf("unexpected error building default config: %v", err)
+	}
+
+	if defaultConfig.Timeout != 30*time.Second {
+		t.Fatalf("expected timeout %s, got %s", 30*time.Second, defaultConfig.Timeout)
+	}
+	if defaultConfig.Impersonate.UserName != "alice" {
+		t.Fatalf("expected impersonation user %q, got %q", "alice", defaultConfig.Impersonate.UserName)
+	}
+	if !reflect.DeepEqual(defaultConfig.Impersonate.Groups, []string{"team-a", "team-b"}) {
+		t.Fatalf("unexpected impersonation groups: %#v", defaultConfig.Impersonate.Groups)
+	}
+
+	expectedOverrides := &clientcmd.ConfigOverrides{
+		ClusterDefaults: clientcmd.ClusterDefaults,
+		AuthInfo: clientcmdapi.AuthInfo{
+			Impersonate:       "alice",
+			ImpersonateGroups: []string{"team-a", "team-b"},
+		},
+		Timeout: "30s",
+	}
+	expectedConfig, err := clientcmd.NewNonInteractiveClientConfig(*clientcmdapi.NewConfig(), "", expectedOverrides, nil).ClientConfig()
+	if err != nil {
+		t.Fatalf("unexpected error building override config: %v", err)
+	}
+	if !loadingRules.IsDefaultConfig(expectedConfig) {
+		t.Fatal("expected override-aware config to remain comparable to the default loader config")
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -610,6 +610,100 @@ type inClusterClientConfig struct {
 
 var _ ClientConfig = &inClusterClientConfig{}
 
+func applyConfigOverrides(cfg *restclient.Config, overrides *ConfigOverrides) error {
+	if overrides == nil {
+		return nil
+	}
+
+	overrideConfig := &DirectClientConfig{
+		config: *clientcmdapi.NewConfig(),
+		overrides: &ConfigOverrides{
+			AuthInfo:    overrides.AuthInfo,
+			ClusterInfo: overrides.ClusterInfo,
+		},
+	}
+
+	clusterInfo, err := overrideConfig.getCluster()
+	if err != nil {
+		return err
+	}
+	authInfo, err := overrideConfig.getAuthInfo()
+	if err != nil {
+		return err
+	}
+
+	if len(overrides.ClusterInfo.Server) > 0 {
+		cfg.Host = clusterInfo.Server
+		if u, err := url.ParseRequestURI(cfg.Host); err == nil && u.Opaque == "" && len(u.Path) > 1 {
+			u.RawQuery = ""
+			u.Fragment = ""
+			cfg.Host = u.String()
+		}
+	}
+	if len(overrides.ClusterInfo.ProxyURL) > 0 {
+		u, err := parseProxyURL(clusterInfo.ProxyURL)
+		if err != nil {
+			return err
+		}
+		cfg.Proxy = http.ProxyURL(u)
+	}
+	if overrides.ClusterInfo.DisableCompression {
+		cfg.DisableCompression = clusterInfo.DisableCompression
+	}
+	if len(overrides.Timeout) > 0 {
+		timeout, err := ParseTimeout(overrides.Timeout)
+		if err != nil {
+			return err
+		}
+		cfg.Timeout = timeout
+	}
+
+	if len(overrides.ClusterInfo.Server) > 0 || overrides.ClusterInfo.InsecureSkipTLSVerify ||
+		len(overrides.ClusterInfo.CertificateAuthority) > 0 || len(overrides.ClusterInfo.CertificateAuthorityData) > 0 {
+		cfg.CAFile = clusterInfo.CertificateAuthority
+		cfg.CAData = clusterInfo.CertificateAuthorityData
+		cfg.Insecure = clusterInfo.InsecureSkipTLSVerify
+	}
+	if len(overrides.ClusterInfo.Server) > 0 || len(overrides.ClusterInfo.TLSServerName) > 0 {
+		cfg.ServerName = clusterInfo.TLSServerName
+	}
+
+	if len(overrides.AuthInfo.Token) > 0 || len(overrides.AuthInfo.TokenFile) > 0 {
+		cfg.BearerToken = authInfo.Token
+		cfg.BearerTokenFile = authInfo.TokenFile
+	}
+	if len(overrides.AuthInfo.Impersonate) > 0 || len(overrides.AuthInfo.ImpersonateUID) > 0 ||
+		len(overrides.AuthInfo.ImpersonateGroups) > 0 || len(overrides.AuthInfo.ImpersonateUserExtra) > 0 {
+		cfg.Impersonate = restclient.ImpersonationConfig{
+			UserName: authInfo.Impersonate,
+			UID:      authInfo.ImpersonateUID,
+			Groups:   authInfo.ImpersonateGroups,
+			Extra:    authInfo.ImpersonateUserExtra,
+		}
+	}
+	if len(overrides.AuthInfo.ClientCertificate) > 0 || len(overrides.AuthInfo.ClientCertificateData) > 0 ||
+		len(overrides.AuthInfo.ClientKey) > 0 || len(overrides.AuthInfo.ClientKeyData) > 0 {
+		cfg.CertFile = authInfo.ClientCertificate
+		cfg.CertData = authInfo.ClientCertificateData
+		cfg.KeyFile = authInfo.ClientKey
+		cfg.KeyData = authInfo.ClientKeyData
+	}
+	if len(overrides.AuthInfo.Username) > 0 || len(overrides.AuthInfo.Password) > 0 {
+		cfg.Username = authInfo.Username
+		cfg.Password = authInfo.Password
+	}
+	if overrides.AuthInfo.AuthProvider != nil {
+		cfg.AuthProvider = authInfo.AuthProvider
+	}
+	if overrides.AuthInfo.Exec != nil {
+		cfg.ExecProvider = authInfo.Exec
+		cfg.ExecProvider.InstallHint = cleanANSIEscapeCodes(cfg.ExecProvider.InstallHint)
+		cfg.ExecProvider.Config = clusterInfo.Extensions[clusterExtensionKey]
+	}
+
+	return nil
+}
+
 func (config *inClusterClientConfig) RawConfig() (clientcmdapi.Config, error) {
 	return clientcmdapi.Config{}, fmt.Errorf("inCluster environment config doesn't support multiple clusters")
 }
@@ -625,19 +719,8 @@ func (config *inClusterClientConfig) ClientConfig() (*restclient.Config, error) 
 		return nil, err
 	}
 
-	// in-cluster configs only takes a host, token, or CA file
-	// if any of them were individually provided, overwrite anything else
-	if config.overrides != nil {
-		if server := config.overrides.ClusterInfo.Server; len(server) > 0 {
-			icc.Host = server
-		}
-		if len(config.overrides.AuthInfo.Token) > 0 || len(config.overrides.AuthInfo.TokenFile) > 0 {
-			icc.BearerToken = config.overrides.AuthInfo.Token
-			icc.BearerTokenFile = config.overrides.AuthInfo.TokenFile
-		}
-		if certificateAuthorityFile := config.overrides.ClusterInfo.CertificateAuthority; len(certificateAuthorityFile) > 0 {
-			icc.TLSClientConfig.CAFile = certificateAuthorityFile
-		}
+	if err := applyConfigOverrides(icc, config.overrides); err != nil {
+		return nil, err
 	}
 
 	return icc, nil

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package clientcmd
 
 import (
+	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -963,6 +966,9 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 
 		if overridenServer := tc.overrides.ClusterInfo.Server; len(overridenServer) > 0 {
 			expectedServer = overridenServer
+			if len(tc.overrides.ClusterInfo.CertificateAuthority) == 0 {
+				expectedCAFile = ""
+			}
 		}
 		if len(tc.overrides.AuthInfo.Token) > 0 || len(tc.overrides.AuthInfo.TokenFile) > 0 {
 			expectedToken = tc.overrides.AuthInfo.Token
@@ -984,6 +990,215 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 		if clientConfig.TLSClientConfig.CAFile != expectedCAFile {
 			t.Errorf("Expected Certificate Authority %v, got %v", expectedCAFile, clientConfig.TLSClientConfig.CAFile)
 		}
+	}
+}
+
+func TestInClusterClientConfigAppliesOverrides(t *testing.T) {
+	baseConfig := func() *restclient.Config {
+		return &restclient.Config{
+			Host:            "https://host-from-cluster.com",
+			BearerToken:     "token-from-cluster",
+			BearerTokenFile: "tokenfile-from-cluster",
+			TLSClientConfig: restclient.TLSClientConfig{
+				CAFile:     "/path/to/ca-from-cluster.crt",
+				ServerName: "cluster-server-name",
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		overrides *ConfigOverrides
+		validate  func(*testing.T, *restclient.Config)
+	}{
+		{
+			name: "timeout override preserves in-cluster host",
+			overrides: &ConfigOverrides{
+				Timeout: "30s",
+			},
+			validate: func(t *testing.T, cfg *restclient.Config) {
+				matchStringArg("https://host-from-cluster.com", cfg.Host, t)
+				if cfg.Timeout != 30*time.Second {
+					t.Fatalf("expected timeout %s, got %s", 30*time.Second, cfg.Timeout)
+				}
+			},
+		},
+		{
+			name: "server override clears inherited TLS settings",
+			overrides: &ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					Server: "https://host-from-overrides.com",
+				},
+			},
+			validate: func(t *testing.T, cfg *restclient.Config) {
+				matchStringArg("https://host-from-overrides.com", cfg.Host, t)
+				matchStringArg("", cfg.CAFile, t)
+				matchStringArg("", cfg.ServerName, t)
+				matchStringArg("token-from-cluster", cfg.BearerToken, t)
+			},
+		},
+		{
+			name: "server override keeps explicit TLS settings",
+			overrides: &ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					Server:               "https://host-from-overrides.com",
+					CertificateAuthority: "/path/to/ca-from-overrides.crt",
+					TLSServerName:        "override-server-name",
+				},
+			},
+			validate: func(t *testing.T, cfg *restclient.Config) {
+				matchStringArg("https://host-from-overrides.com", cfg.Host, t)
+				matchStringArg("/path/to/ca-from-overrides.crt", cfg.CAFile, t)
+				matchStringArg("override-server-name", cfg.ServerName, t)
+			},
+		},
+		{
+			name: "insecure override clears CA",
+			overrides: &ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					InsecureSkipTLSVerify: true,
+				},
+			},
+			validate: func(t *testing.T, cfg *restclient.Config) {
+				matchBoolArg(true, cfg.Insecure, t)
+				matchStringArg("", cfg.CAFile, t)
+			},
+		},
+		{
+			name: "proxy and compression overrides are replayed",
+			overrides: &ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					ProxyURL:           "https://proxy.example.com:8443",
+					DisableCompression: true,
+				},
+			},
+			validate: func(t *testing.T, cfg *restclient.Config) {
+				if cfg.Proxy == nil {
+					t.Fatal("expected proxy function to be configured")
+				}
+				requestURL, err := url.Parse("https://host-from-cluster.com")
+				if err != nil {
+					t.Fatalf("unexpected request url error: %v", err)
+				}
+				proxyURL, err := cfg.Proxy(&http.Request{URL: requestURL})
+				if err != nil {
+					t.Fatalf("unexpected proxy resolution error: %v", err)
+				}
+				if proxyURL == nil {
+					t.Fatal("expected proxy url")
+				}
+				matchStringArg("https://proxy.example.com:8443", proxyURL.String(), t)
+				matchBoolArg(true, cfg.DisableCompression, t)
+			},
+		},
+		{
+			name: "impersonation override is replayed",
+			overrides: &ConfigOverrides{
+				AuthInfo: clientcmdapi.AuthInfo{
+					Impersonate:       "alice",
+					ImpersonateUID:    "1000",
+					ImpersonateGroups: []string{"team-a", "team-b"},
+					ImpersonateUserExtra: map[string][]string{
+						"scope": {"ops"},
+					},
+				},
+			},
+			validate: func(t *testing.T, cfg *restclient.Config) {
+				expected := restclient.ImpersonationConfig{
+					UserName: "alice",
+					UID:      "1000",
+					Groups:   []string{"team-a", "team-b"},
+					Extra: map[string][]string{
+						"scope": {"ops"},
+					},
+				}
+				if !reflect.DeepEqual(expected, cfg.Impersonate) {
+					t.Fatalf("unexpected impersonation config: diff=%s", cmp.Diff(expected, cfg.Impersonate))
+				}
+			},
+		},
+		{
+			name: "token override is replayed",
+			overrides: &ConfigOverrides{
+				AuthInfo: clientcmdapi.AuthInfo{
+					Token:     "token-from-override",
+					TokenFile: "tokenfile-from-override",
+				},
+			},
+			validate: func(t *testing.T, cfg *restclient.Config) {
+				matchStringArg("token-from-override", cfg.BearerToken, t)
+				matchStringArg("tokenfile-from-override", cfg.BearerTokenFile, t)
+			},
+		},
+		{
+			name: "auth provider override is replayed",
+			overrides: &ConfigOverrides{
+				AuthInfo: clientcmdapi.AuthInfo{
+					AuthProvider: &clientcmdapi.AuthProviderConfig{
+						Name: "oidc",
+					},
+				},
+			},
+			validate: func(t *testing.T, cfg *restclient.Config) {
+				if cfg.AuthProvider == nil {
+					t.Fatal("expected auth provider to be configured")
+				}
+				matchStringArg("oidc", cfg.AuthProvider.Name, t)
+			},
+		},
+		{
+			name: "exec provider override is replayed",
+			overrides: &ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					Extensions: map[string]runtime.Object{
+						clusterExtensionKey: &runtime.Unknown{
+							Raw:         []byte(`{"audience":"foo"}`),
+							ContentType: "application/json",
+						},
+					},
+				},
+				AuthInfo: clientcmdapi.AuthInfo{
+					Exec: &clientcmdapi.ExecConfig{
+						APIVersion:      "client.authentication.k8s.io/v1beta1",
+						Command:         "example-plugin",
+						InstallHint:     "install \x1b[1mplugin\x1b[0m",
+						InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+					},
+				},
+			},
+			validate: func(t *testing.T, cfg *restclient.Config) {
+				if cfg.ExecProvider == nil {
+					t.Fatal("expected exec provider to be configured")
+				}
+				matchStringArg("example-plugin", cfg.ExecProvider.Command, t)
+				matchStringArg("install U+001B[1mpluginU+001B[0m", cfg.ExecProvider.InstallHint, t)
+				expectedConfig := &runtime.Unknown{
+					Raw:         []byte(`{"audience":"foo"}`),
+					ContentType: "application/json",
+				}
+				if !reflect.DeepEqual(expectedConfig, cfg.ExecProvider.Config) {
+					t.Fatalf("unexpected exec config: diff=%s", cmp.Diff(expectedConfig, cfg.ExecProvider.Config))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			icc := &inClusterClientConfig{
+				inClusterConfigProvider: func() (*restclient.Config, error) {
+					return baseConfig(), nil
+				},
+				overrides: tt.overrides,
+			}
+
+			cfg, err := icc.ClientConfig()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			tt.validate(t, cfg)
+		})
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
@@ -86,6 +86,17 @@ func TestInClusterConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	timeoutDefaultConfig, ok := NewDefaultClientConfig(*clientcmdapi.NewConfig(), &ConfigOverrides{
+		ClusterDefaults: ClusterDefaults,
+		Timeout:         "30s",
+	}).(*DirectClientConfig)
+	if !ok {
+		t.Fatalf("unexpected default config type %T", NewDefaultClientConfig(*clientcmdapi.NewConfig(), &ConfigOverrides{}))
+	}
+	timeoutConfig, err := timeoutDefaultConfig.ClientConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
 	config2 := &restclient.Config{Host: "config2"}
 	err1 := fmt.Errorf("unique error")
 
@@ -143,6 +154,16 @@ func TestInClusterConfig(t *testing.T) {
 
 			checkedICC: false,
 			result:     config2,
+			err:        nil,
+		},
+
+		"in-cluster checked when config only differs by timeout override": {
+			defaultConfig: timeoutDefaultConfig,
+			clientConfig:  &testClientConfig{config: timeoutConfig},
+			icc:           &testICC{},
+
+			checkedICC: true,
+			result:     timeoutConfig,
 			err:        nil,
 		},
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
Fixes the client config loading path so that setting --request-timeout does not break in-cluster configuration. The timeout flag was incorrectly overriding the entire config object instead of just the timeout value.

**Which issue(s) this PR fixes:**
Fixes #93474

**Special notes for your reviewer:**
Affects client config loading in kubectl. Tests added to verify in-cluster config is preserved when --request-timeout is set.

**Does this PR introduce a user-facing change?**
kubectl --request-timeout no longer breaks in-cluster configuration.

**Additional documentation e.g., KEPs (Kubernetes Enhancements Proposals), usage docs, etc.:**
N/A


```release-note
Fix kubectl --request-timeout flag to work correctly with in-cluster configuration
```