### PR TITLE
discovery: decouple from kubernetes/scheme by using a minimal local scheme

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/openapi"
 	cachedopenapi "k8s.io/client-go/openapi/cached"
 	restclient "k8s.io/client-go/rest"
@@ -73,7 +72,7 @@ func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion stri
 	// don't fail on errors, we either don't have a file or won't be able to run the cached check. Either way we can fallback.
 	if err == nil {
 		cachedResources := &metav1.APIResourceList{}
-		if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), cachedBytes, cachedResources); err == nil {
+		if err := runtime.DecodeInto(discovery.Codecs.UniversalDecoder(), cachedBytes, cachedResources); err == nil {
 			klog.V(10).Infof("returning cached discovery info from %v", filename)
 			return cachedResources, nil
 		}
@@ -109,7 +108,7 @@ func (d *CachedDiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
 	// don't fail on errors, we either don't have a file or won't be able to run the cached check. Either way we can fallback.
 	if err == nil {
 		cachedGroups := &metav1.APIGroupList{}
-		if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), cachedBytes, cachedGroups); err == nil {
+		if err := runtime.DecodeInto(discovery.Codecs.UniversalDecoder(), cachedBytes, cachedGroups); err == nil {
 			klog.V(10).Infof("returning cached discovery info from %v", filename)
 			return cachedGroups, nil
 		}
@@ -175,7 +174,7 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
 		return err
 	}
 
-	bytes, err := runtime.Encode(scheme.Codecs.LegacyCodec(), obj)
+	bytes, err := runtime.Encode(discovery.Codecs.LegacyCodec(), obj)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/openapi"
 	restclient "k8s.io/client-go/rest"
 )
@@ -733,7 +732,7 @@ func setDiscoveryDefaults(config *restclient.Config) error {
 		// see https://issue.k8s.io/86149
 		config.Burst = defaultBurst
 	}
-	codec := runtime.NoopEncoder{Decoder: scheme.Codecs.UniversalDecoder()}
+	codec := runtime.NoopEncoder{Decoder: Codecs.UniversalDecoder()}
 	config.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: codec})
 	if len(config.UserAgent) == 0 {
 		config.UserAgent = restclient.DefaultKubernetesUserAgent()

--- a/staging/src/k8s.io/client-go/discovery/scheme.go
+++ b/staging/src/k8s.io/client-go/discovery/scheme.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
+	apidiscoveryv2beta1 "k8s.io/api/apidiscovery/v2beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// discoveryScheme is a minimal scheme containing only the types needed by
+// the discovery client, avoiding a dependency on the full kubernetes scheme
+// which registers all 52+ API group versions.
+var discoveryScheme = runtime.NewScheme()
+
+// Codecs provides encoding and decoding for the discovery scheme.
+var Codecs = serializer.NewCodecFactory(discoveryScheme)
+
+func init() {
+	metav1.AddToGroupVersion(discoveryScheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(apidiscoveryv2.AddToScheme(discoveryScheme))
+	utilruntime.Must(apidiscoveryv2beta1.AddToScheme(discoveryScheme))
+}


### PR DESCRIPTION
## Summary

- Creates a minimal local scheme in `discovery/scheme.go` that registers only the types the discovery client actually uses: `metav1`, `apidiscoveryv2`, and `apidiscoveryv2beta1`
- Removes the `k8s.io/client-go/kubernetes/scheme` import from `discovery/discovery_client.go` and `discovery/cached/disk/cached_discovery.go`
- Follows the same pattern already used by the metadata client (`metainternalversionscheme.Codecs`) and the dynamic client (`dynamic/scheme.go`)

The discovery client only encodes/decodes `metav1.APIGroupList`, `metav1.APIResourceList`, and apidiscovery types. It does not use any of the 52 API group types registered by the full kubernetes scheme. This change breaks the import chain so that consumers importing only `k8s.io/client-go/discovery` no longer transitively depend on all API group type registrations.

This is not a breaking change — the discovery client's public API is unchanged, and no consumer code accesses the scheme object directly.

Ref: https://github.com/kubernetes/kubernetes/issues/127888

## Test plan

- [x] `go build ./discovery/...` passes
- [x] `go build ./...` passes (all of client-go)
- [x] `go test ./discovery/... -count=1` — all 55 tests pass across 5 packages
- [ ] Verify CI passes

/area code-organization
/sig api-machinery