### PR TITLE
KEP-2570: Add tiered memory protection, metrics, rollback fix, and E2E tests for MemoryQoS

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -63,6 +63,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/flagz"
@@ -120,6 +121,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/watchdog"
 	utilfs "k8s.io/kubernetes/pkg/util/filesystem"
 	"k8s.io/kubernetes/pkg/util/flock"
+	utilkernel "k8s.io/kubernetes/pkg/util/kernel"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/rlimit"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
@@ -642,10 +644,20 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 		return err
 	}
 
-	// Warn if MemoryQoS enabled with cgroups v1
-	if utilfeature.DefaultFeatureGate.Enabled(features.MemoryQoS) &&
-		!kubeletutil.IsCgroup2UnifiedMode() {
-		logger.Info("Warning: MemoryQoS feature only works with cgroups v2 on Linux, but enabled with cgroups v1")
+	// Warn about MemoryQoS compatibility issues
+	if utilfeature.DefaultFeatureGate.Enabled(features.MemoryQoS) {
+		if !kubeletutil.IsCgroup2UnifiedMode() {
+			logger.Info("Warning: MemoryQoS feature only works with cgroups v2 on Linux, but enabled with cgroups v1")
+		} else {
+			kernelVersion, err := utilkernel.GetVersion()
+			if err != nil {
+				logger.Error(err, "Failed to detect kernel version for MemoryQoS compatibility check")
+			} else if kernelVersion.LessThan(utilversion.MustParseGeneric(utilkernel.MemoryQoSMinKernelVersion)) {
+				logger.Info("Warning: MemoryQoS memory.high throttling may cause process livelock on older kernels",
+					"currentKernel", kernelVersion,
+					"minimumKernel", utilkernel.MemoryQoSMinKernelVersion)
+			}
+		}
 	}
 	// Obtain Kubelet Lock File
 	if s.ExitOnLockContention && s.LockFilePath == "" {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -72000,7 +72000,7 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 					},
 					"memoryReservationPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MemoryReservationPolicy controls how the kubelet applies cgroup v2 memory protection. \"None\" (default): The kubelet does not set memory.min for containers and pods, ensuring no hard memory is locked by the kernel. \"HardReservation\": The kubelet sets the cgroup v2 memory.min value based on pod and container memory requests. This ensures the requested memory is never reclaimed by the kernel, but may trigger an OOM if the reservation cannot be satisfied. See https://kep.k8s.io/2570 for more details. Default: None",
+							Description: "MemoryReservationPolicy controls how the kubelet applies cgroup v2 memory protection. \"None\" (default): The kubelet does not set memory.min for containers and pods, ensuring no hard memory is locked by the kernel. \"TieredReservation\": The kubelet sets cgroup v2 memory.min for Guaranteed pods and memory.low for Burstable pods based on memory requests. Guaranteed memory is never reclaimed by the kernel; Burstable memory is preferentially retained but may be reclaimed under extreme pressure. See https://kep.k8s.io/2570 for more details. Default: None",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -506,8 +506,8 @@ type KubeletConfiguration struct {
 	// MemoryReservationPolicy controls how the kubelet applies cgroup v2 memory protection.
 	// "None" (default): The kubelet does not set memory.min for containers and pods,
 	// ensuring no hard memory is locked by the kernel.
-	// "HardReservation": The kubelet sets the cgroup v2 memory.min value based on pod and container memory requests.
-	// This ensures the requested memory is never reclaimed by the kernel, but may trigger an OOM if the reservation cannot be satisfied.
+	// "TieredReservation": The kubelet sets cgroup v2 memory.min for Guaranteed pods and memory.low for Burstable pods based on memory requests.
+	// Guaranteed memory is never reclaimed by the kernel; Burstable memory is preferentially retained but may be reclaimed under extreme pressure.
 	// See https://kep.k8s.io/2570 for more details.
 	// Default: None
 	// +featureGate=MemoryQoS
@@ -869,8 +869,9 @@ const (
 	// NoneMemoryReservationPolicy disables memory.min protection for containers and pods.
 	// This is the default to maintain node stability by preventing "locked" memory.
 	NoneMemoryReservationPolicy MemoryReservationPolicy = "None"
-	// HardReservationMemoryReservationPolicy enables memory.min for containers and pods.
-	HardReservationMemoryReservationPolicy MemoryReservationPolicy = "HardReservation"
+	// TieredReservationMemoryReservationPolicy enables tiered memory protection:
+	// memory.min for Guaranteed pods, memory.low for Burstable pods.
+	TieredReservationMemoryReservationPolicy MemoryReservationPolicy = "TieredReservation"
 )
 
 // ImagePullIntent is a record of the kubelet attempting to pull an image.

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -352,14 +352,14 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration, featur
 	}
 
 	if !localFeatureGate.Enabled(features.MemoryQoS) &&
-		kc.MemoryReservationPolicy == kubeletconfig.HardReservationMemoryReservationPolicy {
+		kc.MemoryReservationPolicy == kubeletconfig.TieredReservationMemoryReservationPolicy {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: memoryReservationPolicy %q requires MemoryQoS feature gate to be enabled",
 			kc.MemoryReservationPolicy))
 	}
 	switch kc.MemoryReservationPolicy {
-	case kubeletconfig.NoneMemoryReservationPolicy, kubeletconfig.HardReservationMemoryReservationPolicy:
+	case kubeletconfig.NoneMemoryReservationPolicy, kubeletconfig.TieredReservationMemoryReservationPolicy:
 	default:
-		allErrors = append(allErrors, fmt.Errorf("invalid configuration: option %q specified for memoryReservationPolicy. Valid options are %q or %q", kc.MemoryReservationPolicy, kubeletconfig.NoneMemoryReservationPolicy, kubeletconfig.HardReservationMemoryReservationPolicy))
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: option %q specified for memoryReservationPolicy. Valid options are %q or %q", kc.MemoryReservationPolicy, kubeletconfig.NoneMemoryReservationPolicy, kubeletconfig.TieredReservationMemoryReservationPolicy))
 	}
 
 	if kc.ContainerRuntimeEndpoint == "" {

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -568,17 +568,17 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 			name: "MemoryReservationPolicy requires MemoryQoS",
 			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
 				conf.FeatureGates = map[string]bool{"MemoryQoS": false}
-				conf.MemoryReservationPolicy = kubeletconfig.HardReservationMemoryReservationPolicy
+				conf.MemoryReservationPolicy = kubeletconfig.TieredReservationMemoryReservationPolicy
 				return conf
 			},
-			errMsg: "invalid configuration: memoryReservationPolicy \"HardReservation\" requires MemoryQoS feature gate to be enabled",
+			errMsg: "invalid configuration: memoryReservationPolicy \"TieredReservation\" requires MemoryQoS feature gate to be enabled",
 		}, {
 			name: "invalid MemoryReservationPolicy",
 			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
 				conf.MemoryReservationPolicy = "invalid"
 				return conf
 			},
