### PR TITLE
Added cachedir tag

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -174,8 +174,8 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
 	dir := filepath.Dir(filename)
 
     if err := os.MkdirAll(dir, 0750); err != nil {
-        return err
-    }
+		return err
+	}
 
 	if d.cacheDirectory != "" {
 	tagFile := filepath.Join(dir, "CACHEDIR.TAG")

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -171,9 +171,17 @@ func (d *CachedDiscoveryClient) getCachedFile(filename string) ([]byte, error) {
 }
 
 func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Object) error {
-	if err := os.MkdirAll(filepath.Dir(filename), 0750); err != nil {
-		return err
-	}
+	dir := filepath.Dir(filename)
+
+    if err := os.MkdirAll(dir, 0750); err != nil {
+        return err
+    }
+
+    tagFile := filepath.Join(dir, "CACHEDIR.TAG")
+    if _, err := os.Stat(tagFile); os.IsNotExist(err) {
+        content := []byte("Signature: 8a477f597d28d172789f06886806bc55\n")
+        _ = os.WriteFile(tagFile, content, 0644)
+    }
 
 	bytes, err := runtime.Encode(scheme.Codecs.LegacyCodec(), obj)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -181,7 +181,7 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
 	if _, err := os.Stat(tagFile); err != nil {
 		if os.IsNotExist(err) {
 			content := []byte("Signature: 8a477f597d28d172789f06886806bc55\n")
-			if err := os.WriteFile(tagFile, content, 0644); err != nil {
+			if err := os.WriteFile(tagFile, content, 0660); err != nil {
 				return err
 			}
 		} else {

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -177,17 +177,16 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
         return err
     }
 
+	if d.cacheDirectory != "" {
 	tagFile := filepath.Join(dir, "CACHEDIR.TAG")
-	if _, err := os.Stat(tagFile); err != nil {
-		if os.IsNotExist(err) {
-			content := []byte("Signature: 8a477f597d28d172789f06886806bc55\n")
-			if err := os.WriteFile(tagFile, content, 0660); err != nil {
-				return err
-			}
-		} else {
+
+	if _, err := os.Stat(tagFile); os.IsNotExist(err) {
+		content := []byte("Signature: 8a477f597d28d172789f06886806bc55\n")
+		if err := os.WriteFile(tagFile, content, 0644); err != nil {
 			return err
 		}
-	}
+	  }
+    }
 
 	bytes, err := runtime.Encode(scheme.Codecs.LegacyCodec(), obj)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -177,11 +177,17 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
         return err
     }
 
-    tagFile := filepath.Join(dir, "CACHEDIR.TAG")
-    if _, err := os.Stat(tagFile); os.IsNotExist(err) {
-        content := []byte("Signature: 8a477f597d28d172789f06886806bc55\n")
-        _ = os.WriteFile(tagFile, content, 0644)
-    }
+	tagFile := filepath.Join(dir, "CACHEDIR.TAG")
+	if _, err := os.Stat(tagFile); err != nil {
+		if os.IsNotExist(err) {
+			content := []byte("Signature: 8a477f597d28d172789f06886806bc55\n")
+			if err := os.WriteFile(tagFile, content, 0644); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
 
 	bytes, err := runtime.Encode(scheme.Codecs.LegacyCodec(), obj)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -124,6 +124,8 @@ func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
 		}
 		if info.IsDir() {
 			assert.Equal(os.FileMode(0750), info.Mode().Perm())
+		} else if info.Name() == "CACHEDIR.TAG" {
+			assert.Equal(os.FileMode(0644), info.Mode().Perm())
 		} else {
 			assert.Equal(os.FileMode(0660), info.Mode().Perm())
 		}
@@ -688,6 +690,9 @@ func numFilesFound(dir string, filename string) (int, error) {
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+		if info.Name() == "CACHEDIR.TAG" {
+			return nil
 		}
 		if info.Name() == filename {
 			numFound++


### PR DESCRIPTION
#### What type of PR is this?

 bug

#### What this PR does / why we need it

Adds a `CACHEDIR.TAG` file to kubectl discovery cache directories to mark them as cache and prevent them from being included in backup systems.

This follows the standard `CACHEDIR.TAG` convention so that tools can safely ignore these directories and avoid 
unnecessary storage usage.

- Updates cache directory creation logic in `writeCachedFile`
- Ensures directory is created using:
  ```go
  dir := filepath.Dir(filename)
  os.MkdirAll(dir, 0750)```

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubectl/issues/1044

#### Does this PR introduce a user-facing change?

```release-note
kubectl: discovery cache directories now include a CACHEDIR.TAG file to indicate they should be excluded from backups.```

