### PR TITLE
feat: add EnvVarKeyDefaultsToName feature gate (KEP-5883)

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2819,11 +2819,11 @@ func validateEnvVarValueFrom(ev core.EnvVar, fldPath *field.Path, opts PodValida
 	}
 	if ev.ValueFrom.ConfigMapKeyRef != nil {
 		numSources++
-		allErrs = append(allErrs, validateConfigMapKeySelector(ev.ValueFrom.ConfigMapKeyRef, fldPath.Child("configMapKeyRef"))...)
+		allErrs = append(allErrs, validateConfigMapKeySelector(ev.ValueFrom.ConfigMapKeyRef, ev.Name, fldPath.Child("configMapKeyRef"))...)
 	}
 	if ev.ValueFrom.SecretKeyRef != nil {
 		numSources++
-		allErrs = append(allErrs, validateSecretKeySelector(ev.ValueFrom.SecretKeyRef, fldPath.Child("secretKeyRef"))...)
+		allErrs = append(allErrs, validateSecretKeySelector(ev.ValueFrom.SecretKeyRef, ev.Name, fldPath.Child("secretKeyRef"))...)
 	}
 
 	if ev.ValueFrom.FileKeyRef != nil {
@@ -3009,7 +3009,7 @@ func validateContainerResourceDivisor(rName string, divisor resource.Quantity, f
 	return allErrs
 }
 
-func validateConfigMapKeySelector(s *core.ConfigMapKeySelector, fldPath *field.Path) field.ErrorList {
+func validateConfigMapKeySelector(s *core.ConfigMapKeySelector, envVarName string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	nameFn := ValidateNameFunc(ValidateSecretName)
@@ -3017,7 +3017,16 @@ func validateConfigMapKeySelector(s *core.ConfigMapKeySelector, fldPath *field.P
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), s.Name, msg))
 	}
 	if len(s.Key) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("key"), ""))
+		if utilfeature.DefaultFeatureGate.Enabled(features.EnvVarKeyDefaultsToName) {
+			// key is omitted; it will default to envVarName at runtime.
+			// Validate that the env var name is also a valid ConfigMap key.
+			for _, msg := range validation.IsConfigMapKey(envVarName) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("key"), envVarName,
+					"may not be omitted: env var name is not a valid ConfigMap key: "+msg))
+			}
+		} else {
+			allErrs = append(allErrs, field.Required(fldPath.Child("key"), ""))
+		}
 	} else {
 		for _, msg := range validation.IsConfigMapKey(s.Key) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("key"), s.Key, msg))
@@ -3027,7 +3036,7 @@ func validateConfigMapKeySelector(s *core.ConfigMapKeySelector, fldPath *field.P
 	return allErrs
 }
 
-func validateSecretKeySelector(s *core.SecretKeySelector, fldPath *field.Path) field.ErrorList {
+func validateSecretKeySelector(s *core.SecretKeySelector, envVarName string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	nameFn := ValidateNameFunc(ValidateSecretName)
@@ -3035,7 +3044,16 @@ func validateSecretKeySelector(s *core.SecretKeySelector, fldPath *field.Path) f
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), s.Name, msg))
 	}
 	if len(s.Key) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("key"), ""))
