### PR TITLE
Adding prometheues metrics for Kubeproxy failed loadbalancer operations.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.5.0
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
 	github.com/Microsoft/go-winio v0.6.2
-	github.com/Microsoft/hnslib v0.1.2
+	github.com/Microsoft/hnslib v0.1.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/container-storage-interface/spec v1.9.0
 	github.com/coredns/corefile-migration v1.0.31

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Microsoft/hnslib v0.1.2 h1:CshjwTQsNx1o7BIA1XO8HtgDsiCqn+b6kGjL/tIxXQQ=
-github.com/Microsoft/hnslib v0.1.2/go.mod h1:5vTyBey4N/VI2ZTNh2gdWhkPMefSbCFYjpvVwye+qtI=
+github.com/Microsoft/hnslib v0.1.3 h1:OCD8uA1IIqaaOV00qwbL8GwHEVCk8UPS8tiUb6pJzTQ=
+github.com/Microsoft/hnslib v0.1.3/go.mod h1:5vTyBey4N/VI2ZTNh2gdWhkPMefSbCFYjpvVwye+qtI=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=

--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -5234,6 +5234,42 @@
   componentEndpoints:
   - component: kube-proxy
     endpoint: /metrics
+- name: sync_proxy_rules_winkernel_lb_create_failures_total
+  subsystem: kubeproxy
+  help: Cumulative proxy winkernel lb create failures
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - error
+  - ip_family
+  - lb_type
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
+- name: sync_proxy_rules_winkernel_lb_delete_failures_total
+  subsystem: kubeproxy
+  help: Cumulative proxy winkernel lb delete failures
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - error
+  - ip_family
+  - lb_type
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
+- name: sync_proxy_rules_winkernel_lb_update_failures_total
+  subsystem: kubeproxy
+  help: Cumulative proxy winkernel lb update failures
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - error
+  - ip_family
+  - lb_type
+  componentEndpoints:
+  - component: kube-proxy
+    endpoint: /metrics
 - name: leader_election_master_status
   help: Gauge of if the reporting system is master of the relevant lease, 0 indicates
     backup, 1 indicates master. 'name' is the string used to identify the lease. Please

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -276,6 +276,39 @@ var (
 		[]string{"traffic_policy", "ip_family"},
 	)
 
+	// WinKernelLBCreateFailure is the number of winkernel lb create failures that the proxy has seen.
+	WinKernelLBCreateFailure = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      kubeProxySubsystem,
+			Name:           "sync_proxy_rules_winkernel_lb_create_failures_total",
+			Help:           "Cumulative proxy winkernel lb create failures",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"ip_family", "lb_type", "error"},
+	)
+
+	// WinKernelLBUpdateFailure is the number of winkernel lb update failures that the proxy has seen.
+	WinKernelLBUpdateFailure = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      kubeProxySubsystem,
+			Name:           "sync_proxy_rules_winkernel_lb_update_failures_total",
+			Help:           "Cumulative proxy winkernel lb update failures",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"ip_family", "lb_type", "error"},
+	)
+
+	// WinKernelLBDeleteFailure is the number of winkernel lb delete failures that the proxy has seen.
+	WinKernelLBDeleteFailure = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      kubeProxySubsystem,
+			Name:           "sync_proxy_rules_winkernel_lb_delete_failures_total",
+			Help:           "Cumulative proxy winkernel lb delete failures",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"ip_family", "lb_type", "error"},
+	)
+
 	// localhostNodePortsAcceptedPacketsDescription describe the metrics for the number of packets accepted
 	// by iptables which were destined for nodeports on loopback interface.
 	localhostNodePortsAcceptedPacketsDescription = metrics.NewDesc(
@@ -361,7 +394,13 @@ func RegisterMetrics(mode kubeproxyconfig.ProxyMode) {
 			legacyregistry.MustRegister(ReconcileConntrackFlowsDeletedEntriesTotal)
 
 		case kubeproxyconfig.ProxyModeKernelspace:
-			// currently no winkernel-specific metrics
+			// Winkernel prometheus metrics.
+			// Cardinality for WinKernelLBCreateFailure, WinKernelLBUpdateFailure, and WinKernelLBDeleteFailure:
+			// ip_family(2) x lb_type(5) x error(5) = 50 max; in practice much lower
+			// since a proxier uses a single ip_family and most error/lb_type combos never fire.
+			legacyregistry.MustRegister(WinKernelLBCreateFailure)
+			legacyregistry.MustRegister(WinKernelLBUpdateFailure)
+			legacyregistry.MustRegister(WinKernelLBDeleteFailure)
 		}
 	})
 }

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -162,6 +162,50 @@ const (
 	MAX_COUNT_STALE_LOADBALANCERS = 20
 )
 
