### PR TITLE
set InPlacePodLevelResourcesVerticalScaling to false if needed

### DIFF
--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -4033,6 +4033,10 @@ func configureCPUManagerInKubelet(oldCfg *kubeletconfig.KubeletConfiguration, ku
 	newCfg.FeatureGates["CPUManagerPolicyAlphaOptions"] = kubeletArguments.enableCPUManagerOptions
 	newCfg.FeatureGates["DisableCPUQuotaWithExclusiveCPUs"] = kubeletArguments.disableCPUQuotaWithExclusiveCPUs
 	newCfg.FeatureGates["PodLevelResources"] = kubeletArguments.enablePodLevelResources
+	// InPlacePodLevelResourcesVerticalScaling is only supported when PodLevelResources is enabled
+	if !kubeletArguments.enablePodLevelResources {
+		newCfg.FeatureGates["InPlacePodLevelResourcesVerticalScaling"] = kubeletArguments.enablePodLevelResources
+	}
 	newCfg.FeatureGates["PodLevelResourceManagers"] = kubeletArguments.enablePodLevelResourceManagers
 
 	if kubeletArguments.customCPUCFSQuotaPeriod != 0 {

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -807,6 +807,10 @@ func configureMemoryManagerInKubelet(oldCfg *kubeletconfig.KubeletConfiguration,
 	}
 
 	newCfg.FeatureGates["PodLevelResources"] = kubeletArguments.enablePodLevelResources
+	// InPlacePodLevelResourcesVerticalScaling is only supported when PodLevelResources is enabled
+	if !kubeletArguments.enablePodLevelResources {
+		newCfg.FeatureGates["InPlacePodLevelResourcesVerticalScaling"] = kubeletArguments.enablePodLevelResources
+	}
 	newCfg.FeatureGates["PodLevelResourceManagers"] = kubeletArguments.enablePodLevelResourceManagers
 
 	newCfg.MemoryManagerPolicy = kubeletArguments.policyName


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/kind flake

#### What this PR does / why we need it:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-node-crio-swap-serial/2036211708862664704

https://storage.googleapis.com/kubernetes-ci-logs/logs//2036211708862664704/artifacts/e2-standard-2-fedora-coreos-43-20260301-3-1-gcp-x86-64-680d1154/kubelet.log
```
I0323 23:49:20.533660   21360 feature_gate.go:477] "Warning: setting GA feature gate. It will be removed in a future release." featureGate="NodeSwap" value=true
I0323 23:49:20.535831   21360 feature_gate.go:477] "Warning: setting GA feature gate. It will be removed in a future release." featureGate="CustomCPUCFSQuotaPeriod" value=false
I0323 23:49:20.535879   21360 feature_gate.go:477] "Warning: setting deprecated feature gate. It will be removed in a future release." featureGate="DisableCPUQuotaWithExclusiveCPUs" value=false
I0323 23:49:20.535893   21360 feature_gate.go:477] "Warning: setting deprecated feature gate. It will be removed in a future release." featureGate="KubeletPodResourcesListUseActivePods" value=false
I0323 23:49:20.535905   21360 feature_gate.go:477] "Warning: setting GA feature gate. It will be removed in a future release." featureGate="NodeSwap" value=true
panic: failed to merge global and in-flight KubeletConfiguration while setting defaults, error: InPlacePodLevelResourcesVerticalScaling is enabled, but depends on features that are disabled: [PodLevelResources]

goroutine 1 [running]:
k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1.SetDefaults_KubeletConfiguration(0xbd964a67c08)
	k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1/defaults.go:72 +0x13e5
k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1.SetObjectDefaults_KubeletConfiguration(0xbd964a67c08)
	k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1/zz_generated.defaults.go:41 +0x2a
k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1.addDefaultingFuncs.RegisterDefaults.func1({0x24f3e60?, 0xbd964a67c08?})
	k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1/zz_generated.defaults.go:35 +0x2d
k8s.io/apimachinery/pkg/runtime.(*Scheme).Default(0x3d0f8b0?, {0x2796f70, 0xbd964a67c08})
	k8s.io/apimachinery/pkg/runtime/scheme.go:357 +0x90
k8s.io/apimachinery/pkg/runtime/serializer/versioning.(*codec).Decode(0xbd964f47c20, {0xbd964da8000?, 0x0?, 0xbd964e31260?}, 0x278de00?, {0x0, 0x0})
	k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go:187 +0x5c4
k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/codec.DecodeKubeletConfiguration({0x27ab950, 0x3d724e0}, 0xbd964d737c0?, {0xbd964da8000, 0xc91, 0xc92})
	k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/codec/codec.go:75 +0xf1
k8s.io/kubernetes/pkg/kubelet/kubeletconfig/configfiles.(*fsLoader).Load(0xbd964d48ed0, {0x27ab950, 0x3d724e0})
	k8s.io/kubernetes/pkg/kubelet/kubeletconfig/configfiles/configfiles.go:76 +0x134
k8s.io/kubernetes/cmd/kubelet/app.loadConfigFile({0x27ab950, 0x3d724e0}, {0x7ffed16bed3c, 0x2c})
	k8s.io/kubernetes/cmd/kubelet/app/server.go:464 +0x23f
k8s.io/kubernetes/cmd/kubelet/app.NewKubeletCommand.func1(0xbd964a28f08, {0xbd96498a190, 0x17, 0x17})
	k8s.io/kubernetes/cmd/kubelet/app/server.go:218 +0x37a
github.com/spf13/cobra.(*Command).execute(0xbd964a28f08, {0xbd96498a190, 0x17, 0x17})
	github.com/spf13/cobra@v1.10.2/command.go:1015 +0xb14
github.com/spf13/cobra.(*Command).ExecuteC(0xbd964a28f08)
	github.com/spf13/cobra@v1.10.2/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.10.2/command.go:1071
k8s.io/component-base/cli.run(0xbd964a28f08)
	k8s.io/component-base/cli/run.go:146 +0x23e
k8s.io/component-base/cli.Run(0x27ab950?)
	k8s.io/component-base/cli/run.go:44 +0x17
main.main()
	k8s.io/kubernetes/cmd/kubelet/kubelet.go:37 +0x2a
```

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/137995

#### Special notes for your reviewer:

This happens after https://github.com/kubernetes/kubernetes/pull/137684 was merged 4 days ago.
cc @ndixita

#### Does this PR introduce a user-facing change?

```release-note
None
```
