### PR TITLE
Add tests for minimum with required and optional

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc.go
@@ -68,6 +68,12 @@ type OptionalStruct struct {
 	// +k8s:optional
 	// +k8s:minimum=1
 	OptionalIntPtrField *int `json:"optionalIntPtrField"`
+
+	// +k8s:optional
+	OptionalTypedefField IntType `json:"optionalTypedefField"`
+
+	// +k8s:optional
+	OptionalTypedefPtrField *IntType `json:"optionalTypedefPtrField"`
 }
 
 type RequiredStruct struct {
@@ -80,6 +86,12 @@ type RequiredStruct struct {
 	// +k8s:required
 	// +k8s:minimum=1
 	RequiredIntPtrField *int `json:"requiredIntPtrField"`
+
+	// +k8s:required
+	RequiredTypedefField IntType `json:"requiredTypedefField"`
+
+	// +k8s:required
+	RequiredTypedefPtrField *IntType `json:"requiredTypedefPtrField"`
 }
 
 type NegativeMinimumStruct struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc.go
@@ -25,7 +25,7 @@ import "k8s.io/code-generator/cmd/validation-gen/testscheme"
 
 var localSchemeBuilder = testscheme.New()
 
-type Struct struct {
+type BasicStruct struct {
 	TypeMeta int
 
 	// +k8s:minimum=1
@@ -56,6 +56,56 @@ type Struct struct {
 
 	TypedefField    IntType  `json:"typedefField"`
 	TypedefPtrField *IntType `json:"typedefPtrField"`
+}
+
+type OptionalStruct struct {
+	TypeMeta int
+
+	// +k8s:optional
+	// +k8s:minimum=1
+	OptionalIntField int `json:"optionalIntField"`
+
+	// +k8s:optional
+	// +k8s:minimum=1
+	OptionalIntPtrField *int `json:"optionalIntPtrField"`
+}
+
+type RequiredStruct struct {
+	TypeMeta int
+
+	// +k8s:required
+	// +k8s:minimum=1
+	RequiredIntField int `json:"requiredIntField"`
+
+	// +k8s:required
+	// +k8s:minimum=1
+	RequiredIntPtrField *int `json:"requiredIntPtrField"`
+}
+
+type NegativeMinimumStruct struct {
+	TypeMeta int
+
+	// +k8s:minimum=-10
+	NegativeMinimumField int `json:"negativeMinimumField"`
+
+	// +k8s:minimum=-10
+	NegativeMinimumPtrField *int `json:"negativeMinimumPtrField"`
+
+	// +k8s:optional
+	// +k8s:minimum=-10
+	OptionalNegativeMinimumField int `json:"optionalNegativeMinimumField"`
+
+	// +k8s:optional
+	// +k8s:minimum=-10
+	OptionalNegativeMinimumPtrField *int `json:"optionalNegativeMinimumPtrField"`
+
+	// +k8s:required
+	// +k8s:minimum=-10
+	RequiredNegativeMinimumField int `json:"requiredNegativeMinimumField"`
+
+	// +k8s:required
+	// +k8s:minimum=-10
+	RequiredNegativeMinimumPtrField *int `json:"requiredNegativeMinimumPtrField"`
 }
 
 // +k8s:minimum=1

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
@@ -23,40 +23,41 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func Test(t *testing.T) {
+func TestBasicStruct(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
-	st.Value(&Struct{
+	st.Value(&BasicStruct{
 		// all zero values
 		IntPtrField:     ptr.To(0),
 		UintPtrField:    ptr.To(uint(0)),
 		TypedefPtrField: ptr.To(IntType(0)),
-	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring(), field.ErrorList{
-		field.Invalid(field.NewPath("intField"), nil, ""),
-		field.Invalid(field.NewPath("intPtrField"), nil, ""),
-		field.Invalid(field.NewPath("int16Field"), nil, ""),
-		field.Invalid(field.NewPath("int32Field"), nil, ""),
-		field.Invalid(field.NewPath("int64Field"), nil, ""),
-		field.Invalid(field.NewPath("uintField"), nil, ""),
-		field.Invalid(field.NewPath("uintPtrField"), nil, ""),
-		field.Invalid(field.NewPath("uint16Field"), nil, ""),
-		field.Invalid(field.NewPath("uint32Field"), nil, ""),
-		field.Invalid(field.NewPath("uint64Field"), nil, ""),
-		field.Invalid(field.NewPath("typedefField"), nil, ""),
-		field.Invalid(field.NewPath("typedefPtrField"), nil, ""),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("intField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("intPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("int16Field"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("int32Field"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("int64Field"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("uintField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("uintPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("uint16Field"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("uint32Field"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("uint64Field"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("typedefField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("typedefPtrField"), nil, "").WithOrigin("minimum"),
 	})
+
 	// Test validation ratcheting
-	st.Value(&Struct{
+	st.Value(&BasicStruct{
 		IntPtrField:     ptr.To(0),
 		UintPtrField:    ptr.To(uint(0)),
 		TypedefPtrField: ptr.To(IntType(0)),
-	}).OldValue(&Struct{
+	}).OldValue(&BasicStruct{
 		IntPtrField:     ptr.To(0),
 		UintPtrField:    ptr.To(uint(0)),
 		TypedefPtrField: ptr.To(IntType(0)),
 	}).ExpectValid()
 
-	st.Value(&Struct{
+	st.Value(&BasicStruct{
 		IntField:        1,
 		IntPtrField:     ptr.To(1),
 		Int16Field:      1,
@@ -70,4 +71,101 @@ func Test(t *testing.T) {
 		TypedefField:    IntType(1),
 		TypedefPtrField: ptr.To(IntType(1)),
 	}).ExpectValid()
+}
+
+func TestOptionalStruct(t *testing.T) {
+	st := localSchemeBuilder.Test(t)
+
+	st.Value(&OptionalStruct{
+		// zero values
+		OptionalIntPtrField: ptr.To(0),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("optionalIntPtrField"), nil, "").WithOrigin("minimum"),
+	})
+
+	st.Value(&OptionalStruct{
+		OptionalIntField:    1,
+		OptionalIntPtrField: ptr.To(1),
+	}).ExpectValid()
+
+	st.Value(&OptionalStruct{
+		OptionalIntField:    -1,
+		OptionalIntPtrField: ptr.To(-1),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("optionalIntField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalIntPtrField"), nil, "").WithOrigin("minimum"),
+	})
+}
+
+func TestRequiredStruct(t *testing.T) {
+	st := localSchemeBuilder.Test(t)
+
+	st.Value(&RequiredStruct{
+		// zero values
+		RequiredIntField:    0,
+		RequiredIntPtrField: ptr.To(0),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Required(field.NewPath("requiredIntField"), ""),
+		field.Invalid(field.NewPath("requiredIntPtrField"), nil, "").WithOrigin("minimum"),
+	})
+
+	st.Value(&RequiredStruct{
+		RequiredIntField:    0,
+		RequiredIntPtrField: ptr.To(0),
+	}).OldValue(&RequiredStruct{
+		RequiredIntField:    0,
+		RequiredIntPtrField: ptr.To(0),
+	}).ExpectValid()
+
+	st.Value(&RequiredStruct{
+		RequiredIntField:    1,
+		RequiredIntPtrField: ptr.To(1),
+	}).ExpectValid()
+
+	st.Value(&RequiredStruct{
+		RequiredIntField:    -1,
+		RequiredIntPtrField: ptr.To(-1),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("requiredIntField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredIntPtrField"), nil, "").WithOrigin("minimum"),
+	})
+}
+
+func TestNegativeMinimumStruct(t *testing.T) {
+	st := localSchemeBuilder.Test(t)
+
+	st.Value(&NegativeMinimumStruct{
+		// zero values (valid for -10)
+		NegativeMinimumPtrField:         ptr.To(0),
+		OptionalNegativeMinimumPtrField: ptr.To(0),
+		RequiredNegativeMinimumField:    0,
+		RequiredNegativeMinimumPtrField: ptr.To(0),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Required(field.NewPath("requiredNegativeMinimumField"), ""),
+	})
+
+	st.Value(&NegativeMinimumStruct{
+		NegativeMinimumField:            -10,
+		NegativeMinimumPtrField:         ptr.To(-10),
+		OptionalNegativeMinimumField:    -10,
+		OptionalNegativeMinimumPtrField: ptr.To(-10),
+		RequiredNegativeMinimumField:    -10,
+		RequiredNegativeMinimumPtrField: ptr.To(-10),
+	}).ExpectValid()
+
+	st.Value(&NegativeMinimumStruct{
+		NegativeMinimumField:            -11,
+		NegativeMinimumPtrField:         ptr.To(-11),
+		OptionalNegativeMinimumField:    -11,
+		OptionalNegativeMinimumPtrField: ptr.To(-11),
+		RequiredNegativeMinimumField:    -11,
+		RequiredNegativeMinimumPtrField: ptr.To(-11),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("negativeMinimumField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("negativeMinimumPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalNegativeMinimumField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalNegativeMinimumPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredNegativeMinimumField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredNegativeMinimumPtrField"), nil, "").WithOrigin("minimum"),
+	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
@@ -26,6 +26,7 @@ import (
 func TestBasicStruct(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
+	// Test that zero values are rejected because they are below the minimum of 1.
 	st.Value(&BasicStruct{
 		// all zero values
 		IntPtrField:     ptr.To(0),
@@ -46,7 +47,7 @@ func TestBasicStruct(t *testing.T) {
 		field.Invalid(field.NewPath("typedefPtrField"), nil, "").WithOrigin("minimum"),
 	})
 
-	// Test validation ratcheting
+	// Test validation ratcheting: unchanged invalid data is allowed.
 	st.Value(&BasicStruct{
 		IntPtrField:     ptr.To(0),
 		UintPtrField:    ptr.To(uint(0)),
@@ -57,6 +58,34 @@ func TestBasicStruct(t *testing.T) {
 		TypedefPtrField: ptr.To(IntType(0)),
 	}).ExpectValid()
 
+	// Changed invalid data is still rejected.
+	st.Value(&BasicStruct{
+		IntField:        -1,
+		IntPtrField:     ptr.To(-1),
+		Int16Field:      -1,
+		Int32Field:      -1,
+		Int64Field:      -1,
+		TypedefField:    IntType(-1),
+		TypedefPtrField: ptr.To(IntType(-1)),
+	}).OldValue(&BasicStruct{
+		IntField:        0,
+		IntPtrField:     ptr.To(0),
+		Int16Field:      0,
+		Int32Field:      0,
+		Int64Field:      0,
+		TypedefField:    IntType(0),
+		TypedefPtrField: ptr.To(IntType(0)),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("intField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("intPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("int16Field"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("int32Field"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("int64Field"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("typedefField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("typedefPtrField"), nil, "").WithOrigin("minimum"),
+	})
+
+	// Test that values meeting the minimum of 1 are valid.
 	st.Value(&BasicStruct{
 		IntField:        1,
 		IntPtrField:     ptr.To(1),
@@ -76,64 +105,161 @@ func TestBasicStruct(t *testing.T) {
 func TestOptionalStruct(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
+	// Test that explicitly provided zero values for optional pointers are still validated against minimum.
 	st.Value(&OptionalStruct{
 		// zero values
-		OptionalIntPtrField: ptr.To(0),
+		OptionalIntPtrField:     ptr.To(0),
+		OptionalTypedefPtrField: ptr.To(IntType(0)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("optionalIntPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalTypedefPtrField"), nil, "").WithOrigin("minimum"),
 	})
 
+	// Test that omitting an optional pointer field (nil) short-circuits minimum validation.
 	st.Value(&OptionalStruct{
-		OptionalIntField:    1,
-		OptionalIntPtrField: ptr.To(1),
+		// OptionalIntField is zero and OptionalIntPtrField is nil, so optional
+		// short-circuits before minimum runs.
 	}).ExpectValid()
 
+	// Test validation ratcheting: unchanged invalid data is allowed.
 	st.Value(&OptionalStruct{
-		OptionalIntField:    -1,
-		OptionalIntPtrField: ptr.To(-1),
+		OptionalIntField:        -1,
+		OptionalIntPtrField:     ptr.To(-1),
+		OptionalTypedefField:    IntType(-1),
+		OptionalTypedefPtrField: ptr.To(IntType(-1)),
+	}).OldValue(&OptionalStruct{
+		OptionalIntField:        -1,
+		OptionalIntPtrField:     ptr.To(-1),
+		OptionalTypedefField:    IntType(-1),
+		OptionalTypedefPtrField: ptr.To(IntType(-1)),
+	}).ExpectValid()
+
+	// Changed invalid data is still rejected.
+	st.Value(&OptionalStruct{
+		OptionalIntField:        -2,
+		OptionalIntPtrField:     ptr.To(-2),
+		OptionalTypedefField:    IntType(-2),
+		OptionalTypedefPtrField: ptr.To(IntType(-2)),
+	}).OldValue(&OptionalStruct{
+		OptionalIntField:        -1,
+		OptionalIntPtrField:     ptr.To(-1),
+		OptionalTypedefField:    IntType(-1),
+		OptionalTypedefPtrField: ptr.To(IntType(-1)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("optionalIntField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("optionalIntPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalTypedefField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalTypedefPtrField"), nil, "").WithOrigin("minimum"),
+	})
+
+	// Test that values meeting the minimum of 1 are valid.
+	st.Value(&OptionalStruct{
+		OptionalIntField:        1,
+		OptionalIntPtrField:     ptr.To(1),
+		OptionalTypedefField:    IntType(1),
+		OptionalTypedefPtrField: ptr.To(IntType(1)),
+	}).ExpectValid()
+
+	// Test that invalid values below the minimum are rejected.
+	st.Value(&OptionalStruct{
+		OptionalIntField:        -1,
+		OptionalIntPtrField:     ptr.To(-1),
+		OptionalTypedefField:    IntType(-1),
+		OptionalTypedefPtrField: ptr.To(IntType(-1)),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("optionalIntField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalIntPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalTypedefField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalTypedefPtrField"), nil, "").WithOrigin("minimum"),
 	})
 }
 
 func TestRequiredStruct(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
+	// Test that explicitly provided zero values for pointers are validated against minimum,
+	// while zero values for non-pointers trigger required validation.
 	st.Value(&RequiredStruct{
 		// zero values
-		RequiredIntField:    0,
-		RequiredIntPtrField: ptr.To(0),
+		RequiredIntField:        0,
+		RequiredIntPtrField:     ptr.To(0),
+		RequiredTypedefField:    IntType(0),
+		RequiredTypedefPtrField: ptr.To(IntType(0)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Required(field.NewPath("requiredIntField"), ""),
 		field.Invalid(field.NewPath("requiredIntPtrField"), nil, "").WithOrigin("minimum"),
+		field.Required(field.NewPath("requiredTypedefField"), ""),
+		field.Invalid(field.NewPath("requiredTypedefPtrField"), nil, "").WithOrigin("minimum"),
 	})
 
+	// Test that omitted required pointer fields (nil) emit field.Required and short-circuit minimum validation.
 	st.Value(&RequiredStruct{
-		RequiredIntField:    0,
-		RequiredIntPtrField: ptr.To(0),
+		// RequiredIntField is zero and RequiredIntPtrField is nil.
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Required(field.NewPath("requiredIntField"), ""),
+		field.Required(field.NewPath("requiredIntPtrField"), ""),
+		field.Required(field.NewPath("requiredTypedefField"), ""),
+		field.Required(field.NewPath("requiredTypedefPtrField"), ""),
+	})
+
+	// Test validation ratcheting: unchanged invalid data is allowed.
+	st.Value(&RequiredStruct{
+		RequiredIntField:        0,
+		RequiredIntPtrField:     ptr.To(0),
+		RequiredTypedefField:    IntType(0),
+		RequiredTypedefPtrField: ptr.To(IntType(0)),
 	}).OldValue(&RequiredStruct{
-		RequiredIntField:    0,
-		RequiredIntPtrField: ptr.To(0),
+		RequiredIntField:        0,
+		RequiredIntPtrField:     ptr.To(0),
+		RequiredTypedefField:    IntType(0),
+		RequiredTypedefPtrField: ptr.To(IntType(0)),
 	}).ExpectValid()
 
+	// Changed invalid data is still rejected.
 	st.Value(&RequiredStruct{
-		RequiredIntField:    1,
-		RequiredIntPtrField: ptr.To(1),
-	}).ExpectValid()
-
-	st.Value(&RequiredStruct{
-		RequiredIntField:    -1,
-		RequiredIntPtrField: ptr.To(-1),
+		RequiredIntField:        -1,
+		RequiredIntPtrField:     ptr.To(-1),
+		RequiredTypedefField:    IntType(-1),
+		RequiredTypedefPtrField: ptr.To(IntType(-1)),
+	}).OldValue(&RequiredStruct{
+		RequiredIntField:        0,
+		RequiredIntPtrField:     ptr.To(0),
+		RequiredTypedefField:    IntType(0),
+		RequiredTypedefPtrField: ptr.To(IntType(0)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("requiredIntField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("requiredIntPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredTypedefField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredTypedefPtrField"), nil, "").WithOrigin("minimum"),
+	})
+
+	// Test that values meeting the minimum of 1 are valid.
+	st.Value(&RequiredStruct{
+		RequiredIntField:        1,
+		RequiredIntPtrField:     ptr.To(1),
+		RequiredTypedefField:    IntType(1),
+		RequiredTypedefPtrField: ptr.To(IntType(1)),
+	}).ExpectValid()
+
+	// Test that invalid values below the minimum are rejected.
+	st.Value(&RequiredStruct{
+		RequiredIntField:        -1,
+		RequiredIntPtrField:     ptr.To(-1),
+		RequiredTypedefField:    IntType(-1),
+		RequiredTypedefPtrField: ptr.To(IntType(-1)),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("requiredIntField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredIntPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredTypedefField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredTypedefPtrField"), nil, "").WithOrigin("minimum"),
 	})
 }
 
 func TestNegativeMinimumStruct(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
+	// Test that zero values for required pointers are validated against the negative minimum,
+	// while zero values for non-pointers trigger required validation.
 	st.Value(&NegativeMinimumStruct{
 		// zero values (valid for -10)
 		NegativeMinimumPtrField:         ptr.To(0),
@@ -144,6 +270,7 @@ func TestNegativeMinimumStruct(t *testing.T) {
 		field.Required(field.NewPath("requiredNegativeMinimumField"), ""),
 	})
 
+	// Test that valid values at the negative minimum boundary (-10) are accepted.
 	st.Value(&NegativeMinimumStruct{
 		NegativeMinimumField:            -10,
 		NegativeMinimumPtrField:         ptr.To(-10),
@@ -153,6 +280,48 @@ func TestNegativeMinimumStruct(t *testing.T) {
 		RequiredNegativeMinimumPtrField: ptr.To(-10),
 	}).ExpectValid()
 
+	// Test validation ratcheting: unchanged invalid data is allowed.
+	st.Value(&NegativeMinimumStruct{
+		NegativeMinimumField:            -11,
+		NegativeMinimumPtrField:         ptr.To(-11),
+		OptionalNegativeMinimumField:    -11,
+		OptionalNegativeMinimumPtrField: ptr.To(-11),
+		RequiredNegativeMinimumField:    -11,
+		RequiredNegativeMinimumPtrField: ptr.To(-11),
+	}).OldValue(&NegativeMinimumStruct{
+		NegativeMinimumField:            -11,
+		NegativeMinimumPtrField:         ptr.To(-11),
+		OptionalNegativeMinimumField:    -11,
+		OptionalNegativeMinimumPtrField: ptr.To(-11),
+		RequiredNegativeMinimumField:    -11,
+		RequiredNegativeMinimumPtrField: ptr.To(-11),
+	}).ExpectValid()
+
+	// Changed invalid data is still rejected.
+	st.Value(&NegativeMinimumStruct{
+		NegativeMinimumField:            -12,
+		NegativeMinimumPtrField:         ptr.To(-12),
+		OptionalNegativeMinimumField:    -12,
+		OptionalNegativeMinimumPtrField: ptr.To(-12),
+		RequiredNegativeMinimumField:    -12,
+		RequiredNegativeMinimumPtrField: ptr.To(-12),
+	}).OldValue(&NegativeMinimumStruct{
+		NegativeMinimumField:            -11,
+		NegativeMinimumPtrField:         ptr.To(-11),
+		OptionalNegativeMinimumField:    -11,
+		OptionalNegativeMinimumPtrField: ptr.To(-11),
+		RequiredNegativeMinimumField:    -11,
+		RequiredNegativeMinimumPtrField: ptr.To(-11),
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("negativeMinimumField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("negativeMinimumPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalNegativeMinimumField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("optionalNegativeMinimumPtrField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredNegativeMinimumField"), nil, "").WithOrigin("minimum"),
+		field.Invalid(field.NewPath("requiredNegativeMinimumPtrField"), nil, "").WithOrigin("minimum"),
+	})
+
+	// Test that invalid values below the negative minimum (-10) are rejected.
 	st.Value(&NegativeMinimumStruct{
 		NegativeMinimumField:            -11,
 		NegativeMinimumPtrField:         ptr.To(-11),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/zz_generated.validations.go
@@ -37,16 +37,61 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	// type Struct
+	// type BasicStruct
 	scheme.AddValidationFunc(
-		(*Struct)(nil),
+		(*BasicStruct)(nil),
 		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 			switch op.Request.SubresourcePath() {
 			case "/":
-				return Validate_Struct(
+				return Validate_BasicStruct(
 					ctx, op, nil, /* fldPath */
-					obj.(*Struct),
-					safe.Cast[*Struct](oldObj))
+					obj.(*BasicStruct),
+					safe.Cast[*BasicStruct](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
+	// type NegativeMinimumStruct
+	scheme.AddValidationFunc(
+		(*NegativeMinimumStruct)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/":
+				return Validate_NegativeMinimumStruct(
+					ctx, op, nil, /* fldPath */
+					obj.(*NegativeMinimumStruct),
+					safe.Cast[*NegativeMinimumStruct](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
+	// type OptionalStruct
+	scheme.AddValidationFunc(
+		(*OptionalStruct)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/":
+				return Validate_OptionalStruct(
+					ctx, op, nil, /* fldPath */
+					obj.(*OptionalStruct),
+					safe.Cast[*OptionalStruct](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
+	// type RequiredStruct
+	scheme.AddValidationFunc(
+		(*RequiredStruct)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/":
+				return Validate_RequiredStruct(
+					ctx, op, nil, /* fldPath */
+					obj.(*RequiredStruct),
+					safe.Cast[*RequiredStruct](oldObj))
 			}
 			return field.ErrorList{
 				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
@@ -55,28 +100,15 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 	return nil
 }
 
-// Validate_IntType validates an instance of IntType according
+// Validate_BasicStruct validates an instance of BasicStruct according
 // to declarative validation rules in the API schema.
-func Validate_IntType(
+func Validate_BasicStruct(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
-	obj, oldObj *IntType) (errs field.ErrorList) {
+	obj, oldObj *BasicStruct) (errs field.ErrorList) {
 
-	if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
-		errs = append(errs, e...)
-	}
+	// field BasicStruct.TypeMeta has no validation
 
-	return errs
-}
-
-// Validate_Struct validates an instance of Struct according
-// to declarative validation rules in the API schema.
-func Validate_Struct(
-	ctx context.Context, op operation.Operation, fldPath *field.Path,
-	obj, oldObj *Struct) (errs field.ErrorList) {
-
-	// field Struct.TypeMeta has no validation
-
-	{ // field Struct.IntField
+	{ // field BasicStruct.IntField
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *int,
@@ -94,13 +126,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *int {
+			func(oldObj *BasicStruct) *int {
 				return &oldObj.IntField
 			})
 		errs = append(errs, fn(fldPath.Child("intField"), &obj.IntField, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.IntPtrField
+	{ // field BasicStruct.IntPtrField
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *int,
@@ -118,13 +150,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *int {
+			func(oldObj *BasicStruct) *int {
 				return oldObj.IntPtrField
 			})
 		errs = append(errs, fn(fldPath.Child("intPtrField"), obj.IntPtrField, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.Int16Field
+	{ // field BasicStruct.Int16Field
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *int16,
@@ -142,13 +174,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *int16 {
+			func(oldObj *BasicStruct) *int16 {
 				return &oldObj.Int16Field
 			})
 		errs = append(errs, fn(fldPath.Child("int16Field"), &obj.Int16Field, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.Int32Field
+	{ // field BasicStruct.Int32Field
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *int32,
@@ -166,13 +198,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *int32 {
+			func(oldObj *BasicStruct) *int32 {
 				return &oldObj.Int32Field
 			})
 		errs = append(errs, fn(fldPath.Child("int32Field"), &obj.Int32Field, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.Int64Field
+	{ // field BasicStruct.Int64Field
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *int64,
@@ -190,13 +222,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *int64 {
+			func(oldObj *BasicStruct) *int64 {
 				return &oldObj.Int64Field
 			})
 		errs = append(errs, fn(fldPath.Child("int64Field"), &obj.Int64Field, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.UintField
+	{ // field BasicStruct.UintField
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *uint,
@@ -214,13 +246,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *uint {
+			func(oldObj *BasicStruct) *uint {
 				return &oldObj.UintField
 			})
 		errs = append(errs, fn(fldPath.Child("uintField"), &obj.UintField, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.UintPtrField
+	{ // field BasicStruct.UintPtrField
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *uint,
@@ -238,13 +270,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *uint {
+			func(oldObj *BasicStruct) *uint {
 				return oldObj.UintPtrField
 			})
 		errs = append(errs, fn(fldPath.Child("uintPtrField"), obj.UintPtrField, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.Uint16Field
+	{ // field BasicStruct.Uint16Field
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *uint16,
@@ -262,13 +294,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *uint16 {
+			func(oldObj *BasicStruct) *uint16 {
 				return &oldObj.Uint16Field
 			})
 		errs = append(errs, fn(fldPath.Child("uint16Field"), &obj.Uint16Field, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.Uint32Field
+	{ // field BasicStruct.Uint32Field
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *uint32,
@@ -286,13 +318,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *uint32 {
+			func(oldObj *BasicStruct) *uint32 {
 				return &oldObj.Uint32Field
 			})
 		errs = append(errs, fn(fldPath.Child("uint32Field"), &obj.Uint32Field, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.Uint64Field
+	{ // field BasicStruct.Uint64Field
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *uint64,
@@ -310,13 +342,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *uint64 {
+			func(oldObj *BasicStruct) *uint64 {
 				return &oldObj.Uint64Field
 			})
 		errs = append(errs, fn(fldPath.Child("uint64Field"), &obj.Uint64Field, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.TypedefField
+	{ // field BasicStruct.TypedefField
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *IntType,
@@ -332,13 +364,13 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *IntType {
+			func(oldObj *BasicStruct) *IntType {
 				return &oldObj.TypedefField
 			})
 		errs = append(errs, fn(fldPath.Child("typedefField"), &obj.TypedefField, oldVal, oldObj != nil)...)
 	}
 
-	{ // field Struct.TypedefPtrField
+	{ // field BasicStruct.TypedefPtrField
 		fn := func(
 			fldPath *field.Path,
 			obj, oldObj *IntType,
@@ -354,10 +386,356 @@ func Validate_Struct(
 			return
 		}
 		oldVal := safe.Field(oldObj,
-			func(oldObj *Struct) *IntType {
+			func(oldObj *BasicStruct) *IntType {
 				return oldObj.TypedefPtrField
 			})
 		errs = append(errs, fn(fldPath.Child("typedefPtrField"), obj.TypedefPtrField, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_IntType validates an instance of IntType according
+// to declarative validation rules in the API schema.
+func Validate_IntType(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *IntType) (errs field.ErrorList) {
+
+	if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+
+	return errs
+}
+
+// Validate_NegativeMinimumStruct validates an instance of NegativeMinimumStruct according
+// to declarative validation rules in the API schema.
+func Validate_NegativeMinimumStruct(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *NegativeMinimumStruct) (errs field.ErrorList) {
+
+	// field NegativeMinimumStruct.TypeMeta has no validation
+
+	{ // field NegativeMinimumStruct.NegativeMinimumField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *NegativeMinimumStruct) *int {
+				return &oldObj.NegativeMinimumField
+			})
+		errs = append(errs, fn(fldPath.Child("negativeMinimumField"), &obj.NegativeMinimumField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field NegativeMinimumStruct.NegativeMinimumPtrField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *NegativeMinimumStruct) *int {
+				return oldObj.NegativeMinimumPtrField
+			})
+		errs = append(errs, fn(fldPath.Child("negativeMinimumPtrField"), obj.NegativeMinimumPtrField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field NegativeMinimumStruct.OptionalNegativeMinimumField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *NegativeMinimumStruct) *int {
+				return &oldObj.OptionalNegativeMinimumField
+			})
+		errs = append(errs, fn(fldPath.Child("optionalNegativeMinimumField"), &obj.OptionalNegativeMinimumField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field NegativeMinimumStruct.OptionalNegativeMinimumPtrField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *NegativeMinimumStruct) *int {
+				return oldObj.OptionalNegativeMinimumPtrField
+			})
+		errs = append(errs, fn(fldPath.Child("optionalNegativeMinimumPtrField"), obj.OptionalNegativeMinimumPtrField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field NegativeMinimumStruct.RequiredNegativeMinimumField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *NegativeMinimumStruct) *int {
+				return &oldObj.RequiredNegativeMinimumField
+			})
+		errs = append(errs, fn(fldPath.Child("requiredNegativeMinimumField"), &obj.RequiredNegativeMinimumField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field NegativeMinimumStruct.RequiredNegativeMinimumPtrField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *NegativeMinimumStruct) *int {
+				return oldObj.RequiredNegativeMinimumPtrField
+			})
+		errs = append(errs, fn(fldPath.Child("requiredNegativeMinimumPtrField"), obj.RequiredNegativeMinimumPtrField, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_OptionalStruct validates an instance of OptionalStruct according
+// to declarative validation rules in the API schema.
+func Validate_OptionalStruct(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *OptionalStruct) (errs field.ErrorList) {
+
+	// field OptionalStruct.TypeMeta has no validation
+
+	{ // field OptionalStruct.OptionalIntField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *OptionalStruct) *int {
+				return &oldObj.OptionalIntField
+			})
+		errs = append(errs, fn(fldPath.Child("optionalIntField"), &obj.OptionalIntField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field OptionalStruct.OptionalIntPtrField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *OptionalStruct) *int {
+				return oldObj.OptionalIntPtrField
+			})
+		errs = append(errs, fn(fldPath.Child("optionalIntPtrField"), obj.OptionalIntPtrField, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_RequiredStruct validates an instance of RequiredStruct according
+// to declarative validation rules in the API schema.
+func Validate_RequiredStruct(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *RequiredStruct) (errs field.ErrorList) {
+
+	// field RequiredStruct.TypeMeta has no validation
+
+	{ // field RequiredStruct.RequiredIntField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *RequiredStruct) *int {
+				return &oldObj.RequiredIntField
+			})
+		errs = append(errs, fn(fldPath.Child("requiredIntField"), &obj.RequiredIntField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field RequiredStruct.RequiredIntPtrField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *RequiredStruct) *int {
+				return oldObj.RequiredIntPtrField
+			})
+		errs = append(errs, fn(fldPath.Child("requiredIntPtrField"), obj.RequiredIntPtrField, oldVal, oldObj != nil)...)
 	}
 
 	return errs

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/zz_generated.validations.go
@@ -663,6 +663,66 @@ func Validate_OptionalStruct(
 		errs = append(errs, fn(fldPath.Child("optionalIntPtrField"), obj.OptionalIntPtrField, oldVal, oldObj != nil)...)
 	}
 
+	{ // field OptionalStruct.OptionalTypedefField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *IntType,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *OptionalStruct) *IntType {
+				return &oldObj.OptionalTypedefField
+			})
+		errs = append(errs, fn(fldPath.Child("optionalTypedefField"), &obj.OptionalTypedefField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field OptionalStruct.OptionalTypedefPtrField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *IntType,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *OptionalStruct) *IntType {
+				return oldObj.OptionalTypedefPtrField
+			})
+		errs = append(errs, fn(fldPath.Child("optionalTypedefPtrField"), obj.OptionalTypedefPtrField, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }
 
@@ -736,6 +796,68 @@ func Validate_RequiredStruct(
 				return oldObj.RequiredIntPtrField
 			})
 		errs = append(errs, fn(fldPath.Child("requiredIntPtrField"), obj.RequiredIntPtrField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field RequiredStruct.RequiredTypedefField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *IntType,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *RequiredStruct) *IntType {
+				return &oldObj.RequiredTypedefField
+			})
+		errs = append(errs, fn(fldPath.Child("requiredTypedefField"), &obj.RequiredTypedefField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field RequiredStruct.RequiredTypedefPtrField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *IntType,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *RequiredStruct) *IntType {
+				return oldObj.RequiredTypedefPtrField
+			})
+		errs = append(errs, fn(fldPath.Child("requiredTypedefPtrField"), obj.RequiredTypedefPtrField, oldVal, oldObj != nil)...)
 	}
 
 	return errs


### PR DESCRIPTION
### PR Description

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds comprehensive test cases for the `+k8s:minimum` validation tag in the `validation-gen` tool. It specifically expands testing coverage to verify the interaction between minimum constraints and the `+k8s:optional` and `+k8s:required` tags. These tests ensure that the generated validation logic correctly handles zero-values, pointer fields, and negative minimum thresholds while respecting field optionality.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
The tests verify that error origins are correctly reported as "minimum" and that validation ratcheting works as expected (allowing existing invalid values to persist if unchanged).

#### Does this PR introduce a user-facing change?
NONE