### PR TITLE
[PodLevelResourceManagers] CPU & Memory managers forward compatibility - Alpha

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -100,7 +100,17 @@ func (cp *CPUManagerCheckpointV1) MarshalCheckpoint() ([]byte, error) {
 func (cp *CPUManagerCheckpointV2) MarshalCheckpoint() ([]byte, error) {
 	// make sure checksum wasn't set before so it doesn't affect output checksum
 	cp.Checksum = 0
-	cp.Checksum = checksum.New(cp)
+
+	// In order to preserve rollback compatibility when the feature gate is disabled,
+	// we must generate a checksum using the legacy struct name "CPUManagerCheckpoint"
+	// instead of "CPUManagerCheckpointV2". Older Kubelets do not have the string
+	// replacement logic and expect the original struct name.
+	object := dump.ForHash(cp)
+	object = strings.Replace(object, "CPUManagerCheckpointV2", "CPUManagerCheckpoint", 1)
+	hash := fnv.New32a()
+	_, _ = fmt.Fprintf(hash, "%v", object)
+	cp.Checksum = checksum.Checksum(hash.Sum32())
+
 	return json.Marshal(*cp)
 }
 

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package state
 
 import (
+	"encoding/json"
 	"os"
 	"reflect"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	testutil "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -635,5 +637,55 @@ func AssertStateEqual(t *testing.T, sf State, sm State) {
 	cpuassignmentSm := sm.GetCPUAssignments()
 	if !reflect.DeepEqual(cpuassignmentSf, cpuassignmentSm) {
 		t.Errorf("State CPU assignments mismatch. Have %s, want %s", cpuassignmentSf, cpuassignmentSm)
+	}
+}
+
+func TestCPUManagerCheckpointV2_MarshalCheckpoint_ForwardCompatibility(t *testing.T) {
+	// 1. Create a V2 checkpoint using the struct defined in the current codebase (1.36+)
+	currentCheckpoint := &CPUManagerCheckpointV2{
+		PolicyName:    "none",
+		DefaultCPUSet: "1-3",
+		Entries:       make(map[string]map[string]string),
+	}
+
+	// Marshal it using the logic that forces the "CPUManagerCheckpoint" name
+	data, err := currentCheckpoint.MarshalCheckpoint()
+	if err != nil {
+		t.Fatalf("Failed to marshal checkpoint: %v", err)
+	}
+
+	// 2. Unmarshal the raw JSON to extract the checksum that was actually written to the file
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	actualChecksumFloat, ok := result["checksum"].(float64)
+	if !ok {
+		t.Fatalf("Checksum field missing or invalid type")
+	}
+	writtenChecksum := checksum.Checksum(uint64(actualChecksumFloat))
+
+	// 3. Reconstruct how versions 1.35 and earlier would calculate the checksum
+	// by defining a struct with the exact legacy name and fields.
+	type CPUManagerCheckpoint struct {
+		PolicyName    string                       `json:"policyName"`
+		DefaultCPUSet string                       `json:"defaultCpuSet"`
+		Entries       map[string]map[string]string `json:"entries,omitempty"`
+		Checksum      checksum.Checksum            `json:"checksum"`
+	}
+
+	legacyCheckpoint := &CPUManagerCheckpoint{
+		PolicyName:    currentCheckpoint.PolicyName,
+		DefaultCPUSet: currentCheckpoint.DefaultCPUSet,
+		Entries:       currentCheckpoint.Entries,
+	}
+
+	expectedLegacyChecksum := checksum.New(legacyCheckpoint)
+
+	// 4. Assert that the checksum written by our 1.36+ code matches
+	// what a 1.35 Kubelet would expect to see.
+	if writtenChecksum != expectedLegacyChecksum {
+		t.Errorf("Written Checksum %d does not match legacy calculation %d. Forward compatibility broken.", writtenChecksum, expectedLegacyChecksum)
 	}
 }

--- a/pkg/kubelet/cm/memorymanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/memorymanager/state/checkpoint.go
@@ -79,7 +79,17 @@ func newMemoryManagerCheckpointV2() *MemoryManagerCheckpointV2 {
 func (mp *MemoryManagerCheckpointV1) MarshalCheckpoint() ([]byte, error) {
 	// make sure checksum wasn't set before so it doesn't affect output checksum
 	mp.Checksum = 0
-	mp.Checksum = checksum.New(mp)
+
+	// In order to preserve rollback compatibility when the feature gate is disabled,
+	// we must generate a checksum using the legacy struct name "MemoryManagerCheckpoint"
+	// instead of "MemoryManagerCheckpointV1". Older Kubelets do not have the string
+	// replacement logic and expect the original struct name.
+	object := dump.ForHash(mp)
+	object = strings.Replace(object, "MemoryManagerCheckpointV1", "MemoryManagerCheckpoint", 1)
+	hash := fnv.New32a()
+	_, _ = fmt.Fprintf(hash, "%v", object)
+	mp.Checksum = checksum.Checksum(hash.Sum32())
+
 	return json.Marshal(*mp)
 }
 

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package state
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -29,6 +30,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 	testutil "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
@@ -590,5 +592,55 @@ func TestCheckpointStateClear(t *testing.T) {
 			assert.Equal(t, NUMANodeMap{}, state.GetMachineState(), "cleared state with non-empty machine state")
 			assert.Equal(t, ContainerMemoryAssignments{}, state.GetMemoryAssignments(), "cleared state with non-empty memory assignments")
 		})
+	}
+}
+
+func TestMemoryManagerCheckpointV1_MarshalCheckpoint_ForwardCompatibility(t *testing.T) {
+	// 1. Create a V1 checkpoint using the struct defined in the current codebase (1.36+)
+	currentCheckpoint := &MemoryManagerCheckpointV1{
+		PolicyName:   "none",
+		MachineState: NUMANodeMap{},
+		Entries:      ContainerMemoryAssignments{},
+	}
+
+	// Marshal it using the logic that forces the "MemoryManagerCheckpoint" name
+	data, err := currentCheckpoint.MarshalCheckpoint()
+	if err != nil {
+		t.Fatalf("Failed to marshal checkpoint: %v", err)
+	}
+
+	// 2. Unmarshal the raw JSON to extract the checksum that was actually written to the file
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	actualChecksumFloat, ok := result["checksum"].(float64)
+	if !ok {
+		t.Fatalf("Checksum field missing or invalid type")
+	}
+	writtenChecksum := checksum.Checksum(uint64(actualChecksumFloat))
+
+	// 3. Reconstruct how versions 1.35 and earlier would calculate the checksum
+	// by defining a struct with the exact legacy name and fields.
+	type MemoryManagerCheckpoint struct {
+		PolicyName   string                     `json:"policyName"`
+		MachineState NUMANodeMap                `json:"machineState"`
+		Entries      ContainerMemoryAssignments `json:"entries,omitempty"`
+		Checksum     checksum.Checksum          `json:"checksum"`
+	}
+
+	legacyCheckpoint := &MemoryManagerCheckpoint{
+		PolicyName:   currentCheckpoint.PolicyName,
+		MachineState: currentCheckpoint.MachineState,
+		Entries:      currentCheckpoint.Entries,
+	}
+
+	expectedLegacyChecksum := checksum.New(legacyCheckpoint)
+
+	// 4. Assert that the checksum written by our 1.36+ code matches
+	// what a 1.35 Kubelet would expect to see.
+	if writtenChecksum != expectedLegacyChecksum {
+		t.Errorf("Written Checksum %d does not match legacy calculation %d. Forward compatibility broken.", writtenChecksum, expectedLegacyChecksum)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

With the new state version introduced in the Pod Level Resource Managers feature (https://github.com/kubernetes/kubernetes/pull/134768), we are effectively changing the checksum that a previous 1.35 Kubelet would write with the same information. So even if the feature gate is disabled, after doing a rollback, the checkpoint would have a different checksum than the one expected.

This PR enables forward compatibility by making the 1.36+ Kubelet write a state checkpoint (`CPUManagerCheckpointV2` for CPU manager and `MemoryManagerCheckpointV1` for Memory manager) as a 1.35 Kubelet would do, when the `PodLevelResourceManagers` feature is disabled. When the feature gate is enabled, we continue to use the newly added checkpoint versions (`CPUManagerCheckpointV3` for CPU manager and `MemoryManagerCheckpointV2` for Memory manager).

Refer to conversation from implementation: https://github.com/kubernetes/kubernetes/pull/134768#discussion_r2933867405.

Refer to slack conversation: https://kubernetes.slack.com/archives/C0409NGC1TK/p1773513656177019.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #137750

#### Special notes for your reviewer:

N/A.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5526-pod-level-resource-managers/README.md
```
