### PR TITLE
Fix goroutine leaks in ephemeral volume controller test

### DIFF
--- a/pkg/controller/volume/ephemeral/controller_test.go
+++ b/pkg/controller/volume/ephemeral/controller_test.go
@@ -120,11 +120,7 @@ func TestSyncHandler(t *testing.T) {
 	for _, tc := range tests {
 		// Run sequentially because of global logging and global metrics.
 		t.Run(tc.name, func(t *testing.T) {
-			// There is no good way to shut down the informers. They spawn
-			// various goroutines and some of them (in particular shared informer)
-			// become very unhappy ("close on closed channel") when using a context
-			// that gets cancelled. Therefore we just keep everything running.
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
 
 			var objects []runtime.Object
 			for _, pod := range tc.pods {
@@ -142,6 +138,9 @@ func TestSyncHandler(t *testing.T) {
 			}
 			setupMetrics()
 			informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+			// cancel must be called before Shutdown to unblock informer goroutines.
+			defer informerFactory.Shutdown()
+			defer cancel()
 			podInformer := informerFactory.Core().V1().Pods()
 			pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 
@@ -150,6 +149,7 @@ func TestSyncHandler(t *testing.T) {
 				t.Fatalf("error creating ephemeral controller : %v", err)
 			}
 			ec, _ := c.(*ephemeralController)
+			defer ec.queue.ShutDown()
 
 			// Ensure informers are up-to-date.
 			informerFactory.Start(ctx.Done())

--- a/pkg/controller/volume/ephemeral/main_test.go
+++ b/pkg/controller/volume/ephemeral/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ephemeral
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
## Summary

Fixes #134565

As discussed in the issue, the `TestSyncHandler` test in `pkg/controller/volume/ephemeral/controller_test.go` leaks goroutines because it uses `context.Background()` which never cancels, leaving informer and workqueue goroutines running after test completion.

Now that context support has been added to `tools/cache` (#126387), the informers can be cleanly shut down via context cancellation. This PR:

- Replaces `context.Background()` with `context.WithCancel()` and defers `cancel()`
- Adds `defer informerFactory.Shutdown()` to properly clean up informer goroutines
- Adds `defer ec.queue.ShutDown()` to clean up workqueue goroutines
- Adds `goleak.VerifyTestMain` in `main_test.go` to prevent goroutine leak regressions

The defer ordering ensures `cancel()` is called before `Shutdown()` (LIFO), so informer goroutines are unblocked before waiting for them to finish.

I'd appreciate any feedback on this approach -- happy to adjust if needed.

/sig api-machinery
/kind bug

## Test plan

- [x] `go test ./pkg/controller/volume/ephemeral/ -count=1` passes with goleak verification
- [x] All three blocking positions reported in #134565 are resolved (controller processLoop, processorListener.pop, FIFO Pop)