### PR TITLE
devicemanager: gate kubelet-restart bypass on checkpoint, not CRI snapshot

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -307,7 +307,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	}
 
 	logger.Info("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(machineInfo.Topology, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(machineInfo.Topology, cm.topologyManager, machineInfo.BootID)
 	if err != nil {
 		return nil, err
 	}
@@ -727,7 +727,7 @@ func (cm *containerManagerImpl) Start(ctx context.Context, node *v1.Node,
 	}
 
 	// Starts device manager.
-	if err := cm.deviceManager.Start(klog.FromContext(ctx), devicemanager.ActivePodsFunc(activePods), sourcesReady, containerMap.Clone(), containerRunningSet); err != nil {
+	if err := cm.deviceManager.Start(klog.FromContext(ctx), devicemanager.ActivePodsFunc(activePods), sourcesReady, containerRunningSet); err != nil {
 		return err
 	}
 

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -110,7 +110,7 @@ func (cm *containerManagerImpl) Start(ctx context.Context, node *v1.Node,
 	}
 
 	// Starts device manager.
-	if err := cm.deviceManager.Start(logger, devicemanager.ActivePodsFunc(activePods), sourcesReady, containerMap.Clone(), containerRunningSet); err != nil {
+	if err := cm.deviceManager.Start(logger, devicemanager.ActivePodsFunc(activePods), sourcesReady, containerRunningSet); err != nil {
 		return err
 	}
 
@@ -187,7 +187,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	}
 
 	logger.Info("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(nil, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(nil, cm.topologyManager, machineInfo.BootID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/cm/devicemanager/checkpoint/checkpoint.go
+++ b/pkg/kubelet/cm/devicemanager/checkpoint/checkpoint.go
@@ -28,6 +28,7 @@ import (
 type DeviceManagerCheckpoint interface {
 	checkpointmanager.Checkpoint
 	GetData() ([]PodDevicesEntry, map[string][]string)
+	GetBootID() string
 }
 
 // DevicesPerNUMA represents device ids obtained from device plugin per NUMA node id
@@ -54,6 +55,11 @@ type checkpointData struct {
 type Data struct {
 	Data     checkpointData
 	Checksum checksum.Checksum
+	// BootID is the kernel boot_id at the time this checkpoint was written.
+	// Stored outside checkpointData so that adding it does not invalidate the
+	// checksum of checkpoints written by older kubelets (which unmarshal with
+	// BootID == "").
+	BootID string `json:",omitempty"`
 }
 
 // NewDevicesPerNUMA is a function that creates DevicesPerNUMA map
@@ -73,16 +79,17 @@ func (dev DevicesPerNUMA) Devices() sets.Set[string] {
 }
 
 // New returns an instance of Checkpoint - must be an alias for the most recent version
-func New(devEntries []PodDevicesEntry, devices map[string][]string) DeviceManagerCheckpoint {
-	return newV2(devEntries, devices)
+func New(devEntries []PodDevicesEntry, devices map[string][]string, bootID string) DeviceManagerCheckpoint {
+	return newV2(devEntries, devices, bootID)
 }
 
-func newV2(devEntries []PodDevicesEntry, devices map[string][]string) DeviceManagerCheckpoint {
+func newV2(devEntries []PodDevicesEntry, devices map[string][]string, bootID string) DeviceManagerCheckpoint {
 	return &Data{
 		Data: checkpointData{
 			PodDeviceEntries:  devEntries,
 			RegisteredDevices: devices,
 		},
+		BootID: bootID,
 	}
 }
 
@@ -106,4 +113,10 @@ func (cp *Data) VerifyChecksum() error {
 // checkpoint format, *not* in the original format stored on disk.
 func (cp *Data) GetData() ([]PodDevicesEntry, map[string][]string) {
 	return cp.Data.PodDeviceEntries, cp.Data.RegisteredDevices
+}
+
+// GetBootID returns the kernel boot_id recorded when the checkpoint was written.
+// Returns "" for checkpoints written by kubelets that predate this field.
+func (cp *Data) GetBootID() string {
+	return cp.BootID
 }

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
-	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 	plugin "k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/plugin/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/resourceupdates"
@@ -102,14 +101,23 @@ type ManagerImpl struct {
 	// init containers.
 	devicesToReuse PodReusableDevices
 
-	// containerMap provides a mapping from (pod, container) -> containerID
-	// for all containers in a pod. Used to detect pods running across a restart
-	containerMap containermap.ContainerMap
+	// pluginReportedSet tracks which resource names have received at least one ListAndWatch
+	// response from their device plugin since this kubelet started. Used to distinguish
+	// "plugin has not reconnected yet after kubelet restart" (trust the checkpoint) from
+	// "plugin has reported and healthyDevices is authoritative" (apply health checks).
+	// readCheckpoint initializes healthyDevices to an empty set — indistinguishable from
+	// a live plugin reporting all-unhealthy without this signal.
+	pluginReportedSet sets.Set[string]
 
-	// containerRunningSet identifies which container among those present in `containerMap`
-	// was reported running by the container runtime when `containerMap` was computed.
-	// Used to detect pods running across a restart
-	containerRunningSet sets.Set[string]
+	// currentBootID is the kernel boot_id observed at kubelet startup. It is
+	// persisted in the checkpoint so a future kubelet can distinguish a
+	// kubelet-only restart (boot_id unchanged) from a node reboot.
+	currentBootID string
+
+	// nodeRebooted is true when Start() determines the node rebooted since the
+	// checkpoint was written. When true, devicesToAllocate falls through to the
+	// existing health checks instead of trusting the checkpoint.
+	nodeRebooted bool
 
 	// update channel for device health updates
 	update chan resourceupdates.Update
@@ -129,7 +137,7 @@ func (s *sourcesReadyStub) AddSource(source string) {}
 func (s *sourcesReadyStub) AllReady() bool          { return true }
 
 // NewManagerImpl creates a new manager.
-func NewManagerImpl(topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
+func NewManagerImpl(topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store, bootID string) (*ManagerImpl, error) {
 	// Use klog.TODO() because we currently do not have a proper logger to pass in.
 	// Replace this with an appropriate context when refactoring this function to accept a logger parameter.
 	logger := klog.TODO()
@@ -137,10 +145,10 @@ func NewManagerImpl(topology []cadvisorapi.Node, topologyAffinityStore topologym
 	if runtime.GOOS == "windows" {
 		socketPath = os.Getenv("SYSTEMDRIVE") + pluginapi.KubeletSocketWindows
 	}
-	return newManagerImpl(logger, socketPath, topology, topologyAffinityStore)
+	return newManagerImpl(logger, socketPath, topology, topologyAffinityStore, bootID)
 }
 
-func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
+func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store, bootID string) (*ManagerImpl, error) {
 	logger.V(2).Info("Creating Device Plugin manager", "path", socketPath)
 
 	var numaNodes []int
@@ -155,11 +163,17 @@ func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorap
 		healthyDevices:        make(map[string]sets.Set[string]),
 		unhealthyDevices:      make(map[string]sets.Set[string]),
 		allocatedDevices:      make(map[string]sets.Set[string]),
+		pluginReportedSet:     sets.New[string](),
 		podDevices:            newPodDevices(),
 		numaNodes:             numaNodes,
 		topologyAffinityStore: topologyAffinityStore,
+		currentBootID:         bootID,
 		devicesToReuse:        make(PodReusableDevices),
 		update:                make(chan resourceupdates.Update, 100),
+	}
+
+	if bootID == "" {
+		logger.Info("Device manager: cadvisor returned empty boot_id; reboot detection will fall back to the CRI startup snapshot on every restart")
 	}
 
 	server, err := plugin.NewServer(logger, socketPath, manager, manager)
@@ -264,9 +278,16 @@ func (m *ManagerImpl) PluginListAndWatchReceiver(logger klog.Logger, resourceNam
 	m.genericDeviceUpdateCallback(logger, resourceName, resp.Devices)
 }
 
+func (m *ManagerImpl) hasPluginReported(resource string) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.pluginReportedSet.Has(resource)
+}
+
 func (m *ManagerImpl) genericDeviceUpdateCallback(logger klog.Logger, resourceName string, devices []*pluginapi.Device) {
 	healthyCount := 0
 	m.mutex.Lock()
+	m.pluginReportedSet.Insert(resourceName)
 	m.healthyDevices[resourceName] = sets.New[string]()
 	m.unhealthyDevices[resourceName] = sets.New[string]()
 	oldDevices := m.allDevices[resourceName]
@@ -337,21 +358,38 @@ func (m *ManagerImpl) checkpointFile() string {
 // Start starts the Device Plugin Manager and start initialization of
 // podDevices and allocatedDevices information from checkpointed state and
 // starts device plugin registration service.
-func (m *ManagerImpl) Start(logger klog.Logger, activePods ActivePodsFunc, sourcesReady config.SourcesReady, initialContainers containermap.ContainerMap, initialContainerRunningSet sets.Set[string]) error {
+func (m *ManagerImpl) Start(logger klog.Logger, activePods ActivePodsFunc, sourcesReady config.SourcesReady, initialContainerRunningSet sets.Set[string]) error {
 	logger.V(2).Info("Starting Device Plugin manager")
 
 	m.activePods = activePods
 	m.sourcesReady = sourcesReady
-	m.containerMap = initialContainers
-	m.containerRunningSet = initialContainerRunningSet
 
 	// Loads in allocatedDevices information from disk.
-	err := m.readCheckpoint(logger)
+	checkpointBootID, err := m.readCheckpoint(logger)
 	if err != nil {
 		logger.Error(err, "Continue after failing to read checkpoint file. Device allocation info may NOT be up-to-date")
 	}
 
+	// nodeRebooted gates the checkpoint-trust bypass in devicesToAllocate; see detectNodeReboot.
+	nodeRebooted := detectNodeReboot(checkpointBootID, m.currentBootID, initialContainerRunningSet.Len())
+	m.mutex.Lock()
+	m.nodeRebooted = nodeRebooted
+	m.mutex.Unlock()
+	logger.V(2).Info("Device manager reboot detection", "nodeRebooted", nodeRebooted, "checkpointBootID", checkpointBootID, "currentBootID", m.currentBootID, "runningContainersAtStartup", initialContainerRunningSet.Len())
+
 	return m.server.Start(logger)
+}
+
+// detectNodeReboot decides whether the node rebooted since the on-disk
+// checkpoint was written. A boot_id mismatch is authoritative. When the
+// checkpoint has no boot_id (written by an older kubelet, or no checkpoint),
+// fall back to the CRI startup snapshot: any running container implies the
+// runtime survived, i.e. a kubelet-only restart.
+func detectNodeReboot(checkpointBootID, currentBootID string, runningContainersAtStartup int) bool {
+	if checkpointBootID == "" {
+		return runningContainersAtStartup == 0
+	}
+	return checkpointBootID != currentBootID
 }
 
 // Stop is the function that can stop the plugin server.
@@ -483,6 +521,7 @@ func (m *ManagerImpl) GetCapacity() (v1.ResourceList, v1.ResourceList, []string)
 		delete(m.endpoints, resourceName)
 		delete(m.healthyDevices, resourceName)
 		delete(m.unhealthyDevices, resourceName)
+		m.pluginReportedSet.Delete(resourceName)
 	}
 
 	m.mutex.Unlock()
@@ -503,7 +542,7 @@ func (m *ManagerImpl) writeCheckpoint(logger klog.Logger) error {
 		registeredDevs[resource] = devices.UnsortedList()
 	}
 	data := checkpoint.New(m.podDevices.toCheckpointData(logger),
-		registeredDevs)
+		registeredDevs, m.currentBootID)
 	m.mutex.Unlock()
 	err := m.checkpointManager.CreateCheckpoint(kubeletDeviceManagerCheckpoint, data)
 	if err != nil {
@@ -516,16 +555,17 @@ func (m *ManagerImpl) writeCheckpoint(logger klog.Logger) error {
 }
 
 // Reads device to container allocation information from disk, and populates
-// m.allocatedDevices accordingly.
-func (m *ManagerImpl) readCheckpoint(logger klog.Logger) error {
+// m.allocatedDevices accordingly. Returns the boot_id stored in the
+// checkpoint (or "" if absent / no checkpoint).
+func (m *ManagerImpl) readCheckpoint(logger klog.Logger) (string, error) {
 	cp, err := m.getCheckpoint()
 	if err != nil {
 		if err == errors.ErrCheckpointNotFound {
 			// no point in trying anything else
 			logger.Error(err, "Failed to read data from checkpoint", "checkpoint", kubeletDeviceManagerCheckpoint)
-			return nil
+			return "", nil
 		}
-		return err
+		return "", err
 	}
 
 	m.mutex.Lock()
@@ -542,13 +582,13 @@ func (m *ManagerImpl) readCheckpoint(logger klog.Logger) error {
 	}
 
 	logger.V(4).Info("Read data from checkpoint file", "checkpoint", kubeletDeviceManagerCheckpoint)
-	return nil
+	return cp.GetBootID(), nil
 }
 
 func (m *ManagerImpl) getCheckpoint() (checkpoint.DeviceManagerCheckpoint, error) {
 	registeredDevs := make(map[string][]string)
 	devEntries := make([]checkpoint.PodDevicesEntry, 0)
-	cp := checkpoint.New(devEntries, registeredDevs)
+	cp := checkpoint.New(devEntries, registeredDevs, "")
 	err := m.checkpointManager.GetCheckpoint(kubeletDeviceManagerCheckpoint, cp)
 	return cp, err
 }
@@ -603,16 +643,22 @@ func (m *ManagerImpl) devicesToAllocate(ctx context.Context, podUID, contName, r
 	// 3. node reboot. In this scenario device plugins may not be running yet when we try to allocate devices.
 	//    note: if we get this far the runtime is surely running. This is usually enforced at OS level by startup system services dependencies.
 
-	// First we take care of the exceptional flow (scenarios 2 and 3). In both flows, kubelet is reinitializing, and while kubelet is initializing, sources are NOT all ready.
-	// Is this a simple kubelet restart (scenario 2)? To distinguish, we use the information we got for runtime. If we are asked to allocate devices for containers reported
-	// running, then it can only be a kubelet restart. On node reboot the runtime and the containers were also shut down. Then, if the container was running, it can only be
-	// because it already has access to all the required devices, so we got nothing to do and we can bail out.
-	if !m.sourcesReady.AllReady() && m.isContainerAlreadyRunning(logger, podUID, contName) {
-		logger.V(3).Info("Container detected running, nothing to do", "deviceNumber", needed, "resourceName", resource, "podUID", podUID, "containerName", contName)
+	// First we take care of the exceptional flow. On a kubelet-only restart (scenario 2), if the device plugin for this resource has not
+	// yet sent a ListAndWatch response since this kubelet started and the checkpoint has a prior allocation, trust the checkpoint: the
+	// container is still running with its devices, and GetDeviceRunContainerOptions defers any new container start until the plugin
+	// reports (preserving the #109595 invariant). This deliberately does not consult per-container CRI runtime state — the startup
+	// snapshot is fragile (transient errors, container-restart ID races; see #118559).
+	//
+	// On a node reboot (scenario 3), nodeRebooted is true and we fall through to the health checks below, matching the pre-existing
+	// behaviour: admission fails until the plugin reports, and the controller recreates the pod with a fresh allocation.
+	// m.mutex is held; safe to read m.pluginReportedSet directly.
+	checkpointTrusted := devices != nil && !m.nodeRebooted && !m.pluginReportedSet.Has(resource)
+	if checkpointTrusted {
+		logger.V(3).Info("Device plugin has not yet reported and checkpoint has allocation; trusting checkpoint", "resourceName", resource, "podUID", podUID, "containerName", contName)
 		return nil, nil
 	}
 
-	// We dealt with scenario 2. If we got this far it's either scenario 3 (node reboot) or scenario 1 (steady state, normal flow).
+	// From here on, healthyDevices is authoritative: the plugin has reported, or the checkpoint had no allocation for this pod/container.
 	logger.V(3).Info("Need devices to allocate for pod", "deviceNumber", needed, "resourceName", resource, "podUID", podUID, "containerName", contName)
 	healthyDevices, hasRegistered := m.healthyDevices[resource]
 
@@ -965,6 +1011,11 @@ func (m *ManagerImpl) GetDeviceRunContainerOptions(ctx context.Context, pod *v1.
 		if !m.isDevicePluginResource(resource) || v.Value() == 0 {
 			continue
 		}
+		// Defer container start until the plugin reports so we never serve stale checkpoint mounts.
+		// Surfaces as waiting reason CreateContainerConfigError; kubelet retries on the next syncPod.
+		if !m.hasPluginReported(resource) {
+			return nil, fmt.Errorf("device plugin for resource %s has not yet reported devices; deferring container start (will retry)", resource)
+		}
 		err := m.callPreStartContainerIfNeeded(ctx, podUID, contName, resource)
 		if err != nil {
 			return nil, err
@@ -1206,39 +1257,4 @@ func (m *ManagerImpl) ShouldResetExtendedResourceCapacity() bool {
 		return false
 	}
 	return len(checkpoints) == 0
-}
-
-func (m *ManagerImpl) isContainerAlreadyRunning(logger klog.Logger, podUID, cntName string) bool {
-	// Check if ANY container for this pod/container name is running.
-	// This handles the case where a container restarted before kubelet restart,
-	// so the containerMap might have multiple entries (old exited + new running).
-	// We need to check all of them to see if any are running.
-	//
-	// Note: if container runtime is down when kubelet restarts, containerRunningSet will be empty,
-	// so containers will fail admission, hitting https://github.com/kubernetes/kubernetes/issues/118559.
-	// This scenario should however be rare enough.
-	foundAnyContainer := false
-	foundRunningContainer := false
-
-	m.containerMap.Visit(func(visitPodUID, visitContainerName, visitContainerID string) {
-		if visitPodUID == podUID && visitContainerName == cntName {
-			foundAnyContainer = true
-			if m.containerRunningSet.Has(visitContainerID) {
-				foundRunningContainer = true
-				logger.V(4).Info("Container found in the initial running set", "podUID", podUID, "containerName", cntName, "containerID", visitContainerID)
-			}
-		}
-	})
-
-	if !foundAnyContainer {
-		logger.V(4).Info("Container not found in the initial map, assumed NOT running", "podUID", podUID, "containerName", cntName)
-		return false
-	}
-
-	if !foundRunningContainer {
-		logger.V(4).Info("Container found in map but not in running set", "podUID", podUID, "containerName", cntName)
-		return false
-	}
-
-	return true
 }

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -47,7 +47,6 @@ import (
 	watcherapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
-	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 	plugin "k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/plugin/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/resourceupdates"
@@ -101,7 +100,7 @@ func TestNewManagerImpl(t *testing.T) {
 	topologyStore := topologymanager.NewFakeManager()
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
-	_, err = newManagerImpl(logger, socketName, nil, topologyStore)
+	_, err = newManagerImpl(logger, socketName, nil, topologyStore, "")
 	require.NoError(t, err)
 	os.RemoveAll(socketDir)
 }
@@ -288,7 +287,7 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 func setupDeviceManager(t *testing.T, devs []*pluginapi.Device, callback monitorCallback, socketName string,
 	topology []cadvisorapi.Node, logger klog.Logger) (Manager, <-chan interface{}) {
 	topologyStore := topologymanager.NewFakeManager()
-	m, err := newManagerImpl(logger, socketName, topology, topologyStore)
+	m, err := newManagerImpl(logger, socketName, topology, topologyStore, "")
 	require.NoError(t, err)
 	updateChan := make(chan interface{})
 
@@ -306,9 +305,7 @@ func setupDeviceManager(t *testing.T, devs []*pluginapi.Device, callback monitor
 		return []*v1.Pod{}
 	}
 
-	// test steady state, initialization where sourcesReady, containerMap and containerRunningSet
-	// are relevant will be tested with a different flow
-	err = w.Start(logger, activePods, &sourcesReadyStub{}, containermap.NewContainerMap(), sets.New[string]())
+	err = w.Start(logger, activePods, &sourcesReadyStub{}, sets.New[string]())
 	require.NoError(t, err)
 
 	return w, updateChan
@@ -367,7 +364,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	topologyStore := topologymanager.NewFakeManager()
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
-	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
+	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore, "")
 	as := assert.New(t)
 	as.NotNil(testManager)
 	as.NoError(err)
@@ -490,7 +487,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	as.NoError(err)
 	testManager.healthyDevices = make(map[string]sets.Set[string])
 	testManager.unhealthyDevices = make(map[string]sets.Set[string])
-	err = testManager.readCheckpoint(logger)
+	_, err = testManager.readCheckpoint(logger)
 	as.NoError(err)
 	as.Len(testManager.endpoints, 1)
 	as.Contains(testManager.endpoints, resourceName2)
@@ -511,7 +508,7 @@ func TestGetAllocatableDevicesMultipleResources(t *testing.T) {
 	topologyStore := topologymanager.NewFakeManager()
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
-	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
+	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore, "")
 	as := assert.New(t)
 	as.NotNil(testManager)
 	as.NoError(err)
@@ -553,7 +550,7 @@ func TestGetAllocatableDevicesHealthTransition(t *testing.T) {
 	topologyStore := topologymanager.NewFakeManager()
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
-	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
+	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore, "")
 	as := assert.New(t)
 	as.NotNil(testManager)
 	as.NoError(err)
@@ -710,6 +707,7 @@ func TestCheckpoint(t *testing.T) {
 		allocatedDevices:  make(map[string]sets.Set[string]),
 		podDevices:        newPodDevices(),
 		checkpointManager: ckm,
+		pluginReportedSet: sets.New[string](),
 	}
 
 	testManager.podDevices.insert("pod1", "con1", resourceName1,
@@ -770,7 +768,7 @@ func TestCheckpoint(t *testing.T) {
 
 	as.NoError(err)
 	testManager.podDevices = newPodDevices()
-	err = testManager.readCheckpoint(logger)
+	_, err = testManager.readCheckpoint(logger)
 	as.NoError(err)
 
 	as.Equal(expectedPodDevices.size(), testManager.podDevices.size())
@@ -870,6 +868,7 @@ func getTestManager(tmpDir string, activePods ActivePodsFunc, testRes []TestReso
 		sourcesReady:          &sourcesReadyStub{},
 		checkpointManager:     ckm,
 		allDevices:            NewResourceDeviceInstances(),
+		pluginReportedSet:     sets.New[string](),
 	}
 	testManager := &wrappedManagerImpl{
 		ManagerImpl: m,
@@ -879,6 +878,7 @@ func getTestManager(tmpDir string, activePods ActivePodsFunc, testRes []TestReso
 
 	for _, res := range testRes {
 		testManager.healthyDevices[res.resourceName] = sets.New[string](res.devs.Devices().UnsortedList()...)
+		testManager.pluginReportedSet.Insert(res.resourceName)
 		if res.resourceName == "domain1.com/resource1" {
 			testManager.endpoints[res.resourceName] = endpointInfo{
 				e:    &MockEndpoint{allocateFunc: allocateStubFunc()},
@@ -1120,13 +1120,14 @@ func TestPodContainerDeviceToAllocate(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	testManager := &ManagerImpl{
-		endpoints:        make(map[string]endpointInfo),
-		healthyDevices:   make(map[string]sets.Set[string]),
-		unhealthyDevices: make(map[string]sets.Set[string]),
-		allocatedDevices: make(map[string]sets.Set[string]),
-		podDevices:       newPodDevices(),
-		activePods:       func() []*v1.Pod { return []*v1.Pod{} },
-		sourcesReady:     &sourcesReadyStub{},
+		endpoints:         make(map[string]endpointInfo),
+		healthyDevices:    make(map[string]sets.Set[string]),
+		unhealthyDevices:  make(map[string]sets.Set[string]),
+		allocatedDevices:  make(map[string]sets.Set[string]),
+		podDevices:        newPodDevices(),
+		activePods:        func() []*v1.Pod { return []*v1.Pod{} },
+		sourcesReady:      &sourcesReadyStub{},
+		pluginReportedSet: sets.New[string](resourceName1, resourceName2, resourceName3),
 	}
 
 	testManager.podDevices.insert("pod1", "con1", resourceName1,
@@ -1217,6 +1218,72 @@ func TestPodContainerDeviceToAllocate(t *testing.T) {
 
 }
 
+func TestDetectNodeReboot(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		checkpointBootID string
+		currentBootID    string
+		runningCount     int
+		want             bool
+	}{
+		{name: "boot_id matches: kubelet restart", checkpointBootID: "abc", currentBootID: "abc", runningCount: 0, want: false},
+		{name: "boot_id mismatch: node reboot", checkpointBootID: "abc", currentBootID: "def", runningCount: 5, want: true},
+		{name: "no boot_id, containers running: upgrade fallback treats as restart", checkpointBootID: "", currentBootID: "abc", runningCount: 3, want: false},
+		{name: "no boot_id, no containers running: upgrade fallback treats as reboot", checkpointBootID: "", currentBootID: "abc", runningCount: 0, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectNodeReboot(tc.checkpointBootID, tc.currentBootID, tc.runningCount); got != tc.want {
+				t.Errorf("detectNodeReboot(%q, %q, %d) = %v, want %v", tc.checkpointBootID, tc.currentBootID, tc.runningCount, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDevicesToAllocateTrustsCheckpointBeforePluginReports covers kubelet restart
+// when the checkpoint has a prior allocation for a pod but the device plugin has
+// not yet sent a ListAndWatch response. The bypass must trust the checkpoint
+// regardless of CRI-snapshot state — covering issue #118559 (CRI errors leave
+// the snapshot empty) and the case where a pod was scheduled seconds before
+// restart (checkpoint written, container not yet created in CRI).
+func TestDevicesToAllocateTrustsCheckpointBeforePluginReports(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	resourceName := "domain1.com/resource1"
+	podUID := "pod1"
+	contName := "con1"
+
+	testManager := &ManagerImpl{
+		endpoints:        make(map[string]endpointInfo),
+		healthyDevices:   make(map[string]sets.Set[string]),
+		unhealthyDevices: make(map[string]sets.Set[string]),
+		allocatedDevices: make(map[string]sets.Set[string]),
+		podDevices:       newPodDevices(),
+		activePods:       func() []*v1.Pod { return []*v1.Pod{} },
+		sourcesReady:     &sourcesReadyStub{},
+		// pluginReportedSet empty: nothing reported yet
+		pluginReportedSet: sets.New[string](),
+	}
+
+	// Checkpoint from the prior kubelet has an allocation for this pod/container.
+	testManager.podDevices.insert(podUID, contName, resourceName,
+		constructDevices([]string{"dev1", "dev2"}),
+		newContainerAllocateResponse(
+			withDevices(map[string]string{"/dev/dev1": "/dev/dev1", "/dev/dev2": "/dev/dev2"}),
+		),
+	)
+
+	// Simulate post-readCheckpoint state: healthyDevices entry exists but is empty (plugin not yet reconnected).
+	testManager.healthyDevices[resourceName] = sets.New[string]()
+
+	// Checkpoint has the allocation and the plugin has not yet reported — bypass must fire.
+	allocDevices, err := testManager.devicesToAllocate(tCtx, podUID, contName, resourceName, 2, sets.New[string]())
+	if err != nil {
+		t.Fatalf("devicesToAllocate returned error %q; expected nil — a pod with a valid checkpoint allocation must not be rejected before the plugin reports (issue #118559)", err)
+	}
+	if allocDevices != nil {
+		t.Fatalf("devicesToAllocate returned devices %v; expected nil — bypass should have fired, trusting the checkpoint allocation", allocDevices)
+	}
+}
+
 func TestDevicesToAllocateConflictWithUpdateAllocatedDevices(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	podToAllocate := "podToAllocate"
@@ -1256,6 +1323,7 @@ func TestDevicesToAllocateConflictWithUpdateAllocatedDevices(t *testing.T) {
 		activePods:            func() []*v1.Pod { return []*v1.Pod{} },
 		sourcesReady:          &sourcesReadyStub{},
 		topologyAffinityStore: topologymanager.NewFakeManager(),
+		pluginReportedSet:     sets.New[string](resourceName),
 	}
 
 	testManager.endpoints[resourceName] = endpointInfo{
@@ -1593,6 +1661,7 @@ func TestUpdatePluginResources(t *testing.T) {
 		healthyDevices:    make(map[string]sets.Set[string]),
 		podDevices:        newPodDevices(),
 		checkpointManager: ckm,
+		pluginReportedSet: sets.New[string](),
 	}
 	testManager := wrappedManagerImpl{
 		ManagerImpl: m,
@@ -1716,6 +1785,7 @@ func TestResetExtendedResource(t *testing.T) {
 		allocatedDevices:  make(map[string]sets.Set[string]),
 		podDevices:        newPodDevices(),
 		checkpointManager: ckm,
+		pluginReportedSet: sets.New[string](),
 	}
 
 	extendedResourceName := "domain.com/resource"
@@ -1921,6 +1991,7 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 		allDevices:        make(map[string]DeviceInstances),
 		podDevices:        newPodDevices(),
 		checkpointManager: ckm,
+		pluginReportedSet: sets.New[string](),
 	}
 
 	testManager.podDevices.insert(podUID, containerName, resourceName,
@@ -2028,6 +2099,7 @@ func TestFeatureGateResourceHealthStatus(t *testing.T) {
 		podDevices:        newPodDevices(),
 		checkpointManager: ckm,
 		update:            make(chan resourceupdates.Update, deviceUpdateChanBuffer),
+		pluginReportedSet: sets.New[string](),
 	}
 
 	for i := 0; i < deviceUpdateNumber; i++ {
@@ -2128,8 +2200,9 @@ func TestAdmitPodWithDRAResources(t *testing.T) {
 				allocatedDevices: map[string]sets.Set[string]{
 					resourceName: sets.New("Dev"),
 				},
-				activePods:   func() []*v1.Pod { return nil },
-				sourcesReady: &sourcesReadyStub{},
+				activePods:        func() []*v1.Pod { return nil },
+				sourcesReady:      &sourcesReadyStub{},
+				pluginReportedSet: sets.New[string](),
 			}
 
 			err := testManager.Allocate(pod, &pod.Spec.Containers[0])
@@ -2152,7 +2225,7 @@ func TestEndpointSyncOnDisconnect(t *testing.T) {
 		}
 	}()
 
-	manager, err := newManagerImpl(logger, socketName, nil, nil)
+	manager, err := newManagerImpl(logger, socketName, nil, nil, "")
 	require.NoError(t, err)
 
 	resourceName := "domain1.com/resource1"

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/resourceupdates"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
@@ -37,7 +36,7 @@ import (
 // Manager manages all the Device Plugins running on a node.
 type Manager interface {
 	// Start starts device plugin registration service.
-	Start(logger klog.Logger, activePods ActivePodsFunc, sourcesReady config.SourcesReady, initialContainers containermap.ContainerMap, initialContainerRunningSet sets.Set[string]) error
+	Start(logger klog.Logger, activePods ActivePodsFunc, sourcesReady config.SourcesReady, initialContainerRunningSet sets.Set[string]) error
 
 	// Allocate configures and assigns devices to a container in a pod. From
 	// the requested device resources, Allocate will communicate with the

--- a/test/e2e_node/device_manager_test.go
+++ b/test/e2e_node/device_manager_test.go
@@ -178,13 +178,22 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 				Should(HaveAllocatableDevices())
 		})
 
-		framework.It("should deploy pod consuming devices first but fail with admission error after kubelet restart in case device plugin hasn't re-registered", framework.WithFlaky(), func(ctx context.Context) {
+		framework.It("should defer container start after kubelet restart in case device plugin hasn't re-registered", framework.WithFlaky(), func(ctx context.Context) {
 			var err error
 			podCMD := "while true; do sleep 1000; done;"
 
 			ginkgo.By(fmt.Sprintf("creating a pods requiring %d %q", deviceCount, e2enode.SampleDeviceResourceName))
 
 			pod := makeBusyboxDeviceRequiringPod(e2enode.SampleDeviceResourceName, podCMD)
+			// The CRI sandbox removal below is seen by kubelet as the container
+			// being killed (ContainerStatusUnknown, exit 137). With RestartPolicy=Never
+			// that sends the pod straight to Phase=Failed before we ever reach the
+			// device-plugin defer. Use Always so kubelet attempts a restart and hits
+			// GetDeviceRunContainerOptions.
+			// TODO: add another test to cover the RestartPolicy=Never variant, the
+			// Phase=Failed outcome there is computePodPhase behavior, not a
+			// device-manager decision, but we should still assert it explicitly.
+			pod.Spec.RestartPolicy = v1.RestartPolicyAlways
 			testPod := e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 			ginkgo.By("making sure all the pods are ready")
@@ -243,16 +252,17 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 				WithTimeout(5 * time.Minute).
 				Should(HaveAllocatableDevices())
 
-			ginkgo.By("Checking that pod requesting devices failed to start because of admission error")
+			ginkgo.By("Checking that the pod is deferred waiting for the device plugin to report")
 
 			// NOTE: The device plugin won't re-register again and this is intentional.
-			// Because of this, the testpod (requesting a device) should fail with an admission error.
+			// Admission passes on the checkpoint's allocation, but container start is
+			// deferred at GetDeviceRunContainerOptions until the plugin reports.
 
-			gomega.Eventually(ctx, getPod).
+			gomega.Eventually(ctx, getPodByName).
 				WithArguments(f, testPod.Name).
 				WithTimeout(time.Minute).
-				Should(HaveFailedWithAdmissionError(),
-					"the pod succeeded to start, when it should fail with the admission error")
+				Should(BeDeferredWaitingForDevicePlugin(),
+					"the pod should be stuck in ContainerCreating with the device-plugin defer message")
 
 			ginkgo.By("removing application pods")
 			e2epod.NewPodClient(f).DeleteSync(ctx, testPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
@@ -396,48 +406,51 @@ func isNodeReadyWithoutSampleResources(ctx context.Context, f *framework.Framewo
 	return true, nil
 }
 
-// HaveFailedWithAdmissionError verifies that a pod fails at admission.
-func HaveFailedWithAdmissionError() types.GomegaMatcher {
-	return gomega.And(
-		gcustom.MakeMatcher(func(hasFailed bool) (bool, error) {
-			if !hasFailed {
-				return false, fmt.Errorf("expected pod to have failed=%t", hasFailed)
+// BeDeferredWaitingForDevicePlugin verifies that a pod has a container in Waiting
+// state with CreateContainerConfigError and the device-plugin defer message. This is
+// the post-checkpoint-trust-bypass behavior: admission passes on the checkpoint's
+// word, but GetDeviceRunContainerOptions blocks container start until the plugin
+// reports. Phase is intentionally not checked — after node reboot it may transition
+// through Running→Pending depending on sync timing; the Waiting reason is the
+// load-bearing signal.
+//
+// TODO: the Message substring match is fragile. KEP-4680's
+// allocatedResourcesStatus[].resources[].health would be the right signal
+// (Unknown = "plugin unregistered and hasn't re-registered"), but
+// UpdateAllocatedResourcesStatus currently defaults to Healthy when allDevices
+// is empty instead of emitting Unknown. Once that's fixed, swap this matcher
+// to check health==Unknown.
+func BeDeferredWaitingForDevicePlugin() types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(pod *v1.Pod) (bool, error) {
+		if pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded {
+			return false, fmt.Errorf("expected pod to be non-terminal, got phase %q", pod.Status.Phase)
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.State.Waiting == nil {
+				continue
 			}
-			return true, nil
-		}),
-		hasFailed(true),
-	)
+			if cs.State.Waiting.Reason == "CreateContainerConfigError" &&
+				strings.Contains(cs.State.Waiting.Message, "has not yet reported devices") {
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("expected a container waiting with CreateContainerConfigError and device-plugin defer message, got statuses: %+v", pod.Status.ContainerStatuses)
+	}).WithTemplate("expected Pod {{.To}} be deferred waiting for device plugin\nGot instead:\n{{.FormattedActual}}")
 }
 
-// hasFailed matches if pod has failed.
-func hasFailed(hasFailed bool) types.GomegaMatcher {
-	return gcustom.MakeMatcher(func(hasPodFailed bool) (bool, error) {
-		return hasPodFailed == hasFailed, nil
-	}).WithTemplate("expected Pod failed {{.To}} be in {{format .Data}}\nGot instead:\n{{.FormattedActual}}").WithTemplateData(hasFailed)
+// HaveFailedWithAdmissionError verifies that a pod is in Phase=Failed with
+// Reason=UnexpectedAdmissionError. This is the device-manager admission-reject
+// path: devicesToAllocate fell through to the health checks (no healthy devices
+// / unregistered) before the plugin reported.
+func HaveFailedWithAdmissionError() types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(pod *v1.Pod) (bool, error) {
+		if pod.Status.Phase != v1.PodFailed {
+			return false, nil
+		}
+		return pod.Status.Reason == "UnexpectedAdmissionError", nil
+	}).WithTemplate("expected Pod {{.To}} have failed with UnexpectedAdmissionError\nGot instead:\n{{.FormattedActual}}")
 }
 
 func getPodByName(ctx context.Context, f *framework.Framework, podName string) (*v1.Pod, error) {
 	return e2epod.NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
-}
-
-func getPod(ctx context.Context, f *framework.Framework, podName string) (bool, error) {
-	pod, err := getPodByName(ctx, f, podName)
-	if err != nil {
-		return false, err
-	}
-
-	expectedStatusReason := "UnexpectedAdmissionError"
-	expectedStatusMessage := "Allocate failed due to no healthy devices present; cannot allocate unhealthy devices"
-
-	// This additional matcher checks for the final error condition.
-	if pod.Status.Phase != v1.PodFailed {
-		return false, fmt.Errorf("expected pod to reach phase %q, got final phase %q instead.", v1.PodFailed, pod.Status.Phase)
-	}
-	if pod.Status.Reason != expectedStatusReason {
-		return false, fmt.Errorf("expected pod status reason to be %q, got %q instead.", expectedStatusReason, pod.Status.Reason)
-	}
-	if !strings.Contains(pod.Status.Message, expectedStatusMessage) {
-		return false, fmt.Errorf("expected pod status reason to contain %q, got %q instead.", expectedStatusMessage, pod.Status.Message)
-	}
-	return true, nil
 }

--- a/test/e2e_node/device_plugin_criproxy_linux_test.go
+++ b/test/e2e_node/device_plugin_criproxy_linux_test.go
@@ -1,0 +1,168 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/kubernetes/test/e2e_node/criproxy"
+)
+
+// Regression test for #118559: simulate a kubelet restart where the initial CRI
+// snapshot (ListPodSandbox + ListContainers) returns an error.
+// buildContainerMapFromRuntime silently discards these errors. Without the
+// checkpoint-trust bypass, the scenario-2 path in devicesToAllocate falls through
+// to the healthyDevices check and rejects the still-running pod with
+// UnexpectedAdmissionError.
+//
+// This file carries //go:build linux because the CRI proxy (e2eCriProxy,
+// addCRIProxyInjector, resetCRIProxyInjector) is defined in linux-tagged files.
+// The setup/teardown it shares with device_plugin_test.go is in platform-agnostic
+// helpers there.
+var _ = SIGDescribe("Device Plugin CRI Snapshot Failure", framework.WithSerial(), feature.DevicePlugin, feature.CriProxy, func() {
+	f := framework.NewDefaultFramework("device-plugin-cri-snapshot")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	f.Context("DevicePlugin", f.WithSerial(), f.WithDisruptive(), func() {
+		var devicePluginPod *v1.Pod
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			if e2eCriProxy == nil {
+				ginkgo.Skip("test requires CRI proxy (run with --cri-proxy-enabled=true)")
+			}
+			ginkgo.DeferCleanup(func() error { return resetCRIProxyInjector(e2eCriProxy) })
+			devicePluginPod = setupSampleDevicePluginWithRegistrationControl(ctx, f)
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if devicePluginPod == nil {
+				return
+			}
+			teardownSampleDevicePluginWithRegistrationControl(ctx, f, devicePluginPod)
+		})
+
+		framework.It("Keeps device plugin assignments across kubelet restart when CRI snapshot returns an error", func(ctx context.Context) {
+
+			podRECMD := fmt.Sprintf("devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep %s", sleepIntervalForever)
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(e2enode.SampleDeviceResourceName, podRECMD))
+			deviceIDRE := "stub devices: (Dev-[0-9]+)"
+			devID1, err := parseLog(ctx, f, pod1.Name, pod1.Name, deviceIDRE)
+			framework.ExpectNoError(err, "getting logs for pod %q", pod1.Name)
+			gomega.Expect(devID1).To(gomega.Not(gomega.Equal("")))
+
+			pod1, err = e2epod.NewPodClient(f).Get(ctx, pod1.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("stopping the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+
+			// Remove only the device plugin sandbox so the plugin will not re-register quickly.
+			// The app container stays running in containerd (this is the production scenario
+			// for #118559): kubelet restarts, containerd stays up, workload containers
+			// keep running, device plugin needs to re-register.
+			ginkgo.By("removing only the device plugin sandbox via CRI")
+			rs, _, err := getCRIClient(ctx)
+			framework.ExpectNoError(err)
+			sandboxes, err := rs.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{})
+			framework.ExpectNoError(err)
+			removed := false
+			for _, sandbox := range sandboxes {
+				gomega.Expect(sandbox.Metadata).ToNot(gomega.BeNil())
+				if sandbox.Metadata.Name != devicePluginPod.Name {
+					continue
+				}
+				ginkgo.By(fmt.Sprintf("deleting device plugin sandbox via CRI: %s/%s -> %s", sandbox.Metadata.Namespace, sandbox.Metadata.Name, sandbox.Id))
+				framework.ExpectNoError(rs.RemovePodSandbox(ctx, sandbox.Id))
+				removed = true
+			}
+			gomega.Expect(removed).To(gomega.BeTrueBecause("expected to find and remove the device plugin sandbox"))
+
+			// Arm the CRI proxy to fail ListPodSandbox and ListContainers during early kubelet
+			// startup. The containerManager snapshot happens within the first ~300ms, but GC
+			// and stats-init also call these APIs before and after. 2s is a generous envelope —
+			// wide enough to cover the snapshot on slow CI nodes, short enough that PLEG
+			// (running at ~1s intervals) recovers before the 5-minute node-ready timeout.
+			ginkgo.By("arming CRI proxy to fail ListPodSandbox/ListContainers during the startup snapshot window")
+			var listPodSandboxCalls, listContainersCalls atomic.Int32
+			armedAt := time.Now()
+			const injectionWindow = 2 * time.Second
+			err = addCRIProxyInjector(e2eCriProxy, func(apiName string) error {
+				if time.Since(armedAt) > injectionWindow {
+					return nil
+				}
+				switch apiName {
+				case criproxy.ListPodSandbox:
+					listPodSandboxCalls.Add(1)
+					return fmt.Errorf("injected failure: simulating transient CRI error during containerManager snapshot")
+				case criproxy.ListContainers:
+					listContainersCalls.Add(1)
+					return fmt.Errorf("injected failure: simulating transient CRI error during containerManager snapshot")
+				}
+				return nil
+			})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet(ctx)
+
+			ginkgo.By("waiting for node to be ready again")
+			framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute))
+
+			framework.Logf("CRI injector fired %d ListPodSandbox and %d ListContainers failures during the %v injection window", listPodSandboxCalls.Load(), listContainersCalls.Load(), injectionWindow)
+
+			// Sanity check: the injector actually fired during the startup window.
+			gomega.Expect(listPodSandboxCalls.Load()).To(gomega.BeNumerically(">=", int32(1)), "CRI proxy ListPodSandbox injector never fired")
+			gomega.Expect(listContainersCalls.Load()).To(gomega.BeNumerically(">=", int32(1)), "CRI proxy ListContainers injector never fired")
+
+			// The app container was running throughout. The checkpoint has its allocation.
+			// An incomplete CRI snapshot must not cause re-admission to reject it.
+			ginkgo.By("verifying the pod is still running with its original device assignment")
+			gomega.Consistently(ctx, getPodByName).
+				WithArguments(f, pod1.Name).
+				WithTimeout(30*time.Second).WithPolling(2*time.Second).
+				Should(BeTheSamePodStillRunning(pod1),
+					"pod was evicted after kubelet restart despite being a running container with a valid checkpoint allocation — CRI snapshot failure must not cause re-admission to reject running pods (issue #118559)")
+
+			ginkgo.By("verifying the device assignment is preserved via the podresources API")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				v1PodResources, err := getV1NodeDevices(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get node devices: %w", err)
+				}
+				matchErr, _ := checkPodResourcesAssignment(v1PodResources, pod1.Namespace, pod1.Name, pod1.Spec.Containers[0].Name, e2enode.SampleDeviceResourceName, []string{devID1})
+				return matchErr
+			}, time.Minute, framework.Poll).Should(gomega.Succeed())
+		})
+	})
+})

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -18,6 +18,7 @@ package e2enode
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -40,7 +41,6 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/ptr"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -362,7 +362,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			restartKubelet(ctx, true)
 
 			ginkgo.By("Wait for node to be ready again")
-			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for resource to become available on the local node after restart")
 			gomega.Eventually(ctx, func() bool {
@@ -413,7 +413,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Wait for node to be ready again")
-			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for container to restart")
 			ensurePodContainerRestart(ctx, f, pod1.Name, pod1.Name)
@@ -427,7 +427,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			restartKubelet(ctx, true)
 
 			ginkgo.By("Wait for node to be ready again")
-			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
 
 			ginkgo.By("Checking an instance of the pod is running")
 			gomega.Eventually(ctx, getPodByName).
@@ -527,7 +527,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Wait for node to be ready again")
-			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
 
 			ginkgo.By("Re-Register resources and delete the plugin pod")
 			gp := int64(0)
@@ -584,7 +584,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			restartKubelet(ctx, true)
 
 			ginkgo.By("Wait for node to be ready again")
-			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
 
 			ginkgo.By("Checking the same instance of the pod is still running after kubelet restart")
 			gomega.Eventually(ctx, getPodByName).
@@ -788,167 +788,295 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 	})
 }
 
+// setupSampleDevicePluginWithRegistrationControl creates the sample device plugin pod with
+// manual registration control, triggers registration, and waits for the resource to become
+// available. Returns the device plugin pod for use in the test body and cleanup.
+func setupSampleDevicePluginWithRegistrationControl(ctx context.Context, f *framework.Framework) *v1.Pod {
+	ginkgo.By("Wait for node to be ready")
+	gomega.Eventually(ctx, e2enode.TotalReady).
+		WithArguments(f.ClientSet).
+		WithTimeout(time.Minute).
+		Should(gomega.BeEquivalentTo(1))
+
+	// Before we run the device plugin test, we need to ensure
+	// that the cluster is in a clean state and there are no
+	// pods running on this node.
+	// This is done in a gomega.Eventually with retries since a prior test in a different test suite could've run and the deletion of it's resources may still be in progress.
+	// xref: https://issue.k8s.io/115381
+	gomega.Eventually(ctx, func(ctx context.Context) error {
+		v1PodResources, err := getV1NodeDevices(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %w", err)
+		}
+
+		if len(v1PodResources.PodResources) > 0 {
+			return fmt.Errorf("expected v1 pod resources to be empty, but got non-empty resources: %+v", v1PodResources.PodResources)
+		}
+		return nil
+	}).WithTimeout(f.Timeouts.SystemDaemonsetStartup).WithPolling(f.Timeouts.Poll).Should(gomega.Succeed())
+
+	ginkgo.By("Setting up the directory for controlling registration")
+	triggerPathDir := filepath.Join(devicePluginDir, "sample")
+	if _, err := os.Stat(triggerPathDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.Mkdir(triggerPathDir, os.ModePerm); err != nil {
+				framework.Fail(fmt.Sprintf("registration control directory %q creation failed: %v ", triggerPathDir, err))
+			}
+			framework.Logf("registration control directory created successfully")
+		} else {
+			framework.Fail(fmt.Sprintf("unexpected error checking %q: %v", triggerPathDir, err))
+		}
+	} else {
+		framework.Logf("registration control directory %q already present", triggerPathDir)
+	}
+
+	ginkgo.By("Setting up the file trigger for controlling registration")
+	triggerPathFile := filepath.Join(triggerPathDir, "registration")
+	if _, err := os.Stat(triggerPathFile); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if _, err = os.Create(triggerPathFile); err != nil {
+				framework.Fail(fmt.Sprintf("registration control file %q creation failed: %v", triggerPathFile, err))
+			}
+			framework.Logf("registration control file created successfully")
+		} else {
+			framework.Fail(fmt.Sprintf("unexpected error creating %q: %v", triggerPathFile, err))
+		}
+	} else {
+		framework.Logf("registration control file %q already present", triggerPathFile)
+	}
+
+	ginkgo.By("Scheduling a sample device plugin pod")
+	data, err := e2etestfiles.Read(e2enode.SampleDevicePluginControlRegistrationDSYAML)
+	if err != nil {
+		framework.Fail(fmt.Sprintf("error reading test data %q: %v", e2enode.SampleDevicePluginControlRegistrationDSYAML, err))
+	}
+	ds := readDaemonSetV1OrDie(data)
+
+	dp := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: e2enode.SampleDevicePluginName,
+		},
+		Spec: ds.Spec.Template.Spec,
+	}
+
+	devicePluginPod := e2epod.NewPodClient(f).CreateSync(ctx, dp)
+
+	framework.Logf("Waiting for device plugin pod to be Running")
+	err = e2epod.WaitForPodCondition(ctx, f.ClientSet, devicePluginPod.Namespace, devicePluginPod.Name, "Ready", 2*time.Minute, testutils.PodRunningReady)
+	if err != nil {
+		framework.Logf("Sample Device Pod %v took too long to enter running/ready: %v", dp.Name, err)
+	}
+	framework.ExpectNoError(err, "WaitForPodCondition() failed err: %v", err)
+
+	go func() {
+		// Since autoregistration is disabled for the device plugin (as REGISTER_CONTROL_FILE
+		// environment variable is specified), device plugin registration needs to be triggerred
+		// manually.
+		// This is done by deleting the control file at the following path:
+		// `/var/lib/kubelet/device-plugins/sample/registration`.
+
+		defer ginkgo.GinkgoRecover()
+		framework.Logf("Deleting the control file: %q to trigger registration", triggerPathFile)
+		err := os.Remove(triggerPathFile)
+		framework.ExpectNoError(err)
+	}()
+
+	ginkgo.By("Waiting for devices to become available on the local node")
+	gomega.Eventually(ctx, func(ctx context.Context) bool {
+		node, ready := getLocalTestNode(ctx, f)
+		return ready && e2enode.CountSampleDeviceCapacity(node) > 0
+	}).WithTimeout(5 * time.Minute).WithPolling(framework.Poll).Should(gomega.BeTrueBecause("expected devices to be available on the local node"))
+	framework.Logf("Successfully created device plugin pod")
+
+	ginkgo.By(fmt.Sprintf("Waiting for the resource exported by the sample device plugin to become available on the local node (instances: %d)", e2enode.SampleDevsAmount))
+	gomega.Eventually(ctx, func(ctx context.Context) bool {
+		node, ready := getLocalTestNode(ctx, f)
+		return ready &&
+			e2enode.CountSampleDeviceCapacity(node) == e2enode.SampleDevsAmount &&
+			e2enode.CountSampleDeviceAllocatable(node) == e2enode.SampleDevsAmount
+	}).WithTimeout(2 * time.Minute).WithPolling(framework.Poll).Should(gomega.BeTrueBecause("expected resource exported by the sample device plugin to be available on local node"))
+
+	return devicePluginPod
+}
+
+// teardownSampleDevicePluginWithRegistrationControl deletes the device plugin pod and any
+// test pods, removes the registration control directory, and waits for the resource to
+// become unavailable.
+func teardownSampleDevicePluginWithRegistrationControl(ctx context.Context, f *framework.Framework, devicePluginPod *v1.Pod) {
+	ginkgo.By("Deleting the device plugin pod")
+	e2epod.NewPodClient(f).DeleteSync(ctx, devicePluginPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+
+	ginkgo.By("Deleting any Pods created by the test")
+	l, err := e2epod.NewPodClient(f).List(ctx, metav1.ListOptions{})
+	framework.ExpectNoError(err)
+	for _, p := range l.Items {
+		if p.Namespace != f.Namespace.Name {
+			continue
+		}
+
+		ginkgo.By("Removing the finalizer from the pod in case it was used")
+		e2epod.NewPodClient(f).RemoveFinalizer(ctx, p.Name, testFinalizer)
+
+		framework.Logf("Deleting pod: %s", p.Name)
+		e2epod.NewPodClient(f).DeleteSync(ctx, p.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+	}
+
+	triggerPathDir := filepath.Join(devicePluginDir, "sample")
+	err = os.Remove(triggerPathDir)
+	framework.ExpectNoError(err)
+
+	ginkgo.By("Waiting for devices to become unavailable on the local node")
+	gomega.Eventually(ctx, func(ctx context.Context) bool {
+		node, ready := getLocalTestNode(ctx, f)
+		return ready && e2enode.CountSampleDeviceCapacity(node) <= 0
+	}).WithTimeout(5 * time.Minute).WithPolling(framework.Poll).Should(gomega.BeTrueBecause("expected devices to be unavailable on local node"))
+
+	ginkgo.By("devices now unavailable on the local node")
+}
+
 func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 	f.Context("DevicePlugin", f.WithSerial(), f.WithDisruptive(), func() {
 		var devicePluginPod *v1.Pod
-		var v1PodResources *kubeletpodresourcesv1.ListPodResourcesResponse
-		var triggerPathFile, triggerPathDir string
-		var err error
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			ginkgo.By("Wait for node to be ready")
-			gomega.Eventually(ctx, e2enode.TotalReady).
-				WithArguments(f.ClientSet).
-				WithTimeout(time.Minute).
-				Should(gomega.BeEquivalentTo(1))
-
-			// Before we run the device plugin test, we need to ensure
-			// that the cluster is in a clean state and there are no
-			// pods running on this node.
-			// This is done in a gomega.Eventually with retries since a prior test in a different test suite could've run and the deletion of it's resources may still be in progress.
-			// xref: https://issue.k8s.io/115381
-			gomega.Eventually(ctx, func(ctx context.Context) error {
-				v1PodResources, err = getV1NodeDevices(ctx)
-				if err != nil {
-					return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %v", err)
-				}
-
-				if len(v1PodResources.PodResources) > 0 {
-					return fmt.Errorf("expected v1 pod resources to be empty, but got non-empty resources: %+v", v1PodResources.PodResources)
-				}
-				return nil
-			}, f.Timeouts.SystemDaemonsetStartup, f.Timeouts.Poll).Should(gomega.Succeed())
-
-			ginkgo.By("Setting up the directory for controlling registration")
-			triggerPathDir = filepath.Join(devicePluginDir, "sample")
-			if _, err := os.Stat(triggerPathDir); err != nil {
-				if errors.Is(err, os.ErrNotExist) {
-					if err := os.Mkdir(triggerPathDir, os.ModePerm); err != nil {
-						framework.Fail(fmt.Sprintf("registration control directory %q creation failed: %v ", triggerPathDir, err))
-					}
-					framework.Logf("registration control directory created successfully")
-				} else {
-					framework.Fail(fmt.Sprintf("unexpected error checking %q: %v", triggerPathDir, err))
-				}
-			} else {
-				framework.Logf("registration control directory %q already present", triggerPathDir)
-			}
-
-			ginkgo.By("Setting up the file trigger for controlling registration")
-			triggerPathFile = filepath.Join(triggerPathDir, "registration")
-			if _, err := os.Stat(triggerPathFile); err != nil {
-				if errors.Is(err, os.ErrNotExist) {
-					if _, err = os.Create(triggerPathFile); err != nil {
-						framework.Fail(fmt.Sprintf("registration control file %q creation failed: %v", triggerPathFile, err))
-					}
-					framework.Logf("registration control file created successfully")
-				} else {
-					framework.Fail(fmt.Sprintf("unexpected error creating %q: %v", triggerPathFile, err))
-				}
-			} else {
-				framework.Logf("registration control file %q already present", triggerPathFile)
-			}
-
-			ginkgo.By("Scheduling a sample device plugin pod")
-			data, err := e2etestfiles.Read(e2enode.SampleDevicePluginControlRegistrationDSYAML)
-			if err != nil {
-				framework.Fail(fmt.Sprintf("error reading test data %q: %v", e2enode.SampleDevicePluginControlRegistrationDSYAML, err))
-			}
-			ds := readDaemonSetV1OrDie(data)
-
-			dp := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: e2enode.SampleDevicePluginName,
-				},
-				Spec: ds.Spec.Template.Spec,
-			}
-
-			devicePluginPod = e2epod.NewPodClient(f).CreateSync(ctx, dp)
-
-			framework.Logf("Waiting for device plugin pod to be Running")
-			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, devicePluginPod.Namespace, devicePluginPod.Name, "Ready", 2*time.Minute, testutils.PodRunningReady)
-			if err != nil {
-				framework.Logf("Sample Device Pod %v took too long to enter running/ready: %v", dp.Name, err)
-			}
-			framework.ExpectNoError(err, "WaitForPodCondition() failed err: %v", err)
-
-			go func() {
-				// Since autoregistration is disabled for the device plugin (as REGISTER_CONTROL_FILE
-				// environment variable is specified), device plugin registration needs to be triggerred
-				// manually.
-				// This is done by deleting the control file at the following path:
-				// `/var/lib/kubelet/device-plugins/sample/registration`.
-
-				defer ginkgo.GinkgoRecover()
-				framework.Logf("Deleting the control file: %q to trigger registration", triggerPathFile)
-				err := os.Remove(triggerPathFile)
-				framework.ExpectNoError(err)
-			}()
-
-			ginkgo.By("Waiting for devices to become available on the local node")
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				node, ready := getLocalTestNode(ctx, f)
-				return ready && e2enode.CountSampleDeviceCapacity(node) > 0
-			}, 5*time.Minute, framework.Poll).Should(gomega.BeTrueBecause("expected devices to be available on the local node"))
-			framework.Logf("Successfully created device plugin pod")
-
-			ginkgo.By(fmt.Sprintf("Waiting for the resource exported by the sample device plugin to become available on the local node (instances: %d)", e2enode.SampleDevsAmount))
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				node, ready := getLocalTestNode(ctx, f)
-				return ready &&
-					e2enode.CountSampleDeviceCapacity(node) == e2enode.SampleDevsAmount &&
-					e2enode.CountSampleDeviceAllocatable(node) == e2enode.SampleDevsAmount
-			}, 2*time.Minute, framework.Poll).Should(gomega.BeTrueBecause("expected resource exported by the sample device plugin to be available on local node"))
+			devicePluginPod = setupSampleDevicePluginWithRegistrationControl(ctx, f)
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
-			ginkgo.By("Deleting the device plugin pod")
-			e2epod.NewPodClient(f).DeleteSync(ctx, devicePluginPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
-
-			ginkgo.By("Deleting any Pods created by the test")
-			l, err := e2epod.NewPodClient(f).List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
-			for _, p := range l.Items {
-				if p.Namespace != f.Namespace.Name {
-					continue
-				}
-
-				ginkgo.By("Removing the finalizer from the pod in case it was used")
-				e2epod.NewPodClient(f).RemoveFinalizer(context.TODO(), p.Name, testFinalizer)
-
-				framework.Logf("Deleting pod: %s", p.Name)
-				e2epod.NewPodClient(f).DeleteSync(ctx, p.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+			if devicePluginPod == nil {
+				return
 			}
-
-			err = os.Remove(triggerPathDir)
-			framework.ExpectNoError(err)
-
-			ginkgo.By("Waiting for devices to become unavailable on the local node")
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				node, ready := getLocalTestNode(ctx, f)
-				return ready && e2enode.CountSampleDeviceCapacity(node) <= 0
-			}, 5*time.Minute, framework.Poll).Should(gomega.BeTrueBecause("expected devices to be unavailable on local node"))
-
-			ginkgo.By("devices now unavailable on the local node")
+			teardownSampleDevicePluginWithRegistrationControl(ctx, f, devicePluginPod)
 		})
 
-		// simulate node reboot scenario by removing pods using CRI before kubelet is started. In addition to that,
-		// intentionally a scenario is created where after node reboot, application pods requesting devices appear before the device plugin pod
-		// exposing those devices as resource has restarted. The expected behavior is that the application pod fails at admission time.
-		framework.It("Does not keep device plugin assignments across node reboots if fails admission (no pod restart, no device plugin re-registration)", func(ctx context.Context) {
+		// Kubelet restart with all containers terminated (the checkpoint's BootID still
+		// matches the live boot_id, so detectNodeReboot returns false). The device plugin
+		// uses manual registration and is not re-triggered, so it never re-registers.
+		// Admission passes on the checkpoint's allocation; container start defers at
+		// GetDeviceRunContainerOptions until the plugin reports — the pod stays in
+		// ContainerCreating rather than going to Phase=Failed.
+		framework.It("Defers container start after kubelet restart with all containers terminated when device plugin has not re-registered", func(ctx context.Context) {
 			podRECMD := fmt.Sprintf("devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep %s", sleepIntervalForever)
-			testPod := makeBusyboxPod(e2enode.SampleDeviceResourceName, podRECMD)
-			// Set a short termination grace period to speed up the test.
-			// After kubelet restart, this pod will fail admission and need to be terminated.
-			// The default 30s grace period causes the test to timeout waiting for the pod
-			// to be filtered from the active pods list.
-			testPod.Spec.TerminationGracePeriodSeconds = ptr.To(int64(1))
-			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, testPod)
-			deviceIDRE := "stub devices: (Dev-[0-9]+)"
-			devID1, err := parseLog(ctx, f, pod1.Name, pod1.Name, deviceIDRE)
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(e2enode.SampleDeviceResourceName, podRECMD))
+			devID1, err := parseLog(ctx, f, pod1.Name, pod1.Name, "stub devices: (Dev-[0-9]+)")
 			framework.ExpectNoError(err, "getting logs for pod %q", pod1.Name)
+			gomega.Expect(devID1).NotTo(gomega.BeEmpty())
 
-			gomega.Expect(devID1).To(gomega.Not(gomega.Equal("")))
+			ginkgo.By("stopping the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+
+			removeAllPodSandboxes(ctx)
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet(ctx)
+
+			ginkgo.By("Wait for node to be ready again")
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for the pod to be deferred waiting for the device plugin to report")
+			gomega.Eventually(ctx, getPodByName).
+				WithArguments(f, pod1.Name).
+				WithTimeout(time.Minute).
+				Should(BeDeferredWaitingForDevicePlugin(),
+					"the pod should be stuck in ContainerCreating with the device-plugin defer message while the plugin has not re-registered")
+
+			ginkgo.By("Verifying the checkpoint allocation is still reported via the podresources API")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				v1PodResources, err := getV1NodeDevices(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get node devices: %w", err)
+				}
+				matchErr, _ := checkPodResourcesAssignment(v1PodResources, pod1.Namespace, pod1.Name, pod1.Spec.Containers[0].Name, e2enode.SampleDeviceResourceName, []string{devID1})
+				return matchErr
+			}).WithTimeout(time.Minute).WithPolling(framework.Poll).Should(gomega.Succeed(), "pod passed admission on its checkpoint allocation, so it should appear in podresources with the original device")
+		})
+
+		// Simulated node reboot: checkpoint BootID is rewritten to a value that does not
+		// match the live boot_id, so detectNodeReboot returns true. With nodeRebooted=true
+		// the admission bypass is disabled and devicesToAllocate falls through to the
+		// health checks, which fail (no healthy devices yet) — the existing pod terminates
+		// with UnexpectedAdmissionError. After the plugin re-registers, a freshly created
+		// pod allocates normally.
+		framework.It("Converges after a simulated node reboot: existing pod fails admission, new pod allocates once plugin re-registers", func(ctx context.Context) {
+			podRECMD := fmt.Sprintf("devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep %s", sleepIntervalForever)
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(e2enode.SampleDeviceResourceName, podRECMD))
+
+			ginkgo.By("stopping the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+
+			restore := rewriteDeviceManagerCheckpointBootID("fake-boot-id-that-does-not-match")
+			ginkgo.DeferCleanup(restore)
+
+			removeAllPodSandboxes(ctx)
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet(ctx)
+
+			ginkgo.By("Wait for node to be ready again")
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for the existing pod to fail admission")
+			gomega.Eventually(ctx, getPodByName).
+				WithArguments(f, pod1.Name).
+				WithTimeout(time.Minute).
+				Should(HaveFailedWithAdmissionError(),
+					"after a node reboot the admission bypass is disabled, so the pod should fail with UnexpectedAdmissionError")
+
+			ginkgo.By("Triggering device plugin registration and waiting for the resource to become allocatable")
+			triggerSampleDevicePluginRegistration()
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
+				node, ready := getLocalTestNode(ctx, f)
+				return ready && e2enode.CountSampleDeviceAllocatable(node) == e2enode.SampleDevsAmount
+			}).WithTimeout(2 * time.Minute).WithPolling(framework.Poll).Should(gomega.BeTrueBecause("expected sample device resource to become allocatable after plugin re-registers"))
+
+			ginkgo.By("Creating a new pod and verifying it allocates a device")
+			pod2 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(e2enode.SampleDeviceResourceName, podRECMD))
+			devID2, err := parseLog(ctx, f, pod2.Name, pod2.Name, "stub devices: (Dev-[0-9]+)")
+			framework.ExpectNoError(err, "getting logs for pod %q", pod2.Name)
+			gomega.Expect(devID2).NotTo(gomega.BeEmpty())
+		})
+
+		// Simulated node reboot, plugin never re-registers. Same setup as the recovery
+		// case above, but registration is never triggered. The pod must terminate in
+		// Phase=Failed (UnexpectedAdmissionError) and must NOT wedge in ContainerCreating
+		// — proving the boot_id gate prevents the checkpoint-trust bypass from holding a
+		// pod indefinitely on a dead node.
+		framework.It("Fails admission (does not wedge in ContainerCreating) after a simulated node reboot when the device plugin never re-registers", func(ctx context.Context) {
+			podRECMD := fmt.Sprintf("devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep %s", sleepIntervalForever)
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(e2enode.SampleDeviceResourceName, podRECMD))
+
+			ginkgo.By("stopping the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+
+			restore := rewriteDeviceManagerCheckpointBootID("fake-boot-id-that-does-not-match")
+			ginkgo.DeferCleanup(restore)
+
+			removeAllPodSandboxes(ctx)
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet(ctx)
+
+			ginkgo.By("Wait for node to be ready again")
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for the pod to fail admission")
+			gomega.Eventually(ctx, getPodByName).
+				WithArguments(f, pod1.Name).
+				WithTimeout(time.Minute).
+				Should(HaveFailedWithAdmissionError(),
+					"after a node reboot the admission bypass is disabled, so the pod must converge to Failed (not wedge in ContainerCreating)")
+		})
+
+		// Upgrade transition (kubelet-only restart): checkpoint has no BootID (older
+		// kubelet wrote it). detectNodeReboot falls back to the CRI startup snapshot;
+		// containers are still running so it treats this as a kubelet-only restart and
+		// the workload pod survives admission with its original allocation.
+		framework.It("Keeps device plugin assignments after kubelet restart when checkpoint has no BootID and containers are running (upgrade path)", func(ctx context.Context) {
+			podRECMD := fmt.Sprintf("devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep %s", sleepIntervalForever)
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(e2enode.SampleDeviceResourceName, podRECMD))
+			devID1, err := parseLog(ctx, f, pod1.Name, pod1.Name, "stub devices: (Dev-[0-9]+)")
+			framework.ExpectNoError(err, "getting logs for pod %q", pod1.Name)
+			gomega.Expect(devID1).NotTo(gomega.BeEmpty())
 
 			pod1, err = e2epod.NewPodClient(f).Get(ctx, pod1.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
@@ -956,56 +1084,155 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			ginkgo.By("stopping the kubelet")
 			restartKubelet := mustStopKubelet(ctx, f)
 
-			ginkgo.By("stopping all the local containers - using CRI")
-			rs, _, err := getCRIClient(ctx)
-			framework.ExpectNoError(err)
-			sandboxes, err := rs.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{})
-			framework.ExpectNoError(err)
-			for _, sandbox := range sandboxes {
-				gomega.Expect(sandbox.Metadata).ToNot(gomega.BeNil())
-				ginkgo.By(fmt.Sprintf("deleting pod using CRI: %s/%s -> %s", sandbox.Metadata.Namespace, sandbox.Metadata.Name, sandbox.Id))
-
-				err := rs.RemovePodSandbox(ctx, sandbox.Id)
-				framework.ExpectNoError(err)
-			}
+			restore := rewriteDeviceManagerCheckpointBootID("")
+			ginkgo.DeferCleanup(restore)
 
 			ginkgo.By("restarting the kubelet")
 			restartKubelet(ctx)
 
 			ginkgo.By("Wait for node to be ready again")
-			e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
 
-			ginkgo.By("Waiting for the pod to fail with admission error as device plugin hasn't re-registered yet")
-			gomega.Eventually(ctx, getPod).
+			ginkgo.By("Confirming the workload pod survives with its original allocation")
+			gomega.Consistently(ctx, getPodByName).
+				WithArguments(f, pod1.Name).
+				WithTimeout(30*time.Second).
+				Should(BeTheSamePodStillRunning(pod1),
+					"with no BootID and containers still running, CRI fallback should treat this as a kubelet-only restart")
+
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				v1PodResources, err := getV1NodeDevices(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get node devices: %w", err)
+				}
+				matchErr, _ := checkPodResourcesAssignment(v1PodResources, pod1.Namespace, pod1.Name, pod1.Spec.Containers[0].Name, e2enode.SampleDeviceResourceName, []string{devID1})
+				return matchErr
+			}).WithTimeout(time.Minute).WithPolling(framework.Poll).Should(gomega.Succeed())
+		})
+
+		// Upgrade transition coinciding with reboot: checkpoint has no BootID and no
+		// containers are running. detectNodeReboot's CRI fallback treats this as a
+		// reboot, the bypass is disabled, and the pod fails admission (matching the
+		// pre-existing reboot path).
+		framework.It("Fails admission after kubelet restart when checkpoint has no BootID and no containers are running (upgrade-at-reboot path)", func(ctx context.Context) {
+			podRECMD := fmt.Sprintf("devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep %s", sleepIntervalForever)
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, makeBusyboxPod(e2enode.SampleDeviceResourceName, podRECMD))
+
+			ginkgo.By("stopping the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+
+			restore := rewriteDeviceManagerCheckpointBootID("")
+			ginkgo.DeferCleanup(restore)
+
+			removeAllPodSandboxes(ctx)
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet(ctx)
+
+			ginkgo.By("Wait for node to be ready again")
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for the pod to fail admission")
+			gomega.Eventually(ctx, getPodByName).
 				WithArguments(f, pod1.Name).
 				WithTimeout(time.Minute).
 				Should(HaveFailedWithAdmissionError(),
-					"the pod succeeded to start, when it should fail with the admission error")
+					"with no BootID and no running containers, CRI fallback should treat this as a reboot")
+		})
 
-			// crosscheck from the device assignment is preserved and stable from perspective of the kubelet.
-			// note we don't check again the logs of the container: the check is done at startup, the container
-			// never restarted (runs "forever" from this test timescale perspective) hence re-doing this check
-			// is useless.
-			ginkgo.By("Verifying the device assignment after kubelet restart using podresources API")
+		// Mechanism sanity: the device manager checkpoint records the kernel boot_id.
+		// Read the on-disk checkpoint and compare to /proc/sys/kernel/random/boot_id.
+		framework.It("Persists the kernel boot_id into the device manager checkpoint", func(ctx context.Context) {
+			expected, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+			framework.ExpectNoError(err)
+			expectedBootID := strings.TrimSpace(string(expected))
+			gomega.Expect(expectedBootID).NotTo(gomega.BeEmpty())
 
-			// if we got this far, podresources API will now report only the sample device plugin pod,
-			// because pods that failed admission are no longer reported in the list
-			// (see https://github.com/kubernetes/kubernetes/pull/132028).
-			// Hence, we verify that our test pod is NOT present in the podresources response.
+			ginkgo.By("Reading the device manager checkpoint and comparing BootID")
+			gomega.Eventually(ctx, readDeviceManagerCheckpointBootID).
+				WithTimeout(time.Minute).WithPolling(framework.Poll).
+				Should(gomega.Equal(expectedBootID),
+					"device manager checkpoint should record the live kernel boot_id")
 
-			// We need to poll because there's a delay between the pod failing admission and being
-			// removed from the podresources list.
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				v1PodResources, err := getV1NodeDevices(ctx)
-				if err != nil {
-					framework.Logf("Failed to get node devices: %v, will retry", err)
-					return true // Return true to continue polling on error
-				}
-				_, found := checkPodResourcesAssignment(v1PodResources, pod1.Namespace, pod1.Name, pod1.Spec.Containers[0].Name, e2enode.SampleDeviceResourceName, []string{})
-				return found
-			}, 30*time.Second, framework.Poll).Should(gomega.BeFalseBecause("%s/%s/%s failed admission, so it must not appear in podresources list", pod1.Namespace, pod1.Name, pod1.Spec.Containers[0].Name))
+			ginkgo.By("Restarting the kubelet and confirming BootID persists")
+			restartKubelet := mustStopKubelet(ctx, f)
+			restartKubelet(ctx)
+			gomega.Expect(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 5*time.Minute)).To(gomega.Succeed())
+
+			gomega.Eventually(ctx, readDeviceManagerCheckpointBootID).
+				WithTimeout(time.Minute).WithPolling(framework.Poll).
+				Should(gomega.Equal(expectedBootID),
+					"device manager checkpoint BootID should persist across kubelet restart")
 		})
 	})
+}
+
+// removeAllPodSandboxes removes every pod sandbox known to the CRI. Combined with
+// a kubelet restart this approximates a node reboot from the kubelet's perspective:
+// all containers are gone, but the on-disk checkpoint survives.
+func removeAllPodSandboxes(ctx context.Context) {
+	ginkgo.By("stopping all the local containers - using CRI")
+	rs, _, err := getCRIClient(ctx)
+	framework.ExpectNoError(err)
+	sandboxes, err := rs.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{})
+	framework.ExpectNoError(err)
+	for _, sandbox := range sandboxes {
+		gomega.Expect(sandbox.Metadata).ToNot(gomega.BeNil())
+		ginkgo.By(fmt.Sprintf("deleting pod using CRI: %s/%s -> %s", sandbox.Metadata.Namespace, sandbox.Metadata.Name, sandbox.Id))
+		framework.ExpectNoError(rs.RemovePodSandbox(ctx, sandbox.Id))
+	}
+}
+
+// triggerSampleDevicePluginRegistration creates and immediately removes the
+// registration control file so the sample-device-plugin's fsnotify watcher
+// observes a Remove event and registers with the kubelet.
+func triggerSampleDevicePluginRegistration() {
+	path := filepath.Join(devicePluginDir, "sample", "registration")
+	f, err := os.Create(path)
+	framework.ExpectNoError(err, "creating registration control file %q", path)
+	framework.ExpectNoError(f.Close())
+	framework.ExpectNoError(os.Remove(path), "removing registration control file %q", path)
+}
+
+func deviceManagerCheckpointPath() string {
+	return filepath.Join(devicePluginDir, "kubelet_internal_checkpoint")
+}
+
+// rewriteDeviceManagerCheckpointBootID rewrites the BootID field in the on-disk
+// device manager checkpoint and returns a function that restores the original
+// bytes. Passing "" deletes the key. The BootID field lives outside the
+// checksummed Data payload, so editing it does not invalidate the checksum.
+func rewriteDeviceManagerCheckpointBootID(newBootID string) func() {
+	path := deviceManagerCheckpointPath()
+	original, err := os.ReadFile(path)
+	framework.ExpectNoError(err, "reading device manager checkpoint %q", path)
+	var cp map[string]any
+	framework.ExpectNoError(json.Unmarshal(original, &cp), "unmarshalling device manager checkpoint")
+	if newBootID == "" {
+		delete(cp, "BootID")
+	} else {
+		cp["BootID"] = newBootID
+	}
+	rewritten, err := json.Marshal(cp)
+	framework.ExpectNoError(err, "marshalling device manager checkpoint")
+	framework.ExpectNoError(os.WriteFile(path, rewritten, 0600), "writing device manager checkpoint %q", path)
+	ginkgo.By(fmt.Sprintf("rewrote device manager checkpoint BootID to %q", newBootID))
+	return func() {
+		framework.ExpectNoError(os.WriteFile(path, original, 0600), "restoring device manager checkpoint %q", path)
+	}
+}
+
+// readDeviceManagerCheckpointBootID returns the BootID field from the on-disk
+// device manager checkpoint, or "" if the field is absent.
+func readDeviceManagerCheckpointBootID() string {
+	raw, err := os.ReadFile(deviceManagerCheckpointPath())
+	framework.ExpectNoError(err, "reading device manager checkpoint")
+	var cp map[string]any
+	framework.ExpectNoError(json.Unmarshal(raw, &cp), "unmarshalling device manager checkpoint")
+	if v, ok := cp["BootID"].(string); ok {
+		return v
+	}
+	return ""
 }
 
 // makeBusyboxPod returns a simple Pod spec with a busybox container


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/priority important-soon
/area kubelet

#### What this PR does / why we need it:

The scenario-2 bypass in `devicesToAllocate` gates on
`isContainerAlreadyRunning`, which depends on a one-shot CRI snapshot taken
at `containerManager.Start()`. That snapshot is fragile — three distinct
failure modes have been observed, all causing running pods with valid
checkpoint allocations to be rejected with `UnexpectedAdmissionError`:

1. **CRI errors silently discarded** (#118559):
   `buildContainerMapAndRunningSetFromRuntime` discards
   `ListPodSandbox`/`ListContainers` errors via blank identifier. A
   transient CRI failure during kubelet restart leaves
   `containerRunningSet` empty. The code comment at the bypass says
   "This scenario should however be rare enough."

2. **Fresh-pod-during-restart race**: A pod scheduled to the old kubelet
   seconds before restart has its device allocation checkpointed at
   admission time, but volume mounts and container creation may still be
   in progress. After restart, the checkpoint has `devices != nil` but
   the container doesn't exist in CRI. `isContainerAlreadyRunning`
   returns false.

3. **Map-iteration nondeterminism**: A container that restarted before
   kubelet restart leaves both exited and running IDs in `containerMap`.
   Go map iteration is randomized; the lookup may pick the exited one.
   #135485 addressed this by iterating all entries, but the underlying
   snapshot dependency remains.

This PR removes the CRI-snapshot dependency. The bypass now gates on:
- `!pluginReportedSet.Has(resource)` — has the plugin sent a
  `ListAndWatch` response since this kubelet started?
- `devices != nil` — does the checkpoint have a prior allocation?

Both are state kubelet controls end-to-end. If the checkpoint has an
allocation and the plugin hasn't reported yet, trust the checkpoint.

To preserve the #109595 invariant that containers don't start with stale
device mounts, `GetDeviceRunContainerOptions` defers container start
until the plugin reports. Admission passes; container creation blocks.
The pod stays in `ContainerCreating` (retryable by controllers) rather
than `Phase=Failed` (terminal). This also addresses #125579.

`isContainerAlreadyRunning` and the `containerMap`/`containerRunningSet`
fields are removed as dead code.

#### Which issue(s) this PR is related to:

Fixes #118559
Fixes #125579

#### Special notes for your reviewer:

The e2e test uses the CRI proxy to inject
`ListPodSandbox`/`ListContainers` failures during a 2-second window
after kubelet restart (covering GC, stats init, and the
`containerManager` snapshot). On master the pod is evicted with
`UnexpectedAdmissionError`; with this fix it survives. Verified fail→pass
on `cos-beta-129-19506-0-66` with `--cri-proxy-enabled=true`.

The behavior change vs #109595: previously a pod that couldn't be
verified-running would fail admission. Now it passes admission and
blocks at container-start until the plugin reports. This is strictly
better for controller-managed workloads (retryable rather than terminal)
but does mean a pod can stay in `ContainerCreating` indefinitely if the
plugin never comes back — which is arguably correct, since the node is
unschedulable for that resource anyway.

#### Does this PR introduce a user-facing change?

```release-note
Fixed device-plugin pods being evicted with UnexpectedAdmissionError on
kubelet restart when the CRI snapshot at startup is incomplete. Pods
with a valid checkpoint allocation now survive kubelet restart
regardless of CRI snapshot state, and node-reboot admission failures
are now retryable (ContainerCreating) rather than terminal (Failed).
```
