### PR TITLE
apiserver: prevent duplicate storage initialization for events and serviceaccounts

### DIFF
--- a/pkg/controlplane/apiserver/apis.go
+++ b/pkg/controlplane/apiserver/apis.go
@@ -69,8 +69,9 @@ func (c *CompletedConfig) GenericStorageProviders(discovery discovery.DiscoveryI
 	// with specific priorities.
 	// TODO: describe the priority all the way down in the RESTStorageProviders and plumb it back through the various discovery
 	// handlers that we have.
+	coreGenericConfig := c.NewCoreGenericConfig()
 	return []RESTStorageProvider{
-		c.NewCoreGenericConfig(),
+		coreGenericConfig,
 		apiserverinternalrest.StorageProvider{},
 		authenticationrest.RESTStorageProvider{Authenticator: c.Generic.Authentication.Authenticator, APIAudiences: c.Generic.Authentication.APIAudiences},
 		authorizationrest.RESTStorageProvider{Authorizer: c.Generic.Authorization.Authorizer, RuleResolver: c.Generic.RuleResolver},
@@ -80,7 +81,7 @@ func (c *CompletedConfig) GenericStorageProviders(discovery discovery.DiscoveryI
 		svmrest.RESTStorageProvider{},
 		flowcontrolrest.RESTStorageProvider{InformerFactory: c.Generic.SharedInformerFactory},
 		admissionregistrationrest.RESTStorageProvider{Authorizer: c.Generic.Authorization.Authorizer, DiscoveryClient: discovery},
-		eventsrest.RESTStorageProvider{TTL: c.EventTTL},
+		eventsrest.RESTStorageProvider{TTL: c.EventTTL, GetEventStorage: coreGenericConfig.GetEventStorage},
 	}, nil
 }
 

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -431,7 +431,7 @@ func (c CompletedConfig) StorageProviders(client *kubernetes.Clientset) ([]contr
 		// See https://github.com/kubernetes/kubernetes/issues/42392
 		appsrest.StorageProvider{},
 		admissionregistrationrest.RESTStorageProvider{Authorizer: c.ControlPlane.Generic.Authorization.Authorizer, DiscoveryClient: client.Discovery()},
-		eventsrest.RESTStorageProvider{TTL: c.ControlPlane.EventTTL},
+		eventsrest.RESTStorageProvider{TTL: c.ControlPlane.EventTTL, GetEventStorage: legacyRESTStorageProvider.GetEventStorage},
 		resourcerest.RESTStorageProvider{NamespaceClient: client.CoreV1().Namespaces()},
 	}
 

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -152,6 +152,9 @@ func New(c Config, authorizer authorizer.Authorizer) (*legacyProvider, error) {
 }
 
 func (p *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, error) {
+	// Skip serviceaccount creation in GenericConfig; we create it below with
+	// the correct pod/node/secret getters, avoiding duplicate storage initialization.
+	p.GenericConfig.SkipServiceAccount = true
 	apiGroupInfo, err := p.GenericConfig.NewRESTStorage(apiResourceConfigSource, restOptionsGetter)
 	if err != nil {
 		return genericapiserver.APIGroupInfo{}, err
@@ -219,7 +222,9 @@ func (p *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.AP
 		storage = map[string]rest.Storage{}
 	}
 
-	// potentially override the generic serviceaccount storage with one that supports pods
+	// Create serviceaccount storage once with the correct getters.
+	// When ServiceAccountIssuer is configured, use real pod/node/secret getters
+	// for token creation support. Otherwise use notFoundGetter placeholders.
 	var serviceAccountStorage *serviceaccountstore.REST
 	if p.ServiceAccountIssuer != nil {
 		var nodeGetter rest.Getter
@@ -228,9 +233,11 @@ func (p *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.AP
 			nodeGetter = nodeStorage.Node.Store
 		}
 		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, p.ServiceAccountIssuer, p.APIAudiences, p.ServiceAccountMaxExpiration, podStorage.Pod.Store, storage["secrets"].(rest.Getter), nodeGetter, p.ExtendExpiration, p.MaxExtendedExpiration)
-		if err != nil {
-			return genericapiserver.APIGroupInfo{}, err
-		}
+	} else {
+		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), false, p.MaxExtendedExpiration)
+	}
+	if err != nil {
+		return genericapiserver.APIGroupInfo{}, err
 	}
 
 	if resource := "pods"; apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {
@@ -271,14 +278,7 @@ func (p *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.AP
 		}
 	}
 
