### PR TITLE
leaderelection: retry release on conflict from inflight renew

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -312,12 +312,20 @@ func (le *LeaderElector) renew(ctx context.Context) {
 }
 
 // release attempts to release the leader lease if we have acquired it.
+// It retries on conflict, which may occur if the context cancellation
+// races with an inflight renew() operation. The client will see a ctx
+// cancellation error while the apiserver completes the update and bumps
+// the resource version.
 func (le *LeaderElector) release(logger klog.Logger) bool {
-	ctx := context.Background()
+	ctx := klog.NewContext(context.Background(), logger)
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, le.config.RenewDeadline)
 	defer timeoutCancel()
-	// update the resourceVersion of lease
-	oldLeaderElectionRecord, _, err := le.config.Lock.Get(timeoutCtx)
+	return le.tryRelease(timeoutCtx)
+}
+
+func (le *LeaderElector) tryRelease(ctx context.Context) bool {
+	logger := klog.FromContext(ctx)
+	oldLeaderElectionRecord, _, err := le.config.Lock.Get(ctx)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			logger.Error(err, "error retrieving resource lock", "lock", le.config.Lock.Describe())
@@ -337,7 +345,11 @@ func (le *LeaderElector) release(logger klog.Logger) bool {
 		RenewTime:            now,
 		AcquireTime:          now,
 	}
-	if err := le.config.Lock.Update(timeoutCtx, leaderElectionRecord); err != nil {
+	if err := le.config.Lock.Update(ctx, leaderElectionRecord); err != nil {
+		if errors.IsConflict(err) {
+			logger.V(4).Info("Conflict when releasing lease, retrying", "lock", le.config.Lock.Describe())
+			return le.tryRelease(ctx)
+		}
 		logger.Error(err, "Failed to release lease", "lock", le.config.Lock.Describe())
 		return false
 	}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -745,6 +745,65 @@ func TestReleaseMethodCallsGet(t *testing.T) {
 	}
 }
 
+// TestReleaseRetriesOnConflict verifies that release retries when the
+// Update call returns a conflict error (e.g. from an inflight renew).
+func TestReleaseRetriesOnConflict(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	objectType := "leases"
+	var conflicted bool
+
+	lockMeta := metav1.ObjectMeta{Namespace: "foo", Name: "bar"}
+	recorder := record.NewFakeRecorder(100)
+	resourceLockConfig := rl.ResourceLockConfig{
+		Identity:      "baz",
+		EventRecorder: recorder,
+	}
+	c := &fake.Clientset{}
+	c.AddReactor("get", objectType, func(action fakeclient.Action) (bool, runtime.Object, error) {
+		return true, createLockObject(t, objectType, action.GetNamespace(), action.(fakeclient.GetAction).GetName(), &rl.LeaderElectionRecord{
+			HolderIdentity:       "baz",
+			LeaseDurationSeconds: 10,
+		}), nil
+	})
+	c.AddReactor("update", objectType, func(action fakeclient.Action) (bool, runtime.Object, error) {
+		if !conflicted {
+			conflicted = true
+			return true, nil, errors.NewConflict(coordinationv1.Resource("leases"), "bar", fmt.Errorf("the object has been modified"))
+		}
+		return true, action.(fakeclient.UpdateAction).GetObject(), nil
+	})
+
+	lock := &rl.LeaseLock{
+		LeaseMeta:  lockMeta,
+		LockConfig: resourceLockConfig,
+		Client:     c.CoordinationV1(),
+	}
+	lec := LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: 10 * time.Second,
+		RenewDeadline: 5 * time.Second,
+		Callbacks: LeaderCallbacks{
+			OnNewLeader: func(l string) {},
+		},
+	}
+	observedRawRecord := GetRawRecordOrDie(t, objectType, rl.LeaderElectionRecord{HolderIdentity: "baz"})
+	le := &LeaderElector{
+		config:            lec,
+		observedRecord:    rl.LeaderElectionRecord{HolderIdentity: "baz"},
+		observedRawRecord: observedRawRecord,
+		observedTime:      time.Now(),
+		clock:             clock.RealClock{},
+		metrics:           globalMetricsFactory.newLeaderMetrics(),
+	}
+
+	if !le.release(logger) {
+		t.Error("release should have succeeded after retrying on conflict")
+	}
+	if !conflicted {
+		t.Error("expected conflict to have occurred")
+	}
+}
+
 func TestReleaseOnCancellation_Leases(t *testing.T) {
 	testReleaseOnCancellation(t, "leases")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

When `release()` is called after the renew loop exits, a conflict error can occur if context cancellation races with an inflight `renew()` operation. The client sees a ctx cancellation error while the apiserver completes the update and bumps the resource version. The subsequent `release()` Get+Update then conflicts against the stale version.

This PR retries the release on conflict by extracting the Get+Update into `tryRelease()` which recurses once on conflict, bounded by the existing timeout context.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is really hard to test because the race requires:

1. A renew update to be in-flight to apiserver
2. Context cancelled at exactly the right moment, right after the server receives the request but before it responds
3. The server completes the write after the client gives up

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```