### PR TITLE
fix: Create workload object before podgroup in the topology-aware integration tests

### DIFF
--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
@@ -1302,6 +1302,13 @@ func runTestScenario(t *testing.T, tt scenario, gangSchedulingEnabled bool) {
 		scheduler.WithPodInitialBackoffSeconds(0))
 	cs, ns := testCtx.ClientSet, testCtx.NS.Name
 
+	workload := st.MakeWorkload().Name("workload").Namespace(ns).
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t1").MinCount(1).Obj()).
+		Obj()
+	if _, err := cs.SchedulingV1alpha2().Workloads(ns).Create(testCtx.Ctx, workload, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Workload: %v", err)
+	}
+
 	for i, step := range tt.steps {
 		t.Logf("Executing step %d: %s", i, step.name)
 		switch {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind dependency
/kind failing-test
/sig-scheduling
/area workload-aware


#### What this PR does / why we need it:

The topology-aware scheduling tests all create PodGroups that reference a Workload, but they never created that Workload. The `PodGroupWorkloadExists` admission plugin rejects the PodGroup creation because the Workload doesn't exist.

The fix creates the referenced Workload at the start of runTestScenario (before any steps execute), so the admission check passes. The admission plugin only validates the Workload exists and contains the named template.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
This issue will block all PRs that enables `GenericWorkload` Feature gate. (#137464)

#### Does this PR introduce a user-facing change?
No

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
KEP: https://github.com/kubernetes/enhancements/issues/5732
