### PR TITLE
persistentvolume: deflake TestControllerSync 5-2-3 startup race

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -85,13 +85,15 @@ func TestControllerSync(t *testing.T) {
 		},
 		{
 			name:            "5-2-3 - complete bind when PV and PVC both exist and PV has AnnPreResizeCapacity annotation",
-			initialVolumes:  volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController)),
+			initialVolumes:  volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			expectedVolumes: volumesWithAnnotation(util.AnnPreResizeCapacity, "1Gi", newVolumeArray("volume5-2", "2Gi", "uid5-2", "claim5-2", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, volume.AnnBoundByController)),
-			initialClaims:   withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil)),
+			initialClaims:   noclaims,
 			expectedClaims:  withExpectedCapacity("1Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "volume5-2", v1.ClaimBound, nil, volume.AnnBoundByController, volume.AnnBindCompleted)),
 			expectedEvents:  noevents,
 			errors:          noerrors,
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
+				claim := withExpectedCapacity("2Gi", newClaimArray("claim5-2", "uid5-2", "2Gi", "", v1.ClaimPending, nil))[0]
+				reactor.AddClaimEvent(claim)
 				return nil
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/sig storage

#### What this PR does / why we need it:

`TestControllerSync` subtest `5-2-3` depends on startup ordering between the initial PV and PVC observations. When the controller sees those initial objects in a different order, the test can time out even though the controller later converges to the expected bound state.

This change models the scenario more explicitly by starting with the volume and then injecting the claim after the controller is running. That removes the ordering dependency without weakening what the test is trying to assert.

#### Which issue(s) this PR is related to:

Related to #137263

#### Special notes for your reviewer:

- This is scoped to subtest `5-2-3 - complete bind when PV and PVC both exist and PV has AnnPreResizeCapacity annotation`.
- Verified with:
- `/opt/homebrew/bin/bash ./hack/verify-gofmt.sh`
- `/opt/homebrew/bin/bash ./hack/verify-typecheck.sh ./pkg/controller/volume/persistentvolume/...`
- `go test -race ./pkg/controller/volume/persistentvolume -run TestControllerSync -count=50`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
