### PR TITLE
apiextensions: include schema for fake NewClientset

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
@@ -49,6 +49,7 @@ kube::codegen::gen_openapi \
 kube::codegen::gen_client \
     --with-watch \
     --with-applyconfig \
+    --applyconfig-openapi-schema <(go run k8s.io/apiextensions-apiserver/pkg/generated/openapi/cmd/models-schema) \
     --output-dir "${SCRIPT_ROOT}/pkg/client" \
     --output-pkg "${THIS_PKG}/pkg/client" \
     --versioned-name "clientset" \

--- a/staging/src/k8s.io/apiextensions-apiserver/hack/verify-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/hack/verify-codegen.sh
@@ -29,6 +29,20 @@ trap "cleanup" EXIT SIGINT
 
 cleanup
 
+# Ensure model-schema generator matches the version from
+# k8s.io/kubernetes/pkg/generated/openapi/cmd/models-schema/main.go
+echo "Ensuring models-schema is up-to-date"
+K8S_MODELS_SCHEMA="${SCRIPT_ROOT}/../../../../pkg/generated/openapi/cmd/models-schema/main.go"
+APIEXTENSIONS_MODELS_SCHEMA="${SCRIPT_ROOT}/pkg/generated/openapi/cmd/models-schema/main.go"
+# These files intentionally differ in import lines and the local lint-safe stderr write.
+if ! diff -I "k8s.io/kubernetes/pkg/generated/openapi" \
+  -I "k8s.io/apiextensions-apiserver/pkg/generated/openapi" \
+  -I "Failed: %v" \
+  "${K8S_MODELS_SCHEMA}" "${APIEXTENSIONS_MODELS_SCHEMA}"; then
+  echo "${APIEXTENSIONS_MODELS_SCHEMA} is out of date. Compare changes with ${K8S_MODELS_SCHEMA}"
+  exit 1
+fi
+
 mkdir -p "${TMP_DIFFROOT}"
 cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinition.go
@@ -19,8 +19,11 @@ limitations under the License.
 package v1
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	internal "k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/internal"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
@@ -48,6 +51,46 @@ func CustomResourceDefinition(name string) *CustomResourceDefinitionApplyConfigu
 	b.WithKind("CustomResourceDefinition")
 	b.WithAPIVersion("apiextensions.k8s.io/v1")
 	return b
+}
+
+// ExtractCustomResourceDefinitionFrom extracts the applied configuration owned by fieldManager from
+// customResourceDefinition for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// customResourceDefinition must be a unmodified CustomResourceDefinition API object that was retrieved from the Kubernetes API.
+// ExtractCustomResourceDefinitionFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractCustomResourceDefinitionFrom(customResourceDefinition *apiextensionsv1.CustomResourceDefinition, fieldManager string, subresource string) (*CustomResourceDefinitionApplyConfiguration, error) {
+	b := &CustomResourceDefinitionApplyConfiguration{}
+	err := managedfields.ExtractInto(customResourceDefinition, internal.Parser().Type("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(customResourceDefinition.Name)
+
+	b.WithKind("CustomResourceDefinition")
+	b.WithAPIVersion("apiextensions.k8s.io/v1")
+	return b, nil
+}
+
+// ExtractCustomResourceDefinition extracts the applied configuration owned by fieldManager from
+// customResourceDefinition. If no managedFields are found in customResourceDefinition for fieldManager, a
+// CustomResourceDefinitionApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// customResourceDefinition must be a unmodified CustomResourceDefinition API object that was retrieved from the Kubernetes API.
+// ExtractCustomResourceDefinition provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractCustomResourceDefinition(customResourceDefinition *apiextensionsv1.CustomResourceDefinition, fieldManager string) (*CustomResourceDefinitionApplyConfiguration, error) {
+	return ExtractCustomResourceDefinitionFrom(customResourceDefinition, fieldManager, "")
+}
+
+// ExtractCustomResourceDefinitionStatus extracts the applied configuration owned by fieldManager from
+// customResourceDefinition for the status subresource.
+func ExtractCustomResourceDefinitionStatus(customResourceDefinition *apiextensionsv1.CustomResourceDefinition, fieldManager string) (*CustomResourceDefinitionApplyConfiguration, error) {
+	return ExtractCustomResourceDefinitionFrom(customResourceDefinition, fieldManager, "status")
 }
 
 func (b CustomResourceDefinitionApplyConfiguration) IsApplyConfiguration() {}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinition.go
@@ -19,8 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	internal "k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/internal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
@@ -49,6 +52,46 @@ func CustomResourceDefinition(name string) *CustomResourceDefinitionApplyConfigu
 	b.WithKind("CustomResourceDefinition")
 	b.WithAPIVersion("apiextensions.k8s.io/v1beta1")
 	return b
