### PR TITLE
Feature/pod group as victim

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -24,8 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
@@ -37,7 +35,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/framework/preemption"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
-	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 // Name of the plugin used in the plugin registry and configurations.
@@ -45,20 +42,24 @@ const Name = names.DefaultPreemption
 
 // IsEligiblePodFunc is a function which may be assigned to the DefaultPreemption plugin.
 // This may implement rules/filtering around preemption eligibility, which is in addition to
-// the internal requirement that the victim pod have lower priority than the preemptor pod.
+// the internal requirement that the victim has lower priority than the preemptor pod.
 // Any customizations should always allow system services to preempt normal pods, to avoid
 // problems if system pods are unable to find space.
-type IsEligiblePodFunc func(nodeInfo fwk.NodeInfo, victim fwk.PodInfo, preemptor *v1.Pod) bool
+//
+// For PodGroup victims, this function is called once per affected node: nodeInfo reflects
+// that specific node, while victim always represents the entire PodGroup across all its nodes.
+// The victim is eligible only if the function returns true for every affected node.
+type IsEligiblePodFunc func(nodeInfo fwk.NodeInfo, victim preemption.Victim, preemptor *v1.Pod) bool
 
-// MoreImportantPodFunc is a function which may be assigned to the DefaultPreemption plugin.
-// Implementations should return true if the first pod is more important than the second pod
+// MoreImportantVictimFunc is a function which may be assigned to the DefaultPreemption plugin.
+// Implementations should return true if the first victim is more important than the second victim
 // and the second one should be considered for preemption before the first one.
 // For performance reasons, the search for nodes eligible for preemption is done by omitting all
 // eligible victims from a node then checking whether the preemptor fits on the node without them,
 // before adding back victims (starting from the most important) that still fit with the preemptor.
 // The default behavior is to not consider pod affinity between the preemptor and the victims,
 // as affinity between pods that are eligible to preempt each other isn't recommended.
