### PR TITLE
fix cgroup v2 pod level cpu request readback issue

### DIFF
--- a/pkg/kubelet/cm/helpers.go
+++ b/pkg/kubelet/cm/helpers.go
@@ -33,6 +33,7 @@ import (
 // for typecheck across platforms
 var _ func(int64, int64) int64 = MilliCPUToQuota
 var _ func(int64) uint64 = MilliCPUToShares
+var _ func(uint64, uint64) bool = CPUSharesEqualAfterV2RoundTrip
 var _ func(*v1.Pod, bool, uint64, bool, kubeletconfig.MemoryReservationPolicy) *ResourceConfig = ResourceConfigForPod
 var _ func() (*CgroupSubsystems, error) = GetCgroupSubsystems
 var _ func(string) ([]int, error) = getCgroupProcs

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -417,6 +417,17 @@ func CPURequestsFromConfig(podConfig *ResourceConfig) *resource.Quantity {
 	return cpuRequest
 }
 
+// CPUSharesEqualAfterV2RoundTrip reports whether readbackShares equals the result of
+// round-tripping allocatedShares through the cgroup v2 conversion path
+// (cpu.shares -> cpu.weight -> cpu.shares).
+//
+// On cgroup v2, cpu.weight has coarse granularity, so writing shares and reading
+// them back can be lossy. Callers can use this to treat the lossy readback as
+// equivalent to the originally allocated shares.
+func CPUSharesEqualAfterV2RoundTrip(allocatedShares, readbackShares uint64) bool {
+	return cpuWeightToCPUShares(getCPUWeight(&allocatedShares)) == readbackShares
+}
+
 func CPULimitsFromConfig(podConfig *ResourceConfig) *resource.Quantity {
 	var cpuLimit *resource.Quantity
 

--- a/pkg/kubelet/cm/helpers_linux_test.go
+++ b/pkg/kubelet/cm/helpers_linux_test.go
@@ -945,3 +945,55 @@ func TestApplyPodLevelMemoryHigh(t *testing.T) {
 		}
 	})
 }
