### PR TITLE
kubelet/dra: roll back prepared drivers on partial NodePrepareResources failure

### DIFF
--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -392,6 +392,30 @@ func (m *Manager) prepareResources(ctx context.Context, pod *v1.Pod) error {
 		return err
 	}
 
+	// preparedByDriverEntry tracks a plugin together with the claims sent to
+	// it via NodePrepareResources in this prepare call.  On any failure we
+	// use this list to call NodeUnprepareResources for every driver that
+	// already completed, preventing partially-prepared state from
+	// accumulating when multiple drivers are involved.
+	type preparedByDriverEntry struct {
+		plugin *draplugin.DRAPlugin
+		claims []*drapb.Claim
+	}
+	var preparedByDriver []preparedByDriverEntry
+	// rollbackPrepared calls NodeUnprepareResources for every entry in
+	// preparedByDriver.  Errors are only logged so as not to shadow the
+	// original prepare error.
+	rollbackPrepared := func() {
+		for _, e := range preparedByDriver {
+			if _, rbErr := e.plugin.NodeUnprepareResources(
+				ctx, &drapb.NodeUnprepareResourcesRequest{Claims: e.claims},
+			); rbErr != nil {
+				logger.Error(rbErr, "NodeUnprepareResources rollback failed after partial prepare failure",
+					"driver", e.plugin.DriverName())
+			}
+		}
+	}
+
 	// Call NodePrepareResources for all claims in each batch.
 	// If there is any error, processing gets aborted.
 	// We could try to continue, but that would make the code more complex.
@@ -400,14 +424,23 @@ func (m *Manager) prepareResources(ctx context.Context, pod *v1.Pod) error {
 		response, err := plugin.NodePrepareResources(ctx, &drapb.NodePrepareResourcesRequest{Claims: claims})
 		if err != nil {
 			// General error unrelated to any particular claim.
+			// Roll back every driver that already completed in this prepare call.
+			rollbackPrepared()
 			return fmt.Errorf("NodePrepareResources: %w", err)
 		}
 		for claimUID, result := range response.Claims {
 			reqClaim := lookupClaimRequest(claims, claimUID)
 			if reqClaim == nil {
+				// The driver returned a response so it may have prepared some
+				// claims already; include it in the rollback list.
+				preparedByDriver = append(preparedByDriver, preparedByDriverEntry{plugin: plugin, claims: claims})
+				rollbackPrepared()
 				return fmt.Errorf("NodePrepareResources returned result for unknown claim UID %s", claimUID)
 			}
 			if result.GetError() != "" {
+				// Same reasoning: the driver ran so roll back its claims too.
+				preparedByDriver = append(preparedByDriver, preparedByDriverEntry{plugin: plugin, claims: claims})
+				rollbackPrepared()
 				return fmt.Errorf("NodePrepareResources failed for ResourceClaim %s: %s", reqClaim.Name, result.Error)
 			}
 
@@ -428,14 +461,22 @@ func (m *Manager) prepareResources(ctx context.Context, pod *v1.Pod) error {
 			})
 			if err != nil {
 				// No wrapping, this is the error above.
+				preparedByDriver = append(preparedByDriver, preparedByDriverEntry{plugin: plugin, claims: claims})
+				rollbackPrepared()
 				return err
 			}
 		}
 
 		unfinished := len(claims) - len(response.Claims)
 		if unfinished != 0 {
+			preparedByDriver = append(preparedByDriver, preparedByDriverEntry{plugin: plugin, claims: claims})
+			rollbackPrepared()
 			return fmt.Errorf("NodePrepareResources skipped %d ResourceClaims", unfinished)
 		}
+
+		// This plugin fully completed; record it so that a failure in a later
+		// plugin can trigger a rollback for its already-prepared claims too.
+		preparedByDriver = append(preparedByDriver, preparedByDriverEntry{plugin: plugin, claims: claims})
 	}
 
 	// Atomically perform some operations on the claimInfo cache.

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -2485,6 +2485,104 @@ func TestUpdateAllocatedResourcesStatus_Subrequest(t *testing.T) {
 	}
 }
 
