### PR TITLE
Remove no-op cloud provider controller registrations from KCM

### DIFF
--- a/cmd/kube-controller-manager/app/controller_descriptor.go
+++ b/cmd/kube-controller-manager/app/controller_descriptor.go
@@ -52,9 +52,8 @@ type ControllerDescriptor struct {
 	constructor               ControllerConstructor
 	requiredFeatureGates      []featuregate.Feature
 	aliases                   []string
-	isDisabledByDefault       bool
-	isCloudProviderController bool
-	requiresSpecialHandling   bool
+	isDisabledByDefault     bool
+	requiresSpecialHandling bool
 }
 
 func (r *ControllerDescriptor) Name() string {
@@ -79,10 +78,6 @@ func (r *ControllerDescriptor) IsDisabledByDefault() bool {
 	return r.isDisabledByDefault
 }
 
-func (r *ControllerDescriptor) IsCloudProviderController() bool {
-	return r.isCloudProviderController
-}
-
 // RequiresSpecialHandling should return true only in a special non-generic controllers like ServiceAccountTokenController
 func (r *ControllerDescriptor) RequiresSpecialHandling() bool {
 	return r.requiresSpecialHandling
@@ -101,11 +96,6 @@ func (r *ControllerDescriptor) BuildController(ctx context.Context, controllerCt
 				"requiredFeatureGates", r.GetRequiredFeatureGates())
 			return nil, nil
 		}
-	}
-
-	if r.IsCloudProviderController() {
-		logger.Info("Skipping a cloud provider controller", "controller", controllerName)
-		return nil, nil
 	}
 
 	ctx = klog.NewContext(ctx, klog.LoggerWithName(logger, controllerName))
@@ -210,11 +200,6 @@ func NewControllerDescriptors() map[string]*ControllerDescriptor {
 	register(newTokenCleanerControllerDescriptor())
 	register(newNodeIpamControllerDescriptor())
 	register(newNodeLifecycleControllerDescriptor())
-
-	register(newServiceLBControllerDescriptor())          // cloud provider controller
-	register(newNodeRouteControllerDescriptor())          // cloud provider controller
-	register(newCloudNodeLifecycleControllerDescriptor()) // cloud provider controller
-
 	register(newPersistentVolumeBinderControllerDescriptor())
 	register(newPersistentVolumeAttachDetachControllerDescriptor())
 	register(newPersistentVolumeExpanderControllerDescriptor())

--- a/cmd/kube-controller-manager/app/controller_descriptor.go
+++ b/cmd/kube-controller-manager/app/controller_descriptor.go
@@ -48,10 +48,10 @@ type Controller interface {
 type ControllerConstructor func(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error)
 
 type ControllerDescriptor struct {
-	name                      string
-	constructor               ControllerConstructor
-	requiredFeatureGates      []featuregate.Feature
-	aliases                   []string
+	name                    string
+	constructor             ControllerConstructor
+	requiredFeatureGates    []featuregate.Feature
+	aliases                 []string
 	isDisabledByDefault     bool
 	requiresSpecialHandling bool
 }

--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/server/healthz"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	cpnames "k8s.io/cloud-provider/names"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
@@ -81,9 +80,6 @@ func TestControllerNamesDeclaration(t *testing.T) {
 		names.NodeIpamController,
 		names.NodeLifecycleController,
 		names.TaintEvictionController,
-		cpnames.ServiceLBController,
-		cpnames.NodeRouteController,
-		cpnames.CloudNodeLifecycleController,
 		names.PersistentVolumeBinderController,
 		names.PersistentVolumeAttachDetachController,
 		names.PersistentVolumeExpanderController,
@@ -234,31 +230,6 @@ func TestTaintEvictionControllerGating(t *testing.T) {
 				t.Errorf("TaintEvictionController healthCheck check failed: expected=%v, got=%v", expectHealthCheck, hasHealthCheck)
 			}
 		})
-	}
-}
-
-func TestNoCloudProviderControllerStarted(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
-	controllerCtx := ControllerContext{}
-	controllerCtx.ComponentConfig.Generic.Controllers = []string{"*"}
-	cpControllerDescriptors := make(map[string]*ControllerDescriptor)
-	for controllerName, controller := range NewControllerDescriptors() {
-		if !controller.IsCloudProviderController() {
-			continue
-		}
-
-		controller.constructor = func(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-			return newControllerLoop(func(ctx context.Context) {
-				t.Error("Controller should not be started:", controllerName)
-			}, controllerName), nil
-		}
-
-		cpControllerDescriptors[controllerName] = controller
-	}
-
-	var healthChecks mockHealthCheckAdder
-	if err := runControllers(ctx, controllerCtx, cpControllerDescriptors, &healthChecks); err != nil {
-		t.Error("Failed to start controllers:", err)
 	}
 }
 

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -34,7 +34,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	restclient "k8s.io/client-go/rest"
-	cpnames "k8s.io/cloud-provider/names"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/controller-manager/controller"
 	csitrans "k8s.io/csi-translation-lib"