+// loadBalancerType identifies the type of load balancer for metrics labeling.
+type loadBalancerType string
+
+const (
+	lbTypeClusterIP   loadBalancerType = "clusterip"
+	lbTypeNodePort    loadBalancerType = "nodeport"
+	lbTypeExternalIP  loadBalancerType = "externalip"
+	lbTypeIngressIP   loadBalancerType = "ingressip"
+	lbTypeHealthCheck loadBalancerType = "healthcheck"
+)
+
+// lbErrorType classifies load balancer operation errors for metrics labeling.
+type lbErrorType string
+
+const (
+	lbErrNetworkNotFound   lbErrorType = "network_not_found"
+	lbErrPortAlreadyExists lbErrorType = "port_already_exists"
+	lbErrNotImplemented    lbErrorType = "not_implemented"
+	lbErrInvalidIP         lbErrorType = "invalid_ip"
+	lbErrOther             lbErrorType = "other"
+	lbErrNone              lbErrorType = "none"
+)
+
+// classifyLBError classifies an HNS/HCN error into a finite set of error categories.
+func classifyLBError(err error) lbErrorType {
+	if err == nil {
+		// Currently unused in practice; included for completeness without adding to the error type cardinality.
+		return lbErrNone
+	}
+	if hcn.IsPortAlreadyExistsError(err) {
+		return lbErrPortAlreadyExists
+	}
+	if hcn.IsNetworkNotFoundError(err) {
+		return lbErrNetworkNotFound
+	}
+	if hcn.IsNotImplemented(err) {
+		return lbErrNotImplemented
+	}
+	if hcn.IsInvalidIPError(err) {
+		return lbErrInvalidIP
+	}
+	return lbErrOther
+}
+
 func newHostNetworkService(hcnImpl HcnService) (HostNetworkService, hcn.SupportedFeatures) {
 	var h HostNetworkService
 	supportedFeatures := hcnImpl.GetSupportedFeatures()
@@ -198,10 +242,12 @@ func (proxier *Proxier) cleanupStaleLoadbalancers() {
 		return
 	}
 	klog.V(3).InfoS("Cleanup of stale loadbalancers triggered", "LB Count", countStaleLB)
-	for lbID := range proxier.mapStaleLoadbalancers {
+	for lbID, lbType := range proxier.mapStaleLoadbalancers {
 		i++
 		if err := proxier.hns.deleteLoadBalancer(lbID); err == nil {
 			delete(proxier.mapStaleLoadbalancers, lbID)
+		} else {
+			metrics.WinKernelLBDeleteFailure.WithLabelValues(string(proxier.ipFamily), string(lbType), string(classifyLBError(err))).Inc()
 		}
 		if i == MAX_COUNT_STALE_LOADBALANCERS {
 			// The remaining stale loadbalancers will be cleaned up in next iteration
@@ -372,7 +418,7 @@ func (proxier *Proxier) onEndpointsMapChange(svcPortName *proxy.ServicePortName,
 		}
 
 		klog.V(3).InfoS("Endpoints are modified. Service is stale", "servicePortName", svcPortName)
-		svcInfo.cleanupAllPolicies(proxier.endpointsMap[*svcPortName], proxier.mapStaleLoadbalancers, true)
+		svcInfo.cleanupAllPolicies(proxier.endpointsMap[*svcPortName], proxier.mapStaleLoadbalancers, true, string(proxier.ipFamily))
 	} else {
 		// If no service exists, just cleanup the remote endpoints
 		klog.V(3).InfoS("Endpoints are orphaned, cleaning up")
@@ -419,7 +465,7 @@ func (proxier *Proxier) onServiceMapChange(svcPortName *proxy.ServicePortName) {
 		}
 
 		klog.V(3).InfoS("Updating existing service port", "servicePortName", svcPortName, "clusterIP", svcInfo.ClusterIP(), "port", svcInfo.Port(), "protocol", svcInfo.Protocol())
-		svcInfo.cleanupAllPolicies(proxier.endpointsMap[*svcPortName], proxier.mapStaleLoadbalancers, false)
+		svcInfo.cleanupAllPolicies(proxier.endpointsMap[*svcPortName], proxier.mapStaleLoadbalancers, false, string(proxier.ipFamily))
 	}
 }
 
@@ -604,8 +650,8 @@ type Proxier struct {
 
 	forwardHealthCheckVip bool
 	rootHnsEndpointName   string
-	mapStaleLoadbalancers map[string]bool // This maintains entries of stale load balancers which are pending delete in last iteration
-	terminatedEndpoints   map[string]bool // This maintains entries of endpoints which are terminated. Key is ip address:portnumber
+	mapStaleLoadbalancers map[string]loadBalancerType // This maintains entries of stale load balancers which are pending delete in last iteration. Value is the lb type.
+	terminatedEndpoints   map[string]bool             // This maintains entries of endpoints which are terminated. Key is ip address:portnumber
 }
 
 type localPort struct {
@@ -786,7 +832,7 @@ func newProxierInternal(
 		healthzPort:           healthzPort,
 		rootHnsEndpointName:   config.RootHnsEndpointName,
 		forwardHealthCheckVip: config.ForwardHealthCheckVip,
-		mapStaleLoadbalancers: make(map[string]bool),
+		mapStaleLoadbalancers: make(map[string]loadBalancerType),
 		terminatedEndpoints:   make(map[string]bool),
 	}
 
@@ -835,7 +881,7 @@ func CleanupLeftovers() (encounteredError bool) {
 	return encounteredError
 }
 
-func (svcInfo *serviceInfo) cleanupAllPolicies(endpoints []proxy.Endpoint, mapStaleLoadbalancers map[string]bool, isEndpointChange bool) {
+func (svcInfo *serviceInfo) cleanupAllPolicies(endpoints []proxy.Endpoint, mapStaleLoadbalancers map[string]loadBalancerType, isEndpointChange bool, ipFamilyStr string) {
 	klog.V(3).InfoS("Service cleanup", "serviceInfo", svcInfo)
 	// if it's an endpoint change and winProxyOptimization annotation enable, skip lb deletion and remoteEndpoint deletion
 	winProxyOptimization := isEndpointChange && svcInfo.winProxyOptimization
@@ -843,7 +889,7 @@ func (svcInfo *serviceInfo) cleanupAllPolicies(endpoints []proxy.Endpoint, mapSt
 		klog.V(3).InfoS("Skipped loadbalancer deletion.", "hnsID", svcInfo.hnsID, "nodePorthnsID", svcInfo.nodePorthnsID, "winProxyOptimization", svcInfo.winProxyOptimization, "isEndpointChange", isEndpointChange)
 	} else {
 		// Skip the svcInfo.policyApplied check to remove all the policies
-		svcInfo.deleteLoadBalancerPolicy(mapStaleLoadbalancers)
+		svcInfo.deleteLoadBalancerPolicy(mapStaleLoadbalancers, ipFamilyStr)
 	}
 	// Cleanup Endpoints references
 	for _, ep := range endpoints {
@@ -863,29 +909,32 @@ func (svcInfo *serviceInfo) cleanupAllPolicies(endpoints []proxy.Endpoint, mapSt
 	svcInfo.policyApplied = false
 }
 
-func (svcInfo *serviceInfo) deleteLoadBalancerPolicy(mapStaleLoadbalancer map[string]bool) {
+func (svcInfo *serviceInfo) deleteLoadBalancerPolicy(mapStaleLoadbalancer map[string]loadBalancerType, ipFamilyStr string) {
 	// Remove the Hns Policy corresponding to this service
 	hns := svcInfo.hns
 	if err := hns.deleteLoadBalancer(svcInfo.hnsID); err != nil {
-		mapStaleLoadbalancer[svcInfo.hnsID] = true
+		mapStaleLoadbalancer[svcInfo.hnsID] = lbTypeClusterIP
 		klog.V(1).ErrorS(err, "Error deleting Hns loadbalancer policy resource.", "hnsID", svcInfo.hnsID, "ClusterIP", svcInfo.ClusterIP())
+		metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeClusterIP), string(classifyLBError(err))).Inc()
 	} else {
 		// On successful delete, remove hnsId
 		svcInfo.hnsID = ""
 	}
 
 	if err := hns.deleteLoadBalancer(svcInfo.nodePorthnsID); err != nil {
-		mapStaleLoadbalancer[svcInfo.nodePorthnsID] = true
+		mapStaleLoadbalancer[svcInfo.nodePorthnsID] = lbTypeNodePort
 		klog.V(1).ErrorS(err, "Error deleting Hns NodePort policy resource.", "hnsID", svcInfo.nodePorthnsID, "NodePort", svcInfo.NodePort())
+		metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeNodePort), string(classifyLBError(err))).Inc()
 	} else {
 		// On successful delete, remove hnsId
 		svcInfo.nodePorthnsID = ""
 	}
 
 	for _, externalIP := range svcInfo.externalIPs {
-		mapStaleLoadbalancer[externalIP.hnsID] = true
 		if err := hns.deleteLoadBalancer(externalIP.hnsID); err != nil {
+			mapStaleLoadbalancer[externalIP.hnsID] = lbTypeExternalIP
 			klog.V(1).ErrorS(err, "Error deleting Hns ExternalIP policy resource.", "hnsID", externalIP.hnsID, "IP", externalIP.ip)
+			metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeExternalIP), string(classifyLBError(err))).Inc()
 		} else {
 			// On successful delete, remove hnsId
 			externalIP.hnsID = ""
@@ -894,8 +943,9 @@ func (svcInfo *serviceInfo) deleteLoadBalancerPolicy(mapStaleLoadbalancer map[st
 	for _, lbIngressIP := range svcInfo.loadBalancerIngressIPs {
 		klog.V(3).InfoS("Loadbalancer Hns LoadBalancer delete triggered for loadBalancer Ingress resources in cleanup", "lbIngressIP", lbIngressIP)
 		if err := hns.deleteLoadBalancer(lbIngressIP.hnsID); err != nil {
-			mapStaleLoadbalancer[lbIngressIP.hnsID] = true
+			mapStaleLoadbalancer[lbIngressIP.hnsID] = lbTypeIngressIP
 			klog.V(1).ErrorS(err, "Error deleting Hns IngressIP policy resource.", "hnsID", lbIngressIP.hnsID, "IP", lbIngressIP.ip)
+			metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeIngressIP), string(classifyLBError(err))).Inc()
 		} else {
 			// On successful delete, remove hnsId
 			lbIngressIP.hnsID = ""
@@ -903,8 +953,9 @@ func (svcInfo *serviceInfo) deleteLoadBalancerPolicy(mapStaleLoadbalancer map[st
 
 		if lbIngressIP.healthCheckHnsID != "" {
 			if err := hns.deleteLoadBalancer(lbIngressIP.healthCheckHnsID); err != nil {
-				mapStaleLoadbalancer[lbIngressIP.healthCheckHnsID] = true
+				mapStaleLoadbalancer[lbIngressIP.healthCheckHnsID] = lbTypeHealthCheck
 				klog.V(1).ErrorS(err, "Error deleting Hns IngressIP HealthCheck policy resource.", "hnsID", lbIngressIP.healthCheckHnsID, "IP", lbIngressIP.ip)
+				metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeHealthCheck), string(classifyLBError(err))).Inc()
 			} else {
 				// On successful delete, remove hnsId
 				lbIngressIP.healthCheckHnsID = ""
@@ -1031,7 +1082,7 @@ func (proxier *Proxier) cleanupAllPolicies() {
 			klog.ErrorS(nil, "Failed to cast serviceInfo", "serviceName", svcName)
 			continue
 		}
-		svcInfo.cleanupAllPolicies(proxier.endpointsMap[svcName], proxier.mapStaleLoadbalancers, false)
+		svcInfo.cleanupAllPolicies(proxier.endpointsMap[svcName], proxier.mapStaleLoadbalancers, false, string(proxier.ipFamily))
 	}
 }
 
@@ -1129,10 +1180,12 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		return
 	}
 
+	ipFamilyStr := string(proxier.ipFamily)
+
 	// Keep track of how long syncs take.
 	start := time.Now()
 	defer func() {
-		metrics.SyncProxyRulesLatency.WithLabelValues(string(proxier.ipFamily)).Observe(metrics.SinceInSeconds(start))
+		metrics.SyncProxyRulesLatency.WithLabelValues(ipFamilyStr).Observe(metrics.SinceInSeconds(start))
 		klog.V(4).InfoS("Syncing proxy rules complete", "elapsed", time.Since(start))
 	}()
 
@@ -1195,9 +1248,9 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		}
 	}
 
-	klog.V(3).InfoS("Syncing Policies", "proxierFamily", proxier.ipFamily, "serviceCount", len(proxier.svcPortMap), "endpointCount", len(proxier.endpointsMap), "queriedEndpointsCount", len(queriedEndpoints), "queriedLoadBalancersCount", len(queriedLoadBalancers))
+	klog.V(3).InfoS("Syncing Policies", "proxierFamily", ipFamilyStr, "serviceCount", len(proxier.svcPortMap), "endpointCount", len(proxier.endpointsMap), "queriedEndpointsCount", len(queriedEndpoints), "queriedLoadBalancersCount", len(queriedLoadBalancers))
 
-	defer klog.V(3).InfoS("Syncing Policies complete", "proxierFamily", proxier.ipFamily)
+	defer klog.V(3).InfoS("Syncing Policies complete", "proxierFamily", ipFamilyStr)
 
 	// Program HNS by adding corresponding policies for each service.
 	for svcName, svc := range proxier.svcPortMap {
@@ -1410,7 +1463,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 			if svcInfo.winProxyOptimization {
 				// Deleting loadbalancers when there are no endpoints to serve.
 				klog.V(3).InfoS("Cleanup existing ", "endpointInfo", hnsEndpoints, "serviceName", svcName)
-				svcInfo.deleteLoadBalancerPolicy(proxier.mapStaleLoadbalancers)
+				svcInfo.deleteLoadBalancerPolicy(proxier.mapStaleLoadbalancers, ipFamilyStr)
 			}
 			klog.ErrorS(nil, "Endpoint information not available for service, not applying any policy", "serviceName", svcName)
 			continue
@@ -1450,12 +1503,13 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 				queriedLoadBalancers,
 			)
 			if skipIteration := proxier.handleUpdateLoadbalancerFailure(err, svcInfo.hnsID, svcInfo.ClusterIP().String(), len(clusterIPEndpoints)); skipIteration {
+				metrics.WinKernelLBUpdateFailure.WithLabelValues(ipFamilyStr, string(lbTypeClusterIP), string(classifyLBError(err))).Inc()
 				continue
 			}
 		}
 
 		if !proxier.requiresUpdateLoadbalancer(svcInfo.hnsID, len(clusterIPEndpoints)) {
-			proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &svcInfo.hnsID, svcInfo.ClusterIP().String(), Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.Port()), clusterIPEndpoints, queriedLoadBalancers)
+			proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &svcInfo.hnsID, svcInfo.ClusterIP().String(), Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.Port()), clusterIPEndpoints, queriedLoadBalancers, lbTypeClusterIP)
 			if len(clusterIPEndpoints) > 0 {
 
 				// If all endpoints are terminating, then no need to create Cluster IP LoadBalancer
@@ -1472,6 +1526,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 				)
 				if err != nil {
 					klog.ErrorS(err, "ClusterIP policy creation failed", "clusterIP", svcInfo.ClusterIP(), "serviceName", svcName, "proxierIPFamily", proxier.ipFamily)
+					metrics.WinKernelLBCreateFailure.WithLabelValues(ipFamilyStr, string(lbTypeClusterIP), string(classifyLBError(err))).Inc()
 					continue
 				}
 
