### PR TITLE
fix duplicate metric collection error in kubelet's custom collector

### DIFF
--- a/pkg/kubelet/metrics/collectors/log_metrics.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics.go
@@ -39,6 +39,10 @@ var (
 	)
 )
 
+type containerKey struct {
+	uid, namespace, pod, container string
+}
+
 type logMetricsCollector struct {
 	metrics.BaseStableCollector
 
@@ -73,9 +77,15 @@ func (c *logMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
 		return
 	}
 
+	seen := make(map[containerKey]bool)
 	for _, ps := range podStats {
 		for _, c := range ps.Containers {
 			if c.Logs != nil && c.Logs.UsedBytes != nil {
+				key := containerKey{ps.PodRef.UID, ps.PodRef.Namespace, ps.PodRef.Name, c.Name}
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
 				ch <- metrics.NewLazyConstMetric(
 					descLogSize,
 					metrics.GaugeValue,

--- a/pkg/kubelet/metrics/collectors/log_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics_test.go
@@ -41,13 +41,17 @@ func TestNoMetricsCollected(t *testing.T) {
 }
 
 func TestMetricsCollected(t *testing.T) {
-	// Refresh Desc to share with different registry
-	descLogSize = descLogSize.GetRawDesc()
+	size18 := uint64(18)
+	size8192 := uint64(8192)
 
-	size := uint64(18)
-	collector := &logMetricsCollector{
-		podStats: func(_ context.Context) ([]statsapi.PodStats, error) {
-			return []statsapi.PodStats{
+	tests := []struct {
+		name     string
+		pods     []statsapi.PodStats
+		expected string
+	}{
+		{
+			name: "single container",
+			pods: []statsapi.PodStats{
 				{
 					PodRef: statsapi.PodReference{
 						Namespace: "some-namespace",
@@ -58,21 +62,65 @@ func TestMetricsCollected(t *testing.T) {
 						{
 							Name: "containerName1",
 							Logs: &statsapi.FsStats{
-								UsedBytes: &size,
+								UsedBytes: &size18,
 							},
 						},
 					},
 				},
-			}, nil
+			},
+			expected: `
+				# HELP kubelet_container_log_filesystem_used_bytes [ALPHA] Bytes used by the container's logs on the filesystem.
+				# TYPE kubelet_container_log_filesystem_used_bytes gauge
+				kubelet_container_log_filesystem_used_bytes{container="containerName1",namespace="some-namespace",pod="podName1",uid="UID_some_id"} 18
+`,
+		},
+		{
+			name: "duplicate container stats are deduped",
+			pods: []statsapi.PodStats{
+				{
+					PodRef: statsapi.PodReference{
+						Namespace: "kubemark",
+						Name:      "hollow-node-jlglr",
+						UID:       "d43e3a5a-40c3-427c-b3b9-69a3aab282dd",
+					},
+					Containers: []statsapi.ContainerStats{
+						{
+							Name: "hollow-proxy",
+							Logs: &statsapi.FsStats{
+								UsedBytes: &size8192,
+							},
+						},
+						{
+							Name: "hollow-proxy",
+							Logs: &statsapi.FsStats{
+								UsedBytes: &size8192,
+							},
+						},
+					},
+				},
+			},
+			expected: `
+				# HELP kubelet_container_log_filesystem_used_bytes [ALPHA] Bytes used by the container's logs on the filesystem.
+				# TYPE kubelet_container_log_filesystem_used_bytes gauge
+				kubelet_container_log_filesystem_used_bytes{container="hollow-proxy",namespace="kubemark",pod="hollow-node-jlglr",uid="d43e3a5a-40c3-427c-b3b9-69a3aab282dd"} 8192
+`,
 		},
 	}
 
-	err := testutil.CustomCollectAndCompare(collector, strings.NewReader(`
-		# HELP kubelet_container_log_filesystem_used_bytes [ALPHA] Bytes used by the container's logs on the filesystem.
-		# TYPE kubelet_container_log_filesystem_used_bytes gauge
-		kubelet_container_log_filesystem_used_bytes{container="containerName1",namespace="some-namespace",pod="podName1",uid="UID_some_id"} 18
-`), "kubelet_container_log_filesystem_used_bytes")
-	if err != nil {
-		t.Fatal(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Refresh Desc to share with different registry
+			descLogSize = descLogSize.GetRawDesc()
+
+			collector := &logMetricsCollector{
+				podStats: func(_ context.Context) ([]statsapi.PodStats, error) {
+					return tt.pods, nil
+				},
+			}
+
+			if err := testutil.CustomCollectAndCompare(collector, strings.NewReader(tt.expected), "kubelet_container_log_filesystem_used_bytes"); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Deduplicate metrics in custom collector by tracking seen (uid, namespace, pod, container) tuples before emitting metrics. The stats provider could return duplicate container entries for the same pod, causing prometheus to reject the scrape with "was collected before with the same name and label values" errors.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Issue: https://github.com/kubernetes/kubernetes/issues/137724

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
