### PR TITLE
Used req.Context() instead of context.TODO() in responder.Error

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -968,9 +968,7 @@ func getPortForwardRequestParams(req *restful.Request) portForwardRequestParams 
 type responder struct{}
 
 func (r *responder) Error(w http.ResponseWriter, req *http.Request, err error) {
-	// Use context.TODO() because we currently do not have a proper context to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
-	logger := klog.FromContext(context.TODO())
+	logger := klog.FromContext(req.Context())
 	logger.Error(err, "Error while proxying request")
 	http.Error(w, err.Error(), http.StatusInternalServerError)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The `responder.Error()` method in `pkg/kubelet/server/server.go` was using
`context.TODO()` to create a logger, despite the HTTP request already being
available as a parameter. This caused loss of trace context and request-scoped
logger values embedded by the OpenTelemetry tracing filter.

This PR replaces `context.TODO()` with `req.Context()` and removes the stale
TODO comment left by the original author.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Minimal one-line change. No functional behavior changes — only the logger
context is corrected. All existing tests pass.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```