### PR TITLE
Fix TestGetConntrackMax to align with capped conntrack max values

### DIFF
--- a/pkg/proxy/conntrack/sysctls_test.go
+++ b/pkg/proxy/conntrack/sysctls_test.go
@@ -37,6 +37,7 @@ import (
 
 func TestGetConntrackMax(t *testing.T) {
 	ncores := runtime.NumCPU()
+	const maxLimit = 1048576
 	testCases := []struct {
 		min        int32
 		maxPerCore int32
@@ -49,7 +50,7 @@ func TestGetConntrackMax(t *testing.T) {
 		{
 			maxPerCore: 67890, // use this if Max is 0
 			min:        1,     // avoid 0 default
-			expected:   67890 * ncores,
+			expected:   min(67890*ncores, maxLimit),
 		},
 		{
 			maxPerCore: 1, // ensure that Min is considered


### PR DESCRIPTION
**PR Description:**
Fixes the `TestGetConntrackMax` test failure on high-core systems by aligning test expectations with the capping logic introduced in PR #137002.

**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it:**
PR #137002 introduced a cap of 1,048,576 for conntrack max values to prevent excessive memory usage on high-core machines. This PR updates the test expectations to be in sync with the capped implementation, ensuring the test correctly expects the capped value when the calculated value exceeds the limit.

**Which issue(s) this PR fixes:**
Fixes test failures: https://storage.googleapis.com/k8s-triage/index.html?text=TestGetConntrackMax

**Special notes for your reviewer:**
The test now uses `min(67890*ncores, maxLimit)` to stay in sync with the capping logic in `getConntrackMax()`, which caps values at 1,048,576.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```