### PR TITLE
Automated cherry pick of #137666: Parallel pod management should not count old, broken pods for maxUnavailable budget

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -772,15 +772,19 @@ func updateStatefulSetAfterInvariantEstablished(ctx context.Context, ssc *defaul
 	}
 	metrics.UnavailableReplicas.WithLabelValues(set.Namespace, set.Name, podManagementPolicy).Set(float64(unavailablePods))
 
-	// For Parallel pod management, pods that are already unavailable AND on an old revision
-	// do not consume the maxUnavailable budget.
-	// For OrderedReady pod management this does not apply to preserve the existing
-	// sequential update behaviour.
+	// For Parallel pod management, pods that are already unavailable (e.g. crashlooping)
+	// AND on an old revision do not consume the maxUnavailable budget, so the controller
+	// can still delete them to trigger a revision update.
+	// Terminating pods (DeletionTimestamp set) on the other hand are excluded,
+	// because they represent in-flight deletions initiated by a prior sync and
+	// must continue to count against the budget until they are fully removed.
 	effectiveUnavailable := unavailablePods
 	if set.Spec.PodManagementPolicy == apps.ParallelPodManagement {
 		unavailablePodsNeedingUpdate := 0
 		for target := len(replicas) - 1; target >= updateMin; target-- {
-			if getPodRevision(replicas[target]) != updateRevision.Name && isUnavailable(replicas[target], set.Spec.MinReadySeconds, now) {
+			if getPodRevision(replicas[target]) != updateRevision.Name &&
+				isUnavailable(replicas[target], set.Spec.MinReadySeconds, now) &&
+				!isTerminating(replicas[target]) {
 				unavailablePodsNeedingUpdate++
 			}
 		}

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -772,9 +772,24 @@ func updateStatefulSetAfterInvariantEstablished(ctx context.Context, ssc *defaul
 	}
 	metrics.UnavailableReplicas.WithLabelValues(set.Namespace, set.Name, podManagementPolicy).Set(float64(unavailablePods))
 
-	if unavailablePods >= maxUnavailable {
+	// For Parallel pod management, pods that are already unavailable AND on an old revision
+	// do not consume the maxUnavailable budget.
+	// For OrderedReady pod management this does not apply to preserve the existing
+	// sequential update behaviour.
+	effectiveUnavailable := unavailablePods
+	if set.Spec.PodManagementPolicy == apps.ParallelPodManagement {
+		unavailablePodsNeedingUpdate := 0
+		for target := len(replicas) - 1; target >= updateMin; target-- {
+			if getPodRevision(replicas[target]) != updateRevision.Name && isUnavailable(replicas[target], set.Spec.MinReadySeconds, now) {
+				unavailablePodsNeedingUpdate++
+			}
+		}
+		effectiveUnavailable = unavailablePods - unavailablePodsNeedingUpdate
+	}
+
+	if effectiveUnavailable >= maxUnavailable {
 		// log only when a true violation occurs.
-		if unavailablePods > maxUnavailable {
+		if effectiveUnavailable > maxUnavailable {
 			logger.V(4).Info("StatefulSet found unavailablePods, more than the allowed maxUnavailable",
 				"statefulSet", klog.KObj(set),
 				"unavailablePods", unavailablePods,
@@ -784,16 +799,14 @@ func updateStatefulSetAfterInvariantEstablished(ctx context.Context, ssc *defaul
 		return &status, nil
 	}
 
-	// Now we need to delete MaxUnavailable- unavailablePods
+	// Now we need to delete MaxUnavailable - effectiveUnavailable
 	// start deleting one by one starting from the highest ordinal first
-	podsToDelete := maxUnavailable - unavailablePods
+	podsToDelete := maxUnavailable - effectiveUnavailable
 
 	deletedPods := 0
 	for target := len(replicas) - 1; target >= updateMin && deletedPods < podsToDelete; target-- {
-
-		// delete the Pod if it is healthy and the revision does not match the target
+		// delete the Pod if it is not already terminating and the revision does not match the target
 		if getPodRevision(replicas[target]) != updateRevision.Name && !isTerminating(replicas[target]) {
-			// delete the Pod if it is healthy and the revision does not match the target
 			logger.V(2).Info("StatefulSet terminating Pod for update",
 				"statefulSet", klog.KObj(set),
 				"pod", klog.KObj(replicas[target]))

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -1354,7 +1354,7 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableAndUnavailableStalePod
 			expectedPodsRemaining: 4,
 		},
 		{
-			name:                "Parallel/3 replicas, highest-ordinal pod terminating on old revision: next pod gets deleted",
+			name:                "Parallel/3 replicas, highest-ordinal pod terminating on old revision: budget consumed, next pod must NOT be deleted",
 			podManagementPolicy: apps.ParallelPodManagement,
 			replicas:            3,
 			maxUnavailable:      intstr.FromInt32(1),
@@ -1363,7 +1363,7 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableAndUnavailableStalePod
 				_, err := spc.setPodTerminated(set, ordinal)
 				return err
 			},
-			expectedPodsRemaining: 2,
+			expectedPodsRemaining: 3,
 		},
 		{
 			name:                "OrderedReady/3 replicas, highest-ordinal pod terminating on old revision blocks update",
@@ -1372,6 +1372,22 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableAndUnavailableStalePod
 			maxUnavailable:      intstr.FromInt32(1),
 			unavailableOrdinals: []int{2},
 			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodTerminated(set, ordinal)
+				return err
+			},
+			expectedPodsRemaining: 3,
+		},
+		{
+			name:                "Parallel/5 replicas maxUnavailable=3, pod-4 terminating + pod-3 crashlooping: only 2 more pods should be deleted",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            5,
+			maxUnavailable:      intstr.FromInt32(3),
+			unavailableOrdinals: []int{3, 4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				if ordinal == 3 {
+					_, err := spc.setPodReadyCondition(set, ordinal, false)
+					return err
+				}
 				_, err := spc.setPodTerminated(set, ordinal)
 				return err
 			},
@@ -1404,7 +1420,7 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableAndUnavailableStalePod
 			expectedPodsRemaining: 3,
 		},
 		{
-			name:                "Parallel/5 replicas, 1 pod unavailable(#3) + 1 pod terminating(#4) on old revision",
+			name:                "Parallel/5 replicas, pod-3 unavailable + pod-4 terminating on old revision, only 2 more pods should be deleted",
 			podManagementPolicy: apps.ParallelPodManagement,
 			replicas:            5,
 			maxUnavailable:      intstr.FromInt32(3),
@@ -1417,10 +1433,10 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableAndUnavailableStalePod
 				_, err := spc.setPodTerminated(set, ordinal)
 				return err
 			},
-			expectedPodsRemaining: 2,
+			expectedPodsRemaining: 3,
 		},
 		{
-			name:                "Parallel/5 replicas, 1 pod terminating(#3) + 1 pod unavailable(#3) on old revision",
+			name:                "Parallel/5 replicas, pod-3 terminating + pod-4 unavailable on old revision, only 2 more pods should be deleted",
 			podManagementPolicy: apps.ParallelPodManagement,
 			replicas:            5,
 			maxUnavailable:      intstr.FromInt32(3),
@@ -1433,7 +1449,7 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableAndUnavailableStalePod
 				_, err := spc.setPodReadyCondition(set, ordinal, false)
 				return err
 			},
-			expectedPodsRemaining: 2,
+			expectedPodsRemaining: 3,
 		},
 		{
 			name:                "OrderedReady/5 replicas, 1 pod unavailable(#3) + 1 pod terminating(#4) on old revision",

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"reflect"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -1259,6 +1259,364 @@ func TestStatefulSetControlRollingUpdateWithMaxUnavailableInOrderedModeVerifyInv
 	}
 }
 
+// Regression test for https://github.com/kubernetes/kubernetes/issues/137409.
+// When MaxUnavailableStatefulSet is enabled and a pod with Parallel pod management is on an
+// old revision AND already unavailable (e.g. crashlooping), the controller must still delete
+// the pod to trigger a revision update. The bug caused a deadlock: the pod could never become
+// available because it had the wrong revision, and the controller would never update it because
+// it treated the pod's existing unavailability as consuming the entire maxUnavailable budget.
+// For OrderedReady pod management the original strict behaviour is preserved for backwards
+// compatibility.
+func TestStatefulSetControlRollingUpdateWithMaxUnavailableAndUnavailableStalePod(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MaxUnavailableStatefulSet, true)
+
+	testCases := []struct {
+		name                  string
+		podManagementPolicy   apps.PodManagementPolicyType
+		replicas              int32
+		partition             int32
+		maxUnavailable        intstr.IntOrString
+		minReadySeconds       int32
+		unavailableOrdinals   []int
+		makeUnavailable       func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error
+		expectedPodsRemaining int
+	}{
+		{
+			name:                "Parallel/single replica: unavailable pod on old revision must be updated",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            1,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{0},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 0,
+		},
+		{
+			name:                "Parallel/3 replicas, highest-ordinal pod unavailable on old revision",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            3,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{2},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 2,
+		},
+		{
+			name:                "Parallel/5 replicas, 2 pods unavailable on old revision",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            5,
+			maxUnavailable:      intstr.FromInt32(2),
+			unavailableOrdinals: []int{4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 3,
+		},
+		{
+			name:                "OrderedReady/single replica: unavailable pod on old revision blocks update",
+			podManagementPolicy: apps.OrderedReadyPodManagement,
+			replicas:            1,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{0},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 1,
+		},
+		{
+			name:                "OrderedReady/3 replicas, highest-ordinal pod unavailable on old revision blocks update",
+			podManagementPolicy: apps.OrderedReadyPodManagement,
+			replicas:            3,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{2},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 3,
+		},
+		{
+			name:                "OrderedReady/5 replicas, 2 pods unavailable on old revision blocks update",
+			podManagementPolicy: apps.OrderedReadyPodManagement,
+			replicas:            5,
+			maxUnavailable:      intstr.FromInt32(2),
+			unavailableOrdinals: []int{4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 4,
+		},
+		{
+			name:                "Parallel/3 replicas, highest-ordinal pod terminating on old revision: next pod gets deleted",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            3,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{2},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodTerminated(set, ordinal)
+				return err
+			},
+			expectedPodsRemaining: 2,
+		},
+		{
+			name:                "OrderedReady/3 replicas, highest-ordinal pod terminating on old revision blocks update",
+			podManagementPolicy: apps.OrderedReadyPodManagement,
+			replicas:            3,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{2},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodTerminated(set, ordinal)
+				return err
+			},
+			expectedPodsRemaining: 3,
+		},
+		{
+			name:                "Parallel/3 replicas, highest-ordinal pod ready but within minReadySeconds on old revision: pod gets deleted",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            3,
+			maxUnavailable:      intstr.FromInt32(1),
+			minReadySeconds:     30,
+			unavailableOrdinals: []int{2},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodAvailable(set, ordinal, time.Now())
+				return err
+			},
+			expectedPodsRemaining: 2,
+		},
+		{
+			name:                "OrderedReady/3 replicas, highest-ordinal pod ready but within minReadySeconds on old revision blocks update",
+			podManagementPolicy: apps.OrderedReadyPodManagement,
+			replicas:            3,
+			maxUnavailable:      intstr.FromInt32(1),
+			minReadySeconds:     30,
+			unavailableOrdinals: []int{2},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodAvailable(set, ordinal, time.Now())
+				return err
+			},
+			expectedPodsRemaining: 3,
+		},
+		{
+			name:                "Parallel/5 replicas, 1 pod unavailable(#3) + 1 pod terminating(#4) on old revision",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            5,
+			maxUnavailable:      intstr.FromInt32(3),
+			unavailableOrdinals: []int{3, 4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				if ordinal == 3 {
+					_, err := spc.setPodReadyCondition(set, ordinal, false)
+					return err
+				}
+				_, err := spc.setPodTerminated(set, ordinal)
+				return err
+			},
+			expectedPodsRemaining: 2,
+		},
+		{
+			name:                "Parallel/5 replicas, 1 pod terminating(#3) + 1 pod unavailable(#3) on old revision",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            5,
+			maxUnavailable:      intstr.FromInt32(3),
+			unavailableOrdinals: []int{3, 4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				if ordinal == 3 {
+					_, err := spc.setPodTerminated(set, ordinal)
+					return err
+				}
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 2,
+		},
+		{
+			name:                "OrderedReady/5 replicas, 1 pod unavailable(#3) + 1 pod terminating(#4) on old revision",
+			podManagementPolicy: apps.OrderedReadyPodManagement,
+			replicas:            5,
+			maxUnavailable:      intstr.FromInt32(3),
+			unavailableOrdinals: []int{3, 4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				if ordinal == 3 {
+					_, err := spc.setPodReadyCondition(set, ordinal, false)
+					return err
+				}
+				_, err := spc.setPodTerminated(set, ordinal)
+				return err
+			},
+			expectedPodsRemaining: 4,
+		},
+		{
+			name:                "OrderedReady/5 replicas, 1 pod terminating(#3) + 1 pod unavailable(#4) on old revision",
+			podManagementPolicy: apps.OrderedReadyPodManagement,
+			replicas:            5,
+			maxUnavailable:      intstr.FromInt32(3),
+			unavailableOrdinals: []int{3, 4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				if ordinal == 3 {
+					_, err := spc.setPodTerminated(set, ordinal)
+					return err
+				}
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 4,
+		},
+		{
+			name:                "Parallel/5 replicas partition=2: unavailable pod in update range (#4) gets deleted",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            5,
+			partition:           2,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 4,
+		},
+		{
+			name:                "Parallel/5 replicas partition=2: unavailable pod at partition boundary (#2) still allows deletion of highest stale pod (#4)",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            5,
+			partition:           2,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{2},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 4,
+		},
+		{
+			name:                "Parallel/5 replicas partition=2: unavailable pod below partition (#1) consumes budget, no update",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            5,
+			partition:           2,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{1},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 5,
+		},
+		{
+			name:                "OrderedReady/5 replicas partition=2: unavailable pod in update range (#4) blocks update",
+			podManagementPolicy: apps.OrderedReadyPodManagement,
+			replicas:            5,
+			partition:           2,
+			maxUnavailable:      intstr.FromInt32(1),
+			unavailableOrdinals: []int{4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 5,
+		},
+		{
+			name:                "Parallel/5 replicas partition=3 maxUnavailable=2: both update-range pods unavailable, both get deleted",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            5,
+			partition:           3,
+			maxUnavailable:      intstr.FromInt32(2),
+			unavailableOrdinals: []int{3, 4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 3,
+		},
+		{
+			name:                "Parallel/5 replicas partition=3 maxUnavailable=2: pod below partition (#1) + pod in range (#4) unavailable, one pod deleted",
+			podManagementPolicy: apps.ParallelPodManagement,
+			replicas:            5,
+			partition:           3,
+			maxUnavailable:      intstr.FromInt32(2),
+			unavailableOrdinals: []int{1, 4},
+			makeUnavailable: func(spc *fakeObjectManager, set *apps.StatefulSet, ordinal int) error {
+				_, err := spc.setPodReadyCondition(set, ordinal, false)
+				return err
+			},
+			expectedPodsRemaining: 4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			set := newStatefulSet(tc.replicas)
+			set.Spec.PodManagementPolicy = tc.podManagementPolicy
+			set.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
+				Type: apps.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+					Partition:      &tc.partition,
+					MaxUnavailable: &tc.maxUnavailable,
+				},
+			}
+			client := fake.NewSimpleClientset()
+			spc, _, ssc := setupController(client)
+			if err := scaleUpStatefulSetControl(set, ssc, spc, assertBurstInvariants); err != nil {
+				t.Fatal(err)
+			}
+			set, err := spc.setsLister.StatefulSets(set.Namespace).Get(set.Name)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, ordinal := range tc.unavailableOrdinals {
+				if err := tc.makeUnavailable(spc, set, ordinal); err != nil {
+					t.Fatalf("makeUnavailable(%d): %v", ordinal, err)
+				}
+			}
+
+			selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sort.Sort(ascendingOrdinal(pods))
+
+			status := apps.StatefulSetStatus{Replicas: tc.replicas}
+			updateRevision := &apps.ControllerRevision{}
+			// set minReadySeconds only for the invariant check
+			set.Spec.MinReadySeconds = tc.minReadySeconds
+			if _, err = updateStatefulSetAfterInvariantEstablished(
+				t.Context(),
+				ssc.(*defaultStatefulSetControl),
+				set,
+				pods,
+				updateRevision,
+				status,
+				time.Now(),
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			podsAfter, err := spc.podsLister.Pods(set.Namespace).List(selector)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(podsAfter) != tc.expectedPodsRemaining {
+				t.Errorf("got %d pods remaining, want %d", len(podsAfter), tc.expectedPodsRemaining)
+			}
+			for _, p := range podsAfter {
+				ordinal := getOrdinal(p)
+				if p.DeletionTimestamp != nil && !slices.Contains(tc.unavailableOrdinals, ordinal) {
+					t.Errorf("pod %s, has DeletionTimestamp set unexpectedly", p.Name)
+				}
+			}
+		})
+	}
+}
+
 func TestStatefulSetControlRollingUpdate(t *testing.T) {
 	type testcase struct {
 		name       string
@@ -2710,15 +3068,22 @@ func (om *fakeObjectManager) addTerminatingPod(set *apps.StatefulSet, ordinal in
 }
 
 func (om *fakeObjectManager) setPodTerminated(set *apps.StatefulSet, ordinal int) ([]*v1.Pod, error) {
-	pod := newStatefulSetPod(set, ordinal)
-	deleted := metav1.NewTime(time.Now())
-	pod.DeletionTimestamp = &deleted
-	fakeResourceVersion(pod)
-	om.podsIndexer.Update(pod)
 	selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
 	if err != nil {
 		return nil, err
 	}
+	pods, err := om.podsLister.Pods(set.Namespace).List(selector)
+	if err != nil {
+		return nil, err
+	}
+	pod := findPodByOrdinal(pods, ordinal)
+	if pod == nil {
+		return nil, fmt.Errorf("setPodTerminated: pod ordinal %d not found", ordinal)
+	}
+	deleted := metav1.NewTime(time.Now())
+	pod.DeletionTimestamp = &deleted
+	fakeResourceVersion(pod)
+	om.podsIndexer.Update(pod) //nolint:errcheck
 	return om.podsLister.Pods(set.Namespace).List(selector)
 }
 


### PR DESCRIPTION
Cherry pick of #137666 on release-1.35.

#137666: Parallel pod management should not count old, broken pods for maxUnavailable budget

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind regression


```release-note
Fix a regression in kubernetes v1.35, where with a Parallel pod management policy unavailable pods from an older revision were incorrectly counted towards maxUnavailable budget. 
```