### PR TITLE
[InPlacePodLevelResourcesVerticalScaling] Plr ippr kubelet bug fixes

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -925,6 +925,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 			}
 		case v1.ResourceMemory:
 			if !setLimitValue {
+				// Memory requests aren't written to cgroups.
 				return nil
 			}
 			resizedResources.Memory = podResources.Memory
@@ -949,7 +950,6 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 
 		// Update our tracking of the current state.
 		currentPodResources = mergedPodResources
-
 		return nil
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -925,7 +925,6 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 			}
 		case v1.ResourceMemory:
 			if !setLimitValue {
-				// Memory requests aren't written to cgroups.
 				return nil
 			}
 			resizedResources.Memory = podResources.Memory
@@ -951,11 +950,6 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		// Update our tracking of the current state.
 		currentPodResources = mergedPodResources
 
-		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
-			if err = updateActuatedPodLevelResources(rName); err != nil {
-				logger.Error(err, "Failed to update pod-level actuated resources", "resource", rName, "pod", klog.KObj(pod))
-			}
-		}
 		return nil
 	}
 
@@ -984,6 +978,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 				return err
 			}
 		}
+
 		// At downsizing, requests should shrink prior to limits in order to keep "requests <= limits".
 		if newPodCgReqValue < currPodCgReqValue {
 			// TODO: Pass logger from context once contextual logging migration is complete
@@ -995,6 +990,12 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 			// TODO(#127825): Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
 				return err
+			}
+		}
+
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) && podContainerChanges.UpdatePodLevelResources {
+			if err = updateActuatedPodLevelResources(rName); err != nil {
+				logger.Error(err, "Failed to update pod-level actuated resources", "resource", rName, "pod", klog.KObj(pod))
 			}
 		}
 		return err

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -3447,6 +3447,91 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 				return &pa
 			},
 		},
+		"Update pod-level limits does not mutate container resources": {
+			setupFn: func(pod *v1.Pod) {
+				pod.Spec.Resources = &v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    cpu100m.DeepCopy(),
+						v1.ResourceMemory: mem100M.DeepCopy(),
+					},
+				}
+				c := &pod.Spec.Containers[1]
+				c.Resources = v1.ResourceRequirements{
+					Limits: v1.ResourceList{},
+				}
+				setupActuatedResources(pod, c, v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU: cpu100m.DeepCopy(),
+					},
+				})
+			},
+			getExpectedPodActionsFn: func(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *podActions {
+				kcs1 := podStatus.FindContainerStatusByName(pod.Spec.Containers[0].Name)
+				kcs2 := podStatus.FindContainerStatusByName(pod.Spec.Containers[1].Name)
+				kcs3 := podStatus.FindContainerStatusByName(pod.Spec.Containers[2].Name)
+				pa := podActions{
+					SandboxID:         podStatus.SandboxStatuses[0].Id,
+					ContainersToStart: []int{},
+					ContainersToKill:  getKillMap(pod, podStatus, []int{}),
+					ContainersToUpdate: map[v1.ResourceName][]containerToUpdateInfo{
+						v1.ResourceCPU: {
+							{
+								container:       &pod.Spec.Containers[0],
+								kubeContainerID: kcs1.ID,
+								desiredContainerResources: resourceRequirements{
+									memoryLimit: mem100M.Value(),
+									cpuLimit:    cpu100m.MilliValue(),
+								},
+								currentContainerResources: &resourceRequirements{},
+							},
+							{
+								container:       &pod.Spec.Containers[2],
+								kubeContainerID: kcs3.ID,
+								desiredContainerResources: resourceRequirements{
+									memoryLimit: mem100M.Value(),
+									cpuLimit:    cpu100m.MilliValue(),
+								},
+								currentContainerResources: &resourceRequirements{},
+							},
+						},
+						v1.ResourceMemory: {
+							{
+								container:       &pod.Spec.Containers[0],
+								kubeContainerID: kcs1.ID,
+								desiredContainerResources: resourceRequirements{
+									memoryLimit: mem100M.Value(),
+									cpuLimit:    cpu100m.MilliValue(),
+								},
+								currentContainerResources: &resourceRequirements{},
+							},
+							{
+								container:       &pod.Spec.Containers[1],
+								kubeContainerID: kcs2.ID,
+								desiredContainerResources: resourceRequirements{
+									memoryLimit: mem100M.Value(),
+									cpuLimit:    cpu100m.MilliValue(),
+								},
+								currentContainerResources: &resourceRequirements{
+									cpuLimit: cpu100m.MilliValue(),
+								},
+							},
+							{
+								container:       &pod.Spec.Containers[2],
+								kubeContainerID: kcs3.ID,
+								desiredContainerResources: resourceRequirements{
+									memoryLimit: mem100M.Value(),
+									cpuLimit:    cpu100m.MilliValue(),
+								},
+								currentContainerResources: &resourceRequirements{},
+							},
+						},
+					},
+					UpdatePodLevelResources: true,
+				}
+				return &pa
+			},
+			podLevelResizeEnabled: true,
+		},
 		"Nothing when spec.Resources and status.Resources are equal": {
 			setupFn: func(pod *v1.Pod) {
 				c := &pod.Spec.Containers[1]
@@ -3739,7 +3824,22 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 
 			tCtx := ktesting.Init(t)
 			expectedActions := test.getExpectedPodActionsFn(pod, status)
+
+			// Capture container resource limits before computePodActions to check for mutation
+			preComputeLimits := make([]v1.ResourceList, len(pod.Spec.Containers))
+			for i := range pod.Spec.Containers {
+				preComputeLimits[i] = pod.Spec.Containers[i].Resources.Limits.DeepCopy()
+			}
+
 			actions := m.computePodActions(tCtx, pod, status, false)
+
+			// Mutation check: Ensure pod.Spec.Containers[i].Resources.Limits is not mutated
+			for i := range pod.Spec.Containers {
+				if !reflect.DeepEqual(preComputeLimits[i], pod.Spec.Containers[i].Resources.Limits) {
+					t.Errorf("pod.Spec.Containers[%d].Resources.Limits was mutated! pre: %v, post: %v", i, preComputeLimits[i], pod.Spec.Containers[i].Resources.Limits)
+				}
+			}
+
 			verifyActions(t, expectedActions, &actions, desc)
 		})
 	}
