### PR TITLE
Remove obsolete thresholdVersion exemption from feature gate removal verification

### DIFF
--- a/test/compatibility_lifecycle/cmd/feature_gates.go
+++ b/test/compatibility_lifecycle/cmd/feature_gates.go
@@ -39,9 +39,6 @@ var (
 	alphabeticalOrder        bool
 	k8RootPath               string
 	versionedFeatureListFile = "test/compatibility_lifecycle/reference/versioned_feature_list.yaml"
-	// thresholdVersion is the version after which we require emulation support for feature removal
-	// 1.31 is when we introduced emulation version support
-	thresholdVersion = version.MajorMinor(1, 31)
 )
 
 const (
@@ -158,7 +155,7 @@ func verifyOrUpdateFeatureList(rootPath, featureListFile string, currentVersion 
 		return err
 	}
 
-	if err := verifyFeatureRemoval(featureList, baseFeatureList, currentVersion, thresholdVersion); err != nil {
+	if err := verifyFeatureRemoval(featureList, baseFeatureList, currentVersion); err != nil {
 		return err
 	}
 
@@ -208,13 +205,10 @@ func dedupeFeatureList(featureList []featureInfo) ([]featureInfo, error) {
 // Returns error if:
 //   - Beta features are removed (not allowed)
 //   - GA/Deprecated features are removed without being locked to default
-//   - GA/Deprecated features locked after v1.31 are removed before 3 minor versions
-//     have passed (required for emulation support)
+//   - GA/Deprecated features are removed before 3 minor versions have passed
+//     since locking (required for emulation support)
 func verifyFeatureRemoval(featureList []featureInfo, baseFeatureList []featureInfo,
-	currentVersion *version.Version, thresholdVersion *version.Version) error {
-	if thresholdVersion == nil {
-		thresholdVersion = version.MajorMinor(0, 0)
-	}
+	currentVersion *version.Version) error {
 	baseFeatures := make(map[string]featureInfo)
 	for _, f := range baseFeatureList {
 		baseFeatures[f.Name] = f
@@ -250,17 +244,11 @@ func verifyFeatureRemoval(featureList []featureInfo, baseFeatureList []featureIn
 			if err != nil {
 				return fmt.Errorf("invalid version \"%s\" for feature %s: %w", lastSpec.Version, name, err)
 			}
-			// we do not require the 3 version retention for features locked before the thresholdVersion.
-			// TODO: remove after 1.34
-			if !specVer.GreaterThan(thresholdVersion) {
-				continue
-			}
 			minRemovalVer := specVer.AddMinor(3)
 			if currentVersion.LessThan(minRemovalVer) {
 				return fmt.Errorf("feature %s cannot be removed until version %s (required for emulation support)",
 					name, minRemovalVer)
 			}
-
 		}
 	}
 	return nil

--- a/test/compatibility_lifecycle/cmd/feature_gates_test.go
+++ b/test/compatibility_lifecycle/cmd/feature_gates_test.go
@@ -739,13 +739,12 @@ func TestParseFeatureSpec(t *testing.T) {
 }
 func TestVerifyFeatureRemoval(t *testing.T) {
 	tests := []struct {
-		name             string
-		featureList      []featureInfo
-		baseFeatureList  []featureInfo
-		currentVersion   *version.Version
-		thresholdVersion *version.Version
-		expectErr        bool
-		expectedErrMsg   string
+		name            string
+		featureList     []featureInfo
+		baseFeatureList []featureInfo
+		currentVersion  *version.Version
+		expectErr       bool
+		expectedErrMsg  string
 	}{
 		{
 			name: "no features removed",
@@ -862,23 +861,10 @@ func TestVerifyFeatureRemoval(t *testing.T) {
 			expectErr:      true,
 			expectedErrMsg: "feature FeatureD cannot be removed because it is in GA or Deprecated state and is not locked to default",
 		},
-		{
-			name: "GA feature removed at threshold version",
-			featureList: []featureInfo{
-				{Name: "FeatureA", VersionedSpecs: []featureSpec{{Version: "1.0", PreRelease: "Alpha"}}},
-			},
-			baseFeatureList: []featureInfo{
-				{Name: "FeatureA", VersionedSpecs: []featureSpec{{Version: "1.0", PreRelease: "Alpha"}}},
-				{Name: "FeatureC", VersionedSpecs: []featureSpec{{Version: "1.4", PreRelease: "GA", LockToDefault: true}}},
-			},
-			currentVersion:   version.MustParse("1.5"),
-			thresholdVersion: version.MustParse("1.4"),
-			expectErr:        false,
-		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := verifyFeatureRemoval(tc.featureList, tc.baseFeatureList, tc.currentVersion, tc.thresholdVersion)
+			err := verifyFeatureRemoval(tc.featureList, tc.baseFeatureList, tc.currentVersion)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove the pre-v1.31 threshold exemption from `verifyFeatureRemoval` (TODO said remove after 1.34; current version is 1.36).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```