### PR TITLE
Reset the rest mapper for recent discovery operations in SVM

### DIFF
--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -61,7 +61,10 @@ type ResourceVersionController struct {
 	svmSynced       cache.InformerSynced
 	queue           workqueue.TypedRateLimitingInterface[string]
 	kubeClient      clientset.Interface
-	mapper          meta.RESTMapper
+	mapper          meta.ResettableRESTMapper
+
+	lastResetLock sync.Mutex
+	lastReset     time.Time
 }
 
 func NewResourceVersionController(
@@ -70,7 +73,7 @@ func NewResourceVersionController(
 	discoveryClient discovery.DiscoveryInterface,
 	metadataClient metadata.Interface,
 	svmInformer svminformers.StorageVersionMigrationInformer,
-	mapper meta.RESTMapper,
+	mapper meta.ResettableRESTMapper,
 ) *ResourceVersionController {
 	logger := klog.FromContext(ctx)
 
@@ -215,6 +218,7 @@ func (rv *ResourceVersionController) sync(ctx context.Context, key string) error
 		// our GC cache could be missing a recently created custom resource, so give it some time to catch up
 		// we resync discovery every 30 seconds so twice that should be sufficient
 		if toBeProcessedSVM.CreationTimestamp.Add(time.Minute).After(time.Now()) {
+			rv.resetMapperIfStale()
 			return fmt.Errorf("resource does not exist in our rest mapper, requeuing to attempt again")
 		}
 		return rv.failMigration(ctx, toBeProcessedSVM, "resource does not exist in discovery")
@@ -361,4 +365,13 @@ func (rv *ResourceVersionController) failMigration(ctx context.Context, svm *svm
 		return err
 	}
 	return nil
+}
+
+func (rv *ResourceVersionController) resetMapperIfStale() {
+	rv.lastResetLock.Lock()
+	defer rv.lastResetLock.Unlock()
+	if time.Since(rv.lastReset) > 10*time.Second {
+		rv.mapper.Reset()
+		rv.lastReset = time.Now()
+	}
 }

--- a/pkg/controller/storageversionmigrator/resourceversion_test.go
+++ b/pkg/controller/storageversionmigrator/resourceversion_test.go
@@ -481,6 +481,14 @@ func filterListWatchActions(actions []kubetesting.Action) []kubetesting.Action {
 	return filteredActions
 }
 
+type testRESTMapper struct {
+	meta.RESTMapper
+}
+
+func (m *testRESTMapper) Reset() {
+	meta.MaybeResetRESTMapper(m.RESTMapper)
+}
+
 // newTestRVController creates a new ResourceVersionController for testing.
 func newTestRVController(
 	kubeClient kubernetes.Interface,
@@ -497,7 +505,7 @@ func newTestRVController(
 		metadataClient:  metadataClient,
 		svmListers:      svmInformer.Lister(),
 		svmSynced:       func() bool { return true },
-		mapper:          mapper,
+		mapper:          &testRESTMapper{mapper},
 	}
 	return rvController
 }

--- a/test/integration/storageversionmigrator/util.go
+++ b/test/integration/storageversionmigrator/util.go
@@ -800,9 +800,7 @@ func (svm *svmTest) waitForCRDUpdate(
 	err := wait.PollUntilContextTimeout(
 		ctx,
 		500*time.Millisecond,
-		// CRD discovery and storage-version reporting can lag well beyond 1 minute
-		// on contended CI nodes while the apiextensions controllers converge.
-		2*time.Minute,
+		time.Second*60,
 		true,
 		func(ctx context.Context) (bool, error) {
 			apiGroups, _, err := svm.discoveryClient.ServerGroupsAndResources()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Reset the rest mapper for newly created resources that we cannot find in discovery.  Reverts https://github.com/kubernetes/kubernetes/pull/137812 in favor of fix.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