+		if utilfeature.DefaultFeatureGate.Enabled(features.EnvVarKeyDefaultsToName) {
+			// key is omitted; it will default to envVarName at runtime.
+			// Validate that the env var name is also a valid ConfigMap key.
+			for _, msg := range validation.IsConfigMapKey(envVarName) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("key"), envVarName,
+					"may not be omitted: env var name is not a valid Secret key: "+msg))
+			}
+		} else {
+			allErrs = append(allErrs, field.Required(fldPath.Child("key"), ""))
+		}
 	} else {
 		for _, msg := range validation.IsConfigMapKey(s.Key) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("key"), s.Key, msg))

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -30599,3 +30599,143 @@ func TestValidatePodSchedulingGroup(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateEnvVarKeyDefaultsToName(t *testing.T) {
+	testCases := []struct {
+		name           string
+		featureEnabled bool
+		envVar         core.EnvVar
+		expectError    bool
+		errorField     string
+	}{
+		{
+			name:           "configMapKeyRef: empty key accepted when gate is on",
+			featureEnabled: true,
+			envVar: core.EnvVar{
+				Name: "LOG_LEVEL",
+				ValueFrom: &core.EnvVarSource{
+					ConfigMapKeyRef: &core.ConfigMapKeySelector{
+						LocalObjectReference: core.LocalObjectReference{Name: "app-config"},
+						Key:                  "",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:           "secretKeyRef: empty key accepted when gate is on",
+			featureEnabled: true,
+			envVar: core.EnvVar{
+				Name: "DB_PASSWORD",
+				ValueFrom: &core.EnvVarSource{
+					SecretKeyRef: &core.SecretKeySelector{
+						LocalObjectReference: core.LocalObjectReference{Name: "db-secret"},
+						Key:                  "",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:           "configMapKeyRef: empty key rejected when gate is off",
+			featureEnabled: false,
+			envVar: core.EnvVar{
+				Name: "LOG_LEVEL",
+				ValueFrom: &core.EnvVarSource{
+					ConfigMapKeyRef: &core.ConfigMapKeySelector{
+						LocalObjectReference: core.LocalObjectReference{Name: "app-config"},
+						Key:                  "",
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "valueFrom.configMapKeyRef.key",
+		},
+		{
+			name:           "secretKeyRef: empty key rejected when gate is off",
+			featureEnabled: false,
+			envVar: core.EnvVar{
+				Name: "DB_PASSWORD",
+				ValueFrom: &core.EnvVarSource{
+					SecretKeyRef: &core.SecretKeySelector{
+						LocalObjectReference: core.LocalObjectReference{Name: "db-secret"},
+						Key:                  "",
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "valueFrom.secretKeyRef.key",
+		},
+		{
+			name:           "configMapKeyRef: env var name that is invalid as a ConfigMap key is rejected when gate is on",
+			featureEnabled: true,
+			envVar: core.EnvVar{
+				Name: "INVALID=NAME",
+				ValueFrom: &core.EnvVarSource{
+					ConfigMapKeyRef: &core.ConfigMapKeySelector{
+						LocalObjectReference: core.LocalObjectReference{Name: "app-config"},
+						Key:                  "",
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "valueFrom.configMapKeyRef.key",
+		},
+		{
+			name:           "explicit key is always accepted when gate is on",
+			featureEnabled: true,
+			envVar: core.EnvVar{
+				Name: "MY_VAR",
+				ValueFrom: &core.EnvVarSource{
+					ConfigMapKeyRef: &core.ConfigMapKeySelector{
+						LocalObjectReference: core.LocalObjectReference{Name: "app-config"},
+						Key:                  "some-key",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:           "explicit key is always accepted when gate is off",
+			featureEnabled: false,
+			envVar: core.EnvVar{
+				Name: "MY_VAR",
+				ValueFrom: &core.EnvVarSource{
+					SecretKeyRef: &core.SecretKeySelector{
+						LocalObjectReference: core.LocalObjectReference{Name: "db-secret"},
+						Key:                  "explicit-key",
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EnvVarKeyDefaultsToName, tc.featureEnabled)
+
+			opts := PodValidationOptions{}
+			errs := validateEnvVarValueFrom(tc.envVar, field.NewPath("valueFrom"), opts)
+
+			if tc.expectError && len(errs) == 0 {
+				t.Errorf("expected validation error for field %q, got none", tc.errorField)
+			}
+			if !tc.expectError && len(errs) > 0 {
+				t.Errorf("expected no validation errors, got: %v", errs)
+			}
+			if tc.expectError && tc.errorField != "" && len(errs) > 0 {
+				found := false
+				for _, e := range errs {
+					if e.Field == tc.errorField {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected error on field %q, got errors on: %v", tc.errorField, errs)
+				}
+			}
+		})
+	}
+}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -302,6 +302,13 @@ const (
 	// from the specified file in the emptyDir volume, without mounting the file.
 	EnvFiles featuregate.Feature = "EnvFiles"
 
+	// owner: @dap0am
+	// kep: http://kep.k8s.io/5883
+	//
+	// Allow the `key` field in `configMapKeyRef` and `secretKeyRef` to be
+	// omitted, defaulting to the enclosing env var's `name` at runtime.
+	EnvVarKeyDefaultsToName featuregate.Feature = "EnvVarKeyDefaultsToName"
+
 	// owner: @harche
 	// kep: http://kep.k8s.io/3386
 	//
@@ -1333,6 +1340,9 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
+	EnvVarKeyDefaultsToName: {
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
+	},
 	EventedPLEG: {
 		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
 	},
@@ -2304,6 +2314,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	DynamicResourceAllocation: {},
 
 	EnvFiles: {},
+
+	EnvVarKeyDefaultsToName: {},
 
 	EventedPLEG: {},
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -869,6 +869,9 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 				cm := envVar.ValueFrom.ConfigMapKeyRef
 				name := cm.Name
 				key := cm.Key
+				if key == "" && utilfeature.DefaultFeatureGate.Enabled(features.EnvVarKeyDefaultsToName) {
+					key = envVar.Name
+				}
 				optional := cm.Optional != nil && *cm.Optional
 				configMap, ok := configMaps[name]
 				if !ok {
@@ -896,6 +899,9 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 				s := envVar.ValueFrom.SecretKeyRef
 				name := s.Name
 				key := s.Key
+				if key == "" && utilfeature.DefaultFeatureGate.Enabled(features.EnvVarKeyDefaultsToName) {
+					key = envVar.Name
+				}
 				optional := s.Optional != nil && *s.Optional
 				secret, ok := secrets[name]
 				if !ok {

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -8332,3 +8332,214 @@ func TestGeneratePodHostNameAndDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeEnvironmentVariablesEnvVarKeyDefaultsToName(t *testing.T) {
+	testCases := []struct {
+		name           string
+		featureEnabled bool
+		envVars        []v1.EnvVar
+		configMaps     []*v1.ConfigMap
+		secrets        []*v1.Secret
+		expectedEnvs   []kubecontainer.EnvVar
+		expectedErrStr string
+	}{
+		{
+			name:           "configMapKeyRef: omitted key defaults to env var name when gate is on",
+			featureEnabled: true,
+			envVars: []v1.EnvVar{
+				{
+					Name: "LOG_LEVEL",
+					ValueFrom: &v1.EnvVarSource{
+						ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "app-config"},
+						},
+					},
+				},
+			},
+			configMaps: []*v1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "app-config", Namespace: "test"},
+					Data:       map[string]string{"LOG_LEVEL": "debug"},
+				},
+			},
+			expectedEnvs: []kubecontainer.EnvVar{
+				{Name: "LOG_LEVEL", Value: "debug"},
+			},
+		},
+		{
+			name:           "secretKeyRef: omitted key defaults to env var name when gate is on",
+			featureEnabled: true,
+			envVars: []v1.EnvVar{
+				{
+					Name: "DB_PASSWORD",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "db-secret"},
+						},
+					},
+				},
+			},
+			secrets: []*v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "db-secret", Namespace: "test"},
+					Data:       map[string][]byte{"DB_PASSWORD": []byte("s3cr3t")},
+				},
+			},
+			expectedEnvs: []kubecontainer.EnvVar{
+				{Name: "DB_PASSWORD", Value: "s3cr3t"},
+			},
+		},
+		{
+			name:           "configMapKeyRef: omitted key with gate off uses empty key (key not found)",
+			featureEnabled: false,
+			envVars: []v1.EnvVar{
+				{
+					Name: "LOG_LEVEL",
+					ValueFrom: &v1.EnvVarSource{
+						ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "app-config"},
+						},
+					},
+				},
+			},
+			configMaps: []*v1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "app-config", Namespace: "test"},
+					Data:       map[string]string{"LOG_LEVEL": "debug"},
+				},
+			},
+			expectedErrStr: "couldn't find key",
+		},
+		{
+			name:           "secretKeyRef: omitted key with gate off uses empty key (key not found)",
+			featureEnabled: false,
+			envVars: []v1.EnvVar{
+				{
+					Name: "DB_PASSWORD",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "db-secret"},
+						},
+					},
+				},
+			},
+			secrets: []*v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "db-secret", Namespace: "test"},
+					Data:       map[string][]byte{"DB_PASSWORD": []byte("s3cr3t")},
+				},
+			},
+			expectedErrStr: "couldn't find key",
+		},
+		{
+			name:           "explicit key is unaffected when gate is on",
+			featureEnabled: true,
+			envVars: []v1.EnvVar{
+				{
+					Name: "MY_VAR",
+					ValueFrom: &v1.EnvVarSource{
+						ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "app-config"},
+							Key:                  "different-key",
+						},
+					},
+				},
+			},
+			configMaps: []*v1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "app-config", Namespace: "test"},
+					Data:       map[string]string{"different-key": "the-value"},
+				},
+			},
+			expectedEnvs: []kubecontainer.EnvVar{
+				{Name: "MY_VAR", Value: "the-value"},
+			},
+		},
+		{
+			name:           "explicit key is unaffected when gate is off",
+			featureEnabled: false,
+			envVars: []v1.EnvVar{
+				{
+					Name: "MY_VAR",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{Name: "db-secret"},
+							Key:                  "explicit-key",
+						},
+					},
+				},
+			},
+			secrets: []*v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "db-secret", Namespace: "test"},
+					Data:       map[string][]byte{"explicit-key": []byte("value123")},
+				},
+			},
+			expectedEnvs: []kubecontainer.EnvVar{
+				{Name: "MY_VAR", Value: "value123"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EnvVarKeyDefaultsToName, tc.featureEnabled)
+
+			testKubelet := newTestKubelet(t, false)
+			defer testKubelet.Cleanup()
+			kl := testKubelet.kubelet
+
+			for _, cm := range tc.configMaps {
+				cmCopy := cm
+				testKubelet.fakeKubeClient.AddReactor("get", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+					return true, cmCopy, nil
+				})
+			}
+			for _, s := range tc.secrets {
+				sCopy := s
+				testKubelet.fakeKubeClient.AddReactor("get", "secrets", func(action core.Action) (bool, runtime.Object, error) {
+					return true, sCopy, nil
+				})
+			}
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test",
+				},
+				Spec: v1.PodSpec{
+					EnableServiceLinks: ptr.To(false),
+					Containers: []v1.Container{
+						{
+							Name: "test-container",
+							Env:  tc.envVars,
+						},
+					},
+				},
+			}
+
+			result, err := kl.makeEnvironmentVariables(pod, &pod.Spec.Containers[0], "192.168.0.1", []string{"192.168.0.1"}, kubecontainer.VolumeMap{})
+			if tc.expectedErrStr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.expectedErrStr)
+				}
+				if !strings.Contains(err.Error(), tc.expectedErrStr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.expectedErrStr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result) != len(tc.expectedEnvs) {
+				t.Fatalf("expected %d env vars, got %d: %v", len(tc.expectedEnvs), len(result), result)
+			}
+			for i, expected := range tc.expectedEnvs {
+				if result[i].Name != expected.Name || result[i].Value != expected.Value {
+					t.Errorf("env[%d]: expected {%q, %q}, got {%q, %q}",
+						i, expected.Name, expected.Value, result[i].Name, result[i].Value)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Implements [KEP-5883](https://github.com/kubernetes/enhancements/pull/5955): when the `EnvVarKeyDefaultsToName` feature gate is enabled, the `key` field in `configMapKeyRef` and `secretKeyRef` may be omitted. The kubelet defaults the lookup key to the enclosing `env[*].name` at runtime.

This eliminates boilerplate in the common case where the env var name and the ConfigMap/Secret key are identical:

```yaml
# Before
env:
  - name: DB_PASSWORD
    valueFrom:
      secretKeyRef:
        name: my-secret
        key: DB_PASSWORD  # redundant when identical to name

# After (with EnvVarKeyDefaultsToName gate enabled)
env:
  - name: DB_PASSWORD
    valueFrom:
      secretKeyRef:
        name: my-secret
        # key omitted — defaults to "DB_PASSWORD"
```

## Changes

- **`pkg/features/kube_features.go`**: Register `EnvVarKeyDefaultsToName` feature gate (alpha, v1.35, default: `false`)
- **`pkg/apis/core/validation/validation.go`**: Allow empty `key` in `validateConfigMapKeySelector` and `validateSecretKeySelector` when gate is on; validate that `env[*].name` is also a valid ConfigMap/Secret key in that case
- **`pkg/kubelet/kubelet_pods.go`**: In `makeEnvironmentVariables()`, default empty `key` to `envVar.Name` for `configMapKeyRef` and `secretKeyRef` when gate is on
- **Tests**: 7 validation unit tests + 6 kubelet unit tests covering gate-on/off, invalid env name, and explicit key scenarios

## Related

- Upstream issue: https://github.com/kubernetes/kubernetes/issues/132195
- KEP PR: https://github.com/kubernetes/enhancements/pull/5955

/sig node
/sig api-machinery
/kind feature
/area kubelet