### PR TITLE
Fix missing SCSI device cleanup in block iSCSI volume detach

### DIFF
--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -539,16 +539,20 @@ func deleteDevice(deviceName string) error {
 // deleteDevices tries to remove all the block devices and multipath map devices
 // associated with a given iscsi device
 func deleteDevices(c iscsiDiskUnmounter) error {
-	lunNumber, err := strconv.Atoi(c.iscsiDisk.Lun)
+	return deleteDevicesForDisk(c.iscsiDisk, c.exec, c.deviceUtil)
+}
+
+func deleteDevicesForDisk(disk *iscsiDisk, exec utilexec.Interface, deviceUtil volumeutil.DeviceUtil) error {
+	lunNumber, err := strconv.Atoi(disk.Lun)
 	if err != nil {
-		klog.Errorf("iscsi delete devices: lun is not a number: %s\nError: %v", c.iscsiDisk.Lun, err)
+		klog.Errorf("iscsi delete devices: lun is not a number: %s\nError: %v", disk.Lun, err)
 		return err
 	}
 	// Enumerate the devices so we can delete them
-	deviceNames, err := c.deviceUtil.FindDevicesForISCSILun(c.iscsiDisk.Iqn, lunNumber)
+	deviceNames, err := deviceUtil.FindDevicesForISCSILun(disk.Iqn, lunNumber)
 	if err != nil {
 		klog.Errorf("iscsi delete devices: could not get devices associated with LUN %d on target %s\nError: %v",
-			lunNumber, c.iscsiDisk.Iqn, err)
+			lunNumber, disk.Iqn, err)
 		return err
 	}
 	// Find the multipath device path(s)
@@ -556,13 +560,13 @@ func deleteDevices(c iscsiDiskUnmounter) error {
 	for _, deviceName := range deviceNames {
 		path := "/dev/" + deviceName
 		// check if the dev is using mpio and if so mount it via the dm-XX device
-		if mappedDevicePath := c.deviceUtil.FindMultipathDeviceForDevice(path); mappedDevicePath != "" {
+		if mappedDevicePath := deviceUtil.FindMultipathDeviceForDevice(path); mappedDevicePath != "" {
 			mpathDevices[mappedDevicePath] = true
 		}
 	}
 	// Flush any multipath device maps
 	for mpathDevice := range mpathDevices {
-		_, err = c.exec.Command("multipath", "-f", mpathDevice).CombinedOutput()
+		_, err = exec.Command("multipath", "-f", mpathDevice).CombinedOutput()
 		if err != nil {
 			klog.Warningf("Warning: Failed to flush multipath device map: %s\nError: %v", mpathDevice, err)
 			// Fall through -- keep deleting the block devices
@@ -704,6 +708,12 @@ func (util *ISCSIUtil) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mapPath string)
 	klog.V(5).Infof("iscsi: devicePath: %s", devicePath)
 	if _, err = os.Stat(devicePath); err != nil {
 		return fmt.Errorf("failed to validate devicePath: %s", devicePath)
+	}
+
+	// Delete all the scsi devices and any multipath devices after unmapping
+	if err = deleteDevicesForDisk(c.iscsiDisk, c.exec, c.deviceUtil); err != nil {
+		klog.Warningf("iscsi detach disk: failed to delete devices\nError: %v", err)
+		// Fall through -- even if deleting fails, a logout may fix problems
 	}
 
 	// Lock the target while we determine if we can safely log out or not

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -462,3 +462,65 @@ func createFakePluginDirs() (string, error) {
 
 	return dir, err
 }
+
+// fakeDeviceUtil implements volumeutil.DeviceUtil for testing deleteDevicesForDisk.
+type fakeDeviceUtil struct {
+	findDevicesResult []string
+	findDevicesErr    error
+	multipathMap      map[string]string // device path -> multipath device path
+	findDevicesCalls  int
+	multipathCalls    int
+}
+
+func (f *fakeDeviceUtil) FindDevicesForISCSILun(targetIqn string, lun int) ([]string, error) {
+	f.findDevicesCalls++
+	return f.findDevicesResult, f.findDevicesErr
+}
+
+func (f *fakeDeviceUtil) FindMultipathDeviceForDevice(disk string) string {
+	f.multipathCalls++
+	if f.multipathMap != nil {
+		return f.multipathMap[disk]
+	}
+	return ""
+}
+
+func (f *fakeDeviceUtil) FindSlaveDevicesOnMultipath(disk string) []string { return nil }
+func (f *fakeDeviceUtil) GetISCSIPortalHostMapForTarget(targetIqn string) (map[string]int, error) {
+	return nil, nil
+}
+
+func TestDeleteDevicesForDisk(t *testing.T) {
+	fakeExec := &testingexec.FakeExec{}
+	fakeDU := &fakeDeviceUtil{
+		findDevicesResult: []string{"sda", "sdb"},
+		multipathMap:      map[string]string{"/dev/sda": "/dev/dm-0"},
+	}
+
+	scripts := []volumetest.CommandScript{
+		{
+			Cmd:  "multipath",
+			Args: []string{"-f", "/dev/dm-0"},
+		},
+	}
+	volumetest.ScriptCommands(fakeExec, scripts)
+
+	disk := &iscsiDisk{
+		Iqn: "iqn.2014-12.com.example:test.tgt00",
+		Lun: "0",
+	}
+
+	err := deleteDevicesForDisk(disk, fakeExec, fakeDU)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if fakeDU.findDevicesCalls != 1 {
+		t.Errorf("expected 1 FindDevicesForISCSILun call, got %d", fakeDU.findDevicesCalls)
+	}
+	if fakeDU.multipathCalls != 2 {
+		t.Errorf("expected 2 FindMultipathDeviceForDevice calls, got %d", fakeDU.multipathCalls)
+	}
+	if fakeExec.CommandCalls != 1 {
+		t.Errorf("expected 1 multipath flush call, got %d", fakeExec.CommandCalls)
+	}
+}


### PR DESCRIPTION
Fixes #137913

## What type of PR is this?

/kind bug
/sig storage

## What this PR does / why we need it

`DetachBlockISCSIDisk` does not clean up SCSI device entries or flush multipath device maps after detaching a block iSCSI volume. The parallel function `DetachDisk` (filesystem volumes) correctly calls `deleteDevices` at line 632 before logging out. This causes stale `/dev/sdX` entries and multipath maps to persist on the node after block volume detach, risking multipath confusion and device handle reuse on long-running nodes.

## How does this PR fix it?

1. Extracts the cleanup logic from `deleteDevices` into `deleteDevicesForDisk(disk, exec, deviceUtil)` — accepts the individual fields that both `iscsiDiskUnmounter` (filesystem) and `iscsiDiskUnmapper` (block) share.
2. `deleteDevices` becomes a one-line wrapper calling `deleteDevicesForDisk` — zero behavior change on the existing filesystem detach path.
3. Adds `deleteDevicesForDisk` call to `DetachBlockISCSIDisk` with identical error handling ("Fall through — even if deleting fails, a logout may fix problems").

## Which issue(s) this PR fixes

Fixes #137913

## Does this PR introduce a user-facing change?

```release-note
Fixed a bug where detaching block iSCSI volumes did not clean up SCSI device entries and multipath device maps, potentially causing stale devices on the node.
```

## Additional context

- The existing `deleteDevices` caller is preserved as a pass-through wrapper, so the filesystem detach path is completely untouched.
- Unit test added for `deleteDevicesForDisk` verifying device enumeration, multipath flush, and command execution.
- `go build`, `go test`, `go vet`, and `gofmt` all pass on `pkg/volume/iscsi/...`.