### PR TITLE
cri-client: use passthrough resolver for socket endpoints

### DIFF
--- a/staging/src/k8s.io/cri-client/pkg/connection_target.go
+++ b/staging/src/k8s.io/cri-client/pkg/connection_target.go
@@ -1,0 +1,28 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+import "strings"
+
+func clientTargetForAddress(addr string) string {
+	// grpc defaults to the DNS resolver for bare targets. Use the passthrough
+	// resolver for socket-style addresses so the custom dialer gets the raw path.
+	if strings.HasPrefix(addr, "/") {
+		return "passthrough:///" + addr
+	}
+	return addr
+}

--- a/staging/src/k8s.io/cri-client/pkg/connection_target.go
+++ b/staging/src/k8s.io/cri-client/pkg/connection_target.go
@@ -19,6 +19,12 @@ package cri
 import "strings"
 
 func clientTargetForAddress(addr string) string {
+	// Defensive: normalize callers that pass a unix endpoint instead of the
+	// parsed socket path.
+	if strings.HasPrefix(addr, "unix:///") {
+		addr = strings.TrimPrefix(addr, "unix://")
+	}
+
 	// grpc defaults to the DNS resolver for bare targets. Use the passthrough
 	// resolver for socket-style addresses so the custom dialer gets the raw path.
 	if strings.HasPrefix(addr, "/") {

--- a/staging/src/k8s.io/cri-client/pkg/connection_target_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/connection_target_test.go
@@ -30,6 +30,11 @@ func TestClientTargetForAddress(t *testing.T) {
 			want: "passthrough:////run/containerd/containerd.sock",
 		},
 		{
+			name: "unix socket endpoint",
+			addr: "unix:///run/containerd/containerd.sock",
+			want: "passthrough:////run/containerd/containerd.sock",
+		},
+		{
 			name: "windows pipe path",
 			addr: "//./pipe/containerd-containerd",
 			want: "passthrough://///./pipe/containerd-containerd",

--- a/staging/src/k8s.io/cri-client/pkg/connection_target_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/connection_target_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cri
+
+import "testing"
+
+func TestClientTargetForAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			name: "unix socket path",
+			addr: "/run/containerd/containerd.sock",
+			want: "passthrough:////run/containerd/containerd.sock",
+		},
+		{
+			name: "windows pipe path",
+			addr: "//./pipe/containerd-containerd",
+			want: "passthrough://///./pipe/containerd-containerd",
+		},
+		{
+			name: "tcp address",
+			addr: "127.0.0.1:1234",
+			want: "127.0.0.1:1234",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clientTargetForAddress(tc.addr); got != tc.want {
+				t.Fatalf("clientTargetForAddress(%q) = %q, want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/cri-client/pkg/remote_image.go
+++ b/staging/src/k8s.io/cri-client/pkg/remote_image.go
@@ -97,7 +97,7 @@ func NewRemoteImageService(ctx context.Context, endpoint string, connectionTimeo
 		grpc.WithConnectParams(connParams),
 	)
 
-	conn, err := grpc.DialContext(ctx, addr, dialOpts...)
+	conn, err := grpc.NewClient(clientTargetForAddress(addr), dialOpts...)
 	if err != nil {
 		logger.Error(err, "Connect remote image service failed", "address", addr)
 		return nil, err

--- a/staging/src/k8s.io/cri-client/pkg/remote_image_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/remote_image_test.go
@@ -19,6 +19,7 @@ package cri
 import (
 	"context"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,4 +97,29 @@ func TestImageServiceSpansWithoutTP(t *testing.T) {
 	err = tp.ForceFlush(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, exp.GetSpans())
+}
+
+func TestNewRemoteImageServiceUnixSocketEndpoint(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket regression test is not applicable on windows")
+	}
+
+	fakeRuntime, endpoint := createAndStartFakeRemoteRuntime(t)
+	defer func() {
+		fakeRuntime.Stop()
+		// clear endpoint file
+		if addr, _, err := util.GetAddressAndDialer(endpoint); err == nil {
+			if _, err := os.Stat(addr); err == nil {
+				if err := os.Remove(addr); err != nil {
+					t.Errorf("remove %q: %v", addr, err)
+				}
+			}
+		}
+	}()
+
+	ctx := context.Background()
+	imgSvc := createRemoteImageServiceWithoutTracerProvider(ctx, endpoint, t)
+	info, err := imgSvc.ImageFsInfo(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, info)
 }

--- a/staging/src/k8s.io/cri-client/pkg/remote_runtime.go
+++ b/staging/src/k8s.io/cri-client/pkg/remote_runtime.go
@@ -128,7 +128,7 @@ func NewRemoteRuntimeService(ctx context.Context, endpoint string, connectionTim
 		grpc.WithConnectParams(connParams),
 	)
 
-	conn, err := grpc.DialContext(ctx, addr, dialOpts...)
+	conn, err := grpc.NewClient(clientTargetForAddress(addr), dialOpts...)
 	if err != nil {
 		logger.Error(err, "Connect remote runtime service failed", "address", addr)
 		return nil, err

--- a/staging/src/k8s.io/cri-client/pkg/remote_runtime_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/remote_runtime_test.go
@@ -19,6 +19,7 @@ package cri
 import (
 	"context"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -107,4 +108,29 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, apitest.FakeVersion, version.Version)
 	assert.Equal(t, apitest.FakeRuntimeName, version.RuntimeName)
+}
+
+func TestNewRemoteRuntimeServiceUnixSocketEndpoint(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket regression test is not applicable on windows")
+	}
+
+	fakeRuntime, endpoint := createAndStartFakeRemoteRuntime(t)
+	defer func() {
+		fakeRuntime.Stop()
+		// clear endpoint file
+		if addr, _, err := util.GetAddressAndDialer(endpoint); err == nil {
+			if _, err := os.Stat(addr); err == nil {
+				if err := os.Remove(addr); err != nil {
+					t.Errorf("remove %q: %v", addr, err)
+				}
+			}
+		}
+	}()
+
+	ctx := context.Background()
+	rtSvc := createRemoteRuntimeService(ctx, endpoint, t)
+	version, err := rtSvc.Version(ctx, apitest.FakeVersion)
+	require.NoError(t, err)
+	assert.Equal(t, apitest.FakeVersion, version.Version)
 }


### PR DESCRIPTION
grpc defaults to the DNS resolver for bare dial targets. For CRI socket endpoints, GetAddressAndDialer returns a socket path plus a custom dialer, but passing the bare path to grpc.DialContext still lets grpc resolve the target first.

found when trying to use the latest 1.36 beta.0 in containerd in a WIP PR:
https://github.com/containerd/containerd/pull/13078

That breaks unix socket clients with errors like "name resolver error: produced zero addresses" before the custom dialer ever sees the raw path. Use the passthrough resolver for socket-style addresses so the runtime and image clients hand the original endpoint directly to the custom dialer.

Add a regression test for unix sockets, Windows named pipes, and TCP addresses.

NOTE: `DialContext` is deprecated as well - https://pkg.go.dev/google.golang.org/grpc#DialContext

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
