### PR TITLE
cri-client: use atomic.Bool for useStreaming to fix data race

### DIFF
--- a/staging/src/k8s.io/cri-client/pkg/remote_image.go
+++ b/staging/src/k8s.io/cri-client/pkg/remote_image.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -46,9 +47,10 @@ type remoteImageService struct {
 	conn        *grpc.ClientConn
 	// useStreaming indicates whether to use streaming RPCs for list operations
 	// when the CRIListStreaming feature gate is enabled. It falls back to false
-	// if a streaming RPC returns Unimplemented. The fallback is racy but kept
-	// simple since the worst case is a few extra fallback attempts.
-	useStreaming bool
+	// if a streaming RPC returns Unimplemented. Multiple goroutines may
+	// concurrently observe Unimplemented and store false, but that is harmless
+	// because the store is idempotent.
+	useStreaming atomic.Bool
 }
 
 // NewRemoteImageService creates a new internalapi.ImageManagerService.
@@ -104,10 +106,11 @@ func NewRemoteImageService(ctx context.Context, endpoint string, connectionTimeo
 	}
 
 	service := &remoteImageService{
-		timeout:      connectionTimeout,
-		conn:         conn,
-		useStreaming: useStreaming,
+		timeout: connectionTimeout,
+		conn:    conn,
 	}
+	service.useStreaming.Store(useStreaming)
+
 	if err := service.validateServiceConnection(ctx, conn, endpoint); err != nil {
 		return nil, fmt.Errorf("validate service connection: %w", err)
 	}
