### PR TITLE
Graduate +k8s:forbidden to beta.

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
@@ -210,18 +210,18 @@ func TestRuleStability(t *testing.T) {
 		},
 		{
 			name:     "alpha context, alpha tag",
-			comments: []string{"+k8s:alpha=+k8s:forbidden"}, // Alpha context, Alpha tag
+			comments: []string{"+k8s:alpha=+k8s:validateTrue"}, // Alpha context, Alpha tag
 			wantMsg:  "",
 		},
 		{
 			name:     "stable context, alpha tag",
-			comments: []string{"+k8s:forbidden"}, // Stable context, Alpha tag
-			wantMsg:  `tag "k8s:forbidden" with stability level "Alpha" cannot be used in Stable validation`,
+			comments: []string{"+k8s:validateTrue"}, // Stable context, Alpha tag
+			wantMsg:  `tag "k8s:validateTrue" with stability level "Alpha" cannot be used in Stable validation`,
 		},
 		{
 			name:     "beta context, alpha tag",
-			comments: []string{"+k8s:beta=+k8s:forbidden"}, // Beta context, Alpha tag
-			wantMsg:  `tag "k8s:forbidden" with stability level "Alpha" cannot be used in Beta validation`,
+			comments: []string{"+k8s:beta=+k8s:validateTrue"}, // Beta context, Alpha tag
+			wantMsg:  `tag "k8s:validateTrue" with stability level "Alpha" cannot be used in Beta validation`,
 		},
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -315,7 +315,7 @@ func (rtv requirednessTagValidator) Docs() TagDoc {
 		doc.StabilityLevel = TagStabilityLevelStable
 		doc.Description = "Indicates that a field is optional to clients."
 	case requirednessForbidden:
-		doc.StabilityLevel = TagStabilityLevelAlpha
+		doc.StabilityLevel = TagStabilityLevelBeta
 		doc.Description = "Indicates that a field may not be specified."
 	default:
 		panic(fmt.Sprintf("unknown requiredness mode: %q", rtv.mode))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR graduates the `+k8s:forbidden` marker to **Beta** stability level. 

Previously, there was not enough confidence to see widespread usage of this tag to justify graduation. However, during the 1.36 release cycle, sufficient usage was found, particularly in conjunction with **modal discriminators** and **ifEnabled/ifDisabled** validations. 

Graduating this tag allows it to be used in Beta-level API validations without triggering linting errors related to stability levels.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
The changes include:
*   Updating `staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go` to change the stability level from `Alpha` to `Beta` for the forbidden requiredness mode.
*   Updating `staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go` to reflect that `+k8s:forbidden` is now permitted in Beta contexts.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
*  NONE