@@ -4039,6 +4139,10 @@ func TestDoPodResizeAction(t *testing.T) {
 		expectedErrorMessage        string
 		expectPodCgroupUpdates      int
 		injectPodUpdateCgroupsError error
+		currentPodLevelResources    *resourceRequirements
+		desiredPodLevelResources    *resourceRequirements
+		updatedPodLevelResources    bool
+		enablePLR                   bool
 	}{
 		{
 			testName: "Increase cpu and memory requests and limits, with computed pod limits",
@@ -4218,11 +4322,172 @@ func TestDoPodResizeAction(t *testing.T) {
 			expectedError:        "",
 			expectedErrorMessage: "",
 		},
+		{
+			testName: "Resize pod-level memory request only (skips cgroup write, updates actuated)",
+			currentResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			desiredResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			currentPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+				memoryRequest: 200, memoryLimit: 100, // Memory request increase
+			},
+			updatedPodLevelResources: true,
+			updatedResources:         []v1.ResourceName{},
+			enablePLR:                true,
+		},
+		{
+			testName: "Resize pod-level memory limit (updates cgroups and actuated)",
+			currentResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			desiredResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			currentPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+				memoryRequest: 100, memoryLimit: 200, // Memory limit increase
+			},
+			updatedPodLevelResources: true,
+			updatedResources:         []v1.ResourceName{},
+			expectPodCgroupUpdates:   1,
+			enablePLR:                true,
+		},
+		{
+			testName: "Resize pod-level CPU request (updates cgroups and actuated)",
+			currentResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+			},
+			desiredResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+			},
+			currentPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				cpuRequest: 200, cpuLimit: 100, // CPU request increase
+			},
+			updatedPodLevelResources: true,
+			updatedResources:         []v1.ResourceName{},
+			expectPodCgroupUpdates:   1,
+			enablePLR:                true,
+		},
+		{
+			testName: "Resize pod-level CPU limit (updates cgroups and actuated)",
+			currentResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+			},
+			desiredResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+			},
+			currentPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 200, // CPU limit increase
+			},
+			updatedPodLevelResources: true,
+			updatedResources:         []v1.ResourceName{},
+			expectPodCgroupUpdates:   1,
+			enablePLR:                true,
+		},
+		{
+			testName: "Resize pod-level CPU limit and container-level CPU limit (updates cgroups and actuated)",
+			currentResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+			},
+			desiredResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 200, // Container limit increase
+			},
+			currentPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 300, // Pod limit increase
+			},
+			updatedPodLevelResources: true,
+			updatedResources:         []v1.ResourceName{v1.ResourceCPU},
+			expectPodCgroupUpdates:   1, // Pod level cgroup update
+			enablePLR:                true,
+		},
+		{
+			testName: "Resize pod-level memory request and container-level memory request (updates actuated)",
+			currentResources: resourceRequirements{
+				memoryRequest: 100, memoryLimit: 200,
+			},
+			desiredResources: resourceRequirements{
+				memoryRequest: 150, memoryLimit: 200, // Container request increase
+			},
+			currentPodLevelResources: &resourceRequirements{
+				memoryRequest: 100, memoryLimit: 200,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				memoryRequest: 200, memoryLimit: 200, // Pod request increase
+			},
+			updatedPodLevelResources: true,
+			updatedResources:         []v1.ResourceName{v1.ResourceMemory},
+			expectPodCgroupUpdates:   0, // Memory request doesn't update cgroup
+			enablePLR:                true,
+		},
+		{
+			testName: "Resize pod-level CPU request and container-level CPU request (updates cgroups and actuated)",
+			currentResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 200,
+			},
+			desiredResources: resourceRequirements{
+				cpuRequest: 150, cpuLimit: 200, // Container request increase
+			},
+			currentPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 200,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				cpuRequest: 200, cpuLimit: 200, // Pod request increase
+			},
+			updatedPodLevelResources: true,
+			updatedResources:         []v1.ResourceName{v1.ResourceCPU},
+			expectPodCgroupUpdates:   1, // Pod level cgroup update for cpu shares
+			enablePLR:                true,
+		},
+		{
+			testName: "Resize pod-level memory limit and container-level memory limit (updates cgroups and actuated)",
+			currentResources: resourceRequirements{
+				memoryLimit: 200,
+			},
+			desiredResources: resourceRequirements{
+				memoryLimit: 250, // Container limit increase
+			},
+			currentPodLevelResources: &resourceRequirements{
+				memoryLimit: 200,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				memoryLimit: 300, // Pod limit increase
+			},
+			updatedPodLevelResources: true,
+			updatedResources:         []v1.ResourceName{v1.ResourceMemory},
+			expectPodCgroupUpdates:   1, // Pod level cgroup update for memory limit
+			enablePLR:                true,
+		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
 			_, _, m, err := createTestRuntimeManagerWithErrors(tCtx, tc.runtimeErrors)
 			require.NoError(t, err)
 			m.cpuCFSQuota = true // Enforce CPU Limits
+
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodLevelResourcesVerticalScaling, tc.enablePLR)
 
 			mockCM := cmtesting.NewMockContainerManager(t)
 			mockCM.EXPECT().PodHasExclusiveCPUs(mock.Anything).Return(false).Maybe()