-type MoreImportantPodFunc func(pod1, pod2 *v1.Pod) bool
+type MoreImportantVictimFunc func(victim1, victim2 preemption.Victim) bool
 
 // DefaultPreemption is a PostFilter plugin implements the preemption logic.
 type DefaultPreemption struct {
@@ -71,17 +72,21 @@ type DefaultPreemption struct {
 	pgLister          fwk.PodGroupLister
 	podGroupEvaluator *preemption.PodGroupEvaluator
 
-	// IsEligiblePod returns whether a victim pod is allowed to be preempted by a preemptor pod.
+	// IsEligiblePod returns whether a victim (individual pod/pod group) is allowed to be preempted by a preemptor pod.
 	// This filtering is in addition to the internal requirement that the victim pod have lower
 	// priority than the preemptor pod. Any customizations should always allow system services
 	// to preempt normal pods, to avoid problems if system pods are unable to find space.
 	IsEligiblePod IsEligiblePodFunc
 
-	// MoreImportantPod is used to sort eligible victims in-place in descending order of highest to
-	// lowest importance. Pods with higher importance are less likely to be preempted.
-	// The default behavior is to order pods by descending priority, then descending runtime duration
-	// for pods with equal priority.
-	MoreImportantPod MoreImportantPodFunc
+	// MoreImportantVictim is used to sort eligible victims in-place in descending order of highest to
+	// lowest importance. Victims with higher importance are less likely to be preempted.
+	//
+	// By default, potential preemption victims are evaluated using a cascading set of rules. The system prioritizes based on
+	// priority first, always deferring to higher-priority victims.
+	// If GenericWorkload is disabled, it simply falls back to prioritizing older victims. However,
+	// if WAP is enabled, it factors in the victim type by favoring PodGroups over standalone Pods. When comparing multiple PodGroups,
+	// it prioritizes those with larger group sizes, ultimately using the start time as the final tiebreaker.
+	MoreImportantVictim MoreImportantVictimFunc
 }
 
 var _ fwk.PostFilterPlugin = &DefaultPreemption{}
@@ -115,14 +120,20 @@ func New(_ context.Context, dpArgs runtime.Object, fh fwk.Handle, fts feature.Fe
 		pl.podGroupEvaluator = preemption.NewPodGroupEvaluator(fh, pl.Executor, pl.fts.EnablePodGroupPreemptionPolicy)
 	}
 
-	// Default behavior: No additional filtering, beyond the internal requirement that the victim pod
-	// have lower priority than the preemptor pod.
-	pl.IsEligiblePod = func(nodeInfo fwk.NodeInfo, victim fwk.PodInfo, preemptor *v1.Pod) bool {
+	// Default behavior: No additional filtering, beyond the internal requirement that the victim
+	// has lower priority than the preemptor.
+	pl.IsEligiblePod = func(nodeInfo fwk.NodeInfo, victim preemption.Victim, preemptor *v1.Pod) bool {
 		return true
 	}
 
-	// Default behavior: Sort by descending priority, then by descending runtime duration as secondary ordering.
-	pl.MoreImportantPod = util.MoreImportantPod
+	// Default behavior, defines the order for victims sorting. The order is:
+	// 1. Higher Priority.
+	// 2. If GenericWorkload is enabled: PodGroup > Individual Pod.
+	// 3. For individual Pods: Older StartTime (longer runtime).
+	// 4. For PodGroups: Larger Group Size, then Older StartTime.
+	pl.MoreImportantVictim = func(vi1, vi2 preemption.Victim) bool {
+		return preemption.MoreImportantVictim(vi1, vi2, pl.fts.EnableGenericWorkload)
+	}
 
 	return &pl, nil
 }
@@ -231,110 +242,168 @@ func (pl *DefaultPreemption) CandidatesToVictimsMap(candidates []preemption.Cand
 	return m
 }
 
-// SelectVictimsOnNode finds minimum set of pods on the given node that should be preempted in order to make enough room
-// for "pod" to be scheduled.
+// SelectVictimsOnNode finds the minimum set of pods that should be preempted to make enough room for the preemptor to be
+// scheduled on the node represented by nodeInfo (the "main node").
+//
+// On entry, nodeInfo represents only the main node. If the candidate victims include a PodGroup that spans additional nodes,
+// SelectVictimsOnNode discovers those nodes from victim.AffectedNodes() during the removal pass and extends its internal nameToNode map
+// accordingly, so PreFilterExtension hooks can run against them. See also the block comment inside the function body for the
+// NodeInfo-mutation contract across main vs. remote nodes.
 func (pl *DefaultPreemption) SelectVictimsOnNode(
 	ctx context.Context,
-	state fwk.CycleState,
-	pod *v1.Pod,
+	cycleState fwk.CycleState,
+	preemptor *v1.Pod,
 	nodeInfo fwk.NodeInfo,
+	allPossibleVictims []*preemption.DomainVictim,
 	pdbs []*policy.PodDisruptionBudget) ([]*v1.Pod, int, *fwk.Status) {
 	logger := klog.FromContext(ctx)
-	var potentialVictims []fwk.PodInfo
-	removePod := func(rpi fwk.PodInfo) error {
-		if err := nodeInfo.RemovePod(logger, rpi.GetPod()); err != nil {
-			return err
+	// Within a single SelectVictimsOnNode evaluation we mutate NodeInfo only for the main node (the node we are trying to fit the preemptor onto).
+	// Filter plugins are re-run against mainNode below via RunFilterPluginsWithNominatedPods, so they must see the post-removal state
+	// of mainNode reflected in NodeInfo.
+	//
+	// For remote nodes that are only affected because a PodGroup victim has members there, we deliberately do NOT mutate their NodeInfo.
+	// Instead we invoke PreFilterExtension Remove/AddPod with the remote NodeInfo so that plugins can update any CycleState they keep
+	// about those pods (e.g. topology spread skew, pod affinity counters). Plugins that read remote NodeInfo directly during Filter
+	// (rather than CycleState) will observe stale state for those nodes; this is acceptable because we only run the Filter pass
+	// against mainNode here.
+	mainNodeName := nodeInfo.Node().Name
+	nameToNode := map[string]fwk.NodeInfo{mainNodeName: nodeInfo}
+
+	removeVictim := func(dv *preemption.DomainVictim) error {
+		for _, pi := range dv.Pods() {
+			nodeInfo := nameToNode[pi.GetPod().Spec.NodeName]
+			// See the block comment in SelectVictimsOnNode: only mainNode's NodeInfo
+			// is mutated; remote nodes go through PreFilterExtension only.
+			if pi.GetPod().Spec.NodeName == mainNodeName {
+				if err := nodeInfo.RemovePod(logger, pi.GetPod()); err != nil {
+					return err
+				}
+			}
+			status := pl.fh.RunPreFilterExtensionRemovePod(ctx, cycleState, preemptor, pi, nodeInfo)
+			if !status.IsSuccess() {
+				return status.AsError()
+			}
 		}
-		status := pl.fh.RunPreFilterExtensionRemovePod(ctx, state, pod, rpi, nodeInfo)
-		if !status.IsSuccess() {
-			return status.AsError()
-		}
+
 		return nil
 	}
-	addPod := func(api fwk.PodInfo) error {
-		nodeInfo.AddPodInfo(api)
-		status := pl.fh.RunPreFilterExtensionAddPod(ctx, state, pod, api, nodeInfo)
-		if !status.IsSuccess() {
-			return status.AsError()
+	addVictim := func(pu *preemption.DomainVictim) error {
+		for _, pi := range pu.Pods() {
+			nodeInfo := nameToNode[pi.GetPod().Spec.NodeName]
+			// See the block comment in SelectVictimsOnNode: only mainNode's NodeInfo
+			// is mutated; remote nodes go through PreFilterExtension only.
+			if pi.GetPod().Spec.NodeName == mainNodeName {
+				nodeInfo.AddPodInfo(pi)
+			}
+			status := pl.fh.RunPreFilterExtensionAddPod(ctx, cycleState, preemptor, pi, nodeInfo)
+			if !status.IsSuccess() {
+				return status.AsError()
+			}
 		}
+
 		return nil
 	}
-	// As the first step, remove all pods eligible for preemption from the node and
-	// check if the given pod can be scheduled without them present.
-	for _, pi := range nodeInfo.GetPods() {
-		if pl.isPreemptionAllowed(nodeInfo, pi, pod) {
-			potentialVictims = append(potentialVictims, pi)
-		}
-	}
-	for _, pi := range potentialVictims {
-		if err := removePod(pi); err != nil {
-			return nil, 0, fwk.AsStatus(err)
+
+	var potentialVictims []*preemption.DomainVictim
+	for _, victim := range allPossibleVictims {
+		if pl.isPreemptionAllowedAcrossAllVictimNodes(victim, preemptor) {
+			potentialVictims = append(potentialVictims, victim)
 		}
 	}
 
-	// No potential victims are found, and so we don't need to evaluate the node again since its state didn't change.
+	// No preemption victims found for incoming preemptor, and so we don't need to evaluate the node again since its state didn't change.
 	if len(potentialVictims) == 0 {
 		return nil, 0, fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "No preemption victims found for incoming pod")
 	}
 
-	// If the new pod does not fit after removing all the eligible pods,
-	// we are almost done and this node is not suitable for preemption. The only
-	// condition that we could check is if the "pod" is failing to schedule due to
-	// inter-pod affinity to one or more victims, but we have decided not to
-	// support this case for performance reasons. Having affinity to lower
-	// importance (priority) pods is not a recommended configuration anyway.
-	if status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo); !status.IsSuccess() {
-		return nil, 0, status
-	}
-	var victims []fwk.PodInfo
-	numViolatingVictim := 0
-	// Sort potentialVictims by descending importance, which ensures reprieve of
-	// higher importance pods first.
-	sort.Slice(potentialVictims, func(i, j int) bool {
-		return pl.MoreImportantPod(potentialVictims[i].GetPod(), potentialVictims[j].GetPod())
-	})
-	// Try to reprieve as many pods as possible. We first try to reprieve the PDB
-	// violating victims and then other non-violating ones. In both cases, we start
-	// from the highest importance victims.
-	violatingVictims, nonViolatingVictims := filterPodsWithPDBViolation(potentialVictims, pdbs)
-	reprievePod := func(pi fwk.PodInfo) (bool, error) {
-		if err := addPod(pi); err != nil {
-			return false, err
-		}
-		status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
-		fits := status.IsSuccess()
-		if !fits {
-			if err := removePod(pi); err != nil {
-				return false, err
+	// As the first step, remove all victims eligible for preemption from the node.
+	for _, victim := range potentialVictims {
+		// If a Victim is a PodGroup spanning multiple nodes, some affected nodes
+		// might not be in the nameToNode map yet. We add them to ensure
+		// they are considered during preemption.
+		for name, nodeInfo := range victim.AffectedNodes() {
+			if _, ok := nameToNode[name]; !ok {
+				nameToNode[name] = nodeInfo
 			}
-			victims = append(victims, pi)
-			logger.V(5).Info("Pod is a potential preemption victim on node", "pod", klog.KObj(pi.GetPod()), "node", klog.KObj(nodeInfo.Node()))
 		}
-		return fits, nil
-	}
-	for _, p := range violatingVictims {
-		if fits, err := reprievePod(p); err != nil {
-			return nil, 0, fwk.AsStatus(err)
-		} else if !fits {
-			numViolatingVictim++
-		}
-	}
-	// Now we try to reprieve non-violating victims.
-	for _, p := range nonViolatingVictims {
-		if _, err := reprievePod(p); err != nil {
+		if err := removeVictim(victim); err != nil {
 			return nil, 0, fwk.AsStatus(err)
 		}
 	}
 
-	// Sort victims after reprieving pods to keep the pods in the victims sorted in order of importance from high to low.
+	// If the preemptor does not fit after removing all the eligible victims,
+	// we are almost done and this node is not suitable for preemption. The only
+	// condition that we could check is if the preemptor is failing to schedule due to
+	// inter-pod affinity to one or more victims, but we have decided not to
+	// support this case for performance reasons. Having affinity to lower
+	// importance (priority) pods is not a recommended configuration anyway.
+	if status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, cycleState, preemptor, nodeInfo); !status.IsSuccess() {
+		return nil, 0, status
+	}
+
+	// Sort potentialVictims by descending importance, which ensures reprieve of
+	// higher importance victims first.
+	sort.Slice(potentialVictims, func(i, j int) bool {
+		return pl.MoreImportantVictim(potentialVictims[i], potentialVictims[j])
+	})
+
+	// Try to reprieve as many pods as possible. We first try to reprieve the PDB
+	// violating victims and then other non-violating ones. In both cases, we start
+	// from the highest importance victims.
+	violatingVictims, nonViolatingVictims := preemption.FilterVictimsWithPDBViolation(potentialVictims, pdbs)
+	var victims []*preemption.DomainVictim
+	reprieveVictim := func(v *preemption.DomainVictim) (bool, error) {
+		if err := addVictim(v); err != nil {
+			return false, err
+		}
+
+		status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, cycleState, preemptor, nodeInfo)
+		fits := status.IsSuccess()
+		if !fits {
+			if err := removeVictim(v); err != nil {
+				return false, err
+			}
+			victims = append(victims, v)
+			if loggerV := logger.V(5); loggerV.Enabled() {
+				var pods []klog.ObjectRef
+				for _, p := range v.Pods() {
+					pods = append(pods, klog.KObj(p.GetPod()))
+				}
+				loggerV.Info("Pods are potential preemption victims on node", "pods", pods, "node", mainNodeName)
+			}
+		}
+
+		return fits, nil
+	}
+
+	numViolatingVictim := 0
+	for _, violatingVictim := range violatingVictims {
+		if fits, err := reprieveVictim(violatingVictim.Victim); err != nil {
+			return nil, 0, fwk.AsStatus(err)
+		} else if !fits {
+			numViolatingVictim += violatingVictim.ViolateCount
+		}
+	}
+
+	// Now we try to reprieve non-violating victims.
+	for _, v := range nonViolatingVictims {
+		if _, err := reprieveVictim(v); err != nil {
+			return nil, 0, fwk.AsStatus(err)
+		}
+	}
+
+	// Sort victims after reprieving pods to keep the victims sorted in order of importance from high to low.
 	if len(violatingVictims) != 0 && len(nonViolatingVictims) != 0 {
-		sort.Slice(victims, func(i, j int) bool { return pl.MoreImportantPod(victims[i].GetPod(), victims[j].GetPod()) })
+		sort.Slice(victims, func(i, j int) bool { return pl.MoreImportantVictim(victims[i], victims[j]) })
 	}
 	var victimPods []*v1.Pod
-	for _, pi := range victims {
-		victimPods = append(victimPods, pi.GetPod())
+	for _, vi := range victims {
+		for _, pi := range vi.Pods() {
+			victimPods = append(victimPods, pi.GetPod())
+		}
 	}
-	return victimPods, numViolatingVictim, fwk.NewStatus(fwk.Success)
+
+	return victimPods, numViolatingVictim, nil
 }
 
 // PodEligibleToPreemptOthers returns one bool and one string. The bool
@@ -361,7 +430,9 @@ func (pl *DefaultPreemption) PodEligibleToPreemptOthers(_ context.Context, pod *
 
 		if nodeInfo, _ := nodeInfos.Get(nomNodeName); nodeInfo != nil {
 			for _, p := range nodeInfo.GetPods() {
-				if pl.isPreemptionAllowed(nodeInfo, p, pod) && preemption.PodTerminatingByPreemption(p.GetPod()) {
+				victim := preemption.NewPodVictim(p, pl.pgLister)
+
+				if pl.isPreemptionAllowed(nodeInfo, victim, pod) && preemption.PodTerminatingByPreemption(p.GetPod()) {
 					// There is a terminating pod on the nominated node.
 					return false, "not eligible due to a terminating pod on the nominated node."
 				}
@@ -371,68 +442,30 @@ func (pl *DefaultPreemption) PodEligibleToPreemptOthers(_ context.Context, pod *
 	return true, ""
 }
 
+// isPreemptionAllowed returns whether the "victim" residing on "nodeInfo" can be preempted by the preemptor pod
+func (pl *DefaultPreemption) isPreemptionAllowed(nodeInfo fwk.NodeInfo, victim preemption.Victim, preemptor *v1.Pod) bool {
+	// The victim must have lower priority than the pod, in addition to any filtering implemented by IsEligiblePod
+	return victim.Priority() < corev1helpers.PodPriority(preemptor) && pl.IsEligiblePod(nodeInfo, victim, preemptor)
+}
+
 // OrderedScoreFuncs returns a list of ordered score functions to select preferable node where victims will be preempted.
 func (pl *DefaultPreemption) OrderedScoreFuncs(ctx context.Context, nodesToVictims map[string]*extenderv1.Victims) []func(node string) int64 {
 	return nil
 }
 
-// isPreemptionAllowed returns whether the victim residing on nodeInfo can be preempted by the preemptor
-func (pl *DefaultPreemption) isPreemptionAllowed(nodeInfo fwk.NodeInfo, victim fwk.PodInfo, preemptor *v1.Pod) bool {
-	// The victim must have lower priority than the preemptor, in addition to any filtering implemented by IsEligiblePod
-	return corev1helpers.PodPriority(victim.GetPod()) < corev1helpers.PodPriority(preemptor) && pl.IsEligiblePod(nodeInfo, victim, preemptor)
-}
-
-// filterPodsWithPDBViolation groups the given "pods" into two groups of "violatingPods"
-// and "nonViolatingPods" based on whether their PDBs will be violated if they are
-// preempted.
-// This function is stable and does not change the order of received pods. So, if it
-// receives a sorted list, grouping will preserve the order of the input list.
-func filterPodsWithPDBViolation(podInfos []fwk.PodInfo, pdbs []*policy.PodDisruptionBudget) (violatingPodInfos, nonViolatingPodInfos []fwk.PodInfo) {
-	pdbsAllowed := make([]int32, len(pdbs))
-	for i, pdb := range pdbs {
-		pdbsAllowed[i] = pdb.Status.DisruptionsAllowed
+// isPreemptionAllowedAcrossAllVictimNodes returns whether the victim can be preempted on all its affected nodes.
+func (pl *DefaultPreemption) isPreemptionAllowedAcrossAllVictimNodes(victim *preemption.DomainVictim, preemptor *v1.Pod) bool {
+	if victim.Priority() >= corev1helpers.PodPriority(preemptor) {
+		return false
 	}
 
-	for _, podInfo := range podInfos {
-		pod := podInfo.GetPod()
-		pdbForPodIsViolated := false
-		// A pod with no labels will not match any PDB. So, no need to check.
-		if len(pod.Labels) != 0 {
-			for i, pdb := range pdbs {
-				if pdb.Namespace != pod.Namespace {
-					continue
-				}
-				selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
-				if err != nil {
-					// This object has an invalid selector, it does not match the pod
-					continue
-				}
-				// A PDB with a nil or empty selector matches nothing.
-				if selector.Empty() || !selector.Matches(labels.Set(pod.Labels)) {
-					continue
-				}
-
-				// Existing in DisruptedPods means it has been processed in API server,
-				// we don't treat it as a violating case.
-				if _, exist := pdb.Status.DisruptedPods[pod.Name]; exist {
-					continue
-				}
-				// Only decrement the matched pdb when it's not in its <DisruptedPods>;
-				// otherwise we may over-decrement the budget number.
-				pdbsAllowed[i]--
-				// We have found a matching PDB.
-				if pdbsAllowed[i] < 0 {
-					pdbForPodIsViolated = true
-				}
-			}
-		}
-		if pdbForPodIsViolated {
-			violatingPodInfos = append(violatingPodInfos, podInfo)
-		} else {
-			nonViolatingPodInfos = append(nonViolatingPodInfos, podInfo)
+	for _, nodeInfo := range victim.AffectedNodes() {
+		if !pl.IsEligiblePod(nodeInfo, victim, preemptor) {
+			return false
 		}
 	}
-	return violatingPodInfos, nonViolatingPodInfos
+
+	return true
 }
 
 // PodGroupPostFilter runs a default preemption for the pod group.

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -1568,28 +1568,33 @@ func TestSelectBestCandidate(t *testing.T) {
 }
 
 func TestCustomSelection(t *testing.T) {
-	podLabelIsEligible := func(key, val string) IsEligiblePodFunc {
-		return func(nodeInfo fwk.NodeInfo, victim fwk.PodInfo, preemptor *v1.Pod) bool {
-			pval, ok := victim.GetPod().Labels[key]
-			if !ok {
-				return false
+	victimLabelsAreEligible := func(key, val string) IsEligiblePodFunc {
+		return func(nodeInfo fwk.NodeInfo, victim preemption.Victim, preemptor *v1.Pod) bool {
+			for _, pod := range victim.Pods() {
+				pval, ok := pod.GetPod().Labels[key]
+				if !ok {
+					return false
+				}
+				if pval != val {
+					return false
+				}
 			}
-			return pval == val
+			return true
 		}
 	}
 	nodeNameIsEligible := func(name string) IsEligiblePodFunc {
-		return func(nodeInfo fwk.NodeInfo, victim fwk.PodInfo, preemptor *v1.Pod) bool {
+		return func(nodeInfo fwk.NodeInfo, victim preemption.Victim, preemptor *v1.Pod) bool {
 			return nodeInfo.Node().Name == name
 		}
 	}
 	priorityBelowThresholdCannotPreempt := func(minPreempting int32) IsEligiblePodFunc {
-		return func(nodeInfo fwk.NodeInfo, victim fwk.PodInfo, preemptor *v1.Pod) bool {
+		return func(nodeInfo fwk.NodeInfo, victim preemption.Victim, preemptor *v1.Pod) bool {
 			return corev1helpers.PodPriority(preemptor) >= minPreempting
 		}
 	}
 	priorityAboveThresholdCannotBePreempted := func(maxPreemptible int32) IsEligiblePodFunc {
-		return func(nodeInfo fwk.NodeInfo, victim fwk.PodInfo, preemptor *v1.Pod) bool {
-			return corev1helpers.PodPriority(victim.GetPod()) <= maxPreemptible
+		return func(nodeInfo fwk.NodeInfo, victim preemption.Victim, preemptor *v1.Pod) bool {
+			return victim.Priority() <= maxPreemptible
 		}
 	}
 
@@ -1599,11 +1604,13 @@ func TestCustomSelection(t *testing.T) {
 		nodeNames    []string
 		pod          *v1.Pod
 		pods         []*v1.Pod
+		podGroups    []*v1alpha3.PodGroup
+		features     feature.Features
 		expected     map[string][]string
 	}{
 		{
 			name:         "filter for matching pod label: high priority",
-			eligiblePods: podLabelIsEligible("preemptible", "yes"),
+			eligiblePods: victimLabelsAreEligible("preemptible", "yes"),
 			nodeNames:    []string{"node1", "node2", "node3", "node4"},
 			pod:          st.MakePod().Name("p1").UID("p1").Priority(highPriority).Req(largeRes).Obj(),
 			pods: []*v1.Pod{
@@ -1616,7 +1623,7 @@ func TestCustomSelection(t *testing.T) {
 		},
 		{
 			name:         "filter for matching pod label: mid priority",
-			eligiblePods: podLabelIsEligible("preemptible", "yes"),
+			eligiblePods: victimLabelsAreEligible("preemptible", "yes"),
 			nodeNames:    []string{"node1", "node2", "node3", "node4"},
 			pod:          st.MakePod().Name("p2").UID("p2").Priority(midPriority).Req(largeRes).Obj(),
 			pods: []*v1.Pod{
@@ -1629,7 +1636,7 @@ func TestCustomSelection(t *testing.T) {
 		},
 		{
 			name:         "filter for matching pod label: low priority",
-			eligiblePods: podLabelIsEligible("preemptible", "yes"),
+			eligiblePods: victimLabelsAreEligible("preemptible", "yes"),
 			nodeNames:    []string{"node1", "node2", "node3", "node4"},
 			pod:          st.MakePod().Name("p3").UID("p3").Priority(lowPriority).Req(largeRes).Obj(),
 			pods: []*v1.Pod{
@@ -1718,12 +1725,47 @@ func TestCustomSelection(t *testing.T) {
 				st.MakePod().Name("v2").UID("v2").Node("node2").Priority(midPriority).Req(largeRes).StartTime(epochTime).Obj(),
 				st.MakePod().Name("v3").UID("v3").Node("node3").Priority(lowPriority).Req(largeRes).StartTime(epochTime).Obj(),
 			},
-			// the lowPriority pod can be preempted but not the midPriority pod
+			// the lowPriority and midPriority pods can be preempted but not the highPriority pod
 			expected: map[string][]string{"node2": {"v2"}, "node3": {"v3"}},
+		},
+		{
+			name:         "filter for matching pod group: all affected nodes eligible",
+			eligiblePods: victimLabelsAreEligible("preemptible", "yes"),
+			nodeNames:    []string{"node1", "node2"},
+			pod:          st.MakePod().Name("p1").UID("p1").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(largeRes).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Namespace(v1.NamespaceDefault).Node("node1").Label("preemptible", "yes").PodGroupName("pg1").Priority(lowPriority).Req(largeRes).StartTime(epochTime).Obj(),
+				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node2").Label("preemptible", "yes").PodGroupName("pg1").Priority(lowPriority).Req(largeRes).StartTime(epochTime).Obj(),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").UID("pg1").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
+			},
+			features: feature.Features{EnableGenericWorkload: true},
+			expected: map[string][]string{"node1": {"v1", "v2"}, "node2": {"v1", "v2"}},
+		},
+		{
+			name:         "filter for matching pod group: one node ineligible rejects entire pod group",
+			eligiblePods: nodeNameIsEligible("node1"),
+			nodeNames:    []string{"node1", "node2"},
+			pod:          st.MakePod().Name("p1").UID("p1").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(largeRes).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
+				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node2").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
+				st.MakePod().Name("v3").UID("v3").Namespace(v1.NamespaceDefault).Node("node1").Priority(midPriority).Req(largeRes).StartTime(epochTime).Obj(),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").UID("pg1").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
+			},
+			features: feature.Features{EnableGenericWorkload: true},
+			expected: map[string][]string{"node1": {"v3"}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate,
+				featuregatetesting.FeatureOverrides{
+					features.GenericWorkload: tt.features.EnableGenericWorkload,
+				})
 			nodes := make([]*v1.Node, len(tt.nodeNames))
 			for i, nodeName := range tt.nodeNames {
 				nodes[i] = st.MakeNode().Name(nodeName).Capacity(veryLargeRes).Obj()
@@ -1734,12 +1776,25 @@ func TestCustomSelection(t *testing.T) {
 			for _, pod := range tt.pods {
 				objs = append(objs, pod)
 			}
+			for _, pg := range tt.podGroups {
+				objs = append(objs, pg)
+			}
+			for _, node := range nodes {
+				objs = append(objs, node)
+			}
 			cs := clientsetfake.NewClientset(objs...)
 			informerFactory := informers.NewSharedInformerFactory(cs, 0)
-			snapshot := internalcache.NewSnapshot(tt.pods, nodes)
+			_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 			logger, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload)
+			for _, pg := range tt.podGroups {
+				cache.AddPodGroup(pg)
+			}
+			snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.pods, nodes, tt.podGroups)
 			fwk, err := tf.NewFramework(
 				ctx,
 				[]tf.RegisterPluginFunc{
@@ -1753,6 +1808,7 @@ func TestCustomSelection(t *testing.T) {
 				frameworkruntime.WithMutableSnapshotLister(snapshot),
 				frameworkruntime.WithInformerFactory(informerFactory),
 				frameworkruntime.WithLogger(logger),
+				frameworkruntime.WithPodGroupManager(cache),
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -1768,7 +1824,7 @@ func TestCustomSelection(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), fwk, feature.Features{})
+			pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), fwk, tt.features)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1798,6 +1854,8 @@ func TestCustomSelection(t *testing.T) {
 				for _, p := range selected.Victims().Pods {
 					gotVictims = append(gotVictims, p.Name)
 				}
+				sort.Strings(gotVictims)
+				sort.Strings(expectVictims)
 				if diff := cmp.Diff(expectVictims, gotVictims); diff != "" {
 					t.Errorf("Unexpected victims on node %s (-want,+got):\n%s", selected.Name(), diff)
 				}
@@ -1816,41 +1874,100 @@ func TestCustomSelection(t *testing.T) {
 }
 
 func TestCustomOrdering(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 	// Two arbitrary examples of custom selection ordering to check that they behave as expected
 	orderByOldestStart := func(pod1, pod2 *v1.Pod) bool {
 		return util.GetPodStartTime(pod1).Before(util.GetPodStartTime(pod2))
 	}
-	orderByPodName := func(pod1, pod2 *v1.Pod) bool {
-		return pod1.Name < pod2.Name
+	orderByOldestStartVictim := func(vi1, vi2 preemption.Victim) bool {
+
+		sort.Slice(vi1.Pods(), func(i, j int) bool {
+			return orderByOldestStart(vi1.Pods()[i].GetPod(), vi1.Pods()[j].GetPod())
+		})
+		sort.Slice(vi2.Pods(), func(i, j int) bool {
+			return orderByOldestStart(vi2.Pods()[i].GetPod(), vi2.Pods()[j].GetPod())
+		})
+
+		return util.GetPodStartTime(vi1.Pods()[0].GetPod()).Before(util.GetPodStartTime(vi2.Pods()[0].GetPod()))
+	}
+	orderByPodNameVictim := func(vi1, vi2 preemption.Victim) bool {
+		sort.Slice(vi1.Pods(), func(i, j int) bool {
+			return vi1.Pods()[i].GetPod().Name < vi1.Pods()[j].GetPod().Name
+		})
+		sort.Slice(vi2.Pods(), func(i, j int) bool {
+			return vi2.Pods()[i].GetPod().Name < vi2.Pods()[j].GetPod().Name
+		})
+		return vi1.Pods()[0].GetPod().Name < vi2.Pods()[0].GetPod().Name
+	}
+	orderByStandaloneOverPodGroupVictim := func(vi1, vi2 preemption.Victim) bool {
+		sort.Slice(vi1.Pods(), func(i, j int) bool {
+			return vi1.Pods()[i].GetPod().Name < vi1.Pods()[j].GetPod().Name
+		})
+		sort.Slice(vi2.Pods(), func(i, j int) bool {
+			return vi2.Pods()[i].GetPod().Name < vi2.Pods()[j].GetPod().Name
+		})
+		if vi1.IsPodGroup() != vi2.IsPodGroup() {
+			return !vi1.IsPodGroup()
+		}
+		return preemption.MoreImportantVictim(vi1, vi2, true)
+	}
+	orderBySmallerPodGroupOverLargerVictim := func(vi1, vi2 preemption.Victim) bool {
+		sort.Slice(vi1.Pods(), func(i, j int) bool {
+			return vi1.Pods()[i].GetPod().Name < vi1.Pods()[j].GetPod().Name
+		})
+		sort.Slice(vi2.Pods(), func(i, j int) bool {
+			return vi2.Pods()[i].GetPod().Name < vi2.Pods()[j].GetPod().Name
+		})
+		if vi1.IsPodGroup() && vi2.IsPodGroup() && len(vi1.Pods()) != len(vi2.Pods()) {
+			return len(vi1.Pods()) < len(vi2.Pods())
+		}
+		return preemption.MoreImportantVictim(vi1, vi2, true)
+	}
+	orderByPodGroupNameVictim := func(vi1, vi2 preemption.Victim) bool {
+		sort.Slice(vi1.Pods(), func(i, j int) bool {
+			return vi1.Pods()[i].GetPod().Name < vi1.Pods()[j].GetPod().Name
+		})
+		sort.Slice(vi2.Pods(), func(i, j int) bool {
+			return vi2.Pods()[i].GetPod().Name < vi2.Pods()[j].GetPod().Name
+		})
+		if vi1.IsPodGroup() && vi2.IsPodGroup() {
+			pg1 := vi1.Pods()[0].GetPod().Spec.SchedulingGroup.PodGroupName
+			pg2 := vi2.Pods()[0].GetPod().Spec.SchedulingGroup.PodGroupName
+			if pg1 != nil && pg2 != nil && *pg1 != *pg2 {
+				return *pg1 < *pg2
+			}
+		}
+		return preemption.MoreImportantVictim(vi1, vi2, true)
 	}
 
 	tests := []struct {
 		name         string
-		orderPods    MoreImportantPodFunc
+		orderVictims MoreImportantVictimFunc
 		nodeNames    []string
-		pod          *v1.Pod
+		preemptor    *v1.Pod
 		pods         []*v1.Pod
+		podGroups    []*v1alpha3.PodGroup
 		expectedPods []string
 	}{
 		{
-			name:      "select newest pods",
-			orderPods: orderByOldestStart,
-			nodeNames: []string{"node1"},
-			pod:       st.MakePod().Name("p2").UID("p2").Priority(highPriority).Req(largeRes).Obj(),
+			name:         "select newest pods",
+			orderVictims: orderByOldestStartVictim,
+			nodeNames:    []string{"node1"},
+			preemptor:    st.MakePod().Name("p2").UID("p2").Priority(highPriority).Req(largeRes).Obj(),
 			// size victims to require at least two to be preempted
 			pods: []*v1.Pod{
 				st.MakePod().Name("v1").UID("v1").Node("node1").Priority(lowPriority).Req(mediumRes).StartTime(epochTime2).Obj(),
 				st.MakePod().Name("v2").UID("v2").Node("node1").Priority(lowPriority).Req(mediumRes).StartTime(epochTime).Obj(),
-				st.MakePod().Name("v3").UID("v3").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime1).Obj(),
+				st.MakePod().Name("v3").UID("v3").Node("node1").Priority(lowPriority).Req(mediumRes).StartTime(epochTime1).Obj(),
 			},
-			// the newest two pods are selected, despite one with higher priority
+			// the two newest pods (v1, v3) are selected; v2 (oldest) is reprieved
 			expectedPods: []string{"v3", "v1"},
 		},
 		{
-			name:      "select alphabetically-last pods",
-			orderPods: orderByPodName,
-			nodeNames: []string{"node1"},
-			pod:       st.MakePod().Name("p2").UID("p2").Priority(highPriority).Req(largeRes).Obj(),
+			name:         "select alphabetically-last pods",
+			orderVictims: orderByPodNameVictim,
+			nodeNames:    []string{"node1"},
+			preemptor:    st.MakePod().Name("p2").UID("p2").Priority(highPriority).Req(largeRes).Obj(),
 			// size victims to require at least two to be preempted
 			pods: []*v1.Pod{
 				st.MakePod().Name("foo").UID("v1").Node("node1").Priority(lowPriority).Req(mediumRes).StartTime(epochTime).Obj(),
@@ -1860,25 +1977,86 @@ func TestCustomOrdering(t *testing.T) {
 			// the last pods in alphabetic order are selected, despite one with higher priority
 			expectedPods: []string{"baz", "foo"},
 		},
+		{
+			name:         "select pod group over standalone pod due to custom ordering",
+			orderVictims: orderByStandaloneOverPodGroupVictim,
+			nodeNames:    []string{"node1"},
+			preemptor:    st.MakePod().Name("p2").UID("p2").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(largeRes).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Namespace(v1.NamespaceDefault).Node("node1").Priority(lowPriority).Req(mediumRes).StartTime(epochTime).Obj(),
+				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
+				st.MakePod().Name("v3").UID("v3").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").UID("pg1").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
+			},
+			// v1 (standalone) is reprieved because it is more important than pg1 in this custom ordering; pg1 pods (v2, v3) are selected
+			expectedPods: []string{"v2", "v3"},
+		},
+		{
+			name:         "select larger pod group over smaller pod group due to custom ordering",
+			orderVictims: orderBySmallerPodGroupOverLargerVictim,
+			nodeNames:    []string{"node1"},
+			preemptor:    st.MakePod().Name("p2").UID("p2").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(largeRes).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-small").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
+				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-large").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
+				st.MakePod().Name("v3").UID("v3").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-large").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg-small").UID("pg-small").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
+				st.MakePodGroup().Name("pg-large").UID("pg-large").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
+			},
+			// pg-small is reprieved because smaller groups are more important in this custom ordering; pg-large pods (v2, v3) are selected
+			expectedPods: []string{"v2", "v3"},
+		},
+		{
+			name:         "select pod group by name alphabetically due to custom ordering",
+			orderVictims: orderByPodGroupNameVictim,
+			nodeNames:    []string{"node1"},
+			preemptor:    st.MakePod().Name("p2").UID("p2").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(largeRes).Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-a").Priority(lowPriority).Req(mediumRes).StartTime(epochTime1).Obj(),
+				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-z").Priority(lowPriority).Req(mediumRes).StartTime(epochTime).Obj(),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg-a").UID("pg-a").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
+				st.MakePodGroup().Name("pg-z").UID("pg-z").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
+			},
+			// pg-a is reprieved because it is alphabetically earlier; pg-z pod (v2) is selected
+			expectedPods: []string{"v2"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 			nodes := make([]*v1.Node, len(tt.nodeNames))
 			for i, nodeName := range tt.nodeNames {
 				nodes[i] = st.MakeNode().Name(nodeName).Capacity(veryLargeRes).Obj()
 			}
 
 			var objs []runtime.Object
-			objs = append(objs, tt.pod)
+			objs = append(objs, tt.preemptor)
 			for _, pod := range tt.pods {
 				objs = append(objs, pod)
 			}
+			for _, pg := range tt.podGroups {
+				objs = append(objs, pg)
+			}
 			cs := clientsetfake.NewClientset(objs...)
 			informerFactory := informers.NewSharedInformerFactory(cs, 0)
-			snapshot := internalcache.NewSnapshot(tt.pods, nodes)
-			logger, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+			_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+			snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.pods, nodes, tt.podGroups)
+
+			cache := internalcache.New(ctx, nil, true)
+			for _, pg := range tt.podGroups {
+				cache.AddPodGroup(pg)
+			}
+
 			fwk, err := tf.NewFramework(
 				ctx,
 				[]tf.RegisterPluginFunc{
@@ -1892,6 +2070,7 @@ func TestCustomOrdering(t *testing.T) {
 				frameworkruntime.WithMutableSnapshotLister(snapshot),
 				frameworkruntime.WithInformerFactory(informerFactory),
 				frameworkruntime.WithLogger(logger),
+				frameworkruntime.WithPodGroupManager(cache),
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -1899,7 +2078,7 @@ func TestCustomOrdering(t *testing.T) {
 
 			state := framework.NewCycleState()
 			// Some tests rely on PreFilter plugin to compute its CycleState.
-			if _, status, _ := fwk.RunPreFilterPlugins(ctx, state, tt.pod); !status.IsSuccess() {
+			if _, status, _ := fwk.RunPreFilterPlugins(ctx, state, tt.preemptor); !status.IsSuccess() {
 				t.Errorf("Unexpected PreFilter Status: %v", status)
 			}
 			nodeInfos, err := snapshot.NodeInfos().List()
@@ -1907,22 +2086,30 @@ func TestCustomOrdering(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), fwk, feature.Features{})
+			pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), fwk, feature.Features{
+				EnableGenericWorkload: true,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}
 			// Override ordering logic
-			if tt.orderPods != nil {
-				pl.MoreImportantPod = tt.orderPods
+			if tt.orderVictims != nil {
+				pl.MoreImportantVictim = tt.orderVictims
 			}
 			offset, numCandidates := pl.GetOffsetAndNumCandidates(int32(len(nodeInfos)))
-			candidates, _, _ := pl.Evaluator.DryRunPreemption(ctx, state, tt.pod, nodeInfos, nil, offset, numCandidates)
+			candidates, _, _ := pl.Evaluator.DryRunPreemption(ctx, state, tt.preemptor, nodeInfos, nil, offset, numCandidates)
 			if len(candidates) != 1 {
 				t.Fatalf("expected exactly one node but got %+v", candidates)
 			}
 			podNames := []string{}
 			for _, p := range candidates[0].Victims().Pods {
 				podNames = append(podNames, p.Name)
+			}
+			// For PodGroups, the order of pods within a group is indeterminate due to map iteration in ScheduledPods().
+			// For standalone pods, MoreImportantVictim establishes a deterministic order that must be preserved.
+			if len(tt.podGroups) > 0 {
+				sort.Strings(podNames)
+				sort.Strings(tt.expectedPods)
 			}
 			if diff := cmp.Diff(tt.expectedPods, podNames); diff != "" {
 				t.Errorf("expect pods %+v, but got pods %+v", tt.expectedPods, podNames)
@@ -1936,7 +2123,9 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 		name                string
 		pod                 *v1.Pod
 		pods                []*v1.Pod
+		podGroups           []*v1alpha3.PodGroup
 		nodes               []string
+		features            feature.Features
 		nominatedNodeStatus *fwk.Status
 		expected            bool
 	}{
@@ -1979,6 +2168,31 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			nodes:    []string{"node1"},
 			expected: true,
 		},
+		{
+			name: "Preemptor with SchedulingGroup, victim priority overridden by PodGroup in victim namespace",
+			pod:  st.MakePod().Name("p").UID("p").Namespace("ns1").Priority(highPriority).PodGroupName("pg1").NominatedNodeName("node1").Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Namespace("ns2").Node("node1").Priority(veryHighPriority).PodGroupName("pg1").Terminating().
+					Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Obj(),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").UID("pg1").Namespace("ns2").Priority(lowPriority).Obj(),
+			},
+			nodes:    []string{"node1"},
+			features: feature.Features{EnableGenericWorkload: true},
+			expected: false,
+		},
+		{
+			name: "Preemptor with SchedulingGroup, PodGroup not found in victim namespace, fallback to pod priority",
+			pod:  st.MakePod().Name("p").UID("p").Namespace("ns1").Priority(highPriority).PodGroupName("pg1").NominatedNodeName("node1").Obj(),
+			pods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Namespace("ns2").Node("node1").Priority(veryHighPriority).PodGroupName("pg1").Terminating().
+					Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Obj(),
+			},
+			nodes:    []string{"node1"},
+			features: feature.Features{EnableGenericWorkload: true},
+			expected: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -1990,28 +2204,40 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			for _, n := range test.nodes {
 				nodes = append(nodes, st.MakeNode().Name(n).Obj())
 			}
-			var pods []runtime.Object
-			pods = append(pods, test.pod)
+			var objs []runtime.Object
+			objs = append(objs, test.pod)
 			for _, pod := range test.pods {
-				pods = append(pods, pod)
+				objs = append(objs, pod)
 			}
-			cs := clientsetfake.NewClientset(pods...)
+			for _, pg := range test.podGroups {
+				objs = append(objs, pg)
+			}
+			cs := clientsetfake.NewClientset(objs...)
 			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
 			registeredPlugins := []tf.RegisterPluginFunc{
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 			}
-			snapshot := internalcache.NewSnapshot(test.pods, nodes)
+			cache := internalcache.New(ctx, nil, test.features.EnableGenericWorkload)
+			for _, pg := range test.podGroups {
+				cache.AddPodGroup(pg)
+			}
+			snapshot := internalcache.NewTestSnapshotWithPodGroups(test.pods, nodes, test.podGroups)
 			f, err := tf.NewFramework(ctx, registeredPlugins, "",
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithMutableSnapshotLister(snapshot),
+				frameworkruntime.WithClientSet(cs),
 				frameworkruntime.WithInformerFactory(informerFactory),
 				frameworkruntime.WithLogger(logger),
+				frameworkruntime.WithPodGroupManager(cache),
 			)
 			if err != nil {
 				t.Fatal(err)
 			}
-			pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), f, feature.Features{})
+			pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), f, test.features)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2026,7 +2252,7 @@ func TestPreempt(t *testing.T) {
 	metrics.Register()
 	tests := []struct {
 		name           string
-		pod            *v1.Pod
+		preemptor      *v1.Pod
 		pods           []*v1.Pod
 		extenders      []*tf.FakeExtender
 		nodeNames      []string
@@ -2035,8 +2261,8 @@ func TestPreempt(t *testing.T) {
 		expectedPods   []string // list of preempted pods
 	}{
 		{
-			name: "basic preemption logic",
-			pod:  st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
+			name:      "basic preemption logic",
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1.1").UID("p1.1").Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
 				st.MakePod().Name("p1.2").UID("p1.2").Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
@@ -2050,7 +2276,7 @@ func TestPreempt(t *testing.T) {
 		},
 		{
 			name: "preemption for topology spread constraints",
-			pod: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Label("foo", "").Priority(highPriority).
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Label("foo", "").Priority(highPriority).
 				SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(), nil, nil, nil, nil).
 				SpreadConstraint(1, "hostname", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(), nil, nil, nil, nil).
 				Obj(),
@@ -2067,8 +2293,8 @@ func TestPreempt(t *testing.T) {
 			expectedPods:   []string{"p-b1"},
 		},
 		{
-			name: "Scheduler extenders allow only node1, otherwise node3 would have been chosen",
-			pod:  st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
+			name:      "Scheduler extenders allow only node1, otherwise node3 would have been chosen",
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1.1").UID("p1.1").Namespace(v1.NamespaceDefault).Node("node1").Priority(midPriority).Req(smallRes).Obj(),
 				st.MakePod().Name("p1.2").UID("p1.2").Namespace(v1.NamespaceDefault).Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
@@ -2090,8 +2316,8 @@ func TestPreempt(t *testing.T) {
 			expectedPods:   []string{"p1.1", "p1.2"},
 		},
 		{
-			name: "Scheduler extenders do not allow any preemption",
-			pod:  st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
+			name:      "Scheduler extenders do not allow any preemption",
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1.1").UID("p1.1").Namespace(v1.NamespaceDefault).Node("node1").Priority(midPriority).Req(smallRes).Obj(),
 				st.MakePod().Name("p1.2").UID("p1.2").Namespace(v1.NamespaceDefault).Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
@@ -2109,8 +2335,8 @@ func TestPreempt(t *testing.T) {
 			expectedPods:   []string{},
 		},
 		{
-			name: "One scheduler extender allows only node1, the other returns error but ignorable. Only node1 would be chosen",
-			pod:  st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
+			name:      "One scheduler extender allows only node1, the other returns error but ignorable. Only node1 would be chosen",
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1.1").UID("p1.1").Namespace(v1.NamespaceDefault).Node("node1").Priority(midPriority).Req(smallRes).Obj(),
 				st.MakePod().Name("p1.2").UID("p1.2").Namespace(v1.NamespaceDefault).Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
@@ -2133,8 +2359,8 @@ func TestPreempt(t *testing.T) {
 			expectedPods:   []string{"p1.1", "p1.2"},
 		},
 		{
-			name: "One scheduler extender allows only node1, but it is not interested in given pod, otherwise node1 would have been chosen",
-			pod:  st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
+			name:      "One scheduler extender allows only node1, but it is not interested in given pod, otherwise node1 would have been chosen",
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1.1").UID("p1.1").Namespace(v1.NamespaceDefault).Node("node1").Priority(midPriority).Req(smallRes).Obj(),
 				st.MakePod().Name("p1.2").UID("p1.2").Namespace(v1.NamespaceDefault).Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
@@ -2158,8 +2384,8 @@ func TestPreempt(t *testing.T) {
 			expectedPods: []string{"p2.1"},
 		},
 		{
-			name: "no preempting in pod",
-			pod:  st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptNever).Obj(),
+			name:      "no preempting in pod",
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).PreemptionPolicy(v1.PreemptNever).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1.1").UID("p1.1").Namespace(v1.NamespaceDefault).Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
 				st.MakePod().Name("p1.2").UID("p1.2").Namespace(v1.NamespaceDefault).Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
@@ -2172,8 +2398,8 @@ func TestPreempt(t *testing.T) {
 			expectedPods:   nil,
 		},
 		{
-			name: "PreemptionPolicy is nil",
-			pod:  st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).Obj(),
+			name:      "PreemptionPolicy is nil",
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).Req(veryLargeRes).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1.1").UID("p1.1").Namespace(v1.NamespaceDefault).Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
 				st.MakePod().Name("p1.2").UID("p1.2").Namespace(v1.NamespaceDefault).Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
@@ -2195,14 +2421,14 @@ func TestPreempt(t *testing.T) {
 					client := clientsetfake.NewClientset()
 					informerFactory := informers.NewSharedInformerFactory(client, 0)
 					podInformer := informerFactory.Core().V1().Pods().Informer()
-					testPod := test.pod.DeepCopy()
-					testPods := make([]*v1.Pod, len(test.pods))
-					for i := range test.pods {
-						testPods[i] = test.pods[i].DeepCopy()
+					testPreemptor := test.preemptor.DeepCopy()
+					var testPods []*v1.Pod
+					for _, pod := range test.pods {
+						testPods = append(testPods, pod.DeepCopy())
 					}
 
-					if err := podInformer.GetStore().Add(testPod); err != nil {
-						t.Fatalf("Failed to add test pod %s: %v", testPod.Name, err)
+					if err := podInformer.GetStore().Add(testPreemptor); err != nil {
+						t.Fatalf("Failed to add test pod %s: %v", testPreemptor.Name, err)
 					}
 					for i := range testPods {
 						if err := podInformer.GetStore().Add(testPods[i]); err != nil {
@@ -2323,11 +2549,11 @@ func TestPreempt(t *testing.T) {
 						schedFramework.SetAPICacher(apicache.New(nil, cache))
 					}
 
-					state := framework.NewCycleState()
-					// Some tests rely on PreFilter plugin to compute its CycleState.
-					if _, s, _ := schedFramework.RunPreFilterPlugins(ctx, state, testPod); !s.IsSuccess() {
+					cycleState := framework.NewCycleState()
+					if _, s, _ := schedFramework.RunPreFilterPlugins(ctx, cycleState, testPreemptor); !s.IsSuccess() {
 						t.Errorf("Unexpected preFilterStatus: %v", s)
 					}
+
 					// Call preempt and check the expected results.
 					features := feature.Features{
 						EnableAsyncPreemption: asyncPreemptionEnabled,
@@ -2344,8 +2570,7 @@ func TestPreempt(t *testing.T) {
 					for _, n := range nodes {
 						nodeToStatusMap.Set(n.Name, fwk.NewStatus(fwk.Unschedulable))
 					}
-
-					res, status := pl.Evaluator.Preempt(ctx, state, testPod, nodeToStatusMap)
+					res, status := pl.Evaluator.Preempt(ctx, cycleState, test.preemptor, nodeToStatusMap)
 					if !status.IsSuccess() && !status.IsRejected() {
 						t.Errorf("unexpected error in preemption: %v", status.AsError())
 					}
@@ -2403,10 +2628,10 @@ func TestPreempt(t *testing.T) {
 							t.Errorf("pod %v is not expected to be a victim.", victimName)
 						}
 					}
-					if res != nil && res.NominatingInfo != nil {
-						testPod.Status.NominatedNodeName = res.NominatedNodeName
-					}
 
+					if res != nil && res.NominatingInfo != nil {
+						test.preemptor.Status.NominatedNodeName = res.NominatedNodeName
+					}
 					// Manually set the deleted Pods' deletionTimestamp to non-nil.
 					for _, pod := range testPods {
 						if deletedPodNames.Has(pod.Name) {
@@ -2418,7 +2643,7 @@ func TestPreempt(t *testing.T) {
 					mu.RUnlock()
 
 					// Call preempt again and make sure it doesn't preempt any more pods.
-					res, status = pl.Evaluator.Preempt(ctx, state, testPod, framework.NewDefaultNodeToStatus())
+					res, status = pl.Evaluator.Preempt(ctx, framework.NewCycleState(), test.preemptor, framework.NewDefaultNodeToStatus())
 					if !status.IsSuccess() && !status.IsRejected() {
 						t.Errorf("unexpected error in preemption: %v", status.AsError())
 					}
@@ -2456,6 +2681,481 @@ func (pa *mockProposedAssignment) GetPodInfo() fwk.PodInfo {
 
 func (pa *mockProposedAssignment) GetCycleState() fwk.CycleState {
 	return pa.cycleState
+}
+
+func TestSelectVictimsOnNode(t *testing.T) {
+	tests := []struct {
+		name                       string
+		nodeNames                  []string
+		mainNode                   string
+		initPods                   []*v1.Pod
+		preemptor                  *v1.Pod
+		pdbs                       []*policy.PodDisruptionBudget
+		podGroups                  []*v1alpha3.PodGroup
+		registerPlugins            []tf.RegisterPluginFunc
+		features                   feature.Features
+		expectedPods               sets.Set[string]
+		expectedNumViolatingVictim int
+		expectedStatus             *fwk.Status
+	}{
+		{
+			name:      "Basic: Preempt single lower priority pod",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(lowPriority).Req(largeRes).Obj(),
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("victim"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Priority: Prefer lower priority victim",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("high-prio").UID("v3").Node("node1").Priority(highPriority).Req(smallRes).Obj(),
+				st.MakePod().Name("mid-prio").UID("v2").Node("node1").Priority(midPriority).Req(smallRes).Obj(),
+				st.MakePod().Name("low-prio").UID("v1").Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("low-prio"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "PDB: Prefer non-violating victim with higher priority over violating victim with lower priority",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("victim-pdb").UID("v1").Node("node1").Label("app", "foo").Priority(lowPriority).Req(mediumRes).Obj(),
+				st.MakePod().Name("victim-no-pdb").UID("v2").Node("node1").Priority(midPriority).Req(mediumRes).Obj(),
+			},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					Spec:   policy.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}}},
+					Status: policy.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+				},
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("victim-no-pdb"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "PDB: Prefer lower prioirity pod for preemption, when preemption without pdb violation is not possible",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Node("node1").Label("app", "foo").Priority(lowPriority).Req(mediumRes).Obj(),
+				st.MakePod().Name("v2").UID("v2").Node("node1").Label("app", "foo").Priority(midPriority).Req(mediumRes).Obj(),
+			},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					Spec:   policy.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}}},
+					Status: policy.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+				},
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("v1"),
+			expectedNumViolatingVictim: 1,
+		},
+		{
+			name:      "Workload Aware: Atomic preemption of PodGroup",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			features:  feature.Features{EnableGenericWorkload: true},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("g1-1").UID("g1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).Obj(),
+				st.MakePod().Name("g1-2").UID("g2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(mediumRes).Obj(),
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("g1-1", "g1-2"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Workload Aware: prefer single pod over podGroup for preemption candidate",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			features:  feature.Features{EnableGenericWorkload: true},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(lowPriority).Req(smallRes).Obj(),
+				st.MakePod().Name("g1-1").UID("g1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).Obj(),
+				st.MakePod().Name("g1-2").UID("g2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).Obj(),
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("p1"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Workload Aware: preempt lower priority pod group instead of higher priority single pod",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			features:  feature.Features{EnableGenericWorkload: true},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(highPriority).Req(mediumRes).Obj(),
+				st.MakePod().Name("g1-1").UID("g1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(mediumRes).Obj(),
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(veryHighPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("g1-1"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Workload Aware: preempt lower priority single pod instead of higher priority pod group",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			features:  feature.Features{EnableGenericWorkload: true},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(highPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(lowPriority).Req(mediumRes).Obj(),
+				st.MakePod().Name("g1-1").UID("g1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(highPriority).Req(mediumRes).Obj(),
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(veryHighPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("p1"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Workload Aware: PDB: PodGroup as victim with 2 PDB violations",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			features:  feature.Features{EnableGenericWorkload: true},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("g1-1").UID("g1").Namespace(v1.NamespaceDefault).Node("node1").Label("app", "foo").PodGroupName("pg1").Priority(lowPriority).Req(mediumRes).Obj(),
+				st.MakePod().Name("g1-2").UID("g2").Namespace(v1.NamespaceDefault).Node("node1").Label("app", "foo").PodGroupName("pg1").Priority(lowPriority).Req(mediumRes).Obj(),
+			},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: v1.NamespaceDefault},
+					Spec:       policy.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}}},
+					Status:     policy.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+				},
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("g1-1", "g1-2"),
+			expectedNumViolatingVictim: 2,
+		},
+		{
+			name:      "Workload Aware: PDB: Prefer non-violating PodGroup over lower-priority violating PodGroup (DisruptionModeAll)",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			features:  feature.Features{EnableGenericWorkload: true},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg-violating").Namespace(v1.NamespaceDefault).UID("pg-violating").Priority(lowPriority).DisruptionModeAll().Obj(),
+				st.MakePodGroup().Name("pg-non-violating").Namespace(v1.NamespaceDefault).UID("pg-non-violating").Priority(midPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("g1-1").UID("g1-1").Namespace(v1.NamespaceDefault).Node("node1").Label("app", "foo").PodGroupName("pg-violating").Priority(lowPriority).Req(mediumRes).Obj(),
+				st.MakePod().Name("g2-1").UID("g2-1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-non-violating").Priority(midPriority).Req(mediumRes).Obj(),
+			},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: v1.NamespaceDefault},
+					Spec:       policy.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}}},
+					Status:     policy.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+				},
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("g2-1"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Workload Aware: PDB: Prefer non-violating PodGroup over lower-priority violating PodGroup (DisruptionModeSingle)",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			features:  feature.Features{EnableGenericWorkload: true},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg-violating").Namespace(v1.NamespaceDefault).UID("pg-violating").Priority(lowPriority).DisruptionModeSingle().Obj(),
+				st.MakePodGroup().Name("pg-non-violating").Namespace(v1.NamespaceDefault).UID("pg-non-violating").Priority(midPriority).DisruptionModeSingle().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("g1-1").UID("g1-1").Namespace(v1.NamespaceDefault).Node("node1").Label("app", "foo").PodGroupName("pg-violating").Priority(lowPriority).Req(mediumRes).Obj(),
+				st.MakePod().Name("g2-1").UID("g2-1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-non-violating").Priority(midPriority).Req(mediumRes).Obj(),
+			},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: v1.NamespaceDefault},
+					Spec:       policy.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}}},
+					Status:     policy.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+				},
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("g2-1"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Failure: Cannot preempt the victim with higher priority",
+			nodeNames: []string{"node1"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(highPriority).Obj(),
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(midPriority).Obj(),
+			expectedPods:               nil,
+			expectedNumViolatingVictim: 0,
+			expectedStatus:             fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+		},
+		{
+			name:                       "Failure: Cannot preempt if node is empty",
+			nodeNames:                  []string{"node1"},
+			mainNode:                   "node1",
+			initPods:                   []*v1.Pod{},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(midPriority).Obj(),
+			expectedPods:               nil,
+			expectedNumViolatingVictim: 0,
+			expectedStatus:             fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+		},
+		{
+			name:      "Cross-node PodGroup: zone anti-affinity blocks reprieve via PreFilterExtension on node-a",
+			nodeNames: []string{"node-a/zone1", "node-b/zone1"},
+			mainNode:  "node-a",
+			features:  feature.Features{EnableGenericWorkload: true},
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterPluginAsExtensions(interpodaffinity.Name, frameworkruntime.FactoryAdapter(feature.Features{}, interpodaffinity.New), "Filter", "PreFilter"),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("pod-x").UID("pod-x").Namespace(v1.NamespaceDefault).Node("node-a").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("pod-y").UID("pod-y").Namespace(v1.NamespaceDefault).Node("node-b").Label("foo", "").PodGroupName("pg1").Priority(lowPriority).Obj(),
+			},
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).
+				PodAntiAffinityExists("foo", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
+			expectedPods:               sets.New("pod-x", "pod-y"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Cross-node PodGroup: zone anti-affinity blocks reprieve via PreFilterExtension on node-b",
+			nodeNames: []string{"node-a/zone1", "node-b/zone1"},
+			mainNode:  "node-b",
+			features:  feature.Features{EnableGenericWorkload: true},
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterPluginAsExtensions(interpodaffinity.Name, frameworkruntime.FactoryAdapter(feature.Features{}, interpodaffinity.New), "Filter", "PreFilter"),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("pod-x").UID("pod-x").Namespace(v1.NamespaceDefault).Node("node-a").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("pod-y").UID("pod-y").Namespace(v1.NamespaceDefault).Node("node-b").Label("foo", "").PodGroupName("pg1").Priority(lowPriority).Obj(),
+			},
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).
+				PodAntiAffinityExists("foo", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
+			expectedPods:               sets.New("pod-x", "pod-y"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Cross-node PodGroup: zone anti-affinity reprieve succeeds when remote pod lacks constraint label (negative control)",
+			nodeNames: []string{"node-a/zone1", "node-b/zone1"},
+			mainNode:  "node-a",
+			features:  feature.Features{EnableGenericWorkload: true},
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterPluginAsExtensions(interpodaffinity.Name, frameworkruntime.FactoryAdapter(feature.Features{}, interpodaffinity.New), "Filter", "PreFilter"),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("pod-x").UID("pod-x").Namespace(v1.NamespaceDefault).Node("node-a").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("pod-y").UID("pod-y").Namespace(v1.NamespaceDefault).Node("node-b").PodGroupName("pg1").Priority(lowPriority).Obj(),
+			},
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Priority(highPriority).
+				PodAntiAffinityExists("foo", "zone", st.PodAntiAffinityWithRequiredReq).Obj(),
+			expectedPods:               nil,
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Cross-node PodGroup: topology spread blocks reprieve via PreFilterExtension on node-a",
+			nodeNames: []string{"node-a/zone1", "node-b/zone1", "node-c/zone2"},
+			mainNode:  "node-a",
+			features:  feature.Features{EnableGenericWorkload: true},
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterPluginAsExtensions(podtopologyspread.Name, podTopologySpreadFunc, "PreFilter", "Filter"),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("pod-a").UID("pod-a").Namespace(v1.NamespaceDefault).Node("node-a").Label("foo", "").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("pod-b").UID("pod-b").Namespace(v1.NamespaceDefault).Node("node-b").Label("foo", "").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("pod-c").UID("pod-c").Namespace(v1.NamespaceDefault).Node("node-c").Label("foo", "").Priority(veryHighPriority).Obj(),
+			},
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Label("foo", "").Priority(highPriority).
+				SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(), nil, nil, nil, nil).Obj(),
+			expectedPods:               sets.New("pod-a", "pod-b"),
+			expectedNumViolatingVictim: 0,
+		},
+		{
+			name:      "Cross-node PodGroup: topology spread blocks reprieve via PreFilterExtension on node-c",
+			nodeNames: []string{"node-a/zone1", "node-b/zone1", "node-c/zone2"},
+			mainNode:  "node-c",
+			features:  feature.Features{EnableGenericWorkload: true},
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterPluginAsExtensions(podtopologyspread.Name, podTopologySpreadFunc, "PreFilter", "Filter"),
+			},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("pod-a").UID("pod-a").Namespace(v1.NamespaceDefault).Node("node-a").Label("foo", "").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("pod-b").UID("pod-b").Namespace(v1.NamespaceDefault).Node("node-b").Label("foo", "").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("pod-c").UID("pod-c").Namespace(v1.NamespaceDefault).Node("node-c").Label("foo", "").Priority(veryHighPriority).Obj(),
+			},
+			preemptor: st.MakePod().Name("p").UID("p").Namespace(v1.NamespaceDefault).Label("foo", "").Priority(highPriority).
+				SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("foo").Obj(), nil, nil, nil, nil).Obj(),
+			expectedPods:               nil,
+			expectedNumViolatingVictim: 0,
+			expectedStatus:             fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+		},
+		{
+			name:      "Cross-node PodGroup: whole pod group across multiple nodes expected to be preempted",
+			nodeNames: []string{"node-a", "node-b"},
+			mainNode:  "node-a",
+			features:  feature.Features{EnableGenericWorkload: true},
+			podGroups: []*v1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("pod-a").UID("pod-a").Namespace(v1.NamespaceDefault).Node("node-a").PodGroupName("pg1").Priority(lowPriority).Req(largeRes).Obj(),
+				st.MakePod().Name("pod-b").UID("pod-b").Namespace(v1.NamespaceDefault).Node("node-b").PodGroupName("pg1").Priority(lowPriority).Req(largeRes).Obj(),
+			},
+			preemptor:                  st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods:               sets.New("pod-a", "pod-b"),
+			expectedNumViolatingVictim: 0,
+		},
+	}
+
+	labelKeys := []string{"hostname", "zone", "region"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, tt.features.EnableGenericWorkload)
+			nodes := make([]*v1.Node, len(tt.nodeNames))
+			fakeFilterRCMap := make(map[string]fwk.Code, len(tt.nodeNames))
+			for i, nodeName := range tt.nodeNames {
+				nodeWrapper := st.MakeNode().Capacity(veryLargeRes)
+				tpKeys := strings.Split(nodeName, "/")
+				nodeWrapper.Name(tpKeys[0])
+				for i, labelVal := range strings.Split(nodeName, "/") {
+					nodeWrapper.Label(labelKeys[i], labelVal)
+				}
+				nodes[i] = nodeWrapper.Obj()
+			}
+
+			fakePlugin := tf.FakeFilterPlugin{
+				FailedNodeReturnCodeMap: fakeFilterRCMap,
+			}
+			registeredPlugins := append([]tf.RegisterPluginFunc{
+				tf.RegisterFilterPlugin(
+					"FakeFilter",
+					func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
+						return &fakePlugin, nil
+					},
+				)},
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterPluginAsExtensions(noderesources.Name, nodeResourcesFitFunc, "Filter", "PreFilter"),
+			)
+			registeredPlugins = append(registeredPlugins, tt.registerPlugins...)
+
+			var objs []runtime.Object
+			objs = append(objs, tt.preemptor)
+			for _, n := range nodes {
+				objs = append(objs, n)
+			}
+			for _, pg := range tt.podGroups {
+				objs = append(objs, pg)
+			}
+			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(objs...), 0)
+			parallelism := parallelize.DefaultParallelism
+
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload)
+			for _, pg := range tt.podGroups {
+				cache.AddPodGroup(pg)
+			}
+			snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.initPods, nodes, tt.podGroups)
+
+			testingFwk, err := tf.NewFramework(
+				ctx,
+				registeredPlugins, "",
+				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithMutableSnapshotLister(snapshot),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithParallelism(parallelism),
+				frameworkruntime.WithLogger(logger),
+				frameworkruntime.WithPodGroupManager(cache),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cycleState := framework.NewCycleState()
+			if _, status, _ := testingFwk.RunPreFilterPlugins(ctx, cycleState, tt.preemptor); !status.IsSuccess() {
+				t.Errorf("Unexpected PreFilter Status: %v", status)
+			}
+
+			pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), testingFwk, tt.features)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			mainNodeInfo, err := snapshot.NodeInfos().Get(tt.mainNode)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			allPossibleVictims, err := pl.Evaluator.GetVictimsOnNode(ctx, mainNodeInfo)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gotPods, gotNumViolating, gotStatus := pl.SelectVictimsOnNode(ctx, cycleState.Clone(), tt.preemptor, mainNodeInfo, allPossibleVictims, tt.pdbs)
+
+			wantStatus := tt.expectedStatus
+			wantCode := wantStatus.Code()
+			gotCode := gotStatus.Code()
+
+			if gotCode != wantCode {
+				t.Errorf("Status mismatch. Want %v, Got %v", wantCode, gotCode)
+			}
+
+			if wantCode != fwk.Success {
+				return
+			}
+
+			if gotNumViolating != tt.expectedNumViolatingVictim {
+				t.Errorf("Violating victim count mismatch. Want %d, Got %d", tt.expectedNumViolatingVictim, gotNumViolating)
+			}
+
+			gotNames := sets.New[string]()
+			for _, p := range gotPods {
+				gotNames.Insert(p.Name)
+			}
+
+			if diff := cmp.Diff(tt.expectedPods, gotNames); diff != "" {
+				t.Errorf("Victims mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestPreEnqueue(t *testing.T) {
@@ -2703,7 +3403,7 @@ func TestDefaultPreemption_PodGroupPostFilter_ErrorWrapping(t *testing.T) {
 	cache := internalcache.New(ctx, nil, true)
 	cache.AddPodGroup(preemptorPG)
 
-	snapshot := internalcache.NewSnapshot(testPods, nodes)
+	snapshot := internalcache.NewTestSnapshotWithPodGroups(testPods, nodes, []*v1alpha3.PodGroup{preemptorPG})
 	f, err := tf.NewFramework(ctx, registeredPlugins, "",
 		frameworkruntime.WithClientSet(client),
 		frameworkruntime.WithSnapshotSharedLister(snapshot),
@@ -2770,7 +3470,7 @@ func TestDefaultPreemption_PodGroupPostFilter_SchedulingConstraints(t *testing.T
 	cache := internalcache.New(ctx, nil, true)
 	cache.AddPodGroup(pgWithConstraints)
 
-	snapshot := internalcache.NewSnapshot(testPods, nodes)
+	snapshot := internalcache.NewTestSnapshotWithPodGroups(testPods, nodes, []*v1alpha3.PodGroup{pgWithConstraints})
 	f, err := tf.NewFramework(ctx, registeredPlugins, "",
 		frameworkruntime.WithClientSet(client),
 		frameworkruntime.WithSnapshotSharedLister(snapshot),
@@ -2855,7 +3555,7 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 			cache := internalcache.New(ctx, nil, true)
 			cache.AddPodGroup(pgOk)
 
-			snapshot := internalcache.NewSnapshot(testPods, nodes)
+			snapshot := internalcache.NewTestSnapshotWithPodGroups(testPods, nodes, []*v1alpha3.PodGroup{pgOk})
 			f, err := tf.NewFramework(ctx, registeredPlugins, "",
 				frameworkruntime.WithClientSet(client),
 				frameworkruntime.WithSnapshotSharedLister(snapshot),

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -29,9 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	policylisters "k8s.io/client-go/listers/policy/v1"
-	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
-	"k8s.io/kubernetes/pkg/scheduler/util"
 
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
@@ -76,11 +74,10 @@ func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodG
 	// In case of workload-aware preemption, the domain is whole cluster.
 	// We do not make a snapshot of node info. Those nodes will be shared
 	// with the PodGroup scheduling algorithm passed as podGroupSchedulingFunc.
-	allNodes, err := ev.Handle.MutableSnapshotSharedLister().NodeInfos().List()
+	domain, err := newDomainForWorkloadPreemption(ev.Handle.MutableSnapshotSharedLister(), ev.podGroupSnapshot, "cluster-domain")
 	if err != nil {
-		return nil, fwk.AsStatus(fmt.Errorf("failed to list node infos: %w", err))
+		return nil, fwk.AsStatus(fmt.Errorf("failed to create domain: %w", err))
 	}
-	domain := newDomainForWorkloadPreemption(allNodes, ev.podGroupSnapshot, "cluster-domain")
 	preemptor := newPodGroupPreemptor(pg, pods, ev.enablePodGroupPreemptionPolicy)
 	pdbs, err := getPodDisruptionBudgets(ev.pdbLister)
 	if err != nil {
@@ -128,7 +125,7 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	// This is called before the podGroupSchedulingFunc so it does not have
 	// to update any cycle states as podGroupSchedulingFunc creates empty CycleStates
 	// and fills them by running PreFilter plugins for preemptor pods.
-	removePods := func(v *victim) error {
+	removePods := func(v *DomainVictim) error {
 		for _, pi := range v.Pods() {
 			if err := mutableLister.RemovePod(logger, pi.GetPod(), pi.GetPod().Spec.NodeName); err != nil {
 				return err
@@ -141,7 +138,7 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	// and calls PreFilterExtensionAddPod() for all preemptor pods's proposed valid assignments.
 	// The node passed to the RunPreFilterExtensionAddPod will have the victim pod
 	// added.
-	addVictimPodsWithPreFilter := func(v *victim, preemptorAssignments []fwk.ProposedAssignment) error {
+	addVictimPodsWithPreFilter := func(v *DomainVictim, preemptorAssignments []fwk.ProposedAssignment) error {
 		for _, pi := range v.Pods() {
 			nodeInfo := nameToNode[pi.GetPod().Spec.NodeName]
 			if err := mutableLister.AddPod(pi, pi.GetPod().Spec.NodeName); err != nil {
@@ -161,7 +158,7 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	// and calls PreFilterExtensionRemovePod(victim) for all preemptor pods.
 	// The node passed to the RunPreFilterExtensionRemovePod will have the victim pod
 	// removed.
-	removeVictimPodsWithPreFilter := func(v *victim, preemptorAssignments []fwk.ProposedAssignment) error {
+	removeVictimPodsWithPreFilter := func(v *DomainVictim, preemptorAssignments []fwk.ProposedAssignment) error {
 		for _, pi := range v.Pods() {
 			nodeInfo := nameToNode[pi.GetPod().Spec.NodeName]
 			if err := mutableLister.RemovePod(logger, pi.GetPod(), pi.GetPod().Spec.NodeName); err != nil {
@@ -177,7 +174,7 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 		return nil
 	}
 
-	var potentialVictims []*victim
+	var potentialVictims []*DomainVictim
 	allPossiblyAffectedVictims := domain.GetAllPossibleVictims()
 	for _, victim := range allPossiblyAffectedVictims {
 		if ev.isPreemptionAllowed(victim, preemptor) {
@@ -213,10 +210,10 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	}
 
 	sort.Slice(potentialVictims, func(i, j int) bool {
-		return moreImportantVictim(potentialVictims[i], potentialVictims[j])
+		return MoreImportantVictim(potentialVictims[i], potentialVictims[j], true)
 	})
 
-	violatingVictims, nonViolatingVictims := filterVictimsWithPDBViolation(potentialVictims, pdbs)
+	violatingVictims, nonViolatingVictims := FilterVictimsWithPDBViolation(potentialVictims, pdbs)
 	numViolatingVictim := 0
 
 	validAssignment := make([]fwk.ProposedAssignment, 0, len(podGroupAssignments.ProposedAssignments))
@@ -239,7 +236,7 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	// This means that the CycleState for the Nth preemptor pod was created with:
 	// - all previous preemptor pods assumed and reserved
 	// - no knowledge of upcoming preemptor pods
-	reprieveVictim := func(v *victim, preemptorAssignments []fwk.ProposedAssignment) (fits bool, err error) {
+	reprieveVictim := func(v *DomainVictim, preemptorAssignments []fwk.ProposedAssignment) (fits bool, err error) {
 		if err = addVictimPodsWithPreFilter(v, preemptorAssignments); err != nil {
 			return false, err
 		}
@@ -284,13 +281,14 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	// Try to reprieve as many pods as possible. We first try to reprieve the PDB
 	// violating victims and then other non-violating ones. In both cases, we start
 	// from the highest importance victims.
-	var victimsToPreempt []*victim
-	for _, v := range violatingVictims {
+	var victimsToPreempt []*DomainVictim
+	for _, violatingVictim := range violatingVictims {
+		v := violatingVictim.Victim
 		if fits, err := reprieveVictim(v, validAssignment); err != nil {
 			return nil, fwk.AsStatus(err)
 		} else if !fits {
 			victimsToPreempt = append(victimsToPreempt, v)
-			numViolatingVictim++
+			numViolatingVictim += violatingVictim.ViolateCount
 		}
 	}
 
@@ -303,7 +301,7 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	}
 
 	sort.Slice(victimsToPreempt, func(i, j int) bool {
-		return moreImportantVictim(victimsToPreempt[i], victimsToPreempt[j])
+		return MoreImportantVictim(victimsToPreempt[i], victimsToPreempt[j], true)
 	})
 	var podsToPreempt []*v1.Pod
 	for _, v := range victimsToPreempt {
@@ -337,9 +335,8 @@ func toPodNames(pods []fwk.PodInfo) string {
 }
 
 // isPreemptionAllowed returns whether the victim residing on nodeInfo can be preempted by the preemptor
-func (ev *PodGroupEvaluator) isPreemptionAllowed(victim *victim, preemptor *podGroupPreemptor) bool {
-	// The victim must have lower priority than the preemptor.
-	return victim.Priority() < preemptor.Priority()
+func (ev *PodGroupEvaluator) isPreemptionAllowed(victim Victim, preemptor *podGroupPreemptor) bool {
+	return victim.Priority() < preemptor.priority
 }
 
 // preemptorEligibleToPreemptOthers returns one bool and one string. The bool
@@ -360,7 +357,7 @@ func (ev *PodGroupEvaluator) preemptorEligibleToPreemptOthers(_ context.Context,
 	for nomNodeName := range nominatedNodes {
 		if nodeInfo, exists := nameToNode[nomNodeName]; exists {
 			for _, p := range nodeInfo.GetPods() {
-				if ev.getPodPriority(p.GetPod()) < preemptor.Priority() && PodTerminatingByPreemption(p.GetPod()) {
+				if GetPodPriority(p.GetPod(), ev.podGroupSnapshot) < preemptor.Priority() && PodTerminatingByPreemption(p.GetPod()) {
 					return false, "not eligible due to a terminating pod on the nominated node."
 				}
 			}
@@ -368,58 +365,4 @@ func (ev *PodGroupEvaluator) preemptorEligibleToPreemptOthers(_ context.Context,
 	}
 
 	return true, ""
-}
-
-// getPodPriority returns the effective preemption priority of a pod. If the pod belongs to
-// a pod group, it returns the priority of the pod group.
-// Otherwise, it returns the pod's own priority.
-func (ev *PodGroupEvaluator) getPodPriority(p *v1.Pod) int32 {
-	if pg := getPodGroup(p, ev.podGroupSnapshot); pg != nil {
-		return util.PodGroupPriority(pg)
-	}
-	return corev1helpers.PodPriority(p)
-}
-
-// moreImportantVictim decides which of two preemption units is considered more critical.
-// This function is dedidcated only for PodGroup preemption.
-//
-// The comparison logic follows this strict hierarchy:
-//
-//  1. Priority: Higher priority units are always more important.
-//
-//  2. Workload Type:
-//     Atomic workloads (PodGroups) are considered more important than individual Pods
-//     of the same priority.
-//
-//  3. Start Time (for Single Pods):
-//     If both units are single Pods, the one with the older StartTime is more important.
-//     This honors "first-come, first-served".
-//
-//  4. Group Size (for PodGroups):
-//     If both units are PodGroups, the one with more members (larger size) is considered
-//     more important. This avoids the high cost of rescheduling massive jobs.
-//
-//  5. Start Time (Tie-breaker for PodGroups):
-//     If sizes are equal, the group that started earlier (has the oldest pod)
-//     is more important.
-func moreImportantVictim(vi1, vi2 *victim) bool {
-	if vi1.Priority() != vi2.Priority() {
-		return vi1.Priority() > vi2.Priority()
-	}
-
-	if vi1.IsPodGroup() != vi2.IsPodGroup() {
-		return vi1.IsPodGroup()
-	}
-
-	if !vi1.IsPodGroup() {
-		return vi1.EarliestStartTime().Before(vi2.EarliestStartTime())
-	}
-
-	if len(vi1.Pods()) != len(vi2.Pods()) {
-		return len(vi1.Pods()) > len(vi2.Pods())
-	}
-
-	t1 := vi1.EarliestStartTime()
-	t2 := vi2.EarliestStartTime()
-	return t1.Before(t2)
 }

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
@@ -31,10 +31,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -1304,6 +1307,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 			logger, ctx := ktesting.NewTestContext(t)
 
 			mockFilterFactory := func(ctx context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
@@ -1328,7 +1332,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			parallelism := parallelize.DefaultParallelism
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			snapshot := internalcache.NewSnapshot(tt.initPods, tt.nodes)
+			snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.initPods, tt.nodes, tt.initPodGroups)
 			f, err := tf.NewFramework(
 				ctx,
 				registeredPlugins, "",
@@ -1404,6 +1408,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			for _, pg := range tt.initPodGroups {
 				podGroups[pg.Name] = pg
 			}
+
 			pgLister := &mockPodGroupLister{podGroups: podGroups}
 			pl := &PodGroupEvaluator{
 				Handle:           f,
@@ -1413,8 +1418,10 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			if err := pl.Handle.MutableSnapshotSharedLister().StartMutations(); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
-			domainNodes, _ := snapshot.NodeInfos().List()
-			domain := newDomainForWorkloadPreemption(domainNodes, pgLister, "test-domain")
+			domain, err := newDomainForWorkloadPreemption(snapshot, pgLister, "test-domain")
+			if err != nil {
+				t.Fatalf("Failed to create domain: %v", err)
+			}
 			res, gotStatus := pl.selectVictimsOnDomain(ctx, tt.preemptor, domain, tt.pdbs, mockSchedulingFunc)
 			if !gotStatus.IsSuccess() {
 				t.Logf("SelectVictimsOnDomain failed: %v", gotStatus.Message())
@@ -1447,144 +1454,8 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 	}
 }
 
-func TestMoreImportantVictim(t *testing.T) {
-	newPodInfo := func(p *v1.Pod) fwk.PodInfo {
-		pi, _ := framework.NewPodInfo(p)
-		return pi
-	}
-
-	now := &metav1.Time{Time: time.Unix(1000, 0)}
-	before := &metav1.Time{Time: time.Unix(500, 0)}
-
-	tests := []struct {
-		name string
-		vi1  *victim
-		vi2  *victim
-		want bool
-	}{
-		{
-			name: "vi1 has higher priority",
-			vi1:  &victim{priority: 20},
-			vi2:  &victim{priority: 10},
-			want: true,
-		},
-		{
-			name: "vi2 has higher priority",
-			vi1:  &victim{priority: 10},
-			vi2:  &victim{priority: 20},
-			want: false,
-		},
-		{
-			name: "vi1 is PG, vi2 is Pod, same priority",
-			vi1:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().PodGroupName("pg").Obj())}},
-			vi2:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}},
-			want: true,
-		},
-		{
-			name: "vi1 is Pod, vi2 is PG, same priority",
-			vi1:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}},
-			vi2:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().PodGroupName("pg").Obj())}},
-			want: false,
-		},
-		{
-			name: "both Pods, vi1 older",
-			vi1:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}, earliestStartTime: before},
-			vi2:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}, earliestStartTime: now},
-			want: true,
-		},
-		{
-			name: "both Pods, vi2 older",
-			vi1:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}, earliestStartTime: now},
-			vi2:  &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}, earliestStartTime: before},
-			want: false,
-		},
-		{
-			name: "both PGs, vi1 larger",
-			vi1: &victim{
-				priority: 10,
-				pods: []fwk.PodInfo{
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-				},
-			},
-			vi2: &victim{
-				priority: 10,
-				pods: []fwk.PodInfo{
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-				},
-			},
-			want: true,
-		},
-		{
-			name: "both PGs, vi2 larger",
-			vi1: &victim{
-				priority: 10,
-				pods: []fwk.PodInfo{
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-				},
-			},
-			vi2: &victim{
-				priority: 10,
-				pods: []fwk.PodInfo{
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-				},
-			},
-			want: false,
-		},
-		{
-			name: "both PGs, same size, vi1 older",
-			vi1: &victim{
-				priority: 10,
-				pods: []fwk.PodInfo{
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-				},
-				earliestStartTime: before,
-			},
-			vi2: &victim{
-				priority: 10,
-				pods: []fwk.PodInfo{
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-				},
-				earliestStartTime: now,
-			},
-			want: true,
-		},
-		{
-			name: "both PGs, same size, vi2 older",
-			vi1: &victim{
-				priority: 10,
-				pods: []fwk.PodInfo{
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-				},
-				earliestStartTime: now,
-			},
-			vi2: &victim{
-				priority: 10,
-				pods: []fwk.PodInfo{
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
-				},
-				earliestStartTime: before,
-			},
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := moreImportantVictim(tt.vi1, tt.vi2)
-			if got != tt.want {
-				t.Errorf("MoreImportantVictim() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 	logger, ctx := ktesting.NewTestContext(t)
 
 	p1 := st.MakePod().Name("p1").UID("p1").Obj()
@@ -1629,7 +1500,10 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingapi.PodGroup)}
-	domain := newDomainForWorkloadPreemption(domainNodes, pgLister, "test-domain")
+	domain, err := newDomainForWorkloadPreemption(snapshot, pgLister, "test-domain")
+	if err != nil {
+		t.Fatalf("Failed to create domain: %v", err)
+	}
 
 	mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 		cs1 := framework.NewCycleState()

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -25,7 +25,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -50,11 +49,11 @@ type Interface interface {
 	// PodEligibleToPreemptOthers returns one bool and one string. The bool indicates whether this pod should be considered for
 	// preempting other pods or not. The string includes the reason if this pod isn't eligible.
 	PodEligibleToPreemptOthers(ctx context.Context, pod *v1.Pod, nominatedNodeStatus *fwk.Status) (bool, string)
-	// SelectVictimsOnNode finds minimum set of pods on the given node that should be preempted in order to make enough room
-	// for "pod" to be scheduled.
-	// Note that both `state` and `nodeInfo` are deep copied.
-	SelectVictimsOnNode(ctx context.Context, state fwk.CycleState,
-		pod *v1.Pod, nodeInfo fwk.NodeInfo, pdbs []*policy.PodDisruptionBudget) ([]*v1.Pod, int, *fwk.Status)
+	// SelectVictimsOnNode finds the minimum set of pods that should be preempted in order to make enough room
+	// for the preemptor pod to be scheduled on the selected node (represented by nodeInfo).
+	// The candidate victims (allPossibleVictims) may include pods that span additional nodes (e.g., pod groups).
+	// Note that `cycleState` is cloned by the caller, and `nodeInfo` is a snapshot copy.
+	SelectVictimsOnNode(ctx context.Context, cycleState fwk.CycleState, preemptor *v1.Pod, nodeInfo fwk.NodeInfo, allPossibleVictims []*DomainVictim, pdbs []*policy.PodDisruptionBudget) ([]*v1.Pod, int, *fwk.Status)
 	// OrderedScoreFuncs returns a list of ordered score functions to select preferable node where victims will be preempted.
 	// The ordered score functions will be processed one by one iff we find more than one node with the highest score.
 	// Default score functions will be processed if nil returned here for backwards-compatibility.
@@ -63,10 +62,11 @@ type Interface interface {
 
 // Evaluator is a preemption evaluator. It runs preemption logic with a given Interface.
 type Evaluator struct {
-	PluginName string
-	Handler    fwk.Handle
-	PodLister  corelisters.PodLister
-	PdbLister  policylisters.PodDisruptionBudgetLister
+	PluginName       string
+	Handler          fwk.Handle
+	PodLister        corelisters.PodLister
+	PdbLister        policylisters.PodDisruptionBudgetLister
+	podGroupSnapshot fwk.PodGroupLister
 
 	Interface
 	executor *Executor
@@ -74,7 +74,7 @@ type Evaluator struct {
 
 // NewEvaluator creates a new Evaluator.
 func NewEvaluator(pluginName string, fh fwk.Handle, i Interface, executor *Executor) *Evaluator {
-	return &Evaluator{
+	ev := &Evaluator{
 		PluginName: pluginName,
 		Handler:    fh,
 		PodLister:  fh.SharedInformerFactory().Core().V1().Pods().Lister(),
@@ -82,6 +82,10 @@ func NewEvaluator(pluginName string, fh fwk.Handle, i Interface, executor *Execu
 		Interface:  i,
 		executor:   executor,
 	}
+	if executor.fts.EnableGenericWorkload {
+		ev.podGroupSnapshot = fh.MutableSnapshotSharedLister().PodGroups()
+	}
+	return ev
 }
 
 // Preempt returns a PostFilterResult carrying suggested nominatedNodeName, along with a Status.
@@ -108,7 +112,7 @@ func (ev *Evaluator) Preempt(ctx context.Context, state fwk.CycleState, pod *v1.
 	// initialized when creating the Scheduler obj.
 	// However, tests may need to manually initialize the shared pod informer.
 	podNamespace, podName := pod.Namespace, pod.Name
-	pod, err := ev.PodLister.Pods(pod.Namespace).Get(pod.Name)
+	pod, err := ev.PodLister.Pods(podNamespace).Get(podName)
 	if err != nil {
 		logger.Error(err, "Could not get the updated preemptor pod object", "pod", klog.KRef(podNamespace, podName))
 		return nil, fwk.AsStatus(err)
@@ -126,6 +130,7 @@ func (ev *Evaluator) Preempt(ctx context.Context, state fwk.CycleState, pod *v1.
 	if err != nil {
 		return nil, fwk.AsStatus(err)
 	}
+
 	candidates, nodeToStatusMap, err := ev.findCandidates(ctx, state, allNodes, pod, m)
 	if err != nil && len(candidates) == 0 {
 		return nil, fwk.AsStatus(err)
@@ -236,7 +241,6 @@ func (ev *Evaluator) callExtenders(logger klog.Logger, pod *v1.Pod, candidates [
 				return nil, fwk.AsStatus(fmt.Errorf("expected at least one victim pod on node %q", nodeName))
 			}
 		}
-
 		// Replace victimsMap with new result after preemption. So the
 		// rest of extenders can continue use it as parameter.
 		victimsMap = nodeNameToVictims
@@ -414,14 +418,31 @@ func (ev *Evaluator) DryRunPreemption(ctx context.Context, state fwk.CycleState,
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Dry run the preemption", "potentialNodesNumber", len(potentialNodes), "pdbsNumber", len(pdbs), "offset", offset, "candidatesNumber", candidatesNum)
 
-	var statusesLock sync.Mutex
+	var mu sync.Mutex
 	var errs []error
+	// checkNode evaluates a single candidate node in isolation. Each goroutine builds its own Domain
+	// via NewDomainForPodByPodPreemption, so a PodGroup victim that spans nodes A and B will be
+	// considered as a candidate victim in both A's and B's evaluations. This is intentional: SelectCandidate
+	// downstream picks at most one candidate per preemption attempt, so the PodGroup is preempted at most
+	// once. Do not assume cross-goroutine coordination here — checkNode must remain independent.
 	checkNode := func(i int) {
-		nodeInfoCopy := potentialNodes[(int(offset)+i)%len(potentialNodes)].Snapshot()
-		logger.V(5).Info("Check the potential node for preemption", "node", nodeInfoCopy.Node().Name)
+		nodeInfo := potentialNodes[(int(offset)+i)%len(potentialNodes)]
+		logger.V(5).Info("Check the potential node for preemption", "node", nodeInfo.Node().Name)
 
-		stateCopy := state.Clone()
-		pods, numPDBViolations, status := ev.SelectVictimsOnNode(ctx, stateCopy, pod, nodeInfoCopy, pdbs)
+		// GetVictimsOnNode is called with a shared nodeInfo. The returned DomainVictims
+		// will contain shared, non-cloned NodeInfos for affected nodes. This is safe because
+		// SelectVictimsOnNode only mutates the main node's NodeInfo (which is passed as a cloned
+		// copy via nodeInfo.Snapshot()). Remote nodes' NodeInfos are only passed to
+		// PreFilterExtension Add/RemovePod hooks, which must not mutate NodeInfo.
+		allPossibleVictims, err := ev.GetVictimsOnNode(ctx, nodeInfo)
+		if err != nil {
+			mu.Lock()
+			errs = append(errs, err)
+			mu.Unlock()
+			return
+		}
+		pods, numPDBViolations, status := ev.SelectVictimsOnNode(ctx, state.Clone(), pod, nodeInfo.Snapshot(), allPossibleVictims, pdbs)
+
 		if status.IsSuccess() && len(pods) != 0 {
 			victims := extenderv1.Victims{
 				Pods:             pods,
@@ -429,7 +450,7 @@ func (ev *Evaluator) DryRunPreemption(ctx context.Context, state fwk.CycleState,
 			}
 			c := &candidate{
 				victims: &victims,
-				name:    nodeInfoCopy.Node().Name,
+				name:    nodeInfo.Node().Name,
 			}
 			if numPDBViolations == 0 {
 				nonViolatingCandidates.add(c)
@@ -443,76 +464,39 @@ func (ev *Evaluator) DryRunPreemption(ctx context.Context, state fwk.CycleState,
 			return
 		}
 		if status.IsSuccess() && len(pods) == 0 {
-			status = fwk.AsStatus(fmt.Errorf("expected at least one victim pod on node %q", nodeInfoCopy.Node().Name))
+			status = fwk.AsStatus(fmt.Errorf("expected at least one victim pod on node %q", nodeInfo.Node().Name))
 		}
-		statusesLock.Lock()
+		mu.Lock()
 		if status.Code() == fwk.Error {
 			errs = append(errs, status.AsError())
 		}
-		nodeStatuses.Set(nodeInfoCopy.Node().Name, status)
-		statusesLock.Unlock()
+		nodeStatuses.Set(nodeInfo.Node().Name, status)
+		mu.Unlock()
 	}
 	fh.Parallelizer().Until(ctx, len(potentialNodes), checkNode, ev.PluginName)
 	return append(nonViolatingCandidates.get(), violatingCandidates.get()...), nodeStatuses, utilerrors.NewAggregate(errs)
 }
 
-func filterVictimsWithPDBViolation(victims []*victim, pdbs []*policy.PodDisruptionBudget) (violatingVictims, nonViolatingVictims []*victim) {
-	pdbsAllowed := make([]int32, len(pdbs))
-	podIsViolating := func(pod *v1.Pod) bool {
-		if len(pod.Labels) == 0 {
-			return false
+// GetVictimsOnNode returns a list of potential preemption victims on the given node.
+// If GenericWorkload is enabled, it groups pods belonging to the same PodGroup
+// (with disruption mode All) across the cluster into a single victim.
+// If GenericWorkload is disabled, it treats each pod on the node as an individual victim.
+func (ev *Evaluator) GetVictimsOnNode(ctx context.Context, nodeInfo fwk.NodeInfo) ([]*DomainVictim, error) {
+	fh := ev.Handler
+
+	// If GenericWorkload is disabled, we treat each pod on the node
+	// as an individual preemption victim. We bypass getCrossNodesVictims and call NewPodVictim
+	// with a nil pgLister to force using the pod's own priority. Otherwise, if we used the
+	// pgLister, it would resolve to the PodGroup's priority, which might be nil (treated as 0)
+	// when GenericWorkload is disabled.
+	if !ev.executor.fts.EnableGenericWorkload {
+		var victims []Victim
+		for _, podInfo := range nodeInfo.GetPods() {
+			victims = append(victims, NewPodVictim(podInfo, nil))
 		}
-
-		for i, pdb := range pdbs {
-			if pdb.Namespace != pod.Namespace {
-				continue
-			}
-			selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
-			if err != nil {
-				// This object has an invalid selector, it does not match the pod
-				continue
-			}
-			// A PDB with a nil or empty selector matches nothing.
-			if selector.Empty() || !selector.Matches(labels.Set(pod.Labels)) {
-				continue
-			}
-
-			// Existing in DisruptedPods means it has been processed in API server,
-			// we don't treat it as a violating case.
-			if _, exist := pdb.Status.DisruptedPods[pod.Name]; exist {
-				continue
-			}
-			// Only decrement the matched pdb when it's not in its <DisruptedPods>;
-			// otherwise we may over-decrement the budget number.
-			pdbsAllowed[i]--
-			// We have found a matching PDB.
-			if pdbsAllowed[i] < 0 {
-				return true
-			}
-		}
-
-		return false
+		return createDomainVictims(fh.MutableSnapshotSharedLister(), victims)
 	}
 
-	for i, pdb := range pdbs {
-		pdbsAllowed[i] = pdb.Status.DisruptionsAllowed
-	}
+	return getCrossNodesVictims(fh.MutableSnapshotSharedLister(), ev.podGroupSnapshot, []fwk.NodeInfo{nodeInfo})
 
-	for _, victim := range victims {
-		isUnitViolating := false
-
-		for _, pi := range victim.Pods() {
-			if podIsViolating(pi.GetPod()) {
-				isUnitViolating = true
-				break
-			}
-		}
-		if isUnitViolating {
-			violatingVictims = append(violatingVictims, victim)
-		} else {
-			nonViolatingVictims = append(nonViolatingVictims, victim)
-		}
-	}
-
-	return violatingVictims, nonViolatingVictims
 }

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -21,20 +21,24 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
 	apicache "k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
 	apidispatcher "k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
@@ -43,6 +47,7 @@ import (
 	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
@@ -67,10 +72,9 @@ type FakePostFilterPlugin struct {
 	numViolatingVictim int
 }
 
-func (pl *FakePostFilterPlugin) SelectVictimsOnNode(
-	ctx context.Context, state fwk.CycleState, pod *v1.Pod,
-	nodeInfo fwk.NodeInfo, pdbs []*policy.PodDisruptionBudget) (victims []*v1.Pod, numViolatingVictim int, status *fwk.Status) {
-	return append(victims, nodeInfo.GetPods()[0].GetPod()), pl.numViolatingVictim, nil
+func (pl *FakePostFilterPlugin) SelectVictimsOnNode(ctx context.Context, cycleState fwk.CycleState, preemptor *v1.Pod, nodeInfo fwk.NodeInfo, allPossibleVictims []*DomainVictim, pdbs []*policy.PodDisruptionBudget) (victims []*v1.Pod, numViolatingVictim int, status *fwk.Status) {
+	victims = append(victims, nodeInfo.GetPods()[0].GetPod())
+	return victims, pl.numViolatingVictim, nil
 }
 
 func (pl *FakePostFilterPlugin) GetOffsetAndNumCandidates(nodes int32) (int32, int32) {
@@ -85,16 +89,19 @@ func (pl *FakePostFilterPlugin) PodEligibleToPreemptOthers(_ context.Context, po
 	return true, ""
 }
 
+func (pl *FakePostFilterPlugin) PodGroupEligibleToPreemptOthers(_ context.Context, podGroupInfo *framework.PodGroupInfo) (bool, string) {
+	return true, ""
+}
+
 func (pl *FakePostFilterPlugin) OrderedScoreFuncs(ctx context.Context, nodesToVictims map[string]*extenderv1.Victims) []func(node string) int64 {
 	return nil
 }
 
 type FakePreemptionScorePostFilterPlugin struct{}
 
-func (pl *FakePreemptionScorePostFilterPlugin) SelectVictimsOnNode(
-	ctx context.Context, state fwk.CycleState, pod *v1.Pod,
-	nodeInfo fwk.NodeInfo, pdbs []*policy.PodDisruptionBudget) (victims []*v1.Pod, numViolatingVictim int, status *fwk.Status) {
-	return append(victims, nodeInfo.GetPods()[0].GetPod()), 1, nil
+func (pl *FakePreemptionScorePostFilterPlugin) SelectVictimsOnNode(ctx context.Context, cycleState fwk.CycleState, preemptor *v1.Pod, nodeInfo fwk.NodeInfo, allPossibleVictims []*DomainVictim, pdbs []*policy.PodDisruptionBudget) (victims []*v1.Pod, numViolatingVictim int, status *fwk.Status) {
+	victims = append(victims, nodeInfo.GetPods()[0].GetPod())
+	return victims, 1, nil
 }
 
 func (pl *FakePreemptionScorePostFilterPlugin) GetOffsetAndNumCandidates(nodes int32) (int32, int32) {
@@ -110,6 +117,10 @@ func (pl *FakePreemptionScorePostFilterPlugin) CandidatesToVictimsMap(candidates
 }
 
 func (pl *FakePreemptionScorePostFilterPlugin) PodEligibleToPreemptOthers(_ context.Context, pod *v1.Pod, nominatedNodeStatus *fwk.Status) (bool, string) {
+	return true, ""
+}
+
+func (pl *FakePreemptionScorePostFilterPlugin) PodGroupEligibleToPreemptOthers(_ context.Context, podGroupInfo *framework.PodGroupInfo) (bool, string) {
 	return true, ""
 }
 
@@ -130,7 +141,7 @@ func TestDryRunPreemption(t *testing.T) {
 	tests := []struct {
 		name               string
 		nodes              []*v1.Node
-		testPods           []*v1.Pod
+		preemptors         []*v1.Pod
 		initPods           []*v1.Pod
 		numViolatingVictim int
 		expected           [][]Candidate
@@ -141,7 +152,7 @@ func TestDryRunPreemption(t *testing.T) {
 				st.MakeNode().Name("node1").Capacity(veryLargeRes).Obj(),
 				st.MakeNode().Name("node2").Capacity(veryLargeRes).Obj(),
 			},
-			testPods: []*v1.Pod{
+			preemptors: []*v1.Pod{
 				st.MakePod().Name("p").UID("p").Priority(highPriority).Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -171,7 +182,7 @@ func TestDryRunPreemption(t *testing.T) {
 				st.MakeNode().Name("node1").Capacity(veryLargeRes).Obj(),
 				st.MakeNode().Name("node2").Capacity(veryLargeRes).Obj(),
 			},
-			testPods: []*v1.Pod{
+			preemptors: []*v1.Pod{
 				st.MakePod().Name("p").UID("p").Priority(highPriority).Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -208,9 +219,11 @@ func TestDryRunPreemption(t *testing.T) {
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 			)
 			var objs []runtime.Object
-			for _, p := range append(tt.testPods, tt.initPods...) {
+
+			for _, p := range append(tt.preemptors, tt.initPods...) {
 				objs = append(objs, p)
 			}
+
 			for _, n := range tt.nodes {
 				objs = append(objs, n)
 			}
@@ -245,14 +258,15 @@ func TestDryRunPreemption(t *testing.T) {
 
 			fakePostPlugin := &FakePostFilterPlugin{numViolatingVictim: tt.numViolatingVictim}
 
-			for cycle, pod := range tt.testPods {
+			for cycle, preemptor := range tt.preemptors {
 				state := framework.NewCycleState()
 				pe := Evaluator{
 					PluginName: "FakePostFilter",
 					Handler:    fwk,
 					Interface:  fakePostPlugin,
+					executor:   NewExecutor(fwk, feature.Features{}),
 				}
-				got, _, _ := pe.DryRunPreemption(ctx, state, pod, nodeInfos, nil, 0, int32(len(nodeInfos)))
+				got, _, _ := pe.DryRunPreemption(ctx, state, preemptor, nodeInfos, nil, 0, int32(len(nodeInfos)))
 				// Sort the values (inner victims) and the candidate itself (by its NominatedNodeName).
 				for i := range got {
 					victims := got[i].Victims().Pods
@@ -328,6 +342,7 @@ func TestSelectCandidate(t *testing.T) {
 				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithMutableSnapshotLister(snapshot),
+				frameworkruntime.WithInformerFactory(informerFactory),
 				frameworkruntime.WithLogger(logger),
 			)
 			if err != nil {
@@ -352,6 +367,7 @@ func TestSelectCandidate(t *testing.T) {
 					PluginName: "FakePreemptionScorePostFilter",
 					Handler:    fwk,
 					Interface:  fakePreemptionScorePostFilterPlugin,
+					executor:   NewExecutor(fwk, feature.Features{}),
 				}
 				candidates, _, _ := pe.DryRunPreemption(ctx, state, pod, nodeInfos, nil, 0, int32(len(nodeInfos)))
 				s := pe.SelectCandidate(ctx, candidates)
@@ -634,211 +650,293 @@ func TestCallExtenders(t *testing.T) {
 	}
 }
 
-func TestFilterVictimsWithPDBViolation(t *testing.T) {
+func TestGetVictimsOnNode(t *testing.T) {
 	newPodInfo := func(p *v1.Pod) fwk.PodInfo {
 		pi, _ := framework.NewPodInfo(p)
 		return pi
 	}
 
-	viNoPDBMatch := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").Label("app", "foo").Obj())}}
-	viMatchPDB := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj())}}
-	viMatchPDB2 := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p2").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj())}}
-	viPodGroup := &victim{
-		pods: []fwk.PodInfo{
-			newPodInfo(st.MakePod().Name("p1").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj()),
-			newPodInfo(st.MakePod().Name("p2").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj()),
-		},
-	}
-	viMatchMultiplePDBs := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").Namespace(metav1.NamespaceDefault).Label("app", "foo").Label("tier", "backend").Obj())}}
-
 	tests := []struct {
-		name                 string
-		victims              []*victim
-		pdbs                 []*policy.PodDisruptionBudget
-		expectedViolating    []*victim
-		expectedNonViolating []*victim
+		name                  string
+		enableGenericWorkload bool
+		nodes                 []*v1.Node
+		pods                  []*v1.Pod
+		podGroups             []*schedulingapi.PodGroup
+		targetNode            string
+		expectedVictims       []*DomainVictim
 	}{
 		{
-			name:                 "no victims, no PDBs",
-			victims:              nil,
-			pdbs:                 nil,
-			expectedViolating:    nil,
-			expectedNonViolating: nil,
-		},
-		{
-			name:    "victim with no matching PDBs",
-			victims: []*victim{viNoPDBMatch},
-			pdbs: []*policy.PodDisruptionBudget{
+			name:                  "GenericWorkload disabled, two pods on target node",
+			enableGenericWorkload: false,
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(midPriority).Obj(),
+				st.MakePod().Name("p2").UID("p2").Node("node1").Priority(lowPriority).Obj(),
+			},
+			targetNode: "node1",
+			expectedVictims: []*DomainVictim{
 				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "bar"}},
+					Victim: &victim{
+						priority: midPriority,
+						pods:     []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").UID("p1").Node("node1").Priority(midPriority).Obj())},
+					},
+				},
+				{
+					Victim: &victim{
+						priority: lowPriority,
+						pods:     []fwk.PodInfo{newPodInfo(st.MakePod().Name("p2").UID("p2").Node("node1").Priority(lowPriority).Obj())},
 					},
 				},
 			},
-			expectedViolating:    nil,
-			expectedNonViolating: []*victim{viNoPDBMatch},
 		},
 		{
-			name:    "victim matching PDB, adequate DisruptionsAllowed",
-			victims: []*victim{viMatchPDB},
-			pdbs: []*policy.PodDisruptionBudget{
+			name:                  "GenericWorkload enabled, pods with no PodGroup",
+			enableGenericWorkload: true,
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(midPriority).Obj(),
+				st.MakePod().Name("p2").UID("p2").Node("node1").Priority(lowPriority).Obj(),
+			},
+			targetNode: "node1",
+			expectedVictims: []*DomainVictim{
 				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+					Victim: &victim{
+						priority: midPriority,
+						pods:     []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").UID("p1").Node("node1").Priority(midPriority).Obj())},
 					},
-					Status: policy.PodDisruptionBudgetStatus{
-						DisruptionsAllowed: 1,
+				},
+				{
+					Victim: &victim{
+						priority: lowPriority,
+						pods:     []fwk.PodInfo{newPodInfo(st.MakePod().Name("p2").UID("p2").Node("node1").Priority(lowPriority).Obj())},
 					},
 				},
 			},
-			expectedViolating:    nil,
-			expectedNonViolating: []*victim{viMatchPDB},
 		},
 		{
-			name:    "victim matching PDB, no DisruptionsAllowed",
-			victims: []*victim{viMatchPDB},
-			pdbs: []*policy.PodDisruptionBudget{
+			name:                  "GenericWorkload enabled, pod belonging to PodGroup with disruptionMode All",
+			enableGenericWorkload: true,
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("default").Priority(midPriority).DisruptionModeAll().Obj(),
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Namespace("default").Node("node1").PodGroupName("pg1").Priority(midPriority).Obj(),
+				st.MakePod().Name("p2").UID("p2").Namespace("default").Node("node2").PodGroupName("pg1").Priority(midPriority).Obj(),
+				st.MakePod().Name("p3").UID("p3").Namespace("default").Node("node1").Priority(lowPriority).Obj(),
+			},
+			targetNode: "node1",
+			expectedVictims: []*DomainVictim{
 				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+					Victim: &victim{
+						priority: midPriority,
+						pods: []fwk.PodInfo{
+							newPodInfo(st.MakePod().Name("p1").UID("p1").Namespace("default").Node("node1").PodGroupName("pg1").Priority(midPriority).Obj()),
+							newPodInfo(st.MakePod().Name("p2").UID("p2").Namespace("default").Node("node2").PodGroupName("pg1").Priority(midPriority).Obj()),
+						},
 					},
-					Status: policy.PodDisruptionBudgetStatus{
-						DisruptionsAllowed: 0,
+				},
+				{
+					Victim: &victim{
+						priority: lowPriority,
+						pods:     []fwk.PodInfo{newPodInfo(st.MakePod().Name("p3").UID("p3").Namespace("default").Node("node1").Priority(lowPriority).Obj())},
 					},
 				},
 			},
-			expectedViolating:    []*victim{viMatchPDB},
-			expectedNonViolating: nil,
 		},
 		{
-			name:    "podgroup victim with multiple pods, one violating",
-			victims: []*victim{viPodGroup},
-			pdbs: []*policy.PodDisruptionBudget{
+			name:                  "GenericWorkload enabled, pods belonging to PodGroup with disruptionMode Single",
+			enableGenericWorkload: true,
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg1").Namespace("default").Priority(midPriority).DisruptionModeSingle().Obj(),
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Namespace("default").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p2").UID("p2").Namespace("default").Node("node2").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p3").UID("p3").Namespace("default").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p4").UID("p4").Namespace("default").Node("node1").Priority(lowPriority).Obj(),
+			},
+			targetNode: "node1",
+			expectedVictims: []*DomainVictim{
 				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
-					},
-					Status: policy.PodDisruptionBudgetStatus{
-						DisruptionsAllowed: 1,
+					Victim: &victim{
+						priority: midPriority,
+						pods: []fwk.PodInfo{
+							newPodInfo(st.MakePod().Name("p1").UID("p1").Namespace("default").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj()),
+						},
 					},
 				},
-			},
-			expectedViolating:    []*victim{viPodGroup},
-			expectedNonViolating: nil,
-		},
-		{
-			name:    "podgroup victim with multiple pods, none violating",
-			victims: []*victim{viPodGroup},
-			pdbs: []*policy.PodDisruptionBudget{
 				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
-					},
-					Status: policy.PodDisruptionBudgetStatus{
-						DisruptionsAllowed: 2,
+					Victim: &victim{
+						priority: midPriority,
+						pods: []fwk.PodInfo{
+							newPodInfo(st.MakePod().Name("p3").UID("p3").Namespace("default").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj()),
+						},
 					},
 				},
-			},
-			expectedViolating:    nil,
-			expectedNonViolating: []*victim{viPodGroup},
-		},
-		{
-			name:    "multiple victims matching the same PDB",
-			victims: []*victim{viMatchPDB, viMatchPDB2},
-			pdbs: []*policy.PodDisruptionBudget{
 				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
-					},
-					Status: policy.PodDisruptionBudgetStatus{
-						DisruptionsAllowed: 1,
-					},
-				},
-			},
-			expectedViolating:    []*victim{viMatchPDB2},
-			expectedNonViolating: []*victim{viMatchPDB},
-		},
-		{
-			name:    "pod in DisruptedPods is ignored",
-			victims: []*victim{viMatchPDB},
-			pdbs: []*policy.PodDisruptionBudget{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
-					},
-					Status: policy.PodDisruptionBudgetStatus{
-						DisruptionsAllowed: 0,
-						DisruptedPods: map[string]metav1.Time{
-							"p1": {Time: time.Now()},
+					Victim: &victim{
+						priority: lowPriority,
+						pods: []fwk.PodInfo{
+							newPodInfo(st.MakePod().Name("p4").UID("p4").Namespace("default").Node("node1").Priority(lowPriority).Obj()),
 						},
 					},
 				},
 			},
-			expectedViolating:    nil,
-			expectedNonViolating: []*victim{viMatchPDB},
 		},
 		{
-			name:    "PDB with empty selector",
-			victims: []*victim{viMatchPDB},
-			pdbs: []*policy.PodDisruptionBudget{
+			name:                  "GenericWorkload enabled, mixed test with individual pods, PodGroup with DisruptionMode Single, and PodGroup with DisruptionMode All",
+			enableGenericWorkload: true,
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg-all").Namespace("default").Priority(highPriority).DisruptionModeAll().Obj(),
+				st.MakePodGroup().Name("pg-single").Namespace("default").Priority(midPriority).DisruptionModeSingle().Obj(),
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("p-all-1").UID("p-all-1").Namespace("default").Node("node1").PodGroupName("pg-all").Priority(highPriority).Obj(),
+				st.MakePod().Name("p-all-2").UID("p-all-2").Namespace("default").Node("node2").PodGroupName("pg-all").Priority(highPriority).Obj(),
+				st.MakePod().Name("p-single-1").UID("p-single-1").Namespace("default").Node("node1").PodGroupName("pg-single").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p-single-2").UID("p-single-2").Namespace("default").Node("node2").PodGroupName("pg-single").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p-ind").UID("p-ind").Namespace("default").Node("node1").Priority(lowPriority).Obj(),
+			},
+			targetNode: "node1",
+			expectedVictims: []*DomainVictim{
 				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{}, // matches nothing
+					Victim: &victim{
+						priority: highPriority,
+						pods: []fwk.PodInfo{
+							newPodInfo(st.MakePod().Name("p-all-1").UID("p-all-1").Namespace("default").Node("node1").PodGroupName("pg-all").Priority(highPriority).Obj()),
+							newPodInfo(st.MakePod().Name("p-all-2").UID("p-all-2").Namespace("default").Node("node2").PodGroupName("pg-all").Priority(highPriority).Obj()),
+						},
 					},
-					Status: policy.PodDisruptionBudgetStatus{
-						DisruptionsAllowed: 0,
+				},
+				{
+					Victim: &victim{
+						priority: midPriority,
+						pods: []fwk.PodInfo{
+							newPodInfo(st.MakePod().Name("p-single-1").UID("p-single-1").Namespace("default").Node("node1").PodGroupName("pg-single").Priority(lowPriority).Obj()),
+						},
+					},
+				},
+				{
+					Victim: &victim{
+						priority: lowPriority,
+						pods: []fwk.PodInfo{
+							newPodInfo(st.MakePod().Name("p-ind").UID("p-ind").Namespace("default").Node("node1").Priority(lowPriority).Obj()),
+						},
 					},
 				},
 			},
-			expectedViolating:    nil,
-			expectedNonViolating: []*victim{viMatchPDB},
-		},
-		{
-			name:    "Multiple PDBs",
-			victims: []*victim{viMatchMultiplePDBs},
-			pdbs: []*policy.PodDisruptionBudget{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
-					},
-					Status: policy.PodDisruptionBudgetStatus{
-						DisruptionsAllowed: 1,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
-					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "backend"}},
-					},
-					Status: policy.PodDisruptionBudgetStatus{
-						DisruptionsAllowed: 0,
-					},
-				},
-			},
-			expectedViolating:    []*victim{viMatchMultiplePDBs},
-			expectedNonViolating: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			violating, nonViolating := filterVictimsWithPDBViolation(tt.victims, tt.pdbs)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, tt.enableGenericWorkload)
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
-			if diff := cmp.Diff(tt.expectedViolating, violating, cmp.Comparer(func(a, b *victim) bool { return a == b })); diff != "" {
-				t.Errorf("violating victims mismatch (-want, +got):\n%s", diff)
+			var objs []runtime.Object
+			for _, p := range tt.pods {
+				objs = append(objs, p)
+			}
+			for _, pg := range tt.podGroups {
+				objs = append(objs, pg)
+			}
+			cs := clientsetfake.NewClientset(objs...)
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+
+			cache := internalcache.New(ctx, nil, tt.enableGenericWorkload)
+			for _, pg := range tt.podGroups {
+				cache.AddPodGroup(pg)
+			}
+			snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.pods, tt.nodes, tt.podGroups)
+
+			registeredPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			fwk, err := tf.NewFramework(
+				ctx,
+				registeredPlugins,
+				"",
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithMutableSnapshotLister(snapshot),
+				frameworkruntime.WithPodGroupManager(cache),
+				frameworkruntime.WithLogger(logger),
+			)
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(tt.expectedNonViolating, nonViolating, cmp.Comparer(func(a, b *victim) bool { return a == b })); diff != "" {
-				t.Errorf("nonViolating victims mismatch (-want, +got):\n%s", diff)
+			pe := Evaluator{
+				PluginName:       "TestPlugin",
+				Handler:          fwk,
+				executor:         NewExecutor(fwk, feature.Features{EnableGenericWorkload: tt.enableGenericWorkload}),
+				podGroupSnapshot: fwk.MutableSnapshotSharedLister().PodGroups(),
+			}
+
+			_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			nodeInfo, err := snapshot.NodeInfos().Get(tt.targetNode)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := pe.GetVictimsOnNode(ctx, nodeInfo)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			victimKey := func(v *DomainVictim) string {
+				var podNames []string
+				for _, p := range v.Pods() {
+					podNames = append(podNames, p.GetPod().Name)
+				}
+				sort.Strings(podNames)
+				var nodes []string
+				for n := range v.affectedNodes {
+					nodes = append(nodes, n)
+				}
+				sort.Strings(nodes)
+				return fmt.Sprintf("priority:%d/pods:%s/nodes:%s", v.Priority(), strings.Join(podNames, ","), strings.Join(nodes, ","))
+			}
+
+			gotKeys := sets.New[string]()
+			for _, v := range got {
+				gotKeys.Insert(victimKey(v))
+			}
+			expectedKeys := sets.New[string]()
+			for _, ev := range tt.expectedVictims {
+				pods := ev.Pods()
+				dv, err := newDomainVictim(snapshot, pods, ev.Priority())
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedKeys.Insert(victimKey(dv))
+			}
+
+			if diff := cmp.Diff(expectedKeys, gotKeys); diff != "" {
+				t.Errorf("GetVictimsOnNode() mismatch (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/preemption/types.go
+++ b/pkg/scheduler/framework/preemption/types.go
@@ -17,18 +17,17 @@ limitations under the License.
 package preemption
 
 import (
-	"maps"
-	"slices"
+	"fmt"
 	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
-
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
@@ -87,15 +86,36 @@ func (p *podGroupPreemptor) PreemptionPolicy() schedulingapi.PreemptionPolicy {
 }
 
 // domain represents the boundary or scope within which the preemption logic is evaluated.
+// It abstracts the scheduling domain, which can range from a single Node (for standard Pod preemption)
+// to a group of Nodes or the entire Cluster (for PodGroup preemption).
 type domain struct {
 	nodes              []fwk.NodeInfo
 	name               string
-	allPossibleVictims []*victim
+	allPossibleVictims []*DomainVictim
+}
+
+// Nodes returns a list of NodeInfo objects that belong to this domain.
+// The preemption logic uses this to check feasibility and resource availability
+// within the specific scope.
+func (d *domain) Nodes() []fwk.NodeInfo {
+	return d.nodes
+}
+
+// GetAllPossibleVictims returns all potential victims running within this domain (individual Pods or PodGroups).
+func (d *domain) GetAllPossibleVictims() []*DomainVictim {
+	return d.allPossibleVictims
+}
+
+// GetName returns a unique identifier for the domain.
+// This is primarily used for logging and debugging purposes.
+func (d *domain) GetName() string {
+	return d.name
 }
 
 // getPodGroup checks if a pod specifies a scheduling group and returns the corresponding PodGroup object if found.
+// This function should be executed only when GenericWorkload feature is enabled.
 func getPodGroup(p *v1.Pod, podGroupSnapshot fwk.PodGroupLister) *schedulingapi.PodGroup {
-	if p.Spec.SchedulingGroup == nil {
+	if podGroupSnapshot == nil || p.Spec.SchedulingGroup == nil {
 		return nil
 	}
 	pgName := p.Spec.SchedulingGroup.PodGroupName
@@ -111,6 +131,21 @@ func isDisruptionModeAll(pg *schedulingapi.PodGroup) bool {
 	return pg != nil && pg.Spec.DisruptionMode != nil && pg.Spec.DisruptionMode.All != nil
 }
 
+// createDomainVictims converts deduplicated Victim entries into DomainVictim objects
+// by enriching them with node blast-radius metadata from the snapshot, allowing the preemption
+// evaluator to assess the cluster-wide impact of evicting each candidate.
+func createDomainVictims(snapshot fwk.SharedLister, victims []Victim) ([]*DomainVictim, error) {
+	var allPossibleVictims []*DomainVictim
+	for _, vi := range victims {
+		v, err := newDomainVictim(snapshot, vi.Pods(), vi.Priority())
+		if err != nil {
+			return nil, err
+		}
+		allPossibleVictims = append(allPossibleVictims, v)
+	}
+	return allPossibleVictims, nil
+}
+
 // newDomainForWorkloadPreemption creates a new domain for workload preemption.
 // The domain is the whole cluster and it contains victims that are computed based
 // on the pods and their scheduling groups.
@@ -118,87 +153,106 @@ func isDisruptionModeAll(pg *schedulingapi.PodGroup) bool {
 // together into a single victim. Otherwise, they are treated as individual victims.
 // In both cases, the priority of the victim is determined by the PodGroup priority
 // if the pod belongs to a PodGroup.
-func newDomainForWorkloadPreemption(nodes []fwk.NodeInfo, podGroupSnapshot fwk.PodGroupLister, name string) *domain {
-	victimMap := map[types.UID]*victim{}
-	for _, node := range nodes {
-		for _, p := range node.GetPods() {
-			pg := getPodGroup(p.GetPod(), podGroupSnapshot)
-			if pg == nil {
-				victimMap[p.GetPod().UID] = newVictim([]fwk.PodInfo{p}, corev1helpers.PodPriority(p.GetPod()), []fwk.NodeInfo{node})
-				continue
-			}
-			if !isDisruptionModeAll(pg) {
-				victimMap[p.GetPod().UID] = newVictim([]fwk.PodInfo{p}, util.PodGroupPriority(pg), []fwk.NodeInfo{node})
-				continue
-			}
-			victim, ok := victimMap[pg.UID]
-			if ok {
-				victim.pods = append(victim.pods, p)
-				victim.affectedNodes[node.Node().Name] = node
-				continue
-			}
-			victimMap[pg.UID] = newVictim([]fwk.PodInfo{p}, util.PodGroupPriority(pg), []fwk.NodeInfo{node})
-		}
+func newDomainForWorkloadPreemption(snapshot fwk.SharedLister, podGroupSnapshot fwk.PodGroupLister, name string) (*domain, error) {
+	nodes, err := snapshot.NodeInfos().List()
+	if err != nil {
+		return nil, err
 	}
 
-	allPossibleVictims := slices.Collect(maps.Values(victimMap))
+	allPossibleVictims, err := getCrossNodesVictims(snapshot, podGroupSnapshot, nodes)
+	if err != nil {
+		return nil, err
+	}
+
 	return &domain{
 		nodes:              nodes,
 		allPossibleVictims: allPossibleVictims,
 		name:               name,
-	}
+	}, nil
 }
 
-// Nodes returns a list of NodeInfo objects that belong to this domain.
-func (d *domain) Nodes() []fwk.NodeInfo {
-	return d.nodes
-}
+// getCrossNodesVictims aggregates pods across the provided nodes into cluster-wide preemption candidates.
+// When a pod belongs to a PodGroup with disruption mode All, it groups all scheduled pods of that gang
+// across the cluster into a single victim so that preemption evaluates the total cluster-wide cost
+// and blast radius of evicting the entire gang.
+func getCrossNodesVictims(snapshot fwk.SharedLister, podGroupSnapshot fwk.PodGroupLister, nodes []fwk.NodeInfo) ([]*DomainVictim, error) {
+	searchCrossNodesVictimPods := func(pg *schedulingapi.PodGroup, podInfo fwk.PodInfo) Victim {
+		pgState, err := snapshot.PodGroupStates().Get(podInfo.GetPod().GetNamespace(), pg.Name)
+		if err != nil {
+			// Assuming this is guaranteed to succeed if feature is on and pods exist.
+			// If it fails, we keep the local pods only.
+			return NewPodVictim(podInfo, podGroupSnapshot)
+		}
 
-// // GetAllPossibleVictims returns all potential victims running within this domain.
-func (d *domain) GetAllPossibleVictims() []*victim {
-	return d.allPossibleVictims
-}
+		pods := pgState.ScheduledPods()
+		podInfos := make([]fwk.PodInfo, len(pods))
+		for i, p := range pods {
+			// pods from ScheduledPods() already passed Filter/Reserve, and cannot error here.
+			podInfos[i], _ = framework.NewPodInfo(p)
+		}
 
-// GetName returns a unique identifier for the domain.
-// This is primarily used for logging and debugging purposes.
-func (d *domain) GetName() string {
-	return d.name
-}
+		// It can only return an error for empty podInfos, which is guaranteed not to be empty here.
+		victim, _ := NewVictim(podInfos, util.PodGroupPriority(pg))
 
-// victim represents an atomic entity that can be preempted (a victim).
-// It abstracts individual Pods and PodGroup, ensuring that
-// atomic entities are treated as a single unit during eviction.
-type victim struct {
-	pods              []fwk.PodInfo
-	priority          int32
-	affectedNodes     map[string]fwk.NodeInfo
-	earliestStartTime *metav1.Time
-}
-
-// newVictim creates a new Victim representing a set of Pods (or a PodGroup) that can be preempted together.
-// It calculates the earliest start time among all provided Pods and identifies all nodes
-// affected by the potential eviction of these Pods.
-func newVictim(pods []fwk.PodInfo, priority int32, nodeInfos []fwk.NodeInfo) *victim {
-	nodes := make(map[string]fwk.NodeInfo)
-	for _, node := range nodeInfos {
-		nodes[node.Node().Name] = node
+		return victim
 	}
 
-	var earliest *metav1.Time
-	for _, pInfo := range pods {
-		t := util.GetPodStartTime(pInfo.GetPod())
-		if earliest == nil || (t != nil && t.Before(earliest)) {
-			earliest = t
+	existing := sets.New[types.UID]()
+	var victims []Victim
+	for _, node := range nodes {
+		for _, podInfo := range node.GetPods() {
+			p := podInfo.GetPod()
+
+			pg := getPodGroup(p, podGroupSnapshot)
+			if pg == nil || !isDisruptionModeAll(pg) {
+				if !existing.Has(p.UID) {
+					existing.Insert(p.UID)
+					victims = append(victims, NewPodVictim(podInfo, podGroupSnapshot))
+				}
+				continue
+			}
+
+			if !existing.Has(pg.UID) {
+				existing.Insert(pg.UID)
+				victims = append(victims, searchCrossNodesVictimPods(pg, podInfo))
+			}
 		}
 	}
 
-	return &victim{
-		affectedNodes:     nodes,
-		priority:          priority,
-		pods:              pods,
-		earliestStartTime: earliest,
-	}
+	return createDomainVictims(snapshot, victims)
 }
+
+// Victim represents an atomic entity that can be preempted (a victim).
+// It abstracts individual Pods and PodGroup, ensuring that
+// atomic entities are treated as a single unit during eviction.
+type Victim interface {
+	// Priority returns the priority of the preemption unit.
+	// For a single Pod, this is the Pod's priority.
+	// For a PodGroup, this is the priority of the PodGroup.
+	Priority() int32
+
+	// Pods returns the list of all Pods that belong to this preemption unit.
+	// Evicting this unit implies evicting all Pods in this list.
+	Pods() []fwk.PodInfo
+
+	// EarliestStartTime returns the earliest start time of all Pods in this preemption unit.
+	EarliestStartTime() *metav1.Time
+
+	// IsPodGroup returns true if the preemption unit represents a PodGroup.
+	// This function should be executed only when GenericWorkload feature is enabled.
+	IsPodGroup() bool
+}
+
+// victim is the concrete implementation of the Victim interface, bundling pods with their
+// collective priority and earliest start time so individual pods and gang pod groups can be
+// evaluated and sorted uniformly during preemption candidate selection.
+type victim struct {
+	pods              []fwk.PodInfo
+	priority          int32
+	earliestStartTime *metav1.Time
+}
+
+var _ Victim = &victim{}
 
 // Pods returns the list of all Pods that belong to this preemption unit.
 // Evicting this unit implies evicting all Pods in this list.
@@ -213,21 +267,91 @@ func (v *victim) Priority() int32 {
 	return v.priority
 }
 
-// AffectedNodes returns a map of Node names to NodeInfo for all nodes
-// where members of this preemption unit are currently running.
-// This allows the preemption logic to identify the blast radius of evicting this unit.
-func (v *victim) AffectedNodes() map[string]fwk.NodeInfo {
-	return v.affectedNodes
-}
-
 // EarliestStartTime returns the earliest start time of all Pods in this victim.
 func (v *victim) EarliestStartTime() *metav1.Time {
 	return v.earliestStartTime
 }
 
 // IsPodGroup returns true if the preemption unit represents a PodGroup.
+// This function should be executed only when GenericWorkload feature is enabled.
 func (v *victim) IsPodGroup() bool {
-	return v.pods[0].GetPod().Spec.SchedulingGroup != nil
+	return len(v.pods) > 0 && v.pods[0].GetPod().Spec.SchedulingGroup != nil
+}
+
+// NewPodVictim creates a new Victim representing a single Pod.
+// It calculates the priority of the pod, taking into account its scheduling group if applicable.
+// It ignores the error from NewVictim internally as it is guaranteed to succeed for a single valid pod.
+func NewPodVictim(podInfo fwk.PodInfo, pgLister fwk.PodGroupLister) Victim {
+	priority := GetPodPriority(podInfo.GetPod(), pgLister)
+	vi, _ := NewVictim([]fwk.PodInfo{podInfo}, priority)
+	return vi
+}
+
+// NewVictim creates a new Victim representing a set of Pods (or a PodGroup) that can be preempted together.
+// It calculates the earliest start time among all provided Pods
+func NewVictim(pods []fwk.PodInfo, priority int32) (Victim, error) {
+	if len(pods) == 0 {
+		return nil, fmt.Errorf("no pods provided")
+	}
+
+	var earliest *metav1.Time
+	for _, pInfo := range pods {
+		t := util.GetPodStartTime(pInfo.GetPod())
+		if earliest == nil || (t != nil && t.Before(earliest)) {
+			earliest = t
+		}
+	}
+
+	return &victim{
+		priority:          priority,
+		pods:              pods,
+		earliestStartTime: earliest,
+	}, nil
+}
+
+// DomainVictim extends Victim to include information about the nodes affected by its eviction.
+// It represents a preemption unit within a specific scheduling domain and allows
+// the preemption logic to understand the blast radius of the eviction across multiple nodes.
+type DomainVictim struct {
+	Victim
+	// affectedNodes tracks every node hosting at least one pod belonging to this victim,
+	// enabling the scheduler to assess node-specific impacts across the entire eviction blast radius.
+	affectedNodes map[string]fwk.NodeInfo
+}
+
+// AffectedNodes returns a map of all nodes currently hosting Pods that belong to this victim.
+func (dv *DomainVictim) AffectedNodes() map[string]fwk.NodeInfo {
+	return dv.affectedNodes
+}
+
+// newDomainVictim creates a DomainVictim from the given pods and priority.
+// It retrieves the NodeInfo for each pod from the snapshot and stores
+// in the affectedNodes map to represent the nodes affected by evicting these pods.
+func newDomainVictim(snapshot fwk.SharedLister, pods []fwk.PodInfo, priority int32) (*DomainVictim, error) {
+	nodeSnapshot := snapshot.NodeInfos()
+	nodes := make(map[string]fwk.NodeInfo)
+	for _, pInfo := range pods {
+		nodeName := pInfo.GetPod().Spec.NodeName
+		if _, ok := nodes[nodeName]; ok {
+			continue
+		}
+
+		nodeInfo, err := nodeSnapshot.Get(nodeName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get node info for node %q from snapshot: %w", nodeName, err)
+		}
+		nodes[nodeName] = nodeInfo
+	}
+
+	victim, err := NewVictim(pods, priority)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DomainVictim{
+		Victim:        victim,
+		affectedNodes: nodes,
+	}, nil
 }
 
 // Candidate represents a nominated node on which the preemptor can be scheduled,
@@ -285,4 +409,11 @@ func (cl *candidateList) size() int32 {
 // assumes that all add() operations have been completed.
 func (cl *candidateList) get() []Candidate {
 	return cl.items[:cl.size()]
+}
+
+// ViolatingVictim represents a victim whose preemption would violate one or more PodDisruptionBudgets.
+// It tracks the victim itself and the number of pods within it that would cause PDB violations on eviction.
+type ViolatingVictim[T Victim] struct {
+	Victim       T
+	ViolateCount int
 }

--- a/pkg/scheduler/framework/preemption/types_test.go
+++ b/pkg/scheduler/framework/preemption/types_test.go
@@ -19,12 +19,20 @@ package preemption
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	v1 "k8s.io/api/core/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
+	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
@@ -54,6 +62,12 @@ func TestGetPodGroup(t *testing.T) {
 				"pg1": st.MakePodGroup().Name("pg1").Namespace("default").Obj(),
 			},
 			wantPodGroup: st.MakePodGroup().Name("pg1").Namespace("default").Obj(),
+		},
+		{
+			name:         "pod group found in pod spec but nil podGroupSnapshot (simulates disabled GenericWorkload)",
+			pod:          st.MakePod().Name("p1").Namespace("default").PodGroupName("pg1").Obj(),
+			podGroups:    nil, // nil snapshot when feature gate is disabled
+			wantPodGroup: nil,
 		},
 	}
 
@@ -259,10 +273,32 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				{pods: sets.New("p4"), affectedNodes: sets.New("node2"), priority: 30},
 			},
 		},
+		{
+			name: "pods with pod group (DisruptionModeAll) but missing pod group state in cache falls back to local pod preemption",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node1").PodGroupName("pg1").Priority(10).Obj(),
+				st.MakePod().Name("p2").UID("p2").Node("node2").PodGroupName("pg1").Priority(10).Obj(),
+			},
+			domainName: "test-domain",
+			wantVictims: []expectedVictim{
+				{pods: sets.New("p1"), affectedNodes: sets.New("node1"), priority: 10},
+				{pods: sets.New("p2"), affectedNodes: sets.New("node2"), priority: 10},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.GenericWorkload, true)
+
+			logger, ctx := ktesting.NewTestContext(t)
+			snapshot := internalcache.NewSnapshot(tt.pods, tt.nodes)
+			cache := internalcache.New(ctx, nil, true)
+
 			nodeInfos := make(map[string]fwk.NodeInfo)
 			for _, node := range tt.nodes {
 				ni := framework.NewNodeInfo()
@@ -276,18 +312,42 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				}
 			}
 
-			var domainNodes []fwk.NodeInfo
 			for _, node := range tt.nodes {
-				if ni, ok := nodeInfos[node.Name]; ok {
-					domainNodes = append(domainNodes, ni)
+				cache.AddNode(logger, node)
+			}
+
+			for _, p := range tt.pods {
+				if err := cache.AddPod(logger, p); err != nil {
+					t.Fatalf("Failed to add pod: %v", err)
+				}
+				if p.Spec.SchedulingGroup != nil && p.Spec.SchedulingGroup.PodGroupName != nil {
+					cache.AddPodGroupMember(p)
 				}
 			}
 
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
 			pgLister := &mockPodGroupLister{podGroups: tt.podGroups}
-			domain := newDomainForWorkloadPreemption(domainNodes, pgLister, tt.domainName)
+			domain, err := newDomainForWorkloadPreemption(snapshot, pgLister, tt.domainName)
+			if err != nil {
+				t.Fatalf("Failed to create domain: %v", err)
+			}
 
 			if domain.GetName() != tt.domainName {
 				t.Errorf("expected domain name %q, got %q", tt.domainName, domain.GetName())
+			}
+
+			gotNodeNames := sets.New[string]()
+			for _, ni := range domain.Nodes() {
+				gotNodeNames.Insert(ni.Node().Name)
+			}
+			wantNodeNames := sets.New[string]()
+			for _, n := range tt.nodes {
+				wantNodeNames.Insert(n.Name)
+			}
+			if diff := cmp.Diff(wantNodeNames, gotNodeNames); diff != "" {
+				t.Errorf("Nodes() mismatch (-want +got):\n%s", diff)
 			}
 
 			victims := domain.GetAllPossibleVictims()
@@ -321,6 +381,165 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 
 			if diff := cmp.Diff(tt.wantVictims, gotVictims, cmp.AllowUnexported(expectedVictim{})); diff != "" {
 				t.Errorf("victims mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewVictim(t *testing.T) {
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-10 * time.Minute))
+	later := metav1.NewTime(now.Add(10 * time.Minute))
+
+	p1 := st.MakePod().Name("p1").StartTime(now).Obj()
+	p2 := st.MakePod().Name("p2").StartTime(later).Obj()
+	p3 := st.MakePod().Name("p3").StartTime(earlier).Obj()
+	p4 := st.MakePod().Name("p4").Obj() // nil start time
+	p5 := st.MakePod().Name("p5").StartTime(now).PodGroupName("pg1").Obj()
+
+	pi1, _ := framework.NewPodInfo(p1)
+	pi2, _ := framework.NewPodInfo(p2)
+	pi3, _ := framework.NewPodInfo(p3)
+	pi4, _ := framework.NewPodInfo(p4)
+	pi5, _ := framework.NewPodInfo(p5)
+
+	tests := []struct {
+		name       string
+		podInfos   []fwk.PodInfo
+		priority   int32
+		wantErr    bool
+		wantVictim *victim
+	}{
+		{
+			name:       "empty pods slice returns error",
+			podInfos:   nil,
+			priority:   10,
+			wantErr:    true,
+			wantVictim: nil,
+		},
+		{
+			name:     "single pod without scheduling group",
+			podInfos: []fwk.PodInfo{pi1},
+			priority: 20,
+			wantErr:  false,
+			wantVictim: &victim{
+				priority:          20,
+				earliestStartTime: &now,
+				pods:              []fwk.PodInfo{pi1},
+			},
+		},
+		{
+			name:     "multiple pods with mixed start times (including nil)",
+			podInfos: []fwk.PodInfo{pi4, pi2, pi3},
+			priority: 30,
+			wantErr:  false,
+			wantVictim: &victim{
+				priority:          30,
+				earliestStartTime: &earlier,
+				pods:              []fwk.PodInfo{pi4, pi2, pi3},
+			},
+		},
+		{
+			name:     "pod with scheduling group is identified as pod group",
+			podInfos: []fwk.PodInfo{pi5},
+			priority: 40,
+			wantErr:  false,
+			wantVictim: &victim{
+				priority:          40,
+				earliestStartTime: &now,
+				pods:              []fwk.PodInfo{pi5},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVictim, err := NewVictim(tt.podInfos, tt.priority)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewVictim() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tt.wantVictim, gotVictim, cmp.AllowUnexported(victim{}, framework.PodInfo{})); diff != "" {
+				t.Errorf("Victim mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewDomainVictim(t *testing.T) {
+	tests := []struct {
+		name              string
+		nodes             []*v1.Node
+		pods              []*v1.Pod
+		priority          int32
+		wantErr           bool
+		wantAffectedNodes sets.Set[string]
+	}{
+		{
+			name: "pod on missing node returns error",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").Node("missing-node").Obj(),
+			},
+			priority:          10,
+			wantErr:           true,
+			wantAffectedNodes: nil,
+		},
+		{
+			name: "multiple pods on same and different nodes deduplicates affectedNodes",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Obj(),
+				st.MakeNode().Name("node2").Obj(),
+			},
+			pods: []*v1.Pod{
+				st.MakePod().Name("p1").Node("node1").Obj(),
+				st.MakePod().Name("p2").Node("node1").Obj(), // same node
+				st.MakePod().Name("p3").Node("node2").Obj(), // different node
+			},
+			priority:          20,
+			wantErr:           false,
+			wantAffectedNodes: sets.New("node1", "node2"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			snapshot := internalcache.NewSnapshot(nil, tt.nodes)
+			cache := internalcache.New(ctx, nil, true)
+			for _, node := range tt.nodes {
+				cache.AddNode(logger, node)
+			}
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			var podInfos []fwk.PodInfo
+			for _, p := range tt.pods {
+				pi, _ := framework.NewPodInfo(p)
+				podInfos = append(podInfos, pi)
+			}
+
+			dv, err := newDomainVictim(snapshot, podInfos, tt.priority)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newDomainVictim() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			gotNodes := sets.New[string]()
+			for nName := range dv.AffectedNodes() {
+				gotNodes.Insert(nName)
+			}
+
+			if diff := cmp.Diff(tt.wantAffectedNodes, gotNodes); diff != "" {
+				t.Errorf("AffectedNodes() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/preemption/util.go
+++ b/pkg/scheduler/framework/preemption/util.go
@@ -18,6 +18,12 @@ package preemption
 
 import (
 	v1 "k8s.io/api/core/v1"
+	policy "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 // PodTerminatingByPreemption returns true if the pod is in the termination state caused by scheduler preemption.
@@ -32,4 +38,125 @@ func PodTerminatingByPreemption(p *v1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// MoreImportantVictim decides which of two preemption units is considered more critical.
+// It applies the following rules in order:
+//
+//  1. Priority:
+//     Higher priority units are more important.
+//
+//  2. Workload Type (if enabled):
+//     If GenericWorkload is enabled, PodGroups are considered more important
+//     than individual Pods to preserve group integrity.
+//
+//  3. Runtime / Start Time (for individual Pods):
+//     For two individual Pods, the one that started earlier (longer runtime)
+//     is more important. This honors "first-come, first-served".
+//
+//  4. Group Size (for PodGroups):
+//     If both units are PodGroups, the one with more members (larger size) is considered
+//     more important. This avoids the high cost of rescheduling massive jobs.
+//
+//  5. Start Time (Tie-breaker for PodGroups):
+//     If sizes are equal, the group that started earlier (has the oldest pod)
+//     is more important.
+func MoreImportantVictim(vi1, vi2 Victim, genericWorkloadEnabled bool) bool {
+	if vi1.Priority() != vi2.Priority() {
+		return vi1.Priority() > vi2.Priority()
+	}
+
+	if !genericWorkloadEnabled {
+		return vi1.EarliestStartTime().Before(vi2.EarliestStartTime())
+	}
+
+	if vi1.IsPodGroup() != vi2.IsPodGroup() {
+		return vi1.IsPodGroup()
+	}
+
+	if vi1.IsPodGroup() && len(vi1.Pods()) != len(vi2.Pods()) {
+		return len(vi1.Pods()) > len(vi2.Pods())
+	}
+
+	return vi1.EarliestStartTime().Before(vi2.EarliestStartTime())
+}
+
+// GetPodPriority returns the effective preemption priority of a pod. If the pod belongs to
+// a pod group, it returns the priority of the pod group.
+// If podGroupLister is nil or the pod does not belong to a pod group, it returns the pod's own priority.
+func GetPodPriority(p *v1.Pod, podGroupLister fwk.PodGroupLister) int32 {
+	if pg := getPodGroup(p, podGroupLister); pg != nil {
+		return util.PodGroupPriority(pg)
+	}
+	return corev1helpers.PodPriority(p)
+}
+
+// FilterVictimsWithPDBViolation groups "victims" into "violatingVictims"
+// and "nonViolatingVictims" based on whether their PDBs will be violated if they are
+// preempted.
+func FilterVictimsWithPDBViolation[T Victim](victims []T, pdbs []*policy.PodDisruptionBudget) (violatingVictims []ViolatingVictim[T], nonViolatingVictims []T) {
+	pdbsAllowed := make([]int32, len(pdbs))
+	podIsViolating := func(pod *v1.Pod) bool {
+		if len(pod.Labels) == 0 {
+			return false
+		}
+
+		for i, pdb := range pdbs {
+			if pdb.Namespace != pod.Namespace {
+				continue
+			}
+			selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+			if err != nil {
+				// This object has an invalid selector, it does not match the pod
+				continue
+			}
+			// A PDB with a nil or empty selector matches nothing.
+			if selector.Empty() || !selector.Matches(labels.Set(pod.Labels)) {
+				continue
+			}
+
+			// Existing in DisruptedPods means it has been processed in API server,
+			// we don't treat it as a violating case.
+			if _, exist := pdb.Status.DisruptedPods[pod.Name]; exist {
+				continue
+			}
+			// Only decrement the matched pdb when it's not in its <DisruptedPods>;
+			// otherwise we may over-decrement the budget number.
+			pdbsAllowed[i]--
+			// We have found a matching PDB.
+			if pdbsAllowed[i] < 0 {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for i, pdb := range pdbs {
+		pdbsAllowed[i] = pdb.Status.DisruptionsAllowed
+	}
+
+	// A Victim is atomic: if any single pod inside it would violate a PDB on
+	// eviction, the entire Victim is classified as violating. This is required
+	// for PodGroup victims, where partial preemption is not allowed — we cannot
+	// "reprieve" only the pods that violate a PDB and keep the rest evicted.
+	for _, victim := range victims {
+		violatingPods := 0
+
+		for _, pi := range victim.Pods() {
+			if podIsViolating(pi.GetPod()) {
+				violatingPods++
+			}
+		}
+		if violatingPods > 0 {
+			violatingVictims = append(violatingVictims, ViolatingVictim[T]{
+				Victim:       victim,
+				ViolateCount: violatingPods,
+			})
+		} else {
+			nonViolatingVictims = append(nonViolatingVictims, victim)
+		}
+	}
+
+	return violatingVictims, nonViolatingVictims
 }

--- a/pkg/scheduler/framework/preemption/util_test.go
+++ b/pkg/scheduler/framework/preemption/util_test.go
@@ -1,0 +1,556 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemption
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	v1 "k8s.io/api/core/v1"
+	policy "k8s.io/api/policy/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+)
+
+func TestFilterVictimsWithPDBViolation(t *testing.T) {
+	newPodInfo := func(p *v1.Pod) fwk.PodInfo {
+		pi, _ := framework.NewPodInfo(p)
+		return pi
+	}
+
+	viNoPDBMatch := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").Label("app", "foo").Obj())}}
+	viMatchPDB := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj())}}
+	viMatchPDB2 := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p2").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj())}}
+	viPodGroup := &victim{
+		pods: []fwk.PodInfo{
+			newPodInfo(st.MakePod().Name("p1").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj()),
+			newPodInfo(st.MakePod().Name("p2").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj()),
+		},
+	}
+	viMatchMultiplePDBs := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").Namespace(metav1.NamespaceDefault).Label("app", "foo").Label("tier", "backend").Obj())}}
+
+	tests := []struct {
+		name                 string
+		victims              []*victim
+		pdbs                 []*policy.PodDisruptionBudget
+		expectedViolating    []ViolatingVictim[*victim]
+		expectedNonViolating []*victim
+	}{
+		{
+			name:                 "no victims, no PDBs",
+			victims:              nil,
+			pdbs:                 nil,
+			expectedViolating:    nil,
+			expectedNonViolating: nil,
+		},
+		{
+			name:    "victim with no matching PDBs",
+			victims: []*victim{viNoPDBMatch},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "bar"}},
+					},
+				},
+			},
+			expectedViolating:    nil,
+			expectedNonViolating: []*victim{viNoPDBMatch},
+		},
+		{
+			name:    "victim matching PDB, adequate DisruptionsAllowed",
+			victims: []*victim{viMatchPDB},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 1,
+					},
+				},
+			},
+			expectedViolating:    nil,
+			expectedNonViolating: []*victim{viMatchPDB},
+		},
+		{
+			name:    "victim matching PDB, no DisruptionsAllowed",
+			victims: []*victim{viMatchPDB},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 0,
+					},
+				},
+			},
+			expectedViolating: []ViolatingVictim[*victim]{
+				{
+					Victim:       viMatchPDB,
+					ViolateCount: 1,
+				},
+			},
+			expectedNonViolating: nil,
+		},
+		{
+			name:    "podgroup victim with multiple pods, all violating",
+			victims: []*victim{viPodGroup},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 0,
+					},
+				},
+			},
+			expectedViolating: []ViolatingVictim[*victim]{
+				{
+					Victim:       viPodGroup,
+					ViolateCount: 2,
+				},
+			},
+			expectedNonViolating: nil,
+		},
+		{
+			name:    "podgroup victim with multiple pods, none violating",
+			victims: []*victim{viPodGroup},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 2,
+					},
+				},
+			},
+			expectedViolating:    nil,
+			expectedNonViolating: []*victim{viPodGroup},
+		},
+		{
+			name:    "multiple victims matching the same PDB",
+			victims: []*victim{viMatchPDB, viMatchPDB2},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 1,
+					},
+				},
+			},
+			expectedViolating: []ViolatingVictim[*victim]{
+				{
+					Victim:       viMatchPDB2,
+					ViolateCount: 1,
+				},
+			},
+			expectedNonViolating: []*victim{viMatchPDB},
+		},
+		{
+			name:    "pod in DisruptedPods is ignored",
+			victims: []*victim{viMatchPDB},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 0,
+						DisruptedPods: map[string]metav1.Time{
+							"p1": {Time: time.Now()},
+						},
+					},
+				},
+			},
+			expectedViolating:    nil,
+			expectedNonViolating: []*victim{viMatchPDB},
+		},
+		{
+			name:    "PDB with empty selector",
+			victims: []*victim{viMatchPDB},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{}, // matches nothing
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 0,
+					},
+				},
+			},
+			expectedViolating:    nil,
+			expectedNonViolating: []*victim{viMatchPDB},
+		},
+		{
+			name:    "Multiple PDBs",
+			victims: []*victim{viMatchMultiplePDBs},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 1,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "backend"}},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 0,
+					},
+				},
+			},
+			expectedViolating: []ViolatingVictim[*victim]{
+				{
+					Victim:       viMatchMultiplePDBs,
+					ViolateCount: 1,
+				},
+			},
+			expectedNonViolating: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violating, nonViolating := FilterVictimsWithPDBViolation(tt.victims, tt.pdbs)
+
+			if diff := cmp.Diff(tt.expectedViolating, violating, cmp.Comparer(func(a, b *victim) bool { return a == b })); diff != "" {
+				t.Errorf("violating victims mismatch (-want, +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.expectedNonViolating, nonViolating, cmp.Comparer(func(a, b *victim) bool { return a == b })); diff != "" {
+				t.Errorf("nonViolating victims mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMoreImportantVictim(t *testing.T) {
+	newPodInfo := func(p *v1.Pod) fwk.PodInfo {
+		pi, _ := framework.NewPodInfo(p)
+		return pi
+	}
+
+	now := &metav1.Time{Time: time.Unix(1000, 0)}
+	before := &metav1.Time{Time: time.Unix(500, 0)}
+
+	tests := []struct {
+		name                   string
+		vi1                    *victim
+		vi2                    *victim
+		genericWorkloadEnabled bool
+		want                   bool
+	}{
+		{
+			name:                   "vi1 has higher priority",
+			vi1:                    &victim{priority: 20},
+			vi2:                    &victim{priority: 10},
+			genericWorkloadEnabled: true,
+			want:                   true,
+		},
+		{
+			name:                   "vi2 has higher priority",
+			vi1:                    &victim{priority: 10},
+			vi2:                    &victim{priority: 20},
+			genericWorkloadEnabled: true,
+			want:                   false,
+		},
+		{
+			name:                   "vi1 is PG, vi2 is Pod, same priority",
+			vi1:                    &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().PodGroupName("pg").Obj())}},
+			vi2:                    &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}},
+			genericWorkloadEnabled: true,
+			want:                   true,
+		},
+		{
+			name:                   "vi1 is Pod, vi2 is PG, same priority",
+			vi1:                    &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}},
+			vi2:                    &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().PodGroupName("pg").Obj())}},
+			genericWorkloadEnabled: true,
+			want:                   false,
+		},
+		{
+			name:                   "both Pods, vi1 older",
+			vi1:                    &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}, earliestStartTime: before},
+			vi2:                    &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}, earliestStartTime: now},
+			genericWorkloadEnabled: true,
+			want:                   true,
+		},
+		{
+			name:                   "both Pods, vi2 older",
+			vi1:                    &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}, earliestStartTime: now},
+			vi2:                    &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}, earliestStartTime: before},
+			genericWorkloadEnabled: true,
+			want:                   false,
+		},
+		{
+			name: "both PGs, vi1 larger",
+			vi1: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+				},
+			},
+			vi2: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+				},
+			},
+			genericWorkloadEnabled: true,
+			want:                   true,
+		},
+		{
+			name: "both PGs, vi2 larger",
+			vi1: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+				},
+			},
+			vi2: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+				},
+			},
+			genericWorkloadEnabled: true,
+			want:                   false,
+		},
+		{
+			name: "both PGs, same size, vi1 older",
+			vi1: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+				},
+				earliestStartTime: before,
+			},
+			vi2: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+				},
+				earliestStartTime: now,
+			},
+			genericWorkloadEnabled: true,
+			want:                   true,
+		},
+		{
+			name: "both PGs, same size, vi2 older",
+			vi1: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+				},
+				earliestStartTime: now,
+			},
+			vi2: &victim{
+				priority: 10,
+				pods: []fwk.PodInfo{
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+					newPodInfo(st.MakePod().PodGroupName("pg").Obj()),
+				},
+				earliestStartTime: before,
+			},
+			genericWorkloadEnabled: true,
+			want:                   false,
+		},
+		{
+			name: "GenereicWorkload disabled: vi1 is larger PodGroup but newer, vi2 is older Pod — start time wins",
+			vi1: &victim{
+				priority:          10,
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().PodGroupName("pg").Obj()), newPodInfo(st.MakePod().PodGroupName("pg").Obj())},
+				earliestStartTime: now,
+			},
+			vi2:                    &victim{priority: 10, pods: []fwk.PodInfo{newPodInfo(st.MakePod().Obj())}, earliestStartTime: before},
+			genericWorkloadEnabled: false,
+			want:                   false,
+		},
+		{
+			name: "GenereicWorkload disabled: both PGs, vi1 larger but newer — start time wins",
+			vi1: &victim{
+				priority:          10,
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().PodGroupName("pg").Obj()), newPodInfo(st.MakePod().PodGroupName("pg").Obj())},
+				earliestStartTime: now,
+			},
+			vi2: &victim{
+				priority:          10,
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().PodGroupName("pg").Obj())},
+				earliestStartTime: before,
+			},
+			genericWorkloadEnabled: false,
+			want:                   false,
+		},
+		{
+			name: "GenereicWorkload disabled: both PGs, vi1 larger and older — start time wins",
+			vi1: &victim{
+				priority:          10,
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().PodGroupName("pg").Obj()), newPodInfo(st.MakePod().PodGroupName("pg").Obj())},
+				earliestStartTime: before,
+			},
+			vi2: &victim{
+				priority:          10,
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().PodGroupName("pg").Obj())},
+				earliestStartTime: now,
+			},
+			genericWorkloadEnabled: false,
+			want:                   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MoreImportantVictim(tt.vi1, tt.vi2, tt.genericWorkloadEnabled)
+			if got != tt.want {
+				t.Errorf("MoreImportantVictim() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPodTerminatingByPreemption(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want bool
+	}{
+		{
+			name: "pod without DeletionTimestamp",
+			pod:  st.MakePod().Name("p1").Obj(),
+			want: false,
+		},
+		{
+			name: "pod with DeletionTimestamp but no DisruptionTarget condition",
+			pod:  st.MakePod().Name("p1").Terminating().Obj(),
+			want: false,
+		},
+		{
+			name: "pod with DeletionTimestamp, DisruptionTarget condition status False",
+			pod: st.MakePod().Name("p1").
+				Terminating().
+				Condition(v1.DisruptionTarget, v1.ConditionFalse, v1.PodReasonPreemptionByScheduler).
+				Obj(),
+			want: false,
+		},
+		{
+			name: "pod with DeletionTimestamp, DisruptionTarget condition reason not PreemptionByScheduler",
+			pod: st.MakePod().Name("p1").
+				Terminating().
+				Condition(v1.DisruptionTarget, v1.ConditionTrue, "SomeOtherReason").
+				Obj(),
+			want: false,
+		},
+		{
+			name: "pod with DeletionTimestamp, DisruptionTarget condition status True and reason PreemptionByScheduler",
+			pod: st.MakePod().Name("p1").
+				Terminating().
+				Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).
+				Obj(),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PodTerminatingByPreemption(tt.pod)
+			if got != tt.want {
+				t.Errorf("PodTerminatingByPreemption() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPodPriority(t *testing.T) {
+	tests := []struct {
+		name             string
+		pod              *v1.Pod
+		podGroupLister   fwk.PodGroupLister
+		expectedPriority int32
+	}{
+		{
+			name:             "pod without PodGroup returns pod priority",
+			pod:              st.MakePod().Name("p1").Priority(10).Obj(),
+			podGroupLister:   &mockPodGroupLister{},
+			expectedPriority: 10,
+		},
+		{
+			name: "pod with PodGroup returns PodGroup priority instead of pod priority",
+			pod:  st.MakePod().Name("p2").Priority(10).PodGroupName("pg1").Obj(),
+			podGroupLister: &mockPodGroupLister{
+				podGroups: map[string]*schedulingapi.PodGroup{
+					"pg1": st.MakePodGroup().Name("pg1").Priority(50).Obj(),
+				},
+			},
+			expectedPriority: 50,
+		},
+		{
+			name:             "pod with PodGroup but nil PodGroupLister falls back to pod priority",
+			pod:              st.MakePod().Name("p4").Priority(20).PodGroupName("pg1").Obj(),
+			podGroupLister:   nil,
+			expectedPriority: 20,
+		},
+		{
+			name:             "pod with PodGroup but PodGroup not found in lister falls back to pod priority",
+			pod:              st.MakePod().Name("p5").Priority(30).PodGroupName("missing-pg").Obj(),
+			podGroupLister:   &mockPodGroupLister{podGroups: map[string]*schedulingapi.PodGroup{}},
+			expectedPriority: 30,
+		},
+		{
+			name:             "pod with nil priority and without PodGroup returns zero priority",
+			pod:              st.MakePod().Name("p6").Obj(),
+			podGroupLister:   &mockPodGroupLister{},
+			expectedPriority: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPodPriority(tt.pod, tt.podGroupLister)
+			if got != tt.expectedPriority {
+				t.Errorf("GetPodPriority() = %v, want %v", got, tt.expectedPriority)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -498,6 +498,11 @@ type EnqueueExtensions interface {
 // PreFilterExtensions is an interface that is included in plugins that allow specifying
 // callbacks to make incremental updates to its supposedly pre-calculated
 // state.
+// Note: In some contexts (e.g., preemption), the passed NodeInfo might be a shared, non-snapshotted
+// instance (especially for remote nodes affected by cross-node victims). Implementations
+// must treat the nodeInfo parameter as read-only and must NOT mutate it (e.g., by calling
+// RemovePod or AddPodInfo). Additionally, plugins that read NodeInfo directly during Filter
+// (rather than CycleState) will observe stale state for those remote nodes.
 type PreFilterExtensions interface {
 	// AddPod is called by the framework while trying to evaluate the impact
 	// of adding podToAdd to the node while scheduling podToSchedule.

--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -2461,7 +2461,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 	testContext := testutils.InitTestAPIServer(t, "preempt-with-permit-plugin", nil)
 
 	ns := testContext.NS.Name
-	lowPriority, highPriority := int32(100), int32(300)
+	lowPriority, midPriority, highPriority := int32(100), int32(150), int32(300)
 	resReq := map[v1.ResourceName]string{
 		v1.ResourceCPU:    "200m",
 		v1.ResourceMemory: "200",
@@ -2489,7 +2489,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 			name:                   "waiting pod is not physically deleted upon preemption",
 			maxNumWaitingPodCalled: 2,
 			runningPod:             st.MakePod().Name("running-pod").Namespace(ns).Priority(lowPriority).Req(resReq).ZeroTerminationGracePeriod().Obj(),
-			waitingPod:             st.MakePod().Name("waiting-pod").Namespace(ns).Priority(lowPriority).Req(resReq).ZeroTerminationGracePeriod().Obj(),
+			waitingPod:             st.MakePod().Name("waiting-pod").Namespace(ns).Priority(midPriority).Req(resReq).ZeroTerminationGracePeriod().Obj(),
 			preemptor:              st.MakePod().Name("preemptor-pod").Namespace(ns).Priority(highPriority).Req(preemptorReq).ZeroTerminationGracePeriod().Obj(),
 		},
 		{

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -162,14 +163,18 @@ func TestPreemption(t *testing.T) {
 	}
 
 	maxTokens := 1000
+
 	tests := []struct {
-		name                string
-		existingPods        []*v1.Pod
-		pod                 *v1.Pod
-		initTokens          int
-		enablePreFilter     bool
-		unresolvable        bool
-		preemptedPodIndexes map[int]struct{}
+		name                   string
+		existingPods           []*v1.Pod
+		pod                    *v1.Pod
+		initTokens             int
+		enablePreFilter        bool
+		unresolvable           bool
+		preemptedPodIndexes    map[int]struct{}
+		extraNodes             []*v1.Node
+		podGroups              []*schedulingapi.PodGroup
+		genericWorkloadEnabled bool
 	}{
 		{
 			name:       "basic pod preemption",
@@ -395,6 +400,282 @@ func TestPreemption(t *testing.T) {
 			}),
 			preemptedPodIndexes: map[int]struct{}{},
 		},
+		{
+			// The PodGroup is treated as a single atomic victim, so both pods
+			// are evicted as a unit even though pod-group-victim-2 lives on node2.
+			name:                   "pod group victim across multiple nodes, pod-group-as-victim enabled",
+			initTokens:             maxTokens,
+			genericWorkloadEnabled: true,
+			extraNodes: []*v1.Node{
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{
+					v1.ResourcePods:   "32",
+					v1.ResourceCPU:    "500m",
+					v1.ResourceMemory: "500",
+				}).Label("node", "node2").Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg1").Priority(lowPriority).BasicPolicy().
+					DisruptionModeAll().Obj(),
+			},
+			existingPods: []*v1.Pod{
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pod-group-victim-1",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node1"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+					}},
+					PodGroupName: "pg1",
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pod-group-victim-2",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node2"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+					}},
+					PodGroupName: "pg1",
+				}),
+			},
+			pod: initPausePod(&testutils.PausePodConfig{
+				Name:         "preemptor-pod",
+				Priority:     &highPriority,
+				NodeSelector: map[string]string{"node": "node1"},
+				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+				}},
+			}),
+			// The entire pod group is evicted as a unit: both index 0 and index 1.
+			preemptedPodIndexes: map[int]struct{}{0: {}, 1: {}},
+		},
+		{
+			// When all pods of a PodGroup reside on a single node and DisruptionModeAll is enabled,
+			// preempting one member to satisfy resource requests triggers atomic eviction of the entire group.
+			name:                   "pod group occupying a single node, pod-group-as-victim enabled",
+			initTokens:             maxTokens,
+			genericWorkloadEnabled: true,
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg-single").Priority(lowPriority).BasicPolicy().
+					DisruptionModeAll().Obj(),
+			},
+			existingPods: []*v1.Pod{
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pod-group-victim-1",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node1"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-single",
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pod-group-victim-2",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node1"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-single",
+				}),
+			},
+			pod: initPausePod(&testutils.PausePodConfig{
+				Name:         "preemptor-pod",
+				Priority:     &highPriority,
+				NodeSelector: map[string]string{"node": "node1"},
+				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+				}},
+			}),
+			preemptedPodIndexes: map[int]struct{}{0: {}, 1: {}},
+		},
+		{
+			// When multiple victim PodGroups exist across nodes, preemption selects only the lowest-priority
+			// group needed to satisfy the request. Its members across all nodes are evicted while higher-priority groups remain intact.
+			name:                   "multiple victim pod groups, only subset selected for preemption",
+			initTokens:             maxTokens,
+			genericWorkloadEnabled: true,
+			extraNodes: []*v1.Node{
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{
+					v1.ResourcePods:   "32",
+					v1.ResourceCPU:    "500m",
+					v1.ResourceMemory: "500",
+				}).Label("node", "node2").Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg-low").Priority(lowPriority).BasicPolicy().
+					DisruptionModeAll().Obj(),
+				st.MakePodGroup().Name("pg-medium").Priority(mediumPriority).BasicPolicy().
+					DisruptionModeAll().Obj(),
+			},
+			existingPods: []*v1.Pod{
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pg-low-node1",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node1"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-low",
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pg-low-node2",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node2"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-low",
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pg-medium-node1",
+					Priority:     &mediumPriority,
+					NodeSelector: map[string]string{"node": "node1"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-medium",
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pg-medium-node2",
+					Priority:     &mediumPriority,
+					NodeSelector: map[string]string{"node": "node2"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-medium",
+				}),
+			},
+			pod: initPausePod(&testutils.PausePodConfig{
+				Name:         "preemptor-pod",
+				Priority:     &highPriority,
+				NodeSelector: map[string]string{"node": "node1"},
+				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+				}},
+			}),
+			preemptedPodIndexes: map[int]struct{}{0: {}, 1: {}},
+		},
+		{
+			// When evicting all lower-priority victim PodGroups on a node is still insufficient to satisfy the request
+			// due to un-preemptible equal-priority pods, preemption aborts without evicting any members of the PodGroup.
+			name:                   "unsuccessful pod group preemption when freeing lower priority group is insufficient",
+			initTokens:             maxTokens,
+			genericWorkloadEnabled: true,
+			extraNodes: []*v1.Node{
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{
+					v1.ResourcePods:   "32",
+					v1.ResourceCPU:    "1000m",
+					v1.ResourceMemory: "1000",
+				}).Label("node", "node2").Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg-victim").Priority(lowPriority).BasicPolicy().
+					DisruptionModeAll().Obj(),
+			},
+			existingPods: []*v1.Pod{
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "unpreemptible-pod",
+					Priority:     &highPriority,
+					NodeSelector: map[string]string{"node": "node2"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+					}},
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pg-victim-1",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node2"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(150, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-victim",
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pg-victim-2",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node2"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(150, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-victim",
+				}),
+			},
+			pod: initPausePod(&testutils.PausePodConfig{
+				Name:         "preemptor-pod",
+				Priority:     &highPriority,
+				NodeSelector: map[string]string{"node": "node2"},
+				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(600, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+				}},
+			}),
+			preemptedPodIndexes: map[int]struct{}{},
+		},
+		{
+			// When a PodGroup across multiple nodes uses DisruptionModeSingle, evicting a member on the target
+			// node does not trigger gang eviction; members on other nodes remain running untouched.
+			name:                   "pod group victim across multiple nodes, DisruptionModeSingle enabled",
+			initTokens:             maxTokens,
+			genericWorkloadEnabled: true,
+			extraNodes: []*v1.Node{
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{
+					v1.ResourcePods:   "32",
+					v1.ResourceCPU:    "500m",
+					v1.ResourceMemory: "500",
+				}).Label("node", "node2").Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("pg-single-multi").Priority(lowPriority).BasicPolicy().
+					DisruptionModeSingle().Obj(),
+			},
+			existingPods: []*v1.Pod{
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pg-single-multi-node1",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node1"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-single-multi",
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "pg-single-multi-node2",
+					Priority:     &lowPriority,
+					NodeSelector: map[string]string{"node": "node2"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-single-multi",
+				}),
+			},
+			pod: initPausePod(&testutils.PausePodConfig{
+				Name:         "preemptor-pod",
+				Priority:     &highPriority,
+				NodeSelector: map[string]string{"node": "node1"},
+				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
+				}},
+			}),
+			// Only index 0 on node1 is evicted; index 1 on node2 is NOT evicted.
+			preemptedPodIndexes: map[int]struct{}{0: {}},
+		},
 	}
 
 	// Create a node with some resources and a label.