-			errMsg: "invalid configuration: option \"invalid\" specified for memoryReservationPolicy. Valid options are \"None\" or \"HardReservation\"",
+			errMsg: "invalid configuration: option \"invalid\" specified for memoryReservationPolicy. Valid options are \"None\" or \"TieredReservation\"",
 		}, {
 			name: "invalid Taint.TimeAdded",
 			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -42,6 +42,8 @@ const (
 	systemdSuffix string = ".slice"
 	// Cgroup2MemoryMin is memory.min for cgroup v2
 	Cgroup2MemoryMin string = "memory.min"
+	// Cgroup2MemoryLow is memory.low for cgroup v2
+	Cgroup2MemoryLow string = "memory.low"
 	// Cgroup2MemoryHigh is memory.high for cgroup v2
 	Cgroup2MemoryHigh      string = "memory.high"
 	Cgroup2MaxCpuLimit     string = "max"

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -208,7 +208,7 @@ func ResourceConfigForPod(allocatedPod *v1.Pod, enforceCPULimits bool, cpuPeriod
 	}
 	result.HugePageLimit = hugePageLimits
 
-	if enforceMemoryQoS && memoryReservationPolicy == kubeletconfig.HardReservationMemoryReservationPolicy {
+	if enforceMemoryQoS && memoryReservationPolicy == kubeletconfig.TieredReservationMemoryReservationPolicy {
 		memoryRequest := int64(0)
 		if request, found := reqs[v1.ResourceMemory]; found {
 			memoryRequest = request.Value()

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -209,13 +209,19 @@ func ResourceConfigForPod(allocatedPod *v1.Pod, enforceCPULimits bool, cpuPeriod
 	result.HugePageLimit = hugePageLimits
 
 	if enforceMemoryQoS && memoryReservationPolicy == kubeletconfig.HardReservationMemoryReservationPolicy {
-		memoryMin := int64(0)
+		memoryRequest := int64(0)
 		if request, found := reqs[v1.ResourceMemory]; found {
-			memoryMin = request.Value()
+			memoryRequest = request.Value()
 		}
-		if memoryMin > 0 {
+		if memoryRequest > 0 {
+			// Guaranteed pods get memory.min (hard protection, kernel never reclaims).
+			// Burstable pods get memory.low (soft protection, kernel prefers not to reclaim).
+			cgroupKey := Cgroup2MemoryLow
+			if qosClass == v1.PodQOSGuaranteed {
+				cgroupKey = Cgroup2MemoryMin
+			}
 			result.Unified = map[string]string{
-				Cgroup2MemoryMin: strconv.FormatInt(memoryMin, 10),
+				cgroupKey: strconv.FormatInt(memoryRequest, 10),
 			}
 		}
 	}

--- a/pkg/kubelet/cm/helpers_linux_test.go
+++ b/pkg/kubelet/cm/helpers_linux_test.go
@@ -850,7 +850,7 @@ func TestResourceConfigForPodWithEnforceMemoryQoS(t *testing.T) {
 
 	for testName, testCase := range testCases {
 
-		actual := ResourceConfigForPod(testCase.pod, testCase.enforceCPULimits, testCase.quotaPeriod, true, kubeletconfig.HardReservationMemoryReservationPolicy)
+		actual := ResourceConfigForPod(testCase.pod, testCase.enforceCPULimits, testCase.quotaPeriod, true, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 		if !reflect.DeepEqual(actual.Unified, testCase.expected.Unified) {
 			t.Errorf("unexpected result, test: %v, unified not as expected", testName)

--- a/pkg/kubelet/cm/helpers_linux_test.go
+++ b/pkg/kubelet/cm/helpers_linux_test.go
@@ -698,7 +698,7 @@ func TestResourceConfigForPodWithEnforceMemoryQoS(t *testing.T) {
 			},
 			enforceCPULimits: true,
 			quotaPeriod:      defaultQuotaPeriod,
-			expected:         &ResourceConfig{CPUShares: &burstableShares, Unified: map[string]string{"memory.min": "104857600"}},
+			expected:         &ResourceConfig{CPUShares: &burstableShares, Unified: map[string]string{"memory.low": "104857600"}},
 		},
 		"burstable-with-limits": {
 			pod: &v1.Pod{
@@ -712,7 +712,7 @@ func TestResourceConfigForPodWithEnforceMemoryQoS(t *testing.T) {
 			},
 			enforceCPULimits: true,
 			quotaPeriod:      defaultQuotaPeriod,
-			expected:         &ResourceConfig{CPUShares: &burstableShares, CPUQuota: &burstableQuota, CPUPeriod: &defaultQuotaPeriod, Memory: &burstableMemory, Unified: map[string]string{"memory.min": "104857600"}},
+			expected:         &ResourceConfig{CPUShares: &burstableShares, CPUQuota: &burstableQuota, CPUPeriod: &defaultQuotaPeriod, Memory: &burstableMemory, Unified: map[string]string{"memory.low": "104857600"}},
 		},
 		"burstable-with-limits-no-cpu-enforcement": {
 			pod: &v1.Pod{
@@ -726,7 +726,7 @@ func TestResourceConfigForPodWithEnforceMemoryQoS(t *testing.T) {
 			},
 			enforceCPULimits: false,
 			quotaPeriod:      defaultQuotaPeriod,
-			expected:         &ResourceConfig{CPUShares: &burstableShares, CPUQuota: &cpuNoLimit, CPUPeriod: &defaultQuotaPeriod, Memory: &burstableMemory, Unified: map[string]string{"memory.min": "104857600"}},
+			expected:         &ResourceConfig{CPUShares: &burstableShares, CPUQuota: &cpuNoLimit, CPUPeriod: &defaultQuotaPeriod, Memory: &burstableMemory, Unified: map[string]string{"memory.low": "104857600"}},
 		},
 		"burstable-partial-limits": {
 			pod: &v1.Pod{
@@ -743,7 +743,7 @@ func TestResourceConfigForPodWithEnforceMemoryQoS(t *testing.T) {
 			},
 			enforceCPULimits: true,
 			quotaPeriod:      defaultQuotaPeriod,
-			expected:         &ResourceConfig{CPUShares: &burstablePartialShares, Unified: map[string]string{"memory.min": "209715200"}},
+			expected:         &ResourceConfig{CPUShares: &burstablePartialShares, Unified: map[string]string{"memory.low": "209715200"}},
 		},
 		"burstable-with-limits-with-tuned-quota": {
 			pod: &v1.Pod{
@@ -757,7 +757,7 @@ func TestResourceConfigForPodWithEnforceMemoryQoS(t *testing.T) {
 			},
 			enforceCPULimits: true,
 			quotaPeriod:      tunedQuotaPeriod,
-			expected:         &ResourceConfig{CPUShares: &burstableShares, CPUQuota: &burstableQuota, CPUPeriod: &tunedQuotaPeriod, Memory: &burstableMemory, Unified: map[string]string{"memory.min": "104857600"}},
+			expected:         &ResourceConfig{CPUShares: &burstableShares, CPUQuota: &burstableQuota, CPUPeriod: &tunedQuotaPeriod, Memory: &burstableMemory, Unified: map[string]string{"memory.low": "104857600"}},
 		},
 		"burstable-with-limits-no-cpu-enforcement-with-tuned-quota": {
 			pod: &v1.Pod{
@@ -771,7 +771,7 @@ func TestResourceConfigForPodWithEnforceMemoryQoS(t *testing.T) {
 			},
 			enforceCPULimits: false,
 			quotaPeriod:      tunedQuotaPeriod,
-			expected:         &ResourceConfig{CPUShares: &burstableShares, CPUQuota: &cpuNoLimit, CPUPeriod: &tunedQuotaPeriod, Memory: &burstableMemory, Unified: map[string]string{"memory.min": "104857600"}},
+			expected:         &ResourceConfig{CPUShares: &burstableShares, CPUQuota: &cpuNoLimit, CPUPeriod: &tunedQuotaPeriod, Memory: &burstableMemory, Unified: map[string]string{"memory.low": "104857600"}},
 		},
 		"burstable-partial-limits-with-tuned-quota": {
 			pod: &v1.Pod{
@@ -788,7 +788,7 @@ func TestResourceConfigForPodWithEnforceMemoryQoS(t *testing.T) {
 			},
 			enforceCPULimits: true,
 			quotaPeriod:      tunedQuotaPeriod,
-			expected:         &ResourceConfig{CPUShares: &burstablePartialShares, Unified: map[string]string{"memory.min": "209715200"}},
+			expected:         &ResourceConfig{CPUShares: &burstablePartialShares, Unified: map[string]string{"memory.low": "209715200"}},
 		},
 		"guaranteed": {
 			pod: &v1.Pod{

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -300,7 +300,7 @@ func (m *qosContainerManagerImpl) setMemoryQoS(logger klog.Logger, configs map[v
 		logger.V(4).Info("MemoryQoS config for qos", "qos", qos, "key", key, "value", value)
 	}
 
-	if m.memoryReservationPolicy != kubeletconfig.HardReservationMemoryReservationPolicy {
+	if m.memoryReservationPolicy != kubeletconfig.TieredReservationMemoryReservationPolicy {
 		setUnified(v1.PodQOSGuaranteed, Cgroup2MemoryMin, 0)
 		setUnified(v1.PodQOSBurstable, Cgroup2MemoryLow, 0)
 		kubeletmetrics.MemoryQoSNodeMemoryMinBytes.Set(0)
@@ -331,7 +331,7 @@ func (m *qosContainerManagerImpl) setMemoryQoS(logger klog.Logger, configs map[v
 }
 
 // reconcilePodMemoryProtection clears stale memory.min and memory.low on pod-level cgroups
-// when MemoryQoS is disabled or memoryReservationPolicy is not HardReservation.
+// when MemoryQoS is disabled or memoryReservationPolicy is not TieredReservation.
 func (m *qosContainerManagerImpl) reconcilePodMemoryProtection(logger klog.Logger) {
 	pods := m.activePods()
 	for _, pod := range pods {

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -38,6 +38,7 @@ import (
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
 )
 
 const (
@@ -288,34 +289,76 @@ func (m *qosContainerManagerImpl) retrySetMemoryReserve(logger klog.Logger, conf
 	}
 }
 
-// setMemoryQoS sums the memory requests of all pods in the Burstable class,
-// and set the sum memory as the memory.min in the Unified field of CgroupConfig.
+// setMemoryQoS sets cgroup v2 memory protection for QoS-class cgroups.
+// Guaranteed pods get memory.min (hard protection), Burstable pods get memory.low (soft protection).
 func (m *qosContainerManagerImpl) setMemoryQoS(logger klog.Logger, configs map[v1.PodQOSClass]*CgroupConfig) {
-	setMemoryMin := func(qos v1.PodQOSClass, memoryMin int64) {
+	setUnified := func(qos v1.PodQOSClass, key string, value int64) {
 		if configs[qos].ResourceParameters.Unified == nil {
 			configs[qos].ResourceParameters.Unified = make(map[string]string)
 		}
-		configs[qos].ResourceParameters.Unified[Cgroup2MemoryMin] = strconv.FormatInt(memoryMin, 10)
-		logger.V(4).Info("MemoryQoS config for qos", "qos", qos, "memoryMin", memoryMin)
+		configs[qos].ResourceParameters.Unified[key] = strconv.FormatInt(value, 10)
+		logger.V(4).Info("MemoryQoS config for qos", "qos", qos, "key", key, "value", value)
 	}
 
 	if m.memoryReservationPolicy != kubeletconfig.HardReservationMemoryReservationPolicy {
-		setMemoryMin(v1.PodQOSGuaranteed, 0)
-		setMemoryMin(v1.PodQOSBurstable, 0)
+		setUnified(v1.PodQOSGuaranteed, Cgroup2MemoryMin, 0)
+		setUnified(v1.PodQOSBurstable, Cgroup2MemoryLow, 0)
+		kubeletmetrics.MemoryQoSNodeMemoryMinBytes.Set(0)
+		kubeletmetrics.MemoryQoSNodeMemoryLowBytes.Set(0)
+		// Clear per-pod memory protection only when MemoryQoS feature gate is
+		// enabled but policy is None (rollback scenario). When the gate is off,
+		// pods never had protection set, so there's nothing to reconcile.
+		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) {
+			m.reconcilePodMemoryProtection(logger)
+		}
 		return
 	}
 
 	qosMemoryRequests := m.getQoSMemoryRequests()
 
-	// Calculate the memory.min:
-	// for burstable(/kubepods/burstable): sum of all burstable pods
-	// for guaranteed(/kubepods): sum of all guaranteed and burstable pods
-	burstableMin := qosMemoryRequests[v1.PodQOSBurstable]
-	guaranteedMin := qosMemoryRequests[v1.PodQOSGuaranteed] + burstableMin
+	burstableRequests := qosMemoryRequests[v1.PodQOSBurstable]
+	guaranteedRequests := qosMemoryRequests[v1.PodQOSGuaranteed]
 
-	// Always set memory.min, even when it is 0, because omitted Unified keys are not cleared by the cgroup manager.
-	setMemoryMin(v1.PodQOSBurstable, burstableMin)
-	setMemoryMin(v1.PodQOSGuaranteed, guaranteedMin)
+	kubeletmetrics.MemoryQoSNodeMemoryMinBytes.Set(float64(guaranteedRequests))
+	kubeletmetrics.MemoryQoSNodeMemoryLowBytes.Set(float64(burstableRequests))
+
+	// Guaranteed QoS class: memory.min = sum of guaranteed + burstable requests
+	// (parent must cover children's protection for it to be effective)
+	setUnified(v1.PodQOSGuaranteed, Cgroup2MemoryMin, guaranteedRequests+burstableRequests)
+
+	// Burstable QoS class: memory.low = sum of burstable pod requests
+	setUnified(v1.PodQOSBurstable, Cgroup2MemoryLow, burstableRequests)
+}
+
+// reconcilePodMemoryProtection clears stale memory.min and memory.low on pod-level cgroups
+// when MemoryQoS is disabled or memoryReservationPolicy is not HardReservation.
+func (m *qosContainerManagerImpl) reconcilePodMemoryProtection(logger klog.Logger) {
+	pods := m.activePods()
+	for _, pod := range pods {
+		podQOS := v1qos.GetPodQOS(pod)
+		var parentContainer CgroupName
+		switch podQOS {
+		case v1.PodQOSGuaranteed:
+			parentContainer = m.qosContainersInfo.Guaranteed
+		case v1.PodQOSBurstable:
+			parentContainer = m.qosContainersInfo.Burstable
+		case v1.PodQOSBestEffort:
+			parentContainer = m.qosContainersInfo.BestEffort
+		}
+		podCgroupName := NewCgroupName(parentContainer, GetPodCgroupNameSuffix(pod.UID))
+		podConfig := &CgroupConfig{
+			Name: podCgroupName,
+			ResourceParameters: &ResourceConfig{
+				Unified: map[string]string{
+					Cgroup2MemoryMin: "0",
+					Cgroup2MemoryLow: "0",
+				},
+			},
+		}
+		if err := m.cgroupManager.Update(logger, podConfig); err != nil {
+			logger.V(4).Info("Failed to reconcile pod memory protection", "pod", klog.KObj(pod), "err", err)
+		}
+	}
 }
 
 func (m *qosContainerManagerImpl) UpdateCgroups(logger logr.Logger) error {
@@ -347,9 +390,9 @@ func (m *qosContainerManagerImpl) UpdateCgroups(logger logr.Logger) error {
 		return err
 	}
 
-	// update the qos level cgrougs v2 settings of memory qos if feature enabled
-	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) &&
-		libcontainercgroups.IsCgroup2UnifiedMode() {
+	// Update cgroup v2 memory.min settings. Called regardless of the MemoryQoS
+	// feature gate to clear stale values when the feature is disabled.
+	if libcontainercgroups.IsCgroup2UnifiedMode() {
 		m.setMemoryQoS(logger, qosConfigs)
 	}
 

--- a/pkg/kubelet/cm/qos_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux_test.go
@@ -218,7 +218,7 @@ func TestQoSContainerCgroup(t *testing.T) {
 			}
 			burstableUnified := map[string]string{}
 			if tc.initialBurstable != "" {
-				burstableUnified[Cgroup2MemoryMin] = tc.initialBurstable
+				burstableUnified[Cgroup2MemoryLow] = tc.initialBurstable
 			}
 
 			qosConfigs := map[v1.PodQOSClass]*CgroupConfig{
@@ -243,65 +243,48 @@ func TestQoSContainerCgroup(t *testing.T) {
 			m.setMemoryQoS(logger, qosConfigs)
 
 			assert.Equal(t, tc.expectedGuaranteed, qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin])
-			assert.Equal(t, tc.expectedBurstable, qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryMin])
+			assert.Equal(t, tc.expectedBurstable, qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryLow])
 		})
 	}
 }
 
 func TestQoSContainerCgroupWithMemoryReservationPolicyNone(t *testing.T) {
-	tests := []struct {
-		name              string
-		initialGuaranteed map[string]string
-		initialBurstable  map[string]string
-	}{
-		{
-			name:              "explicitly resets memory.min to 0 when unset",
-			initialGuaranteed: nil,
-			initialBurstable:  nil,
-		},
-		{
-			name: "sets memory.min to zero when MemoryReservationPolicyNone ",
-			initialGuaranteed: map[string]string{
-				Cgroup2MemoryMin: "1234",
-			},
-			initialBurstable: map[string]string{
-				Cgroup2MemoryMin: "5678",
-			},
+	logger, _ := ktesting.NewTestContext(t)
+	fakeCM := &fakeCgroupManager{}
+	cgroupRoot := ParseCgroupfsToCgroupName("/")
+	cgroupRoot = NewCgroupName(cgroupRoot, defaultNodeAllocatableCgroupName)
+	m := &qosContainerManagerImpl{
+		cgroupManager:           fakeCM,
+		cgroupRoot:              cgroupRoot,
+		activePods:              activeTestPods,
+		memoryReservationPolicy: kubeletconfig.NoneMemoryReservationPolicy,
+		qosContainersInfo: QOSContainersInfo{
+			Guaranteed: cgroupRoot,
+			Burstable:  NewCgroupName(cgroupRoot, "burstable"),
+			BestEffort: NewCgroupName(cgroupRoot, "besteffort"),
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			logger, _ := ktesting.NewTestContext(t)
-			m, err := createTestQOSContainerManager(logger)
-			require.NoError(t, err)
-
-			qosConfigs := map[v1.PodQOSClass]*CgroupConfig{
-				v1.PodQOSGuaranteed: {
-					Name: m.qosContainersInfo.Guaranteed,
-					ResourceParameters: &ResourceConfig{
-						Unified: tc.initialGuaranteed,
-					},
-				},
-				v1.PodQOSBurstable: {
-					Name: m.qosContainersInfo.Burstable,
-					ResourceParameters: &ResourceConfig{
-						Unified: tc.initialBurstable,
-					},
-				},
-				v1.PodQOSBestEffort: {
-					Name:               m.qosContainersInfo.BestEffort,
-					ResourceParameters: &ResourceConfig{},
-				},
-			}
-
-			m.setMemoryQoS(logger, qosConfigs)
-
-			assert.Equal(t, "0", qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin])
-			assert.Equal(t, "0", qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryMin])
-			assert.NotContains(t, qosConfigs[v1.PodQOSBestEffort].ResourceParameters.Unified, Cgroup2MemoryMin)
-		})
+	// memoryReservationPolicy defaults to NoneMemoryReservationPolicy, so memory.min should be explicitly reset.
+	qosConfigs := map[v1.PodQOSClass]*CgroupConfig{
+		v1.PodQOSGuaranteed: {
+			Name:               m.qosContainersInfo.Guaranteed,
+			ResourceParameters: &ResourceConfig{},
+		},
+		v1.PodQOSBurstable: {
+			Name:               m.qosContainersInfo.Burstable,
+			ResourceParameters: &ResourceConfig{},
+		},
+		v1.PodQOSBestEffort: {
+			Name:               m.qosContainersInfo.BestEffort,
+			ResourceParameters: &ResourceConfig{},
+		},
 	}
+
+	m.setMemoryQoS(logger, qosConfigs)
+
+	assert.Equal(t, "0", qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin])
+	assert.Equal(t, "0", qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryLow])
 }
 
 // fakeCgroupManager is used because Start() requires a functional

--- a/pkg/kubelet/cm/qos_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux_test.go
@@ -208,8 +208,8 @@ func TestQoSContainerCgroup(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			m, err := createTestQOSContainerManager(logger)
 			require.NoError(t, err)
-			// Set memory reservation policy to HardReservation to enable memory.min
-			m.memoryReservationPolicy = kubeletconfig.HardReservationMemoryReservationPolicy
+			// Set memory reservation policy to TieredReservation to enable memory.min
+			m.memoryReservationPolicy = kubeletconfig.TieredReservationMemoryReservationPolicy
 			m.activePods = func() []*v1.Pod { return tc.pods }
 
 			guaranteedUnified := map[string]string{}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -155,7 +155,7 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(ctx context.
 		unified := map[string]string{}
 		memoryRequest := container.Resources.Requests.Memory().Value()
 		memoryLimit := container.Resources.Limits.Memory().Value()
-		if memoryRequest != 0 && m.memoryReservationPolicy == kubeletconfiginternal.HardReservationMemoryReservationPolicy {
+		if memoryRequest != 0 && m.memoryReservationPolicy == kubeletconfiginternal.TieredReservationMemoryReservationPolicy {
 			// Guaranteed pods get memory.min (hard protection).
 			// Burstable pods get memory.low (soft protection).
 			if kubeapiqos.GetPodQOS(pod) == v1.PodQOSGuaranteed {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -156,9 +156,16 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(ctx context.
 		memoryRequest := container.Resources.Requests.Memory().Value()
 		memoryLimit := container.Resources.Limits.Memory().Value()
 		if memoryRequest != 0 && m.memoryReservationPolicy == kubeletconfiginternal.HardReservationMemoryReservationPolicy {
-			unified[cm.Cgroup2MemoryMin] = strconv.FormatInt(memoryRequest, 10)
+			// Guaranteed pods get memory.min (hard protection).
+			// Burstable pods get memory.low (soft protection).
+			if kubeapiqos.GetPodQOS(pod) == v1.PodQOSGuaranteed {
+				unified[cm.Cgroup2MemoryMin] = strconv.FormatInt(memoryRequest, 10)
+			} else {
+				unified[cm.Cgroup2MemoryLow] = strconv.FormatInt(memoryRequest, 10)
+			}
 		} else {
 			unified[cm.Cgroup2MemoryMin] = "0"
+			unified[cm.Cgroup2MemoryLow] = "0"
 		}
 
 		// Guaranteed pods by their QoS definition requires that memory request equals memory limit and cpu request must equal cpu limit.

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -559,7 +559,7 @@ func TestGenerateContainerConfigWithMemoryQoSEnforced(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	_, _, m, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
-	m.memoryReservationPolicy = kubeletconfiginternal.HardReservationMemoryReservationPolicy
+	m.memoryReservationPolicy = kubeletconfiginternal.TieredReservationMemoryReservationPolicy
 
 	podRequestMemory := resource.MustParse("128Mi")
 	pod1LimitMemory := resource.MustParse("256Mi")

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -658,7 +658,7 @@ func TestGenerateContainerConfigWithMemoryQoSEnforced(t *testing.T) {
 		linuxConfig, err := m.generateLinuxContainerConfig(tCtx, &test.pod.Spec.Containers[0], test.pod, new(int64), "", nil, true)
 		assert.NoError(t, err)
 		assert.Equal(t, test.expected.containerConfig, linuxConfig, test.name)
-		assert.Equal(t, linuxConfig.GetResources().GetUnified()["memory.min"], strconv.FormatInt(test.expected.memoryLow, 10), test.name)
+		assert.Equal(t, linuxConfig.GetResources().GetUnified()["memory.low"], strconv.FormatInt(test.expected.memoryLow, 10), test.name)
 		assert.Equal(t, linuxConfig.GetResources().GetUnified()["memory.high"], strconv.FormatInt(test.expected.memoryHigh, 10), test.name)
 	}
 }

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -165,6 +165,10 @@ const (
 	DRAOperationsDurationKey     = "operations_duration_seconds"
 	DRAGRPCOperationsDurationKey = "grpc_operations_duration_seconds"
 
+	// Metric keys for MemoryQoS
+	MemoryQoSNodeMemoryMinBytesKey = "memory_qos_node_memory_min_bytes"
+	MemoryQoSNodeMemoryLowBytesKey = "memory_qos_node_memory_low_bytes"
+
 	// Values used in metric labels
 	Container          = "container"
 	InitContainer      = "init_container"
@@ -947,6 +951,26 @@ var (
 		},
 	)
 
+	// MemoryQoSNodeMemoryMinBytes tracks total cgroup v2 memory.min (hard protection) for Guaranteed pods.
+	MemoryQoSNodeMemoryMinBytes = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           MemoryQoSNodeMemoryMinBytesKey,
+			Help:           "Total cgroup v2 memory.min in bytes for Guaranteed pods. This memory is hard-reserved and never reclaimed by the kernel.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	// MemoryQoSNodeMemoryLowBytes tracks total cgroup v2 memory.low (soft protection) for Burstable pods.
+	MemoryQoSNodeMemoryLowBytes = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           MemoryQoSNodeMemoryLowBytesKey,
+			Help:           "Total cgroup v2 memory.low in bytes for Burstable pods. This memory is soft-reserved and may be reclaimed under extreme pressure.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
 	// TopologyManagerAdmissionRequestsTotal tracks the number of times the pod spec will cause the topology manager to admit a pod
 	TopologyManagerAdmissionRequestsTotal = metrics.NewCounter(
 		&metrics.CounterOpts{
@@ -1345,6 +1369,10 @@ func Register() {
 		legacyregistry.MustRegister(ContainerAlignedComputeResourcesFailure)
 		legacyregistry.MustRegister(MemoryManagerPinningRequestTotal)
 		legacyregistry.MustRegister(MemoryManagerPinningErrorsTotal)
+		if utilfeature.DefaultFeatureGate.Enabled(features.MemoryQoS) {
+			legacyregistry.MustRegister(MemoryQoSNodeMemoryMinBytes)
+			legacyregistry.MustRegister(MemoryQoSNodeMemoryLowBytes)
+		}
 		legacyregistry.MustRegister(TopologyManagerAdmissionRequestsTotal)
 		legacyregistry.MustRegister(TopologyManagerAdmissionErrorsTotal)
 		legacyregistry.MustRegister(TopologyManagerAdmissionDuration)

--- a/pkg/util/kernel/constants.go
+++ b/pkg/util/kernel/constants.go
@@ -58,3 +58,9 @@ const TCPReceiveMemoryNamespacedKernelVersion = "4.15"
 // TCPTransmitMemoryNamespacedKernelVersion is the kernel version in which net.ipv4.tcp_wmem was namespaced(netns).
 // (ref: https://github.com/torvalds/linux/commit/356d1833b638bd465672aefeb71def3ab93fc17d)
 const TCPTransmitMemoryNamespacedKernelVersion = "4.15"
+
+// MemoryQoSMinKernelVersion is the minimum kernel version for safe memory.high throttling.
+// Kernels older than 5.9 have a livelock bug where processes can get stuck in an infinite
+// reclaim loop at the memory.high boundary.
+// (ref: https://github.com/torvalds/linux/commit/b3ff92916af3156df27716bb080a407e4caf9085)
+const MemoryQoSMinKernelVersion = "5.9"

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -109,8 +109,9 @@ const (
 	// NoneMemoryReservationPolicy disables memory.min protection for containers and pods.
 	// This is the default to maintain node stability by preventing "locked" memory.
 	NoneMemoryReservationPolicy MemoryReservationPolicy = "None"
-	// HardReservationMemoryReservationPolicy enables memory.min for containers and pods.
-	HardReservationMemoryReservationPolicy MemoryReservationPolicy = "HardReservation"
+	// TieredReservationMemoryReservationPolicy enables tiered memory protection:
+	// memory.min for Guaranteed pods, memory.low for Burstable pods.
+	TieredReservationMemoryReservationPolicy MemoryReservationPolicy = "TieredReservation"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -902,8 +903,8 @@ type KubeletConfiguration struct {
 	// MemoryReservationPolicy controls how the kubelet applies cgroup v2 memory protection.
 	// "None" (default): The kubelet does not set memory.min for containers and pods,
 	// ensuring no hard memory is locked by the kernel.
-	// "HardReservation": The kubelet sets the cgroup v2 memory.min value based on pod and container memory requests.
-	// This ensures the requested memory is never reclaimed by the kernel, but may trigger an OOM if the reservation cannot be satisfied.
+	// "TieredReservation": The kubelet sets cgroup v2 memory.min for Guaranteed pods and memory.low for Burstable pods based on memory requests.
+	// Guaranteed memory is never reclaimed by the kernel; Burstable memory is preferentially retained but may be reclaimed under extreme pressure.
 	// See https://kep.k8s.io/2570 for more details.
 	// Default: None
 	// +featureGate=MemoryQoS

--- a/test/e2e_node/memory_qos_test.go
+++ b/test/e2e_node/memory_qos_test.go
@@ -235,11 +235,11 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		}
 	}
 
-	f.Describe("memory protection [memoryReservationPolicy=HardReservation]", func() {
+	f.Describe("memory protection [memoryReservationPolicy=TieredReservation]", func() {
 		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
 
 		ginkgo.It("should set memory.low = requests.memory for Burstable pod containers", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			requestsMem := resource.MustParse("256Mi")
 			limitsMem := resource.MustParse("512Mi")
@@ -277,7 +277,7 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		})
 
 		ginkgo.It("should set memory.min for Guaranteed pod containers", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			mem := resource.MustParse("256Mi")
 			cpu := resource.MustParse("100m")
@@ -299,7 +299,7 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		})
 
 		ginkgo.It("should NOT set memory.min for BestEffort pod", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -329,7 +329,7 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		})
 
 		ginkgo.It("should set pod-level memory.low = sum(container requests) for multi-container pod", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			req1 := resource.MustParse("128Mi")
 			req2 := resource.MustParse("256Mi")
@@ -377,7 +377,7 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		})
 
 		ginkgo.It("should propagate memory protection through QoS cgroup hierarchy", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			requestsMem := resource.MustParse("128Mi")
 			limitsMem := resource.MustParse("256Mi")
@@ -587,7 +587,7 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
 
 		ginkgo.It("should reset memory protection to 0 when MemoryQoS is disabled", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			pod := memqosMakePod("memqos-rollback", f.Namespace.Name,
 				v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
@@ -745,8 +745,8 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 			}
 		})
 
-		ginkgo.It("should set memory protection when policy is HardReservation", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+		ginkgo.It("should set memory protection when policy is TieredReservation", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			requestsMem := resource.MustParse("256Mi")
 			limitsMem := resource.MustParse("512Mi")
@@ -761,12 +761,12 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 
 			podMemMin, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryLow)
 			framework.ExpectNoError(err)
-			framework.Logf("Policy=HardReservation: pod memory.low=%d, expected=%d", podMemMin, requestsMem.Value())
+			framework.Logf("Policy=TieredReservation: pod memory.low=%d, expected=%d", podMemMin, requestsMem.Value())
 			gomega.Expect(podMemMin).To(gomega.Equal(requestsMem.Value()))
 		})
 
-		ginkgo.It("should clear memory protection at QoS level when switching from HardReservation to None", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+		ginkgo.It("should clear memory protection at QoS level when switching from TieredReservation to None", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			pod := memqosMakePod("memqos-policy-rollback", f.Namespace.Name,
 				v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
@@ -911,7 +911,7 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
 
 		ginkgo.It("should use memory.low for Burstable pod where memory req == limit but CPU differs", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			memSize := resource.MustParse("128Mi")
 			pod := &v1.Pod{
@@ -962,13 +962,13 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		})
 
 		ginkgo.It("should include burstable requests in kubepods root memory.min", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			requestsMem := resource.MustParse("200Mi")
 			pod := memqosMakePod("memqos-hierarchy-check", f.Namespace.Name,
 				v1.ResourceList{v1.ResourceMemory: requestsMem},
 				v1.ResourceList{v1.ResourceMemory: resource.MustParse("400Mi")})
-			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 			var kubepodsCgroupPath string
 			if cgroupDriver == "systemd" {
@@ -985,7 +985,7 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		})
 
 		ginkgo.It("should remove burstable memory.low contribution when pod is deleted", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			var burstableCgroupPath string
 			if cgroupDriver == "systemd" {
@@ -1022,7 +1022,7 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		})
 
 		ginkgo.It("should persist container-level memory.low after rollback [known limitation]", func(ctx context.Context) {
-			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			requestsMem := resource.MustParse("128Mi")
 			pod := memqosMakePod("memqos-container-rollback", f.Namespace.Name,

--- a/test/e2e_node/memory_qos_test.go
+++ b/test/e2e_node/memory_qos_test.go
@@ -1,0 +1,1062 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2enodekubelet "k8s.io/kubernetes/test/e2e_node/kubeletconfig"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+const (
+	cgroupRoot         = "/sys/fs/cgroup"
+	cgroupMemoryMin    = "memory.min"
+	cgroupMemoryLow    = "memory.low"
+	cgroupMemoryHigh   = "memory.high"
+	cgroupMemoryMax    = "memory.max"
+	cgroupMemoryEvents = "memory.events"
+)
+
+// memqosReadCgroupFile reads a cgroup file and returns its content as a string.
+func memqosReadCgroupFile(cgroupPath, fileName string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(cgroupPath, fileName))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// memqosReadCgroupInt64 reads a cgroup file and returns its content as int64.
+// Returns -1 for "max".
+func memqosReadCgroupInt64(cgroupPath, fileName string) (int64, error) {
+	val, err := memqosReadCgroupFile(cgroupPath, fileName)
+	if err != nil {
+		return 0, err
+	}
+	if val == "max" {
+		return -1, nil
+	}
+	return strconv.ParseInt(val, 10, 64)
+}
+
+// memqosReadMemoryEvents reads memory.events and returns a map of counter names to values.
+func memqosReadMemoryEvents(cgroupPath string) (map[string]int64, error) {
+	data, err := memqosReadCgroupFile(cgroupPath, cgroupMemoryEvents)
+	if err != nil {
+		return nil, err
+	}
+	events := make(map[string]int64)
+	for line := range strings.SplitSeq(data, "\n") {
+		parts := strings.Fields(line)
+		if len(parts) == 2 {
+			val, err := strconv.ParseInt(parts[1], 10, 64)
+			if err == nil {
+				events[parts[0]] = val
+			}
+		}
+	}
+	return events, nil
+}
+
+// memqosGetPodCgroupPath returns the cgroup path for a pod.
+func memqosGetPodCgroupPath(pod *v1.Pod, cgroupDriver string) string {
+	uid := string(pod.UID)
+	qosClass := pod.Status.QOSClass
+
+	if cgroupDriver == "systemd" {
+		uid = strings.ReplaceAll(uid, "-", "_")
+		switch qosClass {
+		case v1.PodQOSGuaranteed:
+			return filepath.Join(cgroupRoot, "kubepods.slice",
+				fmt.Sprintf("kubepods-pod%s.slice", uid))
+		case v1.PodQOSBurstable:
+			return filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-burstable.slice",
+				fmt.Sprintf("kubepods-burstable-pod%s.slice", uid))
+		case v1.PodQOSBestEffort:
+			return filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-besteffort.slice",
+				fmt.Sprintf("kubepods-besteffort-pod%s.slice", uid))
+		}
+	}
+
+	// cgroupfs driver
+	switch qosClass {
+	case v1.PodQOSGuaranteed:
+		return filepath.Join(cgroupRoot, "kubepods", fmt.Sprintf("pod%s", uid))
+	case v1.PodQOSBurstable:
+		return filepath.Join(cgroupRoot, "kubepods", "burstable", fmt.Sprintf("pod%s", uid))
+	case v1.PodQOSBestEffort:
+		return filepath.Join(cgroupRoot, "kubepods", "besteffort", fmt.Sprintf("pod%s", uid))
+	}
+	return ""
+}
+
+// memqosGetContainerCgroupPath returns the cgroup path for a container within a pod.
+func memqosGetContainerCgroupPath(podCgroupPath, containerID, cgroupDriver string) string {
+	// containerID format: "containerd://abc123" or "cri-o://abc123"
+	parts := strings.SplitN(containerID, "://", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	runtime := parts[0]
+	id := parts[1]
+
+	if cgroupDriver == "systemd" {
+		switch runtime {
+		case "containerd":
+			return filepath.Join(podCgroupPath, fmt.Sprintf("cri-containerd-%s.scope", id))
+		case "cri-o":
+			return filepath.Join(podCgroupPath, fmt.Sprintf("crio-%s.scope", id))
+		}
+	}
+
+	// cgroupfs driver
+	return filepath.Join(podCgroupPath, id)
+}
+
+// memqosExpectedMemoryHigh calculates the expected memory.high value.
+func memqosExpectedMemoryHigh(requestBytes, limitBytes int64, throttlingFactor float64) int64 {
+	pageSize := int64(os.Getpagesize())
+	raw := float64(requestBytes) + throttlingFactor*float64(limitBytes-requestBytes)
+	return int64(math.Floor(raw/float64(pageSize))) * pageSize
+}
+
+// memqosMakePod creates a test pod with specified resources.
+func memqosMakePod(name, namespace string, requests, limits v1.ResourceList) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "test",
+					Image:   "registry.k8s.io/e2e-test-images/busybox:1.36.1-1",
+					Command: []string{"sleep", "infinity"},
+					Resources: v1.ResourceRequirements{
+						Requests: requests,
+						Limits:   limits,
+					},
+				},
+			},
+		},
+	}
+}
+
+var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
+	f := framework.NewDefaultFramework("memory-qos")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	var (
+		oldCfg       *kubeletconfig.KubeletConfiguration
+		cgroupDriver string
+	)
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		if !IsCgroup2UnifiedMode() {
+			ginkgo.Skip("MemoryQoS requires cgroups v2")
+		}
+
+		var err error
+		oldCfg, err = getCurrentKubeletConfig(ctx)
+		framework.ExpectNoError(err)
+		cgroupDriver = oldCfg.CgroupDriver
+	})
+
+	// configureMemoryQoS restarts kubelet with MemoryQoS enabled and specified settings.
+	configureMemoryQoS := func(ctx context.Context, throttlingFactor float64) {
+		newCfg := oldCfg.DeepCopy()
+		if newCfg.FeatureGates == nil {
+			newCfg.FeatureGates = make(map[string]bool)
+		}
+		newCfg.FeatureGates["MemoryQoS"] = true
+		newCfg.MemoryThrottlingFactor = &throttlingFactor
+		newCfg.CgroupsPerQOS = true
+		newCfg.EnforceNodeAllocatable = []string{"pods"}
+
+		framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
+		restartKubelet(ctx, true)
+		waitForKubeletToStart(ctx, f)
+	}
+
+	// configureMemoryQoSWithPolicy restarts kubelet with MemoryQoS and a specific memoryReservationPolicy.
+	configureMemoryQoSWithPolicy := func(ctx context.Context, throttlingFactor float64, policy kubeletconfig.MemoryReservationPolicy) {
+		newCfg := oldCfg.DeepCopy()
+		if newCfg.FeatureGates == nil {
+			newCfg.FeatureGates = make(map[string]bool)
+		}
+		newCfg.FeatureGates["MemoryQoS"] = true
+		newCfg.MemoryThrottlingFactor = &throttlingFactor
+		newCfg.MemoryReservationPolicy = policy
+		newCfg.CgroupsPerQOS = true
+		newCfg.EnforceNodeAllocatable = []string{"pods"}
+
+		framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
+		restartKubelet(ctx, true)
+		waitForKubeletToStart(ctx, f)
+	}
+
+	restoreConfig := func(ctx context.Context) {
+		if oldCfg != nil {
+			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(oldCfg))
+			restartKubelet(ctx, true)
+			waitForKubeletToStart(ctx, f)
+		}
+	}
+
+	f.Describe("memory protection [memoryReservationPolicy=HardReservation]", func() {
+		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
+
+		ginkgo.It("should set memory.low = requests.memory for Burstable pod containers", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			requestsMem := resource.MustParse("256Mi")
+			limitsMem := resource.MustParse("512Mi")
+
+			pod := memqosMakePod("memqos-burstable", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: limitsMem},
+			)
+
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+			gomega.Expect(podCgroupPath).NotTo(gomega.BeEmpty(), "pod cgroup path should not be empty")
+
+			podMemMin, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err, "reading pod memory.low")
+
+			expectedPodMin := requestsMem.Value()
+			framework.Logf("Pod memory.low: got=%d, expected=%d", podMemMin, expectedPodMin)
+			gomega.Expect(podMemMin).To(gomega.Equal(expectedPodMin),
+				"pod memory.low should equal sum of container requests")
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+				gomega.Expect(containerCgroupPath).NotTo(gomega.BeEmpty())
+
+				containerMemMin, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryLow)
+				framework.ExpectNoError(err, "reading container memory.low")
+
+				framework.Logf("Container %s memory.low: got=%d, expected=%d",
+					cs.Name, containerMemMin, requestsMem.Value())
+				gomega.Expect(containerMemMin).To(gomega.Equal(requestsMem.Value()),
+					"container memory.low should equal container request")
+			}
+		})
+
+		ginkgo.It("should set memory.min for Guaranteed pod containers", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			mem := resource.MustParse("256Mi")
+			cpu := resource.MustParse("100m")
+			resources := v1.ResourceList{
+				v1.ResourceMemory: mem,
+				v1.ResourceCPU:    cpu,
+			}
+
+			pod := memqosMakePod("memqos-guaranteed", f.Namespace.Name, resources, resources)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+			podMemMin, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryMin)
+			framework.ExpectNoError(err)
+
+			framework.Logf("Guaranteed pod memory.min: got=%d, expected=%d", podMemMin, mem.Value())
+			gomega.Expect(podMemMin).To(gomega.Equal(mem.Value()),
+				"Guaranteed pod memory.min should equal requests")
+		})
+
+		ginkgo.It("should NOT set memory.min for BestEffort pod", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "memqos-besteffort",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "test",
+							Image:   "registry.k8s.io/e2e-test-images/busybox:1.36.1-1",
+							Command: []string{"sleep", "infinity"},
+						},
+					},
+				},
+			}
+
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+			podMemMin, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryMin)
+			framework.ExpectNoError(err)
+
+			framework.Logf("BestEffort pod memory.min: got=%d, expected=0", podMemMin)
+			gomega.Expect(podMemMin).To(gomega.Equal(int64(0)),
+				"BestEffort pod memory.min should be 0")
+		})
+
+		ginkgo.It("should set pod-level memory.low = sum(container requests) for multi-container pod", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			req1 := resource.MustParse("128Mi")
+			req2 := resource.MustParse("256Mi")
+			limit := resource.MustParse("512Mi")
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "memqos-multi-container",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "container-1",
+							Image:   "registry.k8s.io/e2e-test-images/busybox:1.36.1-1",
+							Command: []string{"sleep", "infinity"},
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{v1.ResourceMemory: req1},
+								Limits:   v1.ResourceList{v1.ResourceMemory: limit},
+							},
+						},
+						{
+							Name:    "container-2",
+							Image:   "registry.k8s.io/e2e-test-images/busybox:1.36.1-1",
+							Command: []string{"sleep", "infinity"},
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{v1.ResourceMemory: req2},
+								Limits:   v1.ResourceList{v1.ResourceMemory: limit},
+							},
+						},
+					},
+				},
+			}
+
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			podMemMin, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err)
+
+			expectedPodMin := req1.Value() + req2.Value()
+			framework.Logf("Multi-container pod memory.low: got=%d, expected=%d", podMemMin, expectedPodMin)
+			gomega.Expect(podMemMin).To(gomega.Equal(expectedPodMin),
+				"pod memory.low should equal sum of all container requests")
+		})
+
+		ginkgo.It("should propagate memory protection through QoS cgroup hierarchy", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			requestsMem := resource.MustParse("128Mi")
+			limitsMem := resource.MustParse("256Mi")
+
+			pod := memqosMakePod("memqos-hierarchy", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: limitsMem},
+			)
+			e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			var burstableCgroupPath string
+			var kubepodsCgroupPath string
+			if cgroupDriver == "systemd" {
+				kubepodsCgroupPath = filepath.Join(cgroupRoot, "kubepods.slice")
+				burstableCgroupPath = filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-burstable.slice")
+			} else {
+				kubepodsCgroupPath = filepath.Join(cgroupRoot, "kubepods")
+				burstableCgroupPath = filepath.Join(cgroupRoot, "kubepods", "burstable")
+			}
+
+			kubepodsMemMin, err := memqosReadCgroupInt64(kubepodsCgroupPath, cgroupMemoryMin)
+			framework.ExpectNoError(err, "reading kubepods memory.min")
+			framework.Logf("kubepods memory.min: %d", kubepodsMemMin)
+			gomega.Expect(kubepodsMemMin).To(gomega.BeNumerically(">", 0),
+				"kubepods cgroup must have memory.min > 0 for hierarchy protection to work")
+
+			burstableMemMin, err := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err, "reading burstable QoS memory.low")
+			framework.Logf("burstable QoS memory.low: %d", burstableMemMin)
+			gomega.Expect(burstableMemMin).To(gomega.BeNumerically(">", 0),
+				"burstable QoS cgroup must have memory.low > 0")
+		})
+	})
+
+	f.Describe("memory.high throttling", func() {
+		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
+
+		ginkgo.It("should set memory.high for Burstable pod using formula", func(ctx context.Context) {
+			throttlingFactor := 0.9
+			configureMemoryQoS(ctx, throttlingFactor)
+
+			requestsMem := resource.MustParse("256Mi")
+			limitsMem := resource.MustParse("512Mi")
+
+			pod := memqosMakePod("memqos-high-burstable", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: limitsMem},
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+
+				containerMemHigh, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryHigh)
+				framework.ExpectNoError(err, "reading container memory.high")
+
+				expected := memqosExpectedMemoryHigh(requestsMem.Value(), limitsMem.Value(), throttlingFactor)
+				framework.Logf("Container %s memory.high: got=%d, expected=%d", cs.Name, containerMemHigh, expected)
+				gomega.Expect(containerMemHigh).To(gomega.Equal(expected),
+					"memory.high should match formula: floor[(req + factor * (limit - req)) / pageSize] * pageSize")
+			}
+		})
+
+		ginkgo.It("should NOT set memory.high for Guaranteed pod", func(ctx context.Context) {
+			configureMemoryQoS(ctx, 0.9)
+
+			mem := resource.MustParse("256Mi")
+			cpu := resource.MustParse("100m")
+			resources := v1.ResourceList{
+				v1.ResourceMemory: mem,
+				v1.ResourceCPU:    cpu,
+			}
+
+			pod := memqosMakePod("memqos-high-guaranteed", f.Namespace.Name, resources, resources)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+
+				containerMemHigh, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryHigh)
+				framework.ExpectNoError(err, "reading container memory.high")
+
+				framework.Logf("Guaranteed container %s memory.high: got=%d (expect max/-1)", cs.Name, containerMemHigh)
+				gomega.Expect(containerMemHigh).To(gomega.Equal(int64(-1)),
+					"Guaranteed pod should NOT have memory.high set (should be max)")
+			}
+		})
+
+		ginkgo.It("should NOT set memory.high on pod-level cgroup", func(ctx context.Context) {
+			configureMemoryQoS(ctx, 0.9)
+
+			pod := memqosMakePod("memqos-high-pod-level", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("256Mi")},
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+			podMemHigh, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryHigh)
+			framework.ExpectNoError(err, "reading pod memory.high")
+
+			framework.Logf("Pod-level memory.high: got=%d (expect max/-1)", podMemHigh)
+			gomega.Expect(podMemHigh).To(gomega.Equal(int64(-1)),
+				"memory.high should NOT be set at pod level, only container level")
+		})
+
+		ginkgo.It("should set memory.high = limit when memoryThrottlingFactor=1.0", func(ctx context.Context) {
+			configureMemoryQoS(ctx, 1.0)
+
+			requestsMem := resource.MustParse("256Mi")
+			limitsMem := resource.MustParse("512Mi")
+
+			pod := memqosMakePod("memqos-factor-1", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: limitsMem},
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+
+				containerMemHigh, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryHigh)
+				framework.ExpectNoError(err)
+
+				expected := memqosExpectedMemoryHigh(requestsMem.Value(), limitsMem.Value(), 1.0)
+				framework.Logf("Container %s memory.high with factor=1.0: got=%d, expected=%d (limit=%d)",
+					cs.Name, containerMemHigh, expected, limitsMem.Value())
+				// With factor=1.0: high = floor[(req + 1.0*(limit-req))/pageSize]*pageSize = limit (page-aligned)
+				gomega.Expect(containerMemHigh).To(gomega.Equal(expected),
+					"memory.high should equal limit when factor=1.0")
+			}
+		})
+
+		ginkgo.It("should set memory.high using node allocatable when no limit is set", func(ctx context.Context) {
+			throttlingFactor := 0.9
+			configureMemoryQoS(ctx, throttlingFactor)
+
+			requestsMem := resource.MustParse("128Mi")
+
+			pod := memqosMakePod("memqos-no-limit", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{}, // no limits
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+
+				containerMemHigh, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryHigh)
+				framework.ExpectNoError(err)
+
+				framework.Logf("Container %s memory.high (no limit): got=%d", cs.Name, containerMemHigh)
+				// memory.high should be set using node allocatable instead of limit
+				gomega.Expect(containerMemHigh).To(gomega.BeNumerically(">", requestsMem.Value()),
+					"memory.high without limit should use node allocatable and be > requests")
+				gomega.Expect(containerMemHigh).NotTo(gomega.Equal(int64(-1)),
+					"memory.high should not be max when MemoryQoS is enabled for Burstable")
+			}
+		})
+	})
+
+	f.Describe("memory.events observability", func() {
+		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
+
+		ginkgo.It("should have memory.events file with expected counters", func(ctx context.Context) {
+			configureMemoryQoS(ctx, 0.9)
+
+			pod := memqosMakePod("memqos-events", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("256Mi")},
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+
+				events, err := memqosReadMemoryEvents(containerCgroupPath)
+				framework.ExpectNoError(err, "reading memory.events")
+
+				// Verify expected counters exist
+				expectedCounters := []string{"low", "high", "max", "oom", "oom_kill"}
+				for _, counter := range expectedCounters {
+					_, exists := events[counter]
+					framework.Logf("Container %s memory.events[%s] = %d, exists=%v",
+						cs.Name, counter, events[counter], exists)
+					gomega.Expect(exists).To(gomega.BeTrueBecause("memory.events should contain %q counter", counter))
+				}
+
+				// Initially all counters should be 0
+				gomega.Expect(events["high"]).To(gomega.Equal(int64(0)),
+					"high counter should be 0 initially")
+			}
+		})
+	})
+
+	f.Describe("feature rollback", func() {
+		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
+
+		ginkgo.It("should reset memory protection to 0 when MemoryQoS is disabled", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			pod := memqosMakePod("memqos-rollback", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("256Mi")},
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			memMin, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err)
+			gomega.Expect(memMin).To(gomega.BeNumerically(">", 0),
+				"memory.low should be set when MemoryQoS is enabled")
+
+			ginkgo.By("Disabling MemoryQoS feature gate")
+			newCfg := oldCfg.DeepCopy()
+			if newCfg.FeatureGates == nil {
+				newCfg.FeatureGates = make(map[string]bool)
+			}
+			newCfg.FeatureGates["MemoryQoS"] = false
+			newCfg.MemoryReservationPolicy = kubeletconfig.NoneMemoryReservationPolicy
+			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
+			restartKubelet(ctx, true)
+			waitForKubeletToStart(ctx, f)
+
+			// Pod cgroup memory.low is reconciled by the periodic setMemoryQoS loop
+			// (periodicQOSCgroupUpdateInterval = 1 minute) plus kubelet startup time.
+			gomega.Eventually(ctx, func() int64 {
+				val, _ := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryLow)
+				return val
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(gomega.Equal(int64(0)),
+				"memory.low should reset to 0 when MemoryQoS is disabled")
+
+			// TODO(sohankunkerkar): Assert container-level memory.high resets to max once
+			// CRI runtimes support Unified map in UpdateContainerResources.
+		})
+	})
+
+	f.Describe("memory.high formula verification across request/limit ratios", func() {
+		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
+
+		ginkgo.It("should correctly compute memory.high for various request/limit combinations", func(ctx context.Context) {
+			throttlingFactor := 0.9
+			configureMemoryQoS(ctx, throttlingFactor)
+
+			testCases := []struct {
+				name     string
+				requests string
+				limits   string
+			}{
+				{"low-request", "64Mi", "512Mi"},
+				{"half-request", "256Mi", "512Mi"},
+				{"high-request", "480Mi", "512Mi"},
+				{"equal-req-limit", "512Mi", "512Mi"}, // memory req==limit (still Burstable due to CPU mismatch)
+			}
+
+			for _, tc := range testCases {
+				ginkgo.By(fmt.Sprintf("Testing %s: requests=%s limits=%s", tc.name, tc.requests, tc.limits))
+
+				reqMem := resource.MustParse(tc.requests)
+				limMem := resource.MustParse(tc.limits)
+				reqCPU := resource.MustParse("50m")
+				limCPU := resource.MustParse("100m")
+
+				pod := memqosMakePod(fmt.Sprintf("memqos-formula-%s", tc.name), f.Namespace.Name,
+					v1.ResourceList{v1.ResourceMemory: reqMem, v1.ResourceCPU: reqCPU},
+					v1.ResourceList{v1.ResourceMemory: limMem, v1.ResourceCPU: limCPU},
+				)
+				pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+				podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+				for _, cs := range pod.Status.ContainerStatuses {
+					containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+
+					containerMemHigh, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryHigh)
+					framework.ExpectNoError(err)
+
+					containerMemMin, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryLow)
+					framework.ExpectNoError(err)
+
+					if reqMem.Value() == limMem.Value() {
+						// Guaranteed pod - memory.high should be max
+						framework.Logf("[%s] Guaranteed: memory.high=%d (expect max), memory.low=%d",
+							tc.name, containerMemHigh, containerMemMin)
+						gomega.Expect(containerMemHigh).To(gomega.Equal(int64(-1)))
+					} else {
+						expected := memqosExpectedMemoryHigh(reqMem.Value(), limMem.Value(), throttlingFactor)
+						framework.Logf("[%s] Burstable: memory.high=%d (expected=%d), memory.low=%d",
+							tc.name, containerMemHigh, expected, containerMemMin)
+						gomega.Expect(containerMemHigh).To(gomega.Equal(expected))
+					}
+				}
+
+				// Cleanup
+				e2epod.NewPodClient(f).DeleteSync(ctx, pod.Name, metav1.DeleteOptions{}, 2*time.Minute)
+			}
+		})
+	})
+
+	f.Describe("memoryReservationPolicy", func() {
+		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
+
+		ginkgo.It("should NOT set memory protection when policy is None", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.NoneMemoryReservationPolicy)
+
+			requestsMem := resource.MustParse("256Mi")
+			limitsMem := resource.MustParse("512Mi")
+
+			pod := memqosMakePod("memqos-policy-none", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: limitsMem},
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			podMemMin, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err)
+			framework.Logf("Policy=None: pod memory.low=%d", podMemMin)
+			gomega.Expect(podMemMin).To(gomega.Equal(int64(0)))
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+				containerMemMin, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryLow)
+				framework.ExpectNoError(err)
+				framework.Logf("Policy=None: container %s memory.low=%d", cs.Name, containerMemMin)
+				gomega.Expect(containerMemMin).To(gomega.Equal(int64(0)))
+			}
+		})
+
+		ginkgo.It("should set memory.high independent of memoryReservationPolicy", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.NoneMemoryReservationPolicy)
+
+			requestsMem := resource.MustParse("256Mi")
+			limitsMem := resource.MustParse("512Mi")
+
+			pod := memqosMakePod("memqos-policy-none-high", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: limitsMem},
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+				containerMemHigh, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryHigh)
+				framework.ExpectNoError(err)
+
+				expected := memqosExpectedMemoryHigh(requestsMem.Value(), limitsMem.Value(), 0.9)
+				framework.Logf("Policy=None: container %s memory.high=%d, expected=%d",
+					cs.Name, containerMemHigh, expected)
+				gomega.Expect(containerMemHigh).To(gomega.Equal(expected))
+			}
+		})
+
+		ginkgo.It("should set memory protection when policy is HardReservation", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			requestsMem := resource.MustParse("256Mi")
+			limitsMem := resource.MustParse("512Mi")
+
+			pod := memqosMakePod("memqos-policy-hard", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: limitsMem},
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			podMemMin, err := memqosReadCgroupInt64(podCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err)
+			framework.Logf("Policy=HardReservation: pod memory.low=%d, expected=%d", podMemMin, requestsMem.Value())
+			gomega.Expect(podMemMin).To(gomega.Equal(requestsMem.Value()))
+		})
+
+		ginkgo.It("should clear memory protection at QoS level when switching from HardReservation to None", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			pod := memqosMakePod("memqos-policy-rollback", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("256Mi")},
+			)
+			e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			var burstableCgroupPath string
+			if cgroupDriver == "systemd" {
+				burstableCgroupPath = filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-burstable.slice")
+			} else {
+				burstableCgroupPath = filepath.Join(cgroupRoot, "kubepods", "burstable")
+			}
+
+			burstableMemMin, err := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err)
+			framework.Logf("Before rollback: burstable QoS memory.low=%d", burstableMemMin)
+			gomega.Expect(burstableMemMin).To(gomega.BeNumerically(">", 0))
+
+			ginkgo.By("Switching memoryReservationPolicy to None")
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.NoneMemoryReservationPolicy)
+
+			// Wait for periodic QoS cgroup update (periodicQOSCgroupUpdateInterval = 1 minute)
+			gomega.Eventually(ctx, func() int64 {
+				val, _ := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
+				return val
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(gomega.Equal(int64(0)),
+				"burstable QoS memory.low should be cleared after switching to None")
+		})
+	})
+
+	f.Describe("memory.high throttling behavior", func() {
+		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
+
+		ginkgo.It("should increment memory.events high counter when usage exceeds memory.high", func(ctx context.Context) {
+			configureMemoryQoS(ctx, 0.9)
+
+			requestsMem := resource.MustParse("64Mi")
+			limitsMem := resource.MustParse("256Mi")
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "memqos-throttle-test",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "mem-eater",
+							Image: "registry.k8s.io/e2e-test-images/busybox:1.36.1-1",
+							// memory.high = 64 + 0.9*(256-64) = 236.8Mi, memory.max = 256Mi
+							// dd allocates 240Mi which exceeds memory.high but leaves ~16Mi headroom to memory.max.
+							Command: []string{"sh", "-c", "while true; do dd if=/dev/zero of=/dev/null bs=240M 2>/dev/null; done"},
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{v1.ResourceMemory: requestsMem},
+								Limits:   v1.ResourceList{v1.ResourceMemory: limitsMem},
+							},
+						},
+					},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+			pod = e2epod.NewPodClient(f).Create(ctx, pod)
+
+			gomega.Eventually(ctx, func(ctx context.Context) v1.PodPhase {
+				p, err := e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
+				if err != nil {
+					return v1.PodPending
+				}
+				return p.Status.Phase
+			}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).Should(gomega.Equal(v1.PodRunning))
+
+			pod, err := e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+
+				gomega.Eventually(ctx, func() int64 {
+					events, err := memqosReadMemoryEvents(containerCgroupPath)
+					if err != nil {
+						return 0
+					}
+					return events["high"]
+				}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(gomega.BeNumerically(">", 0),
+					"memory.events high counter should increment when usage exceeds memory.high")
+
+				events, err := memqosReadMemoryEvents(containerCgroupPath)
+				framework.ExpectNoError(err)
+				framework.Logf("Container %s memory.events: high=%d, max=%d, oom=%d, oom_kill=%d",
+					cs.Name, events["high"], events["max"], events["oom"], events["oom_kill"])
+				gomega.Expect(events["oom_kill"]).To(gomega.Equal(int64(0)))
+			}
+		})
+
+		ginkgo.It("should OOM kill container when memory usage exceeds memory.max", func(ctx context.Context) {
+			configureMemoryQoS(ctx, 0.9)
+
+			requestsMem := resource.MustParse("15Mi")
+			limitsMem := resource.MustParse("15Mi")
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "memqos-oom-kill",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "oom-trigger",
+							Image: "registry.k8s.io/e2e-test-images/busybox:1.36.1-1",
+							Command: []string{"sh", "-c",
+								"sleep 5 && dd if=/dev/zero of=/dev/null bs=20M"},
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{v1.ResourceMemory: requestsMem},
+								Limits:   v1.ResourceList{v1.ResourceMemory: limitsMem},
+							},
+						},
+					},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+			pod = e2epod.NewPodClient(f).Create(ctx, pod)
+
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
+				p, err := e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
+						return true
+					}
+				}
+				return false
+			}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).Should(gomega.BeTrueBecause("container should be OOM killed when exceeding memory.max"))
+		})
+	})
+
+	f.Describe("tiered protection edge cases", func() {
+		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
+
+		ginkgo.It("should use memory.low for Burstable pod where memory req == limit but CPU differs", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			memSize := resource.MustParse("128Mi")
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "memqos-burstable-equal-mem",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "test",
+							Image:   "registry.k8s.io/e2e-test-images/busybox:1.36.1-1",
+							Command: []string{"sleep", "infinity"},
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: memSize,
+									v1.ResourceCPU:    resource.MustParse("100m"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceMemory: memSize,
+									v1.ResourceCPU:    resource.MustParse("200m"),
+								},
+							},
+						},
+					},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+			gomega.Expect(podCgroupPath).NotTo(gomega.BeEmpty())
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
+				gomega.Expect(containerCgroupPath).NotTo(gomega.BeEmpty())
+
+				memLow, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryLow)
+				framework.ExpectNoError(err)
+				framework.Logf("Container %s memory.low=%d, expected=%d", cs.Name, memLow, memSize.Value())
+				gomega.Expect(memLow).To(gomega.Equal(memSize.Value()),
+					"Burstable pod with CPU mismatch should get memory.low")
+
+				memMin, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryMin)
+				framework.ExpectNoError(err)
+				gomega.Expect(memMin).To(gomega.Equal(int64(0)),
+					"Burstable pod should have memory.min=0")
+			}
+		})
+
+		ginkgo.It("should include burstable requests in kubepods root memory.min", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			requestsMem := resource.MustParse("200Mi")
+			pod := memqosMakePod("memqos-hierarchy-check", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("400Mi")})
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			var kubepodsCgroupPath string
+			if cgroupDriver == "systemd" {
+				kubepodsCgroupPath = filepath.Join(cgroupRoot, "kubepods.slice")
+			} else {
+				kubepodsCgroupPath = filepath.Join(cgroupRoot, "kubepods")
+			}
+
+			kubepodsMemMin, err := memqosReadCgroupInt64(kubepodsCgroupPath, cgroupMemoryMin)
+			framework.ExpectNoError(err)
+			framework.Logf("kubepods memory.min=%d, pod requests=%d", kubepodsMemMin, requestsMem.Value())
+			gomega.Expect(kubepodsMemMin).To(gomega.BeNumerically(">=", requestsMem.Value()),
+				"kubepods memory.min must include burstable pod requests")
+		})
+
+		ginkgo.It("should remove burstable memory.low contribution when pod is deleted", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			var burstableCgroupPath string
+			if cgroupDriver == "systemd" {
+				burstableCgroupPath = filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-burstable.slice")
+			} else {
+				burstableCgroupPath = filepath.Join(cgroupRoot, "kubepods", "burstable")
+			}
+
+			beforeLow, err := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err)
+			framework.Logf("burstable QoS memory.low before: %d", beforeLow)
+
+			requestsMem := resource.MustParse("200Mi")
+			pod := memqosMakePod("memqos-deletion-check", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("400Mi")})
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+			gomega.Eventually(ctx, func() int64 {
+				val, _ := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
+				return val
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(
+				gomega.BeNumerically(">=", beforeLow+requestsMem.Value()),
+				"burstable QoS memory.low should increase after pod creation")
+
+			e2epod.NewPodClient(f).DeleteSync(ctx, pod.Name, metav1.DeleteOptions{}, 60*time.Second)
+
+			gomega.Eventually(ctx, func() int64 {
+				val, _ := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
+				return val
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(
+				gomega.BeNumerically("<=", beforeLow),
+				"burstable QoS memory.low should decrease after pod deletion")
+		})
+
+		ginkgo.It("should persist container-level memory.low after rollback [known limitation]", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.HardReservationMemoryReservationPolicy)
+
+			requestsMem := resource.MustParse("128Mi")
+			pod := memqosMakePod("memqos-container-rollback", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: requestsMem},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("256Mi")})
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+			gomega.Expect(podCgroupPath).NotTo(gomega.BeEmpty())
+
+			containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath,
+				pod.Status.ContainerStatuses[0].ContainerID, cgroupDriver)
+			gomega.Expect(containerCgroupPath).NotTo(gomega.BeEmpty())
+
+			memLowBefore, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryLow)
+			framework.ExpectNoError(err)
+			gomega.Expect(memLowBefore).To(gomega.Equal(requestsMem.Value()))
+
+			ginkgo.By("Disabling MemoryQoS")
+			newCfg := oldCfg.DeepCopy()
+			if newCfg.FeatureGates == nil {
+				newCfg.FeatureGates = make(map[string]bool)
+			}
+			newCfg.FeatureGates["MemoryQoS"] = false
+			newCfg.MemoryReservationPolicy = kubeletconfig.NoneMemoryReservationPolicy
+			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
+			restartKubelet(ctx, true)
+			waitForKubeletToStart(ctx, f)
+
+			gomega.Eventually(ctx, func() int64 {
+				val, _ := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryLow)
+				return val
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(
+				gomega.Equal(memLowBefore),
+				"container-level memory.low persists after rollback (CRI limitation)")
+		})
+	})
+})


