### PR TITLE
Increase test coverage for pods when they are pod group members with WAS enabled

### DIFF
--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -690,13 +690,9 @@ func TestEphemeralStorageResource(t *testing.T) {
 }
 
 func Test_AddPodGroupMember(t *testing.T) {
-	podGroupName := "pg"
-	// Pod with no pod group name.
-	pod1 := st.MakePod().Namespace("namespace").Name("non-workload-pod").Obj()
-	// Unscheduled pod with a pod group name.
-	pod2 := st.MakePod().Namespace("namespace").Name("unscheduled-pod").PodGroupName(podGroupName).Obj()
-	// Assigned pod with the same pod group name.
-	pod3 := st.MakePod().Namespace("namespace").Name("assigned-pod").Node("node1").PodGroupName(podGroupName).Obj()
+	podWithNoPodGroup := st.MakePod().Namespace("namespace").Name("non-workload-pod").Obj()
+	unscheduledPodGroupMember := st.MakePod().Namespace("namespace").Name("unscheduled-pod").PodGroupName("pg").Obj()
+	assignedPodGroupMember := st.MakePod().Namespace("namespace").Name("assigned-pod").Node("node1").PodGroupName("pg").Obj()
 
 	tests := []struct {
 		name                    string
@@ -706,24 +702,24 @@ func Test_AddPodGroupMember(t *testing.T) {
 		expectInAssignedPods    bool
 	}{
 		{
-			name:                   "generic workload disabled",
-			pod:                    pod2,
+			name:                   "add pod group member with GenericWorkload disabled should be no-op",
+			pod:                    unscheduledPodGroupMember,
 			genericWorkloadEnabled: false,
 		},
 		{
-			name:                   "pod with no pod group name",
-			pod:                    pod1,
+			name:                   "add pod with no pod group name",
+			pod:                    podWithNoPodGroup,
 			genericWorkloadEnabled: true,
 		},
 		{
-			name:                    "unscheduled pod with a pod group name",
-			pod:                     pod2,
+			name:                    "add unscheduled pod group member",
+			pod:                     unscheduledPodGroupMember,
 			genericWorkloadEnabled:  true,
 			expectInUnscheduledPods: true,
 		},
 		{
-			name:                   "assigned pod with a pod group name",
-			pod:                    pod3,
+			name:                   "add assigned pod group member",
+			pod:                    assignedPodGroupMember,
 			genericWorkloadEnabled: true,
 			expectInAssignedPods:   true,
 		},
@@ -734,19 +730,16 @@ func Test_AddPodGroupMember(t *testing.T) {
 			cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled)
 			cache.AddPodGroupMember(tt.pod)
 
-			if tt.pod.Spec.SchedulingGroup == nil {
-				if tt.expectInAssignedPods || tt.expectInUnscheduledPods {
-					t.Errorf("Expected pod group to exist, but pod has no pod group")
+			if !tt.genericWorkloadEnabled || tt.pod.Spec.SchedulingGroup == nil {
+				if count := len(cache.podGroupStates); count != 0 {
+					t.Errorf("Expected no pod groups states to exist in cache, but found %d", count)
 				}
 				return
 			}
 
 			podGroupState, err := cache.PodGroupStates().Get(tt.pod.Namespace, *tt.pod.Spec.SchedulingGroup.PodGroupName)
 			if err != nil {
-				if tt.genericWorkloadEnabled {
-					t.Errorf("Expected pod group to exist, but got error: %v", err)
-				}
-				return
+				t.Fatalf("Unexpected error getting pod group state: %v", err)
 			}
 
 			_, inUnscheduledPods := podGroupState.UnscheduledPods()[tt.pod.Name]
@@ -788,20 +781,19 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 		expectInAssignedPods    bool
 	}{
 		{
-			name:                    "updating a pod with genericWorkload disabled should be a no-op",
-			oldPod:                  pod,
-			newPod:                  updatedPod,
-			genericWorkloadEnabled:  false,
-			expectInUnscheduledPods: true,
+			name:                   "update a pod group member with GenericWorkload disabled should be a no-op",
+			oldPod:                 pod,
+			newPod:                 updatedPod,
+			genericWorkloadEnabled: false,
 		},
 		{
-			name:                   "update a pod with no pod group name should be a no-op",
+			name:                   "update a pod with no pod group name",
 			oldPod:                 noPodGroupPod,
 			newPod:                 updatedNoPodGroupPod,
 			genericWorkloadEnabled: true,
 		},
 		{
-			name:                    "update a pod",
+			name:                    "update a pod group member, add label",
 			isAssumedPod:            true,
 			oldPod:                  pod,
 			newPod:                  updatedPod,
@@ -809,7 +801,7 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 			expectInUnscheduledPods: true,
 		},
 		{
-			name:                   "update a pod, move to assigned",
+			name:                   "update an unscheduled pod group member, set NodeName",
 			isAssumedPod:           true,
 			oldPod:                 pod,
 			newPod:                 assignedPod,
@@ -821,9 +813,8 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
-			cache := newCache(context.Background(), time.Second, nil, true)
+			cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled)
 			cache.AddPodGroupMember(tt.oldPod)
-			cache.genericWorkloadEnabled = tt.genericWorkloadEnabled
 
 			newPod := tt.newPod
 			if newPod == nil {
@@ -831,16 +822,16 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 			}
 			cache.UpdatePodGroupMember(logger, tt.oldPod, newPod)
 
-			if newPod.Spec.SchedulingGroup == nil {
-				if tt.expectInAssumedPods || tt.expectInUnscheduledPods || tt.expectInAssignedPods {
-					t.Errorf("Expected pod group to exist, but pod has no SchedulingGroup")
+			if !tt.genericWorkloadEnabled || newPod.Spec.SchedulingGroup == nil {
+				if count := len(cache.podGroupStates); count != 0 {
+					t.Errorf("Expected no pod groups states to exist in cache, but found %d", count)
 				}
 				return
 			}
 
 			podGroupState, err := cache.PodGroupStates().Get(newPod.Namespace, *newPod.Spec.SchedulingGroup.PodGroupName)
 			if err != nil {
-				return
+				t.Fatalf("Unexpected error getting pod group state: %v", err)
 			}
 
 			_, inUnscheduledPods := podGroupState.UnscheduledPods()[newPod.Name]
@@ -854,10 +845,6 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 
 			if inAssumedPods := podGroupState.AssumedPods().Has(newPod.UID); inAssumedPods != tt.expectInAssumedPods {
 				t.Errorf("expected pod in AssumedPods: %v, got %v", tt.expectInAssumedPods, inAssumedPods)
-			}
-
-			if !tt.genericWorkloadEnabled {
-				return
 			}
 
 			podGroupKey := newPodGroupKey(newPod.Namespace, *newPod.Spec.SchedulingGroup.PodGroupName)
@@ -904,13 +891,7 @@ func Test_RemovePodGroupMember(t *testing.T) {
 			genericWorkloadEnabled:   true,
 		},
 		{
-			name:                     "remove a non-existent pod from a group should be a no-op",
-			podToDelete:              pod1,
-			expectPodGroupStateCount: 0,
-			genericWorkloadEnabled:   true,
-		},
-		{
-			name:                     "remove a pod while generic workload disabled should be a no-op",
+			name:                     "remove a pod with GenericWorkload disabled should be a no-op",
 			initPods:                 []*v1.Pod{pod1},
 			expectPodGroupStateCount: 0,
 			podToDelete:              pod1,
@@ -1025,51 +1006,68 @@ func TestUpdatePodGroupStateSnapshot(t *testing.T) {
 	}
 }
 
-// TestBindingPodGroupMember simulates binding and tests that when an assumed pod
-// gets bound, its state within pod group transitions from assumed to assigned.
+// TestBindingPodGroupMember simulates binding and tests that when an assumed or
+// unscheduled pod gets bound, its state within pod group becomes assigned.
 func TestBindingPodGroupMember(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
-	cache := newCache(ctx, time.Second, nil, true)
-	podGroupName := "pg"
-	pod := st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
-		PodGroupName(podGroupName).Obj()
-
-	// Simulate the informer firing an Add event for an unscheduled
-	// pod (no NodeName set) reflecting on PodGroupStates.
-	cache.AddPodGroupMember(pod)
-
-	// Simulate the scheduler assuming the pod on a node.
-	assumedPod := pod.DeepCopy()
-	assumedPod.Spec.NodeName = "node1"
-	if err := cache.AssumePod(logger, assumedPod); err != nil {
-		t.Fatalf("AssumePod failed: %v", err)
+	tests := []struct {
+		name         string
+		pod          *v1.Pod
+		assumedPod   *v1.Pod
+		scheduledPod *v1.Pod
+	}{
+		{
+			name: "bind unscheduled pod group member",
+			pod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Obj(),
+			scheduledPod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Node("node1").Obj(),
+		},
+		{
+			name: "bind assumed pod group member",
+			pod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Obj(),
+			assumedPod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Node("node1").Obj(),
+			scheduledPod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Node("node1").Obj(),
+		},
 	}
 
-	podGroupState, err := cache.PodGroupStates().Get(pod.Namespace, podGroupName)
-	if err != nil {
-		t.Fatalf("Unexpected error getting pod group state after AssumePod: %v", err)
-	}
-	if !podGroupState.AssumedPods().Has(assumedPod.UID) {
-		t.Errorf("Expected pod to be in AssumedPods after AssumePod")
-	}
-	if podGroupState.AssignedPods().Has(assumedPod.UID) {
-		t.Errorf("Expected pod NOT to be in AssignedPods after AssumePod")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			cache := newCache(ctx, time.Second, nil, true)
 
-	// Simulate binding confirmation: the informer fires an Add event with NodeName set.
-	if err := cache.AddPod(logger, assumedPod); err != nil {
-		t.Fatalf("AddPod (binding confirmation) failed: %v", err)
-	}
+			// Simulate the informer firing an Add event for an unscheduled pod.
+			cache.AddPodGroupMember(tt.pod)
 
-	podGroupState, err = cache.PodGroupStates().Get(pod.Namespace, podGroupName)
-	if err != nil {
-		t.Fatalf("Unexpected error getting pod group state after AddPod: %v", err)
-	}
-	if podGroupState.AssumedPods().Has(assumedPod.UID) {
-		t.Errorf("Expected pod not to be in AssumedPods after binding confirmation")
-	}
-	if !podGroupState.AssignedPods().Has(assumedPod.UID) {
-		t.Errorf("Expected pod to be in AssignedPods after binding confirmation")
+			if tt.assumedPod != nil {
+				if err := cache.AssumePod(logger, tt.assumedPod); err != nil {
+					t.Fatalf("AssumePod failed: %v", err)
+				}
+			}
+
+			// Simulate the informer firing an Add event with NodeName set to bind a pod.
+			if err := cache.AddPod(logger, tt.scheduledPod); err != nil {
+				t.Fatalf("AddPod (binding) failed: %v", err)
+			}
+
+			podGroupState, err := cache.PodGroupStates().Get(tt.pod.Namespace, *tt.pod.Spec.SchedulingGroup.PodGroupName)
+			if err != nil {
+				t.Fatalf("Unexpected error getting pod group state: %v", err)
+			}
+			if !podGroupState.AssignedPods().Has(tt.pod.UID) {
+				t.Errorf("Expected pod to be in AssignedPods after binding")
+			}
+			if podGroupState.AssumedPods().Has(tt.pod.UID) {
+				t.Errorf("Expected pod not to be in AssumedPods after binding")
+			}
+			if podGroupState.UnscheduledPods()[tt.pod.Name] != nil {
+				t.Errorf("Expected pod not to be in UnscheduledPods after binding")
+			}
+		})
 	}
 }
 
@@ -1192,6 +1190,145 @@ func TestForgetPod(t *testing.T) {
 		if err := cache.ForgetPod(logger, pod); err != nil {
 			t.Error("expected no error, error found")
 		}
+	}
+}
+
+func TestForgetPodGroupMember(t *testing.T) {
+	pod := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").
+		PodGroupName("pg").Obj()
+	podWithNodeName := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").
+		Node("node-1").PodGroupName("pg").Obj()
+
+	tests := []struct {
+		name                   string
+		pod                    *v1.Pod
+		expectInAssigned       bool
+		expectInUnscheduled    bool
+		genericWorkloadEnabled bool
+	}{
+		{
+			name: "forget pod group member with GenericWorkload disabled",
+			pod:  pod,
+		},
+		{
+			name:                   "add pod group member without NodeName, then call assume and forget",
+			pod:                    pod,
+			genericWorkloadEnabled: true,
+			expectInUnscheduled:    true,
+		},
+		{
+			name:                   "add pod group member with NodeName, then call assume and forget",
+			pod:                    podWithNodeName,
+			genericWorkloadEnabled: true,
+			expectInAssigned:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled)
+			cache.AddPodGroupMember(tt.pod)
+			if err := cache.AssumePod(logger, podWithNodeName); err != nil {
+				t.Fatalf("AssumePod failed: %v", err)
+			}
+
+			if err := cache.ForgetPod(logger, podWithNodeName); err != nil {
+				t.Fatalf("ForgetPod failed: %v", err)
+			}
+
+			if !tt.genericWorkloadEnabled {
+				if count := len(cache.podGroupStates); count != 0 {
+					t.Errorf("Expected no pod group states to exist in cache, but found %d", count)
+				}
+				return
+			}
+
+			pgs, err := cache.PodGroupStates().Get("test-ns", *tt.pod.Spec.SchedulingGroup.PodGroupName)
+			if err != nil {
+				t.Fatalf("expected pod group state to exist, but got error: %v", err)
+			}
+
+			if pgs.AssumedPods().Has(tt.pod.UID) {
+				t.Fatalf("pod cannot be in AssumedPods after ForgetPod")
+			}
+
+			if inAssigned := pgs.AssignedPods().Has(tt.pod.UID); inAssigned != tt.expectInAssigned {
+				t.Errorf("pod in assignedPods: got %v, want %v", inAssigned, tt.expectInAssigned)
+			}
+			if inUnscheduled := pgs.UnscheduledPods()[tt.pod.Name] != nil; inUnscheduled != tt.expectInUnscheduled {
+				t.Errorf("pod in unscheduledPods: got %v, want %v", inUnscheduled, tt.expectInUnscheduled)
+			}
+		})
+	}
+}
+
+func TestAssumePodGroupMember(t *testing.T) {
+	pod := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").
+		PodGroupName("pg").Obj()
+	podWithNodeName := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").
+		Node("node-1").PodGroupName("pg").Obj()
+
+	tests := []struct {
+		name                   string
+		genericWorkloadEnabled bool
+		pod                    *v1.Pod
+		expectInAssumed        bool
+		expectInAssigned       bool
+	}{
+		{
+			name: "assume a pod group member with GenericWorkload disabled",
+			pod:  pod,
+		},
+		{
+			name:                   "add pod group member without NodeName, then call assume",
+			pod:                    pod,
+			genericWorkloadEnabled: true,
+			expectInAssumed:        true,
+		},
+		{
+			name:                   "add pod group member with NodeName, then call assume",
+			pod:                    podWithNodeName,
+			genericWorkloadEnabled: true,
+			expectInAssigned:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled)
+			cache.AddPodGroupMember(tt.pod)
+
+			if err := cache.AssumePod(logger, podWithNodeName); err != nil {
+				t.Fatalf("AssumePod failed: %v", err)
+			}
+
+			if !tt.genericWorkloadEnabled {
+				if count := len(cache.podGroupStates); count != 0 {
+					t.Errorf("Expected no pod group states to exist in cache, but found %d", count)
+				}
+				return
+			}
+
+			pgs, err := cache.PodGroupStates().Get("test-ns", *pod.Spec.SchedulingGroup.PodGroupName)
+			if err != nil {
+				t.Fatalf("unexpected error getting pod group state: %v", err)
+			}
+
+			if inAssigned := pgs.AssignedPods().Has(tt.pod.UID); inAssigned != tt.expectInAssigned {
+				t.Errorf("pod in assignedPods: got %v, want %v", inAssigned, tt.expectInAssigned)
+			}
+			if inAssumed := pgs.AssumedPods().Has(tt.pod.UID); inAssumed != tt.expectInAssumed {
+				t.Errorf("pod in assumedPods: got %v, want %v", inAssumed, tt.expectInAssumed)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -95,6 +95,10 @@ func (d *podGroupStateData) addPod(pod *v1.Pod) {
 	d.allPods[pod.UID] = pod
 	if pod.Spec.NodeName != "" {
 		d.assignedPods.Insert(pod.UID)
+		// Clear from unscheduled or assumed in case the pod previously existed in the pod group
+		// in a different state, e.g., external binding of a previously-queued pod group member.
+		d.unscheduledPods.Delete(pod.UID)
+		delete(d.assumedPods, pod.UID)
 	} else {
 		d.unscheduledPods.Insert(pod.UID)
 	}

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -828,25 +828,51 @@ func TestAdmissionCheck(t *testing.T) {
 }
 
 func TestAddPod(t *testing.T) {
+	basePod := func() *st.PodWrapper {
+		return st.MakePod().Name("pod1").SchedulerName("supported-scheduler").Namespace("ns1").UID("pod1")
+	}
+
 	tests := []struct {
-		name          string
-		pod           *v1.Pod
-		expectInQueue bool
-		expectInCache bool
+		name                             string
+		pod                              *v1.Pod
+		genericWorkloadEnabled           bool
+		expectInQueue                    bool
+		expectInCache                    bool
+		expectInPodGroupStateUnscheduled bool
+		expectInPodGroupStateAssigned    bool
 	}{
 		{
 			name:          "add unscheduled pod",
-			pod:           st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("supported-scheduler").Obj(),
+			pod:           basePod().Obj(),
 			expectInQueue: true,
 		},
 		{
 			name: "add unscheduled pod with other scheduler name",
-			pod:  st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj(),
+			pod:  basePod().SchedulerName("other-scheduler").Obj(),
 		},
 		{
 			name:          "add scheduled pod",
-			pod:           st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").Obj(),
+			pod:           basePod().Node("node1").Obj(),
 			expectInCache: true,
+		},
+		{
+			name:          "add a pod group member with GenericWorkload disabled",
+			pod:           basePod().PodGroupName("pg1").Obj(),
+			expectInQueue: true,
+		},
+		{
+			name:                             "add an unscheduled pod group member",
+			pod:                              basePod().PodGroupName("pg1").Obj(),
+			genericWorkloadEnabled:           true,
+			expectInQueue:                    true,
+			expectInPodGroupStateUnscheduled: true,
+		},
+		{
+			name:                          "add a scheduled pod group member",
+			pod:                           basePod().Node("node1").PodGroupName("pg1").Obj(),
+			genericWorkloadEnabled:        true,
+			expectInCache:                 true,
+			expectInPodGroupStateAssigned: true,
 		},
 	}
 	for _, tt := range tests {
@@ -856,7 +882,7 @@ func TestAddPod(t *testing.T) {
 			defer cancel()
 
 			sched := &Scheduler{
-				Cache:           internalcache.New(ctx, nil, false),
+				Cache:           internalcache.New(ctx, nil, tt.genericWorkloadEnabled),
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 				logger:          logger,
 				Profiles: profile.Map{
@@ -877,6 +903,31 @@ func TestAddPod(t *testing.T) {
 				t.Errorf("Expected pod to be in cache: %v", err)
 			} else if !tt.expectInCache && err == nil {
 				t.Errorf("Expected pod not to be in cache")
+			}
+
+			if tt.pod.Spec.SchedulingGroup == nil {
+				// Pod has no pod group, so there is no pod group state to check, the test can complete.
+				return
+			}
+
+			pgs, err := sched.Cache.PodGroupStates().Get(tt.pod.Namespace, *tt.pod.Spec.SchedulingGroup.PodGroupName)
+
+			if !tt.genericWorkloadEnabled {
+				if err == nil {
+					t.Errorf("Expected no pod group state to exist when GenericWorkload is disabled, but found one")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Expected pod group state to exist, got error: %v", err)
+			}
+
+			if inUnscheduled := pgs.UnscheduledPods()[tt.pod.Name] != nil; inUnscheduled != tt.expectInPodGroupStateUnscheduled {
+				t.Errorf("Expected pod in UnscheduledPods of PodGroupState: got %v, want %v", inUnscheduled, tt.expectInPodGroupStateUnscheduled)
+			}
+			if inAssigned := pgs.AssignedPods().Has(tt.pod.UID); inAssigned != tt.expectInPodGroupStateAssigned {
+				t.Errorf("Expected pod in AssignedPods of PodGroupState: got %v, want %v", inAssigned, tt.expectInPodGroupStateAssigned)
 			}
 		})
 	}
@@ -899,13 +950,23 @@ func TestUpdatePod(t *testing.T) {
 
 	scheduledPodOtherNode := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node2").SchedulerName("supported-scheduler").Obj()
 
+	unscheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	unscheduledPodGroupMemberWithLabels := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	scheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	scheduledPodGroupMemberWithLabels := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	scheduledPodGroupMemberWithOtherNode := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+
 	tests := []struct {
-		name          string
-		oldPod        *v1.Pod
-		assumedPod    *v1.Pod
-		newPod        *v1.Pod
-		expectInQueue *v1.Pod
-		expectInCache *v1.Pod
+		name                             string
+		oldPod                           *v1.Pod
+		assumedPod                       *v1.Pod
+		newPod                           *v1.Pod
+		genericWorkloadEnabled           bool
+		expectInQueue                    *v1.Pod
+		expectInCache                    *v1.Pod
+		expectInPodGroupStateUnscheduled bool
+		expectInPodGroupStateAssumed     bool
+		expectInPodGroupStateAssigned    bool
 	}{
 		{
 			name:          "update unscheduled pod",
@@ -969,6 +1030,63 @@ func TestUpdatePod(t *testing.T) {
 			assumedPod: scheduledPod,
 			newPod:     podWithDeletionTimestamp,
 		},
+		{
+			name:          "update pod group member with GenericWorkload disabled",
+			oldPod:        unscheduledPodGroupMember,
+			newPod:        unscheduledPodGroupMemberWithLabels,
+			expectInQueue: unscheduledPodGroupMemberWithLabels,
+		},
+		{
+			name:                             "update unscheduled pod group member, add label",
+			oldPod:                           unscheduledPodGroupMember,
+			newPod:                           unscheduledPodGroupMemberWithLabels,
+			expectInQueue:                    unscheduledPodGroupMemberWithLabels,
+			genericWorkloadEnabled:           true,
+			expectInPodGroupStateUnscheduled: true,
+		},
+		{
+			name:                         "update assumed pod group member, add label",
+			oldPod:                       unscheduledPodGroupMember,
+			assumedPod:                   scheduledPodGroupMember,
+			newPod:                       unscheduledPodGroupMemberWithLabels,
+			expectInCache:                scheduledPodGroupMember,
+			genericWorkloadEnabled:       true,
+			expectInPodGroupStateAssumed: true,
+		},
+		{
+			name:                          "update scheduled pod group member, add label",
+			oldPod:                        scheduledPodGroupMember,
+			newPod:                        scheduledPodGroupMemberWithLabels,
+			expectInCache:                 scheduledPodGroupMemberWithLabels,
+			genericWorkloadEnabled:        true,
+			expectInPodGroupStateAssigned: true,
+		},
+		{
+			name:                          "bind unscheduled pod group member",
+			oldPod:                        unscheduledPodGroupMember,
+			newPod:                        scheduledPodGroupMember,
+			expectInCache:                 scheduledPodGroupMember,
+			genericWorkloadEnabled:        true,
+			expectInPodGroupStateAssigned: true,
+		},
+		{
+			name:                          "bind assumed pod group member",
+			oldPod:                        unscheduledPodGroupMember,
+			assumedPod:                    scheduledPodGroupMember,
+			newPod:                        scheduledPodGroupMember,
+			expectInCache:                 scheduledPodGroupMember,
+			genericWorkloadEnabled:        true,
+			expectInPodGroupStateAssigned: true,
+		},
+		{
+			name:                          "bind assumed pod group member to a different node",
+			oldPod:                        unscheduledPodGroupMember,
+			assumedPod:                    scheduledPodGroupMember,
+			newPod:                        scheduledPodGroupMemberWithOtherNode,
+			expectInCache:                 scheduledPodGroupMemberWithOtherNode,
+			genericWorkloadEnabled:        true,
+			expectInPodGroupStateAssigned: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -991,7 +1109,7 @@ func TestUpdatePod(t *testing.T) {
 				t.Fatalf("Failed to create framework: %v", err)
 			}
 			sched := &Scheduler{
-				Cache:           internalcache.New(ctx, nil, false),
+				Cache:           internalcache.New(ctx, nil, tt.genericWorkloadEnabled),
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 				logger:          logger,
 				Profiles: profile.Map{
@@ -1000,6 +1118,9 @@ func TestUpdatePod(t *testing.T) {
 			}
 
 			if tt.assumedPod != nil {
+				if tt.oldPod.Spec.SchedulingGroup != nil {
+					sched.Cache.AddPodGroupMember(tt.oldPod)
+				}
 				err := sched.Cache.AssumePod(logger, tt.assumedPod)
 				if err != nil {
 					t.Fatalf("Failed to assume pod: %v", err)
@@ -1030,6 +1151,33 @@ func TestUpdatePod(t *testing.T) {
 			} else if err == nil {
 				t.Errorf("Expected pod not to be in cache")
 			}
+
+			if tt.newPod.Spec.SchedulingGroup == nil {
+				// Pod has no pod group, so there is no pod group state to check, the test can complete.
+				return
+			}
+			pgs, err := sched.Cache.PodGroupStates().Get(tt.oldPod.Namespace, *tt.oldPod.Spec.SchedulingGroup.PodGroupName)
+
+			if !tt.genericWorkloadEnabled {
+				if err == nil {
+					t.Errorf("Expected no pod group state to exist when GenericWorkload is disabled, but found one")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Expected pod group state to exist, got error: %v", err)
+			}
+
+			if inUnscheduled := pgs.UnscheduledPods()[tt.newPod.Name] != nil; inUnscheduled != tt.expectInPodGroupStateUnscheduled {
+				t.Errorf("pod in UnscheduledPods of PodGroupState: got %v, want %v", inUnscheduled, tt.expectInPodGroupStateUnscheduled)
+			}
+			if inAssumed := pgs.AssumedPods().Has(tt.newPod.UID); inAssumed != tt.expectInPodGroupStateAssumed {
+				t.Errorf("pod in AssumedPods of PodGroupState: got %v, want %v", inAssumed, tt.expectInPodGroupStateAssumed)
+			}
+			if inAssigned := pgs.AssignedPods().Has(tt.newPod.UID); inAssigned != tt.expectInPodGroupStateAssigned {
+				t.Errorf("pod in AssignedPods of PodGroupState: got %v, want %v", inAssigned, tt.expectInPodGroupStateAssigned)
+			}
 		})
 	}
 }
@@ -1039,13 +1187,16 @@ func TestDeletePod(t *testing.T) {
 	otherPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj()
 	scheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").SchedulerName("supported-scheduler").Obj()
 	otherScheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").SchedulerName("other-scheduler").Obj()
+	podGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	scheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 
 	tests := []struct {
-		name            string
-		initialPod      *v1.Pod
-		assumed         bool
-		waitingOnPermit bool
-		podToDelete     any
+		name                   string
+		initialPod             *v1.Pod
+		assumed                bool
+		waitingOnPermit        bool
+		podToDelete            any
+		genericWorkloadEnabled bool
 	}{
 		{
 			name:        "delete unscheduled pod",
@@ -1088,6 +1239,23 @@ func TestDeletePod(t *testing.T) {
 			initialPod:  scheduledPod,
 			podToDelete: cache.DeletedFinalStateUnknown{Obj: pod},
 		},
+		{
+			name:        "delete a pod group member, GenericWorkload disabled",
+			initialPod:  podGroupMember,
+			podToDelete: podGroupMember,
+		},
+		{
+			name:                   "delete an unscheduled pod group member",
+			initialPod:             podGroupMember,
+			podToDelete:            podGroupMember,
+			genericWorkloadEnabled: true,
+		},
+		{
+			name:                   "delete a scheduled pod group member",
+			initialPod:             scheduledPodGroupMember,
+			podToDelete:            scheduledPodGroupMember,
+			genericWorkloadEnabled: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1110,7 +1278,7 @@ func TestDeletePod(t *testing.T) {
 				t.Fatalf("Failed to create framework: %v", err)
 			}
 			sched := &Scheduler{
-				Cache:           internalcache.New(ctx, nil, false),
+				Cache:           internalcache.New(ctx, nil, tt.genericWorkloadEnabled),
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 				logger:          logger,
 				Profiles: profile.Map{
@@ -1136,6 +1304,15 @@ func TestDeletePod(t *testing.T) {
 			_, ok := sched.SchedulingQueue.GetPod(tt.initialPod.Name, tt.initialPod.Namespace)
 			if ok {
 				t.Errorf("Unexpected pod in scheduling queue after removal")
+			}
+
+			if tt.initialPod.Spec.SchedulingGroup == nil {
+				// Pod has no pod group, so there is no pod group state to check, the test can complete.
+				return
+			}
+			_, err = sched.Cache.PodGroupStates().Get(tt.initialPod.Namespace, *tt.initialPod.Spec.SchedulingGroup.PodGroupName)
+			if err == nil {
+				t.Errorf("Unexpected pod group state in cache after pod removal")
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Following up with changes introduced here: https://github.com/kubernetes/kubernetes/pull/137073, We are addressing  comments: https://github.com/kubernetes/kubernetes/pull/137073#discussion_r2912459357 & https://github.com/kubernetes/kubernetes/pull/137073#discussion_r2912498561.
Changes:
- Refine some tests, and Increasing Test Coverage in eventhandlers and cache when it comes to pods as pod group members with WAS enabled.
Additional Changes:
- Added safety considering the case where an `unscheduled` pod might get bound, and may result in pod being added both in` unscheduled` and `assigned` together in `PodGroupState`, where it should reside only in assigned pods.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/137648

#### Does this PR introduce a user-facing change?
```release-note
NONE
```