### PR TITLE
[InPlacePodVerticalScaling] Make the hardcoded 'unimplemented' message from CRI a const

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -440,7 +440,7 @@ func (m *kubeGenericRuntimeManager) updatePodSandboxResources(ctx context.Contex
 		// an error with code 'Unimplemented'.
 		// This is being fixed in https://github.com/containerd/containerd/pull/13023, so this hardcoded
 		// string check can be removed once containerd 2.2 is no longer supported.
-		unimplementedMsg := "not implemented"
+		const unimplementedMsg = "not implemented"
 		if stat.Code() == codes.Unimplemented || (stat.Code() == codes.Unknown && strings.Contains(stat.Message(), unimplementedMsg)) {
 			logger.V(3).Info("updatePodSandboxResources failed: unimplemented; this call is best-effort: proceeding with resize", "sandboxID", sandboxID)
 			return nil


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Addressing a nit on https://github.com/kubernetes/kubernetes/pull/137555#discussion_r2928937094, which merged before I saw the comment

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/assign @tallclair 
