### PR TITLE
validation-gen: reject min/max tag values that overflow target integer type

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 
 	"k8s.io/gengo/v2/parser/tags"
@@ -135,6 +136,76 @@ func ParseInt(val string) (int, error) {
 	}
 
 	return intVal, nil
+}
+
+// ParseSignedInt strictly parses a signed integer from a string input and
+// validates that the result fits within the specified bit size. The bitSize
+// parameter should be 8, 16, 32, or 64, corresponding to the target Go type.
+// Values outside the representable range for the target type are rejected at
+// parse time with a descriptive error.
+func ParseSignedInt(val string, bitSize int) (int64, error) {
+	intVal, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %q as int: %w", val, err)
+	}
+
+	// Verify canonical form: reject leading zeros, unary plus, etc.
+	strVal := strconv.FormatInt(intVal, 10)
+	if strVal != val {
+		return 0, fmt.Errorf("%q is not a valid int value", val)
+	}
+
+	// Validate the parsed value fits in the target type's range.
+	var minVal, maxVal int64
+	switch bitSize {
+	case 8:
+		minVal, maxVal = math.MinInt8, math.MaxInt8
+	case 16:
+		minVal, maxVal = math.MinInt16, math.MaxInt16
+	case 32:
+		minVal, maxVal = math.MinInt32, math.MaxInt32
+	default:
+		minVal, maxVal = math.MinInt64, math.MaxInt64
+	}
+	if intVal < minVal || intVal > maxVal {
+		return 0, fmt.Errorf("value %d does not fit in int%d (range [%d, %d])", intVal, bitSize, minVal, maxVal)
+	}
+
+	return intVal, nil
+}
+
+// ParseUnsignedInt strictly parses an unsigned integer from a string input and
+// validates that the result fits within the specified bit size. The bitSize
+// parameter should be 8, 16, 32, or 64, corresponding to the target Go type.
+func ParseUnsignedInt(val string, bitSize int) (uint64, error) {
+	uintVal, err := strconv.ParseUint(val, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %q as uint: %w", val, err)
+	}
+
+	// Verify canonical form: reject leading zeros, unary plus, etc.
+	strVal := strconv.FormatUint(uintVal, 10)
+	if strVal != val {
+		return 0, fmt.Errorf("%q is not a valid uint value", val)
+	}
+
+	// Validate the parsed value fits in the target type's range.
+	var maxVal uint64
+	switch bitSize {
+	case 8:
+		maxVal = math.MaxUint8
+	case 16:
+		maxVal = math.MaxUint16
+	case 32:
+		maxVal = math.MaxUint32
+	default:
+		maxVal = math.MaxUint64
+	}
+	if uintVal > maxVal {
+		return 0, fmt.Errorf("value %d does not fit in uint%d (range [0, %d])", uintVal, bitSize, maxVal)
+	}
+
+	return uintVal, nil
 }
 
 // ParseBool strictly parses a bool from a string input,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util.go
