### PR TITLE
ktesting: cancellation fixes

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -156,7 +156,11 @@ func NewDefaultTestServerOptions() *TestServerInstanceOptions {
 func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, customFlags []string, storageConfig *storagebackend.Config) (result TestServer, err error) {
 	// Some callers may have initialize ktesting already.
 	tCtx, ok := t.(ktesting.TContext)
-	if !ok {
+	if ok {
+		// tCtx.Cancel below must not cancel whatever else might be using
+		// this existing TContext.
+		tCtx = tCtx.WithCancel()
+	} else {
 		tCtx = ktesting.Init(t)
 	}
 

--- a/test/integration/scheduler/batch/batch_test.go
+++ b/test/integration/scheduler/batch/batch_test.go
@@ -597,9 +597,12 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 		tCtx.Fatalf("start apiserver: %v", err)
 	}
 	// Cleanup will be in reverse order: first the clients by canceling the
-	// child context (happens automatically), then the server.
+	// child context, then the server.
 	tCtx.Cleanup(server.TearDownFn)
 	tCtx = tCtx.WithCancel()
+	tCtx.Cleanup(func() {
+		tCtx.Cancel("test is done")
+	})
 
 	// TODO: client connection configuration, such as QPS or Burst is configurable in theory, this could be derived from the `config`, need to
 	// support this when there is any testcase that depends on such configuration.

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -112,9 +112,12 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 		tCtx.Fatalf("start apiserver: %v", err)
 	}
 	// Cleanup will be in reverse order: first the clients by canceling the
-	// child context (happens automatically), then the server.
+	// child context, then the server.
 	tCtx.Cleanup(server.TearDownFn)
 	tCtx = tCtx.WithCancel()
+	tCtx.Cleanup(func() {
+		tCtx.Cancel("test is done")
+	})
 
 	// TODO: client connection configuration, such as QPS or Burst is configurable in theory, this could be derived from the `config`, need to
 	// support this when there is any testcase that depends on such configuration.

--- a/test/utils/ktesting/contexthelper_test.go
+++ b/test/utils/ktesting/contexthelper_test.go
@@ -23,6 +23,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -131,4 +132,41 @@ func TestCause(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestCancel checks how cancellation propagates or doesn't propagate
+// when setting up child contexts through WithCancel or WithoutCancel.
+func TestCancel(t *testing.T) {
+	tCtx := Init(t)
+	tCtx2 := tCtx.WithoutCancel()
+	tCtx3 := tCtx.WithoutCancel()
+	tCtx4 := tCtx.WithCancel()
+	tCtx5 := tCtx.WithCancel()
+
+	tCtx.AssertNoError(tCtx.Err())
+	tCtx.AssertNoError(tCtx2.Err())
+	tCtx.AssertNoError(tCtx3.Err())
+	tCtx.AssertNoError(tCtx4.Err())
+	tCtx.AssertNoError(tCtx5.Err())
+
+	tCtx2.Cancel("cancel 2")
+	tCtx.AssertNoError(tCtx.Err())
+	tCtx.Assert(context.Cause(tCtx2)).To(gomega.MatchError(gomega.ContainSubstring("cancel 2")))
+	tCtx.AssertNoError(tCtx3.Err())
+	tCtx.AssertNoError(tCtx4.Err())
+	tCtx.AssertNoError(tCtx5.Err())
+
+	tCtx4.Cancel("cancel 4")
+	tCtx.AssertNoError(tCtx.Err())
+	tCtx.Assert(context.Cause(tCtx2)).To(gomega.MatchError(gomega.ContainSubstring("cancel 2")))
+	tCtx.AssertNoError(tCtx3.Err())
+	tCtx.Assert(context.Cause(tCtx4)).To(gomega.MatchError(gomega.ContainSubstring("cancel 4")))
+	tCtx.AssertNoError(tCtx5.Err())
+
+	tCtx.Cancel("cancel root")
+	tCtx.Assert(context.Cause(tCtx)).To(gomega.MatchError(gomega.ContainSubstring("cancel root")))
+	tCtx.Assert(context.Cause(tCtx2)).To(gomega.MatchError(gomega.ContainSubstring("cancel 2")))
+	tCtx.AssertNoError(tCtx3.Err())
+	tCtx.Assert(context.Cause(tCtx4)).To(gomega.MatchError(gomega.ContainSubstring("cancel 4")))
+	tCtx.Assert(context.Cause(tCtx5)).To(gomega.MatchError(gomega.ContainSubstring("cancel root")))
 }

--- a/test/utils/ktesting/withcontext.go
+++ b/test/utils/ktesting/withcontext.go
@@ -41,13 +41,13 @@ func (tCtx TContext) WithCancel() TContext {
 }
 
 // WithoutCancel causes the returned context to ignore cancellation of its parent.
-// Calling Cancel will not cancel the parent either.
+// Calling Cancel will only cancel the new context.
 // This matches [context.WithoutCancel].
 func (tCtx TContext) WithoutCancel() TContext {
 	ctx := context.WithoutCancel(tCtx)
 
 	tCtx.Context = ctx
-	tCtx.cancel = nil
+	tCtx = tCtx.WithCancel() // Re-create a cancelable TContext.
 	return tCtx
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fixes two problems related to TContext cancellation
- WithoutCancel not supporting an explicit Cancel in the new context
- test server teardown canceled the parent's context.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Noticed while working on https://github.com/kubernetes/kubernetes/pull/137663

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
