### PR TITLE
[WIP] Metrics for troubleshooting watch stability / latency issues

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -210,8 +210,10 @@ func (c *cacheWatcher) add(event *watchCacheEvent, timer *time.Timer) bool {
 	}
 
 	// OK, block sending, but only until timer fires.
+	start := time.Now()
 	select {
 	case c.input <- event:
+		metrics.RecordCacheWatcherInputQueueBlock(c.groupResource, start)
 		return true
 	case <-timer.C:
 		closeFunc()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -880,7 +880,9 @@ func (c *Cacher) processEvent(event *watchCacheEvent) {
 		// Monitor if this gets backed up, and how much.
 		klog.V(1).Infof("cacher (%v): %v objects queued in incoming channel.", c.groupResource.String(), curLen)
 	}
+	start := time.Now()
 	c.incoming <- *event
+	metrics.RecordCacherIncomingQueueBlock(c.groupResource, start)
 }
 
 func (c *Cacher) dispatchEvents() {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/features"
@@ -171,6 +172,26 @@ var (
 			Buckets:        []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3},
 		}, []string{"group", "resource"})
 
+	cacherIncomingQueueBlockDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "incoming_queue_block_duration_seconds",
+			Help:           "Time spent waiting to write to the incoming channel in Cacher.",
+			StabilityLevel: compbasemetrics.ALPHA,
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 5, 10},
+		}, []string{"group", "resource"})
+
+	cacheWatcherInputQueueBlockDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "cache_watcher_input_queue_block_duration_seconds",
+			Help:           "Time spent waiting to write to the input channel of a cache watcher.",
+			StabilityLevel: compbasemetrics.ALPHA,
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 5, 10},
+		}, []string{"group", "resource"})
+
 	ConsistentReadTotal = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Namespace:      namespace,
@@ -234,6 +255,8 @@ func Register() {
 			legacyregistry.MustRegister(WatchShardsTotal)
 			legacyregistry.MustRegister(WatchFilteredEventsTotal)
 		}
+		legacyregistry.MustRegister(cacherIncomingQueueBlockDuration)
+		legacyregistry.MustRegister(cacheWatcherInputQueueBlockDuration)
 	})
 }
 
@@ -274,4 +297,21 @@ func RecordsWatchCacheCapacityChange(groupResource schema.GroupResource, old, ne
 		return
 	}
 	watchCacheCapacityDecreaseTotal.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
