### PR TITLE
wait: respect timeout in legacy poll helpers

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/poll.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/poll.go
@@ -82,7 +82,7 @@ func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollWithContext(ctx context.Context, interval, timeout time.Duration, condition ConditionWithContextFunc) error {
-	return poll(ctx, false, poller(interval, timeout), condition)
+	return legacyPollWithContext(ctx, interval, timeout, false, condition)
 }
 
 // PollUntil tries a condition func until it returns true, an error or stopCh is
@@ -172,7 +172,24 @@ func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) err
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateWithContext(ctx context.Context, interval, timeout time.Duration, condition ConditionWithContextFunc) error {
-	return poll(ctx, true, poller(interval, timeout), condition)
+	return legacyPollWithContext(ctx, interval, timeout, true, condition)
+}
+
+func legacyPollWithContext(ctx context.Context, interval, timeout time.Duration, immediate bool, condition ConditionWithContextFunc) error {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	err := loopConditionUntilContext(ctx, Backoff{Duration: interval}.Timer(), immediate, false, condition)
+	switch err {
+	case context.Canceled, context.DeadlineExceeded:
+		// Returning the context error would break legacy callers that expect ErrWaitTimeout.
+		return ErrWaitTimeout
+	default:
+		return err
+	}
 }
 
 // PollImmediateUntil tries a condition func until it returns true, an error or stopCh is closed.

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -463,6 +463,23 @@ func TestPollImmediateError(t *testing.T) {
 	}
 }
 
+func TestPollImmediateTimeoutDoesNotInvokeConditionAfterExpiredDeadline(t *testing.T) {
+	var invocations atomic.Int32
+
+	err := PollImmediate(10*time.Millisecond, time.Millisecond, func() (bool, error) {
+		invocations.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return false, nil
+	})
+	if err != ErrWaitTimeout {
+		t.Fatalf("expected ErrWaitTimeout, got %v", err)
+	}
+
+	if got := invocations.Load(); got != 1 {
+		t.Fatalf("expected condition to run once after timeout expiry, got %d invocations", got)
+	}
+}
+
 func TestPollForever(t *testing.T) {
 	ch := make(chan struct{})
 	errc := make(chan error, 1)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Legacy `PollWithContext` and `PollImmediateWithContext` can invoke the condition function one extra time after the timeout has already expired when the condition call itself is slow.

This change keeps the legacy `ErrWaitTimeout` contract, but routes timeout handling through the context-aware polling loop so an expired timeout does not trigger an additional condition invocation.

#### Which issue(s) this PR is related to:

Fixes #113892

#### Special notes for your reviewer:

This change is intentionally scoped to the deprecated legacy poll helpers that still promise `ErrWaitTimeout`. It does not change the broader `waitForWithContext` behavior.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```

#### Test plan:

- `go test ./staging/src/k8s.io/apimachinery/pkg/util/wait -run TestPollImmediateTimeoutDoesNotInvokeConditionAfterExpiredDeadline -count=5`
- `go test ./staging/src/k8s.io/apimachinery/pkg/util/wait -count=1`
