### PR TITLE
[wontfix] kube-proxy: preserve UDP conntrack entries for non-terminating endpoints

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -59,9 +59,9 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 	}
 
 	// serviceIPEndpoints maps service IPs (ClusterIP, LoadBalancerIPs and ExternalIPs) and Service Port
-	// to the set of serving endpoints (Endpoint IP and Port).
+	// to the set of endpoints (Endpoint IP and Port).
 	serviceIPEndpoints := make(map[string]sets.Set[string])
-	// serviceNodePortEndpoints maps service NodePort to the set of serving endpoints  (Endpoint IP and Port).
+	// serviceNodePortEndpoints maps service NodePort to the set of endpoints (Endpoint IP and Port).
 	serviceNodePortEndpoints := make(map[int]sets.Set[string])
 
 	for svcName, svc := range svcPortMap {
@@ -72,15 +72,7 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 
 		endpoints := sets.New[string]()
 		for _, endpoint := range endpointsMap[svcName] {
-			// We need to remove all the conntrack entries for a Service (IP or NodePort)
-			// that are not pointing to a serving endpoint.
-			// We map all the serving endpoints of the service and clear all the conntrack
-			// entries which are destined for the service and are not DNATed to these endpoints.
-			// Changes to the service should not affect existing flows, so we do not take
-			// traffic policies, topology, or terminating status of the service into account.
-			// This ensures that the behavior of UDP services remains consistent with TCP
-			// services.
-			if endpoint.IsServing() {
+			if endpoint.IsServing() || !endpoint.IsTerminating() {
 				portStr := strconv.Itoa(int(endpoint.Port()))
 				endpoints.Insert(net.JoinHostPort(endpoint.IP(), portStr))
 			}
@@ -129,7 +121,7 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 		// if the original destination (--orig-dst) of the entry is service IP (ClusterIP,
 		// LoadBalancerIPs or ExternalIPs) and (--orig-port-dst) is service Port and
 		// the reply source IP (--reply-src) and port (--reply-port-src) does not
-		// represent a serving endpoint of the service, we clear the entry.
+		// represent an endpoint of the service, we clear the entry.
 		endpoints, ok := serviceIPEndpoints[net.JoinHostPort(origDst, origPortDstStr)]
 		if ok && !endpoints.Has(net.JoinHostPort(replySrc, replyPortSrcStr)) {
 			flows = append(flows, entry)
@@ -138,7 +130,7 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 
 		// if the original destination port (--orig-port-dst) of the entry is service
 		// NodePort and the reply source IP (--reply-src) and port (--reply-port-src)
-		// does not represent a serving endpoint of the service, we clear the entry.
+		// does not represent an endpoint of the service, we clear the entry.
 		endpoints, ok = serviceNodePortEndpoints[origPortDst]
 		if ok && !endpoints.Has(net.JoinHostPort(replySrc, replyPortSrcStr)) {
 			flows = append(flows, entry)

--- a/pkg/proxy/conntrack/cleanup_test.go
+++ b/pkg/proxy/conntrack/cleanup_test.go
@@ -152,7 +152,7 @@ func TestCleanStaleEntries(t *testing.T) {
 			},
 			{
 				Addresses:  []string{testNonServingEndpointIP},
-				Conditions: discovery.EndpointConditions{Serving: ptr.To(false)},
+				Conditions: discovery.EndpointConditions{Serving: ptr.To(false), Terminating: ptr.To(false)},
 			},
 		},
 		Ports: []discovery.EndpointPort{
@@ -242,6 +242,9 @@ func TestCleanStaleEntries(t *testing.T) {
 		if endpointsMap[svcPortName][1].IsServing() {
 			t.Fatalf("expected endpointsMap[%q][1] to be not serving", svcPortName.String())
 		}
+		if endpointsMap[svcPortName][1].IsTerminating() {
+			t.Fatalf("expected endpointsMap[%q][1] to be not terminating", svcPortName.String())
+		}
 	}
 
 	// The following mock conntrack flow entries `entriesBeforeCleanup` and `entriesAfterCleanup`
@@ -267,9 +270,9 @@ func TestCleanStaleEntries(t *testing.T) {
 				for _, port := range []uint16{testServicePort, testNonServicePort} {
 					entry := generateConntrackEntry(origDest, port, dnatDest, testEndpointPort, proto)
 					entriesBeforeCleanup = append(entriesBeforeCleanup, entry)
-					if proto == unix.IPPROTO_UDP && port == testServicePort && dnatDest != testServingEndpointIP {
-						// we do not expect UDP entries with destination port `testServicePort` and DNATed destination
-						// address not an address of serving endpoint to be present after cleanup.
+					if proto == unix.IPPROTO_UDP && port == testServicePort && dnatDest == testDeletedEndpointIP {
+						// only the deleted endpoint (terminating) entries should be cleared.
+						// non-serving but non-terminating endpoints (e.g., load shedding) should preserve their flows.
 					} else {
 						entriesAfterCleanup = append(entriesAfterCleanup, entry)
 					}
@@ -278,9 +281,9 @@ func TestCleanStaleEntries(t *testing.T) {
 
 			entry := generateConntrackEntry("", testServiceNodePort, dnatDest, testEndpointPort, proto)
 			entriesBeforeCleanup = append(entriesBeforeCleanup, entry)
-			if proto == unix.IPPROTO_UDP && dnatDest != testServingEndpointIP {
-				// we do not expect UDP entries with DNATed destination address not
-				// an address of serving endpoint to be present after cleanup.
+			if proto == unix.IPPROTO_UDP && dnatDest == testDeletedEndpointIP {
+				// only the deleted endpoint (terminating) entries should be cleared.
+				// non-serving but non-terminating endpoints (e.g., load shedding) should preserve their flows.
 			} else {
 				entriesAfterCleanup = append(entriesAfterCleanup, entry)
 			}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fixes an issue where kube-proxy aggressively flushes conntrack entries for pods that have `ready=false`, even while they are still processing valid existing connections. This breaks UDP pseudo-connections that depend on receiving responses after a pod has failed readiness checks but is still terminating gracefully (e.g., during load shedding).

**The Problem:**
- Pod A sends UDP packets to Pod B via Service ClusterIP
- kube-proxy sets up DNAT/conntrack entries
- Pod B fails readiness check (ready=false) but is still Running and processing existing connections
- kube-proxy immediately flushes the conntrack entry
- Pod B's responses never reach Pod A (dropped at netlink level)
- Protocols like SIP over UDP that rely on receiving multiple responses fail (e.g., INVITE → 100 Trying → 180 Ringing → 200 OK)

**The Solution:**
Modified the conntrack cleanup logic to only flush entries for endpoints that are truly gone (terminating/deleted), not for endpoints that are merely not-ready. This allows pods to complete existing connections even when failing health checks.

The fix changes the condition from `endpoint.IsServing()` to `endpoint.IsServing() || !endpoint.IsTerminating()`, preserving flows for:
1. Serving endpoints (ready, regardless of terminating state)
2. Non-serving but still-running endpoints (load shedding scenario)

Only endpoints that are actually terminating have their flows removed.

## Which issue(s) this PR is related to:

Fixes #134143

## Special notes for your reviewer:

- This is a minimal, surgical fix affecting only the conntrack cleanup decision logic
- The change is backward compatible: pods are still cleaned up when actually terminating
- Updated tests validate that non-terminating, non-serving endpoints preserve their conntrack flows
- All existing tests pass with the new behavior

## Does this PR introduce a user-facing change?

```release-note
Fixes kube-proxy incorrectly flushing UDP conntrack entries for pods that are not-ready but still running. This allows endpoints to gracefully complete existing connections even when failing readiness checks (e.g., during load shedding).
```

## Additional documentation:

- Issue: https://github.com/kubernetes/kubernetes/issues/134143
- Related to graceful shutdown and load shedding patterns
- Maintains UDP service behavior consistency across the endpoint lifecycle
