### PR TITLE
Implement PreferServerVersion API in builder

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -102,6 +102,8 @@ type Builder struct {
 	flatten bool
 	latest  bool
 
+	preferServerVersion bool
+
 	requireObject bool
 
 	singleResourceType bool
@@ -312,10 +314,11 @@ func (b *Builder) Unstructured() *Builder {
 	}
 	b.objectTyper = unstructuredscheme.NewUnstructuredObjectTyper()
 	b.mapper = &mapper{
-		localFn:      b.isLocal,
-		restMapperFn: b.restMapperFn,
-		clientFn:     b.getClient,
-		decoder:      &metadataValidatingDecoder{unstructured.UnstructuredJSONScheme},
+		localFn:             b.isLocal,
+		restMapperFn:        b.restMapperFn,
+		clientFn:            b.getClient,
+		decoder:             &metadataValidatingDecoder{unstructured.UnstructuredJSONScheme},
+		preferServerVersion: b.preferServerVersion,
 	}
 
 	return b
@@ -339,10 +342,12 @@ func (b *Builder) WithScheme(scheme *runtime.Scheme, decodingVersions ...schema.
 	b.negotiatedSerializer = negotiatedSerializer
 
 	b.mapper = &mapper{
-		localFn:      b.isLocal,
-		restMapperFn: b.restMapperFn,
-		clientFn:     b.getClient,
-		decoder:      codecFactory.UniversalDecoder(decodingVersions...),
+		localFn:             b.isLocal,
+		restMapperFn:        b.restMapperFn,
+		clientFn:            b.getClient,
+		decoder:             codecFactory.UniversalDecoder(decodingVersions...),
+		preferServerVersion: b.preferServerVersion,
+		decodingVersions:    decodingVersions,
 	}
 
 	return b
@@ -742,6 +747,16 @@ func (b *Builder) Flatten() *Builder {
 // Latest will fetch the latest copy of any objects loaded from URLs or files from the server.
 func (b *Builder) Latest() *Builder {
 	b.latest = true
+	return b
+}
+
+// PreferServerVersion will attempt to load the preferred version of any objects
+// loaded from URLs or files from the server.
+func (b *Builder) PreferServerVersion() *Builder {
+	b.preferServerVersion = true
+	if b.mapper != nil {
+		b.mapper.preferServerVersion = true
+	}
 	return b
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -46,8 +46,12 @@ import (
 	restclientwatch "k8s.io/client-go/rest/watch"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/utils/dump"
+
 	// TODO we need to remove this linkage and create our own scheme
+	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/api/core/v1"
+
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -1953,5 +1957,125 @@ func TestStdinMultiUseError(t *testing.T) {
 	}
 	if got, want := newUnstructuredDefaultBuilder().StdinInUse().Stdin().Do().Err(), StdinMultiUseError; !errors.Is(got, want) {
 		t.Errorf("got: %q, want: %q", got, want)
+	}
+}
+
+func TestBuilderPreferServerVersionAndDecodingVersions(t *testing.T) {
+	v1beta1GV := schema.GroupVersion{Group: "apps", Version: "v1beta1"}
+	v1beta2GV := schema.GroupVersion{Group: "apps", Version: "v1beta2"}
+	v1GV := schema.GroupVersion{Group: "apps", Version: "v1"}
+
+	// RESTMapper where v1 is preferred over v1beta1 and v1beta2
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{v1GV, v1beta1GV, v1beta2GV})
+	mapper.Add(v1beta1GV.WithKind("Deployment"), meta.RESTScopeNamespace)
+	mapper.Add(v1beta2GV.WithKind("Deployment"), meta.RESTScopeNamespace)
+	mapper.Add(v1GV.WithKind("Deployment"), meta.RESTScopeNamespace)
+
+	priorityMapper := meta.PriorityRESTMapper{
+		Delegate:         mapper,
+		ResourcePriority: []schema.GroupVersionResource{v1GV.WithResource(meta.AnyResource), v1beta1GV.WithResource(meta.AnyResource), v1beta2GV.WithResource(meta.AnyResource)},
+		KindPriority:     []schema.GroupVersionKind{v1GV.WithKind(meta.AnyKind), v1beta1GV.WithKind(meta.AnyKind), v1beta2GV.WithKind(meta.AnyKind)},
+	}
+
+	tests := []struct {
+		name             string
+		decodingVersions []schema.GroupVersion
+		requestArg       string
+		requestURL       string
+		requestObjGV     schema.GroupVersion
+		requestObj       runtime.Object
+		expectedMapping  schema.GroupVersionKind
+		expectedError    bool
+	}{
+		{
+			name:             "preferred version is decodable, returns preferred version immediately",
+			decodingVersions: []schema.GroupVersion{v1GV, v1beta1GV},
+			requestArg:       "deployments.v1beta2.apps",
+			requestURL:       "/namespaces/test/deployments",
+			requestObjGV:     v1beta2GV,
+			requestObj: &appsv1beta2.DeploymentList{
+				Items: []appsv1beta2.Deployment{{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}},
+			},
+			expectedMapping: v1GV.WithKind("Deployment"),
+		},
+		{
+			name:             "match in decodingVersions",
+			decodingVersions: []schema.GroupVersion{v1beta1GV},
+			requestArg:       "deployments.v1beta2.apps",
+			requestURL:       "/namespaces/test/deployments",
+			requestObjGV:     v1beta2GV,
+			requestObj: &appsv1beta2.DeploymentList{
+				Items: []appsv1beta2.Deployment{{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}},
+			},
+			expectedMapping: v1beta1GV.WithKind("Deployment"),
+		},
+		{
+			name: "multiple match in decodingVersions, returns highest priority match",
+			decodingVersions: []schema.GroupVersion{
+				v1beta2GV,
+				v1beta1GV,
+			},
+			requestArg:   "deployments.v1.apps",
+			requestURL:   "/namespaces/test/deployments",
+			requestObjGV: v1GV,
+			requestObj: &appsv1.DeploymentList{
+				Items: []appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}},
+			},
+			expectedMapping: v1beta2GV.WithKind("Deployment"), // Since v1 is not in decodingVersions, it falls back to the client's highest priority decodable version (v1beta2)
+		},
+		{
+			name:             "no match in decodingVersions returns first mapping",
+			decodingVersions: []schema.GroupVersion{{Group: "apps", Version: "v2"}},
+			requestArg:       "deployments.v1beta2.apps",
+			requestURL:       "/namespaces/test/deployments",
+			requestObjGV:     v1beta2GV,
+			requestObj: &appsv1beta2.DeploymentList{
+				Items: []appsv1beta2.Deployment{{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}},
+			},
+			expectedMapping: v1GV.WithKind("Deployment"), // Since v2 not found, returns highest priority which is v1
+		},
+		{
+			name:         "error from RESTMappings",
+			requestArg:   "deployments.v1beta2.apps",
+			requestURL:   "/namespaces/test/deployments",
+			requestObjGV: v1GV,
+			requestObj: &appsv1.DaemonSetList{
+				Items: []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			codec := scheme.Codecs.LegacyCodec(tt.requestObjGV)
+			jsonBytes := runtime.EncodeOrDie(codec, tt.requestObj)
+
+			infos, err := NewFakeBuilder(
+				fakeClientWith("", t, map[string]string{
+					tt.requestURL: string(jsonBytes),
+				}),
+				func() (meta.RESTMapper, error) { return priorityMapper, nil },
+				func() (restmapper.CategoryExpander, error) { return FakeCategoryExpander, nil },
+			).WithScheme(scheme.Scheme, tt.decodingVersions...).
+				NamespaceParam("test").DefaultNamespace().
+				PreferServerVersion().
+				Flatten().
+				ResourceTypeOrNameArgs(true, tt.requestArg).
+				Do().
+				Infos()
+
+			if (err != nil) != tt.expectedError {
+				t.Fatalf("expected error: %v, got: %v", tt.expectedError, err)
+			}
+			if !tt.expectedError {
+				if len(infos) != 1 {
+					t.Fatalf("expected 1 info, got %d", len(infos))
+				}
+				if infos[0].Mapping.GroupVersionKind != tt.expectedMapping {
+					t.Errorf("expected mapping: %v, got: %v", tt.expectedMapping, infos[0].Mapping.GroupVersionKind)
+				}
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/mapper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/mapper.go
@@ -34,6 +34,13 @@ type mapper struct {
 	restMapperFn RESTMapperFunc
 	clientFn     func(version schema.GroupVersion) (RESTClient, error)
 	decoder      runtime.Decoder
+
+	// preferServerVersion indicates that we should use the preferred version
+	// for a resource instead of the one specified in the object.
+	preferServerVersion bool
+
+	// decodingVersions are the versions we are permitted to decode into.
+	decodingVersions []schema.GroupVersion
 }
 
 // InfoForData creates an Info object for the given data. An error is returned
@@ -63,7 +70,8 @@ func (m *mapper) infoForData(data []byte, source string) (*Info, error) {
 		if err != nil {
 			return nil, err
 		}
-		mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+
+		mapping, err := m.mappingForGVK(restMapper, *gvk)
 		if err != nil {
 			if _, ok := err.(*meta.NoKindMatchError); ok {
 				return nil, fmt.Errorf("resource mapping not found for name: %q namespace: %q from %q: %w\nensure CRDs are installed first",
@@ -73,7 +81,7 @@ func (m *mapper) infoForData(data []byte, source string) (*Info, error) {
 		}
 		ret.Mapping = mapping
 
-		client, err := m.clientFn(gvk.GroupVersion())
+		client, err := m.clientFn(mapping.GroupVersionKind.GroupVersion())
 		if err != nil {
 			return nil, fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
 		}
@@ -113,13 +121,14 @@ func (m *mapper) infoForObject(obj runtime.Object, typer runtime.ObjectTyper, pr
 		if err != nil {
 			return nil, err
 		}
-		mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+
+		mapping, err := m.mappingForGVK(restMapper, gvk)
 		if err != nil {
 			return nil, fmt.Errorf("unable to recognize %v", err)
 		}
 		ret.Mapping = mapping
 
-		client, err := m.clientFn(gvk.GroupVersion())
+		client, err := m.clientFn(mapping.GroupVersionKind.GroupVersion())
 		if err != nil {
 			return nil, fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
 		}
@@ -127,6 +136,43 @@ func (m *mapper) infoForObject(obj runtime.Object, typer runtime.ObjectTyper, pr
 	}
 
 	return ret, nil
+}
+
+func (m *mapper) mappingForGVK(restMapper meta.RESTMapper, gvk schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	if !m.preferServerVersion {
+		return restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	}
+
+	// 1. Fetch the server's preferred version (strictly prioritized)
+	preferredMapping, err := restMapper.RESTMapping(gvk.GroupKind())
+	if err != nil {
+		return nil, err
+	}
+
+	// If the client can decode the server's preferred version, use it immediately.
+	for _, allowed := range m.decodingVersions {
+		if preferredMapping.GroupVersionKind.GroupVersion() == allowed {
+			return preferredMapping, nil
+		}
+	}
+
+	// 2. Fetch all supported versions (unordered) to find a decodable fallback
+	mappings, err := restMapper.RESTMappings(gvk.GroupKind())
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the client's highest-priority decodable version from the available mappings.
+	for _, allowed := range m.decodingVersions {
+		for _, mapping := range mappings {
+			if mapping.GroupVersionKind.GroupVersion() == allowed {
+				return mapping, nil
+			}
+		}
+	}
+
+	// 3. Fallback: Return the preferred mapping even if we cannot decode it.
+	return preferredMapping, nil
 }
 
 // preferredObjectKind picks the possibility that most closely matches the priority list in this order:

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/mapper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/mapper.go
@@ -19,6 +19,7 @@ package resource
 import (
 	"fmt"
 	"reflect"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -150,10 +151,8 @@ func (m *mapper) mappingForGVK(restMapper meta.RESTMapper, gvk schema.GroupVersi
 	}
 
 	// If the client can decode the server's preferred version, use it immediately.
-	for _, allowed := range m.decodingVersions {
-		if preferredMapping.GroupVersionKind.GroupVersion() == allowed {
-			return preferredMapping, nil
-		}
+	if slices.Contains(m.decodingVersions, preferredMapping.GroupVersionKind.GroupVersion()) {
+		return preferredMapping, nil
 	}
 
 	// 2. Fetch all supported versions (unordered) to find a decodable fallback


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implements an API that allows to request builder to fetch resource in server-preferred version rather than locally defined version. It will allow us to fix the issue in https://github.com/kubernetes/kubernetes/pull/133498 when describing a resource from file in version older than the server's version.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/133498

#### Does this PR introduce a user-facing change?

```release-note
NONE
```