### PR TITLE
fix(e2e_node): reduce flakiness in image credential pull tests

### DIFF
--- a/test/e2e_node/image_credential_pulls.go
+++ b/test/e2e_node/image_credential_pulls.go
@@ -131,8 +131,9 @@ var _ = SIGDescribe("Ensure Credential Pulled Images", func() {
 						switch credsPolicy {
 						case kubeletconfig.NeverVerifyAllowlistedImages:
 							framework.Context("[NeverVerifyAllowListedImages specific tests]", func() {
-								tempRemoveImagePulledRecord(f, &testImageID)
-								tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+								// This BeforeEach runs after the outer tempSetCurrentKubeletConfig,
+								// so getCurrentKubeletConfig reads the already-applied policy as the base.
+								tempRemoveImagePulledRecordAndSetKubeletConfig(f, &testImageID, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 									initialConfig.ImagePullCredentialsVerificationPolicy = string(credsPolicy)
 									initialConfig.PreloadedImagesVerificationAllowlist = []string{path.Join(registryAddress, "pause")}
 								})

--- a/test/e2e_node/util_kubeletconfig.go
+++ b/test/e2e_node/util_kubeletconfig.go
@@ -98,19 +98,45 @@ func updateKubeletConfig(ctx context.Context, f *framework.Framework, kubeletCon
 	})
 }
 
+const pulledRecordsDir = "/var/lib/kubelet/image_manager/pulled"
+
+func pulledRecordFilenameFromID(imageID string) string {
+	return fmt.Sprintf("sha256-%x", sha256.Sum256([]byte(imageID)))
+}
+
 func tempRemoveImagePulledRecord(f *framework.Framework, imageID *string) {
-	pulledRecordFilenameFromID := func(imageID string) string {
-		return fmt.Sprintf("sha256-%x", sha256.Sum256([]byte(imageID)))
+	tempRemoveImagePulledRecordAndSetKubeletConfig(f, imageID, nil)
+}
+
+// tempRemoveImagePulledRecordAndSetKubeletConfig removes the image pulled record file and
+// optionally updates the kubelet configuration in a single kubelet stop/start cycle.
+// This avoids an extra kubelet restart when both operations are needed.
+//
+// When updateFunction is non-nil, an explicit AfterEach is used for config
+// restoration so it runs in the first cleanup pass alongside the outer
+// tempSetCurrentKubeletConfig's AfterEach (ordered by descending nesting level).
+// DeferCleanup runs in a second pass and would clobber the outer's
+// already-restored config.
+func tempRemoveImagePulledRecordAndSetKubeletConfig(f *framework.Framework, imageID *string, updateFunction func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration)) {
+	var oldCfg *kubeletconfig.KubeletConfiguration
+
+	if updateFunction != nil {
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if oldCfg != nil {
+				updateKubeletConfig(ctx, f, oldCfg, true)
+			}
+		})
 	}
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		pulledRecordsDir := "/var/lib/kubelet/image_manager/pulled"
 		fileName := pulledRecordFilenameFromID(*imageID)
 		origPath := filepath.Join(pulledRecordsDir, fileName)
 		tempPath := filepath.Join(pulledRecordsDir, "temp_"+fileName)
 
-		// wait for the kubelet to create the record
-		err := wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Second, true, func(_ context.Context) (bool, error) {
+		// Wait for the kubelet to create the record. Use a generous timeout because
+		// the preceding kubelet restart (from tempSetCurrentKubeletConfig) can be slow
+		// on loaded CI nodes, and the file must exist on disk before we can rename it.
+		err := wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(_ context.Context) (bool, error) {
 			if _, err := os.Stat(origPath); err != nil {
 				return false, nil
 			}
@@ -118,10 +144,27 @@ func tempRemoveImagePulledRecord(f *framework.Framework, imageID *string) {
 		})
 		framework.ExpectNoError(err, "the file with the pulled record for the image ID never appeared")
 
+		if updateFunction != nil {
+			oldCfg, err = getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+		}
+
 		withStoppedKubelet(ctx, f, false, func() {
 			err := os.Rename(origPath, tempPath)
 			framework.ExpectNoError(err, "failed to move the ImagePulledRecord file")
 
+			if updateFunction != nil {
+				newCfg := oldCfg.DeepCopy()
+				updateFunction(ctx, newCfg)
+
+				deleteStateFile(cpuManagerStateFile)
+				deleteStateFile(memoryManagerStateFile)
+				deleteStateFile(usernsStateFiles)
+				framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
+			}
+
+			// Restore the file on cleanup. Config restoration (when applicable) is
+			// handled by the AfterEach above to maintain correct Ginkgo cleanup ordering.
 			ginkgo.DeferCleanup(func(ctx context.Context) {
 				withStoppedKubelet(ctx, f, false, func() {
 					err := os.Rename(tempPath, origPath)


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Reduces flakiness in the `e2e_node` image credential pull tests by addressing timing issues and unnecessary kubelet restarts.

Increase the PollUntilContextTimeout in tempRemoveImagePulledRecord from
5s to 30s to handle slow kubelet restarts on loaded CI nodes.

Combine the image pulled record removal and kubelet config update into a
single kubelet stop/start cycle for the NeverVerifyAllowlistedImages
sub-context, reducing setup restarts from 2 to 1. Use an explicit
AfterEach for config restoration instead of DeferCleanup to maintain
correct Ginkgo two-pass cleanup ordering.

Deduplicate the pulled record file handling by merging the two code
paths in tempRemoveImagePulledRecordAndSetKubeletConfig into a single
BeforeEach with conditional config update logic.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/137629#discussion_r2976613556

#### Special notes for your reviewer:

The `tempRemoveImagePulledRecordAndSetKubeletConfig` function uses `withStoppedKubelet` to perform both the file rename and config write while the kubelet is stopped, then starts it once. When the `updateFunction` parameter is `nil`, it falls back to the original behavior of only removing/restoring the pulled record file.

The explicit `AfterEach` (instead of `DeferCleanup`) is needed because Ginkgo runs `AfterEach` callbacks in the first cleanup pass (ordered by descending nesting level), while `DeferCleanup` runs in a second pass. Using `DeferCleanup` here would restore the inner config *after* the outer `tempSetCurrentKubeletConfig`'s `AfterEach` had already restored its config, clobbering the restoration.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/triage accepted
/sig node