### PR TITLE
e2e_node: fix pod StartTime assertion to compare time value

### DIFF
--- a/test/e2e_node/standalone_test.go
+++ b/test/e2e_node/standalone_test.go
@@ -394,7 +394,7 @@ var _ = SIGDescribe(feature.StandaloneMode, func() {
 				ginkgo.By("wait for the mirror pod to be updated")
 				gomega.Eventually(ctx, func(g gomega.Gomega) {
 					pod, err := getPodFromStandaloneKubelet(ctx, staticPod.Namespace, staticPod.Name)
-					g.Expect(pod.Status.StartTime.Equal(startTime), fmt.Sprintf("startTime: %v, expected: %v", pod.Status.StartTime, startTime)).To(gomega.BeFalse())
+					g.Expect(pod.Status.StartTime.Equal(startTime)).To(gomega.BeFalseBecause("startTime should not be equal"))
 					g.Expect(err).Should(gomega.Succeed())
 					g.Expect(pod.Status.InitContainerStatuses).To(gomega.HaveLen(1))
 					cstatus := pod.Status.InitContainerStatuses[0]

--- a/test/e2e_node/standalone_test.go
+++ b/test/e2e_node/standalone_test.go
@@ -394,7 +394,7 @@ var _ = SIGDescribe(feature.StandaloneMode, func() {
 				ginkgo.By("wait for the mirror pod to be updated")
 				gomega.Eventually(ctx, func(g gomega.Gomega) {
 					pod, err := getPodFromStandaloneKubelet(ctx, staticPod.Namespace, staticPod.Name)
-					g.Expect(pod.Status.StartTime).NotTo(gomega.Equal(startTime))
+					g.Expect(pod.Status.StartTime.Equal(startTime), fmt.Sprintf("startTime: %v, expected: %v", pod.Status.StartTime, startTime)).To(gomega.BeFalse())
 					g.Expect(err).Should(gomega.Succeed())
 					g.Expect(pod.Status.InitContainerStatuses).To(gomega.HaveLen(1))
 					cstatus := pod.Status.InitContainerStatuses[0]

--- a/test/e2e_node/static_pod_test.go
+++ b/test/e2e_node/static_pod_test.go
@@ -103,7 +103,7 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
 				pod, err := f.ClientSet.CoreV1().Pods(staticPod.Namespace).Get(ctx, mirrorPodName, metav1.GetOptions{})
-				g.Expect(pod.Status.StartTime).NotTo(gomega.Equal(startTime))
+				g.Expect(pod.Status.StartTime.Equal(startTime), fmt.Sprintf("startTime: %v, expected: %v", pod.Status.StartTime, startTime)).To(gomega.BeFalse())
 				g.Expect(err).Should(gomega.Succeed())
 				g.Expect(pod.Status.InitContainerStatuses).To(gomega.HaveLen(1))
 				cstatus := pod.Status.InitContainerStatuses[0]
@@ -181,7 +181,7 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
 				pod, err := f.ClientSet.CoreV1().Pods(staticPod.Namespace).Get(ctx, mirrorPodName, metav1.GetOptions{})
-				g.Expect(pod.Status.StartTime).NotTo(gomega.Equal(startTime))
+				g.Expect(pod.Status.StartTime.Equal(startTime), fmt.Sprintf("startTime: %v, expected: %v", pod.Status.StartTime, startTime)).To(gomega.BeFalse())
 				g.Expect(err).Should(gomega.Succeed())
 				g.Expect(pod.Status.InitContainerStatuses).To(gomega.HaveLen(1))
 				cstatus := pod.Status.InitContainerStatuses[0]

--- a/test/e2e_node/static_pod_test.go
+++ b/test/e2e_node/static_pod_test.go
@@ -103,7 +103,7 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
 				pod, err := f.ClientSet.CoreV1().Pods(staticPod.Namespace).Get(ctx, mirrorPodName, metav1.GetOptions{})
-				g.Expect(pod.Status.StartTime.Equal(startTime), fmt.Sprintf("startTime: %v, expected: %v", pod.Status.StartTime, startTime)).To(gomega.BeFalse())
+				g.Expect(pod.Status.StartTime.Equal(startTime)).To(gomega.BeFalseBecause("startTime should not be equal"))
 				g.Expect(err).Should(gomega.Succeed())
 				g.Expect(pod.Status.InitContainerStatuses).To(gomega.HaveLen(1))
 				cstatus := pod.Status.InitContainerStatuses[0]
@@ -181,7 +181,7 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
 				pod, err := f.ClientSet.CoreV1().Pods(staticPod.Namespace).Get(ctx, mirrorPodName, metav1.GetOptions{})
-				g.Expect(pod.Status.StartTime.Equal(startTime), fmt.Sprintf("startTime: %v, expected: %v", pod.Status.StartTime, startTime)).To(gomega.BeFalse())
+				g.Expect(pod.Status.StartTime.Equal(startTime)).To(gomega.BeFalseBecause("startTime should not be equal"))
 				g.Expect(err).Should(gomega.Succeed())
 				g.Expect(pod.Status.InitContainerStatuses).To(gomega.HaveLen(1))
 				cstatus := pod.Status.InitContainerStatuses[0]


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
when looking into #137737 for failures, the assertion here is not right.
```
The function passed to Eventually failed at k8s.io/kubernetes/test/e2e_node/standalone_test.go:397 with:
Expected
    <*v1.Time | 0x3210635689d8>: {
        Time: 2026-03-16T03:29:45Z,
    }
not to equal
    <*v1.Time | 0x3210635680c0>: {
        Time: 2026-03-16T03:29:45Z,
    }
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
