### PR TITLE
DRA device taints: fix beta-enabled, alpha-disabled configurations

### DIFF
--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -29,7 +29,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	resourcealphaapi "k8s.io/api/resource/v1alpha3"
+	resourcebetaapi "k8s.io/api/resource/v1beta2"
 	schedulingapi "k8s.io/api/scheduling/v1alpha2"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -521,13 +521,13 @@ func TestAddAllEventHandlers(t *testing.T) {
 			enableDRADeviceTaints:     true,
 			enableDRADeviceTaintRules: true,
 			expectStaticInformers: map[reflect.Type]bool{
-				reflect.TypeOf(&v1.Pod{}):                           true,
-				reflect.TypeOf(&v1.Node{}):                          true,
-				reflect.TypeOf(&v1.Namespace{}):                     true,
-				reflect.TypeOf(&resourceapi.ResourceClaim{}):        true,
-				reflect.TypeOf(&resourceapi.ResourceSlice{}):        true,
-				reflect.TypeOf(&resourcealphaapi.DeviceTaintRule{}): true,
-				reflect.TypeOf(&resourceapi.DeviceClass{}):          true,
+				reflect.TypeOf(&v1.Pod{}):                          true,
+				reflect.TypeOf(&v1.Node{}):                         true,
+				reflect.TypeOf(&v1.Namespace{}):                    true,
+				reflect.TypeOf(&resourceapi.ResourceClaim{}):       true,
+				reflect.TypeOf(&resourceapi.ResourceSlice{}):       true,
+				reflect.TypeOf(&resourcebetaapi.DeviceTaintRule{}): true,
+				reflect.TypeOf(&resourceapi.DeviceClass{}):         true,
 			},
 			expectDynamicInformers: map[schema.GroupVersionResource]bool{},
 		},
@@ -658,7 +658,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 					SliceInformer:          informerFactory.Resource().V1().ResourceSlices(),
 				}
 				if opts.EnableDeviceTaintRules {
-					opts.TaintInformer = informerFactory.Resource().V1alpha3().DeviceTaintRules()
+					opts.TaintInformer = informerFactory.Resource().V1beta2().DeviceTaintRules()
 					opts.ClassInformer = informerFactory.Resource().V1().DeviceClasses()
 
 				}

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -3221,7 +3221,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 	resourceSliceTrackerOpts := resourceslicetracker.Options{
 		EnableDeviceTaintRules: true,
 		SliceInformer:          tc.informerFactory.Resource().V1().ResourceSlices(),
-		TaintInformer:          tc.informerFactory.Resource().V1alpha3().DeviceTaintRules(),
+		TaintInformer:          tc.informerFactory.Resource().V1beta2().DeviceTaintRules(),
 		ClassInformer:          tc.informerFactory.Resource().V1().DeviceClasses(),
 		KubeClient:             tc.client,
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -591,7 +591,7 @@ func newTestDRAManager(tCtx ktesting.TContext, objects ...apiruntime.Object) *dy
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	resourceSliceTrackerOpts := tracker.Options{
 		SliceInformer: informerFactory.Resource().V1().ResourceSlices(),
-		TaintInformer: informerFactory.Resource().V1alpha3().DeviceTaintRules(),
+		TaintInformer: informerFactory.Resource().V1beta2().DeviceTaintRules(),
 		ClassInformer: informerFactory.Resource().V1().DeviceClasses(),
 		KubeClient:    client,
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -336,7 +336,7 @@ func New(ctx context.Context,
 		// If device taint rules are disabled, the additional informers are not needed and
 		// the tracker turns into a simple wrapper around the slice informer.
 		if resourceSliceTrackerOpts.EnableDeviceTaintRules {
-			resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1alpha3().DeviceTaintRules()
+			resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1beta2().DeviceTaintRules()
 			resourceSliceTrackerOpts.ClassInformer = informerFactory.Resource().V1().DeviceClasses()
 		}
 		resourceSliceTracker, err = resourceslicetracker.StartTracker(ctx, resourceSliceTrackerOpts)

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -31,7 +31,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	resourceinformers "k8s.io/client-go/informers/resource/v1"
-	resourcealphainformers "k8s.io/client-go/informers/resource/v1alpha3"
+	resourcebetainformers "k8s.io/client-go/informers/resource/v1beta2"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -119,7 +119,7 @@ type Options struct {
 	EnableConsumableCapacity bool
 
 	SliceInformer resourceinformers.ResourceSliceInformer
-	TaintInformer resourcealphainformers.DeviceTaintRuleInformer
+	TaintInformer resourcebetainformers.DeviceTaintRuleInformer
 	ClassInformer resourceinformers.DeviceClassInformer
 
 	// KubeClient is used to generate Events when CEL expressions

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -553,7 +553,7 @@ func TestListPatchedResourceSlices(t *testing.T) {
 		opts := Options{
 			EnableDeviceTaintRules: true,
 			SliceInformer:          informerFactory.Resource().V1().ResourceSlices(),
-			TaintInformer:          informerFactory.Resource().V1alpha3().DeviceTaintRules(),
+			TaintInformer:          informerFactory.Resource().V1beta2().DeviceTaintRules(),
 			ClassInformer:          informerFactory.Resource().V1().DeviceClasses(),
 			KubeClient:             kubeClient,
 		}
@@ -961,7 +961,7 @@ func BenchmarkEventHandlers(b *testing.B) {
 		opts := Options{
 			EnableDeviceTaintRules: true,
 			SliceInformer:          informerFactory.Resource().V1().ResourceSlices(),
-			TaintInformer:          informerFactory.Resource().V1alpha3().DeviceTaintRules(),
+			TaintInformer:          informerFactory.Resource().V1beta2().DeviceTaintRules(),
 			ClassInformer:          informerFactory.Resource().V1().DeviceClasses(),
 			KubeClient:             kubeClient,
 		}

--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -291,7 +291,7 @@ func (op *allocResourceClaimsOp) run(tCtx ktesting.TContext) {
 		KubeClient:               tCtx.Client(),
 	}
 	if resourceSliceTrackerOpts.EnableDeviceTaintRules {
-		resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1alpha3().DeviceTaintRules()
+		resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1beta2().DeviceTaintRules()
 		resourceSliceTrackerOpts.ClassInformer = informerFactory.Resource().V1().DeviceClasses()
 	}
 	resourceSliceTracker, err := resourceslicetracker.StartTracker(tCtx, resourceSliceTrackerOpts)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

DeviceTaintRule is off by default because the corresponding v1beta2 API group is off. When enabled, the potentially still disabled v1alpha3 API version was used instead of the new v1beta2, causing the scheduler to fail while setting up informers and then not scheduling pods.

#### Which issue(s) this PR is related to:

Fixes: #137687

https://testgrid.k8s.io/sig-release-master-blocking#kind-master-beta-features

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

Was not released yet.
