### PR TITLE
Add nmn3m to sig-instrumentation-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -353,6 +353,7 @@ aliases:
     - dgrisonnet
     - pohly
     - mengjiao-liu
+    - nmn3m
     - rexagod
     - richabanker
   api-approvers:


### PR DESCRIPTION
 ## Summary

  Add @nmn3m as a reviewer for sig-instrumentation in OWNERS_ALIASES.

  This was discussed and approved in kubernetes/org#6206, with +1s from @richabanker and
  @dgrisonnet.

  /cc @richabanker @dgrisonnet
  /sig instrumentation
