### PR TITLE
Fix restartable init container startup race

### DIFF
--- a/test/e2e_node/container_lifecycle_pod_construction.go
+++ b/test/e2e_node/container_lifecycle_pod_construction.go
@@ -85,8 +85,8 @@ func ExecCommand(name string, c execCommand) []string {
 		fmt.Fprint(&cmd, sleepCommand(c.StartDelay))
 	}
 	// You can check started file to see if the container has started
-	fmt.Fprintf(&cmd, "touch started; ")
 	fmt.Fprintf(&cmd, "echo %s '%s Started' | tee -a %s >> /proc/1/fd/1; ", timeCmd, name, containerLog)
+	fmt.Fprintf(&cmd, "touch started; ")
 	fmt.Fprintf(&cmd, "echo %s '%s Delaying %d' | tee -a %s >> /proc/1/fd/1; ", timeCmd, name, c.Delay, containerLog)
 	if c.Delay != 0 {
 		fmt.Fprint(&cmd, sleepCommand(c.Delay))
@@ -406,6 +406,16 @@ func preparePod(pod *v1.Pod) {
 			VolumeSource: v1.VolumeSource{
 				EmptyDir: &v1.EmptyDirVolumeSource{},
 			},
+		},
+	}
+}
+
+// startedPostStartGate generates a LifecycleHandler for a PostStart hook that waits for the main
+// container process to reach the `Started` point.
+func startedPostStartGate() *v1.LifecycleHandler {
+	return &v1.LifecycleHandler{
+		Exec: &v1.ExecAction{
+			Command: []string{"sh", "-c", "until [ -f started ]; do sleep 0.1; done"},
 		},
 	}
 }

--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -2288,6 +2288,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 								TerminationSeconds: containerTerminationSeconds,
 								ExitCode:           0,
 							}),
+							Lifecycle: &v1.Lifecycle{
+								PostStart: startedPostStartGate(),
+							},
 							RestartPolicy: &containerRestartPolicyAlways,
 						},
 						{
@@ -2306,6 +2309,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 								TerminationSeconds: 1,
 								ExitCode:           0,
 							}),
+							Lifecycle: &v1.Lifecycle{
+								PostStart: startedPostStartGate(),
+							},
 							RestartPolicy: &containerRestartPolicyAlways,
 						},
 					},
@@ -4566,6 +4572,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 5,
 									ExitCode:           0,
 								}),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+								},
 							},
 							{
 								Name:          restartableInit2,
@@ -4576,6 +4585,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 5,
 									ExitCode:           0,
 								}),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+								},
 							},
 							{
 								Name:          restartableInit3,
@@ -4586,6 +4598,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 5,
 									ExitCode:           0,
 								}),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+								},
 							},
 						},
 						Containers: []v1.Container{
@@ -4776,17 +4791,15 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 				restartableInit3 := "restartable-init-3"
 				regular1 := "regular-1"
 
-				makePrestop := func(containerName string) *v1.Lifecycle {
-					return &v1.Lifecycle{
-						PreStop: &v1.LifecycleHandler{
-							Exec: &v1.ExecAction{
-								Command: ExecCommand(prefixedName(PreStopPrefix, containerName), execCommand{
-									ExitCode:      0,
-									ContainerName: containerName,
-									LoopForever:   true,
-									LoopPeriod:    0.2,
-								}),
-							},
+				makePrestop := func(containerName string) *v1.LifecycleHandler {
+					return &v1.LifecycleHandler{
+						Exec: &v1.ExecAction{
+							Command: ExecCommand(prefixedName(PreStopPrefix, containerName), execCommand{
+								ExitCode:      0,
+								ContainerName: containerName,
+								LoopForever:   true,
+								LoopPeriod:    0.2,
+							}),
 						},
 					}
 				}
@@ -4807,7 +4820,10 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 5,
 									ExitCode:           0,
 								}),
-								Lifecycle: makePrestop(restartableInit1),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+									PreStop:   makePrestop(restartableInit1),
+								},
 							},
 							{
 								Name:          restartableInit2,
@@ -4818,7 +4834,10 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 5,
 									ExitCode:           0,
 								}),