### PR DESCRIPTION
  #### What type of PR is this?
  /kind feature

  #### What this PR does / why we need it:
  Adds supporting infrastructure for KEP-2570 (MemoryQoS) alpha v3 in v1.36:

  1. **Kernel 5.9+ version check**: Logs a warning when MemoryQoS is enabled on kernels older than 5.9, which have a livelock bug in `memory.high` throttling.

  2. **Tiered memory protection**: Guaranteed pods get `memory.min` (hard protection, kernel never reclaims) while Burstable pods get `memory.low` (soft protection, kernel prefers not to reclaim but can under extreme pressure). This avoids hard-locking memory for overcommitted Burstable workloads, as discussed in kubernetes/kubernetes#131077.

  3. **Node-level metrics**: Two separate gauges for memory protection observability:
     - `kubelet_memory_qos_node_memory_min_bytes`: hard-reserved memory (Guaranteed pods)
     - `kubelet_memory_qos_node_memory_low_bytes`: soft-reserved memory (Burstable pods)

  4. **Pod-level rollback fix**: When `memoryReservationPolicy` changes or MemoryQoS is disabled, pod-level `memory.min` and `memory.low` are reconciled to 0 via the periodic `setMemoryQoS` loop. Previously, stale values persisted because the cgroup manager only writes keys present in the Unified map.

  5. **E2E tests**

  Benchmark results: https://github.com/sohankunkerkar/kep-2570-memoryqos-benchmarks

  #### Which issue(s) this PR is related to:

  KEP: https://github.com/kubernetes/enhancements/issues/2570
  Fixes https://github.com/kubernetes/kubernetes/issues/137674
  Depends on https://github.com/kubernetes/kubernetes/pull/137584

 <!--                                                                                                                                              
