### PR TITLE
DRA: [Test] Assign Initial ResourceVersion to ResourceSlices in Create Reactor

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -131,6 +131,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -575,17 +576,17 @@ func TestControllerSyncPool(t *testing.T) {
 			nodeUID: nodeUID,
 			initialObjects: []runtime.Object{
 				// no devices
-				MakeResourceSlice().Name(generateName1+"random1").UID(generateName1+"random1").
+				MakeResourceSlice().Name(resourceSlice1).UID(resourceSlice1).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
 				// matching device
-				MakeResourceSlice().Name(generateName2+"random2").UID(generateName2+"random2").
+				MakeResourceSlice().Name(resourceSlice2).UID(resourceSlice2).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 1}).Obj(),
 				// no devices
-				MakeResourceSlice().Name(generateName3+"random3").UID(generateName3+"random3").
+				MakeResourceSlice().Name(resourceSlice3).UID(resourceSlice3).
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -609,6 +610,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 3, ResourceSliceCount: 1}).Obj(),
@@ -794,6 +796,7 @@ func TestControllerSyncPool(t *testing.T) {
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 4}).Obj(),
 				*MakeResourceSlice().Name(generateName4+"0").GenerateName(generateName4).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName4)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 4}).Obj(),
@@ -816,6 +819,7 @@ func TestControllerSyncPool(t *testing.T) {
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(encodeIndex(0, resourceSliceIndexMinLength) + "-" + driverName + "-0").
 					GenerateName(encodeIndex(0, resourceSliceIndexMinLength) + "-" + driverName + "-").
+					ResourceVersion("0").
 					AllNodes(true).
 					NodeName("").
 					NodeSelector(nil).
@@ -839,6 +843,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(generateName1 + "0").GenerateName(generateName1).
+					ResourceVersion("0").
 					AppOwnerReferences(ownerName).NodeSelector(nodeSelector).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -859,6 +864,7 @@ func TestControllerSyncPool(t *testing.T) {
 			expectedStats: Stats{NumCreates: 1},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).
 					AllNodes(true).
 					NodeName("").
@@ -883,6 +889,7 @@ func TestControllerSyncPool(t *testing.T) {
 			expectedStats: Stats{NumCreates: 1},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).
 					NodeSelector(nodeSelector).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
@@ -903,6 +910,7 @@ func TestControllerSyncPool(t *testing.T) {
 			expectedStats: Stats{NumCreates: 1},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).
 					PerDeviceNodeSelection(true).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName, nodeSelector)}).
@@ -973,6 +981,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					AppOwnerReferences(ownerName).
 					AllNodes(false).
 					NodeName("").
@@ -988,6 +997,7 @@ func TestControllerSyncPool(t *testing.T) {
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).
 					Obj(),
 				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).
+					ResourceVersion("0").
 					AppOwnerReferences(ownerName).
 					AllNodes(false).
 					NodeName("").
@@ -1050,6 +1060,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					AppOwnerReferences(ownerName).
 					AllNodes(false).
 					NodeName("").
@@ -1059,6 +1070,7 @@ func TestControllerSyncPool(t *testing.T) {
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).
 					Obj(),
 				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).
+					ResourceVersion("0").
 					AppOwnerReferences(ownerName).
 					AllNodes(false).
 					NodeName("").
@@ -1097,6 +1109,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices(func() []resourceapi.Device {
@@ -1134,6 +1147,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices([]resourceapi.Device{newDevice(deviceName)}).
@@ -1308,14 +1322,17 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName1)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
 				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName2)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
 				*MakeResourceSlice().Name(resourceSlice3).GenerateName(generateName3).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
@@ -1355,6 +1372,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(generateName1+"0").GenerateName(generateName1).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName1)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
@@ -1363,6 +1381,7 @@ func TestControllerSyncPool(t *testing.T) {
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName2)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
 				*MakeResourceSlice().Name(generateName3+"1").GenerateName(generateName3).
+					ResourceVersion("0").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
@@ -1610,6 +1629,8 @@ func createResourceSliceCreateReactor(features features, timeAdded metav1.Time) 
 		mutex.Lock()
 		defer mutex.Unlock()
 		resourceslice := action.(k8stesting.CreateAction).GetObject().(*resourceapi.ResourceSlice)
+		// Assign initial ResourceVersion "0" to newly created slices.
+		resourceslice.ResourceVersion = "0"
 		if resourceslice.Name == "" && resourceslice.GenerateName != "" {
 			resourceslice.Name = fmt.Sprintf("%s%d", resourceslice.GenerateName, nameCounter)
 		}
@@ -1624,6 +1645,8 @@ func createResourceSliceCreateReactor(features features, timeAdded metav1.Time) 
 func createResourceSliceUpdateReactor(features features, timeAdded metav1.Time) func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 	return func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		resourceslice := action.(k8stesting.UpdateAction).GetObject().(*resourceapi.ResourceSlice)
+		// If ResourceVersion is not set, assume the object started with version "0".
+		// This can happen when initial test objects don't have ResourceVersion assigned.
 		rev := 0
 		if resourceslice.ResourceVersion != "" {
 			oldRev, err := strconv.Atoi(resourceslice.ResourceVersion)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
In https://github.com/kubernetes/kubernetes/pull/136641, we saw flaky tests because of a race condition between MutationCache and the Informer's background sync. See https://github.com/kubernetes/kubernetes/pull/136641#issuecomment-4076468216.

This PR updates the fake client reactors to assign an initial `ResourceVersion` to `ResourceSlices` to avoid the unrealistic state where a created object has an empty `ResourceVersion`, which prevents test flakes caused by the `mutationCache` discarding valid mutations due to a missing `ResourceVersion` when newly created `ResourceSlices` have the same name as old ones.

I didn't end up implementing a global `ResourceVersion` for all slices like we did in https://github.com/kubernetes/kubernetes/blob/b159fc52f7d12d234a00e8c15575553fe12017db/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go#L3309-L3380 because
1. Most existing tests rely on per-object versioning to determine if a slice was actually updated.
2. A global `ResourceVersion` would require test authors to manually calculate expected versions across multiple objects, making tests significantly harder to read and debug.

#### Which issue(s) this PR is related to:
Followup on https://github.com/kubernetes/kubernetes/pull/136641#issuecomment-4076468216

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```