-								Lifecycle: makePrestop(restartableInit2),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+									PreStop:   makePrestop(restartableInit2),
+								},
 							},
 							{
 								Name:          restartableInit3,
@@ -4829,7 +4848,10 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 5,
 									ExitCode:           0,
 								}),
-								Lifecycle: makePrestop(restartableInit3),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+									PreStop:   makePrestop(restartableInit3),
+								},
 							},
 						},
 						Containers: []v1.Container{
@@ -4915,17 +4937,15 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 				restartableInit3 := "restartable-init-3"
 				regular1 := "regular-1"
 
-				makePrestop := func(containerName string) *v1.Lifecycle {
-					return &v1.Lifecycle{
-						PreStop: &v1.LifecycleHandler{
-							Exec: &v1.ExecAction{
-								Command: ExecCommand(prefixedName(PreStopPrefix, containerName), execCommand{
-									Delay:         1,
-									ExitCode:      0,
-									ContainerName: containerName,
-									LoopPeriod:    0.2,
-								}),
-							},
+				makePrestop := func(containerName string) *v1.LifecycleHandler {
+					return &v1.LifecycleHandler{
+						Exec: &v1.ExecAction{
+							Command: ExecCommand(prefixedName(PreStopPrefix, containerName), execCommand{
+								Delay:         1,
+								ExitCode:      0,
+								ContainerName: containerName,
+								LoopPeriod:    0.2,
+							}),
 						},
 					}
 				}
@@ -4946,7 +4966,10 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 5,
 									ExitCode:           0,
 								}),
-								Lifecycle: makePrestop(restartableInit1),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+									PreStop:   makePrestop(restartableInit1),
+								},
 							},
 							{
 								Name:          restartableInit2,
@@ -4957,7 +4980,10 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 5,
 									ExitCode:           0,
 								}),
-								Lifecycle: makePrestop(restartableInit2),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+									PreStop:   makePrestop(restartableInit2),
+								},
 							},
 							{
 								Name:          restartableInit3,
@@ -4968,7 +4994,10 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 5,
 									ExitCode:           0,
 								}),
-								Lifecycle: makePrestop(restartableInit3),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+									PreStop:   makePrestop(restartableInit3),
+								},
 							},
 						},
 						Containers: []v1.Container{
@@ -5605,6 +5634,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 1,
 									ExitCode:           0,
 								}),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+								},
 							},
 							{
 								Name:          restartableInit2,
@@ -5615,6 +5647,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 20,
 									ExitCode:           0,
 								}),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+								},
 							},
 							{
 								Name:          restartableInit3,
@@ -5625,6 +5660,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 1,
 									ExitCode:           0,
 								}),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+								},
 							},
 						},
 						Containers: []v1.Container{
@@ -5706,6 +5744,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 1,
 									ExitCode:           0,
 								}),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+								},
 							},
 							{
 								Name:          restartableInit2,
@@ -5716,6 +5757,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 20,
 									ExitCode:           0,
 								}),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+								},
 							},
 							{
 								Name:          restartableInit3,
@@ -5726,6 +5770,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 									TerminationSeconds: 1,
 									ExitCode:           0,
 								}),
+								Lifecycle: &v1.Lifecycle{
+									PostStart: startedPostStartGate(),
+								},
 							},
 						},
 						Containers: []v1.Container{


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Restartable init containers have guaranteed startup ordering, but not guaranteed execution ordering. When containers are started back-to-back, it's possible that their startup logs will appear out of order, e.g.

```
[FAILED] couldn't find that restartable-init-2 started after restartable-init-1, got
0) 2026-03-08 16:43:31.697 +0000 UTC restartable-init-2 Starting
1) 2026-03-08 16:43:31.697 +0000 UTC restartable-init-1 Starting
2) 2026-03-08 16:43:31.718 +0000 UTC restartable-init-2 Started
3) 2026-03-08 16:43:31.731 +0000 UTC restartable-init-1 Started
```

This PR adds StartupProbes to the restartable init containers to enforce ordering, since the Kubelet waits for startup probe success before starting the next init container.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/137950

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon