### PR TITLE
tests: Wait for pod to be removed on kubelet restarts with userns.idsPerPod

### DIFF
--- a/test/e2e_node/user_namespaces_test.go
+++ b/test/e2e_node/user_namespaces_test.go
@@ -23,22 +23,28 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	kubeletconfigpaths "k8s.io/kubernetes/pkg/kubelet/kubeletconfig"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	"k8s.io/kubernetes/test/e2e_node/services"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -88,8 +94,36 @@ var _ = SIGDescribe("user namespaces kubeconfig tests", "[LinuxOnly]", feature.U
 					RestartPolicy: v1.RestartPolicyNever,
 				},
 			}
-			expected := []string{strconv.FormatInt(customIDsPerPod, 10)}
-			e2eoutput.TestContainerOutput(ctx, f, "idsPerPod is configured correctly", pod, 0, expected)
+			podClient := e2epod.NewPodClient(f)
+			createdPod := podClient.Create(ctx, pod)
+			ginkgo.DeferCleanup(func(ctx context.Context) {
+				ginkgo.By("delete the pod")
+				podClient.DeleteSync(ctx, createdPod.Name, metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))}, f.Timeouts.PodDelete)
+				// DeleteSync waits until the pod is deleted from the API server.
+				// But we need the pod dir to removed from the node before we
+				// continue. The pod dir is not deleted with the pod, but left for
+				// the periodic run of the cleanup function to delete it later. So,
+				// let's wait until the dir is removed.
+				// The reason we need to wait for the dir to be removed is because
+				// tempSetCurrentKubeletConfig's AfterEach will restart the kubelet
+				// with the original idsPerPod. If the pod directory is still on
+				// disk, the kubelet will fail to start as the new kubelet config
+				// can't be honored if we have pods on disk with another config.
+				podDir := filepath.Join(services.KubeletRootDirectory, kubeletconfigpaths.DefaultKubeletPodsDirName, string(createdPod.UID))
+				gomega.Eventually(ctx, func() bool {
+					_, err := os.Stat(podDir)
+					return os.IsNotExist(err)
+				}).WithTimeout(f.Timeouts.PodDelete).Should(gomega.BeTrueBecause("pod directory %s must be removed - kubelet can't restart", podDir))
+			})
+
+			err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, createdPod.Name, f.Namespace.Name, f.Timeouts.PodStart)
+			framework.ExpectNoError(err)
+
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, createdPod.Name, "container")
+			framework.ExpectNoError(err)
+			expected := strconv.FormatInt(customIDsPerPod, 10)
+			gomega.Expect(logs).To(gomega.ContainSubstring(expected))
+
 		})
 	})
 })


### PR DESCRIPTION
The test starts the kubelet with a non-default setting for idsPerPod, runs a pod, deletes it, and then restarts the kubelet.

The issue is that the kubelet guarantees that no two pods userns mappings overlap (for security reasons). But we are not waiting for the pod to be removed from the kubelet, the deleteSync() call only waits for the API server to remove the pod.

So, the pod is on disk (and maybe even running!) when we restart the kubelet. As the previous configuration is incompatible with the new one after restart if pods are running, the kubelet failing is the right thing. We should just wait for the pod to be deleted from the kubelet before restarting it with an incompatible configuration.

So, this commit just changes the pod deleteion (before done in e2eoutput.TestContainerOutput() just waiting for the API server) to wait for the kubelet to delete the pod.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fix a failing test.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes: #137912

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc @AkihiroSuda @giuseppe 