### PR TITLE
webhook timeout fix

### DIFF
--- a/test/integration/apiserver/admissionwebhook/broken_webhook_test.go
+++ b/test/integration/apiserver/admissionwebhook/broken_webhook_test.go
@@ -152,6 +152,7 @@ func exampleDeployment(name string) *appsv1.Deployment {
 func brokenWebhookConfig(name string) *admissionregistrationv1.ValidatingWebhookConfiguration {
 	var path string
 	failurePolicy := admissionregistrationv1.Fail
+	timeoutSeconds := int32(1)
 	return &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -178,6 +179,7 @@ func brokenWebhookConfig(name string) *admissionregistrationv1.ValidatingWebhook
 					CABundle: nil,
 				},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &timeoutSeconds,
 				SideEffects:             &noSideEffects,
 				AdmissionReviewVersions: []string{"v1"},
 			},


### PR DESCRIPTION
#### What type of PR is this?
/kind flake


#### What this PR does / why we need it:
https://storage.googleapis.com/k8s-triage/index.html?text=TestBrokenWebhook
```
Failed
panic: test timed out after 10m0s
	running tests:
		TestBrokenWebhook (9m15s)

goroutine 209613 [running]:
testing.(*M).startAlarm.func1()
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/testing/testing.go:2682 +0x444
created by time.goFunc
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/time/sleep.go:215 +0x42

goroutine 1 [chan receive, 9 minutes]:
testing.(*T).Run(0xc000103c00, {0x40af892, 0x11}, 0x42b4e40)
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/testing/testing.go:2005 +0x568
testing.runTests.func1(0xc000103c00)
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/testing/testing.go:2477 +0x62
testing.tRunner(0xc000103c00, 0xc0009bdb80)
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/testing/testing.go:1934 +0x12e
testing.runTests(0xc0009063c0, {0x68a7ce0, 0x11, 0x11}, {0xc25fd93ede9bb8e8, 0x8bb750dcaf, 0x68ddd40})
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/testing/testing.go:2475 +0x50a
testing.(*M).Run(0xc00064c1e0)
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/testing/testing.go:2337 +0x6ec
k8s.io/kubernetes/test/integration/framework.EtcdMain(0xc0009bdf58)
	/home/prow/go/src/k8s.io/kubernetes/test/integration/framework/etcd.go:288 +0x51c
k8s.io/kubernetes/test/integration/apiserver/admissionwebhook.TestMain(...)
	/home/prow/go/src/k8s.io/kubernetes/test/integration/apiserver/admissionwebhook/main_test.go:26
main.main()
	_testmain.go:79 +0xf0

goroutine 148958 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc00e5d0450, 0x8)
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/runtime/sema.go:606 +0x1cc
sync.(*Cond).Wait(0xc00e5d0440)
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/sync/cond.go:71 +0xc4
k8s.io/apiserver/pkg/storage/cacher/progress.(*ConditionalProgressRequester).Run.func2(0xc00e5d0400)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/cacher/progress/watch_progress.go:88 +0xae
k8s.io/apiserver/pkg/storage/cacher/progress.(*ConditionalProgressRequester).Run(0xc00e5d0400, 0xc00293dc00)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/cacher/progress/watch_progress.go:91 +0x1d2
created by k8s.io/apiserver/pkg/storage/cacher.NewCacherFromConfig in goroutine 148703
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go:468 +0x12ac

goroutine 148703 [chan receive, 9 minutes]:
k8s.io/kubernetes/cmd/kube-apiserver/app/testing.StartTestServer.func1()
	/home/prow/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app/testing/testserver.go:181 +0xac
k8s.io/kubernetes/cmd/kube-apiserver/app/testing.StartTestServer.func6()
	/home/prow/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app/testing/testserver.go:528 +0x3c
k8s.io/kubernetes/test/integration/apiserver/admissionwebhook.TestBrokenWebhook(0xc0024c9c00)
	/home/prow/go/src/k8s.io/kubernetes/test/integration/apiserver/admissionwebhook/broken_webhook_test.go:82 +0xf7c
testing.tRunner(0xc0024c9c00, 0x42b4e40)
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/testing/testing.go:1934 +0x12e
created by testing.(*T).Run in goroutine 1
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-s390x/src/testing/testing.go:1997 +0x548

goroutine 149230 [chan receive]:
k8s.io/apiserver/pkg/storage/etcd3.(*watchChan).startWatching(0xc0071108f0, 0xc00e952c40, 0x1, 0x1)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:390 +0x5cc
k8s.io/apiserver/pkg/storage/etcd3.(*watchChan).run.func1()
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:238 +0x72
created by k8s.io/apiserver/pkg/storage/etcd3.(*watchChan).run in goroutine 149229
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:236 +0x104

goroutine 46 [select]:
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x476a670, 0xc000070150}, 0xc0000c0f68, {0x4732ee0, 0xc00083f6e0}, 0x1)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:267 +0x1d4
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0007f1420, {0x4732ee0, 0xc00083f6e0}, 0x1, 0xc000070150)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:233 +0x68
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0007f1420, 0xdf8475800, 0x0, 0x1, 0xc000070150)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:210 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:163
k8s.io/apimachinery/pkg/util/wait.Forever(...)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:80
created by k8s.io/apiserver/pkg/server/healthz.(*log).Check.func1 in goroutine 1
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go:81 +0x146

goroutine 150648 [select]:
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x476a670, 0xc00d2ec8c0}, 0xc0006bff98, {0x4732ee0, 0xc00e24b530}, 0x1)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:267 +0x1d4
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x476a670, 0xc00d2ec8c0}, 0xc007b38f98, 0xdf8475800, 0x3fe0000000000000, 0x1)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:223 +0x9a
k8s.io/apiserver/pkg/storage/etcd3.(*resourceSizeEstimator).run(0xc002b11ea0)
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats.go:109 +0x10c
k8s.io/apiserver/pkg/storage/etcd3.newResourceSizeEstimator.func1()
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats.go:49 +0x64
created by k8s.io/apiserver/pkg/storage/etcd3.newResourceSizeEstimator in goroutine 148703
	/home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats.go:47 +0x1d4

```
integration

#### Which issue(s) this PR is related to:

```release-note

```
