### PR TITLE
Handle gated pods correctly while popping PodGroup members

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -822,6 +822,12 @@ func (p *PriorityQueue) determineSchedulingHintForInFlightPod(logger klog.Logger
 		// In this case, we should retry scheduling it because this Pod may not be retried until the next flush.
 		return queueAfterBackoff
 	}
+	if p.isGenericWorkloadEnabled && pInfo.Pod.Spec.SchedulingGroup != nil {
+		// When the pod is a member of the pod group, i.e., needs pod group scheduling,
+		// its retry logic should be based solely on backoff, because event-based requeueing logic
+		// is not yet implemented for pod group level.
+		return queueAfterBackoff
+	}
 
 	events, err := p.activeQ.clusterEventsForPod(logger, pInfo)
 	if err != nil {
@@ -1014,36 +1020,23 @@ func (p *PriorityQueue) PopSpecificPod(logger klog.Logger, pod *v1.Pod) *framewo
 
 	pInfoLookup := newQueuedPodInfoForLookup(pod)
 
+	// Try to activate the pod, then obtain it from the activeQ.
+	// This way, the pod behaves almost the same as it would be activated by some event,
+	// moved to the activeQ and popped from there.
+	_ = p.activate(logger, pod)
+
 	var pInfo *framework.QueuedPodInfo
 	p.activeQ.underRLock(func(unlockedActiveQ unlockedActiveQueueReader) {
 		pInfo, _ = unlockedActiveQ.get(pInfoLookup)
 	})
-	if pInfo != nil {
-		if err := p.activeQ.delete(pInfo); err != nil {
-			return nil
-		}
-	} else {
-		var exists bool
-		pInfo, exists = p.backoffQ.get(pInfoLookup)
-		if exists {
-			if !p.backoffQ.delete(pInfo) {
-				return nil
-			}
-		} else {
-			pInfo = p.unschedulablePods.get(pod)
-			if pInfo != nil {
-				if pInfo.Gated() {
-					// Gated pod shouldn't be popped.
-					return nil
-				}
-				p.unschedulablePods.delete(pod, pInfo.Gated())
-			} else {
-				// Not found in any queue
-				return nil
-			}
-		}
+	if pInfo == nil {
+		return nil
 	}
-
+	if err := p.activeQ.delete(pInfo); err != nil {
+		// Error means that the pod disappeared from the activeQ in the meantime.
+		// Returning nil is fine.
+		return nil
+	}
 	err := p.activeQ.movePodToInFlight(pInfo)
 	if err != nil {
 		utilruntime.HandleErrorWithLogger(logger, err, "Discarding the popped pod")

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -1142,6 +1142,121 @@ func TestPriorityQueue_Pop(t *testing.T) {
 	}
 }
 
+func TestPriorityQueue_PopSpecificPod(t *testing.T) {
+	activePod := st.MakePod().Name("pod-active").Namespace("ns1").UID("pod-active").Label("foo", "").Obj()
+	backoffPod := st.MakePod().Name("pod-backoff").Namespace("ns1").UID("pod-backoff").Label("foo", "").Obj()
+	unschedulablePod := st.MakePod().Name("pod-unschedulable").Namespace("ns1").UID("pod-unschedulable").Label("foo", "").Obj()
+	gatedPod := st.MakePod().Name("pod-gated").Namespace("ns1").UID("pod-gated").Obj()
+	temporarilyGatedPod := st.MakePod().Name("pod-temporarily-gated").Namespace("ns1").UID("pod-temporarily-gated").Label("bar", "").Obj()
+	otherPod := st.MakePod().Name("pod-other").Namespace("ns1").UID("pod-other").Label("foo", "").Obj()
+
+	objs := []runtime.Object{activePod, backoffPod, unschedulablePod, gatedPod, temporarilyGatedPod, otherPod}
+
+	tests := []struct {
+		name       string
+		podToPop   *v1.Pod
+		gated      bool
+		wantPopped bool
+	}{
+		{
+			name:       "Pod is in activeQ",
+			podToPop:   activePod,
+			wantPopped: true,
+		},
+		{
+			name:       "Pod is in backoffQ",
+			podToPop:   backoffPod,
+			wantPopped: true,
+		},
+		{
+			name:       "Pod is in unschedulablePods",
+			podToPop:   unschedulablePod,
+			wantPopped: true,
+		},
+		{
+			name:       "Pod is gated in unschedulablePods",
+			podToPop:   gatedPod,
+			wantPopped: false,
+		},
+		{
+			name:       "Pod was gated, but should be no longer",
+			podToPop:   temporarilyGatedPod,
+			wantPopped: true,
+		},
+		{
+			name:       "Pod is not in any queue",
+			podToPop:   otherPod,
+			wantPopped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			plugin := &preEnqueuePlugin{allowlists: []string{"foo"}}
+			m := map[string]map[string]fwk.PreEnqueuePlugin{
+				"": {
+					plugin.Name(): plugin,
+				},
+			}
+			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs, WithPreEnqueuePluginMap(m))
+
+			q.Add(ctx, activePod)
+
+			backoffPodInfo := q.newQueuedPodInfo(ctx, backoffPod)
+			q.backoffQ.add(logger, backoffPodInfo, framework.EventUnscheduledPodAdd.Label())
+
+			unschedPodInfo := q.newQueuedPodInfo(ctx, unschedulablePod)
+			q.unschedulablePods.addOrUpdate(unschedPodInfo, false, framework.EventUnscheduledPodAdd.Label())
+
+			q.Add(ctx, gatedPod)
+			q.Add(ctx, temporarilyGatedPod)
+
+			// Modify the PreEnqueue allowlists to allow the "bar" label of temporarilyGatedPod.
+			plugin.allowlists = []string{"foo", "bar"}
+
+			gotInfo := q.PopSpecificPod(logger, tt.podToPop)
+			if tt.wantPopped {
+				if gotInfo == nil {
+					t.Errorf("Expected pod info to be popped, got nil")
+				} else if gotInfo.Pod.Name != tt.podToPop.Name {
+					t.Errorf("Expected pod %s, got %s", tt.podToPop.Name, gotInfo.Pod.Name)
+				}
+				_, ok := q.GetPod(tt.podToPop.Name, tt.podToPop.Namespace)
+				if ok {
+					t.Errorf("Expected pod not to exist in the scheduling queue after being popped")
+				}
+			} else {
+				if gotInfo != nil {
+					t.Errorf("Expected nil pod info, got %v", gotInfo.Pod.Name)
+				}
+				if tt.podToPop != otherPod {
+					_, ok := q.GetPod(tt.podToPop.Name, tt.podToPop.Namespace)
+					if !ok {
+						t.Errorf("Expected pod to exist in the scheduling queue after not being popped")
+					}
+				}
+			}
+
+			// Verify if it's in inFlight pods.
+			inFlightPods := q.InFlightPods()
+			found := false
+			for _, p := range inFlightPods {
+				if p.UID == tt.podToPop.UID {
+					found = true
+					break
+				}
+			}
+			if found != tt.wantPopped {
+				t.Errorf("Expected pod inFlight: %v, got: %v", tt.wantPopped, found)
+			}
+		})
+	}
+}
+
 func TestPriorityQueue_Update(t *testing.T) {
 	c := testingclock.NewFakeClock(time.Now())
 

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -358,8 +358,8 @@ func (sched *Scheduler) assumeAndReserve(
 }
 
 // unreserveAndForget unreserves and forgets the pod from scheduler's memory.
-// This function shouldn't be called during binding cycle with a pod that has the NeedsPodGroupScheduling set to true,
-// but this shouldn't happen, because such pods cannot reach binding.
+// This function shouldn't be called during binding cycle with a state, where IsPodGroupSchedulingCycle is set to true,
+// but this shouldn't happen, because such pods with such state cannot reach binding.
 func (sched *Scheduler) unreserveAndForget(
 	ctx context.Context,
 	state fwk.CycleState,

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -137,6 +137,9 @@ func (sched *Scheduler) podGroupInfoForPod(ctx context.Context, pInfo *framework
 
 	// Pop all unscheduled pods from the scheduling queue
 	for _, pod := range unscheduledPods {
+		if pod.Name == pInfo.Pod.Name {
+			continue
+		}
 		unscheduledPodInfo := sched.SchedulingQueue.PopSpecificPod(logger, pod)
 		if unscheduledPodInfo == nil {
 			logger.V(5).Info("Pod available in pod group state not available in scheduling queue", "podGroup", klog.KObj(podGroupInfo), "pod", klog.KObj(pod))

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1029,6 +1029,21 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		var gotBinding *v1.Binding
 		var gotNominatingInfo *fwk.NominatingInfo
 
+		if scheduleAsPodGroup {
+			group := &v1.PodSchedulingGroup{
+				PodGroupName: new("pg"),
+			}
+			// When scheduling a pod as a pod group, set scheduling group to all relevant pods.
+			item.sendPod = withSchedulingGroup(item.sendPod, group)
+			item.expectErrorPod = withSchedulingGroup(item.expectErrorPod, group)
+			item.expectPodInBackoffQ = withSchedulingGroup(item.expectPodInBackoffQ, group)
+			if item.expectPodInUnschedulable != nil {
+				// Pods from a pod group skip unschedulablePods structure and land directly in the backoffQ.
+				item.expectPodInBackoffQ = withSchedulingGroup(item.expectPodInUnschedulable, group)
+				item.expectPodInUnschedulable = nil
+			}
+		}
+
 		client := clientsetfake.NewClientset(item.sendPod)
 		informerFactory := informers.NewSharedInformerFactory(client, 0)
 		client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
@@ -1049,14 +1064,6 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		internalCache := internalcache.New(ctx, apiDispatcher, scheduleAsPodGroup)
 
 		if scheduleAsPodGroup {
-			group := &v1.PodSchedulingGroup{
-				PodGroupName: new("pg"),
-			}
-			// When scheduling a pod as a pod group, set scheduling group to all relevant pods.
-			item.sendPod = withSchedulingGroup(item.sendPod, group)
-			item.expectErrorPod = withSchedulingGroup(item.expectErrorPod, group)
-			item.expectPodInBackoffQ = withSchedulingGroup(item.expectPodInBackoffQ, group)
-			item.expectPodInUnschedulable = withSchedulingGroup(item.expectPodInUnschedulable, group)
 			internalCache.AddPodGroupMember(item.sendPod)
 		}
 		cache := &fakecache.Cache{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR ensures that gated pods are handled correctly when trying to pop them for pod group scheduling cycle. Each attempt tries to use activate function to ensure the pod is not blocked on PreEnqueue and can be popped.

Moreover, the code ensures the pod group members are moved directly to the backoffQ after failed scheduling attempt, because we cannot be sure that all inter-pod dependencies are captured correctly via pod-based Queueing Hints.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
