### PR TITLE
Replace util repeatString with strings.Repeat in a cert test.

### DIFF
--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -59,8 +59,8 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 	// maxLengthSignerName is a signerName that is of maximum length, utilising
 	// the max length specifications defined in validation.go.
 	// It is of the form <fqdn(253)>/<resource-namespace(63)>.<resource-name(253)>
-	maxLengthFQDN := fmt.Sprintf("%s.%s.%s.%s", repeatString("a", 63), repeatString("a", 63), repeatString("a", 63), repeatString("a", 61))
-	maxLengthSignerName := fmt.Sprintf("%s/%s.%s", maxLengthFQDN, repeatString("a", 63), repeatString("a", 253))
+	maxLengthFQDN := fmt.Sprintf("%s.%s.%s.%s", strings.Repeat("a", 63), strings.Repeat("a", 63), strings.Repeat("a", 63), strings.Repeat("a", 61))
+	maxLengthSignerName := fmt.Sprintf("%s/%s.%s", maxLengthFQDN, strings.Repeat("a", 63), strings.Repeat("a", 253))
 	tests := map[string]struct {
 		csr  capi.CertificateSigningRequest
 		errs field.ErrorList
@@ -236,7 +236,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				Spec: capi.CertificateSigningRequestSpec{
 					Usages:     validUsages,
 					Request:    newCSRPEM(t),
-					SignerName: fmt.Sprintf("abc.io/%s.%s", repeatString("a", 253), repeatString("a", 253)),
+					SignerName: fmt.Sprintf("abc.io/%s.%s", strings.Repeat("a", 253), strings.Repeat("a", 253)),
 				},
 			},
 		},
@@ -246,11 +246,11 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				Spec: capi.CertificateSigningRequestSpec{
 					Usages:     validUsages,
 					Request:    newCSRPEM(t),
-					SignerName: fmt.Sprintf("%s.example.io/valid-path", repeatString("a", 66)),
+					SignerName: fmt.Sprintf("%s.example.io/valid-path", strings.Repeat("a", 66)),
 				},
 			},
 			errs: field.ErrorList{
-				field.Invalid(specPath.Child("signerName"), fmt.Sprintf("%s.example.io", repeatString("a", 66)), fmt.Sprintf(`validating label "%s": must be no more than 63 characters`, repeatString("a", 66))),
+				field.Invalid(specPath.Child("signerName"), fmt.Sprintf("%s.example.io", strings.Repeat("a", 66)), fmt.Sprintf(`validating label "%s": must be no more than 63 characters`, strings.Repeat("a", 66))),
 			},
 		},
 		"signerName of max length in format <fully-qualified-domain-name>/<resource-namespace>.<resource-name> is valid": {
@@ -439,14 +439,6 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func repeatString(s string, num int) string {
-	l := make([]string, num)
-	for i := 0; i < num; i++ {
-		l[i] = s
-	}
-	return strings.Join(l, "")
 }
 
 func newCSRPEM(t *testing.T) []byte {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Instead of defining functions that are supplied by the standard library, just replace the call.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
