### PR TITLE
api: enable optionalorrequired linter for admissionregistration API group

### DIFF
--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
@@ -171,6 +171,9 @@
             "kind": "MutatingAdmissionPolicy",
             "version": "v1"
           }
+        ],
+        "required": [
+          "spec"
         ]
       },
       "io.k8s.api.admissionregistration.v1.MutatingAdmissionPolicyBinding": {
@@ -210,6 +213,9 @@
             "kind": "MutatingAdmissionPolicyBinding",
             "version": "v1"
           }
+        ],
+        "required": [
+          "spec"
         ]
       },
       "io.k8s.api.admissionregistration.v1.MutatingAdmissionPolicyBindingList": {
@@ -866,6 +872,9 @@
             "kind": "ValidatingAdmissionPolicy",
             "version": "v1"
           }
+        ],
+        "required": [
+          "spec"
         ]
       },
       "io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBinding": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -234,7 +234,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -249,7 +249,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+        path: "staging/src/k8s.io/api/(apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -110,7 +110,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
+  path: "staging/src/k8s.io/api/(apidiscovery|apps|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
@@ -70,6 +70,7 @@ message ApplyConfiguration {
   //
   // Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
   // Required.
+  // +optional
   optional string expression = 1;
 }
 
@@ -90,6 +91,7 @@ message AuditAnnotation {
   // will be discarded.
   //
   // Required.
+  // +required
   optional string key = 1;
 
   // valueExpression represents the expression which is evaluated by CEL to
@@ -107,6 +109,7 @@ message AuditAnnotation {
   // will be joined together in a comma-separated list.
   //
   // Required.
+  // +required
   optional string valueExpression = 2;
 }
 
@@ -115,11 +118,13 @@ message ExpressionWarning {
   // fieldRef is the path to the field that refers to the expression.
   // For example, the reference to the expression of the first item of
   // validations is "spec.validations[0].expression"
+  // +required
   optional string fieldRef = 2;
 
   // warning contains the content of type checking information in a human-readable form.
   // Each line of the warning contains the type that the expression is checked
   // against, followed by the type check error from the compiler.
+  // +required
   optional string warning = 3;
 }
 
@@ -189,6 +194,7 @@ message JSONPatch {
   //
   // Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
   // Required.
+  // +optional
   optional string expression = 1;
 }
 
@@ -203,6 +209,7 @@ message MatchCondition {
   // optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
   //
   // Required.
+  // +required
   optional string name = 1;
 
   // expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
@@ -218,6 +225,7 @@ message MatchCondition {
   // Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
   //
   // Required.
+  // +required
   optional string expression = 2;
 }
 
@@ -323,6 +331,7 @@ message MutatingAdmissionPolicy {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the MutatingAdmissionPolicy.
+  // +required
   optional MutatingAdmissionPolicySpec spec = 2;
 }
 
@@ -343,6 +352,7 @@ message MutatingAdmissionPolicyBinding {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the MutatingAdmissionPolicyBinding.
+  // +required
   optional MutatingAdmissionPolicyBindingSpec spec = 2;
 }
 
@@ -362,6 +372,7 @@ message MutatingAdmissionPolicyBindingSpec {
   // policyName references a MutatingAdmissionPolicy name which the MutatingAdmissionPolicyBinding binds to.
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
+  // +optional
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -411,6 +422,7 @@ message MutatingAdmissionPolicySpec {
   // The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched.
   // '*' matches CREATE, UPDATE and CONNECT.
   // Required.
+  // +optional
   optional MatchResources matchConstraints = 2;
 
   // variables contain definitions of variables that can be used in composition of other expressions.
@@ -480,6 +492,7 @@ message MutatingAdmissionPolicySpec {
   // order with respect to other admission plugins, admission webhooks, bindings of this policy and admission policies.  Mutations are only
   // reinvoked when mutations change the object after this mutation is invoked.
   // Required.
+  // +optional
   optional string reinvocationPolicy = 7;
 }
 
@@ -490,10 +503,12 @@ message MutatingWebhook {
   // "imagepolicy" is the name of the webhook, and kubernetes.io is the name
   // of the organization.
   // Required.
+  // +required
   optional string name = 1;
 
   // clientConfig defines how to communicate with the hook.
   // Required
+  // +required
   optional WebhookClientConfig clientConfig = 2;
 
   // rules describes what operations on what resources/subresources the webhook cares about.
@@ -503,6 +518,7 @@ message MutatingWebhook {
   // disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
   // on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
   // +listType=atomic
+  // +optional
   repeated RuleWithOperations rules = 3;
 
   // failurePolicy defines how unrecognized errors from the admission endpoint are handled -
@@ -593,6 +609,7 @@ message MutatingWebhook {
   // rejected by a future step in the admission chain and the side effects therefore need to be undone.
   // Requests with the dryRun attribute will be auto-rejected if they match a webhook with
   // sideEffects == Unknown or Some.
+  // +required
   optional string sideEffects = 6;
 
   // timeoutSeconds specifies the timeout for this webhook. After the timeout passes,
@@ -611,6 +628,7 @@ message MutatingWebhook {
   // include any versions known to the API Server, calls to the webhook will fail
   // and be subject to the failure policy.
   // +listType=atomic
+  // +required
   repeated string admissionReviewVersions = 8;
 
   // reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
@@ -684,16 +702,19 @@ message Mutation {
   // Required.
   //
   // +unionDiscriminator
+  // +required
   optional string patchType = 2;
 
   // applyConfiguration defines the desired configuration values of an object.
   // The configuration is applied to the admission object using
   // [structured merge diff](https://github.com/kubernetes-sigs/structured-merge-diff).
   // A CEL expression is used to create apply configuration.
+  // +optional
   optional ApplyConfiguration applyConfiguration = 3;
 
   // jsonPatch defines a [JSON patch](https://jsonpatch.com/) operation to perform a mutation to the object.
   // A CEL expression is used to create the JSON patch.
+  // +optional
   optional JSONPatch jsonPatch = 4;
 }
 
@@ -715,10 +736,12 @@ message ParamKind {
   // apiVersion is the API group version the resources belong to.
   // In format of "group/version".
   // Required.
+  // +optional
   optional string apiVersion = 1;
 
   // kind is the API kind the resources belong to.
   // Required.
+  // +optional
   optional string kind = 2;
 }
 
@@ -734,6 +757,7 @@ message ParamRef {
   // A single parameter used for all admission requests can be configured
   // by setting the `name` field, leaving `selector` blank, and setting namespace
   // if `paramKind` is namespace-scoped.
+  // +optional
   optional string name = 1;
 
   // namespace is the namespace of the referenced resource. Allows limiting
@@ -776,6 +800,7 @@ message ParamRef {
   // Allowed values are `Allow` or `Deny`
   //
   // Required
+  // +optional
   optional string parameterNotFoundAction = 4;
 }
 
@@ -786,12 +811,14 @@ message Rule {
   // If '*' is present, the length of the slice must be one.
   // Required.
   // +listType=atomic
+  // +optional
   repeated string apiGroups = 1;
 
   // apiVersions is the API versions the resources belong to. '*' is all versions.
   // If '*' is present, the length of the slice must be one.
   // Required.
   // +listType=atomic
+  // +optional
   repeated string apiVersions = 2;
 
   // resources is a list of resources this rule applies to.
@@ -810,6 +837,7 @@ message Rule {
   // Depending on the enclosing object, subresources might not be allowed.
   // Required.
   // +listType=atomic
+  // +optional
   repeated string resources = 3;
 
   // scope specifies the scope of this rule.
@@ -833,6 +861,7 @@ message RuleWithOperations {
   // If '*' is present, the length of the slice must be one.
   // Required.
   // +listType=atomic
+  // +optional
   repeated string operations = 1;
 
   // Rule is embedded, it describes other criteria of the rule, like
@@ -844,10 +873,12 @@ message RuleWithOperations {
 message ServiceReference {
   // namespace is the namespace of the service.
   // Required
+  // +required
   optional string namespace = 1;
 
   // name is the name of the service.
   // Required
+  // +required
   optional string name = 2;
 
   // path is an optional URL path which will be sent in any request to
@@ -878,6 +909,7 @@ message ValidatingAdmissionPolicy {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the ValidatingAdmissionPolicy.
+  // +required
   optional ValidatingAdmissionPolicySpec spec = 2;
 
   // status represents the current status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy
@@ -1014,6 +1046,7 @@ message ValidatingAdmissionPolicySpec {
   // However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
   // ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
   // Required.
+  // +optional
   optional MatchResources matchConstraints = 2;
 
   // validations contain CEL expressions which is used to apply the validation.
@@ -1109,10 +1142,12 @@ message ValidatingWebhook {
   // "imagepolicy" is the name of the webhook, and kubernetes.io is the name
   // of the organization.
   // Required.
+  // +required
   optional string name = 1;
 
   // clientConfig defines how to communicate with the hook.
   // Required
+  // +required
   optional WebhookClientConfig clientConfig = 2;
 
   // rules describes what operations on what resources/subresources the webhook cares about.
@@ -1122,6 +1157,7 @@ message ValidatingWebhook {
   // disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
   // on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
   // +listType=atomic
+  // +optional
   repeated RuleWithOperations rules = 3;
 
   // failurePolicy defines how unrecognized errors from the admission endpoint are handled -
@@ -1212,6 +1248,7 @@ message ValidatingWebhook {
   // rejected by a future step in the admission chain and the side effects therefore need to be undone.
   // Requests with the dryRun attribute will be auto-rejected if they match a webhook with
   // sideEffects == Unknown or Some.
+  // +required
   optional string sideEffects = 6;
 
   // timeoutSeconds specifies the timeout for this webhook. After the timeout passes,
@@ -1230,6 +1267,7 @@ message ValidatingWebhook {
   // include any versions known to the API Server, calls to the webhook will fail
   // and be subject to the failure policy.
   // +listType=atomic
+  // +required
   repeated string admissionReviewVersions = 8;
 
   // matchConditions is a list of conditions that must be met for a request to be sent to this
@@ -1321,6 +1359,7 @@ message Validation {
   //     are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
   //     non-intersecting keys are appended, retaining their partial order.
   // Required.
+  // +required
   optional string Expression = 1;
 
   // message represents the message displayed when validation fails. The message is required if the Expression contains
@@ -1362,10 +1401,12 @@ message Variable {
   // name is the name of the variable. The name must be a valid CEL identifier and unique among all variables.
   // The variable can be accessed in other expressions through `variables`
   // For example, if name is "foo", the variable will be available as `variables.foo`
+  // +required
   optional string Name = 1;
 
   // expression is the expression that will be evaluated as the value of the variable.
   // The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+  // +required
   optional string Expression = 2;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -148,6 +148,7 @@ type ValidatingAdmissionPolicy struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the ValidatingAdmissionPolicy.
+	// +required
 	Spec ValidatingAdmissionPolicySpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// status represents the current status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy
 	// behaves in the expected way.
@@ -1140,6 +1141,7 @@ type MutatingAdmissionPolicy struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the MutatingAdmissionPolicy.
+	// +required
 	Spec MutatingAdmissionPolicySpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -1420,6 +1422,7 @@ type MutatingAdmissionPolicyBinding struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the MutatingAdmissionPolicyBinding.
+	// +required
 	Spec MutatingAdmissionPolicyBindingSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -1492,7 +1495,6 @@ type RuleWithOperations struct {
 	Operations []OperationType `json:"operations,omitempty" protobuf:"bytes,1,rep,name=operations,casttype=OperationType"`
 	// Rule is embedded, it describes other criteria of the rule, like
 	// APIGroups, APIVersions, Resources, etc.
-	// +required
 	Rule `json:",inline" protobuf:"bytes,2,opt,name=rule"`
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -27,12 +27,14 @@ type Rule struct {
 	// If '*' is present, the length of the slice must be one.
 	// Required.
 	// +listType=atomic
+	// +optional
 	APIGroups []string `json:"apiGroups,omitempty" protobuf:"bytes,1,rep,name=apiGroups"`
 
 	// apiVersions is the API versions the resources belong to. '*' is all versions.
 	// If '*' is present, the length of the slice must be one.
 	// Required.
 	// +listType=atomic
+	// +optional
 	APIVersions []string `json:"apiVersions,omitempty" protobuf:"bytes,2,rep,name=apiVersions"`
 
 	// resources is a list of resources this rule applies to.
@@ -51,6 +53,7 @@ type Rule struct {
 	// Depending on the enclosing object, subresources might not be allowed.
 	// Required.
 	// +listType=atomic
+	// +optional
 	Resources []string `json:"resources,omitempty" protobuf:"bytes,3,rep,name=resources"`
 
 	// scope specifies the scope of this rule.
@@ -187,10 +190,12 @@ type ExpressionWarning struct {
 	// fieldRef is the path to the field that refers to the expression.
 	// For example, the reference to the expression of the first item of
 	// validations is "spec.validations[0].expression"
+	// +required
 	FieldRef string `json:"fieldRef" protobuf:"bytes,2,opt,name=fieldRef"`
 	// warning contains the content of type checking information in a human-readable form.
 	// Each line of the warning contains the type that the expression is checked
 	// against, followed by the type check error from the compiler.
+	// +required
 	Warning string `json:"warning" protobuf:"bytes,3,opt,name=warning"`
 }
 
@@ -222,6 +227,7 @@ type ValidatingAdmissionPolicySpec struct {
 	// However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
 	// ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
 	// Required.
+	// +optional
 	MatchConstraints *MatchResources `json:"matchConstraints,omitempty" protobuf:"bytes,2,rep,name=matchConstraints"`
 
 	// validations contain CEL expressions which is used to apply the validation.
@@ -298,10 +304,12 @@ type ParamKind struct {
 	// apiVersion is the API group version the resources belong to.
 	// In format of "group/version".
 	// Required.
+	// +optional
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,1,rep,name=apiVersion"`
 
 	// kind is the API kind the resources belong to.
 	// Required.
+	// +optional
 	Kind string `json:"kind,omitempty" protobuf:"bytes,2,rep,name=kind"`
 }
 
@@ -348,6 +356,7 @@ type Validation struct {
 	//     are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
 	//     non-intersecting keys are appended, retaining their partial order.
 	// Required.
+	// +required
 	Expression string `json:"expression" protobuf:"bytes,1,opt,name=Expression"`
 	// message represents the message displayed when validation fails. The message is required if the Expression contains
 	// line breaks. The message must not contain line breaks.
@@ -386,10 +395,12 @@ type Variable struct {
 	// name is the name of the variable. The name must be a valid CEL identifier and unique among all variables.
 	// The variable can be accessed in other expressions through `variables`
 	// For example, if name is "foo", the variable will be available as `variables.foo`
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=Name"`
 
 	// expression is the expression that will be evaluated as the value of the variable.
 	// The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+	// +required
 	Expression string `json:"expression" protobuf:"bytes,2,opt,name=Expression"`
 }
 
@@ -410,6 +421,7 @@ type AuditAnnotation struct {
 	// will be discarded.
 	//
 	// Required.
+	// +required
 	Key string `json:"key" protobuf:"bytes,1,opt,name=key"`
 
 	// valueExpression represents the expression which is evaluated by CEL to
@@ -427,6 +439,7 @@ type AuditAnnotation struct {
 	// will be joined together in a comma-separated list.
 	//
 	// Required.
+	// +required
 	ValueExpression string `json:"valueExpression" protobuf:"bytes,2,opt,name=valueExpression"`
 }
 
@@ -552,6 +565,7 @@ type ParamRef struct {
 	// by setting the `name` field, leaving `selector` blank, and setting namespace
 	// if `paramKind` is namespace-scoped.
 	//
+	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,1,rep,name=name"`
 
 	// namespace is the namespace of the referenced resource. Allows limiting
@@ -594,6 +608,7 @@ type ParamRef struct {
 	// Allowed values are `Allow` or `Deny`
 	//
 	// Required
+	// +optional
 	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction,omitempty" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
 }
 
@@ -792,10 +807,12 @@ type ValidatingWebhook struct {
 	// "imagepolicy" is the name of the webhook, and kubernetes.io is the name
 	// of the organization.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// clientConfig defines how to communicate with the hook.
 	// Required
+	// +required
 	ClientConfig WebhookClientConfig `json:"clientConfig" protobuf:"bytes,2,opt,name=clientConfig"`
 
 	// rules describes what operations on what resources/subresources the webhook cares about.
@@ -805,6 +822,7 @@ type ValidatingWebhook struct {
 	// disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
 	// on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
 	// +listType=atomic
+	// +optional
 	Rules []RuleWithOperations `json:"rules,omitempty" protobuf:"bytes,3,rep,name=rules"`
 
 	// failurePolicy defines how unrecognized errors from the admission endpoint are handled -
@@ -895,6 +913,7 @@ type ValidatingWebhook struct {
 	// rejected by a future step in the admission chain and the side effects therefore need to be undone.
 	// Requests with the dryRun attribute will be auto-rejected if they match a webhook with
 	// sideEffects == Unknown or Some.
+	// +required
 	SideEffects *SideEffectClass `json:"sideEffects" protobuf:"bytes,6,opt,name=sideEffects,casttype=SideEffectClass"`
 
 	// timeoutSeconds specifies the timeout for this webhook. After the timeout passes,
@@ -913,6 +932,7 @@ type ValidatingWebhook struct {
 	// include any versions known to the API Server, calls to the webhook will fail
 	// and be subject to the failure policy.
 	// +listType=atomic
+	// +required
 	AdmissionReviewVersions []string `json:"admissionReviewVersions" protobuf:"bytes,8,rep,name=admissionReviewVersions"`
 
 	// matchConditions is a list of conditions that must be met for a request to be sent to this
@@ -942,10 +962,12 @@ type MutatingWebhook struct {
 	// "imagepolicy" is the name of the webhook, and kubernetes.io is the name
 	// of the organization.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// clientConfig defines how to communicate with the hook.
 	// Required
+	// +required
 	ClientConfig WebhookClientConfig `json:"clientConfig" protobuf:"bytes,2,opt,name=clientConfig"`
 
 	// rules describes what operations on what resources/subresources the webhook cares about.
@@ -955,6 +977,7 @@ type MutatingWebhook struct {
 	// disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
 	// on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
 	// +listType=atomic
+	// +optional
 	Rules []RuleWithOperations `json:"rules,omitempty" protobuf:"bytes,3,rep,name=rules"`
 
 	// failurePolicy defines how unrecognized errors from the admission endpoint are handled -
@@ -1045,6 +1068,7 @@ type MutatingWebhook struct {
 	// rejected by a future step in the admission chain and the side effects therefore need to be undone.
 	// Requests with the dryRun attribute will be auto-rejected if they match a webhook with
 	// sideEffects == Unknown or Some.
+	// +required
 	SideEffects *SideEffectClass `json:"sideEffects" protobuf:"bytes,6,opt,name=sideEffects,casttype=SideEffectClass"`
 
 	// timeoutSeconds specifies the timeout for this webhook. After the timeout passes,
@@ -1063,6 +1087,7 @@ type MutatingWebhook struct {
 	// include any versions known to the API Server, calls to the webhook will fail
 	// and be subject to the failure policy.
 	// +listType=atomic
+	// +required
 	AdmissionReviewVersions []string `json:"admissionReviewVersions" protobuf:"bytes,8,rep,name=admissionReviewVersions"`
 
 	// reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
@@ -1148,6 +1173,7 @@ type MutatingAdmissionPolicySpec struct {
 	// The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched.
 	// '*' matches CREATE, UPDATE and CONNECT.
 	// Required.
+	// +optional
 	MatchConstraints *MatchResources `json:"matchConstraints,omitempty" protobuf:"bytes,2,rep,name=matchConstraints"`
 
 	// variables contain definitions of variables that can be used in composition of other expressions.
@@ -1217,6 +1243,7 @@ type MutatingAdmissionPolicySpec struct {
 	// order with respect to other admission plugins, admission webhooks, bindings of this policy and admission policies.  Mutations are only
 	// reinvoked when mutations change the object after this mutation is invoked.
 	// Required.
+	// +optional
 	ReinvocationPolicy ReinvocationPolicyType `json:"reinvocationPolicy,omitempty" protobuf:"bytes,7,opt,name=reinvocationPolicy,casttype=ReinvocationPolicyType"`
 }
 
@@ -1227,16 +1254,19 @@ type Mutation struct {
 	// Required.
 	//
 	// +unionDiscriminator
+	// +required
 	PatchType PatchType `json:"patchType" protobuf:"bytes,2,opt,name=patchType,casttype=PatchType"`
 
 	// applyConfiguration defines the desired configuration values of an object.
 	// The configuration is applied to the admission object using
 	// [structured merge diff](https://github.com/kubernetes-sigs/structured-merge-diff).
 	// A CEL expression is used to create apply configuration.
+	// +optional
 	ApplyConfiguration *ApplyConfiguration `json:"applyConfiguration,omitempty" protobuf:"bytes,3,opt,name=applyConfiguration"`
 
 	// jsonPatch defines a [JSON patch](https://jsonpatch.com/) operation to perform a mutation to the object.
 	// A CEL expression is used to create the JSON patch.
+	// +optional
 	JSONPatch *JSONPatch `json:"jsonPatch,omitempty" protobuf:"bytes,4,opt,name=jsonPatch"`
 }
 
@@ -1293,6 +1323,7 @@ type ApplyConfiguration struct {
 	//
 	// Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
 	// Required.
+	// +optional
 	Expression string `json:"expression,omitempty" protobuf:"bytes,1,opt,name=expression"`
 }
 
@@ -1363,6 +1394,7 @@ type JSONPatch struct {
 	//
 	// Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
 	// Required.
+	// +optional
 	Expression string `json:"expression,omitempty" protobuf:"bytes,1,opt,name=expression"`
 }
 
@@ -1410,6 +1442,7 @@ type MutatingAdmissionPolicyBindingSpec struct {
 	// policyName references a MutatingAdmissionPolicy name which the MutatingAdmissionPolicyBinding binds to.
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
+	// +optional
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.
@@ -1455,9 +1488,11 @@ type RuleWithOperations struct {
 	// If '*' is present, the length of the slice must be one.
 	// Required.
 	// +listType=atomic
+	// +optional
 	Operations []OperationType `json:"operations,omitempty" protobuf:"bytes,1,rep,name=operations,casttype=OperationType"`
 	// Rule is embedded, it describes other criteria of the rule, like
 	// APIGroups, APIVersions, Resources, etc.
+	// +required
 	Rule `json:",inline" protobuf:"bytes,2,opt,name=rule"`
 }
 
@@ -1524,9 +1559,11 @@ type WebhookClientConfig struct {
 type ServiceReference struct {
 	// namespace is the namespace of the service.
 	// Required
+	// +required
 	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
 	// name is the name of the service.
 	// Required
+	// +required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
 	// path is an optional URL path which will be sent in any request to
@@ -1552,6 +1589,7 @@ type MatchCondition struct {
 	// optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
 	//
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
@@ -1567,5 +1605,6 @@ type MatchCondition struct {
 	// Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
 	//
 	// Required.
+	// +required
 	Expression string `json:"expression" protobuf:"bytes,2,opt,name=expression"`
 }

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
@@ -71,6 +71,7 @@ message ApplyConfiguration {
   //
   // Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
   // Required.
+  // +optional
   optional string expression = 1;
 }
 
@@ -91,6 +92,7 @@ message AuditAnnotation {
   // will be discarded.
   //
   // Required.
+  // +required
   optional string key = 1;
 
   // valueExpression represents the expression which is evaluated by CEL to
@@ -108,6 +110,7 @@ message AuditAnnotation {
   // will be joined together in a comma-separated list.
   //
   // Required.
+  // +required
   optional string valueExpression = 2;
 }
 
@@ -116,11 +119,13 @@ message ExpressionWarning {
   // fieldRef is the path to the field that refers to the expression.
   // For example, the reference to the expression of the first item of
   // validations is "spec.validations[0].expression"
+  // +required
   optional string fieldRef = 2;
 
   // warning contains the content of type checking information in a human-readable form.
   // Each line of the warning contains the type that the expression is checked
   // against, followed by the type check error from the compiler.
+  // +required
   optional string warning = 3;
 }
 
@@ -190,6 +195,7 @@ message JSONPatch {
   //
   // Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
   // Required.
+  // +optional
   optional string expression = 1;
 }
 
@@ -324,6 +330,7 @@ message MutatingAdmissionPolicy {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the MutatingAdmissionPolicy.
+  // +required
   optional MutatingAdmissionPolicySpec spec = 2;
 }
 
@@ -344,6 +351,7 @@ message MutatingAdmissionPolicyBinding {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the MutatingAdmissionPolicyBinding.
+  // +required
   optional MutatingAdmissionPolicyBindingSpec spec = 2;
 }
 
@@ -363,6 +371,7 @@ message MutatingAdmissionPolicyBindingSpec {
   // policyName references a MutatingAdmissionPolicy name which the MutatingAdmissionPolicyBinding binds to.
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
+  // +optional
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -412,6 +421,7 @@ message MutatingAdmissionPolicySpec {
   // The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched.
   // '*' matches CREATE, UPDATE and CONNECT.
   // Required.
+  // +optional
   optional MatchResources matchConstraints = 2;
 
   // variables contain definitions of variables that can be used in composition of other expressions.
@@ -481,6 +491,7 @@ message MutatingAdmissionPolicySpec {
   // order with respect to other admission plugins, admission webhooks, bindings of this policy and admission policies.  Mutations are only
   // reinvoked when mutations change the object after this mutation is invoked.
   // Required.
+  // +optional
   optional string reinvocationPolicy = 7;
 }
 
@@ -491,16 +502,19 @@ message Mutation {
   // Required.
   //
   // +unionDiscriminator
+  // +required
   optional string patchType = 2;
 
   // applyConfiguration defines the desired configuration values of an object.
   // The configuration is applied to the admission object using
   // [structured merge diff](https://github.com/kubernetes-sigs/structured-merge-diff).
   // A CEL expression is used to create apply configuration.
+  // +optional
   optional ApplyConfiguration applyConfiguration = 3;
 
   // jsonPatch defines a [JSON patch](https://jsonpatch.com/) operation to perform a mutation to the object.
   // A CEL expression is used to create the JSON patch.
+  // +optional
   optional JSONPatch jsonPatch = 4;
 }
 
@@ -522,10 +536,12 @@ message ParamKind {
   // apiVersion is the API group version the resources belong to.
   // In format of "group/version".
   // Required.
+  // +optional
   optional string apiVersion = 1;
 
   // kind is the API kind the resources belong to.
   // Required.
+  // +optional
   optional string kind = 2;
 }
 
@@ -600,6 +616,7 @@ message ValidatingAdmissionPolicy {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the ValidatingAdmissionPolicy.
+  // +required
   optional ValidatingAdmissionPolicySpec spec = 2;
 
   // status represents the current status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy
@@ -736,6 +753,7 @@ message ValidatingAdmissionPolicySpec {
   // However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
   // ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
   // Required.
+  // +optional
   optional MatchResources matchConstraints = 2;
 
   // validations contain CEL expressions which is used to apply the validation.
@@ -867,6 +885,7 @@ message Validation {
   //     are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
   //     non-intersecting keys are appended, retaining their partial order.
   // Required.
+  // +required
   optional string Expression = 1;
 
   // message represents the message displayed when validation fails. The message is required if the Expression contains
@@ -907,10 +926,12 @@ message Variable {
   // name is the name of the variable. The name must be a valid CEL identifier and unique among all variables.
   // The variable can be accessed in other expressions through `variables`
   // For example, if name is "foo", the variable will be available as `variables.foo`
+  // +required
   optional string Name = 1;
 
   // expression is the expression that will be evaluated as the value of the variable.
   // The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+  // +required
   optional string Expression = 2;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
@@ -87,6 +87,7 @@ type ValidatingAdmissionPolicy struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the ValidatingAdmissionPolicy.
+	// +required
 	Spec ValidatingAdmissionPolicySpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// status represents the current status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy
 	// behaves in the expected way.
@@ -126,10 +127,12 @@ type ExpressionWarning struct {
 	// fieldRef is the path to the field that refers to the expression.
 	// For example, the reference to the expression of the first item of
 	// validations is "spec.validations[0].expression"
+	// +required
 	FieldRef string `json:"fieldRef" protobuf:"bytes,2,opt,name=fieldRef"`
 	// warning contains the content of type checking information in a human-readable form.
 	// Each line of the warning contains the type that the expression is checked
 	// against, followed by the type check error from the compiler.
+	// +required
 	Warning string `json:"warning" protobuf:"bytes,3,opt,name=warning"`
 }
 
@@ -161,6 +164,7 @@ type ValidatingAdmissionPolicySpec struct {
 	// However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
 	// ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
 	// Required.
+	// +optional
 	MatchConstraints *MatchResources `json:"matchConstraints,omitempty" protobuf:"bytes,2,rep,name=matchConstraints"`
 
 	// validations contain CEL expressions which is used to apply the validation.
@@ -239,10 +243,12 @@ type ParamKind struct {
 	// apiVersion is the API group version the resources belong to.
 	// In format of "group/version".
 	// Required.
+	// +optional
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,1,rep,name=apiVersion"`
 
 	// kind is the API kind the resources belong to.
 	// Required.
+	// +optional
 	Kind string `json:"kind,omitempty" protobuf:"bytes,2,rep,name=kind"`
 }
 
@@ -289,6 +295,7 @@ type Validation struct {
 	//     are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
 	//     non-intersecting keys are appended, retaining their partial order.
 	// Required.
+	// +required
 	Expression string `json:"expression" protobuf:"bytes,1,opt,name=Expression"`
 	// message represents the message displayed when validation fails. The message is required if the Expression contains
 	// line breaks. The message must not contain line breaks.
@@ -326,10 +333,12 @@ type Variable struct {
 	// name is the name of the variable. The name must be a valid CEL identifier and unique among all variables.
 	// The variable can be accessed in other expressions through `variables`
 	// For example, if name is "foo", the variable will be available as `variables.foo`
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=Name"`
 
 	// expression is the expression that will be evaluated as the value of the variable.
 	// The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+	// +required
 	Expression string `json:"expression" protobuf:"bytes,2,opt,name=Expression"`
 }
 
@@ -350,6 +359,7 @@ type AuditAnnotation struct {
 	// will be discarded.
 	//
 	// Required.
+	// +required
 	Key string `json:"key" protobuf:"bytes,1,opt,name=key"`
 
 	// valueExpression represents the expression which is evaluated by CEL to
@@ -367,6 +377,7 @@ type AuditAnnotation struct {
 	// will be joined together in a comma-separated list.
 	//
 	// Required.
+	// +required
 	ValueExpression string `json:"valueExpression" protobuf:"bytes,2,opt,name=valueExpression"`
 }
 
@@ -684,6 +695,7 @@ type MutatingAdmissionPolicy struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the MutatingAdmissionPolicy.
+	// +required
 	Spec MutatingAdmissionPolicySpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -717,6 +729,7 @@ type MutatingAdmissionPolicySpec struct {
 	// The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched.
 	// '*' matches CREATE, UPDATE and CONNECT.
 	// Required.
+	// +optional
 	MatchConstraints *MatchResources `json:"matchConstraints,omitempty" protobuf:"bytes,2,rep,name=matchConstraints"`
 
 	// variables contain definitions of variables that can be used in composition of other expressions.
@@ -786,6 +799,7 @@ type MutatingAdmissionPolicySpec struct {
 	// order with respect to other admission plugins, admission webhooks, bindings of this policy and admission policies.  Mutations are only
 	// reinvoked when mutations change the object after this mutation is invoked.
 	// Required.
+	// +optional
 	ReinvocationPolicy ReinvocationPolicyType `json:"reinvocationPolicy,omitempty" protobuf:"bytes,7,opt,name=reinvocationPolicy,casttype=ReinvocationPolicyType"`
 }
 
@@ -796,16 +810,19 @@ type Mutation struct {
 	// Required.
 	//
 	// +unionDiscriminator
+	// +required
 	PatchType PatchType `json:"patchType" protobuf:"bytes,2,opt,name=patchType,casttype=PatchType"`
 
 	// applyConfiguration defines the desired configuration values of an object.
 	// The configuration is applied to the admission object using
 	// [structured merge diff](https://github.com/kubernetes-sigs/structured-merge-diff).
 	// A CEL expression is used to create apply configuration.
+	// +optional
 	ApplyConfiguration *ApplyConfiguration `json:"applyConfiguration,omitempty" protobuf:"bytes,3,opt,name=applyConfiguration"`
 
 	// jsonPatch defines a [JSON patch](https://jsonpatch.com/) operation to perform a mutation to the object.
 	// A CEL expression is used to create the JSON patch.
+	// +optional
 	JSONPatch *JSONPatch `json:"jsonPatch,omitempty" protobuf:"bytes,4,opt,name=jsonPatch"`
 }
 
@@ -862,6 +879,7 @@ type ApplyConfiguration struct {
 	//
 	// Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
 	// Required.
+	// +optional
 	Expression string `json:"expression,omitempty" protobuf:"bytes,1,opt,name=expression"`
 }
 
@@ -932,6 +950,7 @@ type JSONPatch struct {
 	//
 	// Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
 	// Required.
+	// +optional
 	Expression string `json:"expression,omitempty" protobuf:"bytes,1,opt,name=expression"`
 }
 
@@ -972,6 +991,7 @@ type MutatingAdmissionPolicyBinding struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the MutatingAdmissionPolicyBinding.
+	// +required
 	Spec MutatingAdmissionPolicyBindingSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -994,6 +1014,7 @@ type MutatingAdmissionPolicyBindingSpec struct {
 	// policyName references a MutatingAdmissionPolicy name which the MutatingAdmissionPolicyBinding binds to.
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
+	// +optional
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
@@ -71,6 +71,7 @@ message ApplyConfiguration {
   //
   // Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
   // Required.
+  // +optional
   optional string expression = 1;
 }
 
@@ -91,6 +92,7 @@ message AuditAnnotation {
   // will be discarded.
   //
   // Required.
+  // +required
   optional string key = 1;
 
   // valueExpression represents the expression which is evaluated by CEL to
@@ -108,6 +110,7 @@ message AuditAnnotation {
   // will be joined together in a comma-separated list.
   //
   // Required.
+  // +required
   optional string valueExpression = 2;
 }
 
@@ -116,11 +119,13 @@ message ExpressionWarning {
   // fieldRef is the path to the field that refers to the expression.
   // For example, the reference to the expression of the first item of
   // validations is "spec.validations[0].expression"
+  // +required
   optional string fieldRef = 2;
 
   // warning contains the content of type checking information in a human-readable form.
   // Each line of the warning contains the type that the expression is checked
   // against, followed by the type check error from the compiler.
+  // +required
   optional string warning = 3;
 }
 
@@ -190,6 +195,7 @@ message JSONPatch {
   //
   // Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
   // Required.
+  // +optional
   optional string expression = 1;
 }
 
@@ -204,6 +210,7 @@ message MatchCondition {
   // optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
   //
   // Required.
+  // +required
   optional string name = 1;
 
   // expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
@@ -219,6 +226,7 @@ message MatchCondition {
   // Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
   //
   // Required.
+  // +required
   optional string expression = 2;
 }
 
@@ -324,6 +332,7 @@ message MutatingAdmissionPolicy {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the MutatingAdmissionPolicy.
+  // +required
   optional MutatingAdmissionPolicySpec spec = 2;
 }
 
@@ -344,6 +353,7 @@ message MutatingAdmissionPolicyBinding {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the MutatingAdmissionPolicyBinding.
+  // +required
   optional MutatingAdmissionPolicyBindingSpec spec = 2;
 }
 
@@ -363,6 +373,7 @@ message MutatingAdmissionPolicyBindingSpec {
   // policyName references a MutatingAdmissionPolicy name which the MutatingAdmissionPolicyBinding binds to.
   // If the referenced resource does not exist, this binding is considered invalid and will be ignored
   // Required.
+  // +optional
   optional string policyName = 1;
 
   // paramRef specifies the parameter resource used to configure the admission control policy.
@@ -412,6 +423,7 @@ message MutatingAdmissionPolicySpec {
   // The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched.
   // '*' matches CREATE, UPDATE and CONNECT.
   // Required.
+  // +optional
   optional MatchResources matchConstraints = 2;
 
   // variables contain definitions of variables that can be used in composition of other expressions.
@@ -481,6 +493,7 @@ message MutatingAdmissionPolicySpec {
   // order with respect to other admission plugins, admission webhooks, bindings of this policy and admission policies.  Mutations are only
   // reinvoked when mutations change the object after this mutation is invoked.
   // Required.
+  // +optional
   optional string reinvocationPolicy = 7;
 }
 
@@ -491,10 +504,12 @@ message MutatingWebhook {
   // "imagepolicy" is the name of the webhook, and kubernetes.io is the name
   // of the organization.
   // Required.
+  // +required
   optional string name = 1;
 
   // clientConfig defines how to communicate with the hook.
   // Required
+  // +required
   optional WebhookClientConfig clientConfig = 2;
 
   // rules describes what operations on what resources/subresources the webhook cares about.
@@ -504,6 +519,7 @@ message MutatingWebhook {
   // disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
   // on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
   // +listType=atomic
+  // +optional
   repeated .k8s.io.api.admissionregistration.v1.RuleWithOperations rules = 3;
 
   // failurePolicy defines how unrecognized errors from the admission endpoint are handled -
@@ -689,16 +705,19 @@ message Mutation {
   // Required.
   //
   // +unionDiscriminator
+  // +required
   optional string patchType = 2;
 
   // applyConfiguration defines the desired configuration values of an object.
   // The configuration is applied to the admission object using
   // [structured merge diff](https://github.com/kubernetes-sigs/structured-merge-diff).
   // A CEL expression is used to create apply configuration.
+  // +optional
   optional ApplyConfiguration applyConfiguration = 3;
 
   // jsonPatch defines a [JSON patch](https://jsonpatch.com/) operation to perform a mutation to the object.
   // A CEL expression is used to create the JSON patch.
+  // +optional
   optional JSONPatch jsonPatch = 4;
 }
 
@@ -720,10 +739,12 @@ message ParamKind {
   // apiVersion is the API group version the resources belong to.
   // In format of "group/version".
   // Required.
+  // +optional
   optional string apiVersion = 1;
 
   // kind is the API kind the resources belong to.
   // Required.
+  // +optional
   optional string kind = 2;
 }
 
@@ -739,6 +760,7 @@ message ParamRef {
   // A single parameter used for all admission requests can be configured
   // by setting the `name` field, leaving `selector` blank, and setting namespace
   // if `paramKind` is namespace-scoped.
+  // +optional
   optional string name = 1;
 
   // namespace is the namespace of the referenced resource. Allows limiting
@@ -781,6 +803,7 @@ message ParamRef {
   // Allowed values are `Allow` or `Deny`
   //
   // Required
+  // +optional
   optional string parameterNotFoundAction = 4;
 }
 
@@ -788,10 +811,12 @@ message ParamRef {
 message ServiceReference {
   // namespace is the namespace of the service.
   // Required
+  // +required
   optional string namespace = 1;
 
   // name is the name of the service.
   // Required
+  // +required
   optional string name = 2;
 
   // path is an optional URL path which will be sent in any request to
@@ -826,6 +851,7 @@ message ValidatingAdmissionPolicy {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the ValidatingAdmissionPolicy.
+  // +required
   optional ValidatingAdmissionPolicySpec spec = 2;
 
   // status represents the current status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy
@@ -964,6 +990,7 @@ message ValidatingAdmissionPolicySpec {
   // However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
   // ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
   // Required.
+  // +optional
   optional MatchResources matchConstraints = 2;
 
   // validations contain CEL expressions which is used to apply the validation.
@@ -1059,10 +1086,12 @@ message ValidatingWebhook {
   // "imagepolicy" is the name of the webhook, and kubernetes.io is the name
   // of the organization.
   // Required.
+  // +required
   optional string name = 1;
 
   // clientConfig defines how to communicate with the hook.
   // Required
+  // +required
   optional WebhookClientConfig clientConfig = 2;
 
   // rules describes what operations on what resources/subresources the webhook cares about.
@@ -1072,6 +1101,7 @@ message ValidatingWebhook {
   // disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
   // on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
   // +listType=atomic
+  // +optional
   repeated .k8s.io.api.admissionregistration.v1.RuleWithOperations rules = 3;
 
   // failurePolicy defines how unrecognized errors from the admission endpoint are handled -
@@ -1276,6 +1306,7 @@ message Validation {
   //     are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
   //     non-intersecting keys are appended, retaining their partial order.
   // Required.
+  // +required
   optional string Expression = 1;
 
   // message represents the message displayed when validation fails. The message is required if the Expression contains
@@ -1317,10 +1348,12 @@ message Variable {
   // name is the name of the variable. The name must be a valid CEL identifier and unique among all variables.
   // The variable can be accessed in other expressions through `variables`
   // For example, if name is "foo", the variable will be available as `variables.foo`
+  // +required
   optional string Name = 1;
 
   // expression is the expression that will be evaluated as the value of the variable.
   // The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+  // +required
   optional string Expression = 2;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -99,6 +99,7 @@ type ValidatingAdmissionPolicy struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the ValidatingAdmissionPolicy.
+	// +required
 	Spec ValidatingAdmissionPolicySpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// status represents the current status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy
 	// behaves in the expected way.
@@ -141,10 +142,12 @@ type ExpressionWarning struct {
 	// fieldRef is the path to the field that refers to the expression.
 	// For example, the reference to the expression of the first item of
 	// validations is "spec.validations[0].expression"
+	// +required
 	FieldRef string `json:"fieldRef" protobuf:"bytes,2,opt,name=fieldRef"`
 	// warning contains the content of type checking information in a human-readable form.
 	// Each line of the warning contains the type that the expression is checked
 	// against, followed by the type check error from the compiler.
+	// +required
 	Warning string `json:"warning" protobuf:"bytes,3,opt,name=warning"`
 }
 
@@ -175,6 +178,7 @@ type ValidatingAdmissionPolicySpec struct {
 	// However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API
 	// ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
 	// Required.
+	// +optional
 	MatchConstraints *MatchResources `json:"matchConstraints,omitempty" protobuf:"bytes,2,rep,name=matchConstraints"`
 
 	// validations contain CEL expressions which is used to apply the validation.
@@ -251,10 +255,12 @@ type ParamKind struct {
 	// apiVersion is the API group version the resources belong to.
 	// In format of "group/version".
 	// Required.
+	// +optional
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,1,rep,name=apiVersion"`
 
 	// kind is the API kind the resources belong to.
 	// Required.
+	// +optional
 	Kind string `json:"kind,omitempty" protobuf:"bytes,2,rep,name=kind"`
 }
 
@@ -301,6 +307,7 @@ type Validation struct {
 	//     are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
 	//     non-intersecting keys are appended, retaining their partial order.
 	// Required.
+	// +required
 	Expression string `json:"expression" protobuf:"bytes,1,opt,name=Expression"`
 	// message represents the message displayed when validation fails. The message is required if the Expression contains
 	// line breaks. The message must not contain line breaks.
@@ -339,10 +346,12 @@ type Variable struct {
 	// name is the name of the variable. The name must be a valid CEL identifier and unique among all variables.
 	// The variable can be accessed in other expressions through `variables`
 	// For example, if name is "foo", the variable will be available as `variables.foo`
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=Name"`
 
 	// expression is the expression that will be evaluated as the value of the variable.
 	// The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+	// +required
 	Expression string `json:"expression" protobuf:"bytes,2,opt,name=Expression"`
 }
 
@@ -363,6 +372,7 @@ type AuditAnnotation struct {
 	// will be discarded.
 	//
 	// Required.
+	// +required
 	Key string `json:"key" protobuf:"bytes,1,opt,name=key"`
 
 	// valueExpression represents the expression which is evaluated by CEL to
@@ -380,6 +390,7 @@ type AuditAnnotation struct {
 	// will be joined together in a comma-separated list.
 	//
 	// Required.
+	// +required
 	ValueExpression string `json:"valueExpression" protobuf:"bytes,2,opt,name=valueExpression"`
 }
 
@@ -505,6 +516,7 @@ type ParamRef struct {
 	// by setting the `name` field, leaving `selector` blank, and setting namespace
 	// if `paramKind` is namespace-scoped.
 	//
+	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,1,rep,name=name"`
 
 	// namespace is the namespace of the referenced resource. Allows limiting
@@ -547,6 +559,7 @@ type ParamRef struct {
 	// Allowed values are `Allow` or `Deny`
 	//
 	// Required
+	// +optional
 	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction,omitempty" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
 }
 
@@ -759,10 +772,12 @@ type ValidatingWebhook struct {
 	// "imagepolicy" is the name of the webhook, and kubernetes.io is the name
 	// of the organization.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// clientConfig defines how to communicate with the hook.
 	// Required
+	// +required
 	ClientConfig WebhookClientConfig `json:"clientConfig" protobuf:"bytes,2,opt,name=clientConfig"`
 
 	// rules describes what operations on what resources/subresources the webhook cares about.
@@ -772,6 +787,7 @@ type ValidatingWebhook struct {
 	// disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
 	// on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
 	// +listType=atomic
+	// +optional
 	Rules []RuleWithOperations `json:"rules,omitempty" protobuf:"bytes,3,rep,name=rules"`
 
 	// failurePolicy defines how unrecognized errors from the admission endpoint are handled -
@@ -913,10 +929,12 @@ type MutatingWebhook struct {
 	// "imagepolicy" is the name of the webhook, and kubernetes.io is the name
 	// of the organization.
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// clientConfig defines how to communicate with the hook.
 	// Required
+	// +required
 	ClientConfig WebhookClientConfig `json:"clientConfig" protobuf:"bytes,2,opt,name=clientConfig"`
 
 	// rules describes what operations on what resources/subresources the webhook cares about.
@@ -926,6 +944,7 @@ type MutatingWebhook struct {
 	// disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
 	// on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
 	// +listType=atomic
+	// +optional
 	Rules []RuleWithOperations `json:"rules,omitempty" protobuf:"bytes,3,rep,name=rules"`
 
 	// failurePolicy defines how unrecognized errors from the admission endpoint are handled -
@@ -1159,9 +1178,11 @@ type WebhookClientConfig struct {
 type ServiceReference struct {
 	// namespace is the namespace of the service.
 	// Required
+	// +required
 	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
 	// name is the name of the service.
 	// Required
+	// +required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
 	// path is an optional URL path which will be sent in any request to
@@ -1187,6 +1208,7 @@ type MatchCondition struct {
 	// optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
 	//
 	// Required.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
@@ -1202,6 +1224,7 @@ type MatchCondition struct {
 	// Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
 	//
 	// Required.
+	// +required
 	Expression string `json:"expression" protobuf:"bytes,2,opt,name=expression"`
 }
 
@@ -1218,6 +1241,7 @@ type MutatingAdmissionPolicy struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the MutatingAdmissionPolicy.
+	// +required
 	Spec MutatingAdmissionPolicySpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -1252,6 +1276,7 @@ type MutatingAdmissionPolicySpec struct {
 	// The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched.
 	// '*' matches CREATE, UPDATE and CONNECT.
 	// Required.
+	// +optional
 	MatchConstraints *MatchResources `json:"matchConstraints,omitempty" protobuf:"bytes,2,rep,name=matchConstraints"`
 
 	// variables contain definitions of variables that can be used in composition of other expressions.
@@ -1321,6 +1346,7 @@ type MutatingAdmissionPolicySpec struct {
 	// order with respect to other admission plugins, admission webhooks, bindings of this policy and admission policies.  Mutations are only
 	// reinvoked when mutations change the object after this mutation is invoked.
 	// Required.
+	// +optional
 	ReinvocationPolicy ReinvocationPolicyType `json:"reinvocationPolicy,omitempty" protobuf:"bytes,7,opt,name=reinvocationPolicy,casttype=ReinvocationPolicyType"`
 }
 
@@ -1331,16 +1357,19 @@ type Mutation struct {
 	// Required.
 	//
 	// +unionDiscriminator
+	// +required
 	PatchType PatchType `json:"patchType" protobuf:"bytes,2,opt,name=patchType,casttype=PatchType"`
 
 	// applyConfiguration defines the desired configuration values of an object.
 	// The configuration is applied to the admission object using
 	// [structured merge diff](https://github.com/kubernetes-sigs/structured-merge-diff).
 	// A CEL expression is used to create apply configuration.
+	// +optional
 	ApplyConfiguration *ApplyConfiguration `json:"applyConfiguration,omitempty" protobuf:"bytes,3,opt,name=applyConfiguration"`
 
 	// jsonPatch defines a [JSON patch](https://jsonpatch.com/) operation to perform a mutation to the object.
 	// A CEL expression is used to create the JSON patch.
+	// +optional
 	JSONPatch *JSONPatch `json:"jsonPatch,omitempty" protobuf:"bytes,4,opt,name=jsonPatch"`
 }
 
@@ -1397,6 +1426,7 @@ type ApplyConfiguration struct {
 	//
 	// Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
 	// Required.
+	// +optional
 	Expression string `json:"expression,omitempty" protobuf:"bytes,1,opt,name=expression"`
 }
 
@@ -1467,6 +1497,7 @@ type JSONPatch struct {
 	//
 	// Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
 	// Required.
+	// +optional
 	Expression string `json:"expression,omitempty" protobuf:"bytes,1,opt,name=expression"`
 }
 
@@ -1493,6 +1524,7 @@ type MutatingAdmissionPolicyBinding struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the MutatingAdmissionPolicyBinding.
+	// +required
 	Spec MutatingAdmissionPolicyBindingSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -1516,6 +1548,7 @@ type MutatingAdmissionPolicyBindingSpec struct {
 	// policyName references a MutatingAdmissionPolicy name which the MutatingAdmissionPolicyBinding binds to.
 	// If the referenced resource does not exist, this binding is considered invalid and will be ignored
 	// Required.
+	// +optional
 	PolicyName string `json:"policyName,omitempty" protobuf:"bytes,1,rep,name=policyName"`
 
 	// paramRef specifies the parameter resource used to configure the admission control policy.


### PR DESCRIPTION
<!-- Please keep PR body shorter than 5000 characters -->

Closes #136858. Part of #134671.

Added `// +optional` and `// +required` markers to all fields in the admissionregistration v1, v1alpha1, and v1beta1 packages that were missing them, then removed the package from the exclusion list in golangci.yaml, golangci-hints.yaml, and exceptions.yaml.

The general rule I followed: `omitempty` in the json tag means `// +optional`, no `omitempty` means `// +required`. For `Spec` fields on top-level objects I used `// +required` regardless of the json tag, consistent with how ValidatingAdmissionPolicyBinding.Spec was handled in #134675. The openapi spec is updated accordingly for those three fields.

The existing patchStrategy exceptions for admissionregistration conditions are left in place since those are a separate issue unrelated to this linter.

/assign @deads2k
/cc @deads2k @sttts @jpbetz

```release-note
NONE
```
