### PR TITLE
[InPlacePodLevelResourcesVerticalScaling] fix erroneously reporting a PLR resize in progress on pod creation

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -2218,7 +2218,22 @@ func (m *kubeGenericRuntimeManager) isPodLevelResourcesResizeInProgress(allocate
 		return false
 	}
 
-	if allocatedPod.Spec.Resources == nil {
+	if allocatedPod.Spec.Resources == nil || podStatus == nil {
+		return false
+	}
+
+	// If no containers are running, there's nothing to be resized.
+	isAnyContainerRunning := !podutil.VisitContainers(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers,
+		func(allocatedContainer *v1.Container, containerType podutil.ContainerType) (shouldContinue bool) {
+			if !isResizableContainer(allocatedContainer, containerType) {
+				return true
+			}
+			containerStatus := podStatus.FindContainerStatusByName(allocatedContainer.Name)
+			return containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning
+		},
+	)
+
+	if !isAnyContainerRunning {
 		return false
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -5278,6 +5278,19 @@ func TestIsPodResizeInProgress(t *testing.T) {
 		}},
 		expectHasResize:              true,
 		inplacePodLevelResizeEnabled: true,
+	}, {
+		name: "plr mismatch during initial creation (containers not started)",
+		podLevelResources: &testPLR{
+			allocated: testResources{cpuReq: 200},
+			actuated:  &testResources{cpuReq: 100},
+		},
+		containers: []testContainer{{
+			allocated: testResources{cpuReq: 100},
+			actuated:  &testResources{cpuReq: 100},
+			isRunning: false,
+		}},
+		expectHasResize:              false,
+		inplacePodLevelResizeEnabled: true,
 	}}
 
 	mkRequirements := func(r testResources) v1.ResourceRequirements {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When a pod is first created and goes through its first sync loop iteration, the actuated resources != allocated resources, because neither the containers nor pod cgroups have been set up yet. The pod-level resize in-progress check is erroneously reporting in this scenario that a resize is in progress; on the next sync loop iteration it corrects itself - however this results in an unnecessary ResizeCompleted event being emitted due to the status manager believing that the PodResizeInProgress condition has been flipped from `true` to `false`.

For container-level resize, we have a check to prevent this exact circumstance here: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L2198-L2200.

This PR adds an analogous check for pod-level resize, where a pod-level resize in-progress check reports false if none of the containers are running. I have confirmed the fix using the reproduction steps reported in https://github.com/kubernetes/kubernetes/issues/137858.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/137858.

#### Special notes for your reviewer:

~I don't think this is critical for 1.36, but we should try to merge this prior to PLR resize GA.~

ETA: This was deemed important for 1.36 because it impacts every pod that is created with pod-level resources, and both features are now beta and enabled by default.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix erroneously reporting a pod-level resize in progress on pod creation when InPlacePodLevelResourcesVerticalScaling is enabled.
```

/sig node
/assign @ndixita @tallclair 
/priority important-longterm
