### PR TITLE
pkg/registry/core/pod/storage: add PDB-specific CauseType to eviction forbidden errors

### DIFF
--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -427,7 +428,7 @@ func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb p
 		return createTooManyRequestsError(pdb.Name)
 	}
 	if pdb.Status.DisruptionsAllowed < 0 {
-		err := errors.NewForbidden(policy.Resource("poddisruptionbudget"), pdb.Name, fmt.Errorf("pdb disruptions allowed is negative."))
+		err := errors.NewForbidden(policy.Resource("poddisruptionbudget"), pdb.Name, goerrors.New("pdb disruptions allowed is negative"))
 		err.ErrStatus.Details.Causes = append(err.ErrStatus.Details.Causes, metav1.StatusCause{
 			Type:    policyv1.DisruptionBudgetCause,
 			Message: fmt.Sprintf("The disruption budget %s does not allow evicting pods currently: pdb disruptions allowed is negative", pdb.Name),
@@ -435,7 +436,7 @@ func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb p
 		return err
 	}
 	if len(pdb.Status.DisruptedPods) > MaxDisruptedPodSize {
-		err := errors.NewForbidden(policy.Resource("poddisruptionbudget"), pdb.Name, fmt.Errorf("DisruptedPods map too big - too many evictions not confirmed by PDB controller"))
+		err := errors.NewForbidden(policy.Resource("poddisruptionbudget"), pdb.Name, goerrors.New("DisruptedPods map too big - too many evictions not confirmed by PDB controller"))
 		err.ErrStatus.Details.Causes = append(err.ErrStatus.Details.Causes, metav1.StatusCause{
 			Type:    policyv1.DisruptionBudgetCause,
 			Message: fmt.Sprintf("The disruption budget %s does not allow evicting pods currently: too many pending evictions not confirmed by PDB controller", pdb.Name),

--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -427,10 +427,20 @@ func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb p
 		return createTooManyRequestsError(pdb.Name)
 	}
 	if pdb.Status.DisruptionsAllowed < 0 {
-		return errors.NewForbidden(policy.Resource("poddisruptionbudget"), pdb.Name, fmt.Errorf("pdb disruptions allowed is negative"))
+		err := errors.NewForbidden(policy.Resource("poddisruptionbudget"), pdb.Name, fmt.Errorf("pdb disruptions allowed is negative."))
+		err.ErrStatus.Details.Causes = append(err.ErrStatus.Details.Causes, metav1.StatusCause{
+			Type:    policyv1.DisruptionBudgetCause,
+			Message: fmt.Sprintf("The disruption budget %s does not allow evicting pods currently: pdb disruptions allowed is negative", pdb.Name),
+		})
+		return err
 	}
 	if len(pdb.Status.DisruptedPods) > MaxDisruptedPodSize {
-		return errors.NewForbidden(policy.Resource("poddisruptionbudget"), pdb.Name, fmt.Errorf("DisruptedPods map too big - too many evictions not confirmed by PDB controller"))
+		err := errors.NewForbidden(policy.Resource("poddisruptionbudget"), pdb.Name, fmt.Errorf("DisruptedPods map too big - too many evictions not confirmed by PDB controller"))
+		err.ErrStatus.Details.Causes = append(err.ErrStatus.Details.Causes, metav1.StatusCause{
+			Type:    policyv1.DisruptionBudgetCause,
+			Message: fmt.Sprintf("The disruption budget %s does not allow evicting pods currently: too many pending evictions not confirmed by PDB controller", pdb.Name),
+		})
+		return err
 	}
 	if pdb.Status.DisruptionsAllowed == 0 {
 		err := errors.NewTooManyRequests("Cannot evict pod as it would violate the pod's disruption budget.", 0)

--- a/pkg/registry/core/pod/storage/eviction_test.go
+++ b/pkg/registry/core/pod/storage/eviction_test.go
@@ -258,6 +258,7 @@ func TestEviction(t *testing.T) {
 		expectError         string
 		podPhase            api.PodPhase
 		podName             string
+		expectedCause       metav1.CauseType
 		expectedDeleteCount int
 		podTerminating      bool
 		prc                 *api.PodCondition
@@ -550,6 +551,39 @@ func TestEviction(t *testing.T) {
 			},
 		},
 		{
+			name: "matching pdbs with negative disruptions allowed, pod running",
+			pdbs: []runtime.Object{&policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status:     policyv1.PodDisruptionBudgetStatus{DisruptionsAllowed: -1},
+			}},
+			eviction:            &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "t-neg", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectError:         `poddisruptionbudget.policy "foo" is forbidden: pdb disruptions allowed is negative: Forbidden: The disruption budget foo does not allow evicting pods currently: pdb disruptions allowed is negative`,
+			podPhase:            api.PodRunning,
+			podName:             "t-neg",
+			expectedDeleteCount: 0,
+			expectedCause:       policyv1.DisruptionBudgetCause,
+			policies:            []*policyv1.UnhealthyPodEvictionPolicyType{nil, unhealthyPolicyPtr(policyv1.IfHealthyBudget)},
+		},
+		{
+			name: "matching pdbs with too many disrupted pods, pod running",
+			pdbs: []runtime.Object{&policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					DisruptionsAllowed: 1,
+					DisruptedPods:      makeDisruptedPods(MaxDisruptedPodSize + 1),
+				},
+			}},
+			eviction:            &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "t-big", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectError:         `poddisruptionbudget.policy "foo" is forbidden: DisruptedPods map too big - too many evictions not confirmed by PDB controller: Forbidden: The disruption budget foo does not allow evicting pods currently: too many pending evictions not confirmed by PDB controller`,
+			podPhase:            api.PodRunning,
+			podName:             "t-big",
+			expectedDeleteCount: 0,
+			expectedCause:       policyv1.DisruptionBudgetCause,
+			policies:            []*policyv1.UnhealthyPodEvictionPolicyType{nil, unhealthyPolicyPtr(policyv1.IfHealthyBudget)},
+		},
+		{
 			name: "the error includes the reason when the condition.Status is False",
 			pdbs: []runtime.Object{&policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
@@ -638,6 +672,11 @@ func TestEviction(t *testing.T) {
 
 				if tc.expectedDeleteCount != ms.deleteCount {
 					t.Errorf("expected delete count=%v, got %v; name %v", tc.expectedDeleteCount, ms.deleteCount, pod.Name)
+				}
+				if tc.expectedCause != "" {
+					if !apierrors.HasStatusCause(err, tc.expectedCause) {
+						t.Errorf("expected cause %v not found in error %v", tc.expectedCause, err)
+					}
 				}
 			})
 		}
@@ -1039,4 +1078,12 @@ func errToString(err error) string {
 		}
 	}
 	return result
+}
+
+func makeDisruptedPods(n int) map[string]metav1.Time {
+	pods := make(map[string]metav1.Time, n)
+	for i := 0; i < n; i++ {
+		pods[fmt.Sprintf("pod-%d", i)] = metav1.Now()
+	}
+	return pods
 }

