### PR TITLE
.gitignore: ignore AGENTS.override.md for local overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,11 @@ network_closure.sh
 # direnv .envrc files
 .envrc
 
+# Local agent override file
+AGENTS.override.md
+# TODO: remove once there is a merged AGENTS.md
+AGENTS.md
+
 # Downloaded kubernetes binary release tar ball
 kubernetes.tar.gz
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Add `AGENTS.override.md` to root `.gitignore` so contributors can keep local agent overrides without accidentally committing them.

This PR intentionally does **not** ignore `AGENTS.md`:
- `AGENTS.md` may become a tracked project-level default in follow-up work. like #133386.
- Ignoring `AGENTS.md` globally can cause confusion once it is tracked.

#### Which issue(s) this PR is related to:
xref  #133386

#### Special notes for your reviewer:

Scope is intentionally minimal: one `.gitignore` entry only.

#### Does this PR introduce a user-facing change?
```release-note
None
```

