### PR TITLE
kubelet: tolerate user namespace length mismatch to prevent crash on idsPerPod change

### DIFF
--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -240,7 +240,12 @@ func (m *UsernsManager) allocateOne(logger klog.Logger, pod types.UID) (firstID 
 // record stores the user namespace [from; from+length] to the specified pod.
 func (m *UsernsManager) record(logger klog.Logger, pod types.UID, from, length uint32) (err error) {
 	if length != m.userNsLength {
-		return fmt.Errorf("wrong user namespace length %v", length)
+		logger.V(2).Info(
+			"user namespace length mismatch, tolerating existing pod",
+			"podUID", pod,
+			"foundLength", length,
+			"expectedLength", m.userNsLength,
+		)
 	}
 	if from%m.userNsLength != 0 {
 		return fmt.Errorf("wrong user namespace offset specified %v", from)

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /*
 Copyright 2022 The Kubernetes Authors.
 

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 /*
 Copyright 2022 The Kubernetes Authors.
 
@@ -528,4 +526,23 @@ func TestRecordBounds(t *testing.T) {
 	err = m.record(logger, types.UID(fmt.Sprintf("%d", 2)), uint32(2*65536), 65536)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "out of range")
+}
+
+func TestRecord_ToleratesLengthMismatch(t *testing.T) {
+	logger := klog.Background()
+
+	m := &UsernsManager{
+		userNsLength: 65536,
+		usedBy:       make(map[types.UID]uint32),
+		len:          10,
+		off:          0,
+	}
+
+	pod := types.UID("test-pod")
+
+	err := m.record(logger, pod, 0, 131072)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 }


### PR DESCRIPTION
## What this PR does

Fixes a kubelet crash that occurs when `userNamespaces.idsPerPod` is changed and
existing pod user namespace mappings on disk were created with a different value.

Currently, during kubelet startup, existing pod mappings are read from disk and
validated in `UsernsManager.record()`. The code enforces a strict equality check:

    if length != m.userNsLength {
        return fmt.Errorf(...)
    }

This causes kubelet to fail to start if any existing pod directory contains a
mapping created with a previous `idsPerPod` value.

This PR relaxes the validation by logging a warning instead of returning an error
when a mismatch is detected. This allows kubelet to start successfully while
remaining backward-compatible with existing on-disk state.

## Why is this needed

Kubelet configuration (such as `idsPerPod`) may change across restarts, while pod
directories may still exist on disk. The current strict check makes kubelet
unnecessarily fragile and unable to recover from such configuration changes.

## Fix

- Replace strict equality check with a warning log
- Allow kubelet to continue startup when encountering mismatched user namespace lengths

## Testing

- Verified logic via unit-level validation
- Relies on existing e2e test:
  `[sig-node] user namespaces kubeconfig tests`
- Full validation expected via CI (Linux-only behavior)

## Issue

Fixes #137912

/sig node
/kind bug