### PR TITLE
validation-gen: fix signedness handling and typed literal emission for minimum/maximum validators

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1515,8 +1515,45 @@ func toGolangSourceDataLiteral(sw *generator.SnippetWriter, c *generator.Context
 	// are quoted.
 
 	switch v := value.(type) {
-	case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64, float32, float64, bool:
-		sw.Do(fmt.Sprintf("%v", value), nil)
+
+	case int64:
+		sw.Do(fmt.Sprintf("int64(%d)", v), nil)
+
+	case int32:
+		sw.Do(fmt.Sprintf("int32(%d)", v), nil)
+
+	case int16:
+		sw.Do(fmt.Sprintf("int16(%d)", v), nil)
+
+	case int8:
+		sw.Do(fmt.Sprintf("int8(%d)", v), nil)
+
+	case int:
+		sw.Do(fmt.Sprintf("int(%d)", v), nil)
+
+	case uint64:
+		sw.Do(fmt.Sprintf("uint64(%d)", v), nil)
+
+	case uint32:
+		sw.Do(fmt.Sprintf("uint32(%d)", v), nil)
+
+	case uint16:
+		sw.Do(fmt.Sprintf("uint16(%d)", v), nil)
+
+	case uint8:
+		sw.Do(fmt.Sprintf("uint8(%d)", v), nil)
+
+	case uint:
+		sw.Do(fmt.Sprintf("uint(%d)", v), nil)
+
+	case float32:
+		sw.Do(fmt.Sprintf("float32(%v)", v), nil)
+
+	case float64:
+		sw.Do(fmt.Sprintf("float64(%v)", v), nil)
+
+	case bool:
+		sw.Do(fmt.Sprintf("%v", v), nil)
 	case string:
 		// If the incoming string was quoted, we still do it ourselves, JIC.
 		str := value.(string)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
+	"math"
+	"strconv"
 )
 
 const (
@@ -288,14 +290,42 @@ func (minimumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 		return result, fmt.Errorf("can only be used on integer types (%s)", rootTypeString(context.Type, t))
 	}
 
-	intVal, err := util.ParseInt(tag.Value)
-	if err != nil {
-		return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
+	if isUnsignedInt(t) {
+		uintVal, err := strconv.ParseUint(tag.Value, 10, 64)
+		if err != nil {
+			return result, fmt.Errorf("failed to parse tag payload as uint: %w", err)
+		}
+
+		// range validation
+		switch t.Name.Name {
+		case "uint32":
+			if uintVal > math.MaxUint32 {
+				return result, fmt.Errorf("value %d does not fit in uint32", uintVal)
+			}
+		case "uint64":
+			// valid
+		}
+
+		result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, uintVal))
+
+	} else {
+		intVal, err := strconv.ParseInt(tag.Value, 10, 64)
+		if err != nil {
+			return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
+		}
+
+		// range validation
+		switch t.Name.Name {
+		case "int32":
+			if intVal < math.MinInt32 || intVal > math.MaxInt32 {
+				return result, fmt.Errorf("value %d does not fit in int32", intVal)
+			}
+		case "int64":
+			// valid
+		}
+
+		result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, intVal))
 	}
-	if isUnsignedInt(t) && intVal < 0 {
-		return result, fmt.Errorf("must be greater than or equal to zero for unsigned types (%s)", rootTypeString(context.Type, t))
-	}
-	result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, intVal))
 	return result, nil
 }
 
@@ -340,14 +370,43 @@ func (maximumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 		return result, fmt.Errorf("can only be used on integer types (%s)", rootTypeString(context.Type, t))
 	}
 
-	intVal, err := util.ParseInt(tag.Value)
-	if err != nil {
-		return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
+	if isUnsignedInt(t) {
+		uintVal, err := strconv.ParseUint(tag.Value, 10, 64)
+		if err != nil {
+			return result, fmt.Errorf("failed to parse tag payload as uint: %w", err)
+		}
+
+		// range validation
+		switch t.Name.Name {
+		case "uint32":
+			if uintVal > math.MaxUint32 {
+				return result, fmt.Errorf("value %d does not fit in uint32", uintVal)
+			}
+		case "uint64":
+			// valid
+		}
+
+		result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, uintVal))
+
+	} else {
+		intVal, err := strconv.ParseInt(tag.Value, 10, 64)
+		if err != nil {
+			return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
+		}
+
+		// range validation
+		switch t.Name.Name {
+		case "int32":
+			if intVal < math.MinInt32 || intVal > math.MaxInt32 {
+				return result, fmt.Errorf("value %d does not fit in int32", intVal)
+			}
+		case "int64":
+			// valid
+		}
+
+		result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, intVal))
 	}
-	if isUnsignedInt(t) && intVal < 0 {
-		return result, fmt.Errorf("must be greater than or equal to zero for unsigned types (%s)", rootTypeString(context.Type, t))
-	}
-	result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, intVal))
+
 	return result, nil
 }
 


### PR DESCRIPTION
This PR fixes issues in validation-gen related to integer signedness handling and incorrect literal emission for +k8s:minimum and +k8s:maximum tags.

## Problem

1. Signedness handling was incorrect:
   - Tag values were always parsed using ParseInt, even for unsigned types.
   - Negative values could be incorrectly accepted or misinterpreted.
   - No proper validation against type bounds (e.g., int32, uint32).

2. Generated literals were untyped:
   - Values were emitted using fmt.Sprintf("%v", value).
   - This caused potential overflow or incorrect typing in generated Go code.
   - Example:
     - `-2147483649` instead of `int64(-2147483649)`

## Fix

1. Correct parsing based on type:
   - Use `strconv.ParseUint` for unsigned types.
   - Use `strconv.ParseInt` for signed types.

2. Add explicit range validation:
   - Ensure values fit within the target type (e.g., int32, uint32).

3. Emit typed literals in code generation:
   - Replace generic `%v` formatting with explicit types:
     - `int32(...)`, `int64(...)`, `uint32(...)`, etc.
   - Prevents overflow and ensures correct Go type inference.

## Result

- Proper enforcement of signed/unsigned constraints.
- Safe handling of boundary values.
- Correct and explicit typing in generated validation code.

## Testing

- Ran unit tests:

Fixes: #137966