### PR TITLE
kubelet: do not destroy nodeAllocatableResourceClaimStatuses

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -224,7 +224,8 @@ func NewManager(kubeClient clientset.Interface, podManager PodManager, podDeleti
 
 // isPodStatusByKubeletEqual returns true if the given pod statuses are equal, ignoring
 // fields not managed by the kubelet (including non-kubelet-owned pod conditions,
-// ResourceClaimStatuses, and ExtendedResourceClaimStatus). Statuses are assumed to be
+// ResourceClaimStatuses, ExtendedResourceClaimStatus, and
+// NodeAllocatableResourceClaimStatuses). Statuses are assumed to be
 // normalized before calling this function.
 func isPodStatusByKubeletEqual(oldStatus, status *v1.PodStatus) bool {
 	oldCopy := oldStatus.DeepCopy()
@@ -257,6 +258,8 @@ func isPodStatusByKubeletEqual(oldStatus, status *v1.PodStatus) bool {
 	oldCopy.ResourceClaimStatuses = status.ResourceClaimStatuses
 	// ExtendedResourceClaimStatus is not owned and not modified by kubelet.
 	oldCopy.ExtendedResourceClaimStatus = status.ExtendedResourceClaimStatus
+	// NodeAllocatableResourceClaimStatuses is not owned and not modified by kubelet.
+	oldCopy.NodeAllocatableResourceClaimStatuses = status.NodeAllocatableResourceClaimStatuses
 
 	return apiequality.Semantic.DeepEqual(oldCopy, status)
 }
@@ -1393,6 +1396,8 @@ func mergePodStatus(pod *v1.Pod, oldPodStatus, newPodStatus v1.PodStatus, couldH
 	newPodStatus.ResourceClaimStatuses = oldPodStatus.ResourceClaimStatuses
 	// ExtendedResourceClaimStatus is not owned and not modified by kubelet.
 	newPodStatus.ExtendedResourceClaimStatus = oldPodStatus.ExtendedResourceClaimStatus
+	// NodeAllocatableResourceClaimStatuses is not owned and not modified by kubelet.
+	newPodStatus.NodeAllocatableResourceClaimStatuses = oldPodStatus.NodeAllocatableResourceClaimStatuses
 
 	// Delay transitioning a pod to a terminal status unless the pod is actually terminal.
 	// The Kubelet should never transition a pod to terminal status that could have running

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -33,6 +33,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -525,6 +526,13 @@ func TestStatusEquality(t *testing.T) {
 	}
 	oldPodStatus.ResourceClaimStatuses = []v1.PodResourceClaimStatus{claimStatusA}
 	oldPodStatus.ExtendedResourceClaimStatus = extendedClaimStatusA
+	oldPodStatus.NodeAllocatableResourceClaimStatuses = []v1.NodeAllocatableResourceClaimStatus{
+		{
+			ResourceClaimName: "my-claim",
+			Containers:        []string{"ctr0"},
+			Resources:         map[v1.ResourceName]resource.Quantity{v1.ResourceMemory: resource.MustParse("100Mi")},
+		},
+	}
 
 	normalizeStatus(&pod, &oldPodStatus)
 	normalizeStatus(&pod, &podStatus)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

The DRANodeAllocatableResources feature introduces NodeAllocatableResourceClaimStatuses in Pod.Status, to make information on [native resource allocations due to pod's DRA resource claims available to components (like kubelet)](https://github.com/kubernetes/enhancements/blob/c9bb5d4a969c01b5c1dac82a163a91bcbef26b1c/keps/sig-scheduling/5517-dra-native-resources/README.md?plain=1#L654).

However, when kubelet updates its own information in Pod.Status, it accidentally destroys this information.

This fix preserves this information similarly to already preserved `ResourceClaimStatuses` and `ExtendedResourceClaimStatuses` that are not owned by kubelet, either.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This fixes an issue in the new feature that is about to become Alpha in upcoming 1.36.0 release, and enable native resource allocations using DRA.

#### Does this PR introduce a user-facing change?
```release-note
Fixed kubelet to preserve DRA NodeAllocatableResourceClaimStatuses in Pod.Status.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP]: 5517 https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5517-dra-native-resources

/cc @pohly @pravk03