### PR TITLE
Fix race conditions and timing issues in preemption tests

### DIFF
--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1634,9 +1634,9 @@ const blockingPermitPluginName = "blocking-permit-plugin"
 
 var _ fwk.PermitPlugin = &blockingPermitPlugin{}
 
-func newBlockingPermitPlugin(_ context.Context, _ runtime.Object, h fwk.Handle) fwk.Plugin {
+func newBlockingPermitPlugin(_ context.Context, _ runtime.Object, h fwk.Handle, podsToBlock map[string]*blockedPod) fwk.Plugin {
 	return &blockingPermitPlugin{
-		podsToBlock: make(map[string]*blockedPod),
+		podsToBlock: podsToBlock,
 	}
 }
 
@@ -1646,8 +1646,8 @@ func (pl *blockingPermitPlugin) Name() string {
 
 func (pl *blockingPermitPlugin) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
 	if p, ok := pl.podsToBlock[pod.Name]; ok {
-		p.blocked <- struct{}{}
 		delete(pl.podsToBlock, pod.Name)
+		p.blocked <- struct{}{}
 		return fwk.NewStatus(fwk.Wait, "waiting"), time.Minute
 	}
 	return nil, 0
@@ -1674,12 +1674,16 @@ func TestPreemptionRespectsWaitingPod(t *testing.T) {
 	preemptor := st.MakePod().Name("preemptor").Priority(highPriority).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1.5", v1.ResourceMemory: "1.5Gi"}).Obj()
 
 	// Register the blocking plugin
-	var plugin *blockingPermitPlugin
+	victimToBlock := &blockedPod{
+		blocked: make(chan struct{}),
+	}
+	podsToBlock := map[string]*blockedPod{
+		victim.Name: victimToBlock,
+	}
+
 	registry := make(frameworkruntime.Registry)
 	err := registry.Register(blockingPermitPluginName, func(ctx context.Context, obj runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
-		pl := newBlockingPermitPlugin(ctx, obj, fh)
-		plugin = pl.(*blockingPermitPlugin)
-		return pl, nil
+		return newBlockingPermitPlugin(ctx, obj, fh, podsToBlock), nil
 	})
 	if err != nil {
 		t.Fatalf("Error registering plugin: %v", err)
@@ -1697,7 +1701,6 @@ func TestPreemptionRespectsWaitingPod(t *testing.T) {
 			},
 		}},
 	})
