### PR TITLE
fix: correct format string usage in fmt.Errorf

### DIFF
--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -65,7 +65,7 @@ func (plugin *configMapPlugin) GetPluginName() string {
 func (plugin *configMapPlugin) GetVolumeName(spec *volume.Spec) (string, error) {
 	volumeSource, _ := getVolumeSource(spec)
 	if volumeSource == nil {
-		return "", fmt.Errorf("Spec does not reference a ConfigMap volume type")
+		return "", fmt.Errorf("spec does not reference a ConfigMap volume type")
 	}
 
 	return fmt.Sprintf(

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -69,7 +69,7 @@ func (plugin *downwardAPIPlugin) GetPluginName() string {
 func (plugin *downwardAPIPlugin) GetVolumeName(spec *volume.Spec) (string, error) {
 	volumeSource, _ := getVolumeSource(spec)
 	if volumeSource == nil {
-		return "", fmt.Errorf("Spec does not reference a DownwardAPI volume type")
+		return "", fmt.Errorf("spec does not reference a DownwardAPI volume type")
 	}
 
 	// Return user defined volume name, since this is an ephemeral volume type

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -489,7 +489,7 @@ func getVolumeSource(spec *volume.Spec) (*v1.FCVolumeSource, bool, error) {
 		return spec.PersistentVolume.Spec.FC, spec.ReadOnly, nil
 	}
 
-	return nil, false, fmt.Errorf("Spec does not reference a FibreChannel volume type")
+	return nil, false, fmt.Errorf("spec does not reference a FibreChannel volume type")
 }
 
 func createPersistentVolumeFromFCVolumeSource(volumeName string, fc v1.FCVolumeSource) *v1.PersistentVolume {

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -65,7 +65,7 @@ func (plugin *gitRepoPlugin) GetPluginName() string {
 func (plugin *gitRepoPlugin) GetVolumeName(spec *volume.Spec) (string, error) {
 	volumeSource, _ := getVolumeSource(spec)
 	if volumeSource == nil {
-		return "", fmt.Errorf("Spec does not reference a Git repo volume type")
+		return "", fmt.Errorf("spec does not reference a Git repo volume type")
 	}
 
 	return fmt.Sprintf(

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -487,7 +487,7 @@ func getISCSIVolumeInfo(spec *volume.Spec) (bool, string, error) {
 		return spec.ReadOnly, spec.PersistentVolume.Spec.ISCSI.FSType, nil
 	}
 
-	return false, "", fmt.Errorf("Spec does not reference an ISCSI volume type")
+	return false, "", fmt.Errorf("spec does not reference an ISCSI volume type")
 }
 
 // get iSCSI target info: target portal, portals, iqn, and lun
@@ -499,7 +499,7 @@ func getISCSITargetInfo(spec *volume.Spec) (string, []string, string, int32, err
 		return spec.PersistentVolume.Spec.ISCSI.TargetPortal, spec.PersistentVolume.Spec.ISCSI.Portals, spec.PersistentVolume.Spec.ISCSI.IQN, spec.PersistentVolume.Spec.ISCSI.Lun, nil
 	}
 
-	return "", nil, "", 0, fmt.Errorf("Spec does not reference an ISCSI volume type")
+	return "", nil, "", 0, fmt.Errorf("spec does not reference an ISCSI volume type")
 }
 
 // get iSCSI initiator info: iface and initiator name
@@ -511,7 +511,7 @@ func getISCSIInitiatorInfo(spec *volume.Spec) (string, *string, error) {
 		return spec.PersistentVolume.Spec.ISCSI.ISCSIInterface, spec.PersistentVolume.Spec.ISCSI.InitiatorName, nil
 	}
 
-	return "", nil, fmt.Errorf("Spec does not reference an ISCSI volume type")
+	return "", nil, fmt.Errorf("spec does not reference an ISCSI volume type")
 }
 
 // get iSCSI Discovery CHAP boolean
@@ -523,7 +523,7 @@ func getISCSIDiscoveryCHAPInfo(spec *volume.Spec) (bool, error) {
 		return spec.PersistentVolume.Spec.ISCSI.DiscoveryCHAPAuth, nil
 	}
 
-	return false, fmt.Errorf("Spec does not reference an ISCSI volume type")
+	return false, fmt.Errorf("spec does not reference an ISCSI volume type")
 }
 
 // get iSCSI Session CHAP boolean
@@ -535,7 +535,7 @@ func getISCSISessionCHAPInfo(spec *volume.Spec) (bool, error) {
 		return spec.PersistentVolume.Spec.ISCSI.SessionCHAPAuth, nil
 	}
 
-	return false, fmt.Errorf("Spec does not reference an ISCSI volume type")
+	return false, fmt.Errorf("spec does not reference an ISCSI volume type")
 }
 
 // get iSCSI CHAP Secret info: secret name and namespace
@@ -558,7 +558,7 @@ func getISCSISecretNameAndNamespace(spec *volume.Spec, defaultSecretNamespace st
 		return "", "", nil
 	}
 
-	return "", "", fmt.Errorf("Spec does not reference an ISCSI volume type")
+	return "", "", fmt.Errorf("spec does not reference an ISCSI volume type")
 }
 
 func createISCSIDisk(spec *volume.Spec, podUID types.UID, plugin *iscsiPlugin, manager diskManager, secret map[string]string) (*iscsiDisk, error) {

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -493,7 +493,7 @@ func TestGetISCSICHAP(t *testing.T) {
 			spec:                  &volume.Spec{},
 			expectedDiscoveryCHAP: false,
 			expectedSessionCHAP:   false,
-			expectedError:         fmt.Errorf("Spec does not reference an ISCSI volume type"),
+			expectedError:         fmt.Errorf("spec does not reference an ISCSI volume type"),
 		},
 	}
 	for _, testcase := range tests {

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -109,7 +109,7 @@ func getVolumeSource(spec *volume.Spec) (*v1.LocalVolumeSource, bool, error) {
 		return spec.PersistentVolume.Spec.Local, spec.ReadOnly, nil
 	}
 
-	return nil, false, fmt.Errorf("Spec does not reference a Local volume type")
+	return nil, false, fmt.Errorf("spec does not reference a Local volume type")
 }
 
 func (plugin *localVolumePlugin) NewMounter(spec *volume.Spec, pod *v1.Pod) (volume.Mounter, error) {

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -300,7 +300,7 @@ func getVolumeSource(spec *volume.Spec) (*v1.NFSVolumeSource, bool, error) {
 		return spec.PersistentVolume.Spec.NFS, spec.ReadOnly, nil
 	}
 
-	return nil, false, fmt.Errorf("Spec does not reference a NFS volume type")
+	return nil, false, fmt.Errorf("spec does not reference a NFS volume type")
 }
 
 func getServerFromSource(source *v1.NFSVolumeSource) string {

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -72,7 +72,7 @@ func (plugin *secretPlugin) GetPluginName() string {
 func (plugin *secretPlugin) GetVolumeName(spec *volume.Spec) (string, error) {
 	volumeSource, _ := getVolumeSource(spec)
 	if volumeSource == nil {
-		return "", fmt.Errorf("Spec does not reference a Secret volume type")
+		return "", fmt.Errorf("spec does not reference a Secret volume type")
 	}
 
 	return volumeSource.SecretName, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
fmt.Errorf format same
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
