### PR TITLE
Fix user namespace test cleanup race

### DIFF
--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -87,6 +87,7 @@ const (
 	// state files
 	cpuManagerStateFile    = "/var/lib/kubelet/cpu_manager_state"
 	memoryManagerStateFile = "/var/lib/kubelet/memory_manager_state"
+	usernsStateFiles       = "/var/lib/kubelet/pods/*/userns"
 )
 
 var (

--- a/test/e2e_node/util_kubeletconfig.go
+++ b/test/e2e_node/util_kubeletconfig.go
@@ -84,6 +84,7 @@ func updateKubeletConfigWithOptions(ctx context.Context, f *framework.Framework,
 		if opts.deleteStateFiles {
 			deleteStateFile(cpuManagerStateFile)
 			deleteStateFile(memoryManagerStateFile)
+			deleteStateFile(usernsStateFiles)
 		}
 
 		framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(kubeletConfig))


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

There's a race condition with cleanup in the `user namespaces kubeconfig tests`. The Kubelet fails to start with a fatal error `wrong user namespace length 131072` when it encounters stale pod state on disk from a previous test run that used a different `UserNamespaces.IDsPerPod` configuration:

1. The test explicitly configures the Kubelet with `IDsPerPod = 131072` (double the default of `65536`). It creates a pod that uses this custom mapping.
2. When the test completes, it waits for the pod to reach a terminal state and then proceeds to restart the Kubelet with the original configuration.
3. **Race:** If the Kubelet is stopped before it has finished cleaning up the pod's directory on disk (specifically the `userns` mapping file), the stale state remains.
4. Upon restart with the default `IDsPerPod = 65536`, the `UsernsManager` scans the disk for existing pods. When it finds the mapping from the previous test:
   - It reads the `userns` file containing `length: 131072`.
   - It compares the found `length` (131072) with the current `m.userNsLength` (65536).
   - It returns a fatal error that prevents the Kubelet from starting.

**Impact of `PLEGOnDemandRelist`**
Since the test pod runs a command that exits immediately, the on-demand relist immediately detects the terminated container, causing the pod to marked as success much more quickly. This narrows the window for the Kubelet's background disk cleanup to complete before the E2E test detects success and initiates a Kubelet restart.

**The fix:**
By issuing a synchronous delete (which waits for full deletion), it ensures that the Kubelet has finished cleaning up the problematic pod before restarting with the new configuration.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/137950

#### Special notes for your reviewer:

I wasn't able to reproduce locally, so I'm not certain this fixes the flakes we're seeing.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon