### PR TITLE
Add test coverage to ensure that when PLR are checkpointed overhead is excluded from it

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -158,7 +158,15 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 			v1.ResourceMemory: *resource.NewQuantity(2500, resource.DecimalSI),
 		},
 	}
+
+	podWithPodLevelResourcesAndOverhead := podWithPodLevelResources.DeepCopy()
+	podWithPodLevelResourcesAndOverhead.Spec.Overhead = v1.ResourceList{
+		v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+		v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+	}
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeDeclaredFeatures, true)
+
 	tests := []struct {
 		name                         string
 		pod                          *v1.Pod
@@ -249,6 +257,14 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 		},
 		expectUpdate:                 true,
 		expectPod:                    resizedPodWithPodLevelResources,
+		inPlacePodLevelResizeEnabled: true,
+	}, {
+		name: "pod-level resources with overhead, checkpoint matches spec (no overhead stored)",
+		pod:  podWithPodLevelResourcesAndOverhead,
+		allocated: state.PodResourceInfo{
+			PodLevelResources: podWithPodLevelResourcesAndOverhead.Spec.Resources.DeepCopy(),
+		},
+		expectUpdate:                 false,
 		inPlacePodLevelResizeEnabled: true,
 	}, {
 		name: "resized pod-level resources with feature gate disabled",
@@ -1522,6 +1538,11 @@ func TestAllocationManagerAddPodWithPLR(t *testing.T) {
 
 	pod1SmallWithPLR := pod1Small.DeepCopy()
 	pod1SmallWithPLR.Spec.Resources = &v1.ResourceRequirements{Requests: cpu1Mem1G}
+	pod1SmallWithPLRAndOverhead := pod1SmallWithPLR.DeepCopy()
+	pod1SmallWithPLRAndOverhead.Spec.Overhead = v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("100m"),
+		v1.ResourceMemory: resource.MustParse("200Mi"),
+	}
 	pod1LargeWithPLR := pod1Large.DeepCopy()
 	pod1LargeWithPLR.Spec.Resources = &v1.ResourceRequirements{Requests: cpu2Mem2G}
 	pod2SmallWithPLR := pod2Small.DeepCopy()
@@ -1554,6 +1575,17 @@ func TestAllocationManagerAddPodWithPLR(t *testing.T) {
 			admitFunc:                      nil,
 			expectAdmit:                    true,
 			// allocated resources updated with pod1's resources
+			expectedAllocatedResourcesState: map[types.UID]resourceState{pod1UID: {podResources: cpu1Mem1G, containerResources: cpu1Mem1G}},
+			ipprPLRFeatureGate:              true,
+		},
+		{
+			name:                           "PLR IPPR Enabled - New pod with overhead admitted and allocated resources updated without overhead",
+			initialAllocatedResourcesState: map[types.UID]resourceState{},
+			currentActivePods:              []*v1.Pod{},
+			podToAdd:                       pod1SmallWithPLRAndOverhead,
+			admitFunc:                      nil,
+			expectAdmit:                    true,
+			// allocated resources updated with pod1's resources, excluding overhead
 			expectedAllocatedResourcesState: map[types.UID]resourceState{pod1UID: {podResources: cpu1Mem1G, containerResources: cpu1Mem1G}},
 			ipprPLRFeatureGate:              true,
 		},


### PR DESCRIPTION
This PR adds test coverage to ensure that when PLR are checkpointed overhead is excluded from it.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
To improve test coverage
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


