### PR TITLE
Use PodContainerManager.Validate for error-propagating cgroup checks

### DIFF
--- a/pkg/kubelet/cm/fake_pod_container_manager.go
+++ b/pkg/kubelet/cm/fake_pod_container_manager.go
@@ -30,6 +30,9 @@ type FakePodContainerManager struct {
 	sync.Mutex
 	CalledFunctions []string
 	Cgroups         map[types.UID]CgroupName
+	ValidateError   error
+	EnsureExistsErr error
+	ExistsResult    *bool
 }
 
 var _ PodContainerManager = &FakePodContainerManager{}
@@ -46,18 +49,28 @@ func (m *FakePodContainerManager) AddPodFromCgroups(pod *kubecontainer.Pod) {
 	m.Cgroups[pod.ID] = []string{pod.Name}
 }
 
+func (m *FakePodContainerManager) Validate(_ *v1.Pod) error {
+	m.Lock()
+	defer m.Unlock()
+	m.CalledFunctions = append(m.CalledFunctions, "Validate")
+	return m.ValidateError
+}
+
 func (m *FakePodContainerManager) Exists(_ *v1.Pod) bool {
 	m.Lock()
 	defer m.Unlock()
 	m.CalledFunctions = append(m.CalledFunctions, "Exists")
-	return true
+	if m.ExistsResult == nil {
+		return true
+	}
+	return *m.ExistsResult
 }
 
 func (m *FakePodContainerManager) EnsureExists(_ klog.Logger, _ *v1.Pod) error {
 	m.Lock()
 	defer m.Unlock()
 	m.CalledFunctions = append(m.CalledFunctions, "EnsureExists")
-	return nil
+	return m.EnsureExistsErr
 }
 
 func (m *FakePodContainerManager) GetPodContainerName(_ *v1.Pod) (CgroupName, string) {

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -65,10 +65,15 @@ type podContainerManagerImpl struct {
 // Make sure that podContainerManagerImpl implements the PodContainerManager interface
 var _ PodContainerManager = &podContainerManagerImpl{}
 
+// Validate checks whether the pod's cgroup exists and matches the manager's expectations.
+func (m *podContainerManagerImpl) Validate(pod *v1.Pod) error {
+	podContainerName, _ := m.GetPodContainerName(pod)
+	return m.cgroupManager.Validate(podContainerName)
+}
+
 // Exists checks if the pod's cgroup already exists
 func (m *podContainerManagerImpl) Exists(pod *v1.Pod) bool {
-	podContainerName, _ := m.GetPodContainerName(pod)
-	return m.cgroupManager.Exists(podContainerName)
+	return m.Validate(pod) == nil
 }
 
 // EnsureExists takes a pod as argument and makes sure that
@@ -322,6 +327,10 @@ type podContainerManagerNoop struct {
 
 // Make sure that podContainerManagerStub implements the PodContainerManager interface
 var _ PodContainerManager = &podContainerManagerNoop{}
+
+func (m *podContainerManagerNoop) Validate(_ *v1.Pod) error {
+	return nil
+}
 
 func (m *podContainerManagerNoop) Exists(_ *v1.Pod) bool {
 	return true

--- a/pkg/kubelet/cm/pod_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux_test.go
@@ -19,13 +19,17 @@ limitations under the License.
 package cm
 
 import (
+	"errors"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
+	"k8s.io/utils/ptr"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -294,4 +298,221 @@ func TestGetPodContainerName(t *testing.T) {
 			require.Equalf(t, tt.wantLiteralCgroupfs, actualLiteralCgroupfs, "Unexpected literal cgroupfs for pod with UID %s, container resources: %v", tt.args.pod.UID, tt.args.pod.Spec.Containers[0].Resources)
 		})
 	}
+}
+
+func TestPodContainerManagerValidateDelegatesToCgroupManager(t *testing.T) {
+	pod := newBurstablePodForPodContainerManagerTest("pod-uid")
+	qosContainersInfo := podContainerManagerTestQOSContainersInfo()
+	expectedName := NewCgroupName(qosContainersInfo.Burstable, GetPodCgroupNameSuffix(pod.UID))
+	expectedErr := errors.New("pod cgroup validation failed")
+	cgroupManager := &recordingCgroupManager{validateErr: expectedErr}
+	pcm := &podContainerManagerImpl{
+		cgroupManager:     cgroupManager,
+		qosContainersInfo: qosContainersInfo,
+	}
+
+	err := pcm.Validate(pod)
+
+	validatedName, validateCalls, existsCalls := cgroupManager.snapshot()
+	require.ErrorIs(t, err, expectedErr)
+	require.Equal(t, 1, validateCalls)
+	require.Equal(t, expectedName, validatedName)
+	require.Zero(t, existsCalls)
+}
+
+func TestPodContainerManagerExistsUsesValidateResult(t *testing.T) {
+	pod := newBurstablePodForPodContainerManagerTest("pod-uid")
+	qosContainersInfo := podContainerManagerTestQOSContainersInfo()
+
+	testCases := []struct {
+		name          string
+		validateErr   error
+		expectedExist bool
+	}{
+		{
+			name:          "returns true when validation succeeds",
+			validateErr:   nil,
+			expectedExist: true,
+		},
+		{
+			name:          "returns false when validation fails",
+			validateErr:   errors.New("missing pod cgroup"),
+			expectedExist: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cgroupManager := &recordingCgroupManager{validateErr: tc.validateErr}
+			pcm := &podContainerManagerImpl{
+				cgroupManager:     cgroupManager,
+				qosContainersInfo: qosContainersInfo,
+			}
+
+			exists := pcm.Exists(pod)
+
+			_, validateCalls, existsCalls := cgroupManager.snapshot()
+			require.Equal(t, tc.expectedExist, exists)
+			require.Equal(t, 1, validateCalls)
+			require.Zero(t, existsCalls)
+		})
+	}
+}
+
+func TestPodContainerManagerNoopValidateAlwaysSucceeds(t *testing.T) {
+	pcm := &podContainerManagerNoop{}
+	pod := newBurstablePodForPodContainerManagerTest("pod-uid")
+
+	require.NoError(t, pcm.Validate(pod))
+	require.True(t, pcm.Exists(pod))
+}
+
+func TestFakePodContainerManagerUsesConfiguredResults(t *testing.T) {
+	t.Run("Validate", func(t *testing.T) {
+		validateErr := errors.New("validation failed")
+		manager := NewFakePodContainerManager()
+		manager.ValidateError = validateErr
+
+		err := manager.Validate(&v1.Pod{})
+
+		require.ErrorIs(t, err, validateErr)
+		require.Equal(t, []string{"Validate"}, manager.CalledFunctions)
+	})
+
+	t.Run("Exists", func(t *testing.T) {
+		existsResult := false
+		manager := NewFakePodContainerManager()
+		manager.ExistsResult = ptr.To(existsResult)
+
+		exists := manager.Exists(&v1.Pod{})
+
+		require.Equal(t, existsResult, exists)
+		require.Equal(t, []string{"Exists"}, manager.CalledFunctions)
+	})
+
+	t.Run("EnsureExists", func(t *testing.T) {
+		ensureExistsErr := errors.New("ensure exists failed")
+		manager := NewFakePodContainerManager()
+		manager.EnsureExistsErr = ensureExistsErr
+
+		err := manager.EnsureExists(klog.TODO(), &v1.Pod{})
+
+		require.ErrorIs(t, err, ensureExistsErr)
+		require.Equal(t, []string{"EnsureExists"}, manager.CalledFunctions)
+	})
+}
+
+func TestPodContainerManagerStubValidateAndExistsAreNoops(t *testing.T) {
+	manager := &podContainerManagerStub{}
+
+	require.NoError(t, manager.Validate(&v1.Pod{}))
+	require.True(t, manager.Exists(&v1.Pod{}))
+	require.NoError(t, manager.EnsureExists(klog.TODO(), &v1.Pod{}))
+}
+
+func podContainerManagerTestQOSContainersInfo() QOSContainersInfo {
+	return QOSContainersInfo{
+		Guaranteed: RootCgroupName,
+		Burstable:  NewCgroupName(RootCgroupName, strings.ToLower(string(v1.PodQOSBurstable))),
+		BestEffort: NewCgroupName(RootCgroupName, strings.ToLower(string(v1.PodQOSBestEffort))),
+	}
+}
+
+func newBurstablePodForPodContainerManagerTest(uid types.UID) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: uid,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "container",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1000m"),
+							v1.ResourceMemory: resource.MustParse("1G"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type recordingCgroupManager struct {
+	mu            sync.Mutex
+	validatedName CgroupName
+	validateErr   error
+	validateCalls int
+	existsCalls   int
+}
+
+var _ CgroupManager = &recordingCgroupManager{}
+
+func (m *recordingCgroupManager) Create(_ klog.Logger, _ *CgroupConfig) error {
+	return nil
+}
+
+func (m *recordingCgroupManager) Destroy(_ klog.Logger, _ *CgroupConfig) error {
+	return nil
+}
+
+func (m *recordingCgroupManager) Update(_ klog.Logger, _ *CgroupConfig) error {
+	return nil
+}
+
+func (m *recordingCgroupManager) Validate(name CgroupName) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.validatedName = append(CgroupName(nil), name...)
+	m.validateCalls++
+	return m.validateErr
+}
+
+func (m *recordingCgroupManager) Exists(_ CgroupName) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.existsCalls++
+	return false
+}
+
+func (m *recordingCgroupManager) snapshot() (CgroupName, int, int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append(CgroupName(nil), m.validatedName...), m.validateCalls, m.existsCalls
+}
+
+func (m *recordingCgroupManager) Name(name CgroupName) string {
+	return strings.Join(name, "/")
+}
+
+func (m *recordingCgroupManager) CgroupName(name string) CgroupName {
+	if name == "" {
+		return nil
+	}
+	return strings.Split(name, "/")
+}
+
+func (m *recordingCgroupManager) Pids(_ klog.Logger, _ CgroupName) []int {
+	return nil
+}
+
+func (m *recordingCgroupManager) ReduceCPULimits(_ klog.Logger, _ CgroupName) error {
+	return nil
+}
+
+func (m *recordingCgroupManager) MemoryUsage(_ CgroupName) (int64, error) {
+	return 0, nil
+}
+
+func (m *recordingCgroupManager) GetCgroupConfig(_ CgroupName, _ v1.ResourceName) (*ResourceConfig, error) {
+	return nil, nil
+}
+
+func (m *recordingCgroupManager) SetCgroupConfig(_ klog.Logger, _ CgroupName, _ *ResourceConfig) error {
+	return nil
+}
+
+func (m *recordingCgroupManager) Version() int {
+	return 0
 }

