### PR TITLE
test: fix flaky static pod tests by asserting on termination message …

### DIFF
--- a/test/e2e_node/static_pod_test.go
+++ b/test/e2e_node/static_pod_test.go
@@ -75,7 +75,6 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 			})
 
 			var initCtrID string
-			var startTime *metav1.Time
 			mirrorPodName := fmt.Sprintf("%s-%s", staticPod.Name, framework.TestContext.NodeName)
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
@@ -85,9 +84,10 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 				cstatus := pod.Status.InitContainerStatuses[0]
 				// Wait until the init container is terminated.
 				g.Expect(cstatus.State.Terminated).NotTo(gomega.BeNil())
+				g.Expect(cstatus.State.Terminated.Reason).To(gomega.Equal("Completed"))
+				g.Expect(cstatus.State.Terminated.ExitCode).To(gomega.BeZero())
 				g.Expect(cstatus.State.Terminated.ContainerID).NotTo(gomega.BeEmpty())
 				initCtrID = cstatus.ContainerID
-				startTime = pod.Status.StartTime
 			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
 
 			ginkgo.By("remove init container")
@@ -103,7 +103,6 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
 				pod, err := f.ClientSet.CoreV1().Pods(staticPod.Namespace).Get(ctx, mirrorPodName, metav1.GetOptions{})
-				g.Expect(pod.Status.StartTime.Equal(startTime)).To(gomega.BeFalseBecause("startTime should not be equal"))
 				g.Expect(err).Should(gomega.Succeed())
 				g.Expect(pod.Status.InitContainerStatuses).To(gomega.HaveLen(1))
 				cstatus := pod.Status.InitContainerStatuses[0]
@@ -111,6 +110,7 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 				g.Expect(cstatus.State.Terminated).NotTo(gomega.BeNil())
 				g.Expect(cstatus.State.Terminated.Reason).To(gomega.Equal("Completed"))
 				g.Expect(cstatus.State.Terminated.ExitCode).To(gomega.BeZero())
+				g.Expect(cstatus.State.Terminated.Message).To(gomega.ContainSubstring("Unable to get init container status"))
 			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
 		})
 	})
@@ -151,7 +151,6 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 			})
 
 			var sidecarCtrID string
-			var startTime *metav1.Time
 			mirrorPodName := fmt.Sprintf("%s-%s", staticPod.Name, framework.TestContext.NodeName)
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
@@ -162,7 +161,6 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 				// Wait until the sidecar container starts running.
 				g.Expect(cstatus.State.Running).NotTo(gomega.BeNil())
 				sidecarCtrID = cstatus.ContainerID
-				startTime = pod.Status.StartTime
 			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
 
 			// Stop kubelet first not to restart the sidecar container.
@@ -181,12 +179,12 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
 				pod, err := f.ClientSet.CoreV1().Pods(staticPod.Namespace).Get(ctx, mirrorPodName, metav1.GetOptions{})
-				g.Expect(pod.Status.StartTime.Equal(startTime)).To(gomega.BeFalseBecause("startTime should not be equal"))
 				g.Expect(err).Should(gomega.Succeed())
 				g.Expect(pod.Status.InitContainerStatuses).To(gomega.HaveLen(1))
 				cstatus := pod.Status.InitContainerStatuses[0]
 				// Sidecar container should be restarted and running.
 				g.Expect(cstatus.State.Running).NotTo(gomega.BeNil())
+				g.Expect(cstatus.ContainerID).NotTo(gomega.Equal(sidecarCtrID))
 			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

The test verified that the pod's StartTime changes, but that depends on whether the pod is synced before the kubelet adds the mirror pod to the pod manager. We still want to verify that the status has been updated before confirming it, so the test now looks for the specific error message associated with a missing init container. In the sidecar case, it verfies that the container ID changed to reflect the restarted container.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/137737

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon