### PR TITLE
deployment: fix stuck rollout when scaling during rolling update with maxSurge=0

### DIFF
--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -308,10 +308,16 @@ func (dc *DeploymentController) scale(ctx context.Context, deployment *apps.Depl
 	// If there is only one active replica set then we should scale that up to the full count of the
 	// deployment. If there is no active replica set, then we should scale up the newest replica set.
 	if activeOrLatest := deploymentutil.FindActiveOrLatest(newRS, oldRSs); activeOrLatest != nil {
-		if *(activeOrLatest.Spec.Replicas) == *(deployment.Spec.Replicas) {
+		replicasMatch := *(activeOrLatest.Spec.Replicas) == *(deployment.Spec.Replicas)
+		annotationsUpToDate := !deploymentutil.ReplicasAnnotationsNeedUpdate(activeOrLatest,
+			*(deployment.Spec.Replicas), *(deployment.Spec.Replicas)+deploymentutil.MaxSurge(*deployment))
+
+		if replicasMatch && annotationsUpToDate {
 			return nil
 		}
-		_, _, err := dc.scaleReplicaSet(ctx, activeOrLatest, *(deployment.Spec.Replicas), deployment, false)
+		// Pass forceUpdate=replicasMatch: when replicas already match, only the annotations
+		// are stale and forceUpdate=true is needed to bypass scaleReplicaSet's early return.
+		_, _, err := dc.scaleReplicaSet(ctx, activeOrLatest, *(deployment.Spec.Replicas), deployment, replicasMatch)
 		return err
 	}
 

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -61,6 +61,7 @@ func TestScale(t *testing.T) {
 		wasntUpdated map[string]bool
 
 		desiredReplicasAnnotations map[string]int32
+		expectedAnnotations        map[string]string
 	}{
 		{
 			name:          "normal scaling event: 10 -> 12",
@@ -250,6 +251,22 @@ func TestScale(t *testing.T) {
 			expectedNew: nil,
 			expectedOld: []*apps.ReplicaSet{rs("foo-v2", 10, nil, newTimestamp), rs("foo-v1", 4, nil, oldTimestamp)},
 		},
+		// Regression test for #135483: stale desired-replicas annotation must be refreshed
+		// even when RS.Spec.Replicas already matches deployment.Spec.Replicas.
+		{
+			name:          "stale annotation with matching replicas must be updated (issue #135483)",
+			deployment:    newDeployment("foo", 5, nil, nil, nil, nil),
+			oldDeployment: newDeployment("foo", 5, nil, nil, nil, nil),
+
+			newRS:  nil,
+			oldRSs: []*apps.ReplicaSet{rs("foo-v1", 5, nil, newTimestamp)},
+
+			expectedNew: nil,
+			expectedOld: []*apps.ReplicaSet{rs("foo-v1", 5, nil, newTimestamp)},
+
+			desiredReplicasAnnotations: map[string]int32{"foo-v1": int32(10)},
+			expectedAnnotations:        map[string]string{"foo-v1": "5"},
+		},
 		{
 			name:          "saturated but broken new replica set does not affect old pods",
 			deployment:    newDeployment("foo", 2, nil, ptr.To(intstr.FromInt32(1)), ptr.To(intstr.FromInt32(1)), nil),
@@ -335,6 +352,22 @@ func TestScale(t *testing.T) {
 				expected := test.expectedOld[n]
 				if *(expected.Spec.Replicas) != nameToSize[rs.Name] {
 					t.Errorf("%s: expected old (%s) replicas: %d, got: %d", test.name, rs.Name, *(expected.Spec.Replicas), nameToSize[rs.Name])
+				}
+			}
+
+			if len(test.expectedAnnotations) > 0 {
+				// Build a map of rs name → annotation value from UPDATE actions.
+				updatedAnnotations := make(map[string]string)
+				for _, action := range fake.Actions() {
+					updated := action.(testclient.UpdateAction).GetObject().(*apps.ReplicaSet)
+					updatedAnnotations[updated.Name] = updated.Annotations[deploymentutil.DesiredReplicasAnnotation]
+				}
+				for rsName, wantAnnotation := range test.expectedAnnotations {
+					if got, ok := updatedAnnotations[rsName]; !ok {
+						t.Errorf("%s: expected RS %q to be updated with annotation %q, but no update was issued", test.name, rsName, wantAnnotation)
+					} else if got != wantAnnotation {
+						t.Errorf("%s: RS %q desired-replicas annotation = %q, want %q", test.name, rsName, got, wantAnnotation)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
scale() returned early when RS.Spec.Replicas already matched                                                                                                        
deployment.Spec.Replicas, without checking whether the desired-replicas                                                                                             
annotation was current. A stale annotation caused isScalingEvent() to                                                                                               
return true on every sync, permanently routing to sync() instead of                                                                                                 
rolloutRolling().                                                                                                                                                   
                                                                                                                                                                      
Check ReplicasAnnotationsNeedUpdate before returning early. If only the                                                                                             
annotation is stale, call scaleReplicaSet with forceUpdate=true to           
refresh it without changing the replica count.  


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#135483

#### Special notes for your reviewer:

reproduction script i used:

```
#!/usr/bin/env bash
# Reproduces kubernetes/kubernetes#135483
# Deployment stuck when scaled during rolling update with maxSurge=0
#
# APPROACH: Direct annotation injection — reliable, no timing races.
# Simulates the stale annotation state that occurs when a deployment is scaled
# during an in-flight rolling update with maxSurge=0.
#
# EXPECTED RESULT:
#   UP-TO-DATE stays at <none>/0 indefinitely. The annotation never updates.
#   rollout status times out. No new ReplicaSet is ever created.

set -euo pipefail

CLUSTER="bug-135483"
NAMESPACE="default"
DEPLOY="test-deploy"

# --- setup ---

echo "==> Checking dependencies..."
for cmd in kind kubectl docker; do
  command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd not found"; exit 1; }
done
docker info >/dev/null 2>&1 || { echo "ERROR: Docker is not running"; exit 1; }

echo "==> Creating kind cluster (skipping if exists)..."
if ! kind get clusters 2>/dev/null | grep -q "^${CLUSTER}$"; then
  kind create cluster --name "$CLUSTER" --image kindest/node:local
else
  echo "    Cluster '$CLUSTER' already exists, reusing."
fi
kubectl config use-context "kind-$CLUSTER"

echo "==> Cleaning up any previous test deployment..."
kubectl delete deployment "$DEPLOY" -n "$NAMESPACE" --ignore-not-found
kubectl delete rs -l app="$DEPLOY" -n "$NAMESPACE" --ignore-not-found 2>/dev/null || true
# Wait for RSes to fully delete
sleep 2

# --- deploy v1 ---

echo "==> Deploying initial version (nginx:1.24, replicas=5, maxSurge=0)..."
kubectl apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: $DEPLOY
  namespace: $NAMESPACE
spec:
  replicas: 5
  selector:
    matchLabels:
      app: $DEPLOY
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
  template:
    metadata:
      labels:
        app: $DEPLOY
    spec:
      containers:
      - name: app
        image: nginx:1.24
        command: ["sleep", "3600"]
EOF

echo "==> Waiting for initial rollout to complete..."
kubectl rollout status deployment/"$DEPLOY" -n "$NAMESPACE" --timeout=120s

echo ""
echo "==> Initial state (clean — one RS, annotation matches spec):"
kubectl get rs -n "$NAMESPACE" -l app="$DEPLOY" \
  -o 'custom-columns=NAME:.metadata.name,REPLICAS:.spec.replicas,DESIRED-ANN:.metadata.annotations.deployment\.kubernetes\.io/desired-replicas'

# --- inject stale annotation ---

RS=$(kubectl get rs -n "$NAMESPACE" -l app="$DEPLOY" -o jsonpath='{.items[0].metadata.name}')

echo ""
echo "==> Injecting stale annotation on RS '$RS'..."
echo "    Simulates: deployment was previously at replicas=10, scaled down to 5,"
echo "    but the annotation was never updated (the bug condition)."
kubectl annotate rs "$RS" -n "$NAMESPACE" \
  deployment.kubernetes.io/desired-replicas=10 \
  deployment.kubernetes.io/max-replicas=10 \
  --overwrite

echo ""
echo "==> State after annotation injection:"
kubectl get rs -n "$NAMESPACE" -l app="$DEPLOY" \
  -o 'custom-columns=NAME:.metadata.name,REPLICAS:.spec.replicas,DESIRED-ANN:.metadata.annotations.deployment\.kubernetes\.io/desired-replicas'
echo "    ^ DESIRED-ANN=10 but deployment.spec.replicas=5 — this is the stuck state"

# --- trigger rolling update ---

echo ""
echo "==> Triggering rolling update (nginx:1.24 → nginx:1.25)..."
kubectl set image deployment/"$DEPLOY" app=nginx:1.25 -n "$NAMESPACE"

echo ""
echo "==> Watching for 60s — rolling update should NEVER make progress..."
echo "    UP-TO-DATE will stay at 0. DESIRED-ANN will stay at 10. No new RS created."
echo ""

STUCK=true
for i in $(seq 1 12); do
  echo "--- t+${i}5s ---"
  kubectl get deploy "$DEPLOY" -n "$NAMESPACE" \
    -o 'custom-columns=NAME:.metadata.name,DESIRED:.spec.replicas,READY:.status.readyReplicas,UP-TO-DATE:.status.updatedReplicas,AVAILABLE:.status.availableReplicas'
  kubectl get rs -n "$NAMESPACE" -l app="$DEPLOY" \
    -o 'custom-columns=NAME:.metadata.name,RS-REPLICAS:.spec.replicas,DESIRED-ANN:.metadata.annotations.deployment\.kubernetes\.io/desired-replicas'
  RS_COUNT=$(kubectl get rs -n "$NAMESPACE" -l app="$DEPLOY" --no-headers | wc -l | tr -d ' ')
  UPDATED=$(kubectl get deploy "$DEPLOY" -n "$NAMESPACE" -o jsonpath='{.status.updatedReplicas}' 2>/dev/null || echo "0")
  if [ "$RS_COUNT" -gt 1 ] || [ "${UPDATED:-0}" -gt 0 ]; then
    STUCK=false
    echo "    !! Rolling update made progress (RS_COUNT=$RS_COUNT, updatedReplicas=${UPDATED:-0}) — bug NOT triggered"
    break
  fi
  echo ""
  sleep 5
done

# --- verdict ---

echo ""
echo "==> Final rollout status:"
kubectl rollout status deployment/"$DEPLOY" -n "$NAMESPACE" --timeout=5s 2>&1 || true

echo ""
if [ "$STUCK" = true ]; then
  ANN=$(kubectl get rs -n "$NAMESPACE" -l app="$DEPLOY" -o jsonpath='{.items[0].metadata.annotations.deployment\.kubernetes\.io/desired-replicas}')
  SPEC=$(kubectl get deploy "$DEPLOY" -n "$NAMESPACE" -o jsonpath='{.spec.replicas}')
  echo "======================================"
  echo " BUG REPRODUCED"
  echo "======================================"
  echo " desired-replicas annotation : $ANN  (stale)"
  echo " deployment.spec.replicas    : $SPEC"
  echo " new ReplicaSet created      : NO"
  echo " rolling update completed    : NO"
  echo ""
  echo " The deployment controller is stuck in sync() forever."
  echo " isScalingEvent() returns true every cycle because annotation ($ANN) != spec ($SPEC)."
  echo " scale() returns nil without fixing the annotation because RS.Spec.Replicas already == spec.replicas."
  echo "======================================"
else
  echo "Bug NOT reproduced — rollout made progress. Try on an older k8s version."
fi

echo ""
echo "==> Cleanup:"
echo "    kind delete cluster --name $CLUSTER"
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NO
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NO
```