+}
+
+// RecordCacherIncomingQueueBlock updates the incoming_queue_block_duration_seconds metric.
+func RecordCacherIncomingQueueBlock(groupResource schema.GroupResource, startTime time.Time) {
+	cacherIncomingQueueBlockDuration.WithLabelValues(groupResource.Group, groupResource.Resource).Observe(sinceInSeconds(startTime))
+}
+
+// RecordCacheWatcherInputQueueBlock updates the cache_watcher_input_queue_block_duration_seconds metric.
+func RecordCacheWatcherInputQueueBlock(groupResource schema.GroupResource, startTime time.Time) {
+	cacheWatcherInputQueueBlockDuration.WithLabelValues(groupResource.Group, groupResource.Resource).Observe(sinceInSeconds(startTime))
+}
+
+// sinceInSeconds gets the time since the specified start in seconds.
+//
+// This is a variable to facilitate testing.
+var sinceInSeconds = func(start time.Time) float64 {
+	return time.Since(start).Seconds()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics_test.go
@@ -1,0 +1,112 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestRecordCacherMetrics(t *testing.T) {
+	registry := metrics.NewKubeRegistry()
+
+	sinceInSeconds = func(t time.Time) float64 {
+		return time.Unix(0, 500*int64(time.Millisecond)).Sub(t).Seconds()
+	}
+
+	testedMetrics := []metrics.Registerable{
+		cacherIncomingQueueBlockDuration,
+		cacheWatcherInputQueueBlockDuration,
+	}
+
+
+	testedMetricsName := make([]string, 0, len(testedMetrics))
+	for _, m := range testedMetrics {
+		registry.MustRegister(m)
+		testedMetricsName = append(testedMetricsName, m.FQName())
+	}
+
+	testCases := []struct {
+		desc          string
+		isIncoming    bool
+		groupResource schema.GroupResource
+		startTime     time.Time
+		want          string
+	}{
+		{
+			desc:          "incoming_queue_block",
+			isIncoming:    true,
+			groupResource: schema.GroupResource{Group: "foo", Resource: "bar"},
+			startTime:     time.Unix(0, 0),
+
+			want: `# HELP apiserver_watch_cache_incoming_queue_block_duration_seconds [ALPHA] Time spent waiting to write to the incoming channel in Cacher.
+# TYPE apiserver_watch_cache_incoming_queue_block_duration_seconds histogram
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.001"} 0
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.005"} 0
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.025"} 0
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.05"} 0
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.1"} 0
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.2"} 0
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.4"} 0
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.6"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.8"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="1"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="1.25"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="1.5"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="2"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="3"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="5"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="10"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="+Inf"} 1
+apiserver_watch_cache_incoming_queue_block_duration_seconds_sum{group="foo",resource="bar"} 0.5
+apiserver_watch_cache_incoming_queue_block_duration_seconds_count{group="foo",resource="bar"} 1
+`,
+		},
+		{
+			desc:          "cache_watcher_input_queue_block",
+			isIncoming:    false,
+			groupResource: schema.GroupResource{Group: "foo", Resource: "bar"},
+			startTime:     time.Unix(0, 0),
+
+			want: `# HELP apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds [ALPHA] Time spent waiting to write to the input channel of a cache watcher.
+# TYPE apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds histogram
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.001"}	0
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.005"}	0
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.025"}	0
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.05"}	0
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.1"}	0
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.2"}	0
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.4"}	0
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.6"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="0.8"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="1"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="1.25"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="1.5"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="2"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="3"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="5"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="10"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_bucket{group="foo",resource="bar",le="+Inf"}	1
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_sum{group="foo",resource="bar"} 0.5
+apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds_count{group="foo",resource="bar"}	1
+`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer registry.Reset()
+			if test.isIncoming {
+				RecordCacherIncomingQueueBlock(test.groupResource, test.startTime)
+			} else {
+				RecordCacheWatcherInputQueueBlock(test.groupResource, test.startTime)
+			}
+			if err := testutil.GatherAndCompare(registry, strings.NewReader(test.want), testedMetricsName...); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/TROUBLESHOOTING.md
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/TROUBLESHOOTING.md
@@ -1,0 +1,73 @@
+# Watch Stability and Latency Troubleshooting Guide
+
+This guide describes how to use metrics to troubleshoot slow watch events in Kubernetes.
+
+## Watch Event Pipeline
+
+An event flows from etcd to the client through several stages:
+
+1.  **etcd3 Layer (`pkg/storage/etcd3/watcher.go`)**
+    *   `incomingEventChan`: Queue for events received from etcd.
+    *   `transform`: Decodes and decrypts events.
+    *   `processingQueue`: Concurrent processing queue.
+    *   `resultChan`: Sends events to the cacher or client.
+
+2.  **Cacher Layer (`pkg/storage/cacher/cacher.go`)**
+    *   `incoming`: Queue for events dispatched to watchers.
+    *   `cacheWatcher.input`: Queue for a specific watcher.
+    *   `cacheWatcher.result`: Final output to client.
+
+## Single-Threaded vs Concurrent Processing
+
+Event processing inside `etcd3` watcher can run in two modes, controlled by the `ConcurrentWatchObjectDecode` feature gate:
+
+1.  **Concurrent Mode**: Multiple workers decode events in parallel.
+    *   **Note**: This mode is disabled by default in v1.31+ and can be enabled via the `ConcurrentWatchObjectDecode` feature gate.
+    *   **Useful Metrics**:
+        *   `etcd_watcher_concurrent_processing_block_duration_seconds`: Measures time spent waiting for a free worker. If high, check `etcd_watcher_transform_duration_seconds` (CPU bound) or if downstream is slow.
+        *   `etcd_watcher_transform_duration_seconds`: Measures CPU cost of decoding.
+2.  **Single-Threaded Mode (Default)**: Events are decoded sequentially in a single loop (`serialProcessEvents`).
+    *   **Useful Metrics**:
+        *   `etcd_watcher_transform_duration_seconds`: Measures CPU cost of decoding.
+        *   `etcd_watcher_queue_event_block_duration_seconds`: If this is high in single-threaded mode, it can be caused by a slow `transform` (blocking the read loop).
+    *   **Note**: `etcd_watcher_concurrent_processing_block_duration_seconds` is NOT used in this mode.
+
+
+## Troubleshooting Slow Watches
+
+If you observe `etcd_watcher_queue_event_block_duration_seconds` high, it means we are slow to process events *after* receiving them from etcd. Here is how to isolate the bottleneck:
+
+### Step 1: Check `etcd_watcher_send_event_block_duration_seconds`
+
+*   **Metric**: `etcd_watcher_send_event_block_duration_seconds`
+*   **Meaning**: Time spent trying to send the event to the next layer (Cacher or Client).
+*   **High Value**: This means the downstream is slow. If using Cacher, it means `watchCache` is not reading fast enough. If bypassing Cacher, it means the client connection is slow to read.
+*   **Action**: Investigate Cacher or Client throughput.
+
+### Step 2: Check `etcd_watcher_transform_duration_seconds`
+
+*   **Metric**: `etcd_watcher_transform_duration_seconds`
+*   **Meaning**: Time spent decoding/decrypting objects.
+*   **High Value**: Objects are large or decryption is slow. CPU might be a bottleneck.
+*   **Action**: Profile CPU for decoding/decryption cost. Check object sizes.
+
+### Step 3: Check `etcd_watcher_concurrent_processing_block_duration_seconds`
+
+*   **Metric**: `etcd_watcher_concurrent_processing_block_duration_seconds`
+*   **Meaning**: Time spent waiting to schedule concurrent decoding when `p.processingQueue` is full.
+*   **High Value**: We reached the concurrency limit (default 10). Downstream processing is slow or decoding is too slow for the event rate.
+*   **Action**: Check if `transform` is slow or if downstream is slow.
+
+### Step 4: Check Cacher Layer
+
+*   **Metric**: `apiserver_watch_cache_incoming_queue_block_duration_seconds`
+*   **Meaning**: Time spent waiting to push to `c.incoming` in Cacher (dispatching to watchers).
+*   **High Value**: Cacher dispatching is slow. Too many cache watchers are slow or disconnected.
+*   **Action**: Investigate individual watcher queues.
+
+### Step 5: Check Cache Watcher Layer
+
+*   **Metric**: `apiserver_watch_cache_cache_watcher_input_queue_block_duration_seconds`
+*   **Meaning**: Time spent waiting to write to the input channel of a cache watcher.
+*   **High Value**: The watcher's final output to the client is blocked (slow client connection or client processing).
+*   **Action**: Check client network latency or client throughput.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -183,6 +183,42 @@ var (
 		},
 		[]string{"group", "resource"},
 	)
+	watcherQueueEventBlockDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Name:           "etcd_watcher_queue_event_block_duration_seconds",
+			Help:           "Time spent waiting to write to the incoming event channel in queueEvent.",
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 5, 10, 15, 30, 60},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	watcherSendEventBlockDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Name:           "etcd_watcher_send_event_block_duration_seconds",
+			Help:           "Time spent waiting to write to the result channel in sendEvent.",
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 5, 10, 15, 30, 60},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	watcherConcurrentProcessingBlockDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Name:           "etcd_watcher_concurrent_processing_block_duration_seconds",
+			Help:           "Time spent waiting to schedule concurrent event processing when the queue is full.",
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 5, 10},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	watcherTransformDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Name:           "etcd_watcher_transform_duration_seconds",
+			Help:           "Time spent in transform (CPU bound decoding/deserialization) of events.",
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 5, 10},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -208,6 +244,10 @@ func Register() {
 		legacyregistry.MustRegister(listStorageNumSelectorEvals)
 		legacyregistry.MustRegister(listStorageNumReturned)
 		legacyregistry.MustRegister(decodeErrorCounts)
+		legacyregistry.MustRegister(watcherQueueEventBlockDuration)
+		legacyregistry.MustRegister(watcherSendEventBlockDuration)
+		legacyregistry.MustRegister(watcherConcurrentProcessingBlockDuration)
+		legacyregistry.MustRegister(watcherTransformDuration)
 	})
 }
 
