### PR TITLE
[release-1.33] Fix RepairIPAddress controller startup failure when namespace informer is not yet synced

### DIFF
--- a/pkg/registry/core/service/ipallocator/controller/repairip_test.go
+++ b/pkg/registry/core/service/ipallocator/controller/repairip_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -705,5 +706,85 @@ func expectEvents(t *testing.T, actual <-chan string, expected []string) {
 		default:
 			return // No more events, as expected.
 		}
+	}
+}
+
+func TestRepairIPAddress_runOnce(t *testing.T) {
+	tests := []struct {
+		name          string
+		conflictCount int
+		errorType     func(string) error
+		expectedRuns  int
+		expectedErr   bool
+	}{
+		{
+			name:          "Retry on Conflict",
+			conflictCount: 2,
+			errorType: func(name string) error {
+				return apierrors.NewConflict(networkingv1.Resource("ipaddresses"), name, fmt.Errorf("conflict"))
+			},
+			expectedRuns: 3,
+			expectedErr:  false,
+		},
+		{
+			name:          "Retry on Forbidden",
+			conflictCount: 2,
+			errorType: func(name string) error {
+				return apierrors.NewForbidden(networkingv1.Resource("ipaddresses"), name, fmt.Errorf("forbidden"))
+			},
+			expectedRuns: 3,
+			expectedErr:  false,
+		},
+		{
+			name:          "No Retry on InternalError",
+			conflictCount: 1, // It will fail once and stop
+			errorType: func(name string) error {
+				return apierrors.NewInternalError(fmt.Errorf("internal error"))
+			},
+			expectedRuns: 1,
+			expectedErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, r := newFakeRepair(testTimeNow)
+			// Add a service that needs repair (missing IPAddress)
+			svc := newService("test-svc", []string{"10.0.1.1"})
+			err := r.serviceStore.Add(svc)
+			if err != nil {
+				t.Fatalf("Unexpected error adding service: %v", err)
+			}
+			r.servicesSynced = func() bool { return true }
+			r.ipAddressSynced = func() bool { return true }
+			r.serviceCIDRSynced = func() bool { return true }
+
+			// Add a default ServiceCIDR
+			cidr := newServiceCIDR("kubernetes", serviceCIDRv4, serviceCIDRv6)
+			err = r.serviceCIDRStore.Add(cidr)
+			if err != nil {
+				t.Fatalf("Unexpected error adding ServiceCIDR: %v", err)
+			}
+
+			// Track how many times create is called
+			createCalls := 0
+			client.PrependReactor("create", "ipaddresses", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				createCalls++
+				if createCalls <= tt.conflictCount {
+					return true, nil, tt.errorType("10.0.1.1")
+				}
+				// Pass through to the default reactor (which creates the object)
+				return false, nil, nil
+			})
+
+			err = r.runOnce()
+			if (err != nil) != tt.expectedErr {
+				t.Errorf("runOnce() error = %v, expectedErr %v", err, tt.expectedErr)
+			}
+
+			if createCalls != tt.expectedRuns {
+				t.Errorf("Expected %d create calls, got %d", tt.expectedRuns, createCalls)
+			}
+		})
 	}
 }


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cherry-pick of #137147 for release-1.33 (integration test excluded).


#### Which issue(s) this PR is related to:
Fixes #136288
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix apiserver startup failure during upgrade when MultiCIDRServiceAllocator is enabled and the cluster has a large number of namespaces. The IP address repair controller now retries on Forbidden errors from admission plugins that are not yet ready.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
