### PR TITLE
kubelet: deep-copy cached status before syncPod merge

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -1069,7 +1069,8 @@ func (m *manager) syncPod(ctx context.Context, uid types.UID, status versionedPo
 		return
 	}
 
-	mergedStatus := mergePodStatus(pod, pod.Status, status.status, m.podDeletionSafety.PodCouldHaveRunningContainers(pod))
+	statusToPatch := *status.status.DeepCopy()
+	mergedStatus := mergePodStatus(pod, pod.Status, statusToPatch, m.podDeletionSafety.PodCouldHaveRunningContainers(pod))
 
 	newPod, patchBytes, unchanged, err := statusutil.PatchPodStatus(ctx, m.kubeClient, pod.Namespace, pod.Name, pod.UID, pod.Status, mergedStatus)
 	logger.V(3).Info("Patch status for pod", "pod", klog.KObj(pod), "podUID", uid, "patch", string(patchBytes))

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1501,6 +1502,47 @@ func TestReconcilePodStatus(t *testing.T) {
 	syncer.SetPodStatus(logger, testPod, changedPodStatus)
 	syncer.syncBatch(ctx, true)
 	verifyActions(t, syncer, []core.Action{getAction(), patchAction()})
+}
+
+func TestGetPodStatusDataRace(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	pod := getTestPod()
+	client := fake.NewSimpleClientset(pod)
+	m := newTestManager(client)
+	m.podManager.(mutablePodManager).AddPod(pod)
+	status := v1.PodStatus{
+		Conditions: []v1.PodCondition{
+			{
+				Type:   v1.PodReady,
+				Status: v1.ConditionTrue,
+			},
+		},
+	}
+	m.SetPodStatus(logger, pod, status)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 1000 {
+			s, _ := m.GetPodStatus(pod.UID)
+			m.SetPodStatus(logger, pod, s)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 1000 {
+			s, _ := m.GetPodStatus(pod.UID)
+			for i := range s.Conditions {
+				_ = s.Conditions[i].LastTransitionTime
+			}
+		}
+	}()
+	close(start)
+	wg.Wait()
 }
 
 func expectPodStatus(t *testing.T, m *manager, pod *v1.Pod) v1.PodStatus {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a data race in kubelet status_manager syncPod by deep-copying cached PodStatus before mergePodStatus updates LastTransitionTime. This prevents lock-free in-place mutation of shared slice backing arrays when readers concurrently access GetPodStatus.

#### Which issue(s) this PR is related to:
Fixes #137933

#### Special notes for your reviewer:

- syncPod now deep-copies cached status before mergePodStatus to avoid modifying shared memory.
- SetPodStatus keeps a deep copy before caching to preserve immutability of cached snapshots.
- Tests run: go test ./pkg/kubelet/status and go test -race ./pkg/kubelet/status -run TestGetPodStatusDataRace -count=1

#### Does this PR introduce a user-facing change?


NONE

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