@@ -265,6 +305,26 @@ func RecordEtcdBookmark(groupResource schema.GroupResource) {
 // RecordDecodeError sets the storage_decode_errors metrics.
 func RecordDecodeError(groupResource schema.GroupResource) {
 	decodeErrorCounts.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
+}
+
+// RecordWatcherQueueEventBlock updates the etcd_watcher_queue_event_block_duration_seconds metric.
+func RecordWatcherQueueEventBlock(groupResource schema.GroupResource, startTime time.Time) {
+	watcherQueueEventBlockDuration.WithLabelValues(groupResource.Group, groupResource.Resource).Observe(sinceInSeconds(startTime))
+}
+
+// RecordWatcherSendEventBlock updates the etcd_watcher_send_event_block_duration_seconds metric.
+func RecordWatcherSendEventBlock(groupResource schema.GroupResource, startTime time.Time) {
+	watcherSendEventBlockDuration.WithLabelValues(groupResource.Group, groupResource.Resource).Observe(sinceInSeconds(startTime))
+}
+
+// RecordWatcherConcurrentProcessingBlock updates the etcd_watcher_concurrent_processing_block_duration_seconds metric.
+func RecordWatcherConcurrentProcessingBlock(groupResource schema.GroupResource, startTime time.Time) {
+	watcherConcurrentProcessingBlockDuration.WithLabelValues(groupResource.Group, groupResource.Resource).Observe(sinceInSeconds(startTime))
+}
+
+// RecordWatcherTransform updates the etcd_watcher_transform_duration_seconds metric.
+func RecordWatcherTransform(groupResource schema.GroupResource, startTime time.Time) {
+	watcherTransformDuration.WithLabelValues(groupResource.Group, groupResource.Resource).Observe(sinceInSeconds(startTime))
 }
 
 // Reset resets the etcd_request_duration_seconds metric.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
@@ -440,3 +440,206 @@ func (m fakeEtcdMonitor) Monitor(_ context.Context) (StorageMetrics, error) {
 func (m fakeEtcdMonitor) Close() error {
 	return nil
 }
+
+func TestRecordWatcherBlockMetrics(t *testing.T) {
+	registry := metrics.NewKubeRegistry()
+
+	sinceInSeconds = func(t time.Time) float64 {
+		return time.Unix(0, 500*int64(time.Millisecond)).Sub(t).Seconds()
+	}
+
+	testedMetrics := []metrics.Registerable{
+		watcherQueueEventBlockDuration,
+		watcherSendEventBlockDuration,
+	}
+
+	testedMetricsName := make([]string, 0, len(testedMetrics))
+	for _, m := range testedMetrics {
+		registry.MustRegister(m)
+		testedMetricsName = append(testedMetricsName, m.FQName())
+	}
+
+	testCases := []struct {
+		desc          string
+		isQueue       bool
+		groupResource schema.GroupResource
+		startTime     time.Time
+		want          string
+	}{
+		{
+			desc:          "queue_event_block",
+			isQueue:       true,
+			groupResource: schema.GroupResource{Group: "foo", Resource: "bar"},
+			startTime:     time.Unix(0, 0), // 0.5s
+			want: `# HELP etcd_watcher_queue_event_block_duration_seconds [ALPHA] Time spent waiting to write to the incoming event channel in queueEvent.
+# TYPE etcd_watcher_queue_event_block_duration_seconds histogram
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.001"} 0
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.005"} 0
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.025"} 0
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.05"} 0
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.1"} 0
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.2"} 0
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.4"} 0
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.6"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.8"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="1"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="1.25"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="1.5"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="2"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="3"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="5"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="10"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="15"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="30"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="60"} 1
+etcd_watcher_queue_event_block_duration_seconds_bucket{group="foo",resource="bar",le="+Inf"} 1
+etcd_watcher_queue_event_block_duration_seconds_sum{group="foo",resource="bar"} 0.5
+etcd_watcher_queue_event_block_duration_seconds_count{group="foo",resource="bar"} 1
+`,
+		},
+		{
+			desc:          "send_event_block",
+			isQueue:       false,
+			groupResource: schema.GroupResource{Group: "foo", Resource: "bar"},
+			startTime:     time.Unix(0, 0), // 0.5s
+			want: `# HELP etcd_watcher_send_event_block_duration_seconds [ALPHA] Time spent waiting to write to the result channel in sendEvent.
+# TYPE etcd_watcher_send_event_block_duration_seconds histogram
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.001"} 0
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.005"} 0
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.025"} 0
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.05"} 0
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.1"} 0
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.2"} 0
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.4"} 0
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.6"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="0.8"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="1"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="1.25"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="1.5"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="2"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="3"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="5"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="10"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="15"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="30"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="60"} 1
+etcd_watcher_send_event_block_duration_seconds_bucket{group="foo",resource="bar",le="+Inf"} 1
+etcd_watcher_send_event_block_duration_seconds_sum{group="foo",resource="bar"} 0.5
+etcd_watcher_send_event_block_duration_seconds_count{group="foo",resource="bar"} 1
+`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer registry.Reset()
+			if test.isQueue {
+				RecordWatcherQueueEventBlock(test.groupResource, test.startTime)
+			} else {
+				RecordWatcherSendEventBlock(test.groupResource, test.startTime)
+			}
+			if err := testutil.GatherAndCompare(registry, strings.NewReader(test.want), testedMetricsName...); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestRecordWatcherNewMetrics(t *testing.T) {
+	registry := metrics.NewKubeRegistry()
+
+	sinceInSeconds = func(t time.Time) float64 {
+		return time.Unix(0, 500*int64(time.Millisecond)).Sub(t).Seconds()
+	}
+
+	testedMetrics := []metrics.Registerable{
+		watcherConcurrentProcessingBlockDuration,
+		watcherTransformDuration,
+	}
+
+	testedMetricsName := make([]string, 0, len(testedMetrics))
+	for _, m := range testedMetrics {
+		registry.MustRegister(m)
+		testedMetricsName = append(testedMetricsName, m.FQName())
+	}
+
+	testCases := []struct {
+		desc          string
+		isConcurrent  bool
+		groupResource schema.GroupResource
+		startTime     time.Time
+		want          string
+	}{
+		{
+			desc:          "concurrent_processing_block",
+			isConcurrent:  true,
+			groupResource: schema.GroupResource{Group: "foo", Resource: "bar"},
+			startTime:     time.Unix(0, 0), // 0.5s
+			want: `# HELP etcd_watcher_concurrent_processing_block_duration_seconds [ALPHA] Time spent waiting to schedule concurrent event processing when the queue is full.
+# TYPE etcd_watcher_concurrent_processing_block_duration_seconds histogram
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="0.001"} 0
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="0.005"} 0
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="0.025"} 0
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="0.05"} 0
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="0.1"} 0
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="0.2"} 0
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="0.4"} 0
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="0.6"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="0.8"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="1"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="1.25"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="1.5"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="2"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="3"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="5"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="10"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_bucket{group="foo",resource="bar",le="+Inf"} 1
+etcd_watcher_concurrent_processing_block_duration_seconds_sum{group="foo",resource="bar"} 0.5
+etcd_watcher_concurrent_processing_block_duration_seconds_count{group="foo",resource="bar"} 1
+`,
+		},
+		{
+			desc:          "transform_duration",
+			isConcurrent:  false,
+			groupResource: schema.GroupResource{Group: "foo", Resource: "bar"},
+			startTime:     time.Unix(0, 0), // 0.5s
+			want: `# HELP etcd_watcher_transform_duration_seconds [ALPHA] Time spent in transform (CPU bound decoding/deserialization) of events.
+# TYPE etcd_watcher_transform_duration_seconds histogram
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="0.001"} 0
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="0.005"} 0
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="0.025"} 0
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="0.05"} 0
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="0.1"} 0
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="0.2"} 0
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="0.4"} 0
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="0.6"} 1
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="0.8"} 1
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="1"} 1
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="1.25"} 1
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="1.5"} 1
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="2"} 1
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="3"} 1
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="5"} 1
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="10"} 1
+etcd_watcher_transform_duration_seconds_bucket{group="foo",resource="bar",le="+Inf"} 1
+etcd_watcher_transform_duration_seconds_sum{group="foo",resource="bar"} 0.5
+etcd_watcher_transform_duration_seconds_count{group="foo",resource="bar"} 1
+`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer registry.Reset()
+			if test.isConcurrent {
+				RecordWatcherConcurrentProcessingBlock(test.groupResource, test.startTime)
+			} else {
+				RecordWatcherTransform(test.groupResource, test.startTime)
+			}
+			if err := testutil.GatherAndCompare(registry, strings.NewReader(test.want), testedMetricsName...); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -512,10 +512,12 @@ func (p *concurrentOrderedEventProcessing) scheduleEventProcessing(ctx context.C
 		case e = <-p.wc.incomingEventChan:
 		}
 		processingResponse := make(chan *processingResult, 1)
+		start := time.Now()
 		select {
 		case <-ctx.Done():
 			return
 		case p.processingQueue <- processingResponse:
+			metrics.RecordWatcherConcurrentProcessingBlock(p.wc.watcher.groupResource, start)
 		}
 		wg.Add(1)
 		go func(e *event, response chan<- *processingResult) {
@@ -570,6 +572,11 @@ func (wc *watchChan) acceptAll() bool {
 
 // transform transforms an event into a result for user if not filtered.
 func (wc *watchChan) transform(e *event) (res *watch.Event, err error) {
+	start := time.Now()
+	defer func() {
+		metrics.RecordWatcherTransform(wc.watcher.groupResource, start)
+	}()
+
 	curObj, oldObj, err := wc.prepareObjs(e)
 	if err != nil {
 		klog.Errorf("failed to prepare current and previous objects: %v", err)
@@ -680,8 +687,10 @@ func (wc *watchChan) sendEvent(event *watch.Event) bool {
 	// If user couldn't receive results fast enough, we also block incoming events from watcher.
 	// Because storing events in local will cause more memory usage.
 	// The worst case would be closing the fast watcher.
+	start := time.Now()
 	select {
 	case wc.resultChan <- *event:
+		metrics.RecordWatcherSendEventBlock(wc.watcher.groupResource, start)
 		return true
 	case <-wc.ctx.Done():
 		return false
@@ -692,8 +701,10 @@ func (wc *watchChan) queueEvent(e *event) {
 	if len(wc.incomingEventChan) == incomingBufSize {
 		klog.V(3).InfoS("Fast watcher, slow processing. Probably caused by slow decoding, user not receiving fast, or other processing logic", "incomingEvents", incomingBufSize, "objectType", wc.watcher.objectType, "groupResource", wc.watcher.groupResource)
 	}
+	start := time.Now()
 	select {
 	case wc.incomingEventChan <- e:
+		metrics.RecordWatcherQueueEventBlock(wc.watcher.groupResource, start)
 	case <-wc.ctx.Done():
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR adds a new set of metrics that aims to help with troubleshooting the problems with watch latency / stability.

The metrics has been added in places that can be blocking and can generate backpressure to etcd and slowdown event processing.

There is also a TROUBLESHOOTING.md file with some high level guide how to read them.

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
