### PR TITLE
Use UntilWithContext in PV controller resync loop

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -333,7 +333,7 @@ func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
 	metrics.Register(ctrl.volumes.store, ctrl.claims, &ctrl.volumePluginMgr)
 
 	wg.Go(func() {
-		wait.Until(func() { ctrl.resync(ctx) }, ctrl.resyncPeriod, ctx.Done())
+		wait.UntilWithContext(ctx, func(ctx context.Context) { ctrl.resync(ctx) }, ctrl.resyncPeriod)
 	})
 	wg.Go(func() {
 		wait.UntilWithContext(ctx, ctrl.volumeWorker, time.Second)


### PR DESCRIPTION
Switch the persistent volume controller resync loop from `wait.Until` to
`wait.UntilWithContext` so that it uses the contextual wait helper in
`k8s.io/apimachinery/pkg/util/wait`.

The controller already:
- runs with a `context.Context`,
- uses `WaitForNamedCacheSyncWithContext` to wait for informers,
- and uses `wait.UntilWithContext` for its worker goroutines.

This change makes the periodic resync loop consistent with the rest of the
context-aware code and aligns it with the guidance in
https://github.com/kubernetes/kubernetes/issues/126379.

Fixes https://github.com/kubernetes/kubernetes/issues/126379

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the persistent volume controller’s resync loop to use the
context-aware `wait.UntilWithContext`, improving consistency with
contextual-logging-aware helpers and ensuring the loop is directly tied
to the controller’s context.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:

- This only touches the resync loop in
  `pkg/controller/volume/persistentvolume/pv_controller_base.go`.
- The controller already had a `context.Context` and used other `WithContext`
  helpers; this change just converts the remaining `wait.Until` call.

#### Does this PR introduce a user-facing change?

```release-note
NONE