### PR TITLE
[WIP] Safer Kubelet config changes in the e2e_node suite

### DIFF
--- a/test/e2e_node/cpu_manager_metrics_test.go
+++ b/test/e2e_node/cpu_manager_metrics_test.go
@@ -113,7 +113,6 @@ var _ = SIGDescribe("CPU Manager Metrics", framework.WithSerial(), feature.CPUMa
 				deletePodSyncByName(ctx, f, testPod.Name)
 				waitForContainerRemoval(ctx, testPod.Spec.Containers[0].Name, testPod.Name, testPod.Namespace)
 			}
-			updateKubeletConfig(ctx, f, oldCfg, true)
 		})
 
 		ginkgo.It("should report zero pinning counters after a fresh restart", func(ctx context.Context) {
@@ -405,7 +404,9 @@ var _ = SIGDescribe("CPU Manager Metrics", framework.WithSerial(), feature.CPUMa
 				},
 			)
 
-			updateKubeletConfig(ctx, f, newCfg, true)
+			updateKubeletConfigWithOptions(ctx, f, newCfg, updateKubeletOptions{
+				deleteStateFiles: true,
+			})
 
 			ginkgo.By("Checking the cpumanager allocation per NUMA metric right after the kubelet restart, with no pods running")
 			numaNodes, _, _, _ := hostCheck()
@@ -445,7 +446,9 @@ var _ = SIGDescribe("CPU Manager Metrics", framework.WithSerial(), feature.CPUMa
 				},
 			)
 
-			updateKubeletConfig(ctx, f, newCfg, true)
+			updateKubeletConfigWithOptions(ctx, f, newCfg, updateKubeletOptions{
+				deleteStateFiles: true,
+			})
 
 			numaNodes, _, _, cpusNumPerNUMA := hostCheck()
 

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -166,10 +166,6 @@ var _ = SIGDescribe("CPU Manager", ginkgo.Ordered, ginkgo.ContinueOnFailure, fra
 		framework.Logf("runtime: %s", e2enodeRuntimeName)
 	})
 
-	ginkgo.AfterAll(func(ctx context.Context) {
-		updateKubeletConfig(ctx, f, oldCfg, true)
-	})
-
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		// note intentionally NOT set reservedCPUs -  this must be initialized on a test-by-test basis
 		podMap = make(map[string]*v1.Pod)
