### PR TITLE
test/integration/dra: poll ControllerManagerMetrics values

### DIFF
--- a/test/integration/dra/core.go
+++ b/test/integration/dra/core.go
@@ -558,6 +558,15 @@ func testControllerManagerMetrics(tCtx ktesting.TContext) {
 	initialSuccessNoAdmin := getMetricValue("success", "false")
 	initialSuccessWithAdmin := getMetricValue("success", "true")
 
+	expectMetricValue := func(status, adminAccess string, want float64, message string) {
+		tCtx.Eventually(func(tCtx ktesting.TContext) float64 {
+			return getMetricValue(status, adminAccess)
+		}).
+			WithTimeout(30*time.Second).
+			WithPolling(200*time.Millisecond).
+			Should(gomega.BeNumerically("~", want, 0.1), message)
+	}
+
 	// Test 1: Create Pod with ResourceClaimTemplate without admin access (should succeed and trigger controller)
 	template1 := &resourceapi.ResourceClaimTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -604,11 +613,8 @@ func testControllerManagerMetrics(tCtx ktesting.TContext) {
 	_, err = tCtx.Client().CoreV1().Pods(namespace).Create(tCtx, pod1, metav1.CreateOptions{FieldValidation: "Strict"})
 	tCtx.ExpectNoError(err, "create Pod with ResourceClaimTemplate without admin access")
 
-	time.Sleep(200 * time.Millisecond)
-
-	// Verify metrics: success counter with admin_access=false should increment
-	successNoAdmin := getMetricValue("success", "false")
-	require.InDelta(tCtx, initialSuccessNoAdmin+1, successNoAdmin, 0.1, "success metric with admin_access=false should increment")
+	expectMetricValue("success", "false", initialSuccessNoAdmin+1,
+		"success metric with admin_access=false should increment")
 
 	// Test 2: Create admin namespace and Pod with ResourceClaimTemplate with admin access (should succeed)
 	adminNS := createTestNamespace(tCtx, map[string]string{"resource.kubernetes.io/admin-access": "true"})
@@ -658,11 +664,8 @@ func testControllerManagerMetrics(tCtx ktesting.TContext) {
 	_, err = tCtx.Client().CoreV1().Pods(adminNS).Create(tCtx, pod2, metav1.CreateOptions{FieldValidation: "Strict"})
 	tCtx.ExpectNoError(err, "create Pod with ResourceClaimTemplate with admin access in admin namespace")
 
-	time.Sleep(200 * time.Millisecond)
-
-	// Verify metrics: success counter with admin_access=true should increment
-	successWithAdmin := getMetricValue("success", "true")
-	require.InDelta(tCtx, initialSuccessWithAdmin+1, successWithAdmin, 0.1, "success metric with admin_access=true should increment")
+	expectMetricValue("success", "true", initialSuccessWithAdmin+1,
+		"success metric with admin_access=true should increment")
 
 	// Test 3: Try to create ResourceClaimTemplate with admin access in non-admin namespace
 	// should fail at API level, controller not triggered, no metrics change expected
@@ -733,14 +736,10 @@ func testControllerManagerMetrics(tCtx ktesting.TContext) {
 	_, err = tCtx.Client().CoreV1().Pods(namespace).Create(tCtx, pod4, metav1.CreateOptions{FieldValidation: "Strict"})
 	tCtx.ExpectNoError(err, "create second Pod with ResourceClaimTemplate without admin access")
 
-	time.Sleep(200 * time.Millisecond)
-
-	// Verify final metrics
-	finalSuccessNoAdmin := getMetricValue("success", "false")
-	finalSuccessWithAdmin := getMetricValue("success", "true")
-
-	require.InDelta(tCtx, initialSuccessNoAdmin+2, finalSuccessNoAdmin, 0.1, "should have 2 more success metrics with admin_access=false")
-	require.InDelta(tCtx, initialSuccessWithAdmin+1, finalSuccessWithAdmin, 0.1, "should have 1 more success metric with admin_access=true")
+	expectMetricValue("success", "false", initialSuccessNoAdmin+2,
+		"should have 2 more success metrics with admin_access=false")
+	expectMetricValue("success", "true", initialSuccessWithAdmin+1,
+		"should have 1 more success metric with admin_access=true")
 
 	tCtx.Log("ResourceClaim controller success metrics correctly track operations with admin_access labels")
 }


### PR DESCRIPTION
TestDRA/all/ControllerManagerMetrics still waits a fixed 200ms before checking the success counters. In CI this can fail with:

- Max difference between 1 and 0 allowed is 0.1
- success metric with admin_access=false should increment

The controller work then continues into cleanup, which produces follow-on context canceled and handler timeout noise.

Replace the fixed sleeps with polling on the metric values so the test waits for the controller's counters to converge.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
