### PR TITLE
Fix [Flaking Test] k8s.io/kubernetes/test/integration/apiserver/disco…

### DIFF
--- a/test/integration/apiserver/discovery/discovery_test.go
+++ b/test/integration/apiserver/discovery/discovery_test.go
@@ -163,8 +163,8 @@ func setup(t *testing.T) (context.Context, testClientSet, context.CancelFunc) {
 
 	cfg := rest.CopyConfig(server.ClientConfig)
 	// Discovery integration tests can poll very frequently and should not flake due to client-side throttling.
-	cfg.QPS = 50
-	cfg.Burst = 100
+	cfg.QPS = 1000
+	cfg.Burst = 10000
 	cfg.RateLimiter = nil
 
 	kubeClientSet, err := kubernetes.NewForConfig(cfg)


### PR DESCRIPTION
…very.discovery

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:

<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #137686
#### Special notes for your reviewer:
Just a quick update on the flake in TestReadinessAggregatedAPIServiceDiscovery (the same one we saw in https://github.com/kubernetes/kubernetes/pull/137600).

I noticed that https://github.com/kubernetes/kubernetes/pull/137600 already attempted to address a similar discovery flake by increasing the QPS/Burst settings for the aggregated discovery client. However, the flake is still reproducing in recent runs.

After checking other integration tests (e.g., several use QPS=1000 or higher), I suspect the original QPS setting here might be too conservative, causing the client rate limiter to hit context deadline exceeded.

I've just pushed a commit that bumps the QPS to 1000 (and Burst to 10000) for the aggregated discovery client in this test setup.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
