### PR TITLE
kubelet: filter out resource metrics for containers whose Pods are not known

### DIFF
--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -59,6 +59,8 @@ type cadvisorStatsProvider struct {
 	hostStatsProvider HostStatsProvider
 	// containerManager is used to generate the cgroup path for a pod.
 	containerManager cm.ContainerManager
+	// podManager is used to check whether a pod is still known to the kubelet.
+	podManager PodManager
 }
 
 // newCadvisorStatsProvider returns a containerStatsProvider that provides
@@ -70,6 +72,7 @@ func newCadvisorStatsProvider(
 	statusProvider status.PodStatusProvider,
 	hostStatsProvider HostStatsProvider,
 	containerManager cm.ContainerManager,
+	podManager PodManager,
 ) containerStatsProvider {
 	return &cadvisorStatsProvider{
 		cadvisor:          cadvisor,
@@ -78,6 +81,7 @@ func newCadvisorStatsProvider(
 		statusProvider:    statusProvider,
 		hostStatsProvider: hostStatsProvider,
 		containerManager:  containerManager,
+		podManager:        podManager,
 	}
 }
 
@@ -115,6 +119,11 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 			continue
 		}
 		ref := buildPodRef(cinfo.Spec.Labels)
+
+		// Skip containers whose Pod is no longer known to the kubelet
+		if _, found := p.podManager.GetPodByUID(types.UID(ref.UID)); !found {
+			continue
+		}
 
 		// Lookup the PodStats for the pod using the PodRef. If none exists,
 		// initialize a new entry.
@@ -246,6 +255,11 @@ func (p *cadvisorStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([
 			continue
 		}
 		ref := buildPodRef(cinfo.Spec.Labels)
+
+		// Skip containers whose Pod is no longer known to the kubelet
+		if _, found := p.podManager.GetPodByUID(types.UID(ref.UID)); !found {
+			continue
+		}
 
 		// Lookup the PodStats for the pod using the PodRef. If none exists,
 		// initialize a new entry.

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -59,6 +59,8 @@ type cadvisorStatsProvider struct {
 	hostStatsProvider HostStatsProvider
 	// containerManager is used to generate the cgroup path for a pod.
 	containerManager cm.ContainerManager
+	// podManager is used to check whether a pod is still known to the kubelet.
+	podManager PodManager
 }
 
 // newCadvisorStatsProvider returns a containerStatsProvider that provides
@@ -70,6 +72,7 @@ func newCadvisorStatsProvider(
 	statusProvider status.PodStatusProvider,
 	hostStatsProvider HostStatsProvider,
 	containerManager cm.ContainerManager,
+	podManager PodManager,
 ) containerStatsProvider {
 	return &cadvisorStatsProvider{
 		cadvisor:          cadvisor,
@@ -78,6 +81,7 @@ func newCadvisorStatsProvider(
 		statusProvider:    statusProvider,
 		hostStatsProvider: hostStatsProvider,
 		containerManager:  containerManager,
+		podManager:        podManager,
 	}
 }
 
@@ -115,6 +119,11 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 			continue
 		}
 		ref := buildPodRef(cinfo.Spec.Labels)
+
+		// Skip containers whose pod is no longer known to the kubelet
+		if _, found := p.podManager.GetPodByUID(types.UID(ref.UID)); !found {
+			continue
+		}
 
 		// Lookup the PodStats for the pod using the PodRef. If none exists,
 		// initialize a new entry.
@@ -246,6 +255,11 @@ func (p *cadvisorStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([
 			continue
 		}
 		ref := buildPodRef(cinfo.Spec.Labels)
+
+		// Skip containers whose pod is no longer known to the kubelet
+		if _, found := p.podManager.GetPodByUID(types.UID(ref.UID)); !found {
+			continue
+		}
 
 		// Lookup the PodStats for the pod using the PodRef. If none exists,
 		// initialize a new entry.

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -660,7 +660,7 @@ func TestCadvisorImagesFsStatsKubeletSeparateDiskOff(t *testing.T) {
 	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageStats(ctx).Return(imageStats, nil)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 	stats, _, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -741,7 +741,7 @@ func TestImageFsStatsCustomResponse(t *testing.T) {
 			mockCadvisor.EXPECT().ContainerFsInfo(ctx).Return(res, nil)
 		}
 
-		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 		stats, containerfs, err := provider.ImageFsStats(ctx)
 		if tc.shouldErr {
 			require.Error(t, err, desc)
@@ -778,7 +778,7 @@ func TestCadvisorImagesFsStats(t *testing.T) {
 	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -832,7 +832,7 @@ func TestCadvisorSplitImagesFsStats(t *testing.T) {
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -885,7 +885,7 @@ func TestCadvisorSameDiskDifferentLocations(t *testing.T) {
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	require.NoError(t, err, "imageFsStats should have no error")
 

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -294,7 +294,6 @@ func TestCadvisorListPodStats(t *testing.T) {
 	pods, err := p.ListPodStats(ctx)
 	assert.NoError(t, err)
 
-	// Pod4 is filtered out because it is unknown to the PodManager.
 	assert.Len(t, pods, 4)
 	indexPods := make(map[statsapi.PodReference]statsapi.PodStats, len(pods))
 	for _, pod := range pods {
@@ -591,7 +590,6 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 	pods, err := p.ListPodCPUAndMemoryStats(ctx)
 	assert.NoError(t, err)
 
-	// Pod3 is filtered out because it is unknown to the PodManager.
 	assert.Len(t, pods, 3)
 	indexPods := make(map[statsapi.PodReference]statsapi.PodStats, len(pods))
 	for _, pod := range pods {

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -39,6 +39,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
+	kubepodtest "k8s.io/kubernetes/pkg/kubelet/pod/testing"
 	serverstats "k8s.io/kubernetes/pkg/kubelet/server/stats"
 	statustest "k8s.io/kubernetes/pkg/kubelet/status/testing"
 	"k8s.io/kubernetes/pkg/volume"
@@ -138,6 +139,8 @@ func TestCadvisorListPodStats(t *testing.T) {
 		seedPod3Infra         = 7000
 		seedPod3Container0    = 8000
 		seedPod3Container1    = 8001
+		seedPod4Infra         = 8500
+		seedPod4Container0    = 8501
 		seedEphemeralVolume1  = 10000
 		seedEphemeralVolume2  = 10001
 		seedPersistentVolume1 = 20000
@@ -148,6 +151,7 @@ func TestCadvisorListPodStats(t *testing.T) {
 		pName1 = "pod1"
 		pName2 = "pod0" // ensure pName2 conflicts with pName0, but is in a different namespace
 		pName3 = "pod3"
+		pName4 = "pod4" // unknown to the PodManager and so should be filtered out
 	)
 	const (
 		cName00 = "c0"
@@ -172,6 +176,7 @@ func TestCadvisorListPodStats(t *testing.T) {
 	prf1 := statsapi.PodReference{Name: pName1, Namespace: namespace0, UID: "UID" + pName1}
 	prf2 := statsapi.PodReference{Name: pName2, Namespace: namespace2, UID: "UID" + pName2}
 	prf3 := statsapi.PodReference{Name: pName3, Namespace: namespace0, UID: "UID" + pName3}
+	prf4 := statsapi.PodReference{Name: pName4, Namespace: namespace0, UID: "UID" + pName4}
 	infos := map[string]cadvisorapi.ContainerInfo{
 		"/":              getTestContainerInfo(seedRoot, "", "", ""),
 		"/docker-daemon": getTestContainerInfo(seedRuntime, "", "", ""),
@@ -193,6 +198,9 @@ func TestCadvisorListPodStats(t *testing.T) {
 		"/pod3-i":       getTestContainerInfo(seedPod3Infra, pName3, namespace0, kubelettypes.PodInfraContainerName),
 		"/pod3-c0-init": getTestContainerInfo(seedPod3Container0, pName3, namespace0, cName30),
 		"/pod3-c1":      getTestContainerInfo(seedPod3Container1, pName3, namespace0, cName31),
+		// Pod4 is unknown to the PodManager (e.g. already deleted)
+		"/pod4-i":  getTestContainerInfo(seedPod4Infra, pName4, namespace0, kubelettypes.PodInfraContainerName),
+		"/pod4-c0": getTestContainerInfo(seedPod4Container0, pName4, namespace0, cName00),
 	}
 
 	freeRootfsInodes := rootfsInodesFree
@@ -276,10 +284,17 @@ func TestCadvisorListPodStats(t *testing.T) {
 
 	resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: volumeStats}
 
-	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, mockRuntime, mockStatus, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	// All pods except pod4 are known to the PodManager
+	unknownPodUID := types.UID("UID" + pName4)
+	mockPodManager := new(kubepodtest.MockManager)
+	mockPodManager.EXPECT().GetPodByUID(unknownPodUID).Return(nil, false)
+	mockPodManager.EXPECT().GetPodByUID(mock.MatchedBy(func(uid types.UID) bool { return uid != unknownPodUID })).Return(&v1.Pod{}, true)
+
+	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, mockPodManager, mockRuntime, mockStatus, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
 	pods, err := p.ListPodStats(ctx)
 	assert.NoError(t, err)
 
+	// Pod4 is filtered out because it is unknown to the PodManager.
 	assert.Len(t, pods, 4)
 	indexPods := make(map[statsapi.PodReference]statsapi.PodStats, len(pods))
 	for _, pod := range pods {
@@ -368,6 +383,10 @@ func TestCadvisorListPodStats(t *testing.T) {
 	checkSwapStats(t, "Pod3Container1", seedPod3Container1, infos["/pod3-c1"], con.Swap)
 	checkIOStats(t, "Pod3Container1", seedPod3Container1, infos["/pod3-c1"], con.IO)
 	checkContainersSwapStats(t, ps, infos["/pod3-c1"])
+
+	// Pod4 is unknown to the PodManager and so should be filtered out
+	_, found = indexPods[prf4]
+	assert.False(t, found)
 }
 
 func TestCadvisorPodCPUAndMemoryStats(t *testing.T) {
@@ -482,6 +501,8 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 		seedPod1Container     = 4000
 		seedPod2Infra         = 5000
 		seedPod2Container     = 6000
+		seedPod3Infra         = 7000
+		seedPod3Container     = 7001
 		seedEphemeralVolume1  = 10000
 		seedEphemeralVolume2  = 10001
 		seedPersistentVolume1 = 20000
@@ -491,6 +512,7 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 		pName0 = "pod0"
 		pName1 = "pod1"
 		pName2 = "pod0" // ensure pName2 conflicts with pName0, but is in a different namespace
+		pName3 = "pod3" // unknown to the PodManager and so should be filtered out
 	)
 	const (
 		cName00 = "c0"
@@ -502,6 +524,7 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 	prf0 := statsapi.PodReference{Name: pName0, Namespace: namespace0, UID: "UID" + pName0}
 	prf1 := statsapi.PodReference{Name: pName1, Namespace: namespace0, UID: "UID" + pName1}
 	prf2 := statsapi.PodReference{Name: pName2, Namespace: namespace2, UID: "UID" + pName2}
+	prf3 := statsapi.PodReference{Name: pName3, Namespace: namespace0, UID: "UID" + pName3}
 	infos := map[string]cadvisorapi.ContainerInfo{
 		"/":              getTestContainerInfo(seedRoot, "", "", ""),
 		"/docker-daemon": getTestContainerInfo(seedRuntime, "", "", ""),
@@ -519,6 +542,9 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 		"/pod2-c0":                       getTestContainerInfo(seedPod2Container, pName2, namespace2, cName20),
 		"/kubepods/burstable/podUIDpod0": getTestContainerInfo(seedPod0Infra, pName0, namespace0, kubelettypes.PodInfraContainerName),
 		"/kubepods/podUIDpod1":           getTestContainerInfo(seedPod1Infra, pName1, namespace0, kubelettypes.PodInfraContainerName),
+		// Pod3 is unknown to the PodManager (e.g. already deleted)
+		"/pod3-i":  getTestContainerInfo(seedPod3Infra, pName3, namespace0, kubelettypes.PodInfraContainerName),
+		"/pod3-c0": getTestContainerInfo(seedPod3Container, pName3, namespace0, cName00),
 	}
 
 	// memory limit overrides for each container (used to test available bytes if a memory limit is known)
@@ -555,10 +581,17 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 
 	resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: volumeStats}
 
-	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, nil, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	// All pods except pod3 are known to the PodManager
+	unknownPodUID := types.UID("UID" + pName3)
+	mockPodManager := new(kubepodtest.MockManager)
+	mockPodManager.EXPECT().GetPodByUID(unknownPodUID).Return(nil, false)
+	mockPodManager.EXPECT().GetPodByUID(mock.MatchedBy(func(uid types.UID) bool { return uid != unknownPodUID })).Return(&v1.Pod{}, true)
+
+	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, mockPodManager, nil, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
 	pods, err := p.ListPodCPUAndMemoryStats(ctx)
 	assert.NoError(t, err)
 
+	// Pod3 is filtered out because it is unknown to the PodManager.
 	assert.Len(t, pods, 3)
 	indexPods := make(map[statsapi.PodReference]statsapi.PodStats, len(pods))
 	for _, pod := range pods {
@@ -640,6 +673,10 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 	assert.Nil(t, ps.VolumeStats)
 	assert.Nil(t, ps.Network)
 	assert.Nil(t, con.IO)
+
+	// Pod3 is unknown to the PodManager and so should be filtered out
+	_, found = indexPods[prf3]
+	assert.False(t, found)
 }
 
 func TestCadvisorImagesFsStatsKubeletSeparateDiskOff(t *testing.T) {
@@ -659,7 +696,7 @@ func TestCadvisorImagesFsStatsKubeletSeparateDiskOff(t *testing.T) {
 	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageStats(ctx).Return(imageStats, nil)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 	stats, _, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -740,7 +777,7 @@ func TestImageFsStatsCustomResponse(t *testing.T) {
 			mockCadvisor.EXPECT().ContainerFsInfo(ctx).Return(res, nil)
 		}
 
-		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 		stats, containerfs, err := provider.ImageFsStats(ctx)
 		if tc.shouldErr {
 			require.Error(t, err, desc)
@@ -777,7 +814,7 @@ func TestCadvisorImagesFsStats(t *testing.T) {
 	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -831,7 +868,7 @@ func TestCadvisorSplitImagesFsStats(t *testing.T) {
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -884,7 +921,7 @@ func TestCadvisorSameDiskDifferentLocations(t *testing.T) {
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil, nil)
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	require.NoError(t, err, "imageFsStats should have no error")
 
@@ -995,7 +1032,10 @@ func TestCadvisorListPodStatsWhenContainerLogFound(t *testing.T) {
 
 	resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: volumeStats}
 
-	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, mockRuntime, mockStatus, NewFakeHostStatsProviderWithData(fakeStats, fakeOS), nil)
+	mockPodManager := new(kubepodtest.MockManager)
+	mockPodManager.EXPECT().GetPodByUID(mock.Anything).Return(&v1.Pod{}, true).Maybe()
+
+	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, mockPodManager, mockRuntime, mockStatus, NewFakeHostStatsProviderWithData(fakeStats, fakeOS), nil)
 	pods, err := p.ListPodStats(ctx)
 	assert.NoError(t, err)
 

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -84,6 +84,8 @@ type criStatsProvider struct {
 	// useCRIPodSandboxStats is true when PodAndContainerStatsFromCRI is
 	// enabled and the CRI implements PodSandboxStats.
 	useCRIPodSandboxStats bool
+	// podManager is used to check whether a pod is still known to the kubelet.
+	podManager PodManager
 
 	// cpuUsageCache caches the cpu usage for containers.
 	cpuUsageCache map[string]*cpuUsageRecord
@@ -101,6 +103,7 @@ func newCRIStatsProvider(
 	podAndContainerStatsFromCRI bool,
 	podSandboxStatsUnimplemented bool,
 	fallbackStatsProvider containerStatsProvider,
+	podManager PodManager,
 ) containerStatsProvider {
 	return &criStatsProvider{
 		cadvisor:              cadvisor,
@@ -112,6 +115,7 @@ func newCRIStatsProvider(
 		useCRIPodSandboxStats: podAndContainerStatsFromCRI && !podSandboxStatsUnimplemented,
 		clock:                 clock.RealClock{},
 		fallbackStatsProvider: fallbackStatsProvider,
+		podManager:            podManager,
 	}
 }
 
@@ -442,6 +446,10 @@ func (p *criStatsProvider) getPodAndContainerMaps(ctx context.Context) (map[stri
 	}
 	podSandboxes = removeTerminatedPods(podSandboxes)
 	for _, s := range podSandboxes {
+		// Skip sandboxes whose pod is no longer known to the kubelet.
+		if _, found := p.podManager.GetPodByUID(types.UID(s.GetMetadata().GetUid())); !found {
+			continue
+		}
 		podSandboxMap[s.Id] = s
 	}
 

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -28,6 +28,7 @@ import (
 	cadvisorfs "github.com/google/cadvisor/lib/fs"
 	cadvisorapi "github.com/google/cadvisor/lib/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -149,6 +150,11 @@ func TestCRIListPodStats(t *testing.T) {
 		container7      = makeFakeContainer(sandbox5, cName7, 0, true)
 		containerStats7 = makeFakeContainerStats(container7, imageFsMountpoint)
 
+		// Running pod that is unknown to the PodManager (e.g. already deleted)
+		sandbox6        = makeFakePodSandbox("sandbox6-name", "sandbox6-uid", "sandbox6-ns", false)
+		container9      = makeFakeContainer(sandbox6, cName0, 0, false)
+		containerStats9 = makeFakeContainerStats(container9, imageFsMountpoint)
+
 		podLogName0  = "pod-log-0"
 		podLogName1  = "pod-log-1"
 		podLogStats0 = makeFakeLogStats(5000)
@@ -162,6 +168,10 @@ func TestCRIListPodStats(t *testing.T) {
 		fakeRuntimeService = critest.NewFakeRuntimeService()
 		fakeImageService   = critest.NewFakeImageService()
 	)
+	// All sandboxes except sandbox6 are known to the PodManager
+	unknownPodUID := types.UID("sandbox6-uid")
+	mockPodManager.EXPECT().GetPodByUID(unknownPodUID).Return(nil, false)
+	mockPodManager.EXPECT().GetPodByUID(mock.MatchedBy(func(uid types.UID) bool { return uid != unknownPodUID })).Return(&v1.Pod{}, true)
 
 	infos := map[string]cadvisorapi.ContainerInfo{
 		"/":                           getTestContainerInfo(seedRoot, "", "", ""),
@@ -192,13 +202,13 @@ func TestCRIListPodStats(t *testing.T) {
 	mockCadvisor.EXPECT().GetDirFsInfo(unknownMountpoint).Return(cadvisorapi.FsInfo{}, cadvisorfs.ErrNoSuchDevice)
 
 	fakeRuntimeService.SetFakeSandboxes([]*critest.FakePodSandbox{
-		sandbox0, sandbox1, sandbox2, sandbox3, sandbox4, sandbox5,
+		sandbox0, sandbox1, sandbox2, sandbox3, sandbox4, sandbox5, sandbox6,
 	})
 	fakeRuntimeService.SetFakeContainers([]*critest.FakeContainer{
-		container0, container1, container2, container3, container4, container5, container6, container7, container8,
+		container0, container1, container2, container3, container4, container5, container6, container7, container8, container9,
 	})
 	fakeRuntimeService.SetFakeContainerStats([]*runtimeapi.ContainerStats{
-		containerStats0, containerStats1, containerStats2, containerStats3, containerStats4, containerStats5, containerStats6, containerStats7, containerStats8,
+		containerStats0, containerStats1, containerStats2, containerStats3, containerStats4, containerStats5, containerStats6, containerStats7, containerStats8, containerStats9,
 	})
 
 	ephemeralVolumes := makeFakeVolumeStats([]string{"ephVolume1, ephVolumes2"})
@@ -348,6 +358,10 @@ func TestCRIListPodStats(t *testing.T) {
 	checkCRIPodCPUAndMemoryStats(assert, p3, infos[sandbox3Cgroup].Stats[0])
 	checkCRIPodSwapStats(assert, p3, infos[sandbox3Cgroup].Stats[0])
 	checkCRIPodIOStats(assert, p3, infos[sandbox3Cgroup].Stats[0])
+
+	// sandbox6 is unknown to the PodManager and so should be filtered out
+	_, found := podStatsMap[statsapi.PodReference{Name: "sandbox6-name", UID: "sandbox6-uid", Namespace: "sandbox6-ns"}]
+	assert.False(found)
 }
 
 func TestListPodStatsStrictlyFromCRI(t *testing.T) {
@@ -396,6 +410,8 @@ func TestListPodStatsStrictlyFromCRI(t *testing.T) {
 		fakeRuntimeService = critest.NewFakeRuntimeService()
 		fakeImageService   = critest.NewFakeImageService()
 	)
+	mockPodManager.EXPECT().GetPodByUID(mock.Anything).Return(&v1.Pod{}, true).Maybe()
+
 	infos := map[string]cadvisorapi.ContainerInfo{
 		"/":                           getTestContainerInfo(seedRoot, "", "", ""),
 		"/kubelet":                    getTestContainerInfo(seedKubelet, "", "", ""),
@@ -608,6 +624,7 @@ func TestCRIListPodCPUAndMemoryStats(t *testing.T) {
 		resourceAnalyzer   = new(fakeResourceAnalyzer)
 		fakeRuntimeService = critest.NewFakeRuntimeService()
 	)
+	mockPodManager.EXPECT().GetPodByUID(mock.Anything).Return(&v1.Pod{}, true).Maybe()
 
 	infos := map[string]cadvisorapi.ContainerInfo{
 		"/":                           getTestContainerInfo(seedRoot, "", "", ""),

--- a/pkg/kubelet/stats/provider.go
+++ b/pkg/kubelet/stats/provider.go
@@ -42,6 +42,7 @@ import (
 // See pkg/k8s.io/kubernetes/pkg/kubelet/pod.Manager for method godoc.
 type PodManager interface {
 	TranslatePodUID(uid types.UID) kubetypes.ResolvedPodUID
+	GetPodByUID(types.UID) (*v1.Pod, bool)
 }
 
 // NewCRIStatsProvider returns a Provider that provides the node stats
@@ -71,7 +72,7 @@ func NewCadvisorStatsProvider(
 	hostStatsProvider HostStatsProvider,
 	containerManager cm.ContainerManager,
 ) *Provider {
-	return newStatsProvider(cadvisor, podManager, newCadvisorStatsProvider(cadvisor, resourceAnalyzer, imageService, statusProvider, hostStatsProvider, containerManager))
+	return newStatsProvider(cadvisor, podManager, newCadvisorStatsProvider(cadvisor, resourceAnalyzer, imageService, statusProvider, hostStatsProvider, containerManager, podManager))
 }
 
 // newStatsProvider returns a new Provider that provides node stats from

--- a/pkg/kubelet/stats/provider.go
+++ b/pkg/kubelet/stats/provider.go
@@ -42,6 +42,7 @@ import (
 // See pkg/k8s.io/kubernetes/pkg/kubelet/pod.Manager for method godoc.
 type PodManager interface {
 	TranslatePodUID(uid types.UID) kubetypes.ResolvedPodUID
+	GetPodByUID(types.UID) (*v1.Pod, bool)
 }
 
 // NewCRIStatsProvider returns a Provider that provides the node stats
@@ -58,7 +59,7 @@ func NewCRIStatsProvider(
 	fallbackStatsProvider containerStatsProvider,
 ) *Provider {
 	return newStatsProvider(cadvisor, podManager, newCRIStatsProvider(cadvisor, resourceAnalyzer,
-		runtimeService, imageService, hostStatsProvider, podAndContainerStatsFromCRI, podSandboxStatsUnimplemented, fallbackStatsProvider))
+		runtimeService, imageService, hostStatsProvider, podAndContainerStatsFromCRI, podSandboxStatsUnimplemented, fallbackStatsProvider, podManager))
 }
 
 // NewCadvisorStatsProvider returns a containerStatsProvider that provides both
@@ -72,7 +73,7 @@ func NewCadvisorStatsProvider(
 	hostStatsProvider HostStatsProvider,
 	containerManager cm.ContainerManager,
 ) *Provider {
-	return newStatsProvider(cadvisor, podManager, newCadvisorStatsProvider(cadvisor, resourceAnalyzer, imageService, statusProvider, hostStatsProvider, containerManager))
+	return newStatsProvider(cadvisor, podManager, newCadvisorStatsProvider(cadvisor, resourceAnalyzer, imageService, statusProvider, hostStatsProvider, containerManager, podManager))
 }
 
 // newStatsProvider returns a new Provider that provides node stats from


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The kubelet resource metrics endpoint (`/metrics/resource`) can currently return metrics corresponding to containers whose Pods have been deleted from the Kubernetes API server (for example, if container teardown is stuck due to a hung network filesystem mount).

In particular, this can lead to duplicate metrics for the same Pod `name/namespace` key (particularly for StatefulSets with stable Pod names) which can lead to Metrics Server reporting huge CPU utilisation spikes causing incorrect HPA and VPA scaling:

- https://github.com/kubernetes/kubernetes/issues/134518
- https://github.com/kubernetes-sigs/metrics-server/pull/1300

This PR fixes this by changing kubelet to only report metrics for Pods/containers that it is actually managing.

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Filter containers from kubelet resource metrics whose Pods are not known
```