### PR TITLE
Content-Type added to API Server logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -70,9 +70,10 @@ type respLogger struct {
 
 	captureErrorOutput bool
 
-	req       *http.Request
-	userAgent string
-	w         http.ResponseWriter
+	req         *http.Request
+	userAgent   string
+	contentType string
+	w           http.ResponseWriter
 
 	logStacktracePred StacktracePred
 }
@@ -167,6 +168,7 @@ func newLoggedWithStartTime(req *http.Request, w http.ResponseWriter, startTime 
 		startTime:         startTime,
 		req:               req,
 		userAgent:         req.UserAgent(),
+		contentType:       req.Header.Get("Content-Type"),
 		w:                 w,
 		logStacktracePred: DefaultStacktracePred,
 	}
@@ -271,6 +273,7 @@ func (rl *respLogger) Log() {
 		// This can cause apiserver to crash with unrecoverable fatal error.
 		// More info about concurrent read and write for maps: https://golang.org/doc/go1.6#runtime
 		"userAgent", rl.userAgent,
+		"contentType", rl.contentType,
 		"audit-ID", auditID,
 		"srcIP", rl.req.RemoteAddr,
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
@@ -232,3 +232,42 @@ func TestResponseWriterDecorator(t *testing.T) {
 		t.Errorf("Expected the decorator to return the inner http.ResponseWriter object")
 	}
 }
+
+func TestLogContentType(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+	}{
+		{
+			name:        "JSON content type",
+			contentType: "application/json",
+		},
+		{
+			name:        "Protobuf content type",
+			contentType: "application/vnd.kubernetes.protobuf",
+		},
+		{
+			name:        "Empty content type",
+			contentType: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "http://example.com", nil)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if test.contentType != "" {
+				req.Header.Set("Content-Type", test.contentType)
+			}
+
+			w := httptest.NewRecorder()
+			logger := newLogged(req, w)
+
+			if logger.contentType != test.contentType {
+				t.Errorf("Expected contentType %v, got %v", test.contentType, logger.contentType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR enhances Kubernetes API Server observability by including the `Content-Type` header in request logs. These changes allow cluster administrators to distinguish between different request formats, such as identifying clients that have not yet migrated from JSON to Protobuf.

* **Logging Enhancements**:
  * Updated the API server's structured HTTP logs to include a new `contentType` field.
  * Modified respLogger to capture the `Content-Type` header early in the request lifecycle to ensure safe logging even if a request times out.
  
/kind feature

```release-note
NONE
```