### PR TITLE
api/resource: remove util/validation import by inlining constant

### DIFF
--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -262,7 +261,9 @@ type ResourcePool struct {
 const ResourceSliceMaxSharedCapacity = 128
 const ResourceSliceMaxDevices = 128
 const ResourceSliceMaxDevicesWithTaintsOrConsumesCounters = 64
-const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
+// PoolNameMaxLength is a DNS 1123 subdomain maximum length (RFC 1123).
+// Same as for a single node name.
+const PoolNameMaxLength = 253
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -273,7 +272,9 @@ type ResourcePool struct {
 const ResourceSliceMaxSharedCapacity = 128
 const ResourceSliceMaxDevices = 128
 const ResourceSliceMaxDevicesWithTaintsOrConsumesCounters = 64
-const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
+// PoolNameMaxLength is a DNS 1123 subdomain maximum length (RFC 1123).
+// Same as for a single node name.
+const PoolNameMaxLength = 253
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -265,7 +264,9 @@ type ResourcePool struct {
 const ResourceSliceMaxSharedCapacity = 128
 const ResourceSliceMaxDevices = 128
 const ResourceSliceMaxDevicesWithTaintsOrConsumesCounters = 64
-const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
+// PoolNameMaxLength is a DNS 1123 subdomain maximum length (RFC 1123).
+// Same as for a single node name.
+const PoolNameMaxLength = 253
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
 


### PR DESCRIPTION
## Summary

- Replaces `validation.DNS1123SubdomainMaxLength` with its literal value (`253`) in `k8s.io/api/resource` types (v1, v1beta1, v1beta2)
- Removes the `k8s.io/apimachinery/pkg/util/validation` import from these three files
- This is a step toward reducing `k8s.io/api`'s dependency surface on `k8s.io/apimachinery`

The constant was only used in one place per file (`PoolNameMaxLength`), and its value is a well-known DNS RFC 1123 subdomain maximum length. A comment documenting the RFC origin is added in place of the import.

This is a non-breaking change — the constant value is identical (`253`), just sourced locally instead of from apimachinery.

Ref: https://github.com/kubernetes/kubernetes/issues/127888
Ref: https://github.com/kubernetes/kubernetes/issues/127889

## Test plan

- [x] `go build ./resource/...` passes in `staging/src/k8s.io/api`
- [ ] Verify CI passes (no behavioral change, only import removal)

/area code-organization
/sig api-machinery