### PR TITLE
Fix discovery test cleanup to actually wait for object deletion

### DIFF
--- a/test/integration/apiserver/discovery/framework.go
+++ b/test/integration/apiserver/discovery/framework.go
@@ -141,7 +141,7 @@ func (a applyAPIService) Cleanup(ctx context.Context, client testClient) error {
 	name := a.Version + "." + a.Group
 	err := client.ApiregistrationV1().APIServices().Delete(ctx, name, metav1.DeleteOptions{})
 
-	if !errors.IsNotFound(err) {
+	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
@@ -210,7 +210,7 @@ func (a applyCRD) Cleanup(ctx context.Context, client testClient) error {
 	name := a.Names.Plural + "." + a.Group
 	err := client.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, name, metav1.DeleteOptions{})
 
-	if !errors.IsNotFound(err) {
+	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `Cleanup` methods in `applyAPIService` and `applyCRD` have a logic bug: when `Delete` succeeds (`err == nil`), the condition `!errors.IsNotFound(err)` evaluates to `true`, so the method returns `nil` immediately — skipping the poll loop that waits for the object to actually be gone from the API server.

This means the between-subtest discovery reset poll (`discovery_test.go:372-382`) has to absorb both the object deletion latency and discovery convergence time, causing flakes on slow CI nodes.

Fix: change `if !errors.IsNotFound(err)` to `if err != nil && !errors.IsNotFound(err)` so cleanup correctly falls through to the poll loop on successful delete.

#### Which issue(s) this PR is related to:

Related to https://github.com/kubernetes/kubernetes/pull/137813, was investigating what could be slow in the discovery tests.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```