+
+func TestCPUSharesEqualAfterV2RoundTrip(t *testing.T) {
+	testCases := []struct {
+		name            string
+		allocatedShares uint64
+		readbackShares  uint64
+		expected        bool
+	}{
+		{
+			// 50m -> shares=51 -> weight=2 -> shares=28
+			name:            "matches lossy cgroup v2 readback for 50m",
+			allocatedShares: MilliCPUToShares(50),
+			readbackShares:  28,
+			expected:        true,
+		},
+		{
+			name:            "does not match nearby non-roundtrip readback",
+			allocatedShares: MilliCPUToShares(50),
+			readbackShares:  27,
+			expected:        false,
+		},
+		{
+			// 100m -> shares=102 -> weight=4 -> shares=80
+			name:            "matches lossy cgroup v2 readback for 100m",
+			allocatedShares: MilliCPUToShares(100),
+			readbackShares:  80,
+			expected:        true,
+		},
+		{
+			name:            "does not match identity when conversion is lossy",
+			allocatedShares: MilliCPUToShares(100),
+			readbackShares:  MilliCPUToShares(100),
+			expected:        false,
+		},
+		{
+			name:            "does not match unrelated higher readback",
+			allocatedShares: MilliCPUToShares(50),
+			readbackShares:  MilliCPUToShares(100),
+			expected:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CPUSharesEqualAfterV2RoundTrip(tc.allocatedShares, tc.readbackShares)
+			if got != tc.expected {
+				t.Fatalf("CPUSharesEqualAfterV2RoundTrip(%d, %d) = %t, want %t",
+					tc.allocatedShares, tc.readbackShares, got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/cm/helpers_unsupported.go
+++ b/pkg/kubelet/cm/helpers_unsupported.go
@@ -81,6 +81,10 @@ func CPURequestsFromConfig(podConfig *ResourceConfig) *resource.Quantity {
 	return nil
 }
 
+func CPUSharesEqualAfterV2RoundTrip(allocatedShares, readbackShares uint64) bool {
+	return false
+}
+
 func CPULimitsFromConfig(podConfig *ResourceConfig) *resource.Quantity {
 	return nil
 }

--- a/pkg/kubelet/kubelet_pod_level_resources_status_test.go
+++ b/pkg/kubelet/kubelet_pod_level_resources_status_test.go
@@ -1,0 +1,109 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	cm "k8s.io/kubernetes/pkg/kubelet/cm"
+	cmtesting "k8s.io/kubernetes/pkg/kubelet/cm/testing"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+func TestConvertToAPIPodLevelResourcesStatus(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.PodLevelResources:                       true,
+		features.InPlacePodLevelResourcesVerticalScaling: true,
+	})
+
+	testCases := []struct {
+		name             string
+		allocatedCPU     string
+		readbackShares   uint64
+		expectedMilliCPU int64
+	}{
+		{
+			// 50m -> shares=51 -> weight=2 -> shares(readback)=28 -> 28m.
+			// Round-trip match: preserve allocated 50m.
+			name:             "preserve allocated request for lossy v2 roundtrip readback",
+			allocatedCPU:     "50m",
+			readbackShares:   28,
+			expectedMilliCPU: 50,
+		},
+		{
+			// Readback shares do not match the round-tripped allocated shares:
+			// treat as a real actuation and report the readback milliCPU.
+			name:             "use actuated request when readback is not a v2 roundtrip",
+			allocatedCPU:     "50m",
+			readbackShares:   102, // SharesToMilliCPU(102) == 100
+			expectedMilliCPU: 100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+
+			pod := &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse(tc.allocatedCPU),
+							v1.ResourceMemory: resource.MustParse("50Mi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+					Containers: []v1.Container{{Name: "pause"}},
+				},
+				Status: v1.PodStatus{Phase: v1.PodRunning},
+			}
+
+			cpuPeriod := uint64(100000)
+			cpuQuota := int64(0)
+			readbackShares := tc.readbackShares
+			cpuCfg := &cm.ResourceConfig{
+				CPUShares: &readbackShares,
+				CPUPeriod: &cpuPeriod,
+				CPUQuota:  &cpuQuota,
+			}
+
+			mockPCM := cmtesting.NewMockPodContainerManager(t)
+			mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceMemory).Return(nil, nil)
+			mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceCPU).Return(cpuCfg, nil)
+
+			mockCM := cmtesting.NewMockContainerManager(t)
+			mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
+
+			kl := &Kubelet{containerManager: mockCM}
+			got := kl.convertToAPIPodLevelResourcesStatus(logger, pod, v1.PodStatus{})
+			require.NotNil(t, got)
+			require.Equal(t, tc.expectedMilliCPU, got.Requests.Cpu().MilliValue())
+		})
+	}
+}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -22,6 +22,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -2247,11 +2248,29 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 	}
 
 	if cpuRequest != nil {
-		// If both the allocated & actual resources are at
-		// or below MinShares, preserve the allocated value in the API to avoid
-		// confusion and simplify comparisons.
+		// If both the allocated and actuated values are at or below MinShares,
+		// preserve the allocated value in the API to avoid confusion and simplify
+		// comparisons at the cgroup minimum floor.
 		if cpuRequest.MilliValue() > cm.MinShares || resources.Requests.Cpu().MilliValue() > cm.MinShares {
-			resources.Requests[v1.ResourceCPU] = cpuRequest.DeepCopy()
+			allocatedMilliCPU := resources.Requests.Cpu().MilliValue()
+			actuatedMilliCPU := cpuRequest.MilliValue()
+			thresholdMilliCPU := actuatedMilliCPU
+			if thresholdMilliCPU == 0 {
+				thresholdMilliCPU = allocatedMilliCPU
+			}
+			// On cgroup v2, cpu.weight has coarse granularity and converting it back to
+			// millicores can be lossy. If the diff is more than 20% of the actuated
+			// value (falling back to the allocated value if actuated is 0), or more than
+			// 20m, then log a warning and preserve the allocated value. Otherwise, update
+			// status with the actuated value.
+			absDiff := math.Abs(float64(allocatedMilliCPU - actuatedMilliCPU))
+			if thresholdMilliCPU != 0 && (absDiff > float64(thresholdMilliCPU)*0.2 || absDiff > 20.0) {
+				logger.V(2).Info("CPU request mismatch", "allocated", allocatedMilliCPU, "actuated", actuatedMilliCPU)
+			} else {
+				// Preserve actuated value when conversion loss is within expected bounds
+				// (or both values are 0 and there is no meaningful baseline).
+				resources.Requests[v1.ResourceCPU] = cpuRequest.DeepCopy()
+			}
 		}
 	} else {
 		preserveOldResourcesValue(v1.ResourceCPU, oldPodStatus.Resources.Requests, resources.Requests)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -22,7 +22,6 @@ import (
 	goerrors "errors"
 	"fmt"
 	"io"
-	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -2248,27 +2247,23 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 	}
 
 	if cpuRequest != nil {
-		// If both the allocated and actuated values are at or below MinShares,
+		// If both the allocated and actual values are at or below MinShares,
 		// preserve the allocated value in the API to avoid confusion and simplify
 		// comparisons at the cgroup minimum floor.
 		if cpuRequest.MilliValue() > cm.MinShares || resources.Requests.Cpu().MilliValue() > cm.MinShares {
 			allocatedMilliCPU := resources.Requests.Cpu().MilliValue()
-			actuatedMilliCPU := cpuRequest.MilliValue()
-			thresholdMilliCPU := actuatedMilliCPU
-			if thresholdMilliCPU == 0 {
-				thresholdMilliCPU = allocatedMilliCPU
-			}
-			// On cgroup v2, cpu.weight has coarse granularity and converting it back to
-			// millicores can be lossy. If the diff is more than 20% of the actuated
-			// value (falling back to the allocated value if actuated is 0), or more than
-			// 20m, then log a warning and preserve the allocated value. Otherwise, update
-			// status with the actuated value.
-			absDiff := math.Abs(float64(allocatedMilliCPU - actuatedMilliCPU))
-			if thresholdMilliCPU != 0 && (absDiff > float64(thresholdMilliCPU)*0.2 || absDiff > 20.0) {
-				logger.V(2).Info("CPU request mismatch", "allocated", allocatedMilliCPU, "actuated", actuatedMilliCPU)
+			allocatedShares := cm.MilliCPUToShares(allocatedMilliCPU)
+			// On cgroup v2, cpu.weight has coarse granularity and converting
+			// shares -> weight -> shares can be lossy. If the cgroup readback
+			// matches the round-tripped allocated shares, preserve the allocated
+			// milliCPU in the API. Otherwise treat it as a real change and use
+			// the actuated value.
+			if cpuConfig != nil && cpuConfig.CPUShares != nil &&
+				cm.CPUSharesEqualAfterV2RoundTrip(allocatedShares, *cpuConfig.CPUShares) {
+				logger.V(4).Info("Preserving allocated CPU request due to cgroup v2 round-trip",
+					"allocated", allocatedMilliCPU, "actuated", cpuRequest.MilliValue(),
+					"allocatedShares", allocatedShares, "readbackShares", *cpuConfig.CPUShares)
 			} else {
-				// Preserve actuated value when conversion loss is within expected bounds
-				// (or both values are 0 and there is no meaningful baseline).
 				resources.Requests[v1.ResourceCPU] = cpuRequest.DeepCopy()
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
xref #137628

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubelet: fix wrong Pod-level CPU requests status from cgroup v2 readback
```