-	// potentially override generic storage for service account (with pod support)
-	if resource := "serviceaccounts"; serviceAccountStorage != nil && apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {
-		// don't leak go routines
-		storage[resource].Destroy()
-		if storage[resource+"/token"] != nil {
-			storage[resource+"/token"].Destroy()
-		}
-
+	if resource := "serviceaccounts"; apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {
 		storage[resource] = serviceAccountStorage
 		if serviceAccountStorage.Token != nil {
 			storage[resource+"/token"] = serviceAccountStorage.Token

--- a/pkg/registry/core/rest/storage_core_generic.go
+++ b/pkg/registry/core/rest/storage_core_generic.go
@@ -18,6 +18,7 @@ package rest
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -63,6 +64,24 @@ type GenericConfig struct {
 
 	LoopbackClientConfig *restclient.Config
 	Informers            informers.SharedInformerFactory
+
+	// SkipServiceAccount skips serviceaccount storage creation in NewRESTStorage.
+	// Used by legacyProvider which creates serviceaccount storage with real pod/node getters.
+	SkipServiceAccount bool
+
+	eventOnce    sync.Once
+	eventStorage *eventstore.REST
+	eventErr     error
+}
+
+// GetEventStorage returns event storage, creating it on first call. Subsequent calls
+// return the same instance. This allows sharing a single event storage between core/v1
+// and events.k8s.io/v1 API groups, avoiding duplicate etcd stores and watch caches.
+func (c *GenericConfig) GetEventStorage(restOptionsGetter generic.RESTOptionsGetter) (*eventstore.REST, error) {
+	c.eventOnce.Do(func() {
+		c.eventStorage, c.eventErr = eventstore.NewREST(restOptionsGetter, uint64(c.EventTTL.Seconds()))
+	})
+	return c.eventStorage, c.eventErr
 }
 
 func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, error) {
@@ -87,7 +106,7 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 		apiGroupInfo.NegotiatedSerializer = serializer.NewCodecFactory(legacyscheme.Scheme, opts...)
 	}
 
-	eventStorage, err := eventstore.NewREST(restOptionsGetter, uint64(c.EventTTL.Seconds()))
+	eventStorage, err := c.GetEventStorage(restOptionsGetter)
 	if err != nil {
 		return genericapiserver.APIGroupInfo{}, err
 	}
@@ -107,16 +126,6 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 	}
 
 	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage, err := namespacestore.NewREST(restOptionsGetter)
-	if err != nil {
-		return genericapiserver.APIGroupInfo{}, err
-	}
-
-	var serviceAccountStorage *serviceaccountstore.REST
-	if c.ServiceAccountIssuer != nil {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, c.ServiceAccountMaxExpiration, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), secretStorage.Store, newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), c.ExtendExpiration, c.MaxExtendedExpiration)
-	} else {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), false, c.MaxExtendedExpiration)
-	}
 	if err != nil {
 		return genericapiserver.APIGroupInfo{}, err
 	}
@@ -141,10 +150,22 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 		storage[resource] = secretStorage
 	}
 
-	if resource := "serviceaccounts"; apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {
-		storage[resource] = serviceAccountStorage
-		if serviceAccountStorage.Token != nil {
-			storage[resource+"/token"] = serviceAccountStorage.Token
+	if !c.SkipServiceAccount {
+		var serviceAccountStorage *serviceaccountstore.REST
+		if c.ServiceAccountIssuer != nil {
+			serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, c.ServiceAccountMaxExpiration, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), secretStorage.Store, newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), c.ExtendExpiration, c.MaxExtendedExpiration)
+		} else {
+			serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), false, c.MaxExtendedExpiration)
+		}
+		if err != nil {
+			return genericapiserver.APIGroupInfo{}, err
+		}
+
+		if resource := "serviceaccounts"; apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {
+			storage[resource] = serviceAccountStorage
+			if serviceAccountStorage.Token != nil {
+				storage[resource+"/token"] = serviceAccountStorage.Token
+			}
 		}
 	}
 

