### PR TITLE
csi: do not remove mount dir metadata on NodePublishVolume final error

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -396,13 +396,6 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 		nodeStageFSGroupArg)
 
 	if csiRPCError != nil {
-		if volumetypes.IsOperationFinishedError(csiRPCError) {
-			// clean up metadata
-			klog.Error(log("attacher.MountDevice failed: %v", csiRPCError))
-			if err := removeMountDir(c.plugin, deviceMountPath); err != nil {
-				klog.Error(log("attacher.MountDevice failed to remove mount dir after error [%s]: %v", deviceMountPath, err))
-			}
-		}
 		return csiRPCError
 	}
 

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -314,12 +314,6 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 	)
 
 	if csiRPCError != nil {
-		// If operation finished with error then we can remove the mount directory.
-		if volumetypes.IsOperationFinishedError(csiRPCError) && !mounterArgs.ReconstructedVolume {
-			if removeMountDirErr := removeMountDir(c.plugin, dir); removeMountDirErr != nil {
-				klog.Error(log("mounter.SetupAt failed to remove mount dir after a NodePublish() error [%s]: %v", dir, removeMountDirErr))
-			}
-		}
 		return csiRPCError
 	}
 

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -400,10 +400,10 @@ func TestMounterSetupJsonFileHandling(t *testing.T) {
 			shouldRemoveFile: false,
 		},
 		{
-			name:             "final error should remove json file",
+			name:             "final error should not remove json file",
 			volumeID:         fakecsi.NodePublishFinalError_VolumeID,
 			setupShouldFail:  true,
-			shouldRemoveFile: true,
+			shouldRemoveFile: false,
 		},
 		{
 			name:                "error in fsgroup permission change, should not remove json file",
@@ -1247,14 +1247,10 @@ func TestMounterSetUpFWithNodePublishFinalError(t *testing.T) {
 			mountPath := csiMounter.GetPath()
 			volPath := filepath.Dir(mountPath)
 			dataFile := filepath.Join(volPath, volDataFileName)
-			if tc.reconstructedVolume {
-				if _, err := os.Stat(dataFile); os.IsNotExist(err) {
-					t.Errorf("volume file [%s] expects to be exists, but removed", dataFile)
-				}
-				return
-			}
-			if _, err := os.Stat(dataFile); err == nil {
-				t.Errorf("volume file [%s] expects to be removed, but exists", dataFile)
+			// vol_data.json must survive a failed mount regardless of whether the
+			// volume was reconstructed — NewUnmounter needs it to run teardown.
+			if _, err := os.Stat(dataFile); os.IsNotExist(err) {
+				t.Errorf("volume file [%s] expected to exist after failed mount, but was removed", dataFile)
 			}
 		})
 	}
@@ -1371,6 +1367,65 @@ func TestUnmounterTeardownNoClientError(t *testing.T) {
 		t.Errorf("test should fail, but no error occurred")
 	} else if reflect.TypeOf(transientError) != reflect.TypeOf(err) {
 		t.Fatalf("expected exitError type: %v got: %v (%v)", reflect.TypeOf(transientError), reflect.TypeOf(err), err)
+	}
+}
+
+// TestIssue136908_FinalErrorMountFailurePreventsUnmount reproduces the bug
+// reported in https://github.com/kubernetes/kubernetes/issues/136908.
+//
+// When NodePublishVolume returns a final (non-transient) error, removeMountDir
+// deletes vol_data.json along with the mount directory. A subsequent call to
+// NewUnmounter fails because it cannot load vol_data.json, leaving the volume
+// permanently stuck — mount failed, teardown also fails on every retry.
+func TestIssue136908_FinalErrorMountFailurePreventsUnmount(t *testing.T) {
+	modes := []storage.VolumeLifecycleMode{storage.VolumeLifecyclePersistent}
+	csiDriver := getTestCSIDriver("test-driver", nil, nil, modes)
+	fakeClient := fakeclient.NewSimpleClientset(csiDriver)
+	plug, tmpDir := newTestPlugin(t, fakeClient)
+	defer os.RemoveAll(tmpDir)
+
+	registerFakePlugin(testDriver, "endpoint", []string{"1.0.0"}, t)
+
+	// Use the volume ID that causes the fake CSI client to return a final
+	// (codes.Internal) error from NodePublishVolume.
+	pv := makeTestPV("test-pv", 10, testDriver, fakecsi.NodePublishFinalError_VolumeID)
+	pod := &corev1.Pod{
+		ObjectMeta: meta.ObjectMeta{UID: testPodUID, Namespace: testns, Name: testPod},
+	}
+
+	mounter, err := plug.NewMounter(
+		volume.NewSpecFromPersistentVolume(pv, pv.Spec.PersistentVolumeSource.CSI.ReadOnly),
+		pod,
+	)
+	if err != nil {
+		t.Fatalf("NewMounter failed: %v", err)
+	}
+
+	csiMounter := mounter.(*csiMountMgr)
+	csiMounter.csiClient = setupClient(t, true)
+
+	attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
+	attachment := makeTestAttachment(attachID, "test-node", csiMounter.spec.Name())
+	if _, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create VolumeAttachment: %v", err)
+	}
+
+	// Step 1: SetUp fails with a final error.
+	if err := csiMounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("SetUp should have failed with a final error, but succeeded")
+	}
+
+	// Step 2: vol_data.json must survive a failed mount so teardown can run.
+	dataDir := filepath.Dir(csiMounter.GetPath())
+	dataFile := filepath.Join(dataDir, volDataFileName)
+	if _, statErr := os.Stat(dataFile); os.IsNotExist(statErr) {
+		t.Errorf("vol_data.json was deleted after NodePublishVolume final error; NewUnmounter will be unable to run teardown")
+	}
+
+	// Step 3: NewUnmounter must succeed so kubelet can run TearDown.
+	_, err = plug.NewUnmounter(pv.ObjectMeta.Name, testPodUID)
+	if err != nil {
+		t.Errorf("NewUnmounter failed after a final NodePublishVolume error: %v", err)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
removeMountDir() deletes the mount/ subdirectory, vol_data.json and the parent volume directory.
NewUnmounter later needs vol_data.json and the parent path.
simplest solution is to not call removeMountDir() and let the regular lifecycle take over.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#136908

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
No
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
No
```
