### PR TITLE
Update CSI sidecar images in test manifests

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
@@ -324,7 +324,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -39,7 +39,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -73,7 +73,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -102,7 +102,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -343,7 +343,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -387,7 +387,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshot-metadata
-          image: registry.k8s.io/sig-storage/csi-snapshot-metadata:v0.2.0
+          image: registry.k8s.io/sig-storage/csi-snapshot-metadata:v1.0.0
           imagePullPolicy: IfNotPresent
           args:
           - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           args:
             - "--csi-address=$(ADDRESS)"
             # Topology support is needed for the pod rescheduling test

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           args:
             - "--csi-address=$(ADDRESS)"
             # Topology support is needed for the pod rescheduling test


### PR DESCRIPTION
Update CSI sidecar container images to their latest versions in
e2e test manifests.

/kind cleanup
/sig storage
/area test
/priority important-soon

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update CSI sidecar container images in e2e test manifests
(hostpath, mock, volume-group-snapshots, gce-pd):

- csi-provisioner: v6.1.1 -> v6.2.0, v5.2.0 -> v5.3.0
- csi-resizer: v1.13.1 -> v1.13.2
- csi-snapshot-metadata: v0.2.0 -> v1.0.0

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- No cluster/addons changes needed — snapshot-controller is already at v8.5.0 (latest).
- gce-pd provisioner stays on v5.x line (v5.2.0 -> v5.3.0) and resizer on v1.x line (v1.13.1 -> v1.13.2) to avoid breaking major version jumps.
- hostpath/mock/volume-group-snapshots provisioner bumped to latest v6.2.0.
- csi-snapshot-metadata bumped from alpha v0.2.0 to beta v1.0.0.

Changelogs:
- https://github.com/kubernetes-csi/external-provisioner/blob/v6.2.0/CHANGELOG/CHANGELOG-6.2.md
- https://github.com/kubernetes-csi/external-provisioner/blob/v5.3.0/CHANGELOG/CHANGELOG-5.3.md
- https://github.com/kubernetes-csi/external-resizer/blob/release-1.13/CHANGELOG/CHANGELOG-1.13.md
- https://github.com/kubernetes-csi/external-snapshot-metadata/blob/main/CHANGELOG/CHANGELOG-1.0.md

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```