@@ -1505,12 +1560,13 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 					queriedLoadBalancers,
 				)
 				if skipIteration := proxier.handleUpdateLoadbalancerFailure(err, svcInfo.nodePorthnsID, sourceVip, len(nodePortEndpoints)); skipIteration {
+					metrics.WinKernelLBUpdateFailure.WithLabelValues(ipFamilyStr, string(lbTypeNodePort), string(classifyLBError(err))).Inc()
 					continue
 				}
 			}
 
 			if !proxier.requiresUpdateLoadbalancer(svcInfo.nodePorthnsID, len(nodePortEndpoints)) {
-				proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &svcInfo.nodePorthnsID, "", Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.NodePort()), nodePortEndpoints, queriedLoadBalancers)
+				proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &svcInfo.nodePorthnsID, "", Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.NodePort()), nodePortEndpoints, queriedLoadBalancers, lbTypeNodePort)
 
 				if len(nodePortEndpoints) > 0 && endpointsAvailableForLB {
 					// If all endpoints are in terminating stage, then no need to create Node Port LoadBalancer
@@ -1526,6 +1582,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 					)
 					if err != nil {
 						klog.ErrorS(err, "Nodeport policy creation failed", "nodeport", svcInfo.NodePort(), "sourceVip", sourceVip, "proxierIPFamily", proxier.ipFamily, "nodeIP", proxier.nodeIP.String())
+						metrics.WinKernelLBCreateFailure.WithLabelValues(ipFamilyStr, string(lbTypeNodePort), string(classifyLBError(err))).Inc()
 						continue
 					}
 
