### PR TITLE
Fix typo: rename sucessObj to successObj in RealFIFO test

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
@@ -1210,8 +1210,8 @@ func TestRealFIFO_PopMultipleDeltaInBatch(t *testing.T) {
 func TestRealFIFO_PopBrokenItemsInBatch(t *testing.T) {
 	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.InOrderInformersBatchProcess, true)
 	const unlimitedBatchSize = 999999
-	sucessObj1 := mkFifoObj("foo1", 5)
-	sucessObj2 := mkFifoObj("foo2", 5)
+	successObj1 := mkFifoObj("foo1", 5)
+	successObj2 := mkFifoObj("foo2", 5)
 	failObj3 := mkFifoObj("foo3", 5)
 	failObj4 := mkFifoObj("foo4", 5)
 	testDeltaType := Added
@@ -1233,30 +1233,30 @@ func TestRealFIFO_PopBrokenItemsInBatch(t *testing.T) {
 		{
 			name: "nth item is broken",
 			incomingItems: []testFifoObject{
-				sucessObj1, sucessObj2, failObj3,
+				successObj1, successObj2, failObj3,
 			},
 			expectedBatches: [][]Delta{
-				{{testDeltaType, sucessObj1}, {testDeltaType, sucessObj2}, {testDeltaType, failObj3}},
+				{{testDeltaType, successObj1}, {testDeltaType, successObj2}, {testDeltaType, failObj3}},
 			},
 		},
 		{
 			name: "multiple nth items are broken",
 			incomingItems: []testFifoObject{
-				sucessObj1, sucessObj2, failObj3, failObj4,
+				successObj1, successObj2, failObj3, failObj4,
 			},
 			expectedBatches: [][]Delta{
-				{{testDeltaType, sucessObj1}, {testDeltaType, sucessObj2}, {testDeltaType, failObj3}},
+				{{testDeltaType, successObj1}, {testDeltaType, successObj2}, {testDeltaType, failObj3}},
 				{{testDeltaType, failObj4}},
 			},
 		},
 		{
 			name: "mixed 1st and nth items are broken",
 			incomingItems: []testFifoObject{
-				failObj3, sucessObj1, failObj4,
+				failObj3, successObj1, failObj4,
 			},
 			expectedBatches: [][]Delta{
 				{{testDeltaType, failObj3}},
-				{{testDeltaType, sucessObj1}, {testDeltaType, failObj4}},
+				{{testDeltaType, successObj1}, {testDeltaType, failObj4}},
 			},
 		},
 	}

--- a/test/images/windows/powershell-helper/Dockerfile_windows
+++ b/test/images/windows/powershell-helper/Dockerfile_windows
@@ -46,6 +46,6 @@ RUN powershell \
           $ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path $env:PSModuleAnalysisCachePath)) {  \
             Write-Host "'Waiting for $env:PSModuleAnalysisCachePath'" ; \
-            if((get-date) -gt $stopTime) { throw 'timout expired'} \
+            if((get-date) -gt $stopTime) { throw 'timeout expired'} \
             Start-Sleep -Seconds 6 ; \
           }"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR fixes minor typos in both test code and user-facing strings:

- Renames sucessObj1 and sucessObj2 to successObj1 and successObj2 in the RealFIFO unit test to improve readability and maintain consistency between success and failure test fixtures.
- Fixes a user-facing typo in the Windows powershell-helper Dockerfile error message (timout expired → timeout expired), improving troubleshooting clarity and log consistency.

These changes are non-functional and improve overall code quality and maintainability.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a small, non-functional cleanup change limited to test code.
No behavior or logic has been modified.

#### Does this PR introduce a user-facing change?
NONE

####Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Docs