### PR TITLE
API ext integration: Keep polling for expected error when actual is nil

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
@@ -276,14 +276,10 @@ func (u updateMyCRDV1Beta1Schema) Do(ctx *ratchetingTestContext) error {
 					sentinelName: fmt.Sprintf("invalid-%d", counter),
 				}}.Do(ctx)
 
-			if err == nil {
-				return false, errors.New("expected error when creating sentinel resource")
-			}
-
 			// Check to see if the returned error message contains our
 			// unique string. UUID should be unique enough to just check
 			// simple existence in the error.
-			if strings.Contains(err.Error(), uuidString) {
+			if err != nil && strings.Contains(err.Error(), uuidString) {
 				return true, nil
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR targets the flake in the k8s.io/apiextensions-apiserver integration tests described in #137951 and addresses the "reason for failure" there:

> There is a polling loop that waits for the expected error to occur, but fails and stops polling when the error is nil:
> 
> https://github.com/kubernetes/kubernetes/blob/758f86368dc38b134445f6a303cb8ab9e21be586/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go#L279-L281
> 
> Instead of stopping polling, the test should keep retrying.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Should fix flake in https://github.com/kubernetes/kubernetes/issues/137951

#### Special notes for your reviewer:

I tested this change by introducing this artificial delay which reliably reproduces the flake for me locally:
```diff
diff --git a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
index c252e7fe75b..9b7d80d9193 100644
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -510,6 +510,8 @@ func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{})
        }
 
        klog.V(4).Infof("Updating customresourcedefinition %s", newCRD.Name)
+       time.Sleep(500 * time.Millisecond)
        r.removeStorage_locked(newCRD.UID)
 }
```
```
% stress ./integration.test -test.run TestRatchetingFunctionality/Status:_CEL_transition_rules_should_not_ratchet
...
24m40s: 3476 runs so far, 0 failures, 12 active
```

I also checked that introducing a real bug still makes the test fail:
```diff
diff --git a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
index a8ba937224c..891f36bff27 100644
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -465,7 +465,7 @@ func (s *Validator) validateExpressions(ctx context.Context, fldPath *field.Path
                }
 
                addErr := func(e *field.Error) {
-                       if !compiled.UsesOldSelf && correlation.shouldRatchetError() {
+                       if correlation.shouldRatchetError() {
                                warning.AddWarning(ctx, "", e.Error())
                        } else {
                                errs = append(errs, e)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
