### PR TITLE
Re-enable newexpr hint in modernize linter

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -508,10 +508,6 @@ linters:
         # consistency with existing code
         # and it's just syntactic sugar.
         - any
-        # simplify code by using go1.26's new(expr)
-        # should only be updated in old code where it really matters (= always disable in base)
-        # and needs to remain disabled as hint until Go 1.26 is also available for backported code (https://github.com/kubernetes/kubernetes/issues/137595)
-        - newexpr
         # Suggest replacing omitempty with omitzero for struct fields.
         #
         # Disabled because might interfere

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -549,8 +549,7 @@ linters:
         # A useful hint for new code.
         - minmax
         # simplify code by using go1.26's new(expr)
-        # should only be updated in old code where it really matters (= always disable in base)
-        # and needs to remain disabled as hint until Go 1.26 is also available for backported code (https://github.com/kubernetes/kubernetes/issues/137595)
+        # should only be updated in old code where it really matters.
         - newexpr
         # use iterators instead of Len/At-style APIs
         # should only be updated in old code where it really matters.

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -306,12 +306,9 @@ linters:
         #
         # A useful hint for new code.
         - minmax
-        {{- end }}
         # simplify code by using go1.26's new(expr)
-        # should only be updated in old code where it really matters (= always disable in base)
-        # and needs to remain disabled as hint until Go 1.26 is also available for backported code (https://github.com/kubernetes/kubernetes/issues/137595)
+        # should only be updated in old code where it really matters.
         - newexpr
-        {{- if .Base }}
         # use iterators instead of Len/At-style APIs
         # should only be updated in old code where it really matters.
         - stditerators


### PR DESCRIPTION
Revert the changes from PR [#137596](https://github.com/kubernetes/kubernetes/pull/137596) to re‑enable the `modernize` linter’s `newexpr` hint for Go 1.26’s `new(x)` in place of `ptr.To(x)`.

The hint is now enabled in `hack/golangci-hints.yaml` (so developers see the suggestion), while it remains disabled in the base `hack/golangci.yaml` for backport compatibility until older stable branches are also on Go 1.26.

Fixes https://github.com/kubernetes/kubernetes/issues/137595

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Re‑enables the `modernize` linter’s `newexpr` hint in the hints configuration so developers are guided towards using Go 1.26’s `new(x)` instead of `ptr.To(x)`, while keeping the base configuration safe for backports to branches that are not yet on Go 1.26.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/137595

#### Special notes for your reviewer:

- This effectively reverts the `newexpr`‑related changes from PR [#137596](https://github.com/kubernetes/kubernetes/pull/137596).
- `newexpr` remains disabled in the base `golangci` config, and is only enabled as a hint so it doesn’t force changes that could break backports.

#### Does this PR introduce a user-facing change?

```release-note
NONE