### PR TITLE
resource: remove v1beta1 REST storage support

### DIFF
--- a/pkg/registry/resource/rest/storage_resource.go
+++ b/pkg/registry/resource/rest/storage_resource.go
@@ -19,7 +19,6 @@ package rest
 import (
 	resourcev1 "k8s.io/api/resource/v1"
 	resourcev1alpha3 "k8s.io/api/resource/v1alpha3"
-	resourcev1beta1 "k8s.io/api/resource/v1beta1"
 	resourcev1beta2 "k8s.io/api/resource/v1beta2"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -59,12 +58,6 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 		return genericapiserver.APIGroupInfo{}, err
 	} else if len(storageMap) > 0 {
 		apiGroupInfo.VersionedResourcesStorageMap[resourcev1alpha3.SchemeGroupVersion.Version] = storageMap
-	}
-
-	if storageMap, err := p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter, p.NamespaceClient); err != nil {
-		return genericapiserver.APIGroupInfo{}, err
-	} else if len(storageMap) > 0 {
-		apiGroupInfo.VersionedResourcesStorageMap[resourcev1beta1.SchemeGroupVersion.Version] = storageMap
 	}
 
 	if storageMap, err := p.v1beta2Storage(apiResourceConfigSource, restOptionsGetter, p.NamespaceClient); err != nil {
@@ -134,45 +127,6 @@ func (p RESTStorageProvider) v1alpha3Storage(apiResourceConfigSource serverstora
 		}
 		storage[resource] = resourcePoolStatusRequestStorage
 		storage[resource+"/status"] = resourcePoolStatusRequestStatusStorage
-	}
-
-	return storage, nil
-}
-
-func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter, nsClient v1.NamespaceInterface) (map[string]rest.Storage, error) {
-	storage := map[string]rest.Storage{}
-
-	if resource := "deviceclasses"; apiResourceConfigSource.ResourceEnabled(resourcev1beta1.SchemeGroupVersion.WithResource(resource)) {
-		deviceclassStorage, err := deviceclassstore.NewREST(restOptionsGetter)
-		if err != nil {
-			return nil, err
-		}
-		storage[resource] = deviceclassStorage
-	}
-
-	if resource := "resourceclaims"; apiResourceConfigSource.ResourceEnabled(resourcev1beta1.SchemeGroupVersion.WithResource(resource)) {
-		resourceClaimStorage, resourceClaimStatusStorage, err := resourceclaimstore.NewREST(restOptionsGetter, nsClient)
-		if err != nil {
-			return nil, err
-		}
-		storage[resource] = resourceClaimStorage
-		storage[resource+"/status"] = resourceClaimStatusStorage
-	}
-
-	if resource := "resourceclaimtemplates"; apiResourceConfigSource.ResourceEnabled(resourcev1beta1.SchemeGroupVersion.WithResource(resource)) {
-		resourceClaimTemplateStorage, err := resourceclaimtemplatestore.NewREST(restOptionsGetter, nsClient)
-		if err != nil {
-			return nil, err
-		}
-		storage[resource] = resourceClaimTemplateStorage
-	}
-
-	if resource := "resourceslices"; apiResourceConfigSource.ResourceEnabled(resourcev1beta1.SchemeGroupVersion.WithResource(resource)) {
-		resourceSliceStorage, err := resourceslicestore.NewREST(restOptionsGetter)
-		if err != nil {
-			return nil, err
-		}
-		storage[resource] = resourceSliceStorage
 	}
 
 	return storage, nil


### PR DESCRIPTION
## Summary

Remove v1beta1 REST storage registration from the resource API group.

## Changes
- Removed resource/v1beta1 import
- Removed v1beta1Storage() registration from `NewRESTStorage()`
- Removed `v1beta1Storage()` implementation

## Testing
- `gofmt -w pkg/registry/resource/rest/storage_resource.go`