@@ -143,7 +146,7 @@ func (r *remoteImageService) ListImages(ctx context.Context, filter *runtimeapi.
 	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
-	if r.useStreaming {
+	if r.useStreaming.Load() {
 		return r.streamImagesV1(ctx, filter)
 	}
 	return r.listImagesV1(ctx, filter)
@@ -184,7 +187,7 @@ func (r *remoteImageService) streamImagesV1(ctx context.Context, filter *runtime
 			// but when calling Recv() on the stream.
 			if status.Code(err) == codes.Unimplemented {
 				logger.Info("StreamImages not implemented, falling back to ListImages", "filter", filter)
-				r.useStreaming = false
+				r.useStreaming.Store(false)
 				return r.listImagesV1(ctx, filter)
 			}
 			logger.Error(err, "StreamImages recv failed", "filter", filter, "itemsReceived", len(images))

--- a/staging/src/k8s.io/cri-client/pkg/remote_runtime.go
+++ b/staging/src/k8s.io/cri-client/pkg/remote_runtime.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -51,9 +52,10 @@ type remoteRuntimeService struct {
 	conn         *grpc.ClientConn
 	// useStreaming indicates whether to use streaming RPCs for list operations
 	// when the CRIListStreaming feature gate is enabled. It falls back to false
-	// if a streaming RPC returns Unimplemented. The fallback is racy but kept
-	// simple since the worst case is a few extra fallback attempts.
-	useStreaming bool
+	// if a streaming RPC returns Unimplemented. Multiple goroutines may
+	// concurrently observe Unimplemented and store false, but that is harmless
+	// because the store is idempotent.
+	useStreaming atomic.Bool
 }
 
 const (
@@ -138,8 +140,8 @@ func NewRemoteRuntimeService(ctx context.Context, endpoint string, connectionTim
 		timeout:      connectionTimeout,
 		logReduction: logreduction.NewLogReduction(identicalErrorDelay),
 		conn:         conn,
-		useStreaming: useStreaming,
 	}
+	service.useStreaming.Store(useStreaming)
 
 	if err := service.validateServiceConnection(ctx, conn, endpoint); err != nil {
 		return nil, fmt.Errorf("validate service connection: %w", err)
@@ -330,7 +332,7 @@ func (r *remoteRuntimeService) ListPodSandbox(ctx context.Context, filter *runti
 	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
-	if r.useStreaming {
+	if r.useStreaming.Load() {
 		return r.streamPodSandboxesV1(ctx, filter)
 	}
 	return r.listPodSandboxV1(ctx, filter)
@@ -373,7 +375,7 @@ func (r *remoteRuntimeService) streamPodSandboxesV1(ctx context.Context, filter 
 			// but when calling Recv() on the stream.
 			if status.Code(err) == codes.Unimplemented {
 				logger.Info("StreamPodSandboxes not implemented, falling back to ListPodSandbox", "filter", filter)
-				r.useStreaming = false
+				r.useStreaming.Store(false)
 				return r.listPodSandboxV1(ctx, filter)
 			}
 			logger.Error(err, "StreamPodSandboxes recv failed", "filter", filter, "itemsReceived", len(items))
@@ -489,7 +491,7 @@ func (r *remoteRuntimeService) ListContainers(ctx context.Context, filter *runti
 	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
-	if r.useStreaming {
+	if r.useStreaming.Load() {
 		return r.streamContainersV1(ctx, filter)
 	}
 	return r.listContainersV1(ctx, filter)
@@ -531,7 +533,7 @@ func (r *remoteRuntimeService) streamContainersV1(ctx context.Context, filter *r
 			// but when calling Recv() on the stream.
 			if status.Code(err) == codes.Unimplemented {
 				logger.Info("StreamContainers not implemented, falling back to ListContainers", "filter", filter)
-				r.useStreaming = false
+				r.useStreaming.Store(false)
 				return r.listContainersV1(ctx, filter)
 			}
 			logger.Error(err, "StreamContainers recv failed", "filter", filter, "itemsReceived", len(containers))
@@ -846,7 +848,7 @@ func (r *remoteRuntimeService) ListContainerStats(ctx context.Context, filter *r
 	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
-	if r.useStreaming {
+	if r.useStreaming.Load() {
 		return r.streamContainerStatsV1(ctx, filter)
 	}
 	return r.listContainerStatsV1(ctx, filter)
@@ -888,7 +890,7 @@ func (r *remoteRuntimeService) streamContainerStatsV1(ctx context.Context, filte
 			// but when calling Recv() on the stream.
 			if status.Code(err) == codes.Unimplemented {
 				logger.Info("StreamContainerStats not implemented, falling back to ListContainerStats", "filter", filter)
-				r.useStreaming = false
+				r.useStreaming.Store(false)
 				return r.listContainerStatsV1(ctx, filter)
 			}
 			logger.Error(err, "StreamContainerStats recv failed", "filter", filter, "itemsReceived", len(stats))
@@ -937,7 +939,7 @@ func (r *remoteRuntimeService) ListPodSandboxStats(ctx context.Context, filter *
 	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
-	if r.useStreaming {
+	if r.useStreaming.Load() {
 		return r.streamPodSandboxStatsV1(ctx, filter)
 	}
 	return r.listPodSandboxStatsV1(ctx, filter)
@@ -979,7 +981,7 @@ func (r *remoteRuntimeService) streamPodSandboxStatsV1(ctx context.Context, filt
 			// but when calling Recv() on the stream.
 			if status.Code(err) == codes.Unimplemented {
 				logger.Info("StreamPodSandboxStats not implemented, falling back to ListPodSandboxStats", "filter", filter)
-				r.useStreaming = false
+				r.useStreaming.Store(false)
 				return r.listPodSandboxStatsV1(ctx, filter)
 			}
 			logger.Error(err, "StreamPodSandboxStats recv failed", "filter", filter, "itemsReceived", len(stats))
@@ -1112,7 +1114,7 @@ func (r *remoteRuntimeService) ListPodSandboxMetrics(ctx context.Context) ([]*ru
 	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
-	if r.useStreaming {
+	if r.useStreaming.Load() {
 		return r.streamPodSandboxMetricsV1(ctx)
 	}
 	return r.listPodSandboxMetricsV1(ctx)
@@ -1150,7 +1152,7 @@ func (r *remoteRuntimeService) streamPodSandboxMetricsV1(ctx context.Context) ([
 			// but when calling Recv() on the stream.
 			if status.Code(err) == codes.Unimplemented {
 				logger.Info("StreamPodSandboxMetrics not implemented, falling back to ListPodSandboxMetrics")
-				r.useStreaming = false
+				r.useStreaming.Store(false)
 				return r.listPodSandboxMetricsV1(ctx)
 			}
 			logger.Error(err, "StreamPodSandboxMetrics recv failed", "itemsReceived", len(metrics))


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Replace plain bool with sync/atomic.Bool for the useStreaming field in remoteRuntimeService and remoteImageService to eliminate a data race when multiple goroutines concurrently read/write the field during Unimplemented fallback.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #137947

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
