### PR TITLE
client-go: use RunWithContext in informers for contextual logging

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamiclister"
@@ -105,7 +106,7 @@ func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
 			informer := informer.Informer()
 			go func() {
 				defer f.wg.Done()
-				informer.Run(stopCh)
+				informer.RunWithContext(wait.ContextForChannel(stopCh))
 			}()
 			f.startedInformers[informerType] = true
 		}

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
@@ -57,7 +57,7 @@ func TestMutationDetector(t *testing.T) {
 		},
 	}
 	informer.cacheMutationDetector = detector
-	go informer.Run(stopCh)
+	go informer.RunWithContext(wait.ContextForChannel(stopCh))
 
 	fakeWatch.Add(pod)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
client-go: Use `RunWithContext` in informers

This change updates dynamic informers and cache tests to use the new context-aware `RunWithContext` function instead of the legacy `Run` method. 

The following components are updated:
* `dynamicinformer` factory start routine.
* `mutation_detector_test` informer routines.

This is part of the broader effort to enable contextual logging across all Kubernetes components, as tracked in add and use alternative APIs which support contextual logging #126379.

**Which issue(s) this PR fixes:**
Contributes to #126379

**Special notes for your reviewer:**
/wg structured-logging
/sig api-machinery

**Does this PR introduce a user-facing change?:**
```release-note
NONE
```