### PR TITLE
DRA: KEP-5304: add e2e test for discoverable device metadata

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -647,7 +647,7 @@ type MetadataFileOperations struct {
 
 func defaultMetadataFileOperations(ops MetadataFileOperations) MetadataFileOperations {
 	if ops.WriteFile == nil {
-		ops.WriteFile = os.WriteFile
+		ops.WriteFile = writeFileAtomically
 	}
 	if ops.ReadFile == nil {
 		ops.ReadFile = os.ReadFile
@@ -665,6 +665,57 @@ func defaultMetadataFileOperations(ops MetadataFileOperations) MetadataFileOpera
 		ops.Glob = filepath.Glob
 	}
 	return ops
+}
+
+func writeFileAtomically(name string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(name)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(name)+".*.tmp")
+	if err != nil {
+		return err
+	}
+
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, name); err != nil {
+		return err
+	}
+	if err := syncDir(dir); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func syncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return errors.Join(err, f.Close())
+	}
+	return f.Close()
 }
 
 // MetadataFileOps overrides the filesystem operations used by the metadata

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"path/filepath"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -630,6 +631,55 @@ func CDIDirectory(path string) Option {
 	}
 }
 
+// MetadataFileOperations allows callers to override how the metadata writer
+// performs filesystem operations. This is used by E2E tests that need to
+// proxy file I/O into a remote node (e.g. via PodDirIO on kind clusters).
+//
+// Any nil field is defaulted to the corresponding os / filepath function.
+type MetadataFileOperations struct {
+	WriteFile func(name string, data []byte, perm os.FileMode) error
+	ReadFile  func(name string) ([]byte, error)
+	MkdirAll  func(path string, perm os.FileMode) error
+	RemoveAll func(path string) error
+	Remove    func(path string) error
+	Glob      func(pattern string) ([]string, error)
+}
+
+func defaultMetadataFileOperations(ops MetadataFileOperations) MetadataFileOperations {
+	if ops.WriteFile == nil {
+		ops.WriteFile = os.WriteFile
+	}
+	if ops.ReadFile == nil {
+		ops.ReadFile = os.ReadFile
+	}
+	if ops.MkdirAll == nil {
+		ops.MkdirAll = os.MkdirAll
+	}
+	if ops.RemoveAll == nil {
+		ops.RemoveAll = os.RemoveAll
+	}
+	if ops.Remove == nil {
+		ops.Remove = os.Remove
+	}
+	if ops.Glob == nil {
+		ops.Glob = filepath.Glob
+	}
+	return ops
+}
+
+// MetadataFileOps overrides the filesystem operations used by the metadata
+// writer. This is intended for testing environments where the process running
+// the kubelet plugin helper does not share a filesystem with the node
+// (e.g. E2E tests on kind clusters).
+//
+// This option has no effect unless [EnableDeviceMetadata] is also set to true.
+func MetadataFileOps(ops MetadataFileOperations) Option {
+	return func(o *options) error {
+		o.metadataFileOps = ops
+		return nil
+	}
+}
+
 // TODO(KEP #5304): Decide on a version negotiation strategy before exiting alpha
 // so that adding new versions does not break existing consumers, until then
 // defaulting is empty.
@@ -662,6 +712,7 @@ type options struct {
 	enableDeviceMetadata       bool
 	metadataVersions           []schema.GroupVersion
 	cdiDir                     string
+	metadataFileOps            MetadataFileOperations
 }
 
 // Helper combines the kubelet registration service and the DRA node plugin
@@ -778,7 +829,7 @@ func Start(ctx context.Context, plugin DRAPlugin, opts ...Option) (result *Helpe
 		if len(versions) == 0 {
 			versions = defaultMetadataVersions()
 		}
-		mw, err := newMetadataWriter(o.driverName, o.pluginDataDirectoryPath, cdiDir, versions)
+		mw, err := newMetadataWriter(o.driverName, o.pluginDataDirectoryPath, cdiDir, versions, defaultMetadataFileOperations(o.metadataFileOps))
 		if err != nil {
 			return nil, fmt.Errorf("initialize device metadata: %w", err)
 		}

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/metadata.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/metadata.go
@@ -137,13 +137,14 @@ type metadataWriter struct {
 	cdiDir        string
 	versions      []schema.GroupVersion
 	encoders      map[schema.GroupVersion]runtime.Encoder
+	fileOps       MetadataFileOperations
 }
 
 // newMetadataWriter creates a new metadataWriter that writes metadata files
 // for each of the specified API versions. Unsupported versions are silently
 // skipped, but an error is returned if none of the requested versions are
 // supported by the metadata scheme.
-func newMetadataWriter(driverName, pluginDataDir, cdiDir string, versions []schema.GroupVersion) (*metadataWriter, error) {
+func newMetadataWriter(driverName, pluginDataDir, cdiDir string, versions []schema.GroupVersion, fileOps MetadataFileOperations) (*metadataWriter, error) {
 	var supported []schema.GroupVersion
 	encoders := make(map[schema.GroupVersion]runtime.Encoder, len(versions))
 	for _, gv := range versions {
@@ -164,6 +165,7 @@ func newMetadataWriter(driverName, pluginDataDir, cdiDir string, versions []sche
 		cdiDir:        cdiDir,
 		versions:      supported,
 		encoders:      encoders,
+		fileOps:       fileOps,
 	}, nil
 }
 
@@ -207,17 +209,17 @@ func (w *metadataWriter) processPreparedClaim(
 // It is a no-op if no files exist for the given claim.
 func (w *metadataWriter) cleanupClaim(claimNamespace, claimName string, claimUID types.UID) error {
 	metadataDir := w.claimMetadataDir(claimNamespace, claimName)
-	if err := os.RemoveAll(metadataDir); err != nil && !os.IsNotExist(err) {
+	if err := w.fileOps.RemoveAll(metadataDir); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove metadata directory %s: %w", metadataDir, err)
 	}
 
 	pattern := filepath.Join(w.cdiDir, fmt.Sprintf("%s_metadata_%s_*.json", w.driverName, string(claimUID)))
-	matches, err := filepath.Glob(pattern)
+	matches, err := w.fileOps.Glob(pattern)
 	if err != nil {
 		return fmt.Errorf("glob CDI specs %s: %w", pattern, err)
 	}
 	for _, cdiPath := range matches {
-		if err := os.Remove(cdiPath); err != nil && !os.IsNotExist(err) {
+		if err := w.fileOps.Remove(cdiPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove CDI spec %s: %w", cdiPath, err)
 		}
 	}
@@ -241,7 +243,7 @@ func (w *metadataWriter) updateRequestMetadata(
 	baseReq := resourceclaim.BaseRequestRef(requestName)
 	filePath := w.metadataFilePath(ref.namespace, ref.name, baseReq)
 
-	existing, err := os.ReadFile(filePath)
+	existing, err := w.fileOps.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("request %q not found in prepared claim %s/%s", requestName, ref.namespace, ref.name)
@@ -264,7 +266,7 @@ func (w *metadataWriter) updateRequestMetadata(
 		return err
 	}
 
-	if err := os.WriteFile(filePath, data, metadataFilePerms); err != nil {
+	if err := w.fileOps.WriteFile(filePath, data, metadataFilePerms); err != nil {
 		return fmt.Errorf("write metadata file: %w", err)
 	}
 
@@ -290,11 +292,11 @@ func (w *metadataWriter) writeMetadataFile(
 	}
 
 	filePath := w.metadataFilePath(ref.namespace, ref.name, baseRequestName)
-	if err := os.MkdirAll(filepath.Dir(filePath), metadataDirPerms); err != nil {
+	if err := w.fileOps.MkdirAll(filepath.Dir(filePath), metadataDirPerms); err != nil {
 		return fmt.Errorf("create metadata directory: %w", err)
 	}
 
-	if err := os.WriteFile(filePath, data, metadataFilePerms); err != nil {
+	if err := w.fileOps.WriteFile(filePath, data, metadataFilePerms); err != nil {
 		return fmt.Errorf("write metadata file: %w", err)
 	}
 
@@ -395,12 +397,12 @@ func (w *metadataWriter) writeCDISpec(
 		return "", fmt.Errorf("marshal CDI spec: %w", err)
 	}
 
-	if err := os.MkdirAll(w.cdiDir, metadataDirPerms); err != nil {
+	if err := w.fileOps.MkdirAll(w.cdiDir, metadataDirPerms); err != nil {
 		return "", fmt.Errorf("create CDI directory: %w", err)
 	}
 
 	cdiPath := w.cdiSpecFilePath(claim.UID, requestName)
-	if err := os.WriteFile(cdiPath, data, metadataFilePerms); err != nil {
+	if err := w.fileOps.WriteFile(cdiPath, data, metadataFilePerms); err != nil {
 		return "", fmt.Errorf("write CDI spec file: %w", err)
 	}
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/metadata_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/metadata_test.go
@@ -86,7 +86,7 @@ func TestNewMetadataWriterVersionValidation(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			_, err := newMetadataWriter(testDriverName, t.TempDir(), t.TempDir(), tc.versions)
+			_, err := newMetadataWriter(testDriverName, t.TempDir(), t.TempDir(), tc.versions, defaultMetadataFileOperations(MetadataFileOperations{}))
 			if tc.expectErr && err == nil {
 				t.Fatal("expected error but got nil")
 			}
@@ -101,7 +101,7 @@ func newTestWriter(t *testing.T) (*metadataWriter, string, string) {
 	t.Helper()
 	pluginDir := t.TempDir()
 	cdiDir := t.TempDir()
-	w, err := newMetadataWriter(testDriverName, pluginDir, cdiDir, []schema.GroupVersion{v1alpha1.SchemeGroupVersion})
+	w, err := newMetadataWriter(testDriverName, pluginDir, cdiDir, []schema.GroupVersion{v1alpha1.SchemeGroupVersion}, defaultMetadataFileOperations(MetadataFileOperations{}))
 	if err != nil {
 		t.Fatalf("newMetadataWriter: %v", err)
 	}

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -19,6 +19,7 @@ package dra
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -46,6 +47,8 @@ import (
 	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	metadata "k8s.io/dynamic-resource-allocation/api/metadata"
+	"k8s.io/dynamic-resource-allocation/devicemetadata"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/events"
@@ -59,6 +62,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	dratest "k8s.io/kubernetes/test/integration/dra"
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
 )
@@ -623,7 +627,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 		})
 	})
 
-	// ResourcePoolStatusRequest tests with network resources — no kubelet needed.
+	// ResourcePoolStatusRequest tests with network resources - no kubelet needed.
 	framework.Context("control plane", f.WithFeatureGate(features.DRAResourcePoolStatus), func() {
 		nodes := drautils.NewNodes(f, 1, 1)
 		driver := drautils.NewDriver(f, nodes, drautils.NetworkResources(10, false))
@@ -717,6 +721,236 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 						})),
 					})))
 			}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+		})
+	})
+
+	type expectedMetadataFile struct {
+		claimName      string
+		claimNamespace string
+		claimUID       string
+		podClaimName   *string
+		requestName    string
+		driverName     string
+		generation     int64
+	}
+
+	expectStringMetadataAttribute := func(tCtx ktesting.TContext, attributes map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, name resourceapi.QualifiedName, expected, filePath string) {
+		tCtx.Helper()
+		attr, ok := attributes[name]
+		if !ok {
+			tCtx.Fatalf("metadata attribute %q in %s is missing", name, filePath)
+		}
+		tCtx.Expect(attr.StringValue).ToNot(gomega.BeNil(), "metadata attribute %q string value in %s", name, filePath)
+		if attr.StringValue != nil {
+			tCtx.Expect(*attr.StringValue).To(gomega.Equal(expected), "metadata attribute %q in %s", name, filePath)
+		}
+	}
+
+	testContainerMetadataFile := func(tCtx ktesting.TContext, pod *v1.Pod, containerName, filePath string, expected expectedMetadataFile) {
+		tCtx.Helper()
+		stdout, stderr, err := e2epod.Exec(tCtx, e2epod.ExecOptions{
+			Command:       []string{"cat", filePath},
+			Namespace:     pod.Namespace,
+			PodName:       pod.Name,
+			ContainerName: containerName,
+			CaptureStdout: true,
+			CaptureStderr: true,
+			Quiet:         true,
+		})
+		tCtx.ExpectNoError(err, "read metadata file %s in container %s", filePath, containerName)
+		tCtx.Expect(stderr).To(gomega.BeEmpty(), "metadata file stderr for container %s", containerName)
+
+		var md metadata.DeviceMetadata
+		tCtx.ExpectNoError(devicemetadata.DecodeMetadataFromStream(
+			json.NewDecoder(strings.NewReader(stdout)), &md,
+		), "decode metadata file %s", filePath)
+
+		if expected.claimName != "" {
+			tCtx.Expect(md.Name).To(gomega.Equal(expected.claimName), "claim name in %s", filePath)
+		}
+		if expected.claimNamespace != "" {
+			tCtx.Expect(md.Namespace).To(gomega.Equal(expected.claimNamespace), "claim namespace in %s", filePath)
+		}
+		if expected.claimUID != "" {
+			tCtx.Expect(string(md.UID)).To(gomega.Equal(expected.claimUID), "claim UID in %s", filePath)
+		}
+		if expected.generation != 0 {
+			tCtx.Expect(md.Generation).To(gomega.Equal(expected.generation), "metadata generation in %s", filePath)
+		}
+		tCtx.Expect(md.PodClaimName).To(gomega.Equal(expected.podClaimName), "pod claim name in %s", filePath)
+
+		tCtx.Expect(md.Requests).To(gomega.HaveLen(1), "requests in %s", filePath)
+		req := md.Requests[0]
+		tCtx.Expect(req.Name).To(gomega.Equal(expected.requestName), "request name in %s", filePath)
+		tCtx.Expect(req.Devices).ToNot(gomega.BeEmpty(), "devices in request %s of %s", req.Name, filePath)
+		for _, dev := range req.Devices {
+			tCtx.Expect(dev.Driver).To(gomega.Equal(expected.driverName), "device driver in %s", filePath)
+			tCtx.Expect(dev.Pool).ToNot(gomega.BeEmpty(), "device pool in %s", filePath)
+			tCtx.Expect(dev.Name).ToNot(gomega.BeEmpty(), "device name in %s", filePath)
+			expectStringMetadataAttribute(tCtx, dev.Attributes, "driverName", expected.driverName, filePath)
+			expectStringMetadataAttribute(tCtx, dev.Attributes, "pool", dev.Pool, filePath)
+			expectStringMetadataAttribute(tCtx, dev.Attributes, "device", dev.Name, filePath)
+		}
+	}
+
+	f.Context("kubelet", feature.DynamicResourceAllocation, func() {
+		nodes := drautils.NewNodes(f, 1, 1)
+		driver := drautils.NewDriver(f, nodes, drautils.DriverResources(2))
+		driver.EnableDeviceMetadata = true
+		b := drautils.NewBuilder(f, driver)
+
+		ginkgo.It("must mount device metadata for resource claims", func(ctx context.Context) {
+			tCtx := f.TContext(ctx)
+			claim := b.ExternalClaim()
+			pod := b.PodExternal(claim.Name)
+			created := b.Create(tCtx, claim, pod)
+			createdClaim := created[0].(*resourceapi.ResourceClaim)
+
+			err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+			framework.ExpectNoError(err, "start pod")
+
+			expectedPath := metadata.ResourceClaimFilePath(driver.Name, claim.Name, "my-request")
+			testContainerMetadataFile(tCtx, pod, "with-resource", expectedPath, expectedMetadataFile{
+				claimName:      createdClaim.Name,
+				claimNamespace: createdClaim.Namespace,
+				claimUID:       string(createdClaim.UID),
+				requestName:    "my-request",
+				driverName:     driver.Name,
+				generation:     1,
+			})
+		})
+
+		ginkgo.It("must map device metadata to the right containers", func(ctx context.Context) {
+			tCtx := f.TContext(ctx)
+			claim := b.ExternalClaim()
+			claim.Spec.Devices.Requests = append(claim.Spec.Devices.Requests, *claim.Spec.Devices.Requests[0].DeepCopy())
+			claim.Spec.Devices.Requests[0].Name = "req0"
+			claim.Spec.Devices.Requests[1].Name = "req1"
+
+			pod := b.PodExternal(claim.Name)
+			pod.Spec.Containers = append(pod.Spec.Containers, *pod.Spec.Containers[0].DeepCopy())
+			pod.Spec.Containers[0].Name = "all-requests"
+			pod.Spec.Containers[1].Name = "req1-only"
+			pod.Spec.Containers[0].Resources.Claims = []v1.ResourceClaim{{Name: "resource-claim"}}
+			pod.Spec.Containers[1].Resources.Claims = []v1.ResourceClaim{{Name: "resource-claim", Request: "req1"}}
+
+			created := b.Create(tCtx, claim, pod)
+			createdClaim := created[0].(*resourceapi.ResourceClaim)
+
+			err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+			framework.ExpectNoError(err, "start pod")
+
+			expectMetadata := func(containerName, requestName string) {
+				expectedPath := metadata.ResourceClaimFilePath(driver.Name, claim.Name, requestName)
+				testContainerMetadataFile(tCtx, pod, containerName, expectedPath, expectedMetadataFile{
+					claimName:      createdClaim.Name,
+					claimNamespace: createdClaim.Namespace,
+					claimUID:       string(createdClaim.UID),
+					requestName:    requestName,
+					driverName:     driver.Name,
+					generation:     1,
+				})
+			}
+			expectMetadata("all-requests", "req0")
+			expectMetadata("all-requests", "req1")
+			expectMetadata("req1-only", "req1")
+
+			req0Path := metadata.ResourceClaimFilePath(driver.Name, claim.Name, "req0")
+			_, _, err = e2epod.Exec(tCtx, e2epod.ExecOptions{
+				Command:       []string{"cat", req0Path},
+				Namespace:     pod.Namespace,
+				PodName:       pod.Name,
+				ContainerName: "req1-only",
+				CaptureStdout: true,
+				CaptureStderr: true,
+				Quiet:         true,
+			})
+			tCtx.Expect(err).To(gomega.HaveOccurred(), "metadata file %s in container %s", req0Path, "req1-only")
+		})
+
+		ginkgo.It("must mount device metadata for resource claim templates", func(ctx context.Context) {
+			tCtx := f.TContext(ctx)
+			pod, template := b.PodInline()
+			b.Create(tCtx, template, pod)
+
+			err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+			framework.ExpectNoError(err, "start pod")
+
+			expectedPath := metadata.ResourceClaimTemplateFilePath(driver.Name, "my-inline-claim", "my-request")
+			testContainerMetadataFile(tCtx, pod, "with-resource", expectedPath, expectedMetadataFile{
+				claimNamespace: f.Namespace.Name,
+				podClaimName:   new("my-inline-claim"),
+				requestName:    "my-request",
+				driverName:     driver.Name,
+				generation:     1,
+			})
+		})
+	})
+
+	f.Context("kubelet", feature.DynamicResourceAllocation, func() {
+		nodes := drautils.NewNodes(f, 1, 1)
+
+		driverA := drautils.NewDriver(f, nodes, drautils.DriverResources(1))
+		driverA.NameSuffix = "-a"
+		driverA.EnableDeviceMetadata = true
+
+		driverB := drautils.NewDriver(f, nodes, drautils.DriverResources(1))
+		driverB.NameSuffix = "-b"
+		driverB.EnableDeviceMetadata = true
+
+		bA := drautils.NewBuilder(f, driverA)
+
+		ginkgo.It("must not race when multiple drivers write metadata for the same request", func(ctx context.Context) {
+			tCtx := f.TContext(ctx)
+
+			sharedClass := &resourceapi.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: f.Namespace.Name + "-shared-class"},
+				Spec: resourceapi.DeviceClassSpec{
+					Selectors: []resourceapi.DeviceSelector{{
+						CEL: &resourceapi.CELDeviceSelector{
+							Expression: fmt.Sprintf(`device.driver == "%s" || device.driver == "%s"`, driverA.Name, driverB.Name),
+						},
+					}},
+				},
+			}
+
+			claim := &resourceapi.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-driver-claim",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: resourceapi.ResourceClaimSpec{
+					Devices: resourceapi.DeviceClaim{
+						Requests: []resourceapi.DeviceRequest{{
+							Name: "my-request",
+							Exactly: &resourceapi.ExactDeviceRequest{
+								DeviceClassName: sharedClass.Name,
+								AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+								Count:           2,
+							},
+						}},
+					},
+				},
+			}
+
+			pod := bA.PodExternal(claim.Name)
+			created := bA.Create(tCtx, sharedClass, claim, pod)
+			createdClaim := created[1].(*resourceapi.ResourceClaim)
+
+			err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+			framework.ExpectNoError(err, "start pod")
+
+			for _, driverName := range []string{driverA.Name, driverB.Name} {
+				expectedPath := metadata.ResourceClaimFilePath(driverName, claim.Name, "my-request")
+				testContainerMetadataFile(tCtx, pod, "with-resource", expectedPath, expectedMetadataFile{
+					claimName:      createdClaim.Name,
+					claimNamespace: createdClaim.Namespace,
+					claimUID:       string(createdClaim.UID),
+					requestName:    "my-request",
+					driverName:     driverName,
+					generation:     1,
+				})
+			}
 		})
 	})
 