@@ -164,8 +164,10 @@ func ParseSignedInt(val string, bitSize int) (int64, error) {
 		minVal, maxVal = math.MinInt16, math.MaxInt16
 	case 32:
 		minVal, maxVal = math.MinInt32, math.MaxInt32
-	default:
+	case 64:
 		minVal, maxVal = math.MinInt64, math.MaxInt64
+	default:
+		return 0, fmt.Errorf("unsupported bitSize %d; must be 8, 16, 32, or 64", bitSize)
 	}
 	if intVal < minVal || intVal > maxVal {
 		return 0, fmt.Errorf("value %d does not fit in int%d (range [%d, %d])", intVal, bitSize, minVal, maxVal)
@@ -198,8 +200,10 @@ func ParseUnsignedInt(val string, bitSize int) (uint64, error) {
 		maxVal = math.MaxUint16
 	case 32:
 		maxVal = math.MaxUint32
-	default:
+	case 64:
 		maxVal = math.MaxUint64
+	default:
+		return 0, fmt.Errorf("unsupported bitSize %d; must be 8, 16, 32, or 64", bitSize)
 	}
 	if uintVal > maxVal {
 		return 0, fmt.Errorf("value %d does not fit in uint%d (range [0, %d])", uintVal, bitSize, maxVal)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util_test.go
@@ -707,6 +707,12 @@ func TestParseSignedInt(t *testing.T) {
 			bitSize:       32,
 			expectedError: true,
 		},
+		{
+			name:          "unknown bit size returns error",
+			in:            "1",
+			bitSize:       7,
+			expectedError: true,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -843,6 +849,12 @@ func TestParseUnsignedInt(t *testing.T) {
 			name:          "floating point rejected",
 			in:            "1.0",
 			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "unknown bit size returns error",
+			in:            "1",
+			bitSize:       7,
 			expectedError: true,
 		},
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util_test.go
@@ -516,6 +516,354 @@ func TestParseInt(t *testing.T) {
 	}
 }
 
+func TestParseSignedInt(t *testing.T) {
+	type testcase struct {
+		name          string
+		in            string
+		bitSize       int
+		expectedOut   int64
+		expectedError bool
+	}
+
+	testcases := []testcase{
+		// --- int32 valid boundaries ---
+		{
+			name:        "int32 exact minimum boundary",
+			in:          "-2147483648",
+			bitSize:     32,
+			expectedOut: -2147483648,
+		},
+		{
+			name:        "int32 exact maximum boundary",
+			in:          "2147483647",
+			bitSize:     32,
+			expectedOut: 2147483647,
+		},
+		{
+			name:        "int32 zero",
+			in:          "0",
+			bitSize:     32,
+			expectedOut: 0,
+		},
+		{
+			name:        "int32 positive value",
+			in:          "100",
+			bitSize:     32,
+			expectedOut: 100,
+		},
+		{
+			name:        "int32 negative value",
+			in:          "-1",
+			bitSize:     32,
+			expectedOut: -1,
+		},
+		// --- int32 overflow ---
+		{
+			name:          "int32 one below minimum overflows",
+			in:            "-2147483649",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "int32 one above maximum overflows",
+			in:            "2147483648",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:        "int64 accepts value that overflows int32",
+			in:          "2147483648",
+			bitSize:     64,
+			expectedOut: 2147483648,
+		},
+		// --- int64 valid boundaries ---
+		{
+			name:        "int64 exact minimum boundary",
+			in:          "-9223372036854775808",
+			bitSize:     64,
+			expectedOut: -9223372036854775808,
+		},
+		{
+			name:        "int64 exact maximum boundary",
+			in:          "9223372036854775807",
+			bitSize:     64,
+			expectedOut: 9223372036854775807,
+		},
+		// --- int64 overflow ---
+		{
+			name:          "int64 one above maximum overflows",
+			in:            "9223372036854775808",
+			bitSize:       64,
+			expectedError: true,
+		},
+		{
+			name:          "int64 one below minimum overflows",
+			in:            "-9223372036854775809",
+			bitSize:       64,
+			expectedError: true,
+		},
+		// --- int16 boundaries ---
+		{
+			name:        "int16 exact minimum boundary",
+			in:          "-32768",
+			bitSize:     16,
+			expectedOut: -32768,
+		},
+		{
+			name:        "int16 exact maximum boundary",
+			in:          "32767",
+			bitSize:     16,
+			expectedOut: 32767,
+		},
+		{
+			name:          "int16 one above maximum overflows",
+			in:            "32768",
+			bitSize:       16,
+			expectedError: true,
+		},
+		{
+			name:          "int16 one below minimum overflows",
+			in:            "-32769",
+			bitSize:       16,
+			expectedError: true,
+		},
+		// --- int8 boundaries ---
+		{
+			name:        "int8 exact minimum boundary",
+			in:          "-128",
+			bitSize:     8,
+			expectedOut: -128,
+		},
+		{
+			name:        "int8 exact maximum boundary",
+			in:          "127",
+			bitSize:     8,
+			expectedOut: 127,
+		},
+		{
+			name:          "int8 one above maximum overflows",
+			in:            "128",
+			bitSize:       8,
+			expectedError: true,
+		},
+		{
+			name:          "int8 one below minimum overflows",
+			in:            "-129",
+			bitSize:       8,
+			expectedError: true,
+		},
+		// --- canonical form rejection ---
+		{
+			name:          "leading zeros rejected",
+			in:            "0100",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "unary plus rejected",
+			in:            "+1",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "octal notation rejected",
+			in:            "0o77",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "hex notation rejected",
+			in:            "0xFF",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "empty string rejected",
+			in:            "",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "non-numeric string rejected",
+			in:            "abc",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "floating point rejected",
+			in:            "1.5",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "whitespace rejected",
+			in:            " 1",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "negative zero canonical form rejected",
+			in:            "-0",
+			bitSize:       32,
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := ParseSignedInt(tc.in, tc.bitSize)
+			switch {
+			case tc.expectedError && err == nil:
+				t.Errorf("expected an error for input %q with bitSize %d but did not receive one (got %d)", tc.in, tc.bitSize, out)
+			case !tc.expectedError && err != nil:
+				t.Errorf("received an unexpected error for input %q with bitSize %d: %v", tc.in, tc.bitSize, err)
+			}
+
+			if out != tc.expectedOut {
+				t.Errorf("expected output %d but got %d", tc.expectedOut, out)
+			}
+		})
+	}
+}
+
+func TestParseUnsignedInt(t *testing.T) {
+	type testcase struct {
+		name          string
+		in            string
+		bitSize       int
+		expectedOut   uint64
+		expectedError bool
+	}
+
+	testcases := []testcase{
+		// --- uint64 valid boundaries ---
+		{
+			name:        "uint64 maximum boundary",
+			in:          "18446744073709551615",
+			bitSize:     64,
+			expectedOut: 18446744073709551615,
+		},
+		{
+			name:        "uint64 zero",
+			in:          "0",
+			bitSize:     64,
+			expectedOut: 0,
+		},
+		// --- uint64 overflow ---
+		{
+			name:          "uint64 one above maximum overflows",
+			in:            "18446744073709551616",
+			bitSize:       64,
+			expectedError: true,
+		},
+		// --- uint32 valid boundaries ---
+		{
+			name:        "uint32 maximum boundary",
+			in:          "4294967295",
+			bitSize:     32,
+			expectedOut: 4294967295,
+		},
+		{
+			name:        "uint32 zero",
+			in:          "0",
+			bitSize:     32,
+			expectedOut: 0,
+		},
+		{
+			name:          "uint32 one above maximum overflows",
+			in:            "4294967296",
+			bitSize:       32,
+			expectedError: true,
+		},
+		// --- uint16 valid boundaries ---
+		{
+			name:        "uint16 maximum boundary",
+			in:          "65535",
+			bitSize:     16,
+			expectedOut: 65535,
+		},
+		{
+			name:          "uint16 one above maximum overflows",
+			in:            "65536",
+			bitSize:       16,
+			expectedError: true,
+		},
+		// --- uint8 valid boundaries ---
+		{
+			name:        "uint8 maximum boundary",
+			in:          "255",
+			bitSize:     8,
+			expectedOut: 255,
+		},
+		{
+			name:          "uint8 one above maximum overflows",
+			in:            "256",
+			bitSize:       8,
+			expectedError: true,
+		},
+		// --- negative values rejected for unsigned ---
+		{
+			name:          "negative value rejected",
+			in:            "-1",
+			bitSize:       64,
+			expectedError: true,
+		},
+		{
+			name:        "uint64 accepts value that overflows uint32",
+			in:          "4294967296",
+			bitSize:     64,
+			expectedOut: 4294967296,
+		},
+		// --- canonical form rejection ---
+		{
+			name:          "leading zeros rejected",
+			in:            "0100",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "unary plus rejected",
+			in:            "+1",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "empty string rejected",
+			in:            "",
+			bitSize:       64,
+			expectedError: true,
+		},
+		{
+			name:          "hex notation rejected",
+			in:            "0xFF",
+			bitSize:       32,
+			expectedError: true,
+		},
+		{
+			name:          "floating point rejected",
+			in:            "1.0",
+			bitSize:       32,
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := ParseUnsignedInt(tc.in, tc.bitSize)
+			switch {
+			case tc.expectedError && err == nil:
+				t.Errorf("expected an error for input %q with bitSize %d but did not receive one (got %d)", tc.in, tc.bitSize, out)
+			case !tc.expectedError && err != nil:
+				t.Errorf("received an unexpected error for input %q with bitSize %d: %v", tc.in, tc.bitSize, err)
+			}
+
+			if out != tc.expectedOut {
+				t.Errorf("expected output %d but got %d", tc.expectedOut, out)
+			}
+		})
+	}
+}
+
 func TestParseBool(t *testing.T) {
 	type testcase struct {
 		name          string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
@@ -35,11 +35,27 @@ func rootTypeString(src, dst *types.Type) string {
 	return src.String() + " -> " + dst.String()
 }
 
-// isInt returns true if t is a uint type.
+// isUnsignedInt returns true if t is an unsigned integer type.
 func isUnsignedInt(t *types.Type) bool {
 	switch t {
 	case types.Uint, types.Uint64, types.Uint32, types.Uint16, types.Byte:
 		return true
 	}
 	return false
+}
+
+// intBitSize returns the bit width of a gengo integer type. For platform-sized
+// types (int, uint), 64 is returned because all supported Kubernetes platforms
+// are 64-bit. Byte maps to 8.
+func intBitSize(t *types.Type) int {
+	switch t {
+	case types.Byte: // int8 becomes byte in gengo
+		return 8
+	case types.Int16, types.Uint16:
+		return 16
+	case types.Int32, types.Uint32:
+		return 32
+	default: // int, int64, uint, uint64
+		return 64
+	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
@@ -17,6 +17,8 @@ limitations under the License.
 package validators
 
 import (
+	"strconv"
+
 	"k8s.io/gengo/v2/types"
 )
 
@@ -45,8 +47,7 @@ func isUnsignedInt(t *types.Type) bool {
 }
 
 // intBitSize returns the bit width of a gengo integer type. For platform-sized
-// types (int, uint), 64 is returned because all supported Kubernetes platforms
-// are 64-bit. Byte maps to 8.
+// types (int, uint), strconv.IntSize is used. Byte maps to 8.
 func intBitSize(t *types.Type) int {
 	switch t {
 	case types.Byte: // int8 becomes byte in gengo
@@ -55,7 +56,9 @@ func intBitSize(t *types.Type) int {
 		return 16
 	case types.Int32, types.Uint32:
 		return 32
-	default: // int, int64, uint, uint64
+	case types.Int64, types.Uint64:
 		return 64
+	default: // int, uint
+		return strconv.IntSize
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validators
 
 import (
+	"fmt"
 	"strconv"
 
 	"k8s.io/gengo/v2/types"
@@ -47,18 +48,22 @@ func isUnsignedInt(t *types.Type) bool {
 }
 
 // intBitSize returns the bit width of a gengo integer type. For platform-sized
-// types (int, uint), strconv.IntSize is used. Byte maps to 8.
-func intBitSize(t *types.Type) int {
+// types (int, uint), strconv.IntSize is used. Byte maps to 8. Returns an error
+// for any type not in the supported integer set so unrecognized types are
+// caught at codegen time rather than silently falling back.
+func intBitSize(t *types.Type) (int, error) {
 	switch t {
 	case types.Byte: // int8 becomes byte in gengo
-		return 8
+		return 8, nil
 	case types.Int16, types.Uint16:
-		return 16
+		return 16, nil
 	case types.Int32, types.Uint32:
-		return 32
+		return 32, nil
 	case types.Int64, types.Uint64:
-		return 64
-	default: // int, uint
-		return strconv.IntSize
+		return 64, nil
+	case types.Int, types.Uint:
+		return strconv.IntSize, nil
+	default:
+		return 0, fmt.Errorf("unsupported integer type: %v", t)
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -288,7 +288,10 @@ func (minimumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 		return result, fmt.Errorf("can only be used on integer types (%s)", rootTypeString(context.Type, t))
 	}
 
-	bitSize := intBitSize(t)
+	bitSize, err := intBitSize(t)
+	if err != nil {
+		return result, err
+	}
 	if isUnsignedInt(t) {
 		uintVal, err := util.ParseUnsignedInt(tag.Value, bitSize)
 		if err != nil {
@@ -346,7 +349,10 @@ func (maximumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 		return result, fmt.Errorf("can only be used on integer types (%s)", rootTypeString(context.Type, t))
 	}
 
-	bitSize := intBitSize(t)
+	bitSize, err := intBitSize(t)
+	if err != nil {
+		return result, err
+	}
 	if isUnsignedInt(t) {
 		uintVal, err := util.ParseUnsignedInt(tag.Value, bitSize)
 		if err != nil {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -288,14 +288,20 @@ func (minimumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 		return result, fmt.Errorf("can only be used on integer types (%s)", rootTypeString(context.Type, t))
 	}
 
-	intVal, err := util.ParseInt(tag.Value)
-	if err != nil {
-		return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
+	bitSize := intBitSize(t)
+	if isUnsignedInt(t) {
+		uintVal, err := util.ParseUnsignedInt(tag.Value, bitSize)
+		if err != nil {
+			return result, fmt.Errorf("failed to parse tag payload: %w", err)
+		}
+		result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, uintVal))
+	} else {
+		intVal, err := util.ParseSignedInt(tag.Value, bitSize)
+		if err != nil {
+			return result, fmt.Errorf("failed to parse tag payload: %w", err)
+		}
+		result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, intVal))
 	}
-	if isUnsignedInt(t) && intVal < 0 {
-		return result, fmt.Errorf("must be greater than or equal to zero for unsigned types (%s)", rootTypeString(context.Type, t))
-	}
-	result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, intVal))
 	return result, nil
 }
 
@@ -340,14 +346,20 @@ func (maximumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 		return result, fmt.Errorf("can only be used on integer types (%s)", rootTypeString(context.Type, t))
 	}
 
-	intVal, err := util.ParseInt(tag.Value)
-	if err != nil {
-		return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
+	bitSize := intBitSize(t)
+	if isUnsignedInt(t) {
+		uintVal, err := util.ParseUnsignedInt(tag.Value, bitSize)
+		if err != nil {
+			return result, fmt.Errorf("failed to parse tag payload: %w", err)
+		}
+		result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, uintVal))
+	} else {
+		intVal, err := util.ParseSignedInt(tag.Value, bitSize)
+		if err != nil {
+			return result, fmt.Errorf("failed to parse tag payload: %w", err)
+		}
+		result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, intVal))
 	}
-	if isUnsignedInt(t) && intVal < 0 {
-		return result, fmt.Errorf("must be greater than or equal to zero for unsigned types (%s)", rootTypeString(context.Type, t))
-	}
-	result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, intVal))
 	return result, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`validation-gen`'s `ParseInt` uses `strconv.Atoi`, which returns a platform-sized `int` and performs no validation against the target field's actual type. Writing `+k8s:minimum=-2147483649` on an `int32` field passes codegen without error but emits a literal that overflows `int32`, producing a Go compile failure with no indication that the tag value is out of range. For unsigned types, `strconv.Atoi` cannot parse values above `math.MaxInt64`, so valid `uint64` boundary values like `18446744073709551615` cannot be expressed at all.

This PR adds `ParseSignedInt` and `ParseUnsignedInt` to `util.go`, each accepting a `bitSize` parameter that validates the parsed value fits the target type's representable range at codegen time. The `minimumTagValidator` and `maximumTagValidator` in `limits.go` now resolve the field's bit width through a new `intBitSize` helper in `common.go`, select the signed or unsigned parser based on the gengo type, and store the result as `int64` or `uint64` in `FunctionGen.Args`.

The existing `ParseInt` function and all its other callers (maxLength, maxBytes, minItems, maxItems, equality, item, discriminator) are unchanged because those validators operate on lengths and counts that always fit in `int`.

The `toGolangSourceDataLiteral` switch at `validation.go:1518` already handles `int64` and `uint64` in its type list, so storing typed values in `FunctionGen.Args` requires no changes to the emission path.

#### Which issue(s) this PR is related to:

Fixes #137965

#### Special notes for your reviewer:

No Kubernetes API types currently use unsigned integer fields, so the unsigned path is for library correctness. The signed path addresses the gap discovered via PR #136589 where `+k8s:minimum=-2147483648` was applied to an `int32` `Priority` field. That boundary value is valid, but it exposed that values one past the boundary (like `-2147483649`) would pass codegen silently and fail only at compile time.

**Testing done locally:**
- `go test ./staging/src/k8s.io/code-generator/cmd/validation-gen/...` passes all 120 test packages
- New `TestParseSignedInt` (29 cases) and `TestParseUnsignedInt` (17 cases) pass
- Boundary tests cover exact min/max for int8, int16, int32, int64, uint8, uint16, uint32, uint64
- Overflow by one in each direction, cross-boundary acceptance (value valid for int64 but not int32), canonical form rejection (leading zeros, unary plus, hex, octal, floating point, whitespace), and negative zero

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/sig api-machinery
/area api-validation