### PR TITLE
Fix typos in comments in pkg/apis/core/validation/validation.go

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6040,7 +6040,7 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions
 	// Pod QoS is immutable
 	allErrs = append(allErrs, ValidateImmutableField(newPod.Status.QOSClass, oldPod.Status.QOSClass, fldPath.Child("qosClass"))...)
 
-	// Note: there is no check that ContainerStatuses, InitContainerStatuses, and EphemeralContainerStatuses doesn't have duplicate conatainer names
+	// Note: there is no check that ContainerStatuses, InitContainerStatuses, and EphemeralContainerStatuses doesn't have duplicate container names
 	// or statuses of containers that are not defined in the pod spec. Changing this may lead to a breaking changes. So consumers of those fields
 	// must account for unexpected data. Kubelet will never report statuses like this.
 	//
@@ -7448,7 +7448,7 @@ func validateConfigMapNodeConfigSourceSpec(source *core.ConfigMapNodeConfigSourc
 	return append(allErrs, validateConfigMapNodeConfigSource(source, fldPath)...)
 }
 
-// validation specififc to Node.Status.Config
+// validation specific to Node.Status.Config
 func validateNodeConfigStatus(status *core.NodeConfigStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if status.Assigned != nil {
@@ -8968,7 +8968,7 @@ func validateNodeInclusionPolicy(fldPath *field.Path, policy *core.NodeInclusion
 
 // ValidateMatchLabelKeysAndMismatchLabelKeys checks if both matchLabelKeys and mismatchLabelKeys are valid.
 // - validate that all matchLabelKeys and mismatchLabelKeys are valid label names.
-// - validate that the user doens't specify the same key in both matchLabelKeys and labelSelector.
+// - validate that the user doesn't specify the same key in both matchLabelKeys and labelSelector.
 // - validate that any matchLabelKeys are not duplicated with mismatchLabelKeys.
 func ValidateMatchLabelKeysAndMismatchLabelKeys(fldPath *field.Path, matchLabelKeys, mismatchLabelKeys []string, labelSelector *metav1.LabelSelector) field.ErrorList {
 	var allErrs field.ErrorList
@@ -8976,7 +8976,7 @@ func ValidateMatchLabelKeysAndMismatchLabelKeys(fldPath *field.Path, matchLabelK
 	allErrs = append(allErrs, validateLabelKeys(fldPath.Child("matchLabelKeys"), matchLabelKeys, labelSelector)...)
 	allErrs = append(allErrs, validateLabelKeys(fldPath.Child("mismatchLabelKeys"), mismatchLabelKeys, labelSelector)...)
 
-	// 2. validate that the user doens't specify the same key in both matchLabelKeys and labelSelector.
+	// 2. validate that the user doesn't specify the same key in both matchLabelKeys and labelSelector.
 	// It doesn't make sense to have the labelselector with the key specified in matchLabelKeys
 	// because the matchLabelKeys will be `In` labelSelector which matches with only one value in the key
 	// and we cannot make any further filtering with that key.


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it

Fix spelling mistakes in comments in `pkg/apis/core/validation/validation.go` found by codespell:

- `conatainer` → `container` (line 6043)
- `specififc` → `specific` (line 7451)
- `doens't` → `doesn't` (lines 8971, 8979)

All changes are in comments only — no logic is affected.

## Does this PR introduce a user-facing change?
No

```release-note
NONE
```