@@ -4257,7 +4522,33 @@ func TestDoPodResizeAction(t *testing.T) {
 			}
 
 			pod, kps := makeBasePodAndStatus()
-			// pod spec and allocated resources are already updated as desired when doPodResizeAction() is called.
+			if tc.desiredPodLevelResources != nil {
+				// pod spec and allocated resources are already updated as desired when doPodResizeAction() is called.
+				pod.Spec.Resources = &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(tc.desiredPodLevelResources.cpuRequest, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(tc.desiredPodLevelResources.memoryRequest, resource.BinarySI),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(tc.desiredPodLevelResources.cpuLimit, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(tc.desiredPodLevelResources.memoryLimit, resource.BinarySI),
+					},
+				}
+			}
+			if tc.currentPodLevelResources != nil {
+				// Seed initial actuated state
+				initialActuated := &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(tc.currentPodLevelResources.cpuRequest, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(tc.currentPodLevelResources.memoryRequest, resource.BinarySI),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(tc.currentPodLevelResources.cpuLimit, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(tc.currentPodLevelResources.memoryLimit, resource.BinarySI),
+					},
+				}
+				require.NoError(t, m.actuatedState.SetPodLevelResources(pod.UID, initialActuated))
+			}
 			pod.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(tc.desiredResources.cpuRequest, resource.DecimalSI),
