### PR TITLE
nodeipam: buffer TestNodeSyncResync report notifications

### DIFF
--- a/pkg/controller/nodeipam/ipam/sync/sync_test.go
+++ b/pkg/controller/nodeipam/ipam/sync/sync_test.go
@@ -231,8 +231,10 @@ func TestNodeSyncResync(t *testing.T) {
 	fake := &fakeAPIs{
 		nodeRet:       nodeWithCIDRRange,
 		resyncTimeout: time.Millisecond,
-		reportChan:    make(chan struct{}),
-		logger:        logger,
+		// Allow one extra resync notification to land while the test is
+		// closing the loop down.
+		reportChan: make(chan struct{}, 1),
+		logger:     logger,
 	}
 	cidr, _ := cidrset.NewCIDRSet(clusterCIDRRange, 24)
 	sync := New(fake, fake, fake, SyncFromCluster, "node1", cidr)


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/sig network

#### What this PR does / why we need it:

`TestNodeSyncResync` closes `opChan` after observing the first resync and then waits for the loop to exit. There is still a small race where the 1 millisecond resync timer fires again before the select notices the closed channel. When that happens, `ReportResult` sends a second notification on an unbuffered `reportChan`, the loop blocks in that send, and the test hangs until the 5 minute timeout.

This change gives `reportChan` one slot of buffering so the loop can drain that extra notification and then observe the closed channel.

#### Which issue(s) this PR is related to:

Related to #137740

#### Special notes for your reviewer:

- This matches the current open issue and the earlier history in #134563 and #135217, but fixes the still-observable blocked-send path.
- Verified with:
- `/opt/homebrew/bin/bash ./hack/verify-gofmt.sh`
- `/opt/homebrew/bin/bash ./hack/verify-typecheck.sh ./pkg/controller/nodeipam/ipam/sync/...`
- `go test -race ./pkg/controller/nodeipam/ipam/sync -run TestNodeSyncResync -count=200`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
