### PR TITLE
Fix flakiness in integration test for TopologyAwareScheduling with Basic Policy

### DIFF
--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
@@ -751,16 +751,24 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 					createPodGroup: makeBasicPodGroup("pg1", "rack"),
 				},
 				{
-					name: "Create all pods belonging to the podgroup, more than fitting in a single rack",
+					// Fixing test flakiness:
+					// To make the test behave deterministically, first create 2 pods that will fit in a rack,
+					// and only add another pod once these are scheduled.
+					name: "Create first pods belonging to the podgroup, fitting in a single rack",
 					createPods: []*v1.Pod{
 						makePod("p1", "pg1"),
 						makePod("p2", "pg1"),
-						makePod("p3", "pg1"),
 					},
 				},
 				{
 					name:                 "Verify that 2 pods got scheduled",
 					waitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					name: "Create another pod in the same podgroup, not fitting in the assigned rack",
+					createPods: []*v1.Pod{
+						makePod("p3", "pg1"),
+					},
 				},
 				{
 					name:                     "Verify that the last pod becomes unschedulable due to insufficient resources in the rack",
@@ -859,7 +867,7 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 					},
 				},
 				{
-					name:                 "Verify the entire gang is now scheduled",
+					name:                 "Verify the entire podgroup is now scheduled",
 					waitForPodsScheduled: []string{"p1", "p2", "p3"},
 				},
 				// Each node has 2 CPUs, each of gang pods requests 1 CPU.
