### PR TITLE
fix PodGroup protection test flake by waiting for pod watch before delete

### DIFF
--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -386,6 +386,17 @@ func TestPodGroupProtectionController(t *testing.T) {
 			go ctrl.Run(ctx, 1)
 
 			if test.podToDelete != "" {
+				if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+					for _, action := range client.Actions() {
+						if action.GetVerb() == "watch" && action.GetResource().Resource == "pods" {
+							return true, nil
+						}
+					}
+					return false, nil
+				}); err != nil {
+					t.Fatalf("timed out waiting for pod informer watch to start: %v", err)
+				}
+
 				if err := client.CoreV1().Pods(defaultNS).Delete(ctx, test.podToDelete, metav1.DeleteOptions{}); err != nil {
 					t.Fatalf("deleting pod: %v", err)
 				}

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -385,7 +385,7 @@ func TestPodGroupProtectionController(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 			go ctrl.Run(ctx, 1)
 
-			// Create a dummy pod to "warm up" the watch pipe.
+			// In order to reduce test flakiness, make sure that the pod-to-delete is visible in the client set. Create a dummy pod to "warm up" the watch pipe.
 			// Since it's created after LIST (WaitForCacheSync), the informer must see it via WATCH.
 			syncPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "sync-pod", Namespace: defaultNS}}
 			_, err = client.CoreV1().Pods(defaultNS).Create(ctx, syncPod, metav1.CreateOptions{})

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -385,18 +385,23 @@ func TestPodGroupProtectionController(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 			go ctrl.Run(ctx, 1)
 
-			if test.podToDelete != "" {
-				if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-					for _, action := range client.Actions() {
-						if action.GetVerb() == "watch" && action.GetResource().Resource == "pods" {
-							return true, nil
-						}
-					}
-					return false, nil
-				}); err != nil {
-					t.Fatalf("timed out waiting for pod informer watch to start: %v", err)
-				}
+			// Create a dummy pod to "warm up" the watch pipe.
+			// Since it's created after LIST (WaitForCacheSync), the informer must see it via WATCH.
+			syncPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "sync-pod", Namespace: defaultNS}}
+			_, err = client.CoreV1().Pods(defaultNS).Create(ctx, syncPod, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("creating sync pod: %v", err)
+			}
 
+			err = wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				_, err = podInformer.Lister().Pods(defaultNS).Get(syncPod.Name)
+				return err == nil, nil
+			})
+			if err != nil {
+				t.Fatalf("timed out waiting for informer to see the sync pod: %v", err)
+			}
+
+			if test.podToDelete != "" {
 				if err := client.CoreV1().Pods(defaultNS).Delete(ctx, test.podToDelete, metav1.DeleteOptions{}); err != nil {
 					t.Fatalf("deleting pod: %v", err)
 				}


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit/2036633744260993024

#### Which issue(s) this PR is related to:
Fixes #138015

#### Special notes for your reviewer:

Local test with this patch.
```
((myenv3.12) ) pacoxu@PacodeMacBook-Pro kubernetes % go test -race -c ./pkg/controller/scheduling/podgroupprotection

((myenv3.12) ) pacoxu@PacodeMacBook-Pro kubernetes % 
((myenv3.12) ) pacoxu@PacodeMacBook-Pro kubernetes % /Users/pacoxu/git/gopath/bin/stress -p 4 ./podgroupprotection.test -test.run TestPodGroupProtectionController

5s: 12 runs so far, 0 failures, 4 active
10s: 24 runs so far, 0 failures, 4 active
15s: 36 runs so far, 0 failures, 4 active
...

10m25s: 1632 runs so far, 0 failures, 4 active
10m30s: 1644 runs so far, 0 failures, 4 active
10m35s: 1656 runs so far, 0 failures, 4 active

```

without the patch
```
10m20s: 1616 runs so far, 0 failures, 4 active

```


#### Does this PR introduce a user-facing change?

```release-note
None
```