### PR TITLE
Add request_content_type_total counter to track Protobuf migration

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -105,6 +105,17 @@ var (
 		},
 		[]string{"verb", "dry_run", "group", "version", "resource", "subresource", "scope", "component"},
 	)
+	// requestContentTypeCounter tracks the migration from JSON to Protobuf.
+	// It is intended to identify clients that haven't moved to Protobuf yet.
+	requestContentTypeCounter = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Subsystem:      APIServerComponent,
+			Name:           "request_content_type_total",
+			Help:           "Counter of apiserver requests broken out for each verb, resource and media type.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"verb", "resource", "media_type"},
+	)
 	requestSloLatencies = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
 			Subsystem: APIServerComponent,
@@ -299,6 +310,7 @@ var (
 		requestCounter,
 		longRunningRequestsGauge,
 		requestLatencies,
+		requestContentTypeCounter,
 		requestSloLatencies,
 		requestSliLatencies,
 		fieldValidationRequestLatencies,
@@ -590,6 +602,7 @@ func MonitorRequest(req *http.Request, verb, group, version, resource, subresour
 	reportedVerb := cleanVerb(CanonicalVerb(strings.ToUpper(req.Method), scope), verb, req, requestInfo)
 
 	dryRun := cleanDryRun(req.URL)
+	contentType := cleanContentType(req.Header.Get("Content-Type"))
 	elapsedSeconds := elapsed.Seconds()
 	requestCounter.WithContext(req.Context()).WithLabelValues(reportedVerb, dryRun, group, version, resource, subresource, scope, component, codeToString(httpCode)).Inc()
 	// MonitorRequest happens after authentication, so we can trust the username given by the request
@@ -605,6 +618,7 @@ func MonitorRequest(req *http.Request, verb, group, version, resource, subresour
 		}
 	}
 	requestLatencies.WithContext(req.Context()).WithLabelValues(reportedVerb, dryRun, group, version, resource, subresource, scope, component).Observe(elapsedSeconds)
+	requestContentTypeCounter.WithContext(req.Context()).WithLabelValues(reportedVerb, resource, contentType).Inc()
 	fieldValidation := cleanFieldValidation(req.URL)
 	fieldValidationRequestLatencies.WithContext(req.Context()).WithLabelValues(fieldValidation)
 
@@ -963,4 +977,18 @@ func codeToString(s int) string {
 	default:
 		return strconv.Itoa(s)
 	}
+}
+
+func cleanContentType(contentType string) string {
+	if contentType == "" {
+		return ""
+	}
+	lowered := strings.ToLower(contentType)
+	if strings.HasPrefix(lowered, "application/json") {
+		return "application/json"
+	}
+	if strings.HasPrefix(lowered, "application/vnd.kubernetes.protobuf") {
+		return "application/vnd.kubernetes.protobuf"
+	}
+	return "other"
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/fields"
@@ -523,6 +524,115 @@ func TestCleanListScope(t *testing.T) {
 			actualScope := CleanListScope(scenario.ctx, scenario.opts)
 			if actualScope != scenario.expectedScope {
 				t.Errorf("unexpected scope = %s, expected = %s", actualScope, scenario.expectedScope)
+			}
+		})
+	}
+}
+
+func TestCleanContentType(t *testing.T) {
+	testCases := []struct {
+		contentType string
+		expected    string
+	}{
+		{
+			contentType: "",
+			expected:    "",
+		},
+		{
+			contentType: "application/json",
+			expected:    "application/json",
+		},
+		{
+			contentType: "application/JSON",
+			expected:    "application/json",
+		},
+		{
+			contentType: "application/json; charset=utf-8",
+			expected:    "application/json",
+		},
+		{
+			contentType: "application/vnd.kubernetes.protobuf",
+			expected:    "application/vnd.kubernetes.protobuf",
+		},
+		{
+			contentType: "application/VND.KUBERNETES.PROTOBUF",
+			expected:    "application/vnd.kubernetes.protobuf",
+		},
+		{
+			contentType: "application/vnd.kubernetes.protobuf; something=else",
+			expected:    "application/vnd.kubernetes.protobuf",
+		},
+		{
+			contentType: "text/plain",
+			expected:    "other",
+		},
+		{
+			contentType: "application/yaml",
+			expected:    "other",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.contentType, func(t *testing.T) {
+			actual := cleanContentType(tc.contentType)
+			if actual != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestRequestContentTypeCounter(t *testing.T) {
+	Register()
+
+	testCases := []struct {
+		desc        string
+		contentType string
+		labels      map[string]string
+	}{
+		{
+			desc:        "JSON content type",
+			contentType: "application/json",
+			labels: map[string]string{
+				"verb":       "POST",
+				"resource":   "myresource",
+				"media_type": "application/json",
+			},
+		},
+		{
+			desc:        "Protobuf content type",
+			contentType: "application/vnd.kubernetes.protobuf",
+			labels: map[string]string{
+				"verb":       "POST",
+				"resource":   "myresource",
+				"media_type": "application/vnd.kubernetes.protobuf",
+			},
+		},
+		{
+			desc:        "Other content type",
+			contentType: "application/yaml",
+			labels: map[string]string{
+				"verb":       "POST",
+				"resource":   "myresource",
+				"media_type": "other",
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			requestContentTypeCounter.Reset()
+
+			req, _ := http.NewRequest(http.MethodPost, "/api/v1/myresource", nil)
+			req.Header.Set("Content-Type", test.contentType)
+
+			MonitorRequest(req, http.MethodPost, "mygroup", "v1", "myresource", "", "cluster", "apiserver", false, "", 201, 100, 1*time.Millisecond)
+
+			count, err := testutil.GetCounterMetricValue(requestContentTypeCounter.WithLabelValues(test.labels["verb"], test.labels["resource"], test.labels["media_type"]))
+			if err != nil {
+				t.Fatalf("Failed to get counter value: %v", err)
+			}
+			if count != 1 {
+				t.Errorf("Expected counter value 1, got %v", count)
 			}
 		})
 	}


### PR DESCRIPTION
Motivation
   * Identify clients that have not yet migrated from JSON to Protobuf.
   * Use a dedicated counter to avoid the cardinality explosion associated with adding labels to existing histograms.

Key Changes
   * New ALPHA counter `apiserver_request_content_type_total` with labels `verb`, `resource`, and `media_type`.
   * The `media_type` label is used to clarify that the value is a normalized serialization format, rather than a raw `Content-Type` header.
   * Normalizes `Content-Type` to three values: `application/json`, `application/vnd.kubernetes.protobuf`, or `other`.

/kind feature

```release-note
Added a new ALPHA counter metric apiserver_request_content_type_total to the Kubernetes API Server to track request serialization formats.
```