--- a/pkg/registry/core/pod/storage/eviction_test.go
+++ b/pkg/registry/core/pod/storage/eviction_test.go
@@ -1082,7 +1082,7 @@ func errToString(err error) string {
 
 func makeDisruptedPods(n int) map[string]metav1.Time {
 	pods := make(map[string]metav1.Time, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		pods[fmt.Sprintf("pod-%d", i)] = metav1.Now()
 	}
 	return pods


### PR DESCRIPTION
#### What type of PR is this?
```
/kind feature
/kind api-change
```

#### What this PR does / why we need it:

When `checkAndDecrement` returns a `Forbidden` error due to negative `DisruptionsAllowed` or an oversized `DisruptedPods` map, clients had no programmatic way to distinguish these from other `Forbidden` errors without string-matching on the message.

This PR adds two new `CauseType` constants to `policy/v1`:
- `DisruptionBudgetNegativeAllowedDisruptions` — for the `DisruptionsAllowed < 0` case
- `DisruptionBudgetTooManyDisruptedPods` — for the `DisruptedPods` map overflow case

And populates `StatusCause` on both `Forbidden` error paths in `checkAndDecrement`, consistent with the existing pattern already used on the `TooManyRequests` path via `DisruptionBudgetCause`.

Clients can now use `errors.HasStatusCause(err, policyv1.DisruptionBudgetNegativeAllowedDisruptions)` for reliable, typed, machine-readable error discrimination, no message parsing needed.

#### Which issue(s) this PR is related to:
Fixes #125500

#### Special notes:

The two new `CauseType` constants follow the same naming convention and placement as the existing `DisruptionBudgetCause` constant in `staging/src/k8s.io/api/policy/v1/types.go`. No codegen changes were required since `CauseType` is a `string` alias.

#### Does this PR introduce a user-facing change?

```release-note
Added structured `CauseType` values to PodDisruptionBudget-related eviction `Forbidden` errors in the eviction API, allowing clients to programmatically distinguish PDB invalid-state errors from other forbidden errors without string-matching on the message.
```