+}
+
+// ExtractCustomResourceDefinitionFrom extracts the applied configuration owned by fieldManager from
+// customResourceDefinition for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// customResourceDefinition must be a unmodified CustomResourceDefinition API object that was retrieved from the Kubernetes API.
+// ExtractCustomResourceDefinitionFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractCustomResourceDefinitionFrom(customResourceDefinition *apiextensionsv1beta1.CustomResourceDefinition, fieldManager string, subresource string) (*CustomResourceDefinitionApplyConfiguration, error) {
+	b := &CustomResourceDefinitionApplyConfiguration{}
+	err := managedfields.ExtractInto(customResourceDefinition, internal.Parser().Type("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(customResourceDefinition.Name)
+
+	b.WithKind("CustomResourceDefinition")
+	b.WithAPIVersion("apiextensions.k8s.io/v1beta1")
+	return b, nil
+}
+
+// ExtractCustomResourceDefinition extracts the applied configuration owned by fieldManager from
+// customResourceDefinition. If no managedFields are found in customResourceDefinition for fieldManager, a
+// CustomResourceDefinitionApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// customResourceDefinition must be a unmodified CustomResourceDefinition API object that was retrieved from the Kubernetes API.
+// ExtractCustomResourceDefinition provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractCustomResourceDefinition(customResourceDefinition *apiextensionsv1beta1.CustomResourceDefinition, fieldManager string) (*CustomResourceDefinitionApplyConfiguration, error) {
+	return ExtractCustomResourceDefinitionFrom(customResourceDefinition, fieldManager, "")
+}
+
+// ExtractCustomResourceDefinitionStatus extracts the applied configuration owned by fieldManager from
+// customResourceDefinition for the status subresource.
+func ExtractCustomResourceDefinitionStatus(customResourceDefinition *apiextensionsv1beta1.CustomResourceDefinition, fieldManager string) (*CustomResourceDefinitionApplyConfiguration, error) {
+	return ExtractCustomResourceDefinitionFrom(customResourceDefinition, fieldManager, "status")
 }
 
 func (b CustomResourceDefinitionApplyConfiguration) IsApplyConfiguration() {}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/internal/internal.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/internal/internal.go