@@ -1560,12 +1617,13 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 					queriedLoadBalancers,
 				)
 				if skipIteration := proxier.handleUpdateLoadbalancerFailure(err, externalIP.hnsID, externalIP.ip, len(externalIPEndpoints)); skipIteration {
+					metrics.WinKernelLBUpdateFailure.WithLabelValues(ipFamilyStr, string(lbTypeExternalIP), string(classifyLBError(err))).Inc()
 					continue
 				}
 			}
 
 			if !proxier.requiresUpdateLoadbalancer(externalIP.hnsID, len(externalIPEndpoints)) {
-				proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &externalIP.hnsID, externalIP.ip, Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.Port()), externalIPEndpoints, queriedLoadBalancers)
+				proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &externalIP.hnsID, externalIP.ip, Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.Port()), externalIPEndpoints, queriedLoadBalancers, lbTypeExternalIP)
 
 				if len(externalIPEndpoints) > 0 && endpointsAvailableForLB {
 					// If all endpoints are in terminating stage, then no need to External IP LoadBalancer
@@ -1582,6 +1640,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 					)
 					if err != nil {
 						klog.ErrorS(err, "ExternalIP policy creation failed", "externalIP", externalIP.ip)
+						metrics.WinKernelLBCreateFailure.WithLabelValues(ipFamilyStr, string(lbTypeExternalIP), string(classifyLBError(err))).Inc()
 						continue
 					}
 					externalIP.hnsID = hnsLoadBalancer.hnsID