@@ -77,19 +76,6 @@ const (
 	// defaultNodeMaskCIDRIPv6 is default mask size for IPv6 node cidr
 	defaultNodeMaskCIDRIPv6 = 64
 )
-
-func newServiceLBControllerDescriptor() *ControllerDescriptor {
-	return &ControllerDescriptor{
-		name:    cpnames.ServiceLBController,
-		aliases: []string{"service"},
-		constructor: func(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-			logger := klog.FromContext(ctx)
-			logger.Info("Warning: service-controller is set, but no cloud provider functionality is available in kube-controller-manger (KEP-2395). Will not configure service controller.")
-			return nil, nil
-		},
-		isCloudProviderController: true,
-	}
-}
 
 func newNodeIpamControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
@@ -243,32 +229,6 @@ func newTaintEvictionController(ctx context.Context, controllerContext Controlle
 	}
 
 	return newControllerLoop(tec.Run, controllerName), nil
-}
-
-func newCloudNodeLifecycleControllerDescriptor() *ControllerDescriptor {
-	return &ControllerDescriptor{
-		name:    cpnames.CloudNodeLifecycleController,
-		aliases: []string{"cloud-node-lifecycle"},
-		constructor: func(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-			logger := klog.FromContext(ctx)
-			logger.Info("Warning: node-controller is set, but no cloud provider functionality is available in kube-controller-manger (KEP-2395). Will not configure node lifecyle controller.")
-			return nil, nil
-		},
-		isCloudProviderController: true,
-	}
-}
-
-func newNodeRouteControllerDescriptor() *ControllerDescriptor {
-	return &ControllerDescriptor{
-		name:    cpnames.NodeRouteController,
-		aliases: []string{"route"},
-		constructor: func(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-			logger := klog.FromContext(ctx)
-			logger.Info("Warning: configure-cloud-routes is set, but no cloud provider functionality is available in kube-controller-manger (KEP-2395). Will not configure cloud provider routes.")
-			return nil, nil
-		},
-		isCloudProviderController: true,
-	}
 }
 
 func newPersistentVolumeBinderControllerDescriptor() *ControllerDescriptor {

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -66,9 +66,8 @@ const (
 
 // KubeControllerManagerOptions is the main context object for the kube-controller manager.
 type KubeControllerManagerOptions struct {
-	Generic           *cmoptions.GenericControllerManagerConfigurationOptions
-	KubeCloudShared   *cpoptions.KubeCloudSharedOptions
-	ServiceController *cpoptions.ServiceControllerOptions
+	Generic         *cmoptions.GenericControllerManagerConfigurationOptions
+	KubeCloudShared *cpoptions.KubeCloudSharedOptions
 
 	AttachDetachController                    *AttachDetachControllerOptions
 	CSRSigningController                      *CSRSigningControllerOptions
@@ -135,9 +134,6 @@ func NewKubeControllerManagerOptions() (*KubeControllerManagerOptions, error) {
 	s := KubeControllerManagerOptions{
 		Generic:         cmoptions.NewGenericControllerManagerConfigurationOptions(&componentConfig.Generic),
 		KubeCloudShared: cpoptions.NewKubeCloudSharedOptions(&componentConfig.KubeCloudShared),
-		ServiceController: &cpoptions.ServiceControllerOptions{
-			ServiceControllerConfiguration: &componentConfig.ServiceController,
-		},
 		AttachDetachController: &AttachDetachControllerOptions{
 			&componentConfig.AttachDetachController,
 		},
@@ -268,8 +264,6 @@ func (s *KubeControllerManagerOptions) Flags(allControllers []string, disabledBy
 	fss := cliflag.NamedFlagSets{}
 	s.Generic.AddFlags(&fss, allControllers, disabledByDefaultControllers, controllerAliases)
 	s.KubeCloudShared.AddFlags(fss.FlagSet("generic"))
-	s.ServiceController.AddFlags(fss.FlagSet("service-lb-controller"))
-
 	s.SecureServing.AddFlags(fss.FlagSet("secure serving"))
 	s.Authentication.AddFlags(fss.FlagSet("authentication"))
 	s.Authorization.AddFlags(fss.FlagSet("authorization"))
@@ -407,9 +401,6 @@ func (s *KubeControllerManagerOptions) ApplyTo(c *kubecontrollerconfig.Config, a
 	if err := s.SAController.ApplyTo(&c.ComponentConfig.SAController); err != nil {
 		return err
 	}
-	if err := s.ServiceController.ApplyTo(&c.ComponentConfig.ServiceController); err != nil {
-		return err
-	}
 	if err := s.TTLAfterFinishedController.ApplyTo(&c.ComponentConfig.TTLAfterFinishedController); err != nil {
 		return err
 	}
@@ -468,7 +459,6 @@ func (s *KubeControllerManagerOptions) Validate(allControllers []string, disable
 	errs = append(errs, s.ReplicationController.Validate()...)
 	errs = append(errs, s.ResourceQuotaController.Validate()...)
 	errs = append(errs, s.SAController.Validate()...)
-	errs = append(errs, s.ServiceController.Validate()...)
 	errs = append(errs, s.TTLAfterFinishedController.Validate()...)
 	errs = append(errs, s.SecureServing.Validate()...)
 	errs = append(errs, s.Authentication.Validate()...)

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
-	cpnames "k8s.io/cloud-provider/names"
 	cpoptions "k8s.io/cloud-provider/options"
 	cliflag "k8s.io/component-base/cli/flag"
 	basecompatibility "k8s.io/component-base/compatibility"
@@ -269,7 +268,7 @@ func (s *KubeControllerManagerOptions) Flags(allControllers []string, disabledBy
 	fss := cliflag.NamedFlagSets{}
 	s.Generic.AddFlags(&fss, allControllers, disabledByDefaultControllers, controllerAliases)
 	s.KubeCloudShared.AddFlags(fss.FlagSet("generic"))
-	s.ServiceController.AddFlags(fss.FlagSet(cpnames.ServiceLBController))
+	s.ServiceController.AddFlags(fss.FlagSet("service-lb-controller"))
 
 	s.SecureServing.AddFlags(fss.FlagSet("secure serving"))
 	s.Authentication.AddFlags(fss.FlagSet("authentication"))

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -114,7 +114,6 @@ var args = []string{
 	"--concurrent-cron-job-syncs=10",
 	"--concurrent-replicaset-syncs=10",
 	"--concurrent-resource-quota-syncs=10",
-	"--concurrent-service-syncs=2",
 	"--concurrent-serviceaccount-token-syncs=10",
 	"--concurrent_rc_syncs=10",
 	"--concurrent-validating-admission-policy-status-syncs=9",
@@ -231,11 +230,6 @@ func TestAddFlags(t *testing.T) {
 					Name:            "gce",
 					CloudConfigFile: "/cloud-config",
 				},
-			},
-		},
-		ServiceController: &cpoptions.ServiceControllerOptions{
-			ServiceControllerConfiguration: &serviceconfig.ServiceControllerConfiguration{
-				ConcurrentServiceSyncs: 2,
 			},
 		},
 		AttachDetachController: &AttachDetachControllerOptions{
@@ -605,7 +599,7 @@ func TestApplyTo(t *testing.T) {
 				},
 			},
 			ServiceController: serviceconfig.ServiceControllerConfiguration{
-				ConcurrentServiceSyncs: 2,
+				ConcurrentServiceSyncs: 1,
 			},
 			AttachDetachController: attachdetachconfig.AttachDetachControllerConfiguration{
 				ReconcilerSyncLoopPeriod:          metav1.Duration{Duration: 30 * time.Second},

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -598,9 +598,7 @@ func TestApplyTo(t *testing.T) {
 					CloudConfigFile: "/cloud-config",
 				},
 			},
-			ServiceController: serviceconfig.ServiceControllerConfiguration{
-				ConcurrentServiceSyncs: 1,
-			},
+			ServiceController: serviceconfig.ServiceControllerConfiguration{},
 			AttachDetachController: attachdetachconfig.AttachDetachControllerConfiguration{
 				ReconcilerSyncLoopPeriod:          metav1.Duration{Duration: 30 * time.Second},
 				DisableAttachDetachReconcilerSync: true,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes dead cloud provider controller code from KCM. Since v1.31 (KEP-2395), the service-lb, cloud-node-lifecycle, and node-route controllers were registered as no-ops (constructors returned nil, `BuildController` skipped them unconditionally). This removes those registrations, the `isCloudProviderController` machinery, and the `ServiceController` options plumbing (`--concurrent-service-syncs` flag was parsed but never read).

#### Which issue(s) this PR is related to:

KEP-2395

#### Special notes for your reviewer:

`KubeCloudShared` options and the `ServiceController` field in the versioned component config struct are intentionally kept.

#### Does this PR introduce a user-facing change?

```release-note
Removed the `--concurrent-service-syncs` kube-controller-manager flag (no-op since v1.31).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```