### PR TITLE
Fix GCP-specific test breaking serial/disruptive jobs

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"text/template"
 	"time"
 
@@ -163,7 +164,8 @@ func RestartNodes(c clientset.Interface, nodes []v1.Node) error {
 		} else if z, ok := node.Labels[v1.LabelTopologyZone]; ok {
 			zone = z
 		}
-		nodeNamesByZone[zone] = append(nodeNamesByZone[zone], node.Name)
+		nodeName, _, _ := strings.Cut(node.Name, ".")
+		nodeNamesByZone[zone] = append(nodeNamesByZone[zone], nodeName)
 	}
 
 	// Reboot the nodes.


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
`pull-kubernetes-e2e-gce-serial` does not currently pass, because something changed somewhere and the test "should restart all nodes and ensure all nodes and pods recover" fails with an error like:

```
   STEP: restarting all of the nodes @ 03/16/26 20:18:18.349
  I0316 20:18:18.349148   73319 util.go:562] Running gcloud [compute --project=k8s-infra-e2e-boskos-093 instances reset bootstrap-e2e-master.c.k8s-infra-e2e-boskos-093.internal bootstrap-e2e-minion-group-2fwd bootstrap-e2e-minion-group-9vh9 bootstrap-e2e-minion-group-gmxb --zone=us-central1-b]
  I0316 20:19:10.400185   73319 restart.go:95] Unexpected error: 
      <*errors.errorString | 0xc6c7e6f27f0>: 
      error restarting nodes: error running gcloud [compute --project=k8s-infra-e2e-boskos-093 instances reset bootstrap-e2e-master.c.k8s-infra-e2e-boskos-093.internal bootstrap-e2e-minion-group-2fwd bootstrap-e2e-minion-group-9vh9 bootstrap-e2e-minion-group-gmxb --zone=us-central1-b]; got error exit status 1, stdout "", stderr "Updated [https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-093/zones/us-central1-b/instances/bootstrap-e2e-minion-group-2fwd].\nUpdated [https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-093/zones/us-central1-b/instances/bootstrap-e2e-minion-group-9vh9].\nUpdated [https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-093/zones/us-central1-b/instances/bootstrap-e2e-minion-group-gmxb].\nERROR: (gcloud.compute.instances.reset) Could not fetch resource:\n - Invalid value for field 'instance': 'bootstrap-e2e-master.c.k8s-infra-e2e-boskos-093.internal'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}'\n\n"
      stdout: 
      stderr: 
      {
          s: "error restarting nodes: error running gcloud [compute --project=k8s-infra-e2e-boskos-093 instances reset bootstrap-e2e-master.c.k8s-infra-e2e-boskos-093.internal bootstrap-e2e-minion-group-2fwd bootstrap-e2e-minion-group-9vh9 bootstrap-e2e-minion-group-gmxb --zone=us-central1-b]; got error exit status 1, stdout \"\", stderr \"Updated [https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-093/zones/us-central1-b/instances/bootstrap-e2e-minion-group-2fwd].\\nUpdated [https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-093/zones/us-central1-b/instances/bootstrap-e2e-minion-group-9vh9].\\nUpdated [https://www.googleapis.com/compute/v1/projects/k8s-infra-e2e-boskos-093/zones/us-central1-b/instances/bootstrap-e2e-minion-group-gmxb].\\nERROR: (gcloud.compute.instances.reset) Could not fetch resource:\\n - Invalid value for field 'instance': 'bootstrap-e2e-master.c.k8s-infra-e2e-boskos-093.internal'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}'\\n\\n\"\nstdout: \nstderr: ",
      }
  [FAILED] in [It] - k8s.io/kubernetes/test/e2e/cloud/gcp/restart.go:95 @ 03/16/26 20:19:10.4
```

which looks like the gcloud command wants a "short" node name but we're giving it a FQDN.

#### Which issue(s) this PR is related to:
noticed while trying to test #136961

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
