### PR TITLE
Remove leader election annotation checks from endpoints controllers

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -36,7 +36,6 @@ import (
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/endpointslice"
@@ -608,14 +607,6 @@ func (e *Controller) checkLeftoverEndpoints() {
 		return
 	}
 	for _, ep := range list {
-		if _, ok := ep.Annotations[resourcelock.LeaderElectionRecordAnnotationKey]; ok {
-			// when there are multiple controller-manager instances,
-			// we observe that it will delete leader-election endpoints after 5min
-			// and cause re-election
-			// so skip the delete here
-			// as leader-election only have endpoints without service
-			continue
-		}
 		key, err := controller.KeyFunc(ep)
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("Unable to get key for endpoint %#v", ep))

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -366,11 +366,10 @@ func (c *Controller) queueEndpoints(obj interface{}) {
 // controller. This will be false if:
 // - the Endpoints resource is nil.
 // - the Endpoints resource has a skip-mirror label.
-// - the Endpoints resource has a leader election annotation.
 // This does not ensure that a corresponding Service exists with a nil selector.
 // That check should be performed separately.
 func (c *Controller) shouldMirror(endpoints *v1.Endpoints) bool {
-	if endpoints == nil || skipMirror(endpoints.Labels) || hasLeaderElection(endpoints.Annotations) {
+	if endpoints == nil || skipMirror(endpoints.Labels) {
 		return false
 	}
 

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
@@ -307,17 +306,6 @@ func TestShouldMirror(t *testing.T) {
 			},
 		},
 		shouldMirror: true,
-	}, {
-		testName: "Endpoints with leader election annotation",
-		endpoints: &v1.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-endpoints",
-				Annotations: map[string]string{
-					resourcelock.LeaderElectionRecordAnnotationKey: "",
-				},
-			},
-		},
-		shouldMirror: false,
 	}}
 
 	for _, tc := range testCases {

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	endpointsliceutil "k8s.io/endpointslice/util"
 	"k8s.io/kubernetes/pkg/apis/discovery/validation"
 	netutils "k8s.io/utils/net"
@@ -229,13 +228,6 @@ func endpointsControllerKey(endpointSlice *discovery.EndpointSlice) (string, err
 func skipMirror(labels map[string]string) bool {
 	skipMirror, _ := labels[discovery.LabelSkipMirror]
 	return skipMirror == "true"
-}
-
-// hasLeaderElection returns true if the LeaderElectionRecordAnnotationKey is
-// set as an annotation.
-func hasLeaderElection(annotations map[string]string) bool {
-	_, ok := annotations[resourcelock.LeaderElectionRecordAnnotationKey]
-	return ok
 }
 
 // cloneAndRemoveKeys is a copy of CloneAndRemoveLabels

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -31,12 +31,15 @@ import (
 )
 
 const (
+	// Deprecated: This annotation was used by the endpoints and configmap-based leader election
+	// resource locks, which have been removed. Leader election now uses Leases exclusively.
 	LeaderElectionRecordAnnotationKey = "control-plane.alpha.kubernetes.io/leader"
-	endpointsResourceLock             = "endpoints"
-	configMapsResourceLock            = "configmaps"
-	LeasesResourceLock                = "leases"
-	endpointsLeasesResourceLock       = "endpointsleases"
-	configMapsLeasesResourceLock      = "configmapsleases"
+
+	endpointsResourceLock        = "endpoints"
+	configMapsResourceLock       = "configmaps"
+	LeasesResourceLock           = "leases"
+	endpointsLeasesResourceLock  = "endpointsleases"
+	configMapsLeasesResourceLock = "configmapsleases"
 )
 
 // LeaderElectionRecord is the record that is stored in the leader election annotation.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the `LeaderElectionRecordAnnotationKey` checks from the endpoints controller and endpointslice mirroring controller. These checks were added to prevent the controllers from deleting Endpoints objects used for leader election (which intentionally have no backing Service). Since endpoints-based leader election was removed in 1.24 and the hybrid endpointsleases lock was removed in 1.28, these checks are no longer necessary.

This should be a no-op for any cluster upgrading to this release. Users who previously relied on endpoints-based leader election would have hit a hard error ("endpoints lock is removed") since 1.24, forcing them to migrate to lease-based leader election. Any stale leader election Endpoints still present in etcd are inert and safe to clean up.

Also marks `LeaderElectionRecordAnnotationKey` as deprecated in client-go.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The constant itself is kept (with a deprecation comment) since it's exported public API in client-go.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```