### PR TITLE
Automated cherry pick of #134829: test: Fix data race on policy refresh interval

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -47,6 +47,7 @@ import (
 const policyRefreshIntervalDefault = 1 * time.Second
 
 var policyRefreshInterval = policyRefreshIntervalDefault
+var policyRefreshIntervalLock sync.Mutex
 
 type policySource[P runtime.Object, B runtime.Object, E Evaluator] struct {
 	ctx                context.Context
@@ -132,8 +133,12 @@ func NewPolicySource[P runtime.Object, B runtime.Object, E Evaluator](
 // SetPolicyRefreshIntervalForTests allows the refresh interval to be overridden during tests.
 // This should only be called from tests.
 func SetPolicyRefreshIntervalForTests(interval time.Duration) func() {
+	policyRefreshIntervalLock.Lock()
+	defer policyRefreshIntervalLock.Unlock()
 	policyRefreshInterval = interval
 	return func() {
+		policyRefreshIntervalLock.Lock()
+		defer policyRefreshIntervalLock.Unlock()
 		policyRefreshInterval = policyRefreshIntervalDefault
 	}
 }
@@ -194,7 +199,10 @@ func (s *policySource[P, B, E]) Run(ctx context.Context) error {
 	// and needs to be recompiled
 	go func() {
 		// Loop every 1 second until context is cancelled, refreshing policies
-		wait.Until(s.refreshPolicies, policyRefreshInterval, ctx.Done())
+		policyRefreshIntervalLock.Lock()
+		interval := policyRefreshInterval
+		policyRefreshIntervalLock.Unlock()
+		wait.Until(s.refreshPolicies, interval, ctx.Done())
 	}()
 
 	<-ctx.Done()


### PR DESCRIPTION
Cherry pick of #134829 on release-1.34.

#134829: test: Fix data race on policy refresh interval

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
None
```