### PR TITLE
Bump setcap, debian-base to bookworm-v1.0.7

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -79,7 +79,7 @@ readonly REMOTE_OUTPUT_GOPATH="${REMOTE_OUTPUT_SUBPATH}/go"
 # These are the default versions (image tags) for their respective base images.
 readonly __default_distroless_iptables_version=v0.9.1
 readonly __default_go_runner_version=v2.4.0-go1.26.2-bookworm.0
-readonly __default_setcap_version=bookworm-v1.0.6
+readonly __default_setcap_version=bookworm-v1.0.7
 
 # The default image for all binaries which are dynamically linked.
 # Includes everything that is required by kube-proxy, which uses it

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -155,7 +155,7 @@ dependencies:
 
   # Base images
   - name: "registry.k8s.io/debian-base: dependents"
-    version: bookworm-v1.0.6
+    version: bookworm-v1.0.7
     refPaths:
     - path: test/conformance/image/Makefile
       match: BASE_IMAGE_VERSION\?=
@@ -243,7 +243,7 @@ dependencies:
       match: pause\s
 
   - name: "registry.k8s.io/build-image/setcap: dependents"
-    version: bookworm-v1.0.6
+    version: bookworm-v1.0.7
     refPaths:
     - path: build/common.sh
       match: __default_setcap_version=

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -18,7 +18,7 @@ TEMP_DIR:=$(shell mktemp -d)
 VERSION=v9.1.8
 KUBECTL_VERSION?=v1.32.2
 
-BASEIMAGE=registry.k8s.io/build-image/debian-base-$(ARCH):bookworm-v1.0.6
+BASEIMAGE=registry.k8s.io/build-image/debian-base-$(ARCH):bookworm-v1.0.7
 
 SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3193,7 +3193,7 @@ spec:
   - name: vol
   containers:
   - name: pv-recycler
-    image: registry.k8s.io/build-image/debian-base:bookworm-v1.0.6
+    image: registry.k8s.io/build-image/debian-base:bookworm-v1.0.7
     command:
     - /bin/sh
     args:

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -994,7 +994,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:    "pv-recycler",
-					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.6",
+					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.7",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "test -e /scrub && find /scrub -mindepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
 					VolumeMounts: []v1.VolumeMount{

--- a/test/conformance/image/Makefile
+++ b/test/conformance/image/Makefile
@@ -33,7 +33,7 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
 # This is defined in root Makefile, but some build contexts do not refer to them
 KUBE_BASE_IMAGE_REGISTRY?=registry.k8s.io
-BASE_IMAGE_VERSION?=bookworm-v1.0.6
+BASE_IMAGE_VERSION?=bookworm-v1.0.7
 RUNNERIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
 
 TEMP_DIR:=$(shell mktemp -d -t conformance-XXXXXX)

--- a/test/images/nonroot/BASEIMAGE
+++ b/test/images/nonroot/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.6
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.7
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.7
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.7
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.7
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022
 windows/amd64/ltsc2025=mcr.microsoft.com/windows/nanoserver:ltsc2025

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.6
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.7
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.7
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.7
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.7

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,3 +1,3 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.7
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.7
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.7

--- a/test/images/regression-issue-74839/BASEIMAGE
+++ b/test/images/regression-issue-74839/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.6
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.6
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.7
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.7
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.7
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.7
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.7

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.6
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.7
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.7
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.7
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.7
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022
 windows/amd64/ltsc2025=mcr.microsoft.com/windows/nanoserver:ltsc2025


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- updated the setcap and debian-base image version to bookworm-v1.0.7
- kubernetes/release already uses bookworm-v1.0.7 for the setcap image and debian-base (see [images/build/setcap/variants.yaml](https://github.com/kubernetes/release/blob/master/images/build/setcap/variants.yaml#L6)). The master kubernetes/kubernetes repo was still pinned to bookworm-v1.0.6, so builds and tests here were using an older base than what release publishes. This update brings kubernetes/kubernetes in line with kubernetes/release so both use the same image versions (bookworm-v1.0.7).
- Image Promotion - https://github.com/kubernetes/k8s.io/pull/9226
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NA
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NA
```

cc: @liggitt @dims @saschagrunert @cpanato 