--- a/pkg/kubelet/cm/pod_container_manager_stub.go
+++ b/pkg/kubelet/cm/pod_container_manager_stub.go
@@ -27,6 +27,10 @@ type podContainerManagerStub struct {
 
 var _ PodContainerManager = &podContainerManagerStub{}
 
+func (m *podContainerManagerStub) Validate(_ *v1.Pod) error {
+	return nil
+}
+
 func (m *podContainerManagerStub) Exists(_ *v1.Pod) bool {
 	return true
 }

--- a/pkg/kubelet/cm/testing/mocks.go
+++ b/pkg/kubelet/cm/testing/mocks.go
@@ -2482,3 +2482,54 @@ func (_c *MockPodContainerManager_SetPodCgroupConfig_Call) RunAndReturn(run func
 	_c.Call.Return(run)
 	return _c
 }
+
+// Validate provides a mock function for the type MockPodContainerManager
+func (_mock *MockPodContainerManager) Validate(pod *v1.Pod) error {
+	ret := _mock.Called(pod)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Validate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*v1.Pod) error); ok {
+		r0 = returnFunc(pod)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockPodContainerManager_Validate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Validate'
+type MockPodContainerManager_Validate_Call struct {
+	*mock.Call
+}
+
+// Validate is a helper method to define mock.On call
+//   - pod *v1.Pod
+func (_e *MockPodContainerManager_Expecter) Validate(pod interface{}) *MockPodContainerManager_Validate_Call {
+	return &MockPodContainerManager_Validate_Call{Call: _e.mock.On("Validate", pod)}
+}
+
+func (_c *MockPodContainerManager_Validate_Call) Run(run func(pod *v1.Pod)) *MockPodContainerManager_Validate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *v1.Pod
+		if args[0] != nil {
+			arg0 = args[0].(*v1.Pod)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPodContainerManager_Validate_Call) Return(err error) *MockPodContainerManager_Validate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockPodContainerManager_Validate_Call) RunAndReturn(run func(pod *v1.Pod) error) *MockPodContainerManager_Validate_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -115,6 +115,9 @@ type PodContainerManager interface {
 	// If the pod cgroup doesn't already exist this method creates it.
 	EnsureExists(logger klog.Logger, pod *v1.Pod) error
 
+	// Validate checks whether the pod cgroup exists and matches the manager's expectations.
+	Validate(pod *v1.Pod) error
+
 	// Exists returns true if the pod cgroup exists.
 	Exists(*v1.Pod) bool
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2133,15 +2133,19 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		// Don't kill containers in pod if pod's cgroups already
 		// exists or the pod is running for the first time
 		podKilled := false
-		if !pcm.Exists(pod) && !firstSync {
-			p := kubecontainer.ConvertPodStatusToRunningPod(kl.getRuntime().Type(), podStatus)
-			if err := kl.killPod(ctx, pod, p, nil); err == nil {
-				podKilled = true
-			} else {
-				if wait.Interrupted(err) {
-					return false, nil, nil
+		if !firstSync {
+			// Preserve the validation error here because it explains why we need to kill the pod.
+			if validationErr := pcm.Validate(pod); validationErr != nil {
+				logger.V(2).Info("Pod cgroup validation failed; killing pod before recreation", "pod", klog.KObj(pod), "err", validationErr)
+				p := kubecontainer.ConvertPodStatusToRunningPod(kl.getRuntime().Type(), podStatus)
+				if killErr := kl.killPod(ctx, pod, p, nil); killErr == nil {
+					podKilled = true
+				} else {
+					if wait.Interrupted(killErr) {
+						return false, nil, nil
+					}
+					logger.Error(killErr, "KillPod failed", "pod", klog.KObj(pod), "podStatus", podStatus)
 				}
-				logger.Error(err, "KillPod failed", "pod", klog.KObj(pod), "podStatus", podStatus)
 			}
 		}
 		// Create and Update pod's Cgroups

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -19,6 +19,7 @@ package kubelet
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -585,6 +586,103 @@ func TestHandlePodCleanupsPerQOS(t *testing.T) {
 	// Destroy() count in not deterministic on the actual number.
 	// https://github.com/kubernetes/kubernetes/blob/29fdbb065b5e0d195299eb2d260b975cbc554673/pkg/kubelet/kubelet_pods.go#L2006
 	assert.GreaterOrEqual(t, destroyCount, 1, "Expect 1 or more destroys")
+}
+
+func TestSyncPodPodCgroupValidationBehavior(t *testing.T) {
+	testCases := []struct {
+		name                string
+		podStatus           *kubecontainer.PodStatus
+		validateErr         error
+		expectedValidateCnt int
+		expectedExistsCnt   int
+		expectedKilledPods  []string
+	}{
+		{
+			name:                "first sync skips validation",
+			podStatus:           newPodStatusForSyncPodValidationTest(false),
+			validateErr:         errors.New("should not be used"),
+			expectedValidateCnt: 0,
+			expectedExistsCnt:   1,
+			expectedKilledPods:  nil,
+		},
+		{
+			name:                "running pod is killed when validation fails",
+			podStatus:           newPodStatusForSyncPodValidationTest(true),
+			validateErr:         errors.New("pod cgroup validation failed"),
+			expectedValidateCnt: 1,
+			expectedExistsCnt:   1,
+			expectedKilledPods:  []string{"12345678"},
+		},
+		{
+			name:                "running pod is not killed when validation succeeds",
+			podStatus:           newPodStatusForSyncPodValidationTest(true),
+			expectedValidateCnt: 1,
+			expectedExistsCnt:   1,
+			expectedKilledPods:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+			defer testKubelet.Cleanup()
+
+			kubelet := testKubelet.kubelet
+			kubelet.cgroupsPerQOS = true
+
+			pod := podWithUIDNameNsSpec("12345678", "foo", "new", v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "bar", Image: "test:latest"},
+				},
+			})
+			kubelet.podManager.SetPods([]*v1.Pod{pod})
+
+			fakePCM := testKubelet.fakeContainerManager.PodContainerManager
+			fakePCM.ValidateError = tc.validateErr
+			fakePCM.ExistsResult = ptr.To(true)
+
+			isTerminal, _, err := kubelet.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, nil, tc.podStatus)
+			require.NoError(t, err)
+			require.False(t, isTerminal)
+
+			fakePCM.Lock()
+			validateCount := 0
+			existsCount := 0
+			for _, fn := range fakePCM.CalledFunctions {
+				switch fn {
+				case "Validate":
+					validateCount++
+				case "Exists":
+					existsCount++
+				}
+			}
+			fakePCM.Unlock()
+
+			require.Equal(t, tc.expectedValidateCnt, validateCount)
+			require.Equal(t, tc.expectedExistsCnt, existsCount)
+			require.True(t, testKubelet.fakeRuntime.AssertKilledPods(tc.expectedKilledPods))
+		})
+	}
+}
+
+func newPodStatusForSyncPodValidationTest(hasRunningContainer bool) *kubecontainer.PodStatus {
+	if !hasRunningContainer {
+		return &kubecontainer.PodStatus{}
+	}
+
+	return &kubecontainer.PodStatus{
+		ID:        types.UID("12345678"),
+		Name:      "foo",
+		Namespace: "new",
+		ContainerStatuses: []*kubecontainer.Status{
+			{
+				ID:    kubecontainer.ContainerID{Type: "test", ID: "container-1"},
+				Name:  "bar",
+				State: kubecontainer.ContainerStateRunning,
+			},
+		},
+	}
 }
 
 func TestDispatchWorkOfCompletedPod(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:

Today some pod cgroup checks only return a boolean through `PodContainerManager.Exists()`, which can hide the underlying validation error and make troubleshooting harder.

This PR separates the two use cases explicitly:
- `Exists()` remains the boolean-style check
- `Validate()` is used in paths that need the actual validation error

In particular, kubelet `SyncPod()` now uses `PodContainerManager.Validate()` when it needs to understand why pod cgroup validation failed before killing and recreating the pod.

This change is primarily about preserving validation errors in error-propagating paths and aligning the implementation with the direction taken in review. It improves diagnosability without attempting a broader refactoring of pod cgroup management.

#### Which issue(s) this PR fixes:
Fixes #137695 

#### Special notes for your reviewer:
Added unit tests for:
- `PodContainerManager.Validate()` delegation
- `Exists()` behavior based on `Validate()`
- noop/stub/fake implementations
- kubelet `SyncPod()` behavior when validation succeeds or fails

```release-note
NONE
```