### PR TITLE
Set WithSerial on HPA tests that conflict api registration

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autosclaing_external_metrics.go
+++ b/test/e2e/autoscaling/horizontal_pod_autosclaing_external_metrics.go
@@ -33,7 +33,8 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (external metrics)", func() {
+// Requires WithSerial as test sets up external metrics server
+var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (external metrics)", framework.WithSerial(), func() {
 	var (
 		rc                *e2eautoscaling.ResourceConsumer
 		metricsController *e2eautoscaling.ExternalMetricsController
@@ -89,7 +90,8 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (external metrics)"
 	})
 })
 
-var _ = SIGDescribe(feature.HPA, framework.WithFeatureGate(features.HPAScaleToZero),
+// Requires WithSerial as test sets up external metrics server
+var _ = SIGDescribe(feature.HPA, framework.WithFeatureGate(features.HPAScaleToZero), framework.WithSerial(),
 	"Horizontal pod autoscaling (scale to zero)", func() {
 		var (
 			rc                *e2eautoscaling.ResourceConsumer


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Found in https://github.com/kubernetes/kubernetes/pull/137612#issuecomment-4091408479

When 2 tests run in parallel that both register the external metrics provider, one of them will fail.
Prior to the ScaleToZero test, we only had a single test that registered an external metrics provider

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @maxcao13 @johanneswuerbach 