### PR TITLE
Add OWNERS for controller manager integration tests

### DIFF
--- a/test/integration/controllermanager/OWNERS
+++ b/test/integration/controllermanager/OWNERS
@@ -1,0 +1,19 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - deads2k
+  - janetkuo
+  - cheftako
+  - andrewsykim
+  - jpbetz
+  - jefftree
+  - sig-apps-approvers
+reviewers:
+  - andrewsykim
+  - deads2k
+  - cheftako
+  - jpbetz
+  - jefftree
+  - sig-apps-reviewers
+labels:
+  - sig/apps


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds an OWNERS file for `test/integration/controllermanager/`, mirroring `pkg/controller/OWNERS` (sig-apps).

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

Follow-up from https://github.com/kubernetes/kubernetes/pull/137708#discussion_r2947111893

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```