@@ -4314,8 +4605,9 @@ func TestDoPodResizeAction(t *testing.T) {
 			}
 
 			actions := podActions{
-				ContainersToUpdate: containersToUpdate,
-				SandboxID:          "sandbox-id",
+				ContainersToUpdate:      containersToUpdate,
+				UpdatePodLevelResources: tc.updatedPodLevelResources,
+				SandboxID:               "sandbox-id",
 			}
 			resizeResult := m.doPodResizeAction(tCtx, pod, kps, actions)
 
@@ -4325,6 +4617,18 @@ func TestDoPodResizeAction(t *testing.T) {
 				require.Equal(t, tc.expectedErrorMessage, resizeResult.Message)
 			} else {
 				require.NoError(t, resizeResult.Error, resizeResult.Message)
+				if tc.desiredPodLevelResources != nil {
+					// VERIFY Actuated State for successful resizes
+					updatedActuated, found := m.actuatedState.GetPodLevelResources(pod.UID)
+					require.True(t, found, "actuated resources should exist for pod")
+					if tc.enablePLR {
+						assert.Equal(t, tc.desiredPodLevelResources.memoryRequest, updatedActuated.Requests.Memory().Value(), tc.testName)
+						assert.Equal(t, tc.desiredPodLevelResources.cpuRequest, updatedActuated.Requests.Cpu().MilliValue(), tc.testName)
+					} else {
+						assert.Equal(t, tc.currentPodLevelResources.memoryRequest, updatedActuated.Requests.Memory().Value(), tc.testName)
+						assert.Equal(t, tc.currentPodLevelResources.cpuRequest, updatedActuated.Requests.Cpu().MilliValue(), tc.testName)
+					}
+				}
 			}
 
 			mock.AssertExpectationsForObjects(t, mockPCM)

--- a/pkg/kubelet/util/util.go
+++ b/pkg/kubelet/util/util.go
@@ -84,7 +84,7 @@ func GetLimits(res *ResourceOpts) v1.ResourceList {
 		if containerResources == nil || containerResources.Limits == nil {
 			return v1.ResourceList{}
 		}
-		return containerResources.Limits
+		return containerResources.Limits.DeepCopy()
 	}
 
 	containerLimits := limitsOrEmpty(res.ContainerResources)
@@ -99,13 +99,13 @@ func GetLimits(res *ResourceOpts) v1.ResourceList {
 	// When container-level CPU limit is not set, the pod-level
 	// limit CPU is applied at container-level
 	if containerLimits.Cpu().IsZero() && !podLevelLimits.Cpu().IsZero() {
-		containerLimits[v1.ResourceCPU] = podLevelLimits[v1.ResourceCPU]
+		containerLimits[v1.ResourceCPU] = podLevelLimits[v1.ResourceCPU].DeepCopy()
 	}
 
 	// When container-level Memory limit is not set, the pod-level
 	// limit Memory is applied at container-level
 	if containerLimits.Memory().IsZero() && !podLevelLimits.Memory().IsZero() {
-		containerLimits[v1.ResourceMemory] = podLevelLimits[v1.ResourceMemory]
+		containerLimits[v1.ResourceMemory] = podLevelLimits[v1.ResourceMemory].DeepCopy()
 	}
 	return containerLimits
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR addresses several bug fixes for the Kubelet related to InPlacePodLevelResourcesVerticalScaling. Specifically, it ensures that:

- DeepCopy is used in GetLimits to avoid returning direct references to resource objects, preventing accidental side-effect mutations.

- When pod-level memory is modified, it correctly skips unnecessary cgroup writes while ensuring the internal state remains consistent.

- Includes unit tests to verify these edge cases and prevent regressions.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5419
```
