### PR TITLE
Fix ClusterTrustBundle godoc to prevent truncated API reference

### DIFF
--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -276,7 +276,7 @@ const (
 // +k8s:prerelease-lifecycle-gen:deprecated=1.37
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ClusterTrustBundle is a cluster-scoped container for X.509 trust anchors
+// ClusterTrustBundle is a cluster-scoped container for X509(formerly X.509) trust anchors
 // (root certificates).
 //
 // ClusterTrustBundle objects are considered to be readable by any authenticated


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind documentation
/kind api-change

#### What this PR does / why we need it:

The API reference page for `ClusterTrustBundle` was showing a broken/truncated description:

> ClusterTrustBundle is a cluster-scoped container for X.

This happened because the first sentence in the godoc contained `X.509` (the period after `X` was treated as the end of the sentence by the documentation generator).

This PR changes the first line to use `X509` (without the dot) — which is the common pattern used elsewhere in Kubernetes — so the short description renders correctly.

#### Which issue(s) this PR is related to:

Fixes kubernetes/website#55021

#### Special notes for your reviewer:

Only the godoc comment above `type ClusterTrustBundle` was changed.  
No code behavior is affected.

#### Does this PR introduce a user-facing change?

```release-note
NONE