### PR TITLE
Flaky test fix for 'should restart failing container when pod restartPolicy is Always'

### DIFF
--- a/test/e2e_node/container_lifecycle_pod_construction.go
+++ b/test/e2e_node/container_lifecycle_pod_construction.go
@@ -329,11 +329,15 @@ func parseOutput(ctx context.Context, f *framework.Framework, pod *v1.Pod) conta
 	var buf bytes.Buffer
 	for _, cs := range statuses {
 		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, cs.Name)
-		if err != nil {
-			framework.Logf("error getting logs for %s: %v", cs.Name, err)
-			log, err = e2epod.GetPreviousPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, cs.Name)
+		if err != nil || log == "" {
 			if err != nil {
-				framework.Logf("error getting previous logs for %s: %v", cs.Name, err)
+				framework.Logf("error getting logs for %s: %v", cs.Name, err)
+			}
+			prevLog, prevErr := e2epod.GetPreviousPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, cs.Name)
+			if prevErr != nil {
+				framework.Logf("error getting previous logs for %s: %v", cs.Name, prevErr)
+			} else {
+				log = prevLog
 			}
 		}
 		buf.WriteString(log)


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The flaking test waits for the container restart count to be 3 before proceeding. Without `PLEGOnDemandRelist`, there is typically a 2s delay after actually restarting the container before the restart count is updated, which typically gives plenty of time for the container to run and output its logs. With `PLEGOnDemandRelist`, the status is updated immediately, so there's a race condition where the log output hasn't been generated yet. In this case, we can just fall back to the previous logs, since we should have 2 complete container runs before, which should be sufficient.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/pull/137946#issuecomment-4115815566

#### Special notes for your reviewer:

I'm not fully confident in this fix, since I can't reproduce the flake.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon

/assign @BenTheElder 
/cc @liggitt 