### PR TITLE
Fix race in podGroupState locking

### DIFF
--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -232,12 +232,56 @@ func (pgs *podGroupState) snapshot() *podGroupStateSnapshot {
 // empty returns true when the group contains no pods.
 // It must be called under the cache lock.
 func (pgs *podGroupState) empty() bool {
+	pgs.lock.RLock()
+	defer pgs.lock.RUnlock()
+
 	return pgs.podGroupStateData.empty()
 }
 
-// forgetPod moves a pod back from the assumed state to unscheduled.
+// addPod adds the pod to this group.
+// Depending on the NodeName, it can insert the pod into either assignedPods or unscheduledPods.
+// It must be called under the cache lock.
+func (pgs *podGroupState) addPod(pod *v1.Pod) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.podGroupStateData.addPod(pod)
+}
+
+// updatePod updates the pod in this group.
+// In case of binding, it moves the pod to assignedPods.
+// It must be called under the cache lock.
+func (pgs *podGroupState) updatePod(oldPod, newPod *v1.Pod) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.podGroupStateData.updatePod(oldPod, newPod)
+}
+
+// deletePod removes the pod from this pod group state.
+// It must be called under the cache lock.
+func (pgs *podGroupState) deletePod(podUID types.UID) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.podGroupStateData.deletePod(podUID)
+}
+
+// assumePod marks a pod as assumed within the pod group state.
+// It must be called under the cache lock.
+func (pgs *podGroupState) assumePod(podUID types.UID) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.podGroupStateData.assumePod(podUID)
+}
+
+// forgetPod moves a pod back from the assumed state to unscheduled within the pod group state.
 // It must be called under the cache lock.
 func (pgs *podGroupState) forgetPod(podUID types.UID) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
 	pgs.podGroupStateData.forgetPod(podUID)
 }
 

--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -269,11 +269,11 @@ func (pgs *podGroupState) deletePod(podUID types.UID) {
 
 // assumePod marks a pod as assumed within the pod group state.
 // It must be called under the cache lock.
-func (pgs *podGroupState) assumePod(podUID types.UID) {
+func (pgs *podGroupState) assumePod(pod *v1.Pod) {
 	pgs.lock.Lock()
 	defer pgs.lock.Unlock()
 
-	pgs.podGroupStateData.assumePod(podUID)
+	pgs.podGroupStateData.assumePod(pod)
 }
 
 // forgetPod moves a pod back from the assumed state to unscheduled within the pod group state.

--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -2655,7 +2655,7 @@ var _ fwk.PostBindPlugin = &PostBindPlugin{}
 
 type JobPlugin struct {
 	podLister     listersv1.PodLister
-	podsActivated bool
+	podsActivated chan struct{}
 }
 
 func (j *JobPlugin) Name() string {
@@ -2696,7 +2696,7 @@ func (j *JobPlugin) PostBind(_ context.Context, state fwk.CycleState, p *v1.Pod,
 					s.Map[namespacedName] = pod
 				}
 				s.Unlock()
-				j.podsActivated = true
+				j.podsActivated <- struct{}{}
 			}
 		}
 	}
@@ -2710,7 +2710,10 @@ func TestActivatePods(t *testing.T) {
 	var jobPlugin *JobPlugin
 	// Create a plugin registry for testing. Register a Job plugin.
 	registry := frameworkruntime.Registry{jobPluginName: func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
-		jobPlugin = &JobPlugin{podLister: fh.SharedInformerFactory().Core().V1().Pods().Lister()}
+		jobPlugin = &JobPlugin{
+			podLister:     fh.SharedInformerFactory().Core().V1().Pods().Lister(),
+			podsActivated: make(chan struct{}, 10),
+		}
 		return jobPlugin, nil
 	}}
 
@@ -2775,8 +2778,10 @@ func TestActivatePods(t *testing.T) {
 	}
 
 	// Lastly verify the pods activation logic is really called.
-	if jobPlugin.podsActivated == false {
-		t.Errorf("JobPlugin's pods activation logic is not called")
+	select {
+	case <-jobPlugin.podsActivated:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Errorf("JobPlugin's pods activation logic wasn't called")
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Scheduler's cache calls methods on `podGroupState` that modify the embedded `podGroupStateData`. Scheduling cycle can call the `podGroupState` methods at the same time, causing data race. This PR ensures that all `podGroupStateData` methods are wrapped into locked `podGroupState` methods.

This PR also fixes a data race in TestActivatePods method.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/137803
https://github.com/kubernetes/kubernetes/issues/137802

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
