### PR TITLE
Pod events fix

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -2222,22 +2222,11 @@ func (m *kubeGenericRuntimeManager) isPodLevelResourcesResizeInProgress(allocate
 		return false
 	}
 
-	// If no containers are running, there's nothing to be resized.
-	isAnyContainerRunning := !podutil.VisitContainers(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers,
-		func(allocatedContainer *v1.Container, containerType podutil.ContainerType) (shouldContinue bool) {
-			if !isResizableContainer(allocatedContainer, containerType) {
-				return true
-			}
-			containerStatus := podStatus.FindContainerStatusByName(allocatedContainer.Name)
-			return containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning
-		},
-	)
-
-	if !isAnyContainerRunning {
+	actuatedPodResources, found := m.actuatedState.GetPodLevelResources(allocatedPod.UID)
+	if !found || actuatedPodResources == nil {
 		return false
 	}
 
-	actuatedPodResources, _ := m.actuatedState.GetPodLevelResources(allocatedPod.UID)
 	allocatedPodResources := allocatedPod.Spec.Resources
 
 	return !cpuMemoryResourcesEqual(actuatedPodResources, allocatedPodResources)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -2218,7 +2218,22 @@ func (m *kubeGenericRuntimeManager) isPodLevelResourcesResizeInProgress(allocate
 		return false
 	}
 
-	if allocatedPod.Spec.Resources == nil {
+	if allocatedPod.Spec.Resources == nil || podStatus == nil {
+		return false
+	}
+
+	// If no containers are running, there's nothing to be resized.
+	isAnyContainerRunning := !podutil.VisitContainers(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers,
+		func(allocatedContainer *v1.Container, containerType podutil.ContainerType) (shouldContinue bool) {
+			if !isResizableContainer(allocatedContainer, containerType) {
+				return true
+			}
+			containerStatus := podStatus.FindContainerStatusByName(allocatedContainer.Name)
+			return containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning
+		},
+	)
+
+	if !isAnyContainerRunning {
 		return false
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -5279,14 +5279,12 @@ func TestIsPodResizeInProgress(t *testing.T) {
 		expectHasResize:              true,
 		inplacePodLevelResizeEnabled: true,
 	}, {
-		name: "plr mismatch during initial creation (containers not started)",
+		name: "plr mismatch during initial creation",
 		podLevelResources: &testPLR{
 			allocated: testResources{cpuReq: 200},
-			actuated:  &testResources{cpuReq: 100},
 		},
 		containers: []testContainer{{
 			allocated: testResources{cpuReq: 100},
-			actuated:  &testResources{cpuReq: 100},
 			isRunning: false,
 		}},
 		expectHasResize:              false,

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -5278,6 +5278,19 @@ func TestIsPodResizeInProgress(t *testing.T) {
 		}},
 		expectHasResize:              true,
 		inplacePodLevelResizeEnabled: true,
+	}, {
+		name: "plr mismatch during initial creation (containers not started)",
+		podLevelResources: &testPLR{
+			allocated: testResources{cpuReq: 200},
+			actuated:  &testResources{cpuReq: 100},
+		},
+		containers: []testContainer{{
+			allocated: testResources{cpuReq: 100},
+			actuated:  &testResources{cpuReq: 100},
+			isRunning: false,
+		}},
+		expectHasResize:              false,
+		inplacePodLevelResizeEnabled: true,
 	}}
 
 	mkRequirements := func(r testResources) v1.ResourceRequirements {

--- a/test/e2e/common/node/pod_level_resources_resize.go
+++ b/test/e2e/common/node/pod_level_resources_resize.go
@@ -29,7 +29,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/pkg/features"
+	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/common/node/framework/cgroups"
 	"k8s.io/kubernetes/test/e2e/common/node/framework/podresize"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -448,6 +450,7 @@ var _ = SIGDescribe("PLR Pod InPlace Resize", framework.WithFeatureGate(features
 	doGuaranteedPodLevelResizeTests(f)
 	doBurstablePodLevelResizeTests(f)
 	doPodLevelResourcesMemoryLimitDecreaseTest(f)
+	doInitialCreationNoResizeEventTest(f)
 })
 
 func makePodResources(cpuReq, cpuLim, memReq, memLim string) *v1.ResourceRequirements {
@@ -639,6 +642,39 @@ func doPodLevelResourcesMemoryLimitDecreaseTest(f *framework.Framework) {
 
 		ginkgo.By("deleting pod")
 		podClient.DeleteSync(ctx, testPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+	})
+}
+
+func doInitialCreationNoResizeEventTest(f *framework.Framework) {
+	framework.It("should not emit ResizeCompleted event on initial creation", framework.WithKubeletMinVersion("1.36"), func(ctx context.Context) {
+		podClient := e2epod.NewPodClient(f)
+		originalPLR := &v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("200m"),
+				v1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("200m"),
+				v1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		}
+
+		containers := []podresize.ResizableContainerInfo{{
+			Name: "c1",
+		}}
+
+		ginkgo.By("creating and verifying pod")
+		testPod := createAndVerifyPodPLR(ctx, f, podClient, containers, originalPLR, true)
+
+		ginkgo.By("verifying no ResizeCompleted event was emitted")
+		events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).SearchWithContext(ctx, scheme.Scheme, testPod)
+		framework.ExpectNoError(err, "failed to list events")
+
+		for _, event := range events.Items {
+			if event.Reason == kubeletevents.ResizeCompleted {
+				framework.Failf("Unexpected ResizeCompleted event found for pod %s: %v", testPod.Name, event)
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR has cherry-picked changes from https://github.com/kubernetes/kubernetes/pull/138045

When a pod is first created and goes through its first sync loop iteration, the actuated resources != allocated resources, because neither the containers nor pod cgroups have been set up yet. The pod-level resize in-progress check is erroneously reporting in this scenario that a resize is in progress; on the next sync loop iteration it corrects itself - however this results in an unnecessary ResizeCompleted event being emitted due to the status manager believing that the PodResizeInProgress condition has been flipped from true to false.

For container-level resize, we have a check to prevent this exact circumstance here: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L2198-L2200.

This PR adds an analogous check for pod-level resize, where a pod-level resize in-progress check reports false if none of the containers are running. I have confirmed the fix using the reproduction steps reported in https://github.com/kubernetes/kubernetes/issues/137858.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/137858.
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This was deemed important for 1.36 because it impacts every pod that is created with pod-level resources, and both features are now beta and enabled by default.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix erroneously reporting a pod-level resize in progress on pod creation when InPlacePodLevelResourcesVerticalScaling is enabled.
```

/sig node

/priority important-soon

