### PR TITLE
fix: detect int64 overflow in resource.MustParse near math.MaxInt64

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -141,6 +141,18 @@ func MustParse(str string) Quantity {
 	if err != nil {
 		panic(fmt.Errorf("cannot parse '%v': %v", str, err))
 	}
+	// overflow guard: detect silent int64 wraparound (#135487)
+	// Case 1: Value() went negative despite positive input (classic wrap)
+	// Case 2: d.Dec is set and exceeds math.MaxInt64 (large suffix like G/T)
+	if q.Value() < 0 && q.Sign() >= 0 {
+		panic(fmt.Errorf("cannot parse '%v': overflows int64", str))
+	}
+	if q.d.Dec != nil {
+		maxInt64 := inf.NewDec(math.MaxInt64, 0)
+		if q.d.Dec.Cmp(maxInt64) > 0 {
+			panic(fmt.Errorf("cannot parse '%v': overflows int64", str))
+		}
+	}
 	return q
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1820,3 +1820,33 @@ func TestQuantityRoundtripCBOR(t *testing.T) {
 		}
 	}
 }
+
+// TestMustParseNearMaxInt64 ensures that MustParse panics instead of
+// silently returning wrong values for quantities that overflow int64.
+func TestMustParseNearMaxInt64(t *testing.T) {
+	mustPanic := func(t *testing.T, str string) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("MustParse(%q) did not panic on overflow", str)
+			}
+		}()
+		_ = MustParse(str)
+	}
+
+	// Case 1: plain integer just above MaxInt64 wraps negative
+	mustPanic(t, "9223372036854775808")
+
+	// Case 2: large suffixed value overflows via d.Dec path
+	mustPanic(t, "9999999999999999999G")
+
+	// Sanity check: MaxInt64 itself should NOT panic
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("MustParse(MaxInt64) panicked unexpectedly: %v", r)
+			}
+		}()
+		_ = MustParse("9223372036854775807")
+	}()
+}


### PR DESCRIPTION
/kind bug

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

resource.MustParse silently returned wrong values when parsing quantities
near or above math.MaxInt64 due to unchecked integer overflow.

Two overflow cases identified and fixed:
- Value() wraps to negative for inputs just above MaxInt64
- d.Dec path returns wrong positive for very large suffixed values (e.g. 9999999999999999999G)

Fix adds two overflow guards in MustParse and a regression test TestMustParseNearMaxInt64.

#### Which issue(s) this PR is related to:

Fixes #135487

#### Special notes for your reviewer:

Two separate guards are needed because the two overflow paths behave differently.
All existing tests pass. New regression test covers both cases.

#### Does this PR introduce a user-facing change?
```release-note
Fix resource.MustParse to panic with a clear error instead of
silently returning wrong values for quantities that overflow int64.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A