@@ -2004,10 +2000,6 @@ var _ = SIGDescribe("CPU Manager Pod Level Resources", ginkgo.Ordered, ginkgo.Co
 
 		e2enodeRuntimeName = version.GetRuntimeName()
 		framework.Logf("runtime: %s", e2enodeRuntimeName)
-	})
-
-	ginkgo.AfterAll(func(ctx context.Context) {
-		updateKubeletConfig(ctx, f, oldCfg, true)
 	})
 
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e_node/kubelet_config_dir_test.go
+++ b/test/e2e_node/kubelet_config_dir_test.go
@@ -35,20 +35,16 @@ import (
 var _ = SIGDescribe("Kubelet Config", framework.WithSlow(), framework.WithSerial(), framework.WithDisruptive(), feature.KubeletConfigDropInDir, func() {
 	f := framework.NewDefaultFramework("kubelet-config-drop-in-dir-test")
 	ginkgo.Context("when merging drop-in configs", func() {
-		var oldcfg *kubeletconfig.KubeletConfiguration
-		ginkgo.BeforeEach(func(ctx context.Context) {
-			var err error
-			oldcfg, err = getCurrentKubeletConfig(ctx)
-			framework.ExpectNoError(err)
-		})
 		ginkgo.AfterEach(func(ctx context.Context) {
+			restartKubelet := mustStopKubelet(ctx, f)
+			defer restartKubelet(ctx)
+
 			files, err := filepath.Glob(filepath.Join(framework.TestContext.KubeletConfigDropinDir, "*"+".conf"))
 			framework.ExpectNoError(err)
 			for _, file := range files {
 				err := os.Remove(file)
 				framework.ExpectNoError(err)
 			}
-			updateKubeletConfig(ctx, f, oldcfg, true)
 		})
 		ginkgo.It("should merge kubelet configs correctly", func(ctx context.Context) {
 			// Get the initial kubelet configuration

--- a/test/e2e_node/kubelet_server_tls_test.go
+++ b/test/e2e_node/kubelet_server_tls_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/pkg/cluster/ports"
-	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -147,9 +146,6 @@ var _ = SIGDescribe("ReloadKubeletClientCAFileTest", framework.WithNodeConforman
 			tempDir = t.TempDir()
 			cfg, err := getCurrentKubeletConfig(ctx)
 			framework.ExpectNoError(err)
-			ginkgo.DeferCleanup(func(ctx context.Context, cfg *kubeletconfig.KubeletConfiguration) {
-				updateKubeletConfig(ctx, f, cfg, true)
-			}, cfg.DeepCopy())
 
 			caPath, certPath, keyPath, err := createCAWithCertAndKeyFiles(tempDir)
 			framework.ExpectNoError(err)

--- a/test/e2e_node/kubelet_tls_test.go
+++ b/test/e2e_node/kubelet_tls_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/pkg/cluster/ports"
-	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -77,9 +76,6 @@ var _ = SIGDescribe("KubletTLS", framework.WithSerial(), framework.WithNodeConfo
 			tempDir = t.TempDir()
 			cfg, err := getCurrentKubeletConfig(ctx)
 			framework.ExpectNoError(err)
-			ginkgo.DeferCleanup(func(ctx context.Context, cfg *kubeletconfig.KubeletConfiguration) {
-				updateKubeletConfig(ctx, f, cfg, true)
-			}, cfg.DeepCopy())
 
 			certPath, keyPath, err := createCertAndKeyFiles(tempDir)
 			framework.ExpectNoError(err)

--- a/test/e2e_node/memory_manager_metrics_test.go
+++ b/test/e2e_node/memory_manager_metrics_test.go
@@ -76,7 +76,6 @@ var _ = SIGDescribe("Memory Manager Metrics", framework.WithSerial(), feature.Me
 				if testPod != nil {
 					deletePodSyncByName(ctx, f, testPod.Name)
 				}
-				updateKubeletConfig(ctx, f, oldCfg, true)
 			})
 
 			count := printAllPodsOnNode(ctx, f.ClientSet, framework.TestContext.NodeName)

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -823,7 +823,6 @@ var _ = SIGDescribe("Memory Manager Pod Level Resources", ginkgo.Ordered, ginkgo
 	var (
 		allNUMANodes         []int
 		isMultiNUMASupported *bool
-		oldCfg               *kubeletconfig.KubeletConfiguration
 		podMap               map[string]*v1.Pod
 		createPodSync        func(ctx context.Context, pod *v1.Pod) *v1.Pod
 	)
@@ -844,10 +843,6 @@ var _ = SIGDescribe("Memory Manager Pod Level Resources", ginkgo.Ordered, ginkgo
 	}
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
-		var err error
-		oldCfg, err = getCurrentKubeletConfig(ctx)
-		framework.ExpectNoError(err)
-
 		if isMultiNUMASupported == nil {
 			isMultiNUMASupported = ptr.To(isMultiNUMA())
 		}
@@ -855,10 +850,6 @@ var _ = SIGDescribe("Memory Manager Pod Level Resources", ginkgo.Ordered, ginkgo
 		if len(allNUMANodes) == 0 {
 			allNUMANodes = getAllNUMANodes()
 		}
-	})
-
-	ginkgo.AfterAll(func(ctx context.Context) {
-		updateKubeletConfig(ctx, f, oldCfg, true)
 	})
 
 	ginkgo.BeforeEach(func(ctx context.Context) {

--- a/test/e2e_node/memory_qos_test.go
+++ b/test/e2e_node/memory_qos_test.go
@@ -32,7 +32,6 @@ import (
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2enodekubelet "k8s.io/kubernetes/test/e2e_node/kubeletconfig"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
@@ -205,9 +204,9 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		newCfg.CgroupsPerQOS = true
 		newCfg.EnforceNodeAllocatable = []string{"pods"}
 
-		framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
-		restartKubelet(ctx, true)
-		waitForKubeletToStart(ctx, f)
+		updateKubeletConfigWithOptions(ctx, f, newCfg, updateKubeletOptions{
+			deleteStateFiles: true,
+		})
 	}
 
 	// configureMemoryQoSWithPolicy restarts kubelet with MemoryQoS and a specific memoryReservationPolicy.
@@ -222,22 +221,12 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		newCfg.CgroupsPerQOS = true
 		newCfg.EnforceNodeAllocatable = []string{"pods"}
 
-		framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
-		restartKubelet(ctx, true)
-		waitForKubeletToStart(ctx, f)
-	}
-
-	restoreConfig := func(ctx context.Context) {
-		if oldCfg != nil {
-			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(oldCfg))
-			restartKubelet(ctx, true)
-			waitForKubeletToStart(ctx, f)
-		}
+		updateKubeletConfigWithOptions(ctx, f, newCfg, updateKubeletOptions{
+			deleteStateFiles: true,
+		})
 	}
 
 	f.Describe("memory protection [memoryReservationPolicy=TieredReservation]", func() {
-		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
-
 		ginkgo.It("should set memory.low = requests.memory for Burstable pod containers", func(ctx context.Context) {
 			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
@@ -413,8 +402,6 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 	})
 
 	f.Describe("memory.high throttling", func() {
-		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
-
 		ginkgo.It("should set memory.high for Burstable pod using formula", func(ctx context.Context) {
 			throttlingFactor := 0.9
 			configureMemoryQoS(ctx, throttlingFactor)
@@ -548,8 +535,6 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 	})
 
 	f.Describe("memory.events observability", func() {
-		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
-
 		ginkgo.It("should have memory.events file with expected counters", func(ctx context.Context) {
 			configureMemoryQoS(ctx, 0.9)
 
@@ -584,8 +569,6 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 	})
 
 	f.Describe("feature rollback", func() {
-		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
-
 		ginkgo.It("should reset memory protection to 0 when MemoryQoS is disabled", func(ctx context.Context) {
 			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
@@ -609,9 +592,9 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 			}
 			newCfg.FeatureGates["MemoryQoS"] = false
 			newCfg.MemoryReservationPolicy = kubeletconfig.NoneMemoryReservationPolicy
-			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
-			restartKubelet(ctx, true)
-			waitForKubeletToStart(ctx, f)
+			updateKubeletConfigWithOptions(ctx, f, newCfg, updateKubeletOptions{
+				deleteStateFiles: true,
+			})
 
 			// QoS-class cgroup memory.low is cleared by the periodic setMemoryQoS loop
 			// (periodicQOSCgroupUpdateInterval = 1 minute) plus kubelet startup time.
@@ -634,8 +617,6 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 	})
 
 	f.Describe("memory.high formula verification across request/limit ratios", func() {
-		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
-
 		ginkgo.It("should correctly compute memory.high for various request/limit combinations", func(ctx context.Context) {
 			throttlingFactor := 0.9
 			configureMemoryQoS(ctx, throttlingFactor)
@@ -696,8 +677,6 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 	})
 
 	f.Describe("memoryReservationPolicy", func() {
-		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
-
 		ginkgo.It("should NOT set memory protection when policy is None", func(ctx context.Context) {
 			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.NoneMemoryReservationPolicy)
 
@@ -806,8 +785,6 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 	})
 
 	f.Describe("memory.high throttling behavior", func() {
-		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
-
 		ginkgo.It("should increment memory.events high counter when usage exceeds memory.high", func(ctx context.Context) {
 			configureMemoryQoS(ctx, 0.9)
 
@@ -915,8 +892,6 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 	})
 
 	f.Describe("tiered protection edge cases", func() {
-		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
-
 		ginkgo.It("should use memory.low for Burstable pod where memory req == limit but CPU differs", func(ctx context.Context) {
 			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
@@ -1054,9 +1029,9 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 			}
 			newCfg.FeatureGates["MemoryQoS"] = false
 			newCfg.MemoryReservationPolicy = kubeletconfig.NoneMemoryReservationPolicy
-			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
-			restartKubelet(ctx, true)
-			waitForKubeletToStart(ctx, f)
+			updateKubeletConfigWithOptions(ctx, f, newCfg, updateKubeletOptions{
+				deleteStateFiles: true,
+			})
 
 			gomega.Eventually(ctx, func() int64 {
 				val, _ := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryLow)

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -38,13 +38,12 @@ import (
 
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2enodekubelet "k8s.io/kubernetes/test/e2e_node/kubeletconfig"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
 
-func setDesiredConfiguration(initialConfig *kubeletconfig.KubeletConfiguration, cgroupManager cm.CgroupManager) {
+func setDesiredConfiguration(initialConfig *kubeletconfig.KubeletConfiguration) {
 	initialConfig.EnforceNodeAllocatable = []string{"pods", kubeReservedCgroup, systemReservedCgroup}
 	initialConfig.SystemReserved = map[string]string{
 		string(v1.ResourceCPU):    "100m",
@@ -214,53 +213,36 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 
 	// Create a cgroup manager object for manipulating cgroups.
 	cgroupManager := cm.NewCgroupManager(klog.Background(), subsystems, oldCfg.CgroupDriver)
-
-	ginkgo.DeferCleanup(destroyTemporaryCgroupsForReservation, cgroupManager)
-	ginkgo.DeferCleanup(func(ctx context.Context) {
-		if oldCfg != nil {
-			updateKubeletConfigWithOptions(ctx, f, oldCfg, updateKubeletOptions{
-				deleteStateFiles: true,
-				skipCleanup:      true, // This is the cleanup.
-			})
+	expectedNAPodCgroup := cm.NewCgroupName(cm.RootCgroupName, nodeAllocatableCgroup)
+	updateKubeletCgroups := func(ctx context.Context) (func(context.Context), error) {
+		cleanup := func(context.Context) {
+			destroyTemporaryCgroupsForReservation(cgroupManager)
 		}
-	})
-	if err := createTemporaryCgroupsForReservation(cgroupManager); err != nil {
-		return err
+		if err := createTemporaryCgroupsForReservation(cgroupManager); err != nil {
+			return cleanup, err
+		}
+
+		// Cleanup from the previous kubelet, to verify the new one creates it correctly
+		if err := cgroupManager.Destroy(klog.Background(), &cm.CgroupConfig{
+			Name: cm.NewCgroupName(expectedNAPodCgroup),
+		}); err != nil {
+			return cleanup, err
+		}
+		if cgroupManager.Exists(expectedNAPodCgroup) {
+			return cleanup, fmt.Errorf("Expected Node Allocatable Cgroup %q not to exist", expectedNAPodCgroup)
+		}
+		return cleanup, nil
 	}
 
 	newCfg := oldCfg.DeepCopy()
 	// Change existing kubelet configuration
-	setDesiredConfiguration(newCfg, cgroupManager)
+	setDesiredConfiguration(newCfg)
 	// Set the new kubelet configuration.
-	// Update the Kubelet configuration.
-	ginkgo.By("Stopping the kubelet")
-	restartKubelet := mustStopKubelet(ctx, f)
+	updateKubeletConfigWithOptions(ctx, f, newCfg, updateKubeletOptions{
+		deleteStateFiles: true,
+		extraAction:      updateKubeletCgroups,
+	})
 
-	expectedNAPodCgroup := cm.NewCgroupName(cm.RootCgroupName, nodeAllocatableCgroup)
-
-	// Cleanup from the previous kubelet, to verify the new one creates it correctly
-	if err := cgroupManager.Destroy(klog.Background(), &cm.CgroupConfig{
-		Name: cm.NewCgroupName(expectedNAPodCgroup),
-	}); err != nil {
-		return err
-	}
-	if cgroupManager.Exists(expectedNAPodCgroup) {
-		return fmt.Errorf("Expected Node Allocatable Cgroup %q not to exist", expectedNAPodCgroup)
-	}
-
-	framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
-
-	ginkgo.By("Starting the kubelet")
-	restartKubelet(ctx)
-
-	// wait until the kubelet health check will succeed
-	gomega.Eventually(ctx, func() bool {
-		return kubeletHealthCheck(kubeletHealthCheckURL)
-	}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
-
-	if err != nil {
-		return err
-	}
 	// Set new config and current config.
 	currentConfig := newCfg
 

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -98,19 +98,6 @@ var _ = SIGDescribe("Node Container Manager", framework.WithSerial(), func() {
 			oldCfg, err = getCurrentKubeletConfig(ctx)
 			framework.ExpectNoError(err)
 
-			ginkgo.DeferCleanup(func(ctx context.Context) {
-				if oldCfg != nil {
-					// Update the Kubelet configuration.
-					framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(oldCfg))
-
-					ginkgo.By("Restarting the kubelet")
-					restartKubelet(ctx, true)
-
-					waitForKubeletToStart(ctx, f)
-					ginkgo.By("Started the kubelet")
-				}
-			})
-
 			newCfg := oldCfg.DeepCopy()
 			// Change existing kubelet configuration
 			newCfg.CPUManagerPolicy = "none"
@@ -118,17 +105,10 @@ var _ = SIGDescribe("Node Container Manager", framework.WithSerial(), func() {
 			newCfg.FailCgroupV1 = true // extra safety. We want to avoid false negatives though, so we added the skip check earlier
 
 			// Update the Kubelet configuration.
-			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
-
-			ginkgo.By("Restarting the kubelet")
-			restartKubelet(ctx, true)
-
-			waitForKubeletToStart(ctx, f)
-			ginkgo.By("Started the kubelet")
-
-			gomega.Consistently(ctx, func(ctx context.Context) bool {
-				return getNodeReadyStatus(ctx, f) && kubeletHealthCheck(kubeletHealthCheckURL)
-			}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(gomega.BeTrueBecause("node keeps reporting ready status"))
+			updateKubeletConfigWithOptions(ctx, f, newCfg, updateKubeletOptions{
+				deleteStateFiles:          true,
+				ensureConsistentReadyNode: true,
+			})
 		})
 	})
 })
@@ -238,24 +218,10 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 	ginkgo.DeferCleanup(destroyTemporaryCgroupsForReservation, cgroupManager)
 	ginkgo.DeferCleanup(func(ctx context.Context) {
 		if oldCfg != nil {
-			// Update the Kubelet configuration.
-			ginkgo.By("Stopping the kubelet")
-			restartKubelet := mustStopKubelet(ctx, f)
-
-			// wait until the kubelet health check will fail
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, time.Minute, time.Second).Should(gomega.BeFalseBecause("expected kubelet health check to be failed"))
-
-			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(oldCfg))
-
-			ginkgo.By("Restarting the kubelet")
-			restartKubelet(ctx)
-
-			// wait until the kubelet health check will succeed
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
+			updateKubeletConfigWithOptions(ctx, f, oldCfg, updateKubeletOptions{
+				deleteStateFiles: true,
+				skipCleanup:      true, // This is the cleanup.
+			})
 		}
 	})
 	if err := createTemporaryCgroupsForReservation(cgroupManager); err != nil {

--- a/test/e2e_node/node_perf_test.go
+++ b/test/e2e_node/node_perf_test.go
@@ -28,10 +28,8 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
-	e2enodekubelet "k8s.io/kubernetes/test/e2e_node/kubeletconfig"
 	"k8s.io/kubernetes/test/e2e_node/perf/workloads"
 
 	"github.com/onsi/ginkgo/v2"
@@ -46,26 +44,6 @@ func makeNodePerfPod(w workloads.NodePerfWorkload) *v1.Pod {
 		},
 		Spec: w.PodSpec(),
 	}
-}
-
-func setKubeletConfig(ctx context.Context, f *framework.Framework, cfg *kubeletconfig.KubeletConfiguration) {
-	if cfg != nil {
-		// Update the Kubelet configuration.
-		ginkgo.By("Stopping the kubelet")
-		restartKubelet := mustStopKubelet(ctx, f)
-
-		framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(cfg))
-
-		ginkgo.By("Restarting the kubelet")
-		restartKubelet(ctx)
-	}
-
-	// Wait for the Kubelet to be ready.
-	gomega.Eventually(ctx, func(ctx context.Context) bool {
-		nodes, err := e2enode.TotalReady(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
-		return nodes == 1
-	}, time.Minute, time.Second).Should(gomega.BeTrueBecause("expected kubelet to be in ready state"))
 }
 
 // Serial because the test updates kubelet configuration.
@@ -86,7 +64,9 @@ var _ = SIGDescribe("Node Performance Testing", framework.WithSerial(), framewor
 		framework.ExpectNoError(err)
 		newCfg, err = wl.KubeletConfig(oldCfg)
 		framework.ExpectNoError(err)
-		setKubeletConfig(ctx, f, newCfg)
+		updateKubeletConfigWithOptions(ctx, f, newCfg, updateKubeletOptions{
+			deleteStateFiles: true,
+		})
 	})
 
 	cleanup := func(ctx context.Context) {
@@ -107,7 +87,6 @@ var _ = SIGDescribe("Node Performance Testing", framework.WithSerial(), framewor
 		ginkgo.By("running the post test exec from the workload")
 		err := wl.PostTestExec()
 		framework.ExpectNoError(err)
-		setKubeletConfig(ctx, f, oldCfg)
 	}
 
 	runWorkload := func(ctx context.Context) {

--- a/test/e2e_node/topology_manager_metrics_test.go
+++ b/test/e2e_node/topology_manager_metrics_test.go
@@ -65,7 +65,6 @@ var _ = SIGDescribe("Topology Manager Metrics", framework.WithSerial(), feature.
 			if testPod != nil {
 				deletePodSyncByName(ctx, f, testPod.Name)
 			}
-			updateKubeletConfig(ctx, f, oldCfg, true)
 		})
 
 		ginkgo.It("should report zero admission counters after a fresh restart", func(ctx context.Context) {

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -1352,13 +1352,6 @@ func runTopologyManagerTests(f *framework.Framework, topologyOptions map[string]
 
 		runTMScopeResourceAlignmentTestSuite(ctx, f, configMap, reservedSystemCPUs, policy, numaNodes, coreCount)
 	})
-
-	ginkgo.AfterEach(func(ctx context.Context) {
-		if oldCfg != nil {
-			// restore kubelet config
-			updateKubeletConfig(ctx, f, oldCfg, true)
-		}
-	})
 }
 
 func runPreferClosestNUMATests(f *framework.Framework) {
@@ -1384,13 +1377,6 @@ func runPreferClosestNUMATests(f *framework.Framework) {
 		updateKubeletConfig(ctx, f, newCfg, true)
 
 		runPreferClosestNUMATestSuite(ctx, f, numaNodes, numaDistances)
-	})
-
-	ginkgo.AfterEach(func(ctx context.Context) {
-		if oldCfg != nil {
-			// restore kubelet config
-			updateKubeletConfig(ctx, f, oldCfg, true)
-		}
 	})
 }
 

--- a/test/e2e_node/util_kubeletconfig.go
+++ b/test/e2e_node/util_kubeletconfig.go
@@ -74,40 +74,48 @@ type updateKubeletOptions struct {
 	deleteStateFiles bool
 	// In addition to the standard ready node check, ensure that the node stays consistently ready.
 	ensureConsistentReadyNode bool
-	// Whether to skip the cleanup step. This should only be used in special circumstances.
-	skipCleanup bool
+	// extraAction performs any extra configuration actions that are needed while the Kubelet is stopped.
+	// the function returned by extraAction will be called during the cleanup step (if non-nil)
+	extraAction func(context.Context) (func(context.Context), error)
 	// TODO: add option to use systemctl stop, now we only use systemctl kill for historical reasons
 }
 
 func updateKubeletConfigWithOptions(ctx context.Context, f *framework.Framework, kubeletConfig *kubeletconfig.KubeletConfiguration, opts updateKubeletOptions) {
 	ginkgo.GinkgoHelper()
 
-	updateConfig := func(ctx context.Context, kubeletConfig *kubeletconfig.KubeletConfiguration, opts updateKubeletOptions) {
-		withStoppedKubelet(ctx, f, opts.ensureConsistentReadyNode, func() {
-			if opts.deleteStateFiles {
-				deleteStateFiles()
-			}
-			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(kubeletConfig))
-		})
-	}
+	oldCfg, err := getCurrentKubeletConfig(ctx)
+	framework.ExpectNoError(err)
 
-	if !opts.skipCleanup {
-		oldCfg, err := getCurrentKubeletConfig(ctx)
-		framework.ExpectNoError(err)
-		ginkgo.DeferCleanup(func(ctx context.Context) {
-			// We just need the initial readiness check to succeed.
-			opts.ensureConsistentReadyNode = false
-			// A failure to successfully restore the kubelet is a fatal error.
-			err := gomega.InterceptGomegaFailure(func() {
-				updateConfig(ctx, oldCfg, opts)
+	var cleanupAction func(context.Context)
+	ginkgo.DeferCleanup(func(ctx context.Context) {
+		ginkgo.By("Restoring original Kubelet Configuration")
+		// A failure to successfully restore the kubelet is a fatal error.
+		err := gomega.InterceptGomegaFailure(func() {
+			withStoppedKubelet(ctx, f, false, func() {
+				if opts.deleteStateFiles {
+					deleteStateFiles()
+				}
+				framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(oldCfg))
+				if cleanupAction != nil {
+					cleanupAction(ctx)
+				}
 			})
-			if err != nil {
-				ginkgo.AbortSuite(fmt.Sprintf("Fatal Error: Failed to restore kubelet: %v", err.Error()))
-			}
 		})
-	}
+		if err != nil {
+			ginkgo.AbortSuite(fmt.Sprintf("Fatal Error: Failed to restore kubelet: %v", err.Error()))
+		}
+	})
 
-	updateConfig(ctx, kubeletConfig, opts)
+	withStoppedKubelet(ctx, f, opts.ensureConsistentReadyNode, func() {
+		if opts.deleteStateFiles {
+			deleteStateFiles()
+		}
+		framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(kubeletConfig))
+		if opts.extraAction != nil {
+			cleanupAction, err = opts.extraAction(ctx)
+			framework.ExpectNoError(err, "error performing extraAction during Kubelet configuration")
+		}
+	})
 }
 
 func deleteStateFiles() {

--- a/test/e2e_node/util_kubeletconfig.go
+++ b/test/e2e_node/util_kubeletconfig.go
@@ -71,25 +71,49 @@ func tempSetCurrentKubeletConfig(f *framework.Framework, updateFunction func(ctx
 }
 
 type updateKubeletOptions struct {
-	deleteStateFiles          bool
+	deleteStateFiles bool
+	// In addition to the standard ready node check, ensure that the node stays consistently ready.
 	ensureConsistentReadyNode bool
+	// Whether to skip the cleanup step. This should only be used in special circumstances.
+	skipCleanup bool
 	// TODO: add option to use systemctl stop, now we only use systemctl kill for historical reasons
 }
 
 func updateKubeletConfigWithOptions(ctx context.Context, f *framework.Framework, kubeletConfig *kubeletconfig.KubeletConfiguration, opts updateKubeletOptions) {
 	ginkgo.GinkgoHelper()
 
-	withStoppedKubelet(ctx, f, opts.ensureConsistentReadyNode, func() {
-		// Delete CPU and memory manager state files to be sure it will not prevent the kubelet restart
-		if opts.deleteStateFiles {
-			deleteStateFile(cpuManagerStateFile)
-			deleteStateFile(memoryManagerStateFile)
-			deleteStateFile(usernsStateFiles)
-		}
+	updateConfig := func(ctx context.Context, kubeletConfig *kubeletconfig.KubeletConfiguration, opts updateKubeletOptions) {
+		withStoppedKubelet(ctx, f, opts.ensureConsistentReadyNode, func() {
+			if opts.deleteStateFiles {
+				deleteStateFiles()
+			}
+			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(kubeletConfig))
+		})
+	}
 
-		framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(kubeletConfig))
-	})
+	if !opts.skipCleanup {
+		oldCfg, err := getCurrentKubeletConfig(ctx)
+		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			// We just need the initial readiness check to succeed.
+			opts.ensureConsistentReadyNode = false
+			// A failure to successfully restore the kubelet is a fatal error.
+			err := gomega.InterceptGomegaFailure(func() {
+				updateConfig(ctx, oldCfg, opts)
+			})
+			if err != nil {
+				ginkgo.AbortSuite(fmt.Sprintf("Fatal Error: Failed to restore kubelet: %v", err.Error()))
+			}
+		})
+	}
 
+	updateConfig(ctx, kubeletConfig, opts)
+}
+
+func deleteStateFiles() {
+	deleteStateFile(cpuManagerStateFile)
+	deleteStateFile(memoryManagerStateFile)
+	deleteStateFile(usernsStateFiles)
 }
 
 func updateKubeletConfig(ctx context.Context, f *framework.Framework, kubeletConfig *kubeletconfig.KubeletConfiguration, deleteStateFiles bool) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

There have been a few examples recently of Kubelet failing to come up after a bad configuration:
- https://github.com/kubernetes/kubernetes/issues/137995
- https://github.com/kubernetes/kubernetes/issues/137950

This PR automatically adds the cleanup to restore the configuration after changing it, but it also requires that restoration to be successful, and aborts the whole suite if it is not. That is because if the Kubelet is not running, every subsequent test will fail. Aborting the suite early saves on CI resources and makes it easier to pinpoint the failure.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/137995
https://github.com/kubernetes/kubernetes/issues/137950

#### Special notes for your reviewer:

I'm depending on CI jobs to exercise the tests. I will remove the WIP label when I'm satisfied with the coverage.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node