### PR TITLE
kubectl: add option to respect the propagationPolicy of server-side a…

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -395,8 +395,9 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		if o.GracePeriod >= 0 {
 			options = metav1.NewDeleteOptions(int64(o.GracePeriod))
 		}
-		options.PropagationPolicy = &o.CascadingStrategy
-
+		if o.CascadingStrategy != "" {
+			options.PropagationPolicy = &o.CascadingStrategy
+		}
 		if warnClusterScope && info.Mapping.Scope.Name() == meta.RESTScopeNameRoot {
 			o.WarningPrinter.Print("deleting cluster-scoped resources, not scoped to the provided namespace")
 			warnClusterScope = false

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -395,7 +395,8 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		if o.GracePeriod >= 0 {
 			options = metav1.NewDeleteOptions(int64(o.GracePeriod))
 		}
-		if o.CascadingStrategy != "" {
+		// Skip setting PropagationPolicy to respect server-side propagation policy when --cascade flag is "none"
+		if len(o.CascadingStrategy) != 0 {
 			options.PropagationPolicy = &o.CascadingStrategy
 		}
 		if warnClusterScope && info.Mapping.Scope.Name() == meta.RESTScopeNameRoot {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -79,7 +79,8 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 	if f.AllNamespaces != nil {
 		options.DeleteAllNamespaces = *f.AllNamespaces
 	}
-	if f.CascadingStrategy != nil {
+	// Set CascadingStrategy only when the user explicitly specifies a value other than server.
+	if f.CascadingStrategy != nil && *f.CascadingStrategy != "server" {
 		var err error
 		options.CascadingStrategy, err = parseCascadingFlag(streams, *f.CascadingStrategy)
 		if err != nil {
@@ -135,9 +136,9 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 		cmd.Flags().StringVar(
 			f.CascadingStrategy,
 			"cascade",
-			*f.CascadingStrategy,
-			`Must be "background", "orphan", or "foreground". Selects the deletion cascading strategy for the dependents (e.g. Pods created by a ReplicationController). Defaults to background.`)
-		cmd.Flags().Lookup("cascade").NoOptDefVal = "background"
+			"server",
+			`Must be "server", "background", "orphan", or "foreground". Selects the deletion cascading strategy for the dependents (e.g. Pods created by a ReplicationController). Defaults to server.`)
+		cmd.Flags().Lookup("cascade").NoOptDefVal = "server"
 	}
 	if f.Now != nil {
 		cmd.Flags().BoolVar(f.Now, "now", *f.Now, "If true, resources are signaled for immediate shutdown (same as --grace-period=1).")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -80,13 +80,10 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 		options.DeleteAllNamespaces = *f.AllNamespaces
 	}
 	if f.CascadingStrategy != nil {
-		// Skip to set CascadingStrategy when CascadingFlag is "server"
-		if *f.CascadingStrategy != "server" {
-			var err error
-			options.CascadingStrategy, err = parseCascadingFlag(streams, *f.CascadingStrategy)
-			if err != nil {
-				return nil, err
-			}
+		var err error
+		options.CascadingStrategy, err = parseCascadingFlag(streams, *f.CascadingStrategy)
+		if err != nil {
+			return nil, err
 		}
 	}
 	if f.Force != nil {
@@ -139,8 +136,7 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 			f.CascadingStrategy,
 			"cascade",
 			*f.CascadingStrategy,
-			`Must be "background", "orphan", "foreground" or "server". Selects the deletion cascading strategy for the dependents (e.g. Pods created by a ReplicationController). Defaults to background.`)
-		cmd.Flags().Lookup("cascade").NoOptDefVal = "background"
+			`Must be "background", "orphan", "foreground" or "none". Selects the deletion cascading strategy for the dependents (e.g. Pods created by a ReplicationController). Defaults to background. When --cascade is none, deletion cascading strategy respects server-side propagation policy.`)
 	}
 	if f.Now != nil {
 		cmd.Flags().BoolVar(f.Now, "now", *f.Now, "If true, resources are signaled for immediate shutdown (same as --grace-period=1).")
@@ -250,8 +246,11 @@ func parseCascadingFlag(streams genericiooptions.IOStreams, cascadingFlag string
 			return metav1.DeletePropagationForeground, nil
 		case "background":
 			return metav1.DeletePropagationBackground, nil
+		case "none":
+			// Represents respecting the server-side propagation policy as an empty string.
+			return "", nil
 		default:
-			return metav1.DeletePropagationBackground, fmt.Errorf(`invalid cascade value (%v). Must be "background", "foreground", or "orphan"`, cascadingFlag)
+			return metav1.DeletePropagationBackground, fmt.Errorf(`invalid cascade value (%v). Must be "background", "foreground", "orphan", or "none"`, cascadingFlag)
 		}
 	}
 	// The flag was a boolean

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -79,12 +79,14 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 	if f.AllNamespaces != nil {
 		options.DeleteAllNamespaces = *f.AllNamespaces
 	}
-	// Set CascadingStrategy only when the user explicitly specifies a value other than server.
-	if f.CascadingStrategy != nil && *f.CascadingStrategy != "server" {
-		var err error
-		options.CascadingStrategy, err = parseCascadingFlag(streams, *f.CascadingStrategy)
-		if err != nil {
-			return nil, err
+	if f.CascadingStrategy != nil {
+		// Skip to set CascadingStrategy when CascadingFlag is "server"
+		if *f.CascadingStrategy != "server" {
+			var err error
+			options.CascadingStrategy, err = parseCascadingFlag(streams, *f.CascadingStrategy)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if f.Force != nil {
@@ -136,9 +138,9 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 		cmd.Flags().StringVar(
 			f.CascadingStrategy,
 			"cascade",
-			"server",
-			`Must be "server", "background", "orphan", or "foreground". Selects the deletion cascading strategy for the dependents (e.g. Pods created by a ReplicationController). Defaults to server.`)
-		cmd.Flags().Lookup("cascade").NoOptDefVal = "server"
+			*f.CascadingStrategy,
+			`Must be "background", "orphan", "foreground" or "server". Selects the deletion cascading strategy for the dependents (e.g. Pods created by a ReplicationController). Defaults to background.`)
+		cmd.Flags().Lookup("cascade").NoOptDefVal = "background"
 	}
 	if f.Now != nil {
 		cmd.Flags().BoolVar(f.Now, "now", *f.Now, "If true, resources are signaled for immediate shutdown (same as --grace-period=1).")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -139,6 +139,65 @@ func TestDeleteObjectByTuple(t *testing.T) {
 	}
 }
 
+func isPropagationPolicyEmpty(body io.ReadCloser) bool {
+	if body == nil {
+		return false
+	}
+	var parsedBody metav1.DeleteOptions
+	rawBody, _ := io.ReadAll(body)
+	json.Unmarshal(rawBody, &parsedBody)
+	if parsedBody.PropagationPolicy == nil {
+		return true
+	}
+	return false
+}
+
+// TestCascadingStrategyForServer tests that DeleteOptions.DeletionPropagation isn't appropriately set while deleting objects.
+func TestCascadingStrategyForServer(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+	_, _, rc := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m, b := req.URL.Path, req.Method, req.Body; {
+
+			case p == "/namespaces/test/secrets/mysecret" && m == "DELETE" && isPropagationPolicyEmpty(b):
+
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
+			default:
+				return nil, nil
+			}
+		}),
+	}
+
+	// DeleteOptions.PropagationPolicy shouldn't be set, when cascading strategy is empty. (default)
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdDelete(tf, streams)
+	cmd.Flags().Set("namespace", "test")
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{"secrets/mysecret"})
+	if buf.String() != "secret/mysecret\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+
+	// DeleteOptions.PropagationPolicy shouldn't be set, when cascading strategy is server.
+	streams, _, buf, _ = genericiooptions.NewTestIOStreams()
+	cmd = NewCmdDelete(tf, streams)
+	cmd.Flags().Set("namespace", "test")
+	cmd.Flags().Set("cascade", "server")
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{"secrets/mysecret"})
+	if buf.String() != "secret/mysecret\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}
+
 func hasExpectedPropagationPolicy(body io.ReadCloser, policy *metav1.DeletionPropagation) bool {
 	if body == nil || policy == nil {
 		return body == nil && policy == nil
@@ -177,12 +236,13 @@ func TestCascadingStrategy(t *testing.T) {
 		}),
 	}
 
-	// DeleteOptions.PropagationPolicy should be Background, when cascading strategy is empty (default).
+	// DeleteOptions.PropagationPolicy should be Background, when cascading strategy is background.
 	backgroundPolicy := metav1.DeletePropagationBackground
 	policy = &backgroundPolicy
 	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
+	cmd.Flags().Set("cascade", "background")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"secrets/mysecret"})
 	if buf.String() != "secret/mysecret\n" {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -146,56 +146,7 @@ func isPropagationPolicyEmpty(body io.ReadCloser) bool {
 	var parsedBody metav1.DeleteOptions
 	rawBody, _ := io.ReadAll(body)
 	json.Unmarshal(rawBody, &parsedBody)
-	if parsedBody.PropagationPolicy == nil {
-		return true
-	}
-	return false
-}
-
-// TestCascadingStrategyForServer tests that DeleteOptions.DeletionPropagation isn't appropriately set while deleting objects.
-func TestCascadingStrategyForServer(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-	_, _, rc := cmdtesting.TestData()
-
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
-
-	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-
-	tf.UnstructuredClient = &fake.RESTClient{
-		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m, b := req.URL.Path, req.Method, req.Body; {
-
-			case p == "/namespaces/test/secrets/mysecret" && m == "DELETE" && isPropagationPolicyEmpty(b):
-
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
-			default:
-				return nil, nil
-			}
-		}),
-	}
-
-	// DeleteOptions.PropagationPolicy shouldn't be set, when cascading strategy is empty. (default)
-	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
-	cmd := NewCmdDelete(tf, streams)
-	cmd.Flags().Set("namespace", "test")
-	cmd.Flags().Set("output", "name")
-	cmd.Run(cmd, []string{"secrets/mysecret"})
-	if buf.String() != "secret/mysecret\n" {
-		t.Errorf("unexpected output: %s", buf.String())
-	}
-
-	// DeleteOptions.PropagationPolicy shouldn't be set, when cascading strategy is server.
-	streams, _, buf, _ = genericiooptions.NewTestIOStreams()
-	cmd = NewCmdDelete(tf, streams)
-	cmd.Flags().Set("namespace", "test")
-	cmd.Flags().Set("cascade", "server")
-	cmd.Flags().Set("output", "name")
-	cmd.Run(cmd, []string{"secrets/mysecret"})
-	if buf.String() != "secret/mysecret\n" {
-		t.Errorf("unexpected output: %s", buf.String())
-	}
+	return parsedBody.PropagationPolicy == nil
 }
 
 func hasExpectedPropagationPolicy(body io.ReadCloser, policy *metav1.DeletionPropagation) bool {
@@ -230,19 +181,21 @@ func TestCascadingStrategy(t *testing.T) {
 			case p == "/namespaces/test/secrets/mysecret" && m == "DELETE" && hasExpectedPropagationPolicy(b, policy):
 
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
+			case p == "/namespaces/test/secrets/mysecret-server" && m == "DELETE" && isPropagationPolicyEmpty(b):
+
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 			default:
 				return nil, nil
 			}
 		}),
 	}
 
