### PR TITLE
scheduler metrics: Let async recorder stop immediately

### DIFF
--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -251,14 +251,13 @@ func (r *MetricAsyncRecorder) observeMetricAsync(m *metrics.HistogramVec, value 
 // run flushes buffered metrics into Prometheus every second.
 func (r *MetricAsyncRecorder) run() {
 	for {
+		r.FlushMetrics()
 		select {
 		case <-r.stopCh:
 			close(r.IsStoppedCh)
 			return
-		default:
+		case <-time.After(r.interval):
 		}
-		r.FlushMetrics()
-		time.Sleep(r.interval)
 	}
 }
 

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -325,4 +326,74 @@ func TestQueuedEntitiesRecorder(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewMetricsAsyncRecorder(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		Register()
+
+		bufferSize := 10
+		interval := 1 * time.Second
+		stop := make(chan struct{})
+
+		r := NewMetricsAsyncRecorder(bufferSize, interval, stop)
+
+		var buffered int
+		var flushed uint64
+		check := func(step string) {
+			t.Helper()
+
+			actualBuffered := len(r.bufferCh)
+			if actualBuffered != buffered {
+				t.Errorf("%s: expected %d elements in the buffer waiting to be flushed, got %d", step, buffered, actualBuffered)
+			}
+
+			actualFlushed, err := testutil.GetHistogramMetricCount(PluginExecutionDuration.WithLabelValues("", "", ""))
+			if err != nil {
+				t.Errorf("%s: error getting metric: %v", step, err)
+			}
+			if actualFlushed != flushed {
+				t.Errorf("%s: expected metric to have count %v, got %v", step, flushed, actualFlushed)
+			}
+		}
+
+		check("nothing should be buffered or flushed immediately after starting")
+
+		synctest.Wait()
+		r.ObservePluginDurationAsync("", "", "", 1)
+		buffered++
+		check("a metric observed immediately after flushing should only be buffered")
+
+		time.Sleep(interval / 2)
+		r.ObservePluginDurationAsync("", "", "", 1)
+		buffered++
+		check("a metric observed during the interval should only be buffered")
+
+		time.Sleep(interval / 2)
+		synctest.Wait()
+		flushed += uint64(buffered)
+		buffered = 0
+		check("when the interval is reached, buffered metrics should be flushed")
+
+		r.ObservePluginDurationAsync("", "", "", 1)
+		time.Sleep(interval)
+		synctest.Wait()
+		flushed++
+		check("metrics should be flushed at each interval")
+
+		r.ObservePluginDurationAsync("", "", "", 1)
+		time.Sleep(interval / 2)
+		buffered++
+		check("metrics should continue to be buffered during the last interval")
+
+		closedAt := time.Now()
+		close(stop)
+		<-r.IsStoppedCh
+		expectedStopDelay := interval / 2
+		if actualStopDelay := time.Since(closedAt); actualStopDelay != expectedStopDelay {
+			t.Errorf("recorder was stopped halfway through its %v interval, expected it to stop after %v but it actually stopped after %v", interval, expectedStopDelay, actualStopDelay)
+		}
+
+		check("buffered metrics are not flushed after stopping")
+	})
 }

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -389,9 +389,8 @@ func TestNewMetricsAsyncRecorder(t *testing.T) {
 		closedAt := time.Now()
 		close(stop)
 		<-r.IsStoppedCh
-		expectedStopDelay := interval / 2
-		if actualStopDelay := time.Since(closedAt); actualStopDelay != expectedStopDelay {
-			t.Errorf("recorder was stopped halfway through its %v interval, expected it to stop after %v but it actually stopped after %v", interval, expectedStopDelay, actualStopDelay)
+		if actualStopDelay := time.Since(closedAt); actualStopDelay != 0 {
+			t.Errorf("recorder was stopped halfway through its %v interval, expected it to stop immediately but it actually stopped after %v", interval, actualStopDelay)
 		}
 
 		check("buffered metrics are not flushed after stopping")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The default metrics recorder for `runtime.NewFramework` spawns a background goroutine that can be stopped asynchronously by closing a channel, but that channel is only checked in between calls to `time.Sleep`. When the channel is closed while the goroutine is sleeping, it has to finish sleeping before noticing that it closed. This change allows the recorder to stop immediately.

This drastically speeds up the DynamicResources plugin unit tests where many test cases run serially and each call framework.NewFramework with the default metrics recorder and shut it down with `runtime.WaitForShutdown`.

Before:
```
% go test ./pkg/scheduler/framework/plugins/dynamicresources
ok  	k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources	91.268s
```
After:
```
% go test ./pkg/scheduler/framework/plugins/dynamicresources
ok  	k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources	13.480s
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
ref. https://github.com/kubernetes/kubernetes/issues/137929#issuecomment-4099273019

#### Special notes for your reviewer:

The first commit only adds a unit test exercising the background goroutine, ensuring it buffers and flushes metrics at the expected times. With the functional change in the second commit, only the shutdown behavior is affected. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