@@ -1613,12 +1672,13 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 					queriedLoadBalancers,
 				)
 				if skipIteration := proxier.handleUpdateLoadbalancerFailure(err, lbIngressIP.hnsID, lbIngressIP.ip, len(lbIngressEndpoints)); skipIteration {
+					metrics.WinKernelLBUpdateFailure.WithLabelValues(ipFamilyStr, string(lbTypeIngressIP), string(classifyLBError(err))).Inc()
 					continue
 				}
 			}
 
 			if !proxier.requiresUpdateLoadbalancer(lbIngressIP.hnsID, len(lbIngressEndpoints)) {
-				proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &lbIngressIP.hnsID, lbIngressIP.ip, Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.Port()), lbIngressEndpoints, queriedLoadBalancers)
+				proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &lbIngressIP.hnsID, lbIngressIP.ip, Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.Port()), lbIngressEndpoints, queriedLoadBalancers, lbTypeIngressIP)
 
 				if len(lbIngressEndpoints) > 0 {
 					hnsLoadBalancer, err := hns.getLoadBalancer(
@@ -1633,6 +1693,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 					)
 					if err != nil {
 						klog.ErrorS(err, "IngressIP policy creation failed", "lbIngressIP", lbIngressIP.ip, "serviceName", svcName, "proxierIPFamily", proxier.ipFamily)
+						metrics.WinKernelLBCreateFailure.WithLabelValues(ipFamilyStr, string(lbTypeIngressIP), string(classifyLBError(err))).Inc()
 						continue
 					}
 					lbIngressIP.hnsID = hnsLoadBalancer.hnsID
@@ -1669,7 +1730,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 				}
 
 				if !proxier.requiresUpdateLoadbalancer(lbIngressIP.healthCheckHnsID, len(gwEndpoints)) {
-					proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &lbIngressIP.healthCheckHnsID, lbIngressIP.ip, Enum(svcInfo.Protocol()), uint16(nodeport), uint16(nodeport), gwEndpoints, queriedLoadBalancers)
+					proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &lbIngressIP.healthCheckHnsID, lbIngressIP.ip, Enum(svcInfo.Protocol()), uint16(nodeport), uint16(nodeport), gwEndpoints, queriedLoadBalancers, lbTypeHealthCheck)
 
 					hnsHealthCheckLoadBalancer, err := hns.getLoadBalancer(
 						gwEndpoints,
@@ -1699,7 +1760,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	if proxier.healthzServer != nil {
 		proxier.healthzServer.Updated(proxier.ipFamily)
 	}
-	metrics.SyncProxyRulesLastTimestamp.WithLabelValues(string(proxier.ipFamily)).SetToCurrentTime()
+	metrics.SyncProxyRulesLastTimestamp.WithLabelValues(ipFamilyStr).SetToCurrentTime()
 
 	// Update service healthchecks.  The endpoints list might include services that are
 	// not "OnlyLocal", but the services list will not, and the serviceHealthServer
@@ -1740,7 +1801,7 @@ func (proxier *Proxier) deleteTerminatedEndpoints(queriedEndpoints map[string]*(
 
 // deleteExistingLoadBalancer checks whether loadbalancer delete is needed or not.
 // If it is needed, the function will delete the existing loadbalancer and return true, else false.
-func (proxier *Proxier) deleteExistingLoadBalancer(hns HostNetworkService, winProxyOptimization bool, lbHnsID *string, vip string, protocol, intPort, extPort uint16, endpoints []endpointInfo, queriedLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo) bool {
+func (proxier *Proxier) deleteExistingLoadBalancer(hns HostNetworkService, winProxyOptimization bool, lbHnsID *string, vip string, protocol, intPort, extPort uint16, endpoints []endpointInfo, queriedLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo, lbType loadBalancerType) bool {
 
 	if !winProxyOptimization || *lbHnsID == "" {
 		// Loadbalancer delete not needed
@@ -1757,7 +1818,7 @@ func (proxier *Proxier) deleteExistingLoadBalancer(hns HostNetworkService, winPr
 	)
 
 	if lbIdErr != nil {
-		return proxier.deleteLoadBalancer(hns, lbHnsID)
+		return proxier.deleteLoadBalancer(hns, lbHnsID, lbType)
 	}
 
 	if _, ok := queriedLoadBalancers[lbID]; ok {
@@ -1765,17 +1826,16 @@ func (proxier *Proxier) deleteExistingLoadBalancer(hns HostNetworkService, winPr
 		return false
 	}
 
-	return proxier.deleteLoadBalancer(hns, lbHnsID)
+	return proxier.deleteLoadBalancer(hns, lbHnsID, lbType)
 }
 
-func (proxier *Proxier) deleteLoadBalancer(hns HostNetworkService, lbHnsID *string) bool {
-	klog.V(3).InfoS("Hns LoadBalancer delete triggered for loadBalancer resources", "lbHnsID", *lbHnsID, "proxierIPFamily", proxier.ipFamily)
+func (proxier *Proxier) deleteLoadBalancer(hns HostNetworkService, lbHnsID *string, lbType loadBalancerType) bool {
+	klog.V(3).InfoS("Hns LoadBalancer delete triggered for loadBalancer resources", "lbHnsID", *lbHnsID, "lbType", lbType, "proxierIPFamily", proxier.ipFamily)
 	if err := hns.deleteLoadBalancer(*lbHnsID); err != nil {
 		klog.ErrorS(err, "LoadBalancer deletion failed. Adding to stale loadbalancers.", "hnsID", *lbHnsID)
-		// This will be cleanup by cleanupStaleLoadbalancer fnction.
-		proxier.mapStaleLoadbalancers[*lbHnsID] = true
-	} else {
-		klog.V(3).InfoS("Hns LoadBalancer resource deleted for loadBalancer resources", "lbHnsID", *lbHnsID)
+		metrics.WinKernelLBDeleteFailure.WithLabelValues(string(proxier.ipFamily), string(lbType), string(classifyLBError(err))).Inc()
+		// This will be cleanup by cleanupStaleLoadbalancer function.
+		proxier.mapStaleLoadbalancers[*lbHnsID] = lbType
 	}
 	*lbHnsID = ""
 	return true

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -20,6 +20,7 @@ package winkernel
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -35,10 +36,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	basemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/proxy"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
+	"k8s.io/kubernetes/pkg/proxy/metrics"
 	fakehcn "k8s.io/kubernetes/pkg/proxy/winkernel/testing"
 	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
@@ -2673,4 +2677,142 @@ func TestEndpointTransitionWithLBFailures(t *testing.T) {
 	epANew := findRemoteEp(svcPortName1, localIP)
 	assert.NotNil(t, epANew, "Local endpoint A should still exist")
 	assert.True(t, epANew.IsLocal(), "A should be local")
+}
+
+func TestClassifyLBError(t *testing.T) {
+	// Note: classifyLBError uses hcn.Is*Error functions which check for *hcn.HcnError
+	// with specific error codes. Since HcnError can only be created internally by the
+	// hcn package, we can only test nil and generic error cases here. The actual HCN
+	// error classification is tested through the hcn package's own tests.
+	tests := []struct {
+		name     string
+		err      error
+		expected lbErrorType
+	}{
+		{
+			name:     "nil error returns other",
+			err:      nil,
+			expected: lbErrOther,
+		},
+		{
+			name:     "generic error returns other",
+			err:      errors.New("something went wrong"),
+			expected: lbErrOther,
+		},
+		{
+			// hcn.NetworkNotFoundError is a shim error type, not an HCN system error.
+			// hcn.IsNetworkNotFoundError checks for HcnError with HCN_E_NETWORK_NOT_FOUND code,
+			// so this returns lbErrOther.
+			name:     "hcn NetworkNotFoundError shim type returns other",
+			err:      hcn.NetworkNotFoundError{NetworkName: "testnet"},
+			expected: lbErrOther,
+		},
+		{
+			name:     "hcn LoadBalancerNotFoundError shim type returns other",
+			err:      hcn.LoadBalancerNotFoundError{LoadBalancerId: "lb-123"},
+			expected: lbErrOther,
+		},
+		{
+			name:     "hcn EndpointNotFoundError shim type returns other",
+			err:      hcn.EndpointNotFoundError{EndpointID: "ep-123"},
+			expected: lbErrOther,
+		},
+		{
+			name:     "wrapped generic error returns other",
+			err:      fmt.Errorf("wrapped: %w", errors.New("inner error")),
+			expected: lbErrOther,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := classifyLBError(tc.err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestLoadBalancerTypeConstants(t *testing.T) {
+	// Verify all loadBalancerType constants have non-empty string values.
+	lbTypes := []loadBalancerType{
+		lbTypeClusterIP,
+		lbTypeNodePort,
+		lbTypeExternalIP,
+		lbTypeIngressIP,
+		lbTypeHealthCheck,
+	}
+	seen := make(map[loadBalancerType]bool)
+	for _, lbt := range lbTypes {
+		assert.NotEmpty(t, string(lbt), "loadBalancerType constant should not be empty")
+		assert.False(t, seen[lbt], "duplicate loadBalancerType constant: %s", lbt)
+		seen[lbt] = true
+	}
+}
+
+func TestLBErrorTypeConstants(t *testing.T) {
+	// Verify all lbErrorType constants have non-empty, unique string values.
+	errTypes := []lbErrorType{
+		lbErrNetworkNotFound,
+		lbErrPortAlreadyExists,
+		lbErrNotImplemented,
+		lbErrInvalidIP,
+		lbErrOther,
+	}
+	seen := make(map[lbErrorType]bool)
+	for _, et := range errTypes {
+		assert.NotEmpty(t, string(et), "lbErrorType constant should not be empty")
+		assert.False(t, seen[et], "duplicate lbErrorType constant: %s", et)
+		seen[et] = true
+	}
+}
+
+func TestLBMetricEmission(t *testing.T) {
+	metrics.RegisterMetrics(kubeproxyconfig.ProxyModeKernelspace)
+
+	tests := []struct {
+		name      string
+		metricVec *basemetrics.CounterVec
+		ipFamily  string
+		lbType    loadBalancerType
+		errType   lbErrorType
+	}{
+		{
+			name:      "create failure with clusterip and network_not_found",
+			metricVec: metrics.WinKernelLBCreateFailure,
+			ipFamily:  "IPv4",
+			lbType:    lbTypeClusterIP,
+			errType:   lbErrNetworkNotFound,
+		},
+		{
+			name:      "update failure with nodeport and port_already_exists",
+			metricVec: metrics.WinKernelLBUpdateFailure,
+			ipFamily:  "IPv4",
+			lbType:    lbTypeNodePort,
+			errType:   lbErrPortAlreadyExists,
+		},
+		{
+			name:      "delete failure with ingressip and other",
+			metricVec: metrics.WinKernelLBDeleteFailure,
+			ipFamily:  "IPv6",
+			lbType:    lbTypeIngressIP,
+			errType:   lbErrOther,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.metricVec.Reset()
+
+			tc.metricVec.WithLabelValues(tc.ipFamily, string(tc.lbType), string(tc.errType)).Inc()
+
+			val, err := testutil.GetCounterMetricValue(tc.metricVec.WithLabelValues(tc.ipFamily, string(tc.lbType), string(tc.errType)))
+			assert.NoError(t, err)
+			assert.Equal(t, float64(1), val)
+
+			// Verify a different label combination was not incremented.
+			val, err = testutil.GetCounterMetricValue(tc.metricVec.WithLabelValues(tc.ipFamily, string(lbTypeHealthCheck), string(lbErrInvalidIP)))
+			assert.NoError(t, err)
+			assert.Equal(t, float64(0), val)
+		})
+	}
 }

--- a/vendor/github.com/Microsoft/hnslib/hcn/hcnerrors.go
+++ b/vendor/github.com/Microsoft/hnslib/hcn/hcnerrors.go
@@ -37,7 +37,7 @@ func checkForErrors(methodName string, hr error, resultBuffer *uint16) error {
 	}
 
 	if errorFound {
-		returnError := new(hr, methodName, result)
+		returnError := newHcnError(hr, methodName, result)
 		logrus.Debugf(returnError.Error()) // HCN errors logged for debugging.
 		return returnError
 	}
@@ -52,6 +52,11 @@ const (
 	ERROR_NOT_FOUND                     = ErrorCode(windows.ERROR_NOT_FOUND)
 	HCN_E_PORT_ALREADY_EXISTS ErrorCode = ErrorCode(windows.HCN_E_PORT_ALREADY_EXISTS)
 	HCN_E_NOTIMPL             ErrorCode = ErrorCode(windows.E_NOTIMPL)
+	HCN_E_NETWORK_NOT_FOUND   ErrorCode = ErrorCode(windows.HCN_E_NETWORK_NOT_FOUND)
+	HCN_E_ENDPOINT_NOT_FOUND  ErrorCode = ErrorCode(windows.HCN_E_ENDPOINT_NOT_FOUND)
+	HCN_E_PORT_NOT_FOUND      ErrorCode = ErrorCode(windows.HCN_E_PORT_NOT_FOUND)
+	HCN_E_INVALID_IP          ErrorCode = ErrorCode(windows.HCN_E_INVALID_IP)
+	HCN_E_ADAPTER_NOT_FOUND   ErrorCode = ErrorCode(windows.HCN_E_ADAPTER_NOT_FOUND)
 )
 
 type HcnError struct {
@@ -83,7 +88,27 @@ func IsNotImplemented(err error) bool {
 	return CheckErrorWithCode(err, HCN_E_NOTIMPL)
 }
 
-func new(hr error, title string, rest string) error {
+func IsNetworkNotFoundError(err error) bool {
+	return CheckErrorWithCode(err, HCN_E_NETWORK_NOT_FOUND)
+}
+
+func IsEndpointNotFoundError(err error) bool {
+	return CheckErrorWithCode(err, HCN_E_ENDPOINT_NOT_FOUND)
+}
+
+func IsPortNotFoundError(err error) bool {
+	return CheckErrorWithCode(err, HCN_E_PORT_NOT_FOUND)
+}
+
+func IsInvalidIPError(err error) bool {
+	return CheckErrorWithCode(err, HCN_E_INVALID_IP)
+}
+
+func IsAdapterNotFoundError(err error) bool {
+	return CheckErrorWithCode(err, HCN_E_ADAPTER_NOT_FOUND)
+}
+
+func newHcnError(hr error, title string, rest string) error {
 	err := &HcnError{}
 	hnsError := hns.NewHnsError(hr, title, rest)
 	err.HnsError = hnsError.(*hns.HnsError) //nolint:errorlint

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,7 +31,7 @@ github.com/Microsoft/go-winio/internal/fs
 github.com/Microsoft/go-winio/internal/socket
 github.com/Microsoft/go-winio/internal/stringbuffer
 github.com/Microsoft/go-winio/pkg/guid
-# github.com/Microsoft/hnslib v0.1.2
+# github.com/Microsoft/hnslib v0.1.3
 ## explicit; go 1.22.0
 github.com/Microsoft/hnslib
 github.com/Microsoft/hnslib/hcn


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds Prometheus metrics for Windows kube-proxy (winkernel) load balancer
operation failures. Previously, the winkernel proxier had no metrics for LB
failures, making it difficult to monitor and diagnose issues in production
Windows clusters.

This PR introduces three new `ALPHA` stability counter metrics:

- `kubeproxy_sync_proxy_rules_winkernel_lb_create_failures_total` - tracks LB creation failures
- `kubeproxy_sync_proxy_rules_winkernel_lb_update_failures_total` - tracks LB update failures
- `kubeproxy_sync_proxy_rules_winkernel_lb_delete_failures_total` - tracks LB deletion failures

Each metric has three labels for fine-grained observability:

- `ip_family` - `IPv4` or `IPv6`
- `lb_type` - `clusterip`, `nodeport`, `externalip`, `ingressip`, or `healthcheck`
- `error`  - `network_not_found`, `port_already_exists`, `not_implemented`, `invalid_ip`, or `other`

The maximum cardinality per metric is 50 (2 × 5 × 5), but in practice is much
lower since a proxier instance uses a single IP family and most error/lb_type
combinations never fire.

**Implementation details:**

- Defines type-safe `loadBalancerType` and `lbErrorType` string typedefs with constants
- Adds a `classifyLBError` function that maps HCN/HNS errors to a finite set of error categories using the hcn package's error classification helpers
- Changes `mapStaleLoadbalancers` from `map[string]bool` to `map[string]loadBalancerType` to preserve the LB type through stale LB cleanup retries
- Threads `lbType` through `deleteExistingLoadBalancer`, `deleteLoadBalancer`, `deleteLoadBalancerPolicy`, and `cleanupAllPolicies`
- Emits metrics at all 8 failure sites (3 create, 3 update, 2 delete paths)
- Registers the new metrics under `ProxyModeKernelspace` in `RegisterMetrics`

**Example metrics from a real AKS Windows node:**

```
HELP kubeproxy_sync_proxy_rules_winkernel_lb_create_failures_total [ALPHA] Cumulative proxy winkernel lb create failures
TYPE kubeproxy_sync_proxy_rules_winkernel_lb_create_failures_total counter
kubeproxy_sync_proxy_rules_winkernel_lb_create_failures_total{error="other",ip_family="IPv4",lb_type="clusterip"} 222
kubeproxy_sync_proxy_rules_winkernel_lb_create_failures_total{error="port_already_exists",ip_family="IPv4",lb_type="nodeport"} 310
kubeproxy_sync_proxy_rules_winkernel_lb_create_failures_total{error="port_already_exists",ip_family="IPv6",lb_type="clusterip"} 83

HELP kubeproxy_sync_proxy_rules_winkernel_lb_delete_failures_total [ALPHA] Cumulative proxy winkernel lb delete failures
TYPE kubeproxy_sync_proxy_rules_winkernel_lb_delete_failures_total counter
kubeproxy_sync_proxy_rules_winkernel_lb_delete_failures_total{error="invalid_ip",ip_family="IPv4",lb_type="nodeport"} 116
kubeproxy_sync_proxy_rules_winkernel_lb_delete_failures_total{error="network_not_found",ip_family="IPv4",lb_type="nodeport"} 290
```

#### Which issue(s) this PR is related to:

Fixes #137766

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Added Prometheus metrics for Windows kube-proxy (winkernel) load balancer operation failures: `kubeproxy_sync_proxy_rules_winkernel_lb_create_failures_total`, `kubeproxy_sync_proxy_rules_winkernel_lb_update_failures_total`, and `kubeproxy_sync_proxy_rules_winkernel_lb_delete_failures_total`. Each metric includes `ip_family`, `lb_type`, and `error` labels for fine-grained failure observability.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```

/sig windows
/sig network
/area kube-proxy