@@ -414,6 +695,7 @@ func TestPreemption(t *testing.T) {
 							features.SchedulerAsyncPreemption:              asyncPreemptionEnabled,
 							features.SchedulerAsyncAPICalls:                asyncAPICallsEnabled,
 							features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
+							features.GenericWorkload:                       test.genericWorkloadEnabled,
 						})
 
 						testCtx := testutils.InitTestSchedulerWithOptions(t,
@@ -427,8 +709,21 @@ func TestPreemption(t *testing.T) {
 						if _, err := createNode(testCtx.ClientSet, nodeObject); err != nil {
 							t.Fatalf("Error creating node: %v", err)
 						}
+						for _, n := range test.extraNodes {
+							if _, err := createNode(testCtx.ClientSet, n); err != nil {
+								t.Fatalf("Error creating extra node %s: %v", n.Name, err)
+							}
+						}
 
 						cs := testCtx.ClientSet
+						ns := testCtx.NS.Name
+
+						for _, pg := range test.podGroups {
+							pg.Namespace = ns
+							if _, err := cs.SchedulingV1alpha3().PodGroups(ns).Create(testCtx.Ctx, pg, metav1.CreateOptions{}); err != nil {
+								t.Fatalf("Error creating PodGroup %s: %v", pg.Name, err)
+							}
+						}
 
 						filter.Tokens = test.initTokens
 						filter.EnablePreFilter = test.enablePreFilter
@@ -436,14 +731,14 @@ func TestPreemption(t *testing.T) {
 						pods := make([]*v1.Pod, len(test.existingPods))
 						// Create and run existingPods.
 						for i, p := range test.existingPods {
-							p.Namespace = testCtx.NS.Name
+							p.Namespace = ns
 							pods[i], err = runPausePod(cs, p)
 							if err != nil {
 								t.Fatalf("Error running pause pod: %v", err)
 							}
 						}
 						// Create the "pod".
-						test.pod.Namespace = testCtx.NS.Name
+						test.pod.Namespace = ns
 						preemptor, err := createPausePod(cs, test.pod)
 						if err != nil {
 							t.Errorf("Error while creating high priority pod: %v", err)
@@ -463,8 +758,15 @@ func TestPreemption(t *testing.T) {
 								if cond == nil {
 									t.Errorf("Pod %q does not have the expected condition: %q", klog.KObj(pod), v1.DisruptionTarget)
 								}
-							} else if p.DeletionTimestamp != nil {
-								t.Errorf("Didn't expect pod %v to get preempted.", p.Name)
+							} else {
+								// Re-fetch to get current state; the pod object from runPausePod
+								// always has DeletionTimestamp=nil and cannot detect unexpected eviction.
+								current, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
+								if err != nil {
+									t.Errorf("Error getting pod %v: %v", p.Name, err)
+								} else if current.DeletionTimestamp != nil {
+									t.Errorf("Pod %v was unexpectedly preempted", p.Name)
+								}
 							}
 						}
 						// Also check that the preemptor pod gets the NominatedNodeName field set.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR enhances the standard Pod-by-Pod preemption flow to support PodGroups as preemption victims. Previously, the preemption logic treated all pods individually. With this change, if a pod belongs to a PodGroup, the preemption logic can treat the group as a single atomic victim.

High-level overview of how this was achieved:
- **Interface Abstraction**: Introduced `Victim` and `DomainVictim` separation.
    - **`Victim`**: A general type used to generalize single Pods and `PodGroups`. It supports operations that do not depend on a specific preemption domain.
    - **`DomainVictim`**: Tied strictly to a preemption domain. It tracks `nodeInfos` (copies of node state, not active snapshot references, except WAP flow, for WAP we are using actual reference) representing the affected blast radius, which the preemption algorithm uses to identify pods for eviction. It cannot be created outside of a domain.
- **Constructor Methods**:
    - `NewVictim` signature was updated to return the `Victim` interface and made public.
    - Added `NewDomainForPodByPodPreemption` which initializes the preemption domain by grouping pods on a node by their `PodGroupName` (if applicable).
    - The `DomainVictim` constructor (`newDomainVictim`) calculates `nodeInfos` internally using a snapshot reference, rather than requiring them to be passed from outside the domain.

#### Special notes for your reviewer:
The changes focus on abstracting the "unit of preemption" into a `Victim` interface. The `NewDomainForPodByPodPreemption` constructor is where the grouping logic lives.

#### Does this PR introduce a user-facing change?
```release-note
Enhanced Pod-by-Pod preemption to support PodGroups as preemption victims.
```