+
+// TestPrepareResourcesRollbackOnPartialFailure verifies that when a Pod requires
+// ResourceClaims managed by two different DRA drivers and the second driver fails
+// during NodePrepareResources, the kubelet calls NodeUnprepareResources on the
+// first (already-succeeded) driver to prevent a device leak.
+//
+// This is a regression test for https://github.com/kubernetes/kubernetes/issues/137819
+func TestPrepareResourcesRollbackOnPartialFailure(t *testing.T) {
+tCtx := ktesting.Init(t)
+backgroundCtx, cancel := context.WithCancel(tCtx)
+defer cancel()
+
+const (
+   = "driver-a"
+   = "driver-b"
+ame  = "claim-a"
+ame  = "claim-b"
+)
+
+claimAUID := types.UID(claimAName + "-uid")
+claimBUID := types.UID(claimBName + "-uid")
+
+fakeKubeClient := fake.NewClientset()
+manager, err := NewManager(tCtx.Logger(), fakeKubeClient, t.TempDir())
+require.NoError(t, err)
+
+backgroundCtx = klog.NewContext(backgroundCtx, tCtx.Logger())
+manager.initDRAPluginManager(backgroundCtx, getFakeNode, time.Second)
+
+// Pod that references both claims.
+pod := genTestPodWithClaims(claimAName, claimBName)
+
+// Claim A belongs to driver A — will succeed.
+claimA := genTestClaim(claimAName, driverA, deviceName, string(pod.UID))
+// Claim B belongs to driver B — will fail with a per-claim error.
+claimB := genTestClaim(claimBName, driverB, deviceName, string(pod.UID))
+
+_, err = fakeKubeClient.ResourceV1().ResourceClaims(namespace).Create(tCtx, claimA, metav1.CreateOptions{})
+require.NoError(t, err)
+_, err = fakeKubeClient.ResourceV1().ResourceClaims(namespace).Create(tCtx, claimB, metav1.CreateOptions{})
+require.NoError(t, err)
+
+// Driver A: returns a valid prepare response (success).
+respA := &drapb.NodePrepareResourcesResponse{
+g]*drapb.NodePrepareResourceResponse{
+g(claimAUID): {
+ame:     poolName,
+ame:   deviceName,
+uestNames: []string{requestName},
+g{cdiID},
+:= setupFakeDRADriverGRPCServer(backgroundCtx, false, nil, respA, nil, nil)
+require.NoError(t, err)
+defer serverA.teardownFn()
+
+// Driver B: returns a per-claim error, simulating a driver failure after A succeeds.
+respB := &drapb.NodePrepareResourcesResponse{
+g]*drapb.NodePrepareResourceResponse{
+g(claimBUID): {
+tentional prepare failure for claim " + claimBName,
+:= setupFakeDRADriverGRPCServer(backgroundCtx, false, nil, respB, nil, nil)
+require.NoError(t, err)
+defer serverB.teardownFn()
+
+plg := manager.GetWatcherHandler()
+require.NoError(t, plg.RegisterPlugin(driverA, serverA.socketName, []string{drapb.DRAPluginService}, nil))
+require.NoError(t, plg.RegisterPlugin(driverB, serverB.socketName, []string{drapb.DRAPluginService}, nil))
+
+err = manager.PrepareResources(backgroundCtx, pod)
+
+// PrepareResources must return an error because driver B failed.
+require.ErrorContains(t, err, claimBName,
+return an error referencing the failing claim")
+
+// Driver A completed NodePrepareResources, so it must have received exactly one
+// NodeUnprepareResources call to roll back the partial prepare.
+assert.Equal(t, uint32(1), serverA.server.unprepareResourceCalls.Load(),
+must be rolled back via NodeUnprepareResources after driver B failed")
+
+// Driver B itself failed during prepare, so it must NOT be unprepared.
+assert.Equal(t, uint32(0), serverB.server.unprepareResourceCalls.Load(),
+must NOT be unprepared since its own NodePrepareResources returned an error")
+
+// The cache must not retain a prepared entry for either claim since the whole
+// prepare failed.
+_, okA := manager.cache.get(claimAName, namespace)
+_, okB := manager.cache.get(claimBName, namespace)
+// Claims may still be in the cache (tracked for reconciliation) but must NOT
+// be marked as prepared.
+if okA {
+foA, _ := manager.cache.get(claimAName, namespace)
+foA.isPrepared(), "claim A must not be marked as prepared after rollback")
+}
+if okB {
+foB, _ := manager.cache.get(claimBName, namespace)
+foB.isPrepared(), "claim B must not be marked as prepared after failed prepare")
+}
+}
+
 func TestTruncateHealthMessage(t *testing.T) {
 	testCases := map[string]struct {
 		input    string

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -2583,6 +2583,104 @@ foB.isPrepared(), "claim B must not be marked as prepared after failed prepare")
 }
 }
 
+
+// TestPrepareResourcesRollbackOnPartialFailure verifies that when a Pod requires
+// ResourceClaims managed by two different DRA drivers and the second driver fails
+// during NodePrepareResources, the kubelet calls NodeUnprepareResources on the
+// first (already-succeeded) driver to prevent a device leak.
+//
+// This is a regression test for https://github.com/kubernetes/kubernetes/issues/137819
+func TestPrepareResourcesRollbackOnPartialFailure(t *testing.T) {
+tCtx := ktesting.Init(t)
+backgroundCtx, cancel := context.WithCancel(tCtx)
+defer cancel()
+
+const (
+   = "driver-a"
+   = "driver-b"
+ame  = "claim-a"
+ame  = "claim-b"
+)
+
+claimAUID := types.UID(claimAName + "-uid")
+claimBUID := types.UID(claimBName + "-uid")
+
+fakeKubeClient := fake.NewClientset()
+manager, err := NewManager(tCtx.Logger(), fakeKubeClient, t.TempDir())
+require.NoError(t, err)
+
+backgroundCtx = klog.NewContext(backgroundCtx, tCtx.Logger())
+manager.initDRAPluginManager(backgroundCtx, getFakeNode, time.Second)
+
+// Pod that references both claims.
+pod := genTestPodWithClaims(claimAName, claimBName)
+
+// Claim A belongs to driver A — will succeed.
+claimA := genTestClaim(claimAName, driverA, deviceName, string(pod.UID))
+// Claim B belongs to driver B — will fail with a per-claim error.
+claimB := genTestClaim(claimBName, driverB, deviceName, string(pod.UID))
+
+_, err = fakeKubeClient.ResourceV1().ResourceClaims(namespace).Create(tCtx, claimA, metav1.CreateOptions{})
+require.NoError(t, err)
+_, err = fakeKubeClient.ResourceV1().ResourceClaims(namespace).Create(tCtx, claimB, metav1.CreateOptions{})
+require.NoError(t, err)
+
+// Driver A: returns a valid prepare response (success).
+respA := &drapb.NodePrepareResourcesResponse{
+g]*drapb.NodePrepareResourceResponse{
+g(claimAUID): {
+ame:     poolName,
+ame:   deviceName,
+uestNames: []string{requestName},
+g{cdiID},
+:= setupFakeDRADriverGRPCServer(backgroundCtx, false, nil, respA, nil, nil)
+require.NoError(t, err)
+defer serverA.teardownFn()
+
+// Driver B: returns a per-claim error, simulating a driver failure after A succeeds.
+respB := &drapb.NodePrepareResourcesResponse{
+g]*drapb.NodePrepareResourceResponse{
+g(claimBUID): {
+tentional prepare failure for claim " + claimBName,
+:= setupFakeDRADriverGRPCServer(backgroundCtx, false, nil, respB, nil, nil)
+require.NoError(t, err)
+defer serverB.teardownFn()
+
+plg := manager.GetWatcherHandler()
+require.NoError(t, plg.RegisterPlugin(driverA, serverA.socketName, []string{drapb.DRAPluginService}, nil))
+require.NoError(t, plg.RegisterPlugin(driverB, serverB.socketName, []string{drapb.DRAPluginService}, nil))
+
+err = manager.PrepareResources(backgroundCtx, pod)
+
+// PrepareResources must return an error because driver B failed.
+require.ErrorContains(t, err, claimBName,
+return an error referencing the failing claim")
+
+// Driver A completed NodePrepareResources, so it must have received exactly one
+// NodeUnprepareResources call to roll back the partial prepare.
+assert.Equal(t, uint32(1), serverA.server.unprepareResourceCalls.Load(),
+must be rolled back via NodeUnprepareResources after driver B failed")
+
+// Driver B itself failed during prepare, so it must NOT be unprepared.
+assert.Equal(t, uint32(0), serverB.server.unprepareResourceCalls.Load(),
+must NOT be unprepared since its own NodePrepareResources returned an error")
+
+// The cache must not retain a prepared entry for either claim since the whole
+// prepare failed.
+_, okA := manager.cache.get(claimAName, namespace)
+_, okB := manager.cache.get(claimBName, namespace)
+// Claims may still be in the cache (tracked for reconciliation) but must NOT
+// be marked as prepared.
+if okA {
+foA, _ := manager.cache.get(claimAName, namespace)
+foA.isPrepared(), "claim A must not be marked as prepared after rollback")
+}
+if okB {
+foB, _ := manager.cache.get(claimBName, namespace)
+foB.isPrepared(), "claim B must not be marked as prepared after failed prepare")
+}
+}
+
 func TestTruncateHealthMessage(t *testing.T) {
 	testCases := map[string]struct {
 		input    string


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #137819.

When a Pod has ResourceClaims served by more than one DRA driver,
`NodePrepareResources` is called once per driver.  If driver A succeeds
but driver B subsequently fails, the existing code returns an error
immediately without calling `NodeUnprepareResources` on driver A.  This
leaves driver A's devices in a prepared/reserved state indefinitely,
stranding capacity until the driver's own reconciliation reclaims it
and leaving the Pod stuck in `FailedPrepareDynamicResources`.

**Fix**: introduce a `preparedByDriver` list that records each driver
that has completed `NodePrepareResources` in the current call.  Any
error path in the batch loop now calls `rollbackPrepared()`, which
issues `NodeUnprepareResources` for every driver that already
completed.  Rollback errors are logged but not propagated.

The rollback is also triggered when:
- A driver response references an unknown claim UID
- A per-claim result carries an error string
- A driver skips claims (`unfinished != 0`)
- Writing CDI device data to the local cache fails

## Which issue(s) this PR fixes

Fixes #137819

## Testing

Added `TestPrepareResourcesRollbackOnPartialFailure` to `pkg/kubelet/cm/dra/manager_test.go` that:
- Creates a Pod with two claims served by two different drivers
- Driver A succeeds; driver B returns a per-claim error
- Asserts PrepareResources returns an error referencing driver B's claim
- Asserts driver A receives exactly one `NodeUnprepareResources` call (rollback)
- Asserts driver B receives no `NodeUnprepareResources` call
- Asserts neither claim is marked as prepared in the cache

## Special notes for your reviewer

The change is limited to `pkg/kubelet/cm/dra/manager.go` and `pkg/kubelet/cm/dra/manager_test.go`.
The new `type preparedByDriverEntry` is function-scoped to avoid polluting the package namespace.

## Does this PR introduce a user-facing change?

```release-note
Fix a bug where partial DRA prepare (multiple drivers, one succeeds
and one fails) left already-prepared drivers without a rollback,
stranding devices and leaving the Pod in FailedPrepareDynamicResources.
```