--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -29,7 +29,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -723,10 +722,12 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 		if d.EnableDeviceMetadata {
 			pluginOpts = append(pluginOpts,
 				kubeletplugin.MetadataVersions(metadatav1alpha1.SchemeGroupVersion),
-				kubeletplugin.MetadataFileOps(d.buildMetadataFileOps(tCtx, &pod)),
 			)
 			if !d.IsLocal {
-				pluginOpts = append(pluginOpts, kubeletplugin.CDIDirectory("/cdi"))
+				pluginOpts = append(pluginOpts,
+					kubeletplugin.MetadataFileOps(d.buildRemoteMetadataFileOps(tCtx, &pod)),
+					kubeletplugin.CDIDirectory("/cdi"),
+				)
 			}
 		}
 
@@ -869,18 +870,7 @@ func (d *Driver) podIO(tCtx ktesting.TContext, pod *v1.Pod) proxy.PodDirIO {
 	}
 }
 
-func (d *Driver) buildMetadataFileOps(tCtx ktesting.TContext, pod *v1.Pod) kubeletplugin.MetadataFileOperations {
-	if d.IsLocal {
-		return kubeletplugin.MetadataFileOperations{
-			WriteFile: os.WriteFile,
-			ReadFile:  os.ReadFile,
-			MkdirAll:  os.MkdirAll,
-			RemoveAll: os.RemoveAll,
-			Remove:    os.Remove,
-			Glob:      filepath.Glob,
-		}
-	}
-
+func (d *Driver) buildRemoteMetadataFileOps(tCtx ktesting.TContext, pod *v1.Pod) kubeletplugin.MetadataFileOperations {
 	execInPod := func(command []string) (string, error) {
 		stdout, stderr, err := e2epod.Exec(tCtx, e2epod.ExecOptions{
 			Command:       command,

--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -63,6 +64,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
+	metadatav1alpha1 "k8s.io/dynamic-resource-allocation/api/metadata/v1alpha1"
 	draclient "k8s.io/dynamic-resource-allocation/client"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
@@ -73,6 +75,7 @@ import (
 	testdrivergomega "k8s.io/kubernetes/test/e2e/dra/test-driver/gomega"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2ereplicaset "k8s.io/kubernetes/test/e2e/framework/replicaset"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/storage/drivers/proxy"
@@ -396,6 +399,8 @@ type Driver struct {
 	// Run driver pods. If false, only set up slices and class.
 	WithRealNodes bool
 
+	EnableDeviceMetadata bool
+
 	mutex      sync.Mutex
 	fail       map[MethodInstance]bool
 	callCounts map[MethodInstance]int64
@@ -691,7 +696,7 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 			serialize = false
 		}
 
-		plugin, err := app.StartPlugin(loggerCtx, "/cdi", d.Name, driverClient, nodename, fileOps,
+		pluginOpts := []any{
 			app.Options{EnableHealthService: true},
 			kubeletplugin.GRPCVerbosity(0),
 			kubeletplugin.GRPCInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
@@ -712,7 +717,20 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 
 			kubeletplugin.RegistrarDirectoryPath(registrarDirectoryPath),
 			kubeletplugin.RegistrarListener(d.listen(tCtx, &pod, &listenerPort)),
-		)
+
+			kubeletplugin.EnableDeviceMetadata(d.EnableDeviceMetadata),
+		}
+		if d.EnableDeviceMetadata {
+			pluginOpts = append(pluginOpts,
+				kubeletplugin.MetadataVersions(metadatav1alpha1.SchemeGroupVersion),
+				kubeletplugin.MetadataFileOps(d.buildMetadataFileOps(tCtx, &pod)),
+			)
+			if !d.IsLocal {
+				pluginOpts = append(pluginOpts, kubeletplugin.CDIDirectory("/cdi"))
+			}
+		}
+
+		plugin, err := app.StartPlugin(loggerCtx, "/cdi", d.Name, driverClient, nodename, fileOps, pluginOpts...)
 		tCtx.ExpectNoError(err, "start kubelet plugin for node %s", pod.Spec.NodeName)
 		d.cleanup = append(d.cleanup, func(tCtx ktesting.TContext) {
 			// Depends on cancel being called first.
@@ -848,6 +866,70 @@ func (d *Driver) podIO(tCtx ktesting.TContext, pod *v1.Pod) proxy.PodDirIO {
 		PodName:       pod.Name,
 		ContainerName: pod.Spec.Containers[0].Name,
 		Logger:        &logger,
+	}
+}
+
+func (d *Driver) buildMetadataFileOps(tCtx ktesting.TContext, pod *v1.Pod) kubeletplugin.MetadataFileOperations {
+	if d.IsLocal {
+		return kubeletplugin.MetadataFileOperations{
+			WriteFile: os.WriteFile,
+			ReadFile:  os.ReadFile,
+			MkdirAll:  os.MkdirAll,
+			RemoveAll: os.RemoveAll,
+			Remove:    os.Remove,
+			Glob:      filepath.Glob,
+		}
+	}
+
+	execInPod := func(command []string) (string, error) {
+		stdout, stderr, err := e2epod.Exec(tCtx, e2epod.ExecOptions{
+			Command:       command,
+			Namespace:     pod.Namespace,
+			PodName:       pod.Name,
+			ContainerName: pod.Spec.Containers[0].Name,
+			CaptureStdout: true,
+			CaptureStderr: true,
+			Quiet:         true,
+		})
+		if err != nil {
+			return "", fmt.Errorf("%v: stderr=%q, %w", command, stderr, err)
+		}
+		return stdout, nil
+	}
+
+	return kubeletplugin.MetadataFileOperations{
+		WriteFile: func(name string, data []byte, perm os.FileMode) error {
+			return d.createFile(tCtx, pod, name, data)
+		},
+		ReadFile: func(name string) ([]byte, error) {
+			stdout, err := execInPod([]string{"cat", name})
+			if err != nil {
+				return nil, err
+			}
+			return []byte(stdout), nil
+		},
+		MkdirAll: func(p string, perm os.FileMode) error {
+			_, err := execInPod([]string{"mkdir", "-p", p})
+			return err
+		},
+		RemoveAll: func(p string) error {
+			return d.podIO(tCtx, pod).RemoveAll(p)
+		},
+		Remove: func(name string) error {
+			_, err := execInPod([]string{"rm", "-f", name})
+			return err
+		},
+		Glob: func(pattern string) ([]string, error) {
+			stdout, err := execInPod([]string{"sh", "-c", fmt.Sprintf("ls -1d %s 2>/dev/null || true", pattern)})
+			if err != nil {
+				return nil, err
+			}
+			stdout = strings.TrimSpace(stdout)
+			if stdout == "" {
+				return nil, nil
+			}
+			return strings.Split(stdout, "\n"), nil
+		},
 	}
 }
 


### PR DESCRIPTION
Assisted By: <noreply@cursor.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR added e2e test for KEP-5304, follow up from https://github.com/kubernetes/kubernetes/pull/137086

In the process of running e2e tests, a bug was found where a minimum of
0.5.0 version of CDI spec is needed. This PR fixes that bug by importing 
specs-go library, which is a small dep that generates the CDI spec.

This library has a utility MinimumRequiredVersion which helps avoid such
bugs in the future.

This PR also updates the test driver to use cdi library and completely 
removes in-tree CDI structs reducing redundancies. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/5304

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kep-5304: make cdi spec version dynamic to avoid incompatible spec generation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