-
 	testCtx := testutils.InitTestSchedulerWithOptions(t,
 		testutils.InitTestAPIServer(t, "preemption-waiting", nil),
 		0,
@@ -1705,11 +1708,6 @@ func TestPreemptionRespectsWaitingPod(t *testing.T) {
 		scheduler.WithFrameworkOutOfTreeRegistry(registry))
 	testutils.SyncSchedulerInformerFactory(testCtx)
 	go testCtx.Scheduler.Run(testCtx.Ctx)
-
-	victimToBlock := &blockedPod{
-		blocked: make(chan struct{}),
-	}
-	plugin.podsToBlock[victim.Name] = victimToBlock
 
 	cs := testCtx.ClientSet
 
@@ -1822,9 +1820,9 @@ const blockingPreBindPluginName = "blocking-prebind-plugin"
 
 var _ fwk.PreBindPlugin = &blockingPreBindPlugin{}
 
-func newBlockingPreBindPlugin(_ context.Context, _ runtime.Object, h fwk.Handle) (fwk.Plugin, error) {
+func newBlockingPreBindPlugin(_ context.Context, _ runtime.Object, h fwk.Handle, podToChannels map[string]*perPodBlockingPlugin) (fwk.Plugin, error) {
 	return &blockingPreBindPlugin{
-		podToChannels: make(map[string]*perPodBlockingPlugin),
+		podToChannels: podToChannels,
 		handle:        h,
 	}, nil
 }
@@ -1860,7 +1858,8 @@ func TestPreemptionRespectsBindingPod(t *testing.T) {
 	// 1. Create a "blocking" prebind plugin that signals when it's running and waits for a specific close.
 	// 2. Schedule a low-priority pod (victim) that hits this plugin.
 	// 3. While victim is blocked in PreBind, add a small node and schedule a high-priority pod (preemptor) that fits only on a bigger node.
-	// 4. Verify that:
+	// 4. Wait for preemptor to be scheduled.
+	// 5. Verify that:
 	//		- preemptor takes place on the bigger node
 	//		- victim is NOT deleted, it's rescheduled on to a smaller node
 
@@ -1875,14 +1874,23 @@ func TestPreemptionRespectsBindingPod(t *testing.T) {
 	preemptor := st.MakePod().Name("preemptor").Priority(highPriority).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1.5", v1.ResourceMemory: "1.5Gi"}).Obj()
 
 	// Register the blocking plugin.
-	var plugin *blockingPreBindPlugin
+	victimBlockingPlugin := &perPodBlockingPlugin{
+		shouldBlock: true,
+		blocked:     make(chan struct{}),
+		released:    make(chan struct{}),
+	}
+	podToChannels := map[string]*perPodBlockingPlugin{
+		victim.Name: victimBlockingPlugin,
+		preemptor.Name: {
+			shouldBlock: false,
+			blocked:     make(chan struct{}),
+			released:    make(chan struct{}),
+		},
+	}
+
 	registry := make(frameworkruntime.Registry)
 	err := registry.Register(blockingPreBindPluginName, func(ctx context.Context, obj runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
-		pl, err := newBlockingPreBindPlugin(ctx, obj, fh)
-		if err == nil {
-			plugin = pl.(*blockingPreBindPlugin)
-		}
-		return pl, err
+		return newBlockingPreBindPlugin(ctx, obj, fh, podToChannels)
 	})
 	if err != nil {
 		t.Fatalf("Error registering plugin: %v", err)
@@ -1908,18 +1916,6 @@ func TestPreemptionRespectsBindingPod(t *testing.T) {
 		scheduler.WithFrameworkOutOfTreeRegistry(registry))
 	testutils.SyncSchedulerInformerFactory(testCtx)
 	go testCtx.Scheduler.Run(testCtx.Ctx)
-
-	victimBlockingPlugin := &perPodBlockingPlugin{
-		shouldBlock: true,
-		blocked:     make(chan struct{}),
-		released:    make(chan struct{}),
-	}
-	plugin.podToChannels[victim.Name] = victimBlockingPlugin
-	plugin.podToChannels[preemptor.Name] = &perPodBlockingPlugin{
-		shouldBlock: false,
-		blocked:     make(chan struct{}),
-		released:    make(chan struct{}),
-	}
 
 	cs := testCtx.ClientSet
 
@@ -1959,7 +1955,7 @@ func TestPreemptionRespectsBindingPod(t *testing.T) {
 		t.Fatalf("Error creating preemptor: %v", err)
 	}
 
-	// 3. Wait for preemptor to be scheduled (or at least nominated) and Check victim
+	// 4. Wait for victim to be rescheduled.
 	// Preemptor should eventually be scheduled or cause victim preemption.
 	// Since victim is in PreBind (Binding Cycle), Preemptor's preemption logic (PostFilter) should find it.
 	// It should call CancelPod() on the victim's BindingPod, causing it to go to backoff queue.
@@ -1985,23 +1981,40 @@ func TestPreemptionRespectsBindingPod(t *testing.T) {
 		t.Fatalf("Failed waiting for victim validation: %v", err)
 	}
 
+	// 5. Wait for preemptor to be scheduled.
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		p, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(ctx, preemptor.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		// Check if preemptor is scheduled
+		_, cond := podutil.GetPodCondition(&p.Status, v1.PodScheduled)
+		if cond != nil && cond.Status == v1.ConditionTrue {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed waiting for preemptor to be scheduled: %v", err)
+	}
+
 	// 6. Check that preemptor and victim are scheduled on expected nodes: victim on a small node and preemptor on a big node.
 	v, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, victim.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting victim: %v", err)
-	}
-	if v.Spec.NodeName != "small-node" {
-		t.Fatalf("Victim should be scheduled on node2, but was scheduled on %s", v.Spec.NodeName)
 	}
 
 	p, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, preemptor.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting preemptor: %v", err)
 	}
-	if p.Spec.NodeName != "big-node" {
-		t.Fatalf("Preemptor should be scheduled on big-node, but was scheduled on %s", v.Spec.NodeName)
+	// Verify the assignments are correct
+	if v.Spec.NodeName != "small-node" {
+		t.Errorf("victim should be scheduled on small-node, but was scheduled on %s", v.Spec.NodeName)
 	}
-
+	if p.Spec.NodeName != "big-node" {
+		t.Errorf("preemptor should be scheduled on big-node, but was scheduled on %s", p.Spec.NodeName)
+	}
 	// Start a goroutine to release the plugin just in case, ensuring clean teardown.
 	close(victimBlockingPlugin.released)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR added mutex to prevent race conditions in node assignment and fixed timing issues in node assignment for preemption tests

#### Which issue(s) this PR is related to:
Fixes #137320
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
I utilised agent help to root cause the issue and changes with respect to node-assignment polling. Here is the o/p from stress tool with the fix,

```
# stress ./preemption.test -test.run TestPreemptionRespectsBindingPod
5s: 0 runs so far, 0 failures, 8 active
10s: 0 runs so far, 0 failures, 8 active
15s: 0 runs so far, 0 failures, 8 active
20s: 8 runs so far, 0 failures, 8 active
25s: 10 runs so far, 0 failures, 8 active
30s: 15 runs so far, 0 failures, 8 active
35s: 19 runs so far, 0 failures, 8 active
40s: 24 runs so far, 0 failures, 8 active
45s: 28 runs so far, 0 failures, 8 active
50s: 33 runs so far, 0 failures, 8 active
55s: 37 runs so far, 0 failures, 8 active
1m0s: 43 runs so far, 0 failures, 8 active
1m5s: 47 runs so far, 0 failures, 8 active
1m10s: 52 runs so far, 0 failures, 8 active
1m15s: 57 runs so far, 0 failures, 8 active
1m20s: 62 runs so far, 0 failures, 8 active
1m25s: 67 runs so far, 0 failures, 8 active
1m30s: 71 runs so far, 0 failures, 8 active
1m35s: 76 runs so far, 0 failures, 8 active
1m40s: 80 runs so far, 0 failures, 8 active
1m45s: 85 runs so far, 0 failures, 8 active
1m50s: 90 runs so far, 0 failures, 8 active
1m55s: 94 runs so far, 0 failures, 8 active
2m0s: 99 runs so far, 0 failures, 8 active
2m5s: 104 runs so far, 0 failures, 8 active
2m10s: 109 runs so far, 0 failures, 8 active
2m15s: 113 runs so far, 0 failures, 8 active
2m20s: 118 runs so far, 0 failures, 8 active
2m25s: 123 runs so far, 0 failures, 8 active
2m30s: 127 runs so far, 0 failures, 8 active
2m35s: 132 runs so far, 0 failures, 8 active
2m40s: 137 runs so far, 0 failures, 8 active
2m45s: 142 runs so far, 0 failures, 8 active
2m50s: 145 runs so far, 0 failures, 8 active
2m55s: 150 runs so far, 0 failures, 8 active
3m0s: 154 runs so far, 0 failures, 8 active
3m5s: 159 runs so far, 0 failures, 8 active
3m10s: 164 runs so far, 0 failures, 8 active
3m15s: 169 runs so far, 0 failures, 8 active
3m20s: 173 runs so far, 0 failures, 8 active
3m25s: 177 runs so far, 0 failures, 8 active
3m30s: 183 runs so far, 0 failures, 8 active
3m35s: 187 runs so far, 0 failures, 8 active
3m40s: 192 runs so far, 0 failures, 8 active
3m45s: 197 runs so far, 0 failures, 8 active
3m50s: 202 runs so far, 0 failures, 8 active
3m55s: 206 runs so far, 0 failures, 8 active
4m0s: 211 runs so far, 0 failures, 8 active
4m5s: 216 runs so far, 0 failures, 8 active
4m10s: 220 runs so far, 0 failures, 8 active
4m15s: 225 runs so far, 0 failures, 8 active
4m20s: 230 runs so far, 0 failures, 8 active
4m25s: 235 runs so far, 0 failures, 8 active
4m30s: 239 runs so far, 0 failures, 8 active
4m35s: 244 runs so far, 0 failures, 8 active
4m40s: 249 runs so far, 0 failures, 8 active
4m45s: 254 runs so far, 0 failures, 8 active
4m50s: 258 runs so far, 0 failures, 8 active
4m55s: 263 runs so far, 0 failures, 8 active
5m0s: 267 runs so far, 0 failures, 8 active
5m5s: 272 runs so far, 0 failures, 8 active
5m10s: 277 runs so far, 0 failures, 8 active
5m15s: 281 runs so far, 0 failures, 8 active
5m20s: 286 runs so far, 0 failures, 8 active
5m25s: 291 runs so far, 0 failures, 8 active
5m30s: 296 runs so far, 0 failures, 8 active
5m35s: 300 runs so far, 0 failures, 8 active
5m40s: 304 runs so far, 0 failures, 8 active
5m45s: 310 runs so far, 0 failures, 8 active
5m50s: 314 runs so far, 0 failures, 8 active
5m55s: 318 runs so far, 0 failures, 8 active
6m0s: 323 runs so far, 0 failures, 8 active
6m5s: 328 runs so far, 0 failures, 8 active
6m10s: 333 runs so far, 0 failures, 8 active
6m15s: 338 runs so far, 0 failures, 8 active
6m20s: 342 runs so far, 0 failures, 8 active
6m25s: 347 runs so far, 0 failures, 8 active
6m30s: 351 runs so far, 0 failures, 8 active
6m35s: 356 runs so far, 0 failures, 8 active
6m40s: 360 runs so far, 0 failures, 8 active
6m45s: 366 runs so far, 0 failures, 8 active
6m50s: 370 runs so far, 0 failures, 8 active
6m55s: 374 runs so far, 0 failures, 8 active
7m0s: 379 runs so far, 0 failures, 8 active
7m5s: 384 runs so far, 0 failures, 8 active
7m10s: 389 runs so far, 0 failures, 8 active
7m15s: 393 runs so far, 0 failures, 8 active
7m20s: 398 runs so far, 0 failures, 8 active
7m25s: 403 runs so far, 0 failures, 8 active
7m30s: 407 runs so far, 0 failures, 8 active
7m35s: 412 runs so far, 0 failures, 8 active
7m40s: 417 runs so far, 0 failures, 8 active
7m45s: 421 runs so far, 0 failures, 8 active
7m50s: 426 runs so far, 0 failures, 8 active
7m55s: 431 runs so far, 0 failures, 8 active
8m0s: 435 runs so far, 0 failures, 8 active
8m5s: 440 runs so far, 0 failures, 8 active
8m10s: 445 runs so far, 0 failures, 8 active
8m15s: 449 runs so far, 0 failures, 8 active
8m20s: 454 runs so far, 0 failures, 8 active
8m25s: 459 runs so far, 0 failures, 8 active
8m30s: 464 runs so far, 0 failures, 8 active
8m35s: 469 runs so far, 0 failures, 8 active
8m40s: 473 runs so far, 0 failures, 8 active
8m45s: 478 runs so far, 0 failures, 8 active
8m50s: 483 runs so far, 0 failures, 8 active
8m55s: 487 runs so far, 0 failures, 8 active
9m0s: 492 runs so far, 0 failures, 8 active
9m5s: 497 runs so far, 0 failures, 8 active
9m10s: 502 runs so far, 0 failures, 8 active
9m15s: 507 runs so far, 0 failures, 8 active
9m20s: 512 runs so far, 0 failures, 8 active
9m25s: 516 runs so far, 0 failures, 8 active
9m30s: 519 runs so far, 0 failures, 8 active
9m35s: 525 runs so far, 0 failures, 8 active
9m40s: 529 runs so far, 0 failures, 8 active
9m45s: 534 runs so far, 0 failures, 8 active
9m50s: 539 runs so far, 0 failures, 8 active
9m55s: 544 runs so far, 0 failures, 8 active
10m0s: 548 runs so far, 0 failures, 8 active
10m5s: 553 runs so far, 0 failures, 8 active
10m10s: 558 runs so far, 0 failures, 8 active
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
