### PR TITLE
Add topology-aware routing to winkernel proxier

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -253,6 +253,10 @@ type endpointInfo struct {
 	ready       bool
 	serving     bool
 	terminating bool
+
+	// topology hints
+	zoneHints sets.Set[string]
+	nodeHints sets.Set[string]
 }
 
 // String is part of proxy.Endpoint interface.
@@ -282,12 +286,12 @@ func (info *endpointInfo) IsTerminating() bool {
 
 // ZoneHints returns the zone hints for the endpoint.
 func (info *endpointInfo) ZoneHints() sets.Set[string] {
-	return sets.Set[string]{}
+	return info.zoneHints
 }
 
 // NodeHints returns the node hints for the endpoint.
 func (info *endpointInfo) NodeHints() sets.Set[string] {
-	return sets.Set[string]{}
+	return info.nodeHints
 }
 
 // IP returns just the IP part of the endpoint, it's a part of proxy.Endpoint interface.
@@ -437,6 +441,9 @@ func (proxier *Proxier) newEndpointInfo(baseInfo *proxy.BaseEndpointInfo, _ *pro
 		ready:       baseInfo.IsReady(),
 		serving:     baseInfo.IsServing(),
 		terminating: baseInfo.IsTerminating(),
+
+		zoneHints: baseInfo.ZoneHints(),
+		nodeHints: baseInfo.NodeHints(),
 	}
 
 	return info
@@ -588,6 +595,10 @@ type Proxier struct {
 	// These are effectively const and do not need the mutex to be held.
 	nodeName string
 	nodeIP   net.IP
+
+	// topologyLabels stores the node's topology labels for topology-aware
+	// routing (KEP-2433 and KEP-4444). Protected by mu.
+	topologyLabels map[string]string
 
 	serviceHealthServer healthcheck.ServiceHealthServer
 	healthzServer       *healthcheck.ProxyHealthServer
@@ -1022,12 +1033,22 @@ func (proxier *Proxier) OnEndpointSlicesSynced() {
 // in any of the ServiceCIDRs, and provides complete list of service cidrs.
 func (proxier *Proxier) OnServiceCIDRsChanged(_ []string) {}
 
-// TODO(imroc): implement OnTopologyChanged for winkernel proxier.
 // OnTopologyChange is called whenever node topology labels are changed.
 // The informer is tweaked to listen for updates of the node where this
 // instance of kube-proxy is running, this guarantees the changed labels
 // are for this node.
-func (proxier *Proxier) OnTopologyChange(topologyLabels map[string]string) {}
+func (proxier *Proxier) OnTopologyChange(topologyLabels map[string]string) {
+	proxier.mu.Lock()
+	proxier.topologyLabels = topologyLabels
+	// Reset policyApplied on all services to force re-evaluation with new topology.
+	// Winkernel proxier uses per-service policyApplied flags so
+	// 'cleanupAllPolicies()' achieves the same effect as 'needFullSync=true'.
+	proxier.cleanupAllPolicies()
+	proxier.mu.Unlock()
+
+	klog.V(3).InfoS("Updated proxier node topology labels", "labels", topologyLabels)
+	proxier.Sync()
+}
 
 func (proxier *Proxier) cleanupAllPolicies() {
 	for svcName, svc := range proxier.svcPortMap {
@@ -1241,48 +1262,53 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 
 		var hnsEndpoints []endpointInfo
 		var hnsLocalEndpoints []endpointInfo
+		var hnsClusterEndpoints []endpointInfo
 		klog.V(4).InfoS("Applying Policy", "serviceInfo", svcName)
-		// Create Remote endpoints for every endpoint, corresponding to the service
+
+		// CategorizeEndpoints returns topology-aware (zone/node hints) endpoint lists,
+		// filtering for readiness and falling back to serving-terminating endpoints.
+		// allReachableEndpoints excludes remote endpoints when UsesClusterEndpoints()==false
+		// (i.e. both traffic policies are Local), so the loop below only creates HNS
+		// endpoints for reachable ones. DSR-awareness is not needed at this stage because
+		// DSR only affects which LB policy uses which endpoint list, handled below via
+		// svcInfo.localTrafficDSR.
+		allEndpoints := proxier.endpointsMap[svcName]
+		clusterEndpoints, localEndpoints, allReachableEndpoints, hasAnyEndpoints := proxy.CategorizeEndpoints(allEndpoints, svcInfo, proxier.nodeName, proxier.topologyLabels)
+
+		if !hasAnyEndpoints {
+			klog.V(3).InfoS("Service has no usable endpoints", "serviceName", svcName)
+		}
+
+		// Build endpoint key sets for classifying HNS endpoints during the loop below.
+		clusterEndpointSet := make(map[string]bool, len(clusterEndpoints))
+		for _, ep := range clusterEndpoints {
+			clusterEndpointSet[ep.String()] = true
+		}
+		localEndpointSet := make(map[string]bool, len(localEndpoints))
+		for _, ep := range localEndpoints {
+			localEndpointSet[ep.String()] = true
+		}
+
+		// Create Remote endpoints for every reachable endpoint, corresponding to the service
 		containsPublicIP := false
 		containsNodeIP := false
 		var allEndpointsTerminating, allEndpointsNonServing bool
-		someEndpointsServing := true
 
 		if len(svcInfo.loadBalancerIngressIPs) > 0 {
 			// Check should be done only if comes under the feature gate or enabled
 			// The check should be done only if Spec.Type == Loadbalancer.
 			allEndpointsTerminating = proxier.isAllEndpointsTerminating(svcName, svcInfo.localTrafficDSR)
 			allEndpointsNonServing = proxier.isAllEndpointsNonServing(svcName, svcInfo.localTrafficDSR)
-			someEndpointsServing = !allEndpointsNonServing
 			klog.V(4).InfoS("Terminating status checked for all endpoints", "svcClusterIP", svcInfo.ClusterIP(), "allEndpointsTerminating", allEndpointsTerminating, "allEndpointsNonServing", allEndpointsNonServing, "localTrafficDSR", svcInfo.localTrafficDSR)
 		} else {
 			klog.V(4).InfoS("Skipped terminating status check for all endpoints", "svcClusterIP", svcInfo.ClusterIP(), "ingressLBCount", len(svcInfo.loadBalancerIngressIPs))
 		}
 
-		for _, epInfo := range proxier.endpointsMap[svcName] {
+		for _, epInfo := range allReachableEndpoints {
 			ep, ok := epInfo.(*endpointInfo)
 			if !ok {
 				klog.ErrorS(nil, "Failed to cast endpointInfo", "serviceName", svcName)
 				continue
-			}
-
-			if svcInfo.internalTrafficLocal && svcInfo.localTrafficDSR && !ep.IsLocal() {
-				// No need to use or create remote endpoint when internal and external traffic policy is remote
-				klog.V(3).InfoS("Skipping the endpoint. Both internalTraffic and external traffic policies are local", "EpIP", ep.ip, " EpPort", ep.port)
-				continue
-			}
-
-			if someEndpointsServing {
-
-				if !allEndpointsTerminating && !ep.IsReady() {
-					klog.V(3).InfoS("Skipping the endpoint for LB creation. Endpoint is either not ready or all not all endpoints are terminating", "EpIP", ep.ip, " EpPort", ep.port, "allEndpointsTerminating", allEndpointsTerminating, "IsEpReady", ep.IsReady())
-					continue
-				}
-				if !ep.IsServing() {
-					klog.V(3).InfoS("Skipping the endpoint for LB creation. Endpoint is not serving", "EpIP", ep.ip, " EpPort", ep.port, "IsEpServing", ep.IsServing())
-					continue
-				}
-
 			}
 
 			var newHnsEndpoint *endpointInfo
@@ -1387,9 +1413,16 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 			klog.V(1).InfoS("Hns endpoint resource", "endpointInfo", newHnsEndpoint)
 
 			hnsEndpoints = append(hnsEndpoints, *newHnsEndpoint)
-			if newHnsEndpoint.IsLocal() {
+			// Classify into cluster/local HNS endpoint lists using
+			// the sets built from CategorizeEndpoints results.
+			epKey := epInfo.String()
+			if clusterEndpointSet[epKey] {
+				hnsClusterEndpoints = append(hnsClusterEndpoints, *newHnsEndpoint)
+			}
+			if localEndpointSet[epKey] {
 				hnsLocalEndpoints = append(hnsLocalEndpoints, *newHnsEndpoint)
-			} else {
+			}
+			if !newHnsEndpoint.IsLocal() {
 				// We only share the refCounts for remote endpoints
 				ep.refCount = proxier.endPointsRefCount.getRefCount(newHnsEndpoint.hnsID)
 				*ep.refCount++
@@ -1431,10 +1464,14 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 			klog.InfoS("Session Affinity is not supported on this version of Windows")
 		}
 
+		// Note: we use the DSR-aware isAllEndpointsTerminating/isAllEndpointsNonServing checks
+		// rather than len(hnsEndpoints) > 0, because on a DSR-enabled host where all local
+		// endpoints are terminating but remote endpoints are healthy, len(hnsEndpoints) > 0
+		// would be true but we should not create LBs for DSR-local traffic.
 		endpointsAvailableForLB := !allEndpointsTerminating && !allEndpointsNonServing
 
 		// clusterIPEndpoints is the endpoint list used for creating ClusterIP loadbalancer.
-		clusterIPEndpoints := hnsEndpoints
+		clusterIPEndpoints := hnsClusterEndpoints
 		if svcInfo.internalTrafficLocal {
 			// Take local endpoints for clusterip loadbalancer when internal traffic policy is local.
 			clusterIPEndpoints = hnsLocalEndpoints
@@ -1490,7 +1527,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		if svcInfo.NodePort() > 0 {
 			// If the preserve-destination service annotation is present, we will disable routing mesh for NodePort.
 			// This means that health services can use Node Port without falsely getting results from a different node.
-			nodePortEndpoints := hnsEndpoints
+			nodePortEndpoints := hnsClusterEndpoints
 			if svcInfo.preserveDIP || svcInfo.localTrafficDSR {
 				nodePortEndpoints = hnsLocalEndpoints
 			}
@@ -1545,7 +1582,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		// Create a Load Balancer Policy for each external IP
 		for _, externalIP := range svcInfo.externalIPs {
 			// Disable routing mesh if ExternalTrafficPolicy is set to local
-			externalIPEndpoints := hnsEndpoints
+			externalIPEndpoints := hnsClusterEndpoints
 			if svcInfo.localTrafficDSR {
 				externalIPEndpoints = hnsLocalEndpoints
 			}
@@ -1598,7 +1635,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		// Create a Load Balancer Policy for each loadbalancer ingress
 		for _, lbIngressIP := range svcInfo.loadBalancerIngressIPs {
 			// Try loading existing policies, if already available
-			lbIngressEndpoints := hnsEndpoints
+			lbIngressEndpoints := hnsClusterEndpoints
 			if svcInfo.preserveDIP || svcInfo.localTrafficDSR {
 				lbIngressEndpoints = hnsLocalEndpoints
 			}

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -1927,6 +1927,259 @@ func TestETPClusterIngressIPServiceWithRequireDualStack(t *testing.T) {
 	testDualStackService(t, false, v1.IPFamilyPolicyRequireDualStack, v1.ServiceExternalTrafficPolicyCluster)
 }
 
+func TestOnTopologyChange(t *testing.T) {
+	proxier := NewFakeProxier(t, testNodeName, netutils.ParseIPSloppy("10.0.0.1"), "L2Bridge", false)
+	if proxier == nil {
+		t.Fatal("Failed to create proxier")
+	}
+
+	assert.Nil(t, proxier.topologyLabels, "topologyLabels should be nil initially")
+
+	topologyLabels := map[string]string{
+		v1.LabelTopologyZone: "zone-a",
+	}
+	proxier.OnTopologyChange(topologyLabels)
+
+	proxier.mu.Lock()
+	assert.Equal(t, "zone-a", proxier.topologyLabels[v1.LabelTopologyZone], "topologyLabels should be updated")
+	proxier.mu.Unlock()
+}
+
+func TestTopologyAwareZoneHintFiltering(t *testing.T) {
+	proxier := NewFakeProxier(t, testNodeName, netutils.ParseIPSloppy("10.0.0.1"), "L2Bridge", false)
+	if proxier == nil {
+		t.Fatal("Failed to create proxier")
+	}
+
+	svcIP := "10.20.30.41"
+	svcPort := 80
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	// Set topology labels on the proxier (simulates OnTopologyChange)
+	proxier.topologyLabels = map[string]string{
+		v1.LabelTopologyZone: "zone-a",
+	}
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: v1.ProtocolTCP,
+			}}
+		}),
+	)
+
+	// Create endpoints with zone hints: one in zone-a, one in zone-b
+	// Both are remote endpoints (no NodeName set)
+	populateEndpointSlices(proxier,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{
+				{
+					Addresses: []string{epIpAddressRemote}, // 192.168.2.3 - in zone-a
+					Hints: &discovery.EndpointHints{
+						ForZones: []discovery.ForZone{{Name: "zone-a"}},
+					},
+				},
+				{
+					Addresses: []string{"192.168.2.4"}, // in zone-b
+					Hints: &discovery.EndpointHints{
+						ForZones: []discovery.ForZone{{Name: "zone-b"}},
+					},
+				},
+			}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+	)
+
+	proxier.setInitialized(true)
+	proxier.syncProxyRules()
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo")
+	// A load balancer should have been created with only the zone-a endpoint
+	assert.NotEmpty(t, svcInfo.hnsID, "Expected ClusterIP LB to be created")
+
+	lb, err := proxier.hcn.GetLoadBalancerByID(svcInfo.hnsID)
+	assert.Nil(t, err, "Failed to fetch loadbalancer")
+	assert.NotNil(t, lb, "Loadbalancer object should not be nil")
+	// Only the zone-a endpoint should be in the load balancer
+	assert.Equal(t, 1, len(lb.HostComputeEndpoints), "Expected 1 endpoint in LB (zone-a only)")
+}
+
+func TestTopologyFallbackWhenNoMatchingZone(t *testing.T) {
+	proxier := NewFakeProxier(t, testNodeName, netutils.ParseIPSloppy("10.0.0.1"), "L2Bridge", false)
+	if proxier == nil {
+		t.Fatal("Failed to create proxier")
+	}
+
+	svcIP := "10.20.30.41"
+	svcPort := 80
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	// Set topology labels with zone-c, which has no endpoints
+	proxier.topologyLabels = map[string]string{
+		v1.LabelTopologyZone: "zone-c",
+	}
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: v1.ProtocolTCP,
+			}}
+		}),
+	)
+
+	// Create endpoints only in zone-a and zone-b (NOT zone-c)
+	populateEndpointSlices(proxier,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{
+				{
+					Addresses: []string{epIpAddressRemote},
+					Hints: &discovery.EndpointHints{
+						ForZones: []discovery.ForZone{{Name: "zone-a"}},
+					},
+				},
+				{
+					Addresses: []string{"192.168.2.4"},
+					Hints: &discovery.EndpointHints{
+						ForZones: []discovery.ForZone{{Name: "zone-b"}},
+					},
+				},
+			}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+	)
+
+	proxier.setInitialized(true)
+	proxier.syncProxyRules()
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo")
+	// When no endpoints match the node's zone, CategorizeEndpoints falls back
+	// to all ready endpoints (no topology filtering)
+	assert.NotEmpty(t, svcInfo.hnsID, "Expected ClusterIP LB to be created")
+
+	lb, err := proxier.hcn.GetLoadBalancerByID(svcInfo.hnsID)
+	assert.Nil(t, err, "Failed to fetch loadbalancer")
+	assert.NotNil(t, lb, "Loadbalancer object should not be nil")
+	// Both endpoints should be included since topology hint was ignored (no matching zone)
+	assert.Equal(t, 2, len(lb.HostComputeEndpoints), "Expected 2 endpoints in LB (fallback, no topology filtering)")
+}
+
+func TestTopologyWithETPLocal(t *testing.T) {
+	proxier := NewFakeProxier(t, testNodeName, netutils.ParseIPSloppy("10.0.0.1"), "L2Bridge", true)
+	if proxier == nil {
+		t.Fatal("Failed to create proxier")
+	}
+
+	svcIP := "10.20.30.41"
+	svcPort := 80
+	svcNodePort := 30001
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	// Set topology labels
+	proxier.topologyLabels = map[string]string{
+		v1.LabelTopologyZone: "zone-a",
+	}
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeNodePort
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: v1.ProtocolTCP,
+				NodePort: int32(svcNodePort),
+			}}
+		}),
+	)
+
+	// Create endpoints: one local (zone-a), one remote (zone-a), one remote (zone-b)
+	populateEndpointSlices(proxier,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{
+				{
+					Addresses: []string{epIpAddressLocal1},
+					NodeName:  ptr.To(testNodeName), // local
+					Hints: &discovery.EndpointHints{
+						ForZones: []discovery.ForZone{{Name: "zone-a"}},
+					},
+				},
+				{
+					Addresses: []string{epIpAddressRemote}, // remote, zone-a
+					Hints: &discovery.EndpointHints{
+						ForZones: []discovery.ForZone{{Name: "zone-a"}},
+					},
+				},
+			}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+	)
+
+	hcnMock := (proxier.hcn).(*fakehcn.HcnMock)
+	hcnMock.PopulateQueriedEndpoints(endpointLocal1, networkId, epIpAddressLocal1, macAddressLocal1, prefixLen)
+
+	proxier.setInitialized(true)
+	proxier.syncProxyRules()
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo")
+
+	// ClusterIP LB should use topology-filtered cluster endpoints (zone-a = both local + remote)
+	assert.NotEmpty(t, svcInfo.hnsID, "Expected ClusterIP LB to be created")
+	lb, err := proxier.hcn.GetLoadBalancerByID(svcInfo.hnsID)
+	assert.Nil(t, err, "Failed to fetch ClusterIP loadbalancer")
+	assert.NotNil(t, lb, "ClusterIP loadbalancer should not be nil")
+	assert.Equal(t, 2, len(lb.HostComputeEndpoints), "ClusterIP LB should have 2 endpoints (both in zone-a)")
+
+	// NodePort LB should use only local endpoints (ETP:Local)
+	assert.NotEmpty(t, svcInfo.nodePorthnsID, "Expected NodePort LB to be created")
+	nodeLB, err := proxier.hcn.GetLoadBalancerByID(svcInfo.nodePorthnsID)
+	assert.Nil(t, err, "Failed to fetch NodePort loadbalancer")
+	assert.NotNil(t, nodeLB, "NodePort loadbalancer should not be nil")
+	assert.Equal(t, 1, len(nodeLB.HostComputeEndpoints), "NodePort LB should have 1 endpoint (local only, ETP:Local)")
+}
+
+
 func makeNSN(namespace, name string) types.NamespacedName {
 	return types.NamespacedName{Namespace: namespace, Name: name}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes #123823.

The winkernel proxier's `OnTopologyChange` was so far a no-op, Windows kube-proxy ignored EndpointSlice topology hints and always load-balanced across all ready endpoints regardless of zone or node proximity.

This change wires the winkernel proxier into the shared `CategorizeEndpoints` in `topology.go` to support topology-aware routing:

- Implement `OnTopologyChange` to store topology labels and force re-evaluation of all services via `cleanupAllPolicies`.

- Introduce zoneHints/nodeHints fields in `endpointInfo` and propagate them from `BaseEndpointInfo` in `newEndpointInfo`.

- Use `CategorizeEndpoints` in `syncProxyRules` to obtain topology-filtered cluster/local/allReachable endpoint lists. Iterate `allReachableEndpoints` (instead of raw `endpointsMap`) and classify HNS endpoints into hnsClusterEndpoints/hnsLocalEndpoints using endpoint key sets built from `CategorizeEndpoints` output.

- Use `hnsClusterEndpoints` as the default for ClusterIP, NodePort,ExternalIP, and LB Ingress load balancers, switching to `hnsLocalEndpoints` based on existing DSR-aware condition (localTrafficDSR, preserveDIP, internalTrafficLocal).

This change preserves existing DSR behavior:
- LB endpoint selection uses `svcInfo.localTrafficDSR` (which is false when DSR is not supported) rather than `ExternalPolicyLocal`.
- `endpointsAvailableForLB` continues to use DSR-aware `isAllEndpointsTerminating`/`isAllEndpointsNonServing` checks.

Backward compatible: when `topologyLabels` is nil (no `OnTopologyChange` received), `CategorizeEndpoints` returns all ready endpoints with no topology filtering, identical to previous behavior.


#### Which issue(s) this PR is related to:

Fixes #123823
KEP: https://github.com/kubernetes/enhancements/blob/c74bd0418f7b36d5f6b6799cc8aa63a9dcb3670a/keps/sig-network/2433-topology-aware-hints/README.md
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added topology-aware routing support (KEP-2433) to the Windows winkernel kube-proxy. EndpointSlice topology hints (zone and node affinity) are now respected when load-balancing traffic, bringing the winkernel proxier to parity with the iptables and ipvs proxiers. No user action required.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/c74bd0418f7b36d5f6b6799cc8aa63a9dcb3670a/keps/sig-network/2433-topology-aware-hints/README.md
```
