### PR TITLE
[WIP] Restore ToRESTFriendlyName fallback in GetDefinitionName

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/openapi.go
@@ -164,12 +164,42 @@ func NewDefinitionNamer(schemes ...*runtime.Scheme) *DefinitionNamer {
 	return ret
 }
 
-// GetDefinitionName returns the name and tags for a given definition
+// GetDefinitionName returns the name and tags for a given definition.
+//
+// For types that implement OpenAPIModelName(), the code generator and
+// NewDefinitionNamer both use the model name (e.g. "io.k8s.api.core.v1.Pod"),
+// so the direct lookup succeeds.
+//
+// For types that do NOT implement OpenAPIModelName(), there is a mismatch:
+//   - The code generator keys definitions by Go type path
+//     (e.g. "example.com/api/v1.MyType")
+//   - NewDefinitionNamer keys the GVK map by the REST-friendly form from
+//     ToOpenAPIDefinitionName (e.g. "com.example.api.v1.MyType")
+//
+// The fallback handles this by converting Go type paths to REST-friendly
+// names before retrying the GVK lookup. This also ensures definition names
+// never contain "/" (a JSON Pointer special character), which would cause
+// $ref mismatches in the OpenAPI spec.
+//
+// Before the OpenAPIModelName() migration, ToRESTFriendlyName was applied
+// unconditionally to all names. It cannot be applied unconditionally now
+// because it would mangle names already in REST-friendly form (reversing
+// the dot-separated segments). The "/" check distinguishes Go type paths
+// (need conversion) from model names (already correct).
 func (d *DefinitionNamer) GetDefinitionName(name string) (string, spec.Extensions) {
 	if groupVersionKinds, ok := d.typeGroupVersionKinds[name]; ok {
 		return name, spec.Extensions{
 			extensionGVK: groupVersionKinds.JSON(),
 		}
+	}
+	if strings.Contains(name, "/") {
+		restFriendlyName := util.ToRESTFriendlyName(name)
+		if groupVersionKinds, ok := d.typeGroupVersionKinds[restFriendlyName]; ok {
+			return restFriendlyName, spec.Extensions{
+				extensionGVK: groupVersionKinds.JSON(),
+			}
+		}
+		return restFriendlyName, nil
 	}
 	return name, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/openapi_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/openapi_test.go
@@ -60,6 +60,36 @@ func TestGetDefinitionName(t *testing.T) {
 	assertEqual(t, e2, spec.Extensions(nil))
 }
 
+func TestGetDefinitionNameFallbackToRESTFriendlyName(t *testing.T) {
+	testType := openapitesting.TestType{}
+	s := runtime.NewScheme()
+	s.AddKnownTypeWithName(testType.GroupVersionKind(), &testType)
+	namer := NewDefinitionNamer(s)
+
+	expectedGVK := []interface{}{
+		map[string]interface{}{
+			"group":   "test",
+			"version": "v1",
+			"kind":    "TestType",
+		},
+	}
+
+	// When the code generator keys definitions by Go type path (with slashes)
+	// but the GVK map is keyed by the REST-friendly name (dots), the fallback
+	// should convert and find the match. This is the case for types that do
+	// not implement OpenAPIModelName().
+	goTypePath := "k8s.io/apiserver/pkg/endpoints/openapi/testing.TestType"
+	n, e := namer.GetDefinitionName(goTypePath)
+	assertEqual(t, "io.k8s.apiserver.pkg.endpoints.openapi.testing.TestType", n)
+	assertEqual(t, expectedGVK, e["x-kubernetes-group-version-kind"])
+
+	// Types not in the GVK map should still get their slashes converted to dots.
+	subTypePath := "example.com/api/apps/v1.SomeSpec"
+	n, e2 := namer.GetDefinitionName(subTypePath)
+	assertEqual(t, "com.example.api.apps.v1.SomeSpec", n)
+	assertEqual(t, e2, spec.Extensions(nil))
+}
+
 func TestToValidOperationID(t *testing.T) {
 	scenarios := []struct {
 		s                     string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
#### What this PR does / why we need it:

#131755 moved OpenAPI definition naming from reflection-based `typeName(rtype)` + `ToRESTFriendlyName` to the declarative `OpenAPIModelName()` approach. However, for types that do not implement `OpenAPIModelName()`, the code generator still keys definitions by Go type path (with slashes), while `NewDefinitionNamer` now keys the GVK map by the REST-friendly form from `ToOpenAPIDefinitionName` (with dots). The removal of `ToRESTFriendlyName` from `GetDefinitionName` means these two keys no longer match, causing:

1. **Lost GVK extensions**: `x-kubernetes-group-version-kind` is never attached because the GVK map lookup fails (slashes ≠ dots).
2. **Broken `$ref` resolution**: definition names containing `/` cause JSON Pointer escaping mismatches — `$ref` values are escaped (`~1`) but map keys are not.

This restores the `ToRESTFriendlyName` conversion as a fallback in `GetDefinitionName` for names containing `/`, bridging the mismatch between the code generator and `NewDefinitionNamer` for types without `OpenAPIModelName()`.

#### Name resolution flow

**Before #131755** (`OpenAPIModelName()` did not exist):

|  | Root type | Sub-type (no GVK) |
|---|---|---|
| **Code gen key** | `github.com/.../v1.MyType` (slashes) | `github.com/.../v1.MySpec` (slashes) |
| **Code gen dep refs** | slashes | slashes |
| **GVK map key** | `github.com/.../v1.MyType` (slashes, `typeName(rtype)`) | not in map |
| **GetDefinitionName** | direct hit → `ToRESTFriendlyName` → dots | miss → `ToRESTFriendlyName` → dots |
| **TypeConverter** | N/A (did not exist) | N/A |

All names matched internally (slashes). `ToRESTFriendlyName` converted to dots at the output stage.

**After #131755, for types WITH `OpenAPIModelName()` (e.g. Pod):**

|  | Root type | Sub-type (no GVK) |
|---|---|---|
| **Code gen key** | `io.k8s.api.core.v1.Pod` (dots, `OpenAPIModelName()`) | `io.k8s.api.core.v1.PodSpec` (dots, `OpenAPIModelName()`) |
| **Code gen dep refs** | dots (`OpenAPIModelName()`) | dots (`OpenAPIModelName()`) |
| **GVK map key** | `io.k8s.api.core.v1.Pod` (dots, `OpenAPIModelName()`) | not in map |
| **GetDefinitionName** | direct hit → dots | miss, no `/` → as-is (dots) |
| **TypeConverter** | `ToOpenAPIDefinitionName` → dots | N/A |

No mismatch. Both sides use `OpenAPIModelName()`.

**After #131755, for types WITHOUT `OpenAPIModelName()`:**

|  | Root type | Sub-type (no GVK) |
|---|---|---|
| **Code gen key** | `github.com/.../v1.MyType` (slashes) | `github.com/.../v1.MySpec` (slashes) |
| **Code gen dep refs** | slashes | slashes |
| **GVK map key** | `com.github...v1.MyType` (dots, reflect + `toOpenAPIDefinitionName`) | not in map |
| **GetDefinitionName** | miss (slashes ≠ dots), returns slashes as-is ❌ | miss, returns slashes as-is ❌ |
| **TypeConverter** | `ToOpenAPIDefinitionName` → dots, but schema has slashes ❌ | N/A |

GVK lookup fails. Names contain `/`. `$ref` escaping mismatches.

**After this PR, for types WITHOUT `OpenAPIModelName()`:**

|  | Root type | Sub-type (no GVK) |
|---|---|---|
| **Code gen key** | `github.com/.../v1.MyType` (slashes) | `github.com/.../v1.MySpec` (slashes) |
| **Code gen dep refs** | slashes | slashes |
| **GVK map key** | `com.github...v1.MyType` (dots) | not in map |
| **GetDefinitionName** | miss, has `/` → convert to dots → fallback hit ✅ | miss, has `/` → convert to dots ✅ |
| **TypeConverter** | `ToOpenAPIDefinitionName` → dots, schema has dots ✅ | N/A |

GVK extensions restored. All names are dots. No `/` in definition names.

#### Special notes for your reviewer:

The root cause is that #131755 changed two things that needed to stay in sync but only updated one side:
1. GVK map key: `typeName(rtype)` (slashes) → `ToOpenAPIDefinitionName` (dots)
2. `GetDefinitionName` output: `ToRESTFriendlyName(name)` → `name` (as-is)

But the code generator fallback was not updated — it still produces Go type paths with slashes. This fix restores the bridge between the two naming conventions.

`ToRESTFriendlyName` cannot be applied unconditionally because it reverses dot-separated segments, which would mangle names already in REST-friendly form (e.g. `com.test.Type` → `Type.test.com`). The `strings.Contains(name, "/")` check distinguishes Go type paths (need conversion) from model names (already correct).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```