### PR TITLE
Use +k8s:minItems on a required list field

### DIFF
--- a/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
@@ -489,6 +489,7 @@ func Validate_WorkloadSpec(ctx context.Context, op operation.Operation, fldPath 
 			if earlyReturn {
 				return // do not proceed
 			}
+			errs = append(errs, validate.MinItems(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha()...)
 			// lists with map semantics require unique keys
 			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a schedulingv1alpha2.PodGroupTemplate, b schedulingv1alpha2.PodGroupTemplate) bool {
 				return a.Name == b.Name

--- a/staging/src/k8s.io/api/scheduling/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha2/types.go
@@ -79,6 +79,7 @@ type WorkloadSpec struct {
 	// +k8s:required
 	// +k8s:listType=map
 	// +k8s:listMapKey=name
+	// +k8s:alpha(since:"1.36")=+k8s:minItems=1
 	// +k8s:maxItems=8
 	// +k8s:alpha(since:"1.36")=+k8s:immutable
 	PodGroupTemplates []PodGroupTemplate `json:"podGroupTemplates" protobuf:"bytes,2,rep,name=podGroupTemplates"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minitems/slice_of_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minitems/slice_of_primitive/zz_generated.validations.go
@@ -57,12 +57,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	// field Struct.Min0Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []int, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			errs = append(errs, validate.MinItems(ctx, op, fldPath, obj, oldObj, 0)...)
+			// minItems=0: lists can't have negative length, so this is a no-op
 			return
 		}(fldPath.Child("min0Field"), obj.Min0Field, safe.Field(oldObj, func(oldObj *Struct) []int { return oldObj.Min0Field }), oldObj != nil)...)
 
@@ -81,12 +76,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	// field Struct.Min0TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []IntType, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			errs = append(errs, validate.MinItems(ctx, op, fldPath, obj, oldObj, 0)...)
+			// minItems=0: lists can't have negative length, so this is a no-op
 			return
 		}(fldPath.Child("min0TypedefField"), obj.Min0TypedefField, safe.Field(oldObj, func(oldObj *Struct) []IntType { return oldObj.Min0TypedefField }), oldObj != nil)...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minitems/slice_of_struct/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minitems/slice_of_struct/zz_generated.validations.go
@@ -57,12 +57,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	// field Struct.Min0Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherStruct, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			errs = append(errs, validate.MinItems(ctx, op, fldPath, obj, oldObj, 0)...)
+			// minItems=0: lists can't have negative length, so this is a no-op
 			return
 		}(fldPath.Child("min0Field"), obj.Min0Field, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.Min0Field }), oldObj != nil)...)
 
@@ -81,12 +76,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	// field Struct.Min0TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherTypedefStruct, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			errs = append(errs, validate.MinItems(ctx, op, fldPath, obj, oldObj, 0)...)
+			// minItems=0: lists can't have negative length, so this is a no-op
 			return
 		}(fldPath.Child("min0TypedefField"), obj.Min0TypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.Min0TypedefField }), oldObj != nil)...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minitems/typedef_to_slice/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minitems/typedef_to_slice/zz_generated.validations.go
@@ -52,7 +52,7 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 // Validate_Min0Type validates an instance of Min0Type according
 // to declarative validation rules in the API schema.
 func Validate_Min0Type(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj Min0Type) (errs field.ErrorList) {
-	errs = append(errs, validate.MinItems(ctx, op, fldPath, obj, oldObj, 0)...)
+	// minItems=0: lists can't have negative length, so this is a no-op
 
 	return errs
 }
@@ -60,7 +60,7 @@ func Validate_Min0Type(ctx context.Context, op operation.Operation, fldPath *fie
 // Validate_Min0TypedefType validates an instance of Min0TypedefType according
 // to declarative validation rules in the API schema.
 func Validate_Min0TypedefType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj Min0TypedefType) (errs field.ErrorList) {
-	errs = append(errs, validate.MinItems(ctx, op, fldPath, obj, oldObj, 0)...)
+	// minItems=0: lists can't have negative length, so this is a no-op
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -187,6 +187,18 @@ func (minItemsTagValidator) GetValidations(context Context, tag codetags.Tag) (V
 	if intVal < 0 {
 		return result, fmt.Errorf("must be greater than or equal to zero")
 	}
+	if intVal == 0 {
+		// nothing needed in this case
+		result.AddComment("minItems=0: lists can't have negative length, so this is a no-op")
+		return result, nil
+	}
+	// TODO: If a field is required, then minItems=1 is redundant.  We could
+	// handle that as a special-case and skip validating it, but we'd need to
+	// pass the full list of tags to to every tag validator.  This is tricky
+	// because nested tags would need to be evaluated (e.g.
+	// +k8s:alpha=+k8s:required).
+	//
+	// For now, we just allow the redundancy.
 	result.AddFunction(Function(minItemsTagName, DefaultFlags, minItemsValidator, intVal))
 	return result, nil
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
@@ -192,8 +192,8 @@ func (reg *registry) ExtractTagValidations(context Context, tags ...codetags.Tag
 	validations := Validations{}
 	// Run tag-validators first.
 	phases := reg.sortTagsIntoPhases(tags)
-	for _, tags := range phases {
-		for _, tag := range tags {
+	for _, phase := range phases {
+		for _, tag := range phase {
 			tv := reg.tagValidators[tag.Name]
 			// At this point we know tv exists and is not nil due to the upfront check
 			if scopes := tv.ValidScopes(); !scopes.Has(context.Scope) {
@@ -285,7 +285,7 @@ type TagValidationExtractor interface {
 	// ExtractTagValidations extracts all validations associated with the given tags.
 	// Some tag validators may return empty validations and update internal state
 	// that is then used by FieldValidators.
-	ExtractTagValidations(context Context, Tags ...codetags.Tag) (Validations, error)
+	ExtractTagValidations(context Context, tags ...codetags.Tag) (Validations, error)
 }
 
 // ValidationExtractor represents an aggregation of validator plugins.


### PR DESCRIPTION
For discussion: Is this redundant or useful?  "required" means something different to openapi (the field was specified, but `field=[]` is allowed) than it means in DV (the field must have at least 1 element).  This makes me feel like having both is useful, since the tags can be used to generate different things.  OTOH, we could simply assert that DV 'required' always means both 'required' and 'minItems=1'.

This commit adds a call to `validate.MinItems(..., 1)` which is totally redundant, but avoiding it requires a little more scaffolding.  IMO it's not very important right now.

This commit also elides calls to `validate.MinItems(..., 0)` - lists cannot have less than 0 items, obviously

xref https://github.com/kubernetes/kubernetes/pull/136976#discussion_r2906508641

/kind cleanup
/kind feature

```release-note
NONE
```