### PR TITLE
add support for invariant testing in integration testing

### DIFF
--- a/cmd/kube-apiserver/.import-restrictions
+++ b/cmd/kube-apiserver/.import-restrictions
@@ -4,5 +4,6 @@ rules:
       - k8s.io/kubernetes/cmd/kube-apiserver
       - k8s.io/kubernetes/pkg
       - k8s.io/kubernetes/plugin
+      - k8s.io/kubernetes/test/e2e/invariants/metrics
       - k8s.io/kubernetes/test/utils
       - k8s.io/kubernetes/third_party

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -63,11 +63,11 @@ import (
 	zpagesfeatures "k8s.io/component-base/zpages/features"
 	"k8s.io/klog/v2"
 	"k8s.io/kube-aggregator/pkg/apiserver"
-	testutil "k8s.io/kubernetes/test/utils"
-	"k8s.io/kubernetes/test/utils/ktesting"
-
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/test/e2e/invariants/metrics"
+	testutil "k8s.io/kubernetes/test/utils"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func init() {
@@ -92,6 +92,8 @@ type TestServerInstanceOptions struct {
 	// SkipHealthzCheck returns without waiting for the server to become healthy.
 	// Useful for testing server configurations expected to prevent /healthz from completing.
 	SkipHealthzCheck bool
+	// DisableInvariantChecks skips the invariant checks at the end of the test.
+	DisableInvariantChecks bool
 	// Enable cert-auth for the kube-apiserver
 	EnableCertAuth bool
 	// Wrap the storage version interface of the created server's generic server.
@@ -528,8 +530,22 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	result.ClientConfig.Burst = 10000
 	result.ServerOpts = s
 	result.TearDownFn = func() {
-		tearDown()
-		etcdClient.Close()
+		defer func() {
+			if err := etcdClient.Close(); err != nil {
+				tCtx.Errorf("Failed to close etcd client: %v", err)
+			}
+		}()
+		defer tearDown()
+		if instanceOptions.DisableInvariantChecks {
+			return
+		}
+		if tCtx.Err() != nil {
+			tCtx.Logf("Skipping metrics scrape because context is already canceled: %v", tCtx.Err())
+			return
+		}
+		if err := metrics.CheckMetricInvariants(tCtx, client, false); err != nil {
+			tCtx.Errorf("Invariant check failed (if the test intentionally breaks metrics/auth, consider setting DisableInvariantChecks: true in TestServerInstanceOptions): %v", err)
+		}
 	}
 	result.EtcdClient = etcdClient
 	result.EtcdStoragePrefix = storageConfig.Prefix

--- a/test/e2e/invariants/metrics.go
+++ b/test/e2e/invariants/metrics.go
@@ -20,12 +20,10 @@ package invariants
 
 import (
 	"context"
-	"strings"
 
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+	"k8s.io/kubernetes/test/e2e/invariants/metrics"
 
 	"github.com/onsi/ginkgo/v2"
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
@@ -64,62 +62,6 @@ var _ = ginkgo.ReportAfterSuite("Invariant Metrics", func(ctx ginkgo.SpecContext
 	checkInvariantMetrics(ctx)
 })
 
-// apiServerMetricInvariant represents an api-server metric invariant, all
-// fields must be specified
-type apiServerMetricInvariant struct {
-	// Metric is the metric name
-	Metric string
-	// SIG associated with the invariant
-	// Bugs related to this invariant check failing should be labeled with
-	// this SIG.
-	SIG string
-	// Owners are the individuals responsible for the invariant
-	// Bugs related to this invariant check failing should be assigned to these
-	// GitHub handles
-	Owners []string
-	// IsValid should return false if the metric samples violate the invariant
-	IsValid func(testutil.Samples) bool
-}
-
-// Please speak to SIG-Testing leads before adding anything here.
-// All fields must be specified
-var apiServerMetricInvariants = []apiServerMetricInvariant{
-	{
-		// TODO: Migrate to apiserver_validation_declarative_validation_parity_discrepancies_total
-		// when it reaches beta / when this metric is deprecated.
-		// For now we uare using the previous beta metric.
-		Metric: "apiserver_validation_declarative_validation_mismatch_total",
-		SIG:    "api-machinery",
-		Owners: []string{"aaron-prindle", "jpbetz", "thockin"},
-		IsValid: func(samples testutil.Samples) bool {
-			// declarative validation mismatch should never be non-zero
-			for _, sample := range samples {
-				if sample.Value != 0 {
-					return false
-				}
-			}
-			return true
-		},
-	},
-	{
-		// TODO: Migrate to apiserver_validation_declarative_validation_panics_total
-		// when it reaches beta / when this metric is deprecated.
-		// For now we uare using the previous beta metric.
-		Metric: "apiserver_validation_declarative_validation_panic_total",
-		SIG:    "api-machinery",
-		Owners: []string{"aaron-prindle", "jpbetz", "thockin"},
-		IsValid: func(samples testutil.Samples) bool {
-			// declarative validation panics should never be non-zero
-			for _, sample := range samples {
-				if sample.Value != 0 {
-					return false
-				}
-			}
-			return true
-		},
-	},
-}
-
 func checkInvariantMetrics(ctx context.Context) {
 	// Grab metrics
 	config, err := framework.LoadConfig()
@@ -130,53 +72,9 @@ func checkInvariantMetrics(ctx context.Context) {
 	if err != nil {
 		framework.Failf("error loading client config: %v", err)
 	}
-	grabber, err := e2emetrics.NewMetricsGrabber(ctx, c, nil, config, false, false, false, true, false, false)
-	if err != nil {
-		framework.Failf("error creating metrics grabber: %v", err)
-	}
-	apiserverMetrics, err := grabber.GrabFromAPIServer(ctx)
-	if err != nil {
-		framework.Failf("error grabbing api-server metrics: %v", err)
-	}
 
 	// Check invariant metrics.
-	//
-	//
-	// Please speak to SIG-Testing leads before adding anything here.
-	for _, invariant := range apiServerMetricInvariants {
-		checkAPIServerInvariant(apiserverMetrics, &invariant)
-	}
-}
-
-func checkAPIServerInvariant(metrics e2emetrics.APIServerMetrics, invariant *apiServerMetricInvariant) {
-	metric := invariant.Metric
-	samples, ok := metrics[metric]
-	if !ok || len(samples) == 0 {
-		framework.Failf(
-			`Invariant failed for missing metric: %v
-
-If this failed on a pull request, please check if the PR changes may be related to the failure.
-If not, you can also search for an existing GitHub issue before filing a new issue.
-
-If this failed in a periodic CI job, please file a bug and /assign the owners.
-
-Owners for this metric: %v
-Associated SIG: %v`,
-			metric, strings.Join(invariant.Owners, " "), invariant.SIG,
-		)
-	}
-	if !invariant.IsValid(samples) {
-		framework.Failf(
-			`Invariant failed for metric: %v
-
-If this failed on a pull request, please check if the PR changes may be related to the failure.
-If not, you can also search for an existing GitHub issue before filing a new issue.
-
-If this failed in a periodic CI job, please file a bug and /assign the owners.
-
-Owners for this metric: %v
-Associated SIG: %v`,
-			metric, strings.Join(invariant.Owners, " "), invariant.SIG,
-		)
+	if err := metrics.CheckMetricInvariants(ctx, c, false); err != nil {
+		framework.Failf("Invariant check failed: %v", err)
 	}
 }

--- a/test/e2e/invariants/metrics/invariants.go
+++ b/test/e2e/invariants/metrics/invariants.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes"
+	metricstestutil "k8s.io/component-base/metrics/testutil"
+)
+
+const (
+	// apiServerValidationDeclarativeValidationMismatchTotal is the metric name for declarative validation mismatches.
+	apiServerValidationDeclarativeValidationMismatchTotal = "apiserver_validation_declarative_validation_mismatch_total"
+	// apiServerValidationDeclarativeValidationPanicTotal is the metric name for declarative validation panics.
+	apiServerValidationDeclarativeValidationPanicTotal = "apiserver_validation_declarative_validation_panic_total"
+)
+
+// metricInvariant defines an invariant check for a metric.
+type metricInvariant struct {
+	metricName string
+	// sig associated with the invariant
+	// Bugs related to this invariant check failing should be labeled with
+	// this sig.
+	sig string
+	// owners are the individuals responsible for the invariant
+	// Bugs related to this invariant check failing should be assigned to these
+	// GitHub handles
+	owners  []string
+	isValid func(metricstestutil.Samples) bool
+}
+
+// apiServerInvariants are the standard invariants checked for the API server.
+//
+// Please speak to SIG-Testing leads before adding anything here.
+var apiServerInvariants = []metricInvariant{
+	{
+		metricName: apiServerValidationDeclarativeValidationMismatchTotal,
+		sig:        "api-machinery",
+		owners:     []string{"aaron-prindle", "jpbetz", "thockin"},
+		isValid:    allSamplesZero,
+	},
+	{
+		metricName: apiServerValidationDeclarativeValidationPanicTotal,
+		sig:        "api-machinery",
+		owners:     []string{"aaron-prindle", "jpbetz", "thockin"},
+		isValid:    allSamplesZero,
+	},
+}
+
+// checkInvariants checks the provided metrics against a list of invariants.
+// If failOnMissing is true, it returns an error if a metric listed in invariants is missing from the metrics map.
+func checkInvariants(metrics map[string]metricstestutil.Samples, invariants []metricInvariant, failOnMissing bool) error {
+	var errs []error
+	for _, inv := range invariants {
+		samples, ok := metrics[inv.metricName]
+		if !ok || len(samples) == 0 {
+			if failOnMissing {
+				errs = append(errs, fmt.Errorf(`metric %s is missing from scrape (SIG: %s, Owners: %s)
+
+If this failed on a pull request, please check if the PR changes may be related to the failure.
+If not, you can also search for an existing GitHub issue before filing a new issue.
+
+If this failed in a periodic CI job, please file a bug and /assign the owners`, inv.metricName, inv.sig, strings.Join(inv.owners, ", ")))
+			}
+			continue
+		}
+		if !inv.isValid(samples) {
+			errs = append(errs, fmt.Errorf(`metric %s invariant failed (SIG: %s, Owners: %s)
+
+If this failed on a pull request, please check if the PR changes may be related to the failure.
+If not, you can also search for an existing GitHub issue before filing a new issue.
+
+If this failed in a periodic CI job, please file a bug and /assign the owners`, inv.metricName, inv.sig, strings.Join(inv.owners, ", ")))
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// allSamplesZero is a helper function that returns true if all samples have a value of zero.
+func allSamplesZero(samples metricstestutil.Samples) bool {
+	for _, sample := range samples {
+		if sample.Value != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// CheckMetricInvariants scrapes metrics from the API server and checks that
+// invariant metrics have the expected values.
+func CheckMetricInvariants(ctx context.Context, client kubernetes.Interface, failOnMissing bool) error {
+	scrapeCtx, cancelScrape := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelScrape()
+	body, err := client.Discovery().RESTClient().Get().AbsPath("metrics").DoRaw(scrapeCtx)
+	if err != nil {
+		return fmt.Errorf("failed to scrape metrics: %w", err)
+	}
+
+	scrapedMetrics := metricstestutil.NewMetrics()
+	if err := metricstestutil.ParseMetrics(string(body), &scrapedMetrics); err != nil {
+		return fmt.Errorf("failed to parse metrics: %w", err)
+	}
+
+	return checkInvariants(scrapedMetrics, apiServerInvariants, failOnMissing)
+}

--- a/test/e2e/invariants/metrics/invariants_test.go
+++ b/test/e2e/invariants/metrics/invariants_test.go
@@ -14,24 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package invariants
+package metrics
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestApiServerMetricInvariantsFieldsAreSet(t *testing.T) {
 	// enforce that all fields are set for all registered metrics
-	for i, inv := range apiServerMetricInvariants {
-		if inv.Metric == "" {
-			t.Errorf("apiServerMetricInvariants[%d].Metric is not set", i)
+	for i, inv := range apiServerInvariants {
+		if inv.metricName == "" {
+			t.Errorf("apiServerInvariants[%d].metricName is not set", i)
 		}
-		if inv.SIG == "" {
-			t.Errorf("apiServerMetricInvariants[%d].SIG is not set", i)
+		if inv.sig == "" {
+			t.Errorf("apiServerInvariants[%d].sig is not set", i)
 		}
-		if len(inv.Owners) == 0 {
-			t.Errorf("apiServerMetricInvariants[%d].Owners is not set", i)
+		if len(inv.owners) == 0 {
+			t.Errorf("apiServerInvariants[%d].owners is not set", i)
 		}
-		if inv.IsValid == nil {
-			t.Errorf("apiServerMetricInvariants[%d].IsValid is not set", i)
+		if inv.isValid == nil {
+			t.Errorf("apiServerInvariants[%d].isValid is not set", i)
 		}
 	}
 }

--- a/test/integration/.import-restrictions
+++ b/test/integration/.import-restrictions
@@ -15,6 +15,9 @@ rules:
   - selectorRegexp: k8s[.]io/kubernetes/test/e2e/dra/utils
     allowedPrefixes:
       - ""
+  - selectorRegexp: k8s[.]io/kubernetes/test/e2e/invariants/metrics
+    allowedPrefixes:
+      - ""
   - selectorRegexp: k8s[.]io/kubernetes/test/e2e
     forbiddenPrefixes:
       - ""

--- a/test/integration/auth/accessreview_test.go
+++ b/test/integration/auth/accessreview_test.go
@@ -178,6 +178,12 @@ func TestSelfSubjectAccessReview(t *testing.T) {
 		},
 	})
 	defer tearDownFn()
+	// Switch back to a working authorizer so that tests in tear down work as expected.
+	defer func() {
+		mutex.Lock()
+		defer mutex.Unlock()
+		username = "alice"
+	}()
 
 	tests := []struct {
 		name           string

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
+	"k8s.io/kubernetes/test/e2e/invariants/metrics"
 	"k8s.io/kubernetes/test/utils"
 )
 
@@ -66,6 +67,8 @@ AwEHoUQDQgAEH6cuzP8XuD5wal6wf9M6xDljTOPLX2i8uIp/C/ASqiIGUeeKQtX0
 type TestServerSetup struct {
 	ModifyServerRunOptions func(*options.ServerRunOptions)
 	ModifyServerConfig     func(*controlplane.Config)
+	// DisableInvariantChecks skips the invariant checks at the end of the test.
+	DisableInvariantChecks bool
 }
 
 type TearDownFunc func()
@@ -81,24 +84,6 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 	}
 
 	var errCh chan error
-	tearDownFn := func() {
-		// Calling cancel function is stopping apiserver and cleaning up
-		// after itself, including shutting down its storage layer.
-		cancel()
-
-		// If the apiserver was started, let's wait for it to
-		// shutdown clearly.
-		if errCh != nil {
-			err, ok := <-errCh
-			if ok && err != nil {
-				t.Error(err)
-			}
-		}
-		if err := os.RemoveAll(certDir); err != nil {
-			t.Log(err)
-		}
-	}
-
 	_, defaultServiceClusterIPRange, _ := netutils.ParseCIDRSloppy("10.0.0.0/24")
 	proxySigningKey, err := utils.NewPrivateKey()
 	if err != nil {
@@ -276,6 +261,34 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 	kubeAPIServerClient, err := client.NewForConfig(kubeAPIServerClientConfig)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	tearDownFn := func() {
+		// Scrape metrics before stopping
+		if !setup.DisableInvariantChecks {
+			if ctx.Err() != nil {
+				t.Logf("Skipping metrics scrape because context is already canceled: %v", ctx.Err())
+			} else {
+				if err := metrics.CheckMetricInvariants(ctx, kubeAPIServerClient, false); err != nil {
+					t.Errorf("Invariant check failed (if the test intentionally breaks metrics/auth, consider setting DisableInvariantChecks: true in TestServerSetup): %v", err)
+				}
+			}
+		}
+		// Calling cancel function is stopping apiserver and cleaning up
+		// after itself, including shutting down its storage layer.
+		cancel()
+
+		// If the apiserver was started, let's wait for it to
+		// shutdown clearly.
+		if errCh != nil {
+			err, ok := <-errCh
+			if ok && err != nil {
+				t.Error(err)
+			}
+		}
+		if err := os.RemoveAll(certDir); err != nil {
+			t.Log(err)
+		}
 	}
 
 	return kubeAPIServerClient, kubeAPIServerClientConfig, tearDownFn


### PR DESCRIPTION
/kind feature

Add support for invariant testing in integration testing

Invariant testing in Integration tests is useful, will help in catching issues like https://kubernetes.slack.com/archives/C0EG7JC6T/p1773417403771049, early in the process.

**Usage Example in Integration Tests:**
To use invariant checks, no extra code is required; `StartTestServer` automatically verifies invariant metrics upon teardown. If your test intentionally breaks these metrics (e.g., custom auth tests), you can disable the invariant checks in `TestServerSetup` or `TestServerInstanceOptions`:

```go
clientset, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
    ModifyServerConfig: func(config *controlplane.Config) {
        // ...
    },
    DisableInvariantChecks: true,
})
defer tearDownFn()
```

/sig testing

```release-note
Added support for testing invariant metrics in integration tests.
```