### PR TITLE
test/e2e/node: tolerate exit code 2 in pod status flake

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -1001,6 +1001,11 @@ func (v *podStartVerifier) Verify(event watch.Event) error {
 		switch {
 		case t.ExitCode == 1:
 			// expected
+		case t.ExitCode == 2 && t.Reason == "Error" && t.Message == "":
+			// Some runtimes occasionally surface exit code 2 if stopped before execve makes
+			// it to launching /bin/false in fast-delete scenarios. The test only cares
+			// that the container failed.
+			framework.Logf("pod %s on node %s failed with the symptoms of https://github.com/kubernetes/kubernetes/issues/135713", pod.Name, pod.Spec.NodeName)
 		case t.ExitCode == 137 && (t.Reason == "ContainerStatusUnknown" || t.Reason == "Error"):
 			// expected, pod was force-killed after grace period
 		case t.ExitCode == 128 && (t.Reason == "StartError" || t.Reason == "ContainerCannotRun") && reBug88766.MatchString(t.Message):


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The fast-delete pod status tests intentionally run a container that should fail and then verify the real invariant: the workload container must never start.

In CI, some runtimes occasionally surface that intentionally failing container with `exitCode: 2` and `reason: Error` instead of `exitCode: 1`, even though the pod state still satisfies the behavior under test. The latest `dims/test-k8s` failure showed exactly that: the pod stayed `Failed`, `Initialized=False`, the blocked container remained `started=false`, and only the failing init container drifted from exit code 1 to 2.

This change accepts that known flaky signature so the test keeps asserting the behavior it is actually meant to cover instead of a lower-layer exit-code detail.

Fixes #135713
Related-to #131605

#### Which issue(s) this PR fixes:
Fixes #135713

#### Special notes for your reviewer:
Public reproduction from `dims/test-k8s`:
- https://github.com/dims/test-k8s/actions/runs/23092972391

Local validation:
- `hack/verify-gofmt.sh`
- `hack/verify-test-code.sh`
- `hack/verify-typecheck.sh ./test/e2e/node/...`
- `go test ./test/e2e/node -run TestNonExistent -count=1`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
