### PR TITLE
kubectl/drain: widen namespace termination retry timeout

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -536,7 +536,9 @@ func TestEvictDuringNamespaceTerminating(t *testing.T) {
 	testNamespace := "default"
 
 	retryDelay := 5 * time.Millisecond
-	globalTimeout := 2 * retryDelay
+	// Give the helper enough room for a retry plus scheduler jitter on loaded CI
+	// hosts. A 10ms total timeout is too small under -race.
+	globalTimeout := 20 * retryDelay
 
 	tests := []struct {
 		description string


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/sig cli

#### What this PR does / why we need it:

`TestEvictDuringNamespaceTerminating` intentionally exercises the retry path after a `NamespaceTerminating` eviction failure, but the subtest only gives the whole operation 10 milliseconds. The production loop sleeps, refreshes the pod, and retries under that same deadline, so one retry plus ordinary scheduler jitter is enough to make the test fail even when the behavior is correct.

This change keeps the retry interval small and widens the overall timeout so the test checks the retry semantics instead of machine speed.

#### Which issue(s) this PR is related to:

Related to #137739

#### Special notes for your reviewer:

- This targets the exact failing subtest from the issue: `TestEvictDuringNamespaceTerminating/Pod_refreshed_after_NamespaceTerminating_error`.
- The observed failure is `global timeout reached: 10ms` after the retry path refreshes the pod.
- Verified with:
- `/opt/homebrew/bin/bash ./hack/verify-gofmt.sh`
- `/opt/homebrew/bin/bash ./hack/verify-typecheck.sh ./staging/src/k8s.io/kubectl/pkg/drain/...`
- `go test -race ./staging/src/k8s.io/kubectl/pkg/drain -run TestEvictDuringNamespaceTerminating -count=100`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