@@ -39,6 +39,1194 @@ func Parser() *typed.Parser {
 var parserOnce sync.Once
 var parser *typed.Parser
 var schemaYAML = typed.YAMLObject(`types:
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition
+  map:
+    fields:
+    - name: description
+      type:
+        scalar: string
+    - name: format
+      type:
+        scalar: string
+    - name: jsonPath
+      type:
+        scalar: string
+      default: ""
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: priority
+      type:
+        scalar: numeric
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion
+  map:
+    fields:
+    - name: strategy
+      type:
+        scalar: string
+      default: ""
+    - name: webhook
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+      default: {}
+    - name: spec
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec
+      default: {}
+    - name: status
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus
+      default: {}
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+      default: ""
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames
+  map:
+    fields:
+    - name: categories
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+      default: ""
+    - name: listKind
+      type:
+        scalar: string
+    - name: plural
+      type:
+        scalar: string
+      default: ""
+    - name: shortNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: singular
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec
+  map:
+    fields:
+    - name: conversion
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion
+    - name: group
+      type:
+        scalar: string
+      default: ""
+    - name: names
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames
+      default: {}
+    - name: preserveUnknownFields
+      type:
+        scalar: boolean
+    - name: scope
+      type:
+        scalar: string
+      default: ""
+    - name: versions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion
+          elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus
+  map:
+    fields:
+    - name: acceptedNames
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames
+      default: {}
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: storedVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion
+  map:
+    fields:
+    - name: additionalPrinterColumns
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition
+          elementRelationship: atomic
+    - name: deprecated
+      type:
+        scalar: boolean
+    - name: deprecationWarning
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: schema
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation
+    - name: selectableFields
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.SelectableField
+          elementRelationship: atomic
+    - name: served
+      type:
+        scalar: boolean
+      default: false
+    - name: storage
+      type:
+        scalar: boolean
+      default: false
+    - name: subresources
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale
+  map:
+    fields:
+    - name: labelSelectorPath
+      type:
+        scalar: string
+    - name: specReplicasPath
+      type:
+        scalar: string
+      default: ""
+    - name: statusReplicasPath
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus
+  map:
+    elementType:
+      scalar: untyped
+      list:
+        elementType:
+          namedType: __untyped_atomic_
+        elementRelationship: atomic
+      map:
+        elementType:
+          namedType: __untyped_deduced_
+        elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources
+  map:
+    fields:
+    - name: scale
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale
+    - name: status
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation
+  map:
+    fields:
+    - name: openAPIV3Schema
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation
+  map:
+    fields:
+    - name: description
+      type:
+        scalar: string
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps
+  map:
+    fields:
+    - name: $ref
+      type:
+        scalar: string
+    - name: $schema
+      type:
+        scalar: string
+    - name: additionalItems
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool
+    - name: additionalProperties
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool
+    - name: allOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: anyOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: default
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON
+    - name: definitions
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps
+    - name: dependencies
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray
+    - name: description
+      type:
+        scalar: string
+    - name: enum
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON
+          elementRelationship: atomic
+    - name: example
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON
+    - name: exclusiveMaximum
+      type:
+        scalar: boolean
+    - name: exclusiveMinimum
+      type:
+        scalar: boolean
+    - name: externalDocs
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation
+    - name: format
+      type:
+        scalar: string
+    - name: id
+      type:
+        scalar: string
+    - name: items
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray
+    - name: maxItems
+      type:
+        scalar: numeric
+    - name: maxLength
+      type:
+        scalar: numeric
+    - name: maxProperties
+      type:
+        scalar: numeric
+    - name: maximum
+      type:
+        scalar: numeric
+    - name: minItems
+      type:
+        scalar: numeric
+    - name: minLength
+      type:
+        scalar: numeric
+    - name: minProperties
+      type:
+        scalar: numeric
+    - name: minimum
+      type:
+        scalar: numeric
+    - name: multipleOf
+      type:
+        scalar: numeric
+    - name: not
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps
+    - name: nullable
+      type:
+        scalar: boolean
+    - name: oneOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: pattern
+      type:
+        scalar: string
+    - name: patternProperties
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps
+    - name: properties
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps
+    - name: required
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: title
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+    - name: uniqueItems
+      type:
+        scalar: boolean
+    - name: x-kubernetes-embedded-resource
+      type:
+        scalar: boolean
+    - name: x-kubernetes-int-or-string
+      type:
+        scalar: boolean
+    - name: x-kubernetes-list-map-keys
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: x-kubernetes-list-type
+      type:
+        scalar: string
+    - name: x-kubernetes-map-type
+      type:
+        scalar: string
+    - name: x-kubernetes-preserve-unknown-fields
+      type:
+        scalar: boolean
+    - name: x-kubernetes-validations
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule
+          elementRelationship: associative
+          keys:
+          - rule
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.SelectableField
+  map:
+    fields:
+    - name: jsonPath
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: namespace
+      type:
+        scalar: string
+      default: ""
+    - name: path
+      type:
+        scalar: string
+    - name: port
+      type:
+        scalar: numeric
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule
+  map:
+    fields:
+    - name: fieldPath
+      type:
+        scalar: string
+    - name: message
+      type:
+        scalar: string
+    - name: messageExpression
+      type:
+        scalar: string
+    - name: optionalOldSelf
+      type:
+        scalar: boolean
+    - name: reason
+      type:
+        scalar: string
+    - name: rule
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: service
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion
+  map:
+    fields:
+    - name: clientConfig
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig
+    - name: conversionReviewVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition
+  map:
+    fields:
+    - name: JSONPath
+      type:
+        scalar: string
+      default: ""
+    - name: description
+      type:
+        scalar: string
+    - name: format
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: priority
+      type:
+        scalar: numeric
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceConversion
+  map:
+    fields:
+    - name: conversionReviewVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: strategy
+      type:
+        scalar: string
+      default: ""
+    - name: webhookClientConfig
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.WebhookClientConfig
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+      default: {}
+    - name: spec
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec
+      default: {}
+    - name: status
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus
+      default: {}
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+      default: ""
+    - name: type
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames
+  map:
+    fields:
+    - name: categories
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+      default: ""
+    - name: listKind
+      type:
+        scalar: string
+    - name: plural
+      type:
+        scalar: string
+      default: ""
+    - name: shortNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: singular
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec
+  map:
+    fields:
+    - name: additionalPrinterColumns
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition
+          elementRelationship: atomic
+    - name: conversion
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceConversion
+    - name: group
+      type:
+        scalar: string
+      default: ""
+    - name: names
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames
+      default: {}
+    - name: preserveUnknownFields
+      type:
+        scalar: boolean
+    - name: scope
+      type:
+        scalar: string
+      default: ""
+    - name: selectableFields
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.SelectableField
+          elementRelationship: atomic
+    - name: subresources
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources
+    - name: validation
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation
+    - name: version
+      type:
+        scalar: string
+    - name: versions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion
+          elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus
+  map:
+    fields:
+    - name: acceptedNames
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames
+      default: {}
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: storedVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion
+  map:
+    fields:
+    - name: additionalPrinterColumns
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition
+          elementRelationship: atomic
+    - name: deprecated
+      type:
+        scalar: boolean
+    - name: deprecationWarning
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: schema
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation
+    - name: selectableFields
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.SelectableField
+          elementRelationship: atomic
+    - name: served
+      type:
+        scalar: boolean
+      default: false
+    - name: storage
+      type:
+        scalar: boolean
+      default: false
+    - name: subresources
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceScale
+  map:
+    fields:
+    - name: labelSelectorPath
+      type:
+        scalar: string
+    - name: specReplicasPath
+      type:
+        scalar: string
+      default: ""
+    - name: statusReplicasPath
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceStatus
+  map:
+    elementType:
+      scalar: untyped
+      list:
+        elementType:
+          namedType: __untyped_atomic_
+        elementRelationship: atomic
+      map:
+        elementType:
+          namedType: __untyped_deduced_
+        elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources
+  map:
+    fields:
+    - name: scale
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceScale
+    - name: status
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceStatus
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation
+  map:
+    fields:
+    - name: openAPIV3Schema
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ExternalDocumentation
+  map:
+    fields:
+    - name: description
+      type:
+        scalar: string
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+  map:
+    fields:
+    - name: $ref
+      type:
+        scalar: string
+    - name: $schema
+      type:
+        scalar: string
+    - name: additionalItems
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool
+    - name: additionalProperties
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool
+    - name: allOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: anyOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: default
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+    - name: definitions
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: dependencies
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray
+    - name: description
+      type:
+        scalar: string
+    - name: enum
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+          elementRelationship: atomic
+    - name: example
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+    - name: exclusiveMaximum
+      type:
+        scalar: boolean
+    - name: exclusiveMinimum
+      type:
+        scalar: boolean
+    - name: externalDocs
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ExternalDocumentation
+    - name: format
+      type:
+        scalar: string
+    - name: id
+      type:
+        scalar: string
+    - name: items
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray
+    - name: maxItems
+      type:
+        scalar: numeric
+    - name: maxLength
+      type:
+        scalar: numeric
+    - name: maxProperties
+      type:
+        scalar: numeric
+    - name: maximum
+      type:
+        scalar: numeric
+    - name: minItems
+      type:
+        scalar: numeric
+    - name: minLength
+      type:
+        scalar: numeric
+    - name: minProperties
+      type:
+        scalar: numeric
+    - name: minimum
+      type:
+        scalar: numeric
+    - name: multipleOf
+      type:
+        scalar: numeric
+    - name: not
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: nullable
+      type:
+        scalar: boolean
+    - name: oneOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: pattern
+      type:
+        scalar: string
+    - name: patternProperties
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: properties
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: required
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: title
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+    - name: uniqueItems
+      type:
+        scalar: boolean
+    - name: x-kubernetes-embedded-resource
+      type:
+        scalar: boolean
+    - name: x-kubernetes-int-or-string
+      type:
+        scalar: boolean
+    - name: x-kubernetes-list-map-keys
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: x-kubernetes-list-type
+      type:
+        scalar: string
+    - name: x-kubernetes-map-type
+      type:
+        scalar: string
+    - name: x-kubernetes-preserve-unknown-fields
+      type:
+        scalar: boolean
+    - name: x-kubernetes-validations
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ValidationRule
+          elementRelationship: associative
+          keys:
+          - rule
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.SelectableField
+  map:
+    fields:
+    - name: jsonPath
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: namespace
+      type:
+        scalar: string
+      default: ""
+    - name: path
+      type:
+        scalar: string
+    - name: port
+      type:
+        scalar: numeric
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ValidationRule
+  map:
+    fields:
+    - name: fieldPath
+      type:
+        scalar: string
+    - name: message
+      type:
+        scalar: string
+    - name: messageExpression
+      type:
+        scalar: string
+    - name: optionalOldSelf
+      type:
+        scalar: boolean
+    - name: reason
+      type:
+        scalar: string
+    - name: rule
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.WebhookClientConfig
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: service
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ServiceReference
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1
+  map:
+    elementType:
+      scalar: untyped
+      list:
+        elementType:
+          namedType: __untyped_atomic_
+        elementRelationship: atomic
+      map:
+        elementType:
+          namedType: __untyped_deduced_
+        elementRelationship: separable
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: fieldsType
+      type:
+        scalar: string
+    - name: fieldsV1
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1
+    - name: manager
+      type:
+        scalar: string
+    - name: operation
+      type:
+        scalar: string
+    - name: subresource
+      type:
+        scalar: string
+    - name: time
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+  map:
+    fields:
+    - name: annotations
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: creationTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: deletionGracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: deletionTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: finalizers
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: generateName
+      type:
+        scalar: string
+    - name: generation
+      type:
+        scalar: numeric
+    - name: labels
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: managedFields
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: ownerReferences
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+          elementRelationship: associative
+          keys:
+          - uid
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: selfLink
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+      default: ""
+    - name: blockOwnerDeletion
+      type:
+        scalar: boolean
+    - name: controller
+      type:
+        scalar: boolean
+    - name: kind
+      type:
+        scalar: string
+      default: ""
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: uid
+      type:
+        scalar: string
+      default: ""
+    elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+  scalar: untyped
 - name: __untyped_atomic_
   scalar: untyped
   list:

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset_test/clientset_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset_test/clientset_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientset_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestManagedFieldClientsetSupportsCustomResourceDefinitions(t *testing.T) {
+	client := fake.NewClientset()
+
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "widgets.example.com"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "example.com",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "widgets",
+				Singular: "widget",
+				Kind:     "Widget",
+				ListKind: "WidgetList",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    "v1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+					},
+				},
+			}},
+		},
+	}
+
+	created, err := client.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), crd, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, crd.Name, created.Name)
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/cmd/models-schema/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/cmd/models-schema/main.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"k8s.io/apiextensions-apiserver/pkg/generated/openapi"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// Outputs openAPI schema JSON containing the schema definitions in zz_generated.openapi.go.
+func main() {
+	err := output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed: %v", err) //nolint:errcheck
+		os.Exit(1)
+	}
+}
+
+func output() error {
+	refFunc := func(name string) spec.Ref {
+		return spec.MustCreateRef(fmt.Sprintf("#/definitions/%s", name))
+	}
+	defs := openapi.GetOpenAPIDefinitions(refFunc)
+	schemaDefs := make(map[string]spec.Schema, len(defs))
+	for k, v := range defs {
+		// Replace top-level schema with v2 if a v2 schema is embedded
+		// so that the output of this program is always in OpenAPI v2.
+		// This is done by looking up an extension that marks the embedded v2
+		// schema, and, if the v2 schema is found, make it the resulting schema for
+		// the type.
+		if schema, ok := v.Schema.Extensions[common.ExtensionV2Schema]; ok {
+			if v2Schema, isOpenAPISchema := schema.(spec.Schema); isOpenAPISchema {
+				schemaDefs[k] = v2Schema
+				continue
+			}
+		}
+
+		schemaDefs[k] = v.Schema
+	}
+	data, err := json.Marshal(&spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Definitions: schemaDefs,
+			Info: &spec.Info{
+				InfoProps: spec.InfoProps{
+					Title:   "Kubernetes",
+					Version: "unversioned",
+				},
+			},
+			Swagger: "2.0",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error serializing api definitions: %w", err)
+	}
+	os.Stdout.Write(data) // nolint:errcheck
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes the fake `NewClientset()` in `k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake`.

Before this change, creating a `CustomResourceDefinition` through the managed-field fake client failed because the generated applyconfiguration parser for apiextensions was not populated with the apiextensions schema. As a result, SMD conversion could not resolve types like `apiextensions.k8s.io/v1, Kind=CustomResourceDefinition`.

This change wires the apiextensions codegen to pass an OpenAPI schema into `applyconfiguration-gen`, which generates the necessary schema for the apiextensions applyconfiguration parser. It also adds a regression test that verifies `NewClientset()` can create a CRD successfully.

#### Which issue(s) this PR is related to:

Fixes #126850

#### Special notes for your reviewer:

This follows the existing `--applyconfig-openapi-schema <(go run .../pkg/generated/openapi/cmd/models-schema)` pattern already used in other staged repos such as `kube-aggregator`, `sample-apiserver`, and `sample-controller`.

Verified with:
- `go test ./staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake -run TestManagedFieldClientsetSupportsCustomResourceDefinitions -count=1`
- `go test ./staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/... -count=1`
- `API_KNOWN_VIOLATIONS_DIR=$PWD/api/api-rules CODEGEN_PKG=$PWD/staging/src/k8s.io/code-generator /usr/local/bin/bash staging/src/k8s.io/apiextensions-apiserver/hack/verify-codegen.sh`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
