### PR TITLE
Fix flaky kubetest.diffResources test

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -3652,6 +3652,79 @@ function remove-replica-from-etcd() {
   return "${res}"
 }
 
+# Robustly try to delete a managed instance group.
+# Retry transient gcloud failures, but also treat the group as deleted if a
+# previous delete request succeeded and only the status response was lost.
+# $1: The name of the managed instance group.
+# $2: The zone of the managed instance group.
+function delete-managed-instance-group-with-retries() {
+  local -r group_name="${1}"
+  local -r zone="${2}"
+  local attempt=0
+
+  while true; do
+    if ! gcloud compute instance-groups managed describe "${group_name}" --project "${PROJECT}" --zone "${zone}" &>/dev/null; then
+      return 0
+    fi
+
+    if gcloud compute instance-groups managed delete \
+      --project "${PROJECT}" \
+      --quiet \
+      --zone "${zone}" \
+      "${group_name}"; then
+      return 0
+    fi
+
+    if ! gcloud compute instance-groups managed describe "${group_name}" --project "${PROJECT}" --zone "${zone}" &>/dev/null; then
+      echo -e "${color_yellow}Managed instance group ${group_name} was deleted by a previous attempt.${color_norm}" >&2
+      return 0
+    fi
+
+    if (( attempt > 4 )); then
+      echo -e "${color_red}Failed to delete managed instance group ${group_name} ${color_norm}" >&2
+      return 1
+    fi
+    attempt=$((attempt + 1))
+    echo -e "${color_yellow}Attempt ${attempt} failed to delete managed instance group ${group_name}. Retrying.${color_norm}" >&2
+    sleep $((attempt * 5))
+  done
+}
+
+# Robustly try to delete an instance template.
+# Retry transient gcloud failures, but also treat the template as deleted if a
+# previous delete request succeeded and only the status response was lost.
+# $1: The name of the instance template.
+function delete-instance-template-with-retries() {
+  local -r template_name="${1}"
+  local attempt=0
+
+  while true; do
+    if ! gcloud compute instance-templates describe --project "${PROJECT}" "${template_name}" &>/dev/null; then
+      return 0
+    fi
+
+    if gcloud compute instance-templates delete \
+      --project "${PROJECT}" \
+      --quiet \
+      "${template_name}"; then
+      return 0
+    fi
+
+    if ! gcloud compute instance-templates describe --project "${PROJECT}" "${template_name}" &>/dev/null; then
+      echo -e "${color_yellow}Instance template ${template_name} was deleted by a previous attempt.${color_norm}" >&2
+      return 0
+    fi
+
+    if (( attempt > 4 )); then
+      echo -e "${color_red}Failed to delete instance template ${template_name} ${color_norm}" >&2
+      return 1
+    fi
+    attempt=$((attempt + 1))
+    echo -e "${color_yellow}Attempt ${attempt} failed to delete instance template ${template_name}. Retrying.${color_norm}" >&2
+    sleep $((attempt * 5))
+  done
+}
+
 # Delete a kubernetes cluster. This is called from test-teardown.
 #
 # Assumed vars:
@@ -3686,11 +3759,7 @@ function kube-down() {
     for group in ${all_instance_groups[@]:-}; do
       {
         if gcloud compute instance-groups managed describe "${group}" --project "${PROJECT}" --zone "${ZONE}" &>/dev/null; then
-          gcloud compute instance-groups managed delete \
-            --project "${PROJECT}" \
-            --quiet \
-            --zone "${ZONE}" \
-            "${group}"
+          delete-managed-instance-group-with-retries "${group}" "${ZONE}"
         fi
       } &
     done
@@ -3756,10 +3825,7 @@ function kube-down() {
     for template in ${templates[@]:-}; do
       {
         if gcloud compute instance-templates describe --project "${PROJECT}" "${template}" &>/dev/null; then
-          gcloud compute instance-templates delete \
-            --project "${PROJECT}" \
-            --quiet \
-            "${template}" &
+          delete-instance-template-with-retries "${template}"
         fi
       } &
     done


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The `kubetest.diffResources` test is flaky because transient `gcloud` failures during cluster teardown (`kube-down`) leave behind leaked GCE resources (instance templates and managed instance groups). When `diffResources` compares pre- and post-test resource inventories, these leaked resources cause false failures.

This PR wraps the `gcloud compute instance-groups managed delete` and `gcloud compute instance-templates delete` calls in `kube-down()` with retry helpers that:

1. **Check before deleting** — skip if the resource is already gone
2. **Retry on failure** — up to 5 attempts with exponential backoff
3. **Handle split-brain** — if the delete API succeeded but the response was lost (a common transient failure mode), the post-delete describe will return 404 and the helper treats it as success

#### Which issue(s) this PR is related to:

Fixes #129953

#### Special notes for your reviewer:

The two new helper functions (`delete-managed-instance-group-with-retries` and `delete-instance-template-with-retries`) follow the same idempotent-retry pattern already used elsewhere in `cluster/gce/util.sh` (e.g., the existing retry loops for firewall rule deletion).

Only `cluster/gce/util.sh` is modified.

/sig testing
/area cluster-lifecycle
/priority important-soon

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```