### PR TITLE
Fix race condition in updating the PodStatus cache

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -221,6 +221,8 @@ type Pod struct {
 	// Sandboxes are sorted by creation time, newest -> oldest.
 	// TODO: use the runtimeApi.PodSandbox type directly.
 	Sandboxes []*Container
+	// Timestamp is the time that this Pod object was read from the runtime.
+	Timestamp time.Time
 }
 
 // PodPair contains both runtime#Pod and api#Pod

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2343,6 +2343,7 @@ func (kl *Kubelet) SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatu
 				ID:        pod.UID,
 				Name:      pod.Name,
 				Namespace: pod.Namespace,
+				Timestamp: kl.clock.Now(),
 			}
 		} else {
 			return fmt.Errorf("unable to get pod prior to final pod termination: %w", err)

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -97,10 +97,6 @@ func (f *fakePodPullingTimeRecorder) RecordImageFinishedPulling(podUID types.UID
 
 func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.RuntimeService, imageService internalapi.ImageManagerService, machineInfo *cadvisorapi.MachineInfo, osInterface kubecontainer.OSInterface, runtimeHelper kubecontainer.RuntimeHelper, tracer trace.Tracer) (*kubeGenericRuntimeManager, error) {
 	recorder := &record.FakeRecorder{}
-	logManager, err := logs.NewContainerLogManager(runtimeService, osInterface, "1", 2, 10, metav1.Duration{Duration: 10 * time.Second})
-	if err != nil {
-		return nil, err
-	}
 	kubeRuntimeManager := &kubeGenericRuntimeManager{
 		recorder:               recorder,
 		cpuCFSQuota:            false,
@@ -116,7 +112,7 @@ func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.R
 		seccompProfileRoot:     fakeSeccompProfileRoot,
 		internalLifecycle:      cm.NewFakeInternalContainerLifecycle(),
 		logReduction:           logreduction.NewLogReduction(identicalErrorDelay),
-		logManager:             logManager,
+		logManager:             logs.NewStubContainerLogManager(),
 		memoryThrottlingFactor: 0.9,
 		podLogsDirectory:       fakePodLogsDirectory,
 		actuatedState:          state.NewStateMemory(nil),

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -36,12 +36,6 @@ import (
 	"k8s.io/kubernetes/pkg/security/apparmor"
 )
 
-type podsByID []*kubecontainer.Pod
-
-func (b podsByID) Len() int           { return len(b) }
-func (b podsByID) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
-func (b podsByID) Less(i, j int) bool { return b[i].ID < b[j].ID }
-
 type containerByCreatedThenID []*runtimeapi.Container
 
 func (b containerByCreatedThenID) Len() int      { return len(b) }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -2087,7 +2087,7 @@ func TestUpdatePodSandboxResources(t *testing.T) {
 	}
 
 	// Create fake sandbox and container
-	fakeSandbox, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
+	fakeSandbox, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 	assert.Len(t, fakeContainers, 1)
 
 	runtimePod, err := m.GetPod(tCtx, pod.UID)

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -46,6 +46,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/logs"
 )
 
 // TestRemoveContainer tests removing the container and its corresponding container logs.
@@ -53,6 +54,11 @@ func TestRemoveContainer(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
+	// Swap in real ContainerLogManager for the stub.
+	logManager, err := logs.NewContainerLogManager(m.runtimeService, m.osInterface, "1", 2, 10, metav1.Duration{Duration: 10 * time.Second})
+	require.NoError(t, err)
+	m.logManager = logManager
+
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",
@@ -71,7 +77,7 @@ func TestRemoveContainer(t *testing.T) {
 	}
 
 	// Create fake sandbox and container
-	_, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
+	_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 	assert.Len(t, fakeContainers, 1)
 
 	containerID := fakeContainers[0].Id
@@ -108,6 +114,11 @@ func TestRemoveContainer_keepLogs(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
+	// Swap in real ContainerLogManager for the stub.
+	logManager, err := logs.NewContainerLogManager(m.runtimeService, m.osInterface, "1", 2, 10, metav1.Duration{Duration: 10 * time.Second})
+	require.NoError(t, err)
+	m.logManager = logManager
+
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",
@@ -126,7 +137,7 @@ func TestRemoveContainer_keepLogs(t *testing.T) {
 	}
 
 	// Create fake sandbox and container
-	_, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
+	_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 	assert.Len(t, fakeContainers, 1)
 
 	containerID := fakeContainers[0].Id
@@ -683,7 +694,7 @@ func testLifeCycleHook(t *testing.T, testPod *v1.Pod, testContainer *v1.Containe
 	t.Run("PostStart-CmdExe", func(t *testing.T) {
 		tCtx := ktesting.Init(t)
 		// Fake all the things you need before trying to create a container
-		fakeSandBox, _ := makeAndSetFakePod(t, m, fakeRuntime, testPod)
+		fakeSandBox, _ := makeAndSetFakePod(tCtx, m, fakeRuntime, testPod)
 		fakeSandBoxConfig, _ := m.generatePodSandboxConfig(tCtx, testPod, 0)
 		testContainer.Lifecycle = cmdPostStart
 		fakePodStatus := &kubecontainer.PodStatus{
@@ -1088,7 +1099,7 @@ func TestUpdateContainerResources(t *testing.T) {
 	}
 
 	// Create fake sandbox and container
-	_, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
+	_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 	assert.Len(t, fakeContainers, 1)
 
 	runtimePod, err := m.GetPod(tCtx, pod.UID)

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
@@ -164,8 +164,8 @@ func TestSandboxGC(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			podStateProvider.removed = make(map[types.UID]struct{})
 			podStateProvider.terminated = make(map[types.UID]struct{})
-			fakeSandboxes := makeFakePodSandboxes(t, m, test.sandboxes)
-			fakeContainers := makeFakeContainers(t, m, test.containers)
+			fakeSandboxes := makeFakePodSandboxes(tCtx, m, test.sandboxes)
+			fakeContainers := makeFakeContainers(tCtx, m, test.containers)
 			for _, s := range test.sandboxes {
 				if !s.running && s.pod.Name == "deleted" {
 					podStateProvider.removed[s.pod.UID] = struct{}{}
@@ -393,7 +393,7 @@ func TestContainerGC(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			podStateProvider.removed = make(map[types.UID]struct{})
 			podStateProvider.terminated = make(map[types.UID]struct{})
-			fakeContainers := makeFakeContainers(t, m, test.containers)
+			fakeContainers := makeFakeContainers(tCtx, m, test.containers)
 			for _, s := range test.containers {
 				if s.pod.Name == "deleted" {
 					podStateProvider.removed[s.pod.UID] = struct{}{}
@@ -471,7 +471,7 @@ func TestUnknownStateContainerGC(t *testing.T) {
 	// podStateProvider := m.containerGC.podStateProvider.(*fakePodStateProvider)
 	defaultGCPolicy := kubecontainer.GCPolicy{MinAge: time.Hour, MaxPerPodContainer: 0, MaxContainers: 0}
 
-	fakeContainers := makeFakeContainers(t, m, []containerTemplate{
+	fakeContainers := makeFakeContainers(tCtx, m, []containerTemplate{
 		makeGCContainer("foo", "bar", 0, 0, runtimeapi.ContainerState_CONTAINER_UNKNOWN),
 	})
 	fakeRuntime.SetFakeContainers(fakeContainers)

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -277,7 +277,8 @@ func TestImageStatsWithError(t *testing.T) {
 }
 
 func TestPullWithSecrets(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 	// auth value is equivalent to: "username":"passed-user","password":"passed-password"
 	dockerCfg := map[string]map[string]string{"index.docker.io/v1/": {"email": "passed-email", "auth": "cGFzc2VkLXVzZXI6cGFzc2VkLXBhc3N3b3Jk"}}
 	dockercfgContent, err := json.Marshal(dockerCfg)
@@ -390,7 +391,8 @@ func TestPullWithSecrets(t *testing.T) {
 }
 
 func TestPullWithSecretsWithError(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 
 	dockerCfg := map[string]map[string]map[string]string{
 		"auths": {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -481,6 +481,7 @@ func (m *kubeGenericRuntimeManager) GetPods(ctx context.Context, all bool) ([]*k
 func (m *kubeGenericRuntimeManager) getPods(ctx context.Context, opts listOptions) (map[kubetypes.UID]*kubecontainer.Pod, error) {
 	logger := klog.FromContext(ctx)
 	pods := make(map[kubetypes.UID]*kubecontainer.Pod)
+	timestamp := time.Now()
 	sandboxes, err := m.getSandboxes(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -499,6 +500,7 @@ func (m *kubeGenericRuntimeManager) getPods(ctx context.Context, opts listOption
 				ID:        podUID,
 				Name:      s.Metadata.Name,
 				Namespace: s.Metadata.Namespace,
+				Timestamp: timestamp,
 			}
 		}
 		p := pods[podUID]
@@ -536,6 +538,7 @@ func (m *kubeGenericRuntimeManager) getPods(ctx context.Context, opts listOption
 				ID:        labelledInfo.PodUID,
 				Name:      labelledInfo.PodName,
 				Namespace: labelledInfo.PodNamespace,
+				Timestamp: timestamp,
 			}
 			pods[labelledInfo.PodUID] = pod
 		}
@@ -2019,7 +2022,12 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, pod *kubec
 	sandboxStatuses := []*runtimeapi.PodSandboxStatus{}
 	containerStatuses := []*kubecontainer.Status{}
 	activeContainerStatuses := []*kubecontainer.Status{}
-	timestamp := time.Now()
+
+	// Since we rely on the sandbox & container IDs in the kubecontainer.Pod, we must be
+	// conservative and use it's timestamp as the status timestamp. Otherwise, we risk reporting a
+	// newer PodStatus timestamp that is missing Sandboxes or Containers that should have been
+	// present at that time.
+	timestamp := pod.Timestamp
 
 	podIPs := []string{}
 	var activePodSandboxID string

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -70,11 +70,11 @@ var (
 	containerRestartPolicyAlways       = v1.ContainerRestartPolicyAlways
 )
 
-func createTestRuntimeManager(ctx context.Context) (*apitest.FakeRuntimeService, *apitest.FakeImageService, *kubeGenericRuntimeManager, error) {
-	return createTestRuntimeManagerWithErrors(ctx, nil)
+func createTestRuntimeManager(tCtx ktesting.TContext) (*apitest.FakeRuntimeService, *apitest.FakeImageService, *kubeGenericRuntimeManager, error) {
+	return createTestRuntimeManagerWithErrors(tCtx, nil)
 }
 
-func createTestRuntimeManagerWithErrors(ctx context.Context, errors map[string][]error) (*apitest.FakeRuntimeService, *apitest.FakeImageService, *kubeGenericRuntimeManager, error) {
+func createTestRuntimeManagerWithErrors(tCtx ktesting.TContext, errors map[string][]error) (*apitest.FakeRuntimeService, *apitest.FakeImageService, *kubeGenericRuntimeManager, error) {
 	fakeRuntimeService := apitest.NewFakeRuntimeService()
 	if errors != nil {
 		fakeRuntimeService.Errors = errors
@@ -88,7 +88,7 @@ func createTestRuntimeManagerWithErrors(ctx context.Context, errors map[string][
 		MemoryCapacity: uint64(memoryCapacityQuantity.Value()),
 	}
 	osInterface := &containertest.FakeOS{}
-	manager, err := newFakeKubeRuntimeManager(ctx, fakeRuntimeService, fakeImageService, machineInfo, osInterface, &containertest.FakeRuntimeHelper{}, noopoteltrace.NewTracerProvider().Tracer(""))
+	manager, err := newFakeKubeRuntimeManager(tCtx, fakeRuntimeService, fakeImageService, machineInfo, osInterface, &containertest.FakeRuntimeHelper{}, noopoteltrace.NewTracerProvider().Tracer(""))
 	return fakeRuntimeService, fakeImageService, manager, err
 }
 
@@ -114,10 +114,10 @@ type containerTemplate struct {
 
 // makeAndSetFakePod is a helper function to create and set one fake sandbox for a pod and
 // one fake container for each of its container.
-func makeAndSetFakePod(t *testing.T, m *kubeGenericRuntimeManager, fakeRuntime *apitest.FakeRuntimeService,
+func makeAndSetFakePod(tCtx ktesting.TContext, m *kubeGenericRuntimeManager, fakeRuntime *apitest.FakeRuntimeService,
 	pod *v1.Pod,
 ) (*apitest.FakePodSandbox, []*apitest.FakeContainer) {
-	sandbox := makeFakePodSandbox(t, m, sandboxTemplate{
+	sandbox := makeFakePodSandbox(tCtx, m, sandboxTemplate{
 		pod:       pod,
 		createdAt: fakeCreatedAt,
 		state:     runtimeapi.PodSandboxState_SANDBOX_READY,
@@ -133,7 +133,7 @@ func makeAndSetFakePod(t *testing.T, m *kubeGenericRuntimeManager, fakeRuntime *
 		}
 	}
 	podutil.VisitContainers(&pod.Spec, podutil.AllFeatureEnabledContainers(), func(c *v1.Container, containerType podutil.ContainerType) bool {
-		containers = append(containers, makeFakeContainer(t, m, newTemplate(c)))
+		containers = append(containers, makeFakeContainer(tCtx, m, newTemplate(c)))
 		return true
 	})
 
@@ -143,8 +143,8 @@ func makeAndSetFakePod(t *testing.T, m *kubeGenericRuntimeManager, fakeRuntime *
 }
 
 // makeFakePodSandbox creates a fake pod sandbox based on a sandbox template.
-func makeFakePodSandbox(t *testing.T, m *kubeGenericRuntimeManager, template sandboxTemplate) *apitest.FakePodSandbox {
-	tCtx := ktesting.Init(t)
+func makeFakePodSandbox(tCtx ktesting.TContext, m *kubeGenericRuntimeManager, template sandboxTemplate) *apitest.FakePodSandbox {
+	t := tCtx.TB()
 	config, err := m.generatePodSandboxConfig(tCtx, template.pod, template.attempt)
 	assert.NoError(t, err, "generatePodSandboxConfig for sandbox template %+v", template)
 
@@ -177,17 +177,17 @@ func makeFakePodSandbox(t *testing.T, m *kubeGenericRuntimeManager, template san
 
 // makeFakePodSandboxes creates a group of fake pod sandboxes based on the sandbox templates.
 // The function guarantees the order of the fake pod sandboxes is the same with the templates.
-func makeFakePodSandboxes(t *testing.T, m *kubeGenericRuntimeManager, templates []sandboxTemplate) []*apitest.FakePodSandbox {
+func makeFakePodSandboxes(tCtx ktesting.TContext, m *kubeGenericRuntimeManager, templates []sandboxTemplate) []*apitest.FakePodSandbox {
 	var fakePodSandboxes []*apitest.FakePodSandbox
 	for _, template := range templates {
-		fakePodSandboxes = append(fakePodSandboxes, makeFakePodSandbox(t, m, template))
+		fakePodSandboxes = append(fakePodSandboxes, makeFakePodSandbox(tCtx, m, template))
 	}
 	return fakePodSandboxes
 }
 
 // makeFakeContainer creates a fake container based on a container template.
-func makeFakeContainer(t *testing.T, m *kubeGenericRuntimeManager, template containerTemplate) *apitest.FakeContainer {
-	tCtx := ktesting.Init(t)
+func makeFakeContainer(tCtx ktesting.TContext, m *kubeGenericRuntimeManager, template containerTemplate) *apitest.FakeContainer {
+	t := tCtx.TB()
 	sandboxConfig, err := m.generatePodSandboxConfig(tCtx, template.pod, template.sandboxAttempt)
 	assert.NoError(t, err, "generatePodSandboxConfig for container template %+v", template)
 
@@ -215,10 +215,10 @@ func makeFakeContainer(t *testing.T, m *kubeGenericRuntimeManager, template cont
 
 // makeFakeContainers creates a group of fake containers based on the container templates.
 // The function guarantees the order of the fake containers is the same with the templates.
-func makeFakeContainers(t *testing.T, m *kubeGenericRuntimeManager, templates []containerTemplate) []*apitest.FakeContainer {
+func makeFakeContainers(tCtx ktesting.TContext, m *kubeGenericRuntimeManager, templates []containerTemplate) []*apitest.FakeContainer {
 	var fakeContainers []*apitest.FakeContainer
 	for _, template := range templates {
-		fakeContainers = append(fakeContainers, makeFakeContainer(t, m, template))
+		fakeContainers = append(fakeContainers, makeFakeContainer(tCtx, m, template))
 	}
 	return fakeContainers
 }
@@ -243,19 +243,6 @@ func makeTestPod(podName, podNamespace, podUID string, containers []v1.Container
 			Containers: containers,
 		},
 	}
-}
-
-// verifyPods returns true if the two pod slices are equal.
-func verifyPods(a, b []*kubecontainer.Pod) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	// Sort the pods by UID.
-	sort.Sort(podsByID(a))
-	sort.Sort(podsByID(b))
-
-	return reflect.DeepEqual(a, b)
 }
 
 func verifyFakeContainerList(fakeRuntime *apitest.FakeRuntimeService, expected sets.Set[string]) (sets.Set[string], bool) {
@@ -348,7 +335,7 @@ func TestGetPodStatus(t *testing.T) {
 	}
 
 	// Set fake sandbox and faked containers to fakeRuntime.
-	makeAndSetFakePod(t, m, fakeRuntime, pod)
+	makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 
 	runtimePod, err := m.GetPod(tCtx, pod.UID)
 	require.NoError(t, err)
@@ -389,7 +376,7 @@ func TestStopContainerWithNotFoundError(t *testing.T) {
 	}
 
 	// Set fake sandbox and faked containers to fakeRuntime.
-	makeAndSetFakePod(t, m, fakeRuntime, pod)
+	makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 	fakeRuntime.InjectError("StopContainer", status.Error(codes.NotFound, "No such container"))
 	runtimePod, err := m.GetPod(tCtx, pod.UID)
 	require.NoError(t, err)
@@ -430,7 +417,7 @@ func TestGetPodStatusWithNotFoundError(t *testing.T) {
 	}
 
 	// Set fake sandbox and faked containers to fakeRuntime.
-	makeAndSetFakePod(t, m, fakeRuntime, pod)
+	makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 	fakeRuntime.InjectError("ContainerStatus", status.Error(codes.NotFound, "No such container"))
 	runtimePod, err := m.GetPod(tCtx, pod.UID)
 	require.NoError(t, err)
@@ -444,6 +431,11 @@ func TestGetPodStatusWithNotFoundError(t *testing.T) {
 
 func TestGetPods(t *testing.T) {
 	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("", testGetPods)
+}
+
+func testGetPods(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
@@ -468,7 +460,7 @@ func TestGetPods(t *testing.T) {
 	}
 
 	// Set fake sandbox and fake containers to fakeRuntime.
-	fakeSandbox, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
+	fakeSandbox, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 
 	// Convert the fakeContainers to kubecontainer.Container
 	containers := make([]*kubecontainer.Container, len(fakeContainers))
@@ -511,21 +503,18 @@ func TestGetPods(t *testing.T) {
 		CreatedAt:  uint64(fakeSandbox.CreatedAt),
 		Containers: []*kubecontainer.Container{containers[0], containers[1]},
 		Sandboxes:  []*kubecontainer.Container{sandbox},
+		Timestamp:  time.Now(),
 	}
 	expected := []*kubecontainer.Pod{expectedPod}
 
 	actual, err := m.GetPods(tCtx, false)
 	require.NoError(t, err)
 
-	if !verifyPods(expected, actual) {
-		t.Errorf("expected %#v, got %#v", expected, actual)
-	}
+	assert.ElementsMatch(t, expected, actual)
 
 	actualPod, err := m.GetPod(tCtx, pod.UID)
 	require.NoError(t, err)
-	if !verifyPods([]*kubecontainer.Pod{expectedPod}, []*kubecontainer.Pod{actualPod}) {
-		t.Errorf("expected %#v, got %#v", expectedPod, actualPod)
-	}
+	assert.Equal(t, expectedPod, actualPod)
 
 	_, err = m.GetPod(tCtx, "non-existent-uid")
 	assert.ErrorIs(t, err, kubecontainer.ErrPodNotFound)
@@ -542,7 +531,7 @@ func TestGetPodsSorted(t *testing.T) {
 	fakeSandboxes := []*apitest.FakePodSandbox{}
 	for i, createdAt := range createdTimestamps {
 		pod.UID = types.UID(fmt.Sprint(i))
-		fakeSandboxes = append(fakeSandboxes, makeFakePodSandbox(t, m, sandboxTemplate{
+		fakeSandboxes = append(fakeSandboxes, makeFakePodSandbox(tCtx, m, sandboxTemplate{
 			pod:       pod,
 			createdAt: int64(createdAt),
 			state:     runtimeapi.PodSandboxState_SANDBOX_READY,
@@ -595,7 +584,7 @@ func TestKillPod(t *testing.T) {
 	}
 
 	// Set fake sandbox and fake containers to fakeRuntime.
-	fakeSandbox, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
+	fakeSandbox, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 
 	// Convert the fakeContainers to kubecontainer.Container
 	containers := make([]*kubecontainer.Container, len(fakeContainers))
@@ -768,7 +757,7 @@ func TestPruneInitContainers(t *testing.T) {
 		{pod: pod, container: &init2, attempt: 0, createdAt: 0, state: runtimeapi.ContainerState_CONTAINER_EXITED},
 		{pod: pod, container: &init1, attempt: 0, createdAt: 0, state: runtimeapi.ContainerState_CONTAINER_EXITED},
 	}
-	fakes := makeFakeContainers(t, m, templates)
+	fakes := makeFakeContainers(tCtx, m, templates)
 	fakeRuntime.SetFakeContainers(fakes)
 	runtimePod, err := m.GetPod(tCtx, pod.UID)
 	require.NoError(t, err)
@@ -2726,6 +2715,7 @@ func TestComputePodActionsWithInitAndEphemeralContainers(t *testing.T) {
 }
 
 func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	// Make sure existing test cases pass with feature enabled
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ContainerRestartRules, true)
 	TestComputePodActions(t)
@@ -2736,8 +2726,7 @@ func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
 		containerRestartPolicyOnFailure = v1.ContainerRestartPolicyOnFailure
 		containerRestartPolicyNever     = v1.ContainerRestartPolicyNever
 	)
-	ctx := context.Background()
-	_, _, m, err := createTestRuntimeManager(ctx)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
 	// Creating a pair reference pod and status for the test cases to refer
@@ -3878,7 +3867,7 @@ func TestUpdatePodContainerResources(t *testing.T) {
 	res350m350Mi := v1.ResourceList{v1.ResourceCPU: cpu350m, v1.ResourceMemory: mem350M}
 
 	pod, _ := makeBasePodAndStatusWithRestartableInitContainers()
-	makeAndSetFakePod(t, m, fakeRuntime, pod)
+	makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
 
 	for dsc, tc := range map[string]struct {
 		resourceName            v1.ResourceName

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -425,9 +425,9 @@ func (g *GenericPLEG) relistPod(podUID types.UID) {
 
 	g.logger.V(5).Info("GenericPLEG: Relisting Pod", "podUID", podUID)
 
-	timestamp := g.clock.Now()
+	startTime := g.clock.Now()
 	defer func() {
-		metrics.PLEGPodRelistDuration.Observe(metrics.SinceInSeconds(timestamp))
+		metrics.PLEGPodRelistDuration.Observe(metrics.SinceInSeconds(startTime))
 	}()
 	pod, err := g.runtime.GetPod(ctx, podUID)
 	if err != nil {
@@ -448,7 +448,7 @@ func (g *GenericPLEG) relistPod(podUID types.UID) {
 
 	// Since we're not setting the global timestamp, we need to mark this pod as observed in case it
 	// wasn't modified.
-	g.cache.SetObservedTime(podUID, timestamp)
+	g.cache.SetObservedTime(podUID, pod.Timestamp)
 }
 
 func getContainersFromPods(pods ...*kubecontainer.Pod) []*kubecontainer.Container {
@@ -525,8 +525,7 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 		return nil, true, nil
 	}
 
-	timestamp := g.clock.Now()
-
+	timestamp := pod.Timestamp
 	status, err := g.runtime.GetPodStatus(ctx, pod)
 	if err != nil {
 		// nolint:logcheck // Not using the result of klog.V inside the

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -871,6 +871,7 @@ func TestWorkerLoop(t *testing.T) {
 		mctx := context.Background()
 		call = runtimeMock.EXPECT().GetPod(mctx, pod1.ID).RunAndReturn(func(ctx context.Context, uid types.UID) (*kubecontainer.Pod, error) {
 			assert.Equal(t, pod1.ID, uid)
+			pod1.Timestamp = time.Now()
 			return pod1, nil
 		}).Once()
 		call = runtimeMock.EXPECT().GetPodStatus(mctx, pod1).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
@@ -893,6 +894,8 @@ func TestWorkerLoop(t *testing.T) {
 		time.Sleep(2 * time.Second)
 
 		call = runtimeMock.EXPECT().GetPods(mctx, true).RunAndReturn(func(_ context.Context, _ bool) ([]*kubecontainer.Pod, error) {
+			pod1.Timestamp = time.Now()
+			pod2.Timestamp = time.Now()
 			return []*kubecontainer.Pod{pod1, pod2}, nil
 		}).NotBefore(call).Once()
 		call = runtimeMock.EXPECT().GetPodStatus(mctx, pod2).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
@@ -922,6 +925,8 @@ func TestWorkerLoop(t *testing.T) {
 		time.Sleep(2 * time.Second)
 
 		call = runtimeMock.EXPECT().GetPods(mctx, true).RunAndReturn(func(_ context.Context, _ bool) ([]*kubecontainer.Pod, error) {
+			pod1.Timestamp = time.Now()
+			pod2.Timestamp = time.Now()
 			return []*kubecontainer.Pod{pod1, pod2}, nil
 		}).NotBefore(call).Once()
 		runtimeMock.EXPECT().GetPodStatus(mctx, pod1).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

(previously) A PLEG relist operation that updates the cached pod status does the following:

1. List the pod sandboxes
2. Grab a timestamp
3. For each sandbox, get the sandbox status
4. For each container, get the container status
5. Update the cache, setting the timestamp to the timestamp collected in step 2

There is a race condition, where a new sandbox is added between steps 1 & 2. Before https://github.com/kubernetes/kubernetes/pull/137471, the race window was extremely small, but with that change the race window is larger.

This PR gets the timestamp before the initial sandbox listing. The timestamp is plumbed through the `kubecontainer.Pod` object, so that any code interacting with the Pod can know it's freshness.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/137724

#### Special notes for your reviewer:

There are a bunch of seemingly unrelated test changes, but these are related to leaking go-routines that cross the SyncTest bubble. Most notably, doing `ktesting.Init(t)` within the bubble causes problems for some reason. Also, the ContainerLogManager leaks it's go-routine, and needed to be swapped for a stub.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
