### PR TITLE
logs: Improve route formatting and path length validation tests

### DIFF
--- a/pkg/routes/logs.go
+++ b/pkg/routes/logs.go
@@ -34,7 +34,15 @@ func (l Logs) Install(c *restful.Container) {
 	ws := new(restful.WebService)
 	ws.Path("/logs")
 	ws.Doc("get log files")
-	ws.Route(ws.GET("/{logpath:*}").To(logFileHandler).Param(ws.PathParameter("logpath", "path to the log").DataType("string")))
+
+	ws.Route(ws.GET("/{logpath:*}").
+		To(logFileHandler).
+		Param(
+			ws.PathParameter("logpath", "path to the log").
+				DataType("string"),
+		),
+	)
+
 	ws.Route(ws.GET("/").To(logFileListHandler))
 
 	c.Add(ws)
@@ -57,8 +65,9 @@ func logFileListHandler(req *restful.Request, resp *restful.Response) {
 	http.ServeFile(resp.ResponseWriter, req.Request, logdir)
 }
 
-// logFileNameIsTooLong checks filename length, returns true if it's longer than 255.
-// cause http.ServeFile returns default error code 500 except for NotExist and Forbidden, but we need to separate the real 500 from oversize filename here.
+// logFileNameIsTooLong checks path length, returns true if it can exist according to length
+// used to avoid http.ServeFile return 500 statusCode
+// we need to separate the real 500 from oversize filename here
 func logFileNameIsTooLong(filePath string) bool {
 	_, err := os.Stat(filePath)
 	if err != nil {

--- a/pkg/routes/logs_test.go
+++ b/pkg/routes/logs_test.go
@@ -20,17 +20,43 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestPreCheckLogFileNameLength(t *testing.T) {
-	// In windows, with long file name support enabled, file names can have up to 32,767 characters.
-	oversizeFileName := fmt.Sprintf("%032768s", "a")
-	normalFileName := fmt.Sprintf("%0255s", "a")
+	// in linux file paths can be up to 4096 bytes
+	// and one filename 255 bytes
+
+	// in macos file paths can be up to 1024 bytes
+	// and one filename 255 bytes
+
+	// in windows realtive file paths can have up to 260 bytes
+	// and one filename 255 bytes
+	// https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+
+	// endpoint in logs.go takes relative path to log
+	// logFileNameIsTooLong uses os.Stat which on os level adds cwd to relative path ( cwd + relative )
+
+	// oversizeFileName won't work on any os
+	oversizeFileName := fmt.Sprintf("%256s", "a")
+
+	// oversizeFilePath is a relative path, that is 2097 itself + pwd also can't work on any system
+	oversizeFilePath := "." + strings.Repeat("/a", 2048)
+	oversizeFilePath, err := filepath.Abs(oversizeFilePath)
+	if err != nil {
+		t.Error("error getting abs path")
+	}
+
+	normalFileName := fmt.Sprintf("%255s", "a")
 
 	// check file with oversize name.
 	if !logFileNameIsTooLong(oversizeFileName) {
 		t.Error("failed to check oversize filename")
+	}
+
+	if !logFileNameIsTooLong(oversizeFilePath) {
+		t.Error("failed to check oversize for relative path")
 	}
 
 	// check file with normal name which doesn't exist.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reformat the GET route definition in logs.go for better readability
by splitting the chained method calls across multiple lines.

Update comments for better test cases understanding.

Add a test case with a relative path of 2048 segments, that cannot exist on any supported OS.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```