@@ -908,16 +916,28 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 					createPodGroup: makeBasicPodGroup("pg1", "rack"),
 				},
 				{
-					name: "Create all pods belonging to the podgroup",
+					// Fixing test flakiness:
+					// To make the test behave deterministically, first create 1 pod, based on which scores will be
+					// calculated, and only add more pods once the first is scheduled.
+					name: "Create the first pod belonging to the podgroup",
 					createPods: []*v1.Pod{
 						makePod("p1", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the pod is scheduled",
+					waitForPodsScheduled: []string{"p1"},
+				},
+				{
+					name: "Create other pods belonging to the podgroup",
+					createPods: []*v1.Pod{
 						makePod("p2", "pg1"),
 						makePod("p3", "pg1"),
 					},
 				},
 				{
 					name:                 "Verify the entire podgroup is now scheduled",
-					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+					waitForPodsScheduled: []string{"p2", "p3"},
 				},
 				// Each node has 2 CPUs, each of podgroup pods requests 1 CPU.
 				// Scores are first calculated when scheduling the first pod, without the knowledge how many pods would be in the podgroup.
@@ -959,9 +979,21 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 					createPodGroup: makeBasicPodGroup("pg1", "rack"),
 				},
 				{
-					name: "Create all pods belonging to the podgroup",
+					// Fixing test flakiness:
+					// To make the test behave deterministically, first create 1 pod, based on which scores will be
+					// calculated, and only add more pods once the first is scheduled.
+					name: "Create the first pod belonging to the podgroup",
 					createPods: []*v1.Pod{
 						makePod("p1", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the pod is scheduled",
+					waitForPodsScheduled: []string{"p1"},
+				},
+				{
+					name: "Create other pods belonging to the podgroup",
+					createPods: []*v1.Pod{
 						makePod("p2", "pg1"),
 						makePod("p3", "pg1"),
 					},
@@ -973,8 +1005,8 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 				// - rack1: 3/8 = 0.375
 				// - rack2: 1/2 = 0.5
 				{
-					name:                 "Verify that the first two pods are now scheduled",
-					waitForPodsScheduled: []string{"p1", "p2"},
+					name:                 "Verify the one of the additional pods is scheduled",
+					waitForPodsScheduled: []string{"p2"},
 				},
 				{
 					name: "Verify pod scheduled on rack2",
@@ -1165,11 +1197,44 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 					createPodGroup: makeBasicPodGroup("pg1", "rack"),
 				},
 				{
-					name: "Create all pods belonging to podgroup pg1",
+					// Fixing test flakiness:
+					// To make the test behave deterministically, first create 1 pod, based on which scores will be
+					// calculated, and only add more pods once the first is scheduled.
+					name: "Create the first pod belonging to the podgroup",
 					createPods: []*v1.Pod{
 						makePod("p1", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the pod is scheduled",
+					waitForPodsScheduled: []string{"p1"},
+				},
+				{
+					name: "Create other pods belonging to the podgroup",
+					createPods: []*v1.Pod{
 						makePod("p2", "pg1"),
 						makePod("p3", "pg1"),
+					},
+				},
+				{
+					name:                 "Verify the first of additional pods in pg1 is now scheduled",
+					waitForPodsScheduled: []string{"p2"},
+				},
+				{
+					name:                     "Verify the last pod becomes unschedulable due to insufficient resources",
+					waitForPodsUnschedulable: []string{"p3"},
+				},
+				// Each node has 2 CPUs, each of gang pods requests 1 CPU.
+				// Scores are first calculated when scheduling the first pod, without the knowledge how many pods would be in the podgroup.
+				// PodGroupPodsCount will score the same for each rack (because both racks can fit the first pod).
+				// Allocation fractions in racks (for the default "most allocated" strategy the highest allocation is picked):
+				// - rack1: 1/4 = 0.25
+				// - rack2: 1/2 = 0.5
+				{
+					name: "Verify all pods in pg1 scheduled on rack2 (which scored higher allocation)",
+					verifyAssignments: &verifyAssignments{
+						pods:  []string{"p1", "p2"},
+						nodes: sets.New("node3-rack2"),
 					},
 				},
 				{
@@ -1183,27 +1248,6 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 						makePod("p5", "pg2"),
 						makePod("p6", "pg2"),
 					},
-				},
-				// Each node has 2 CPUs, each of gang pods requests 1 CPU.
-				// Scores are first calculated when scheduling the first pod, without the knowledge how many pods would be in the podgroup.
-				// PodGroupPodsCount will score the same for each rack (because both racks can fit the first pod).
-				// Allocation fractions in racks (for the default "most allocated" strategy the highest allocation is picked):
-				// - rack1: 1/4 = 0.25
-				// - rack2: 1/2 = 0.5
-				{
-					name:                 "Verify part of podgroup p1 is now scheduled",
-					waitForPodsScheduled: []string{"p1", "p2"},
-				},
-				{
-					name: "Verify all pods in pg1 scheduled on rack2 (which scored higher allocation)",
-					verifyAssignments: &verifyAssignments{
-						pods:  []string{"p1", "p2"},
-						nodes: sets.New("node3-rack2"),
-					},
-				},
-				{
-					name:                     "Verify the last pod becomes unschedulable due to insufficient resources",
-					waitForPodsUnschedulable: []string{"p3"},
 				},
 				{
 					name:                 "Verify the entire podgroup pg2 is now scheduled",
@@ -1235,19 +1279,31 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 					},
 				},
 				{
+					name:                 "Verify that the blocker pod got scheduled",
+					waitForPodsScheduled: []string{"existing1"},
+				},
+				{
 					name:           "Create the PodGroup object that should be scheduled on one rack",
 					createPodGroup: makeBasicPodGroup("pg1", "rack"),
 				},
 				{
-					name: "Create all pods belonging to the podgroup, more than fitting in rack1",
+					// Fixing test flakiness:
+					// To make the test behave deterministically, first create 1 pod, based on which scores will be
+					// calculated, and only add more pods once the first is scheduled.
+					name: "Create the first pod belonging to the podgroup",
 					createPods: []*v1.Pod{
 						makePod("p1", "pg1"),
-						makePod("p2", "pg1"),
 					},
 				},
 				{
-					name:                 "Verify that 1 pod got scheduled",
+					name:                 "Verify the pod is scheduled",
 					waitForPodsScheduled: []string{"p1"},
+				},
+				{
+					name: "Create other pods belonging to the podgroup, exceeding the capacity of rack1",
+					createPods: []*v1.Pod{
+						makePod("p2", "pg1"),
+					},
 				},
 				{
 					name: "Verify that p1 got scheduled on rack1, which scored higher in mostAllocated strategy",
@@ -1257,7 +1313,7 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 					},
 				},
 				{
-					name:                     "Verify that the last pod becomes unschedulable due to insufficient resources in the rack",
+					name:                     "Verify that the other pod becomes unschedulable due to insufficient resources in the rack",
 					waitForPodsUnschedulable: []string{"p2"},
 				},
 				{

--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
@@ -751,24 +751,16 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 					createPodGroup: makeBasicPodGroup("pg1", "rack"),
 				},
 				{
-					// Fixing test flakiness:
-					// To make the test behave deterministically, first create 2 pods that will fit in a rack,
-					// and only add another pod once these are scheduled.
-					name: "Create first pods belonging to the podgroup, fitting in a single rack",
+					name: "Create all pods belonging to the podgroup, more than fitting in a single rack",
 					createPods: []*v1.Pod{
 						makePod("p1", "pg1"),
 						makePod("p2", "pg1"),
+						makePod("p3", "pg1"),
 					},
 				},
 				{
 					name:                 "Verify that 2 pods got scheduled",
 					waitForPodsScheduled: []string{"p1", "p2"},
-				},
-				{
-					name: "Create another pod in the same podgroup, not fitting in the assigned rack",
-					createPods: []*v1.Pod{
-						makePod("p3", "pg1"),
-					},
 				},
 				{
 					name:                     "Verify that the last pod becomes unschedulable due to insufficient resources in the rack",
@@ -916,28 +908,16 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 					createPodGroup: makeBasicPodGroup("pg1", "rack"),
 				},
 				{
-					// Fixing test flakiness:
-					// To make the test behave deterministically, first create 1 pod, based on which scores will be
-					// calculated, and only add more pods once the first is scheduled.
-					name: "Create the first pod belonging to the podgroup",
+					name: "Create all pods belonging to the podgroup",
 					createPods: []*v1.Pod{
 						makePod("p1", "pg1"),
-					},
-				},
-				{
-					name:                 "Verify the pod is scheduled",
-					waitForPodsScheduled: []string{"p1"},
-				},
-				{
-					name: "Create other pods belonging to the podgroup",
-					createPods: []*v1.Pod{
 						makePod("p2", "pg1"),
 						makePod("p3", "pg1"),
 					},
 				},
 				{
 					name:                 "Verify the entire podgroup is now scheduled",
-					waitForPodsScheduled: []string{"p2", "p3"},
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
 				},
 				// Each node has 2 CPUs, each of podgroup pods requests 1 CPU.
 				// Scores are first calculated when scheduling the first pod, without the knowledge how many pods would be in the podgroup.
@@ -1005,7 +985,7 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 				// - rack1: 3/8 = 0.375
 				// - rack2: 1/2 = 0.5
 				{
-					name:                 "Verify the one of the additional pods is scheduled",
+					name:                 "Verify one of the additional pods is scheduled",
 					waitForPodsScheduled: []string{"p2"},
 				},
 				{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test

/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
#137948
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
I carefully examined all test cases and did not modify the ones where the number of pods in the podgroup observed then entering the scheduling cycle does not impact the test result.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
