### PR TITLE
Fix goroutine leak in TestMultipleHPAs test

### DIFF
--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -5484,7 +5484,9 @@ func TestMultipleHPAs(t *testing.T) {
 	testScaleClient := &scalefake.FakeScaleClient{}
 	testMetricsClient := &metricsfake.Clientset{}
 	hpaWatcher := watch.NewFake()
+	defer hpaWatcher.Stop()
 	podWatcher := watch.NewFake()
+	defer podWatcher.Stop()
 
 	testClient.AddWatchReactor("horizontalpodautoscalers", core.DefaultWatchReactor(hpaWatcher, nil))
 	testClient.AddWatchReactor("pods", core.DefaultWatchReactor(podWatcher, nil))
@@ -5732,7 +5734,19 @@ func TestMultipleHPAs(t *testing.T) {
 	hpaController.monitor = monitor.New()
 
 	informerFactory.Start(tCtx.Done())
-	go hpaController.Run(tCtx, 5)
+	// Use a separate context for the controller that we can cancel before the test ends
+	controllerCtx, cancelController := context.WithCancel(tCtx)
+	go hpaController.Run(controllerCtx, 5)
+	// Register cleanup to ensure controller shuts down gracefully
+	tCtx.Cleanup(func() {
+		// Cancel the controller context first
+		cancelController()
+		// Wait for the queue to be fully processed and shut down
+		// Give it some time to finish processing current items
+		_ = wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+			return hpaController.queue.Len() == 0, nil
+		})
+	})
 
 	timeoutTime := time.After(15 * time.Second)
 	timeout := false


### PR DESCRIPTION
The TestMultipleHPAs test was creating fake watchers (hpaWatcher and podWatcher) using watch.NewFake() but never calling Stop() on them. This caused goroutine leaks as the watchers' result channels were never closed.

Add hpaWatcher.Stop() and podWatcher.Stop() calls at the end of the test to properly clean up resources and prevent goroutine leaks.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
