### PR TITLE
Reduce log level for optimistic lease update fallback

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -451,7 +451,7 @@ func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 			le.setObservedRecord(&leaderElectionRecord)
 			return true
 		}
-		logger.Error(err, "Failed to update lease optimistically, falling back to slow path", "lock", le.config.Lock.Describe())
+		logger.V(2).Info("Failed to update lease optimistically, falling back to slow path", "lock", le.config.Lock.Describe(), "err", err)
 	}
 
 	// 2. obtain or create the ElectionRecord


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The "Failed to update lease optimistically, falling back to slow path" message in leader election (`tryAcquireOrRenew`) is currently logged at `Error` level. However, this is not an actual error — it's expected behavior when the optimistic update encounters a conflict (e.g. resource version mismatch). The system gracefully falls back to the slow path (Get + Update), which succeeds normally.

Logging this at `Error` level causes unnecessary noise in production logs and can trigger false alerts in monitoring systems that watch for error-level log entries. This PR downgrades the log level to `V(2)` (Info with verbosity 2), which keeps the message available for debugging at moderate verbosity but removes it from default log output.

#### Which issue(s) this PR is related to:

None

#### Special notes for your reviewer:

This PR was co-developed with AI assistance (Cursor CLI using Claude Opus 4.6). The change is a single-line log level adjustment. All existing tests pass.

#### Does this PR introduce a user-facing change?

```release-note
The "Failed to update lease optimistically" log message may not be shown to users anymore, depending on the log level they have set.
```

Created with Cursor using Claude Opus 4.6, committed/pushed With OpenCode CLI with OpenCode Zen Big Pickle