### PR TITLE
kubelet: fix nil pointer panic in doPodResizeAction when cgroupsPerQOS=false

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1004,33 +1004,30 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 	// partially actuated.
 	defer m.runtimeHelper.RequestPodReinspect(pod.UID)
 
-	if (len(podContainerChanges.ContainersToUpdate[v1.ResourceMemory]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources) && currentPodMemoryConfig != nil {
-		if podResources.Memory == nil {
+	if len(podContainerChanges.ContainersToUpdate[v1.ResourceMemory]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
+		if podResources.Memory == nil && currentPodMemoryConfig != nil {
 			// Default pod memory limit to the current memory limit if unset to prevent it from updating.
 			// TODO(#128675): This does not support removing limits.
 			podResources.Memory = currentPodMemoryConfig.Memory
 		}
 		var currentMemoryLimit, desiredMemoryLimit int64
-		if currentPodMemoryConfig.Memory != nil {
-			currentMemoryLimit = *currentPodMemoryConfig.Memory
-		}
 		if podResources.Memory != nil {
 			desiredMemoryLimit = *podResources.Memory
+		}
+		if currentPodMemoryConfig != nil && currentPodMemoryConfig.Memory != nil {
+			currentMemoryLimit = *currentPodMemoryConfig.Memory
+		} else {
+			// currentPodMemoryConfig is nil (e.g. cgroupsPerQOS=false): default current to desired
+			// so resizeContainers sees no pod-level change. SetPodCgroupConfig is a no-op in this
+			// path; actuated state is still updated at the end of resizeContainers.
+			currentMemoryLimit = desiredMemoryLimit
 		}
 		if errResize := resizeContainers(v1.ResourceMemory, currentMemoryLimit, desiredMemoryLimit, 0, 0); errResize != nil {
 			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, errResize.Error())
 			return resizeResult
 		}
-	} else if currentPodMemoryConfig == nil && len(podContainerChanges.ContainersToUpdate[v1.ResourceMemory]) > 0 {
-		// Pod-level cgroup not managed (e.g. cgroupsPerQOS=false). Skip pod
-		// cgroup updates but still resize containers directly.
-		if err := m.updatePodContainerResources(ctx, pod, v1.ResourceMemory, podContainerChanges.ContainersToUpdate[v1.ResourceMemory]); err != nil {
-			logger.Error(err, "updatePodContainerResources failed", "pod", format.Pod(pod), "resource", v1.ResourceMemory)
-			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, err.Error())
-			return resizeResult
-		}
 	}
-	if (len(podContainerChanges.ContainersToUpdate[v1.ResourceCPU]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources) && currentPodCPUConfig != nil {
+	if len(podContainerChanges.ContainersToUpdate[v1.ResourceCPU]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
 		if podResources.CPUShares == nil {
 			// This shouldn't happen: ResourceConfigForPod always returns a non-nil value for CPUShares.
 			logger.Error(nil, "podResources.CPUShares is nil", "pod", pod.Name)
@@ -1038,34 +1035,35 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 			return resizeResult
 		}
 
-		// Default pod CPUQuota to the current CPUQuota if no limit is set to prevent the pod limit
-		// from updating.
-		// TODO(#128675): This does not support removing limits.
-		if podResources.CPUQuota == nil {
+		if podResources.CPUQuota == nil && currentPodCPUConfig != nil {
+			// Default pod CPUQuota to the current CPUQuota if no limit is set to prevent the pod limit
+			// from updating.
+			// TODO(#128675): This does not support removing limits.
 			podResources.CPUQuota = currentPodCPUConfig.CPUQuota
 		}
 		var currentCPUQuota, desiredCPUQuota int64
-		if currentPodCPUConfig.CPUQuota != nil {
-			currentCPUQuota = *currentPodCPUConfig.CPUQuota
-		}
 		if podResources.CPUQuota != nil {
 			desiredCPUQuota = *podResources.CPUQuota
 		}
+		desiredCPUShares := int64(*podResources.CPUShares)
 		var currentCPUShares int64
-		if currentPodCPUConfig.CPUShares != nil {
-			currentCPUShares = int64(*currentPodCPUConfig.CPUShares)
+		if currentPodCPUConfig != nil {
+			if currentPodCPUConfig.CPUQuota != nil {
+				currentCPUQuota = *currentPodCPUConfig.CPUQuota
+			}
+			if currentPodCPUConfig.CPUShares != nil {
+				currentCPUShares = int64(*currentPodCPUConfig.CPUShares)
+			}
+		} else {
+			// currentPodCPUConfig is nil (e.g. cgroupsPerQOS=false): default current to desired
+			// so resizeContainers sees no pod-level change. SetPodCgroupConfig is a no-op in this
+			// path; actuated state is still updated at the end of resizeContainers.
+			currentCPUQuota = desiredCPUQuota
+			currentCPUShares = desiredCPUShares
 		}
 		if errResize := resizeContainers(v1.ResourceCPU, currentCPUQuota, desiredCPUQuota,
-			currentCPUShares, int64(*podResources.CPUShares)); errResize != nil {
+			currentCPUShares, desiredCPUShares); errResize != nil {
 			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, errResize.Error())
-			return resizeResult
-		}
-	} else if currentPodCPUConfig == nil && len(podContainerChanges.ContainersToUpdate[v1.ResourceCPU]) > 0 {
-		// Pod-level cgroup not managed (e.g. cgroupsPerQOS=false). Skip pod
-		// cgroup updates but still resize containers directly.
-		if err := m.updatePodContainerResources(ctx, pod, v1.ResourceCPU, podContainerChanges.ContainersToUpdate[v1.ResourceCPU]); err != nil {
-			logger.Error(err, "updatePodContainerResources failed", "pod", format.Pod(pod), "resource", v1.ResourceCPU)
-			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, err.Error())
 			return resizeResult
 		}
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -848,6 +848,16 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		resizeResult.Fail(kubecontainer.ErrResizePodInPlace, fmt.Sprintf("unable to get pod cgroup cpu config for pod %q", format.Pod(pod)))
 		return resizeResult
 	}
+	// When the pod container manager does not manage pod-level cgroups
+	// (e.g. cgroupsPerQOS=false), GetPodCgroupConfig returns nil.
+	// Track this so we skip pod-level cgroup updates in resizeContainers.
+	podCgroupsManaged := currentPodMemoryConfig != nil && currentPodCPUConfig != nil
+	if currentPodMemoryConfig == nil {
+		currentPodMemoryConfig = &cm.ResourceConfig{}
+	}
+	if currentPodCPUConfig == nil {
+		currentPodCPUConfig = &cm.ResourceConfig{}
+	}
 
 	currentPodResources := podResources
 	currentPodResources = mergeResourceConfig(currentPodResources, currentPodMemoryConfig)
@@ -960,13 +970,13 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 	resizeContainers := func(rName v1.ResourceName, currPodCgLimValue, newPodCgLimValue, currPodCgReqValue, newPodCgReqValue int64) error {
 		var err error
 		// At upsizing, limits should expand prior to requests in order to keep "requests <= limits".
-		if newPodCgLimValue > currPodCgLimValue {
+		if podCgroupsManaged && newPodCgLimValue > currPodCgLimValue {
 			// TODO: Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
 				return err
 			}
 		}
-		if newPodCgReqValue > currPodCgReqValue {
+		if podCgroupsManaged && newPodCgReqValue > currPodCgReqValue {
 			// TODO: Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
 				return err
@@ -980,13 +990,13 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		}
 
 		// At downsizing, requests should shrink prior to limits in order to keep "requests <= limits".
-		if newPodCgReqValue < currPodCgReqValue {
+		if podCgroupsManaged && newPodCgReqValue < currPodCgReqValue {
 			// TODO: Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
 				return err
 			}
 		}
-		if newPodCgLimValue < currPodCgLimValue {
+		if podCgroupsManaged && newPodCgLimValue < currPodCgLimValue {
 			// TODO(#127825): Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
 				return err
@@ -1011,7 +1021,14 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 			// TODO(#128675): This does not support removing limits.
 			podResources.Memory = currentPodMemoryConfig.Memory
 		}
-		if errResize := resizeContainers(v1.ResourceMemory, int64(*currentPodMemoryConfig.Memory), *podResources.Memory, 0, 0); errResize != nil {
+		var currentMemoryLimit, desiredMemoryLimit int64
+		if currentPodMemoryConfig.Memory != nil {
+			currentMemoryLimit = *currentPodMemoryConfig.Memory
+		}
+		if podResources.Memory != nil {
+			desiredMemoryLimit = *podResources.Memory
+		}
+		if errResize := resizeContainers(v1.ResourceMemory, currentMemoryLimit, desiredMemoryLimit, 0, 0); errResize != nil {
 			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, errResize.Error())
 			return resizeResult
 		}
@@ -1030,8 +1047,19 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		if podResources.CPUQuota == nil {
 			podResources.CPUQuota = currentPodCPUConfig.CPUQuota
 		}
-		if errResize := resizeContainers(v1.ResourceCPU, *currentPodCPUConfig.CPUQuota, *podResources.CPUQuota,
-			int64(*currentPodCPUConfig.CPUShares), int64(*podResources.CPUShares)); errResize != nil {
+		var currentCPUQuota, desiredCPUQuota int64
+		if currentPodCPUConfig.CPUQuota != nil {
+			currentCPUQuota = *currentPodCPUConfig.CPUQuota
+		}
+		if podResources.CPUQuota != nil {
+			desiredCPUQuota = *podResources.CPUQuota
+		}
+		var currentCPUShares int64
+		if currentPodCPUConfig.CPUShares != nil {
+			currentCPUShares = int64(*currentPodCPUConfig.CPUShares)
+		}
+		if errResize := resizeContainers(v1.ResourceCPU, currentCPUQuota, desiredCPUQuota,
+			currentCPUShares, int64(*podResources.CPUShares)); errResize != nil {
 			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, errResize.Error())
 			return resizeResult
 		}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -848,17 +848,6 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		resizeResult.Fail(kubecontainer.ErrResizePodInPlace, fmt.Sprintf("unable to get pod cgroup cpu config for pod %q", format.Pod(pod)))
 		return resizeResult
 	}
-	// When the pod container manager does not manage pod-level cgroups
-	// (e.g. cgroupsPerQOS=false), GetPodCgroupConfig returns nil.
-	// Default to the desired values so resizeContainers sees no pod-level
-	// diff and skips pod cgroup writes, while container updates still proceed.
-	if currentPodMemoryConfig == nil {
-		currentPodMemoryConfig = &cm.ResourceConfig{Memory: podResources.Memory}
-	}
-	if currentPodCPUConfig == nil {
-		currentPodCPUConfig = &cm.ResourceConfig{CPUQuota: podResources.CPUQuota, CPUShares: podResources.CPUShares}
-	}
-
 	currentPodResources := podResources
 	currentPodResources = mergeResourceConfig(currentPodResources, currentPodMemoryConfig)
 	currentPodResources = mergeResourceConfig(currentPodResources, currentPodCPUConfig)
@@ -1015,7 +1004,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 	// partially actuated.
 	defer m.runtimeHelper.RequestPodReinspect(pod.UID)
 
-	if len(podContainerChanges.ContainersToUpdate[v1.ResourceMemory]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
+	if (len(podContainerChanges.ContainersToUpdate[v1.ResourceMemory]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources) && currentPodMemoryConfig != nil {
 		if podResources.Memory == nil {
 			// Default pod memory limit to the current memory limit if unset to prevent it from updating.
 			// TODO(#128675): This does not support removing limits.
@@ -1032,8 +1021,16 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, errResize.Error())
 			return resizeResult
 		}
+	} else if currentPodMemoryConfig == nil && len(podContainerChanges.ContainersToUpdate[v1.ResourceMemory]) > 0 {
+		// Pod-level cgroup not managed (e.g. cgroupsPerQOS=false). Skip pod
+		// cgroup updates but still resize containers directly.
+		if err := m.updatePodContainerResources(ctx, pod, v1.ResourceMemory, podContainerChanges.ContainersToUpdate[v1.ResourceMemory]); err != nil {
+			logger.Error(err, "updatePodContainerResources failed", "pod", format.Pod(pod), "resource", v1.ResourceMemory)
+			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, err.Error())
+			return resizeResult
+		}
 	}
-	if len(podContainerChanges.ContainersToUpdate[v1.ResourceCPU]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
+	if (len(podContainerChanges.ContainersToUpdate[v1.ResourceCPU]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources) && currentPodCPUConfig != nil {
 		if podResources.CPUShares == nil {
 			// This shouldn't happen: ResourceConfigForPod always returns a non-nil value for CPUShares.
 			logger.Error(nil, "podResources.CPUShares is nil", "pod", pod.Name)
@@ -1061,6 +1058,14 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		if errResize := resizeContainers(v1.ResourceCPU, currentCPUQuota, desiredCPUQuota,
 			currentCPUShares, int64(*podResources.CPUShares)); errResize != nil {
 			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, errResize.Error())
+			return resizeResult
+		}
+	} else if currentPodCPUConfig == nil && len(podContainerChanges.ContainersToUpdate[v1.ResourceCPU]) > 0 {
+		// Pod-level cgroup not managed (e.g. cgroupsPerQOS=false). Skip pod
+		// cgroup updates but still resize containers directly.
+		if err := m.updatePodContainerResources(ctx, pod, v1.ResourceCPU, podContainerChanges.ContainersToUpdate[v1.ResourceCPU]); err != nil {
+			logger.Error(err, "updatePodContainerResources failed", "pod", format.Pod(pod), "resource", v1.ResourceCPU)
+			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, err.Error())
 			return resizeResult
 		}
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -850,13 +850,13 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 	}
 	// When the pod container manager does not manage pod-level cgroups
 	// (e.g. cgroupsPerQOS=false), GetPodCgroupConfig returns nil.
-	// Track this so we skip pod-level cgroup updates in resizeContainers.
-	podCgroupsManaged := currentPodMemoryConfig != nil && currentPodCPUConfig != nil
+	// Default to the desired values so resizeContainers sees no pod-level
+	// diff and skips pod cgroup writes, while container updates still proceed.
 	if currentPodMemoryConfig == nil {
-		currentPodMemoryConfig = &cm.ResourceConfig{}
+		currentPodMemoryConfig = &cm.ResourceConfig{Memory: podResources.Memory}
 	}
 	if currentPodCPUConfig == nil {
-		currentPodCPUConfig = &cm.ResourceConfig{}
+		currentPodCPUConfig = &cm.ResourceConfig{CPUQuota: podResources.CPUQuota, CPUShares: podResources.CPUShares}
 	}
 
 	currentPodResources := podResources
@@ -970,13 +970,13 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 	resizeContainers := func(rName v1.ResourceName, currPodCgLimValue, newPodCgLimValue, currPodCgReqValue, newPodCgReqValue int64) error {
 		var err error
 		// At upsizing, limits should expand prior to requests in order to keep "requests <= limits".
-		if podCgroupsManaged && newPodCgLimValue > currPodCgLimValue {
+		if newPodCgLimValue > currPodCgLimValue {
 			// TODO: Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
 				return err
 			}
 		}
-		if podCgroupsManaged && newPodCgReqValue > currPodCgReqValue {
+		if newPodCgReqValue > currPodCgReqValue {
 			// TODO: Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
 				return err
@@ -990,13 +990,13 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		}
 
 		// At downsizing, requests should shrink prior to limits in order to keep "requests <= limits".
-		if podCgroupsManaged && newPodCgReqValue < currPodCgReqValue {
+		if newPodCgReqValue < currPodCgReqValue {
 			// TODO: Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
 				return err
 			}
 		}
-		if podCgroupsManaged && newPodCgLimValue < currPodCgLimValue {
+		if newPodCgLimValue < currPodCgLimValue {
 			// TODO(#127825): Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
 				return err

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -4143,6 +4143,7 @@ func TestDoPodResizeAction(t *testing.T) {
 		desiredPodLevelResources    *resourceRequirements
 		updatedPodLevelResources    bool
 		enablePLR                   bool
+		nilCgroupConfig             bool
 	}{
 		{
 			testName: "Increase cpu and memory requests and limits, with computed pod limits",
@@ -4481,6 +4482,21 @@ func TestDoPodResizeAction(t *testing.T) {
 			expectPodCgroupUpdates:   1, // Pod level cgroup update for memory limit
 			enablePLR:                true,
 		},
+		{
+			testName: "Nil pod cgroup config does not panic (cgroupsPerQOS=false)",
+			currentResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 100,
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			desiredResources: resourceRequirements{
+				cpuRequest: 200, cpuLimit: 200,
+				memoryRequest: 200, memoryLimit: 200,
+			},
+			otherContainersHaveLimits: true,
+			updatedResources:          []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
+			expectPodCgroupUpdates:    0, // pod cgroups not managed, no pod-level cgroup updates
+			nilCgroupConfig:           true,
+		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
 			_, _, m, err := createTestRuntimeManagerWithErrors(tCtx, tc.runtimeErrors)
@@ -4496,21 +4512,26 @@ func TestDoPodResizeAction(t *testing.T) {
 			mockPCM := cmtesting.NewMockPodContainerManager(t)
 			mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
 
-			mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceMemory).Return(&cm.ResourceConfig{
-				Memory: ptr.To(tc.currentResources.memoryLimit),
-			}, nil).Maybe()
-			mockPCM.EXPECT().GetPodCgroupMemoryUsage(mock.Anything).Return(0, nil).Maybe()
-			// Set up mock pod cgroup config
-			podCPURequest := tc.currentResources.cpuRequest
-			podCPULimit := tc.currentResources.cpuLimit
-			if tc.otherContainersHaveLimits {
-				podCPURequest += 200
-				podCPULimit += 200
+			if tc.nilCgroupConfig {
+				mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceMemory).Return(nil, nil).Maybe()
+				mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceCPU).Return(nil, nil).Maybe()
+			} else {
+				mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceMemory).Return(&cm.ResourceConfig{
+					Memory: ptr.To(tc.currentResources.memoryLimit),
+				}, nil).Maybe()
+				// Set up mock pod cgroup config
+				podCPURequest := tc.currentResources.cpuRequest
+				podCPULimit := tc.currentResources.cpuLimit
+				if tc.otherContainersHaveLimits {
+					podCPURequest += 200
+					podCPULimit += 200
+				}
+				mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceCPU).Return(&cm.ResourceConfig{
+					CPUShares: ptr.To(cm.MilliCPUToShares(podCPURequest)),
+					CPUQuota:  ptr.To(cm.MilliCPUToQuota(podCPULimit, cm.QuotaPeriod)),
+				}, nil).Maybe()
 			}
-			mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceCPU).Return(&cm.ResourceConfig{
-				CPUShares: ptr.To(cm.MilliCPUToShares(podCPURequest)),
-				CPUQuota:  ptr.To(cm.MilliCPUToQuota(podCPULimit, cm.QuotaPeriod)),
-			}, nil).Maybe()
+			mockPCM.EXPECT().GetPodCgroupMemoryUsage(mock.Anything).Return(0, nil).Maybe()
 			if tc.expectPodCgroupUpdates > 0 {
 				// TODO: Update to use proper logger once contextual logging migration is complete
 				call := mockPCM.EXPECT().SetPodCgroupConfig(klog.TODO(), mock.Anything, mock.Anything)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `--enforce-node-allocatable` doesn't include `pods` or `cgroupsPerQOS` is disabled, the kubelet uses `podContainerManagerNoop` as the pod container manager. Its `GetPodCgroupConfig` returns `(nil, nil)` — no cgroup config and no error.

`doPodResizeAction` calls `GetPodCgroupConfig` for both memory and CPU, checks for errors, but doesn't check for a nil config. It then directly dereferences pointer fields (`*currentPodMemoryConfig.Memory`, `*currentPodCPUConfig.CPUQuota`, `*currentPodCPUConfig.CPUShares`), which panics.

The fix keeps the unified `resizeContainers` code path for both normal and nil-config cases:

1. When `GetPodCgroupConfig` returns nil (e.g. `cgroupsPerQOS=false`), default `currentMemoryLimit`, `currentCPUQuota`, and `currentCPUShares` to their desired values. This way `resizeContainers` sees current == desired at the pod-cgroup level, so `setPodCgroupConfig` is never triggered (it's a no-op in this path anyway).
2. Guard existing `podResources.Memory == nil` and `podResources.CPUQuota == nil` defaults with `currentPodConfig != nil` checks to avoid dereferencing nil.
3. Container-level resizes via `updatePodContainerResources` still proceed through the CRI as before.
4. `updateActuatedPodLevelResources` is always reached (no split code path), so resize state tracking stays correct.

Tested on a kind cluster with `cgroupsPerQOS: false` — both scale-up and scale-down complete cleanly, zero panics (results posted in comments).

#### Which issue(s) this PR fixes:

Fixes #137993

#### Does this PR introduce a user-facing change?

```release-note
Fixed a kubelet panic during in-place pod vertical scaling when cgroupsPerQOS is disabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancements Proposals), usage docs, etc.:

n/a

/sig node
/area kubelet
/priority important-soon