Please link relevant issues to help with tracking.                                                                                                
                                                                                                                                                  
To automatically close the linked issue(s) when this PR is merged,                                                                                
add the word "Fixes" before the issue number or link.                                                                                             
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.                                                                                
                                                                                                                                                  
Reference KEPs when applicable in addition to specific issues.                                                                                    
                                                                                                                                                  
Examples:                                                                                                                                         
Fixes #<issue number>                                                                                                                             
<issue link> (issue in a different repository)                                                                                                    
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>                                                                         
                                                                                                                                                  
If there is no associated issue, then write "N/A".                                                                                                
-->                                                                                                                                               
                                                                                                                                                  
#### Special notes for your reviewer:                                                                                                             
                                                                                                                                                  
#### Does this PR introduce a user-facing change?                                                                                                 
<!--                                                                                                                                              
If no, just write "NONE" in the release-note block below.                                                                                         
If yes, a release note is required:                                                                                                               
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the    
string "action required".                                                                                                                         
                                                                                                                                                  
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md                                       
-->                                                                                                                                               
```release-note                                                                                                                                   
Add tiered cgroup v2 memory protection for MemoryQoS: memory.min for Guaranteed pods, memory.low for Burstable pods, with node-level metrics and rollback reconciliation (KEP-2570)                                                                                                                                         
```                                                                                                                                               
                                                                                                                                                  
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:                                                    
                                                                                                                                                  
<!--                                                                                                                                              
This section can be blank if this pull request does not require a release note.                                                                   
                                                                                                                                                  
When adding links which point to resources within git repositories, like                                                                          
KEPs or supporting documentation, please reference a specific commit and avoid                                                                    
linking directly to the master branch. This ensures that links reference a                                                                        
specific point in time, rather than a document that may change over time.                                                                         
                                                                                                                                                  
See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files                   
                                                                                                                                                  
Please use the following format for linking documentation:                                                                                        
- [KEP]: <link>                                                                                                                                   
- [Usage]: <link>                                                                                                                                 
- [Other doc]: <link>                                                                                                                             
-->                                                                                                                                               
```docs                                                                                                                                           
[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2570-memory-qos/README.md                                             
```                                                                                                                                               