### PR TITLE
[kubelet] migrate to NewFileStoreWithLogger for contextual logging

### DIFF
--- a/pkg/kubelet/certificate/bootstrap/bootstrap.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap.go
@@ -66,7 +66,7 @@ func LoadClientConfig(logger klog.Logger, kubeconfigPath, bootstrapPath, certDir
 		return clientConfig, restclient.CopyConfig(clientConfig), nil
 	}
 
-	store, err := certificate.NewFileStore("kubelet-client", certDir, certDir, "", "")
+	store, err := certificate.NewFileStoreWithLogger(logger, "kubelet-client", certDir, certDir, "", "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to build bootstrap cert store")
 	}
@@ -130,7 +130,7 @@ func LoadClientCert(ctx context.Context, kubeconfigPath, bootstrapPath, certDir 
 		return fmt.Errorf("unable to create certificates signing request client: %v", err)
 	}
 
-	store, err := certificate.NewFileStore("kubelet-client", certDir, certDir, "", "")
+	store, err := certificate.NewFileStoreWithLogger(logger, "kubelet-client", certDir, certDir, "", "")
 	if err != nil {
 		return fmt.Errorf("unable to build bootstrap cert store")
 	}

--- a/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
@@ -24,6 +24,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/klog/v2"
+
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
 
@@ -195,7 +197,7 @@ users:
 		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
 	}
 
-	store, err := certificate.NewFileStore("kubelet-client", dir, dir, "", "")
+	store, err := certificate.NewFileStoreWithLogger(klog.Background(), "kubelet-client", dir, dir, "", "")
 	if err != nil {
 		t.Errorf("unable to build bootstrap cert store")
 	}

--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -79,7 +79,8 @@ func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg 
 			return kubeClient, nil
 		}
 	}
-	certificateStore, err := certificate.NewFileStore(
+	certificateStore, err := certificate.NewFileStoreWithLogger(
+		klog.Background(),
 		"kubelet-server",
 		certDirectory,
 		certDirectory,
@@ -206,7 +207,8 @@ func NewKubeletClientCertificateManager(
 	clientsetFn certificate.ClientsetFunc,
 ) (certificate.Manager, error) {
 
-	certificateStore, err := certificate.NewFileStore(
+	certificateStore, err := certificate.NewFileStoreWithLogger(
+		klog.Background(),
 		"kubelet-client",
 		certDirectory,
 		certDirectory,


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
kubelet: Use certificate.NewFileStoreWithLogger in certificate components

Migrates `certificate.NewFileStore` to `certificate.NewFileStoreWithLogger` to support contextual logging in the kubelet certificate managers and bootstrap processes.

This is part of the broader effort to enable contextual logging across all Kubernetes components, as tracked in add and use alternative APIs which support contextual logging #126379.

**Which issue(s) this PR fixes:**
Contributes to #126379

**Special notes for your reviewer:**
/wg structured-logging
/sig node

**Does this PR introduce a user-facing change?:**
```release-note
NONE
```