### PR TITLE
test/integration: give apiserver startup more room in CI

### DIFF
--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -237,7 +237,9 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 	kubeAPIServerClientConfig.ServerName = ""
 
 	// wait for health
-	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+	// Allow slower environments more time to finish etcd/apiserver startup
+	// before the integration framework gives up on the test server.
+	err = wait.PollImmediate(100*time.Millisecond, 60*time.Second, func() (done bool, err error) {
 		select {
 		case err := <-errCh:
 			return false, err


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/sig api-machinery

#### What this PR does / why we need it:

`StartTestServer` currently gives the embedded apiserver 10 seconds to become healthy. In the failures tracked by #137741, that window is too short on slower or contended runners: `Test4xxStatusCodeInvalidPatch` and `TestClientCAUpdate` time out in the test framework while the local etcd/apiserver pair is still starting and RBAC bootstrap is still retrying.

This change raises the startup wait to 60 seconds so the integration framework fails on real startup problems instead of machine speed.

#### Which issue(s) this PR is related to:

Related to #137741

#### Special notes for your reviewer:

- This is intentionally scoped to the integration test framework timeout. It does not change apiserver production behavior.
- A 30 second timeout was still too low on the failing self-hosted runner path; those failures were landing at roughly 31 to 35 seconds.
- Local verification on this host covered formatting, typecheck, and compilation of the affected integration packages. Running the exact integration tests here hits a separate advertise-address selection problem before startup, so it does not reproduce the Linux CI failure mode directly.
- Verified with:
- `/opt/homebrew/bin/bash ./hack/verify-gofmt.sh`
- `/opt/homebrew/bin/bash ./hack/verify-typecheck.sh ./test/integration/framework/... ./test/integration/apiserver/... ./test/integration/apiserver/certreload/... ./test/integration/auth/...`
- `go test ./test/integration/framework -run '^$' -count=1`
- `go test ./test/integration/apiserver -run '^$' -count=1`
- `go test ./test/integration/apiserver/certreload -run '^$' -count=1`
- `go test ./test/integration/auth -run '^$' -count=1`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
