### PR TITLE
client-go: return context error directly instead of wrapping as rate limiter error

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -671,7 +671,7 @@ func (r *Request) tryThrottleWithInfo(ctx context.Context, retryInfo string) err
 	now := time.Now()
 
 	err := r.rateLimiter.Wait(ctx)
-	if err != nil {
+	if err != nil && ctx.Err() == nil {
 		err = fmt.Errorf("client rate limiter Wait returned an error: %w", err)
 	}
 	latency := time.Since(now)

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"mime"
@@ -671,7 +672,8 @@ func (r *Request) tryThrottleWithInfo(ctx context.Context, retryInfo string) err
 	now := time.Now()
 
 	err := r.rateLimiter.Wait(ctx)
-	if err != nil && ctx.Err() == nil {
+	// Don't wrap context errors as caller initiated ctx cancellations is not a rate limiter error.
+	if err != nil && !stderrors.Is(err, context.Canceled) && !stderrors.Is(err, context.DeadlineExceeded) {
 		err = fmt.Errorf("client rate limiter Wait returned an error: %w", err)
 	}
 	latency := time.Since(now)

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -4275,3 +4275,16 @@ func TestRequestWarningHandler(t *testing.T) {
 		assert.Nil(t, request.warningHandler)
 	})
 }
+
+func TestTryThrottleWithInfoContextDeadline(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := &Request{
+		rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
+		c:           &RESTClient{base: &url.URL{Path: "/"}},
+	}
+	err := r.tryThrottleWithInfo(ctx, "")
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotContains(t, err.Error(), "client rate limiter")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a context expires (deadline or cancellation), `tryThrottleWithInfo` in `client-go/rest/request.go` wraps the error as `"client rate limiter Wait returned an error: context deadline exceeded"`. This is misleading, the rate limiter isn't the cause, the context is already cancelled.

After `Wait`, returns the raw context error instead of wrapping it as a rate limiter error.



#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

The `rate.Limiter.Wait(ctx)` from `golang.org/x/time/rate` always checks `ctx.Err()` first, so even when tokens are available, it returns the context error if the context is done. The previous wrapping unconditionally added `"client rate limiter Wait returned an error:"` regardless of whether the rate limiter was actually throttling and made debugging confusing, and caused a red herring when debugging https://github.com/kubernetes/kubernetes/issues/137422

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```