### PR TITLE
kubelet: use DecimalSI format for ephemeral-storage capacity

### DIFF
--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -64,7 +64,7 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 	c := v1.ResourceList{
 		v1.ResourceEphemeralStorage: *resource.NewQuantity(
 			int64(info.Capacity),
-			resource.BinarySI),
+			resource.DecimalSI),
 	}
 	return c
 }

--- a/pkg/kubelet/cadvisor/util_test.go
+++ b/pkg/kubelet/cadvisor/util_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/cadvisor/container/crio"
 	info "github.com/google/cadvisor/info/v1"
+	infov2 "github.com/google/cadvisor/info/v2"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -50,6 +51,38 @@ func TestCapacityFromMachineInfoWithHugePagesEnable(t *testing.T) {
 	actual := CapacityFromMachineInfo(machineInfo)
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("when set hugepages true, got resource list %v, want %v", actual, expected)
+	}
+}
+
+func TestEphemeralStorageCapacityFromFsInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity uint64
+		expected v1.ResourceList
+	}{
+		{
+			name:     "non-1024-aligned capacity uses DecimalSI",
+			capacity: 97842800000,
+			expected: v1.ResourceList{
+				v1.ResourceEphemeralStorage: *resource.NewQuantity(int64(97842800000), resource.DecimalSI),
+			},
+		},
+		{
+			name:     "1024-aligned capacity uses DecimalSI",
+			capacity: 1048576,
+			expected: v1.ResourceList{
+				v1.ResourceEphemeralStorage: *resource.NewQuantity(int64(1048576), resource.DecimalSI),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fsInfo := infov2.FsInfo{Capacity: tt.capacity}
+			actual := EphemeralStorageCapacityFromFsInfo(fsInfo)
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("got resource list %v, want %v", actual, tt.expected)
+			}
+		})
 	}
 }
 

--- a/pkg/kubelet/cadvisor/util_test.go
+++ b/pkg/kubelet/cadvisor/util_test.go
@@ -54,35 +54,28 @@ func TestCapacityFromMachineInfoWithHugePagesEnable(t *testing.T) {
 	}
 }
 
+// TestEphemeralStorageCapacityFromFsInfo verifies that capacity uses DecimalSI.
+// Allocatable inherits capacity's format via DeepCopy().Sub() in setters.go.
+// DecimalSI produces clean suffixed values for any byte count, while BinarySI
+// falls back to bare integers for non-1024-aligned sizes. See #133927.
 func TestEphemeralStorageCapacityFromFsInfo(t *testing.T) {
-	tests := []struct {
-		name     string
-		capacity uint64
-		expected v1.ResourceList
-	}{
-		{
-			name:     "non-1024-aligned capacity uses DecimalSI",
-			capacity: 97842800000,
-			expected: v1.ResourceList{
-				v1.ResourceEphemeralStorage: *resource.NewQuantity(int64(97842800000), resource.DecimalSI),
-			},
-		},
-		{
-			name:     "1024-aligned capacity uses DecimalSI",
-			capacity: 1048576,
-			expected: v1.ResourceList{
-				v1.ResourceEphemeralStorage: *resource.NewQuantity(int64(1048576), resource.DecimalSI),
-			},
-		},
+	// Use a non-1024-aligned capacity typical of real filesystem sizes.
+	fsInfo := infov2.FsInfo{Capacity: 97842800000}
+	capacity := EphemeralStorageCapacityFromFsInfo(fsInfo)
+	ephemeralCapacity := capacity[v1.ResourceEphemeralStorage]
+
+	if ephemeralCapacity.Format != resource.DecimalSI {
+		t.Errorf("capacity format = %v, want DecimalSI", ephemeralCapacity.Format)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fsInfo := infov2.FsInfo{Capacity: tt.capacity}
-			actual := EphemeralStorageCapacityFromFsInfo(fsInfo)
-			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Errorf("got resource list %v, want %v", actual, tt.expected)
-			}
-		})
+
+	// Simulate allocatable derivation (setters.go): allocatable = capacity - reservation.
+	// DeepCopy preserves the format, so allocatable inherits DecimalSI from capacity.
+	allocatable := ephemeralCapacity.DeepCopy()
+	reservation := resource.MustParse("1Gi")
+	allocatable.Sub(reservation)
+
+	if allocatable.Format != resource.DecimalSI {
+		t.Errorf("allocatable format = %v, want DecimalSI (inherited from capacity)", allocatable.Format)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I dug into why `kubectl describe node` shows mismatched formats for ephemeral-storage between capacity and allocatable. I realized the root cause is in `EphemeralStorageCapacityFromFsInfo()` in `pkg/kubelet/cadvisor/util.go`. It creates the ephemeral-storage capacity Quantity with `resource.BinarySI`. But filesystem byte counts from cadvisor aren't necessarily divisible by 1024, so `CanonicalizeBytes()` can't find a binary suffix (Ki, Mi, Gi) and falls back to a bare integer like `97842800000`. The API server then re-parses that bare integer as `DecimalSI`, since no suffix defaults to DecimalSI. This creates a format mismatch between capacity and allocatable.

I changed `resource.BinarySI` to `resource.DecimalSI` in `EphemeralStorageCapacityFromFsInfo()`. DecimalSI should produces a clean suffixed representation (k, M, G) for any byte count, so both capacity and allocatable display consistently.

#### Which issue(s) this PR is related to:

Fixes #133927

#### Special notes for your reviewer:

The existing `setters_test.go` tests use `apiequality.Semantic.DeepEqual` which compares Quantities by numeric value only (ignoring format), so they pass without modification. The new test in `util_test.go` uses `reflect.DeepEqual` which checks format, confirming the fix and catching any regression back to BinarySI.

#### Does this PR introduce a user-facing change?

```release-note
Fixed inconsistent ephemeral-storage format between capacity and allocatable in node status by using DecimalSI format for ephemeral-storage capacity.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
