### PR TITLE
test: Fix PodGroup CRUD test failing due to missing Workload reference

### DIFF
--- a/test/e2e/scheduling/workload.go
+++ b/test/e2e/scheduling/workload.go
@@ -83,12 +83,6 @@ var _ = SIGDescribe("Workload", framework.WithFeatureGate(features.GenericWorklo
 					Namespaced: new(true),
 					InitialSpec: &schedulingv1alpha2.PodGroup{
 						Spec: schedulingv1alpha2.PodGroupSpec{
-							PodGroupTemplateRef: &schedulingv1alpha2.PodGroupTemplateReference{
-								Workload: &schedulingv1alpha2.WorkloadPodGroupTemplateReference{
-									PodGroupTemplateName: "pg1",
-									WorkloadName:         "w1",
-								},
-							},
 							SchedulingPolicy: schedulingv1alpha2.PodGroupSchedulingPolicy{
 								Gang: &schedulingv1alpha2.GangSchedulingPolicy{
 									MinCount: 5,


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Removes the `PodGroupTemplateRef` from the PodGroup e2e CRUD test. The `PodGroupWorkloadExists` admission plugin (introduced in #137464) rejects PodGroups that reference a non-existent Workload, causing the `PodGroup API availability` test to fail with:

```
podgroups.scheduling.k8s.io "test" is forbidden: PodGroup rejected: Workload "w1" not found
```

The workload reference is not needed to test basic PodGroup API CRUD operations.

#### Which issue(s) this PR is related to:

Fixes #137915

#### Special notes for your reviewer:

The admission plugin short-circuits when `PodGroupTemplateRef` is nil (`admission.go:125`), so removing the reference is sufficient.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).