--- a/pkg/registry/events/rest/storage_events.go
+++ b/pkg/registry/events/rest/storage_events.go
@@ -31,6 +31,10 @@ import (
 
 type RESTStorageProvider struct {
 	TTL time.Duration
+	// GetEventStorage returns a shared event storage instance. When set, this
+	// is used instead of creating a new event storage, ensuring that core/v1
+	// and events.k8s.io/v1 share a single etcd store and watch cache.
+	GetEventStorage func(generic.RESTOptionsGetter) (*eventstore.REST, error)
 }
 
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, error) {
@@ -52,7 +56,13 @@ func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.API
 
 	// events
 	if resource := "events"; apiResourceConfigSource.ResourceEnabled(eventsapiv1.SchemeGroupVersion.WithResource(resource)) {
-		eventsStorage, err := eventstore.NewREST(restOptionsGetter, uint64(p.TTL.Seconds()))
+		var eventsStorage *eventstore.REST
+		var err error
+		if p.GetEventStorage != nil {
+			eventsStorage, err = p.GetEventStorage(restOptionsGetter)
+		} else {
+			eventsStorage, err = eventstore.NewREST(restOptionsGetter, uint64(p.TTL.Seconds()))
+		}
 		if err != nil {
 			return storage, err
 		}


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

The API server creates duplicate etcd stores and watch caches for `events` and `serviceaccounts`. Each `eventstore.NewREST()` / `serviceaccountstore.NewREST()` call allocates a new etcd client, a new watch cache that independently LISTs and WATCHes etcd, and caches all objects in memory. This wastes memory and CPU, and having multiple independent watch caches for the same data can cause consistency issues.

**Problem 1 — Events (two independent etcd stores):**

`eventstore.NewREST()` is called twice:
1. In `GenericConfig.NewRESTStorage()` (`storage_core_generic.go:90`) for `core/v1/events`
2. In `RESTStorageProvider.v1Storage()` (`storage_events.go:55`) for `events.k8s.io/v1/events`

Both serve the same underlying etcd data, but each creates a completely independent storage backend with its own watch cache. These two stores persist for the lifetime of the apiserver.

**Problem 2 — ServiceAccounts (wasteful create-destroy-recreate):**

When `ServiceAccountIssuer` is configured:
1. `GenericConfig.NewRESTStorage()` (`storage_core_generic.go:114-119`) creates serviceaccount storage with `notFoundGetter` placeholders for pods/nodes
2. `legacyProvider.NewRESTStorage()` (`storage_core.go:222-234`) creates a *second* serviceaccount storage with real pod/node/secret getters
3. The first storage is then explicitly destroyed (`storage_core.go:274-286`) and replaced with the second

The first storage's etcd store and watch cache are created, fully initialized (LIST + WATCH), and then immediately thrown away.

**Fix for Events — `sync.Once` getter (following #132924 HPA pattern):**

Added `GetEventStorage()` method to `GenericConfig` protected by `sync.Once`. Both `core/v1` (via `GenericConfig.NewRESTStorage()`) and `events.k8s.io/v1` (via `RESTStorageProvider.v1Storage()`) call this getter, which ensures `eventstore.NewREST()` is invoked exactly once regardless of call order. The shared getter is passed from the core provider to the events provider at construction time in both `instance.go` (kube-apiserver) and `apis.go` (generic controlplane).

**Fix for ServiceAccounts — single creation with correct config:**

Added `SkipServiceAccount` flag to `GenericConfig`. The `legacyProvider` sets this flag before calling `GenericConfig.NewRESTStorage()`, then creates serviceaccount storage exactly once with the correct getters:
- When `ServiceAccountIssuer != nil`: real pod, secret, and node getters (with feature-gated node binding support)
- When `ServiceAccountIssuer == nil`: `notFoundGetter` placeholders

This eliminates the create-destroy-recreate cycle. The generic controlplane path (`apis.go`) is unaffected since `SkipServiceAccount` defaults to `false`.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/133877

Related: #132924 (HPA deduplication using `sync.Once`, which established the pattern used here for events)

#### Special notes for your reviewer:

**Verification:**

All existing tests pass without modification, confirming no behavioral change:

```
$ go build ./pkg/registry/core/rest/... ./pkg/registry/events/rest/... ./pkg/controlplane/...
# all clean

$ go test ./pkg/registry/core/rest/ -v -count=1
=== RUN   TestGetServersToValidate
--- PASS: TestGetServersToValidate (0.00s)
PASS

$ go test ./pkg/controlplane/ -v -count=1
=== RUN   TestGroupVersions
--- PASS: TestGroupVersions (0.00s)
=== RUN   TestTypeTags
--- PASS: TestTypeTags (0.02s)
=== RUN   TestLegacyRestStorageStrategies
--- PASS: TestLegacyRestStorageStrategies (1.62s)
=== RUN   TestGenericStorageProviders
--- PASS: TestGenericStorageProviders (0.92s)
... (all PASS)
```

**Code paths affected:**
- `pkg/registry/core/rest/storage_core_generic.go` — `GenericConfig` gains `GetEventStorage()` (sync.Once) and `SkipServiceAccount` flag
- `pkg/registry/core/rest/storage_core.go` — `legacyProvider.NewRESTStorage()` sets `SkipServiceAccount=true`, creates SA once with correct getters, removes destroy-and-replace block
- `pkg/registry/events/rest/storage_events.go` — `RESTStorageProvider` accepts optional `GetEventStorage` getter
- `pkg/controlplane/instance.go` — wires `GetEventStorage` from legacy provider to events provider
- `pkg/controlplane/apiserver/apis.go` — wires `GetEventStorage` for generic controlplane path

**No behavioral change:** the same storage objects are created with the same parameters — just once instead of twice. The only observable difference is reduced memory and CPU usage from eliminating redundant etcd stores and watch caches.

/assign @serathius

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Alarm CLI Alarm CLI Alarm CLI Alarm CLI Alarm CLI Alarm ... design proposals), usage docs, etc.:

```docs
N/A
```