-	// DeleteOptions.PropagationPolicy should be Background, when cascading strategy is background.
+	// DeleteOptions.PropagationPolicy should be Background, when cascading strategy is empty (default).
 	backgroundPolicy := metav1.DeletePropagationBackground
 	policy = &backgroundPolicy
 	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
-	cmd.Flags().Set("cascade", "background")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"secrets/mysecret"})
 	if buf.String() != "secret/mysecret\n" {
@@ -274,6 +227,18 @@ func TestCascadingStrategy(t *testing.T) {
 	if buf.String() != "secret/mysecret\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
+
+	// DeleteOptions.PropagationPolicy shouldn't be set, when cascading strategy is server.
+	streams, _, buf, _ = genericiooptions.NewTestIOStreams()
+	cmd = NewCmdDelete(tf, streams)
+	cmd.Flags().Set("namespace", "test")
+	cmd.Flags().Set("cascade", "server")
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{"secrets/mysecret-server"})
+	if buf.String() != "secret/mysecret-server\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+
 }
 
 func TestDeleteNamedObject(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -139,16 +139,8 @@ func TestDeleteObjectByTuple(t *testing.T) {
 	}
 }
 
-func isPropagationPolicyEmpty(body io.ReadCloser) bool {
-	if body == nil {
-		return false
-	}
-	var parsedBody metav1.DeleteOptions
-	rawBody, _ := io.ReadAll(body)
-	json.Unmarshal(rawBody, &parsedBody)
-	return parsedBody.PropagationPolicy == nil
-}
-
+// hasExpectedPropagationPolicy checks whether the PropagationPolicy in the request body matches the expected policy.
+// Note: When policy is "" (--cascade is none), this function expects PropagationPolicy to be nil.
 func hasExpectedPropagationPolicy(body io.ReadCloser, policy *metav1.DeletionPropagation) bool {
 	if body == nil || policy == nil {
 		return body == nil && policy == nil
@@ -156,6 +148,9 @@ func hasExpectedPropagationPolicy(body io.ReadCloser, policy *metav1.DeletionPro
 	var parsedBody metav1.DeleteOptions
 	rawBody, _ := io.ReadAll(body)
 	json.Unmarshal(rawBody, &parsedBody)
+	if *policy == "" {
+                 return parsedBody.PropagationPolicy == nil
+        }
 	if parsedBody.PropagationPolicy == nil {
 		return false
 	}
@@ -179,9 +174,6 @@ func TestCascadingStrategy(t *testing.T) {
 			switch p, m, b := req.URL.Path, req.Method, req.Body; {
 
 			case p == "/namespaces/test/secrets/mysecret" && m == "DELETE" && hasExpectedPropagationPolicy(b, policy):
-
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
-			case p == "/namespaces/test/secrets/mysecret-server" && m == "DELETE" && isPropagationPolicyEmpty(b):
 
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
 			default:
@@ -228,14 +220,17 @@ func TestCascadingStrategy(t *testing.T) {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
-	// DeleteOptions.PropagationPolicy shouldn't be set, when cascading strategy is server.
+	// Test that delete options shouldn't be set when cascading strategy is none.
+	// Note: Cast string to DeletionPropagation type because the policy requires pointer to DeletionPropagation.
+	nonePolicy := metav1.DeletionPropagation("")
+	policy = &nonePolicy
 	streams, _, buf, _ = genericiooptions.NewTestIOStreams()
 	cmd = NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
-	cmd.Flags().Set("cascade", "server")
+	cmd.Flags().Set("cascade", "none")
 	cmd.Flags().Set("output", "name")
-	cmd.Run(cmd, []string{"secrets/mysecret-server"})
-	if buf.String() != "secret/mysecret-server\n" {
+	cmd.Run(cmd, []string{"secrets/mysecret"})
+	if buf.String() != "secret/mysecret\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- Introduces a "none" option for the `--cascade` flag to respect server-side finalizers.
- ~Sets "server" as the default value for the `--cascade` option when the user does not explicitly specify the flag, so that server-side finalizers are respected by default.~
- Adds unit tests for the "none" option.


#### Which issue(s) this PR is related to:

Fixes #137439

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add a "none" option to the `--cascade` flag of `kubectl delete` to respect server-side propagation policy.
```

~This PR changes the default value of the `--cascade` flag from "background" to "server".
I believe the impact is low for the following reasons.~

~If a target resource has a finalizer other than "background" and the user does not specify `--cascade="background"`, the propagation policy already follows the resource's finalizer.~

~For users who do not explicitly specify the `--cascade` option, this does not introduce a behavioral change, as they typically do not rely on a specific propagation policy.~

~Without this PR, such users need to check which finalizer is set on the target resource before deleting it and explicitly specify the appropriate `--cascade` option.~

~This PR provides a safer and more convenient default by allowing users to respect the server-side propagation policy when deleting resources with kubectl.~

Based on the discussion in this PR, I decided to introduce a "none" option while keeping the default value of the `--cascade` flag unchanged.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: