### PR TITLE
leaderelection: add fast path for coordinated lease renewal

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -359,7 +359,24 @@ func (le *LeaderElector) tryCoordinatedRenew(ctx context.Context) bool {
 		AcquireTime:          now,
 	}
 
-	// 1. obtain the electionRecord
+	// 1. fast path for the leader to update optimistically assuming that the record observed
+	// last time is the current version.
+	if le.IsLeader() && le.isLeaseValid(now.Time) {
+		oldObservedRecord := le.getObservedRecord()
+		leaderElectionRecord.AcquireTime = oldObservedRecord.AcquireTime
+		leaderElectionRecord.LeaderTransitions = oldObservedRecord.LeaderTransitions
+		// For coordinated, also preserve Strategy
+		leaderElectionRecord.Strategy = oldObservedRecord.Strategy
+
+		err := le.config.Lock.Update(ctx, leaderElectionRecord)
+		if err == nil {
+			le.setObservedRecord(&leaderElectionRecord)
+			return true
+		}
+		logger.V(2).Info("Failed to update lease optimistically, falling back to slow path", "lock", le.config.Lock.Describe(), "err", err)
+	}
+
+	// 2. obtain the electionRecord
 	oldLeaderElectionRecord, oldLeaderElectionRawRecord, err := le.config.Lock.Get(ctx)
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -370,19 +387,14 @@ func (le *LeaderElector) tryCoordinatedRenew(ctx context.Context) bool {
 		return false
 	}
 
-	// 2. Record obtained, check the Identity & Time
+	// 3. Record obtained, check the Identity & Time
 	if !bytes.Equal(le.observedRawRecord, oldLeaderElectionRawRecord) {
 		le.setObservedRecord(oldLeaderElectionRecord)
 
 		le.observedRawRecord = oldLeaderElectionRawRecord
 	}
 
-	le.observedRecordLock.RLock()
-	obsTime := le.observedTime
-	le.observedRecordLock.RUnlock()
-
-	hasExpired := obsTime.Add(time.Second * time.Duration(oldLeaderElectionRecord.LeaseDurationSeconds)).Before(now.Time)
-	if hasExpired {
+	if !le.isLeaseValid(now.Time) {
 		logger.Info("Lease has expired", "lock", le.config.Lock.Describe())
 		return false
 	}
@@ -392,8 +404,8 @@ func (le *LeaderElector) tryCoordinatedRenew(ctx context.Context) bool {
 		return false
 	}
 
-	// 2b. If the lease has been marked as "end of term", don't renew it
-	if le.IsLeader() && oldLeaderElectionRecord.PreferredHolder != "" {
+	// 3b. If the lease has been marked as "end of term", don't renew it
+	if oldLeaderElectionRecord.PreferredHolder != "" {
 		logger.V(4).Info("Lease is marked as 'end of term'", "lock", le.config.Lock.Describe())
 		// TODO: Instead of letting lease expire, the holder may deleted it directly
 		// This will not be compatible with all controllers, so it needs to be opt-in behavior.
@@ -405,16 +417,12 @@ func (le *LeaderElector) tryCoordinatedRenew(ctx context.Context) bool {
 		return false
 	}
 
-	// 3. We're going to try to update. The leaderElectionRecord is set to it's default
+	// 4. We're going to try to update. The leaderElectionRecord is set to it's default
 	// here. Let's correct it before updating.
-	if le.IsLeader() {
-		leaderElectionRecord.AcquireTime = oldLeaderElectionRecord.AcquireTime
-		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions
-		leaderElectionRecord.Strategy = oldLeaderElectionRecord.Strategy
-		le.metrics.slowpathExercised(le.config.Name)
-	} else {
-		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions + 1
-	}
+	leaderElectionRecord.AcquireTime = oldLeaderElectionRecord.AcquireTime
+	leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions
+	leaderElectionRecord.Strategy = oldLeaderElectionRecord.Strategy
+	le.metrics.slowpathExercised(le.config.Name)
 
 	// update the lock itself
 	if err = le.config.Lock.Update(ctx, leaderElectionRecord); err != nil {

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -365,15 +365,23 @@ func (le *LeaderElector) tryCoordinatedRenew(ctx context.Context) bool {
 		oldObservedRecord := le.getObservedRecord()
 		leaderElectionRecord.AcquireTime = oldObservedRecord.AcquireTime
 		leaderElectionRecord.LeaderTransitions = oldObservedRecord.LeaderTransitions
-		// For coordinated, also preserve Strategy
+		// For coordinated, also preserve Strategy and PreferredHolder so the
+		// optimistic Update does not clear server-set fields.
 		leaderElectionRecord.Strategy = oldObservedRecord.Strategy
+		leaderElectionRecord.PreferredHolder = oldObservedRecord.PreferredHolder
 
-		err := le.config.Lock.Update(ctx, leaderElectionRecord)
-		if err == nil {
-			le.setObservedRecord(&leaderElectionRecord)
-			return true
+		// If PreferredHolder is set, the server is signaling end-of-term.
+		// Skip the fast path so the slow path can read the current state and handle it.
+		if leaderElectionRecord.PreferredHolder != "" {
+			logger.V(4).Info("PreferredHolder set, skipping fast path", "lock", le.config.Lock.Describe())
+		} else {
+			err := le.config.Lock.Update(ctx, leaderElectionRecord)
+			if err == nil {
+				le.setObservedRecord(&leaderElectionRecord)
+				return true
+			}
+			logger.V(2).Info("Failed to update lease optimistically, falling back to slow path", "lock", le.config.Lock.Describe(), "err", err)
 		}
-		logger.V(2).Info("Failed to update lease optimistically, falling back to slow path", "lock", le.config.Lock.Describe(), "err", err)
 	}
 
 	// 2. obtain the electionRecord

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -1057,6 +1057,10 @@ func TestFastPathLeaderElection(t *testing.T) {
 		coordinated     bool
 		reactors        []Reactor
 		expectedLockOps []string
+		// lockOpsPrefix, if set, is checked instead of expectedLockOps:
+		// the recorded ops must start with the prefix, and remaining ops must all equal lockOpsTail.
+		lockOpsPrefix []string
+		lockOpsTail   string
 	}{
 		{
 			name: "Exercise fast path after lock acquired",
@@ -1278,9 +1282,12 @@ func TestFastPathLeaderElection(t *testing.T) {
 			// renewal 1: update (fast path succeeds)
 			// renewal 2: update (fast path, rv conflict from server PreferredHolder write)
 			//   → slow path: get (sees PreferredHolder) → returns false
-			// renewal 3-4: fast path skipped (PreferredHolder in observed) → slow path:
+			// renewal 3+: fast path skipped (PreferredHolder in observed) → slow path:
 			//   get → PreferredHolder → returns false (retries until RenewDeadline expires)
-			expectedLockOps: []string{"get", "update", "update", "update", "get", "get", "get"},
+			// The exact number of trailing GETs depends on timing, so we assert the
+			// deterministic prefix and verify the tail is all "get" operations.
+			lockOpsPrefix: []string{"get", "update", "update", "update", "get"},
+			lockOpsTail:   "get",
 		},
 	}
 
@@ -1330,7 +1337,16 @@ func TestFastPathLeaderElection(t *testing.T) {
 			cancelFunc = cancel
 
 			elector.Run(ctx)
-			assert.Equal(t, test.expectedLockOps, lockOps, "Expected lock ops %q, got %q", test.expectedLockOps, lockOps)
+			if test.lockOpsPrefix != nil {
+				if assert.GreaterOrEqual(t, len(lockOps), len(test.lockOpsPrefix)+1, "Expected at least %d ops (prefix + tail), got %d: %q", len(test.lockOpsPrefix)+1, len(lockOps), lockOps) {
+					assert.Equal(t, test.lockOpsPrefix, lockOps[:len(test.lockOpsPrefix)], "Lock ops prefix mismatch: got %q", lockOps)
+					for i := len(test.lockOpsPrefix); i < len(lockOps); i++ {
+						assert.Equal(t, test.lockOpsTail, lockOps[i], "Lock op [%d] expected %q, got %q (full: %q)", i, test.lockOpsTail, lockOps[i], lockOps)
+					}
+				}
+			} else {
+				assert.Equal(t, test.expectedLockOps, lockOps, "Expected lock ops %q, got %q", test.expectedLockOps, lockOps)
+			}
 		})
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -1038,6 +1038,7 @@ func assertEqualEvents(t *testing.T, expected []string, actual <-chan string) {
 
 func TestFastPathLeaderElection(t *testing.T) {
 	objectType := "leases"
+	identity := "baz"
 	var (
 		lockObj    runtime.Object
 		updates    int
@@ -1050,21 +1051,10 @@ func TestFastPathLeaderElection(t *testing.T) {
 		lockOps = []string{}
 		cancelFunc = nil
 	}
-	lec := LeaderElectionConfig{
-		LeaseDuration: 15 * time.Second,
-		RenewDeadline: 2 * time.Second,
-		RetryPeriod:   1 * time.Second,
-
-		Callbacks: LeaderCallbacks{
-			OnNewLeader:      func(identity string) {},
-			OnStoppedLeading: func() {},
-			OnStartedLeading: func(context.Context) {
-			},
-		},
-	}
 
 	tests := []struct {
 		name            string
+		coordinated     bool
 		reactors        []Reactor
 		expectedLockOps []string
 	}{
@@ -1149,83 +1139,9 @@ func TestFastPathLeaderElection(t *testing.T) {
 			},
 			expectedLockOps: []string{"get", "create", "update", "update", "get", "update", "update"},
 		},
-	}
-
-	for i := range tests {
-		test := &tests[i]
-		t.Run(test.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-
-			resetVars()
-
-			recorder := record.NewFakeRecorder(100)
-			resourceLockConfig := rl.ResourceLockConfig{
-				Identity:      "baz",
-				EventRecorder: recorder,
-			}
-			c := &fake.Clientset{}
-			for _, reactor := range test.reactors {
-				c.AddReactor(reactor.verb, objectType, reactor.reaction)
-			}
-			c.AddReactor("*", "*", func(action fakeclient.Action) (bool, runtime.Object, error) {
-				t.Errorf("unreachable action. testclient called too many times: %+v", action)
-				return true, nil, fmt.Errorf("unreachable action")
-			})
-			lock, err := rl.New("leases", "foo", "bar", c.CoreV1(), c.CoordinationV1(), resourceLockConfig)
-			if err != nil {
-				t.Fatal("resourcelock.New() = ", err)
-			}
-
-			lec.Lock = lock
-			elector, err := NewLeaderElector(lec)
-			if err != nil {
-				t.Fatal("Failed to create leader elector: ", err)
-			}
-
-			ctx, cancel := context.WithCancel(ctx)
-			cancelFunc = cancel
-
-			elector.Run(ctx)
-			assert.Equal(t, test.expectedLockOps, lockOps, "Expected lock ops %q, got %q", test.expectedLockOps, lockOps)
-		})
-	}
-}
-
-func TestCoordinatedFastPathLeaderElection(t *testing.T) {
-	objectType := "leases"
-	identity := "baz"
-	var (
-		lockObj    runtime.Object
-		updates    int
-		lockOps    []string
-		cancelFunc func()
-	)
-	resetVars := func() {
-		lockObj = nil
-		updates = 0
-		lockOps = []string{}
-		cancelFunc = nil
-	}
-	lec := LeaderElectionConfig{
-		LeaseDuration: 15 * time.Second,
-		RenewDeadline: 2 * time.Second,
-		RetryPeriod:   1 * time.Second,
-		Coordinated:   true,
-
-		Callbacks: LeaderCallbacks{
-			OnNewLeader:      func(identity string) {},
-			OnStoppedLeading: func() {},
-			OnStartedLeading: func(context.Context) {},
-		},
-	}
-
-	tests := []struct {
-		name            string
-		reactors        []Reactor
-		expectedLockOps []string
-	}{
 		{
-			name: "Exercise fast path after coordinated lock acquired",
+			name:        "Exercise fast path after coordinated lock acquired",
+			coordinated: true,
 			reactors: []Reactor{
 				{
 					verb:       "get",
@@ -1235,7 +1151,7 @@ func TestCoordinatedFastPathLeaderElection(t *testing.T) {
 						if lockObj != nil {
 							return true, lockObj, nil
 						}
-						// Pre-existing lease held by this identity (coordinated leases are created externally)
+						// Coordinated leases are created externally; return a pre-existing lease
 						lockObj = createLockObject(t, objectType, action.GetNamespace(), action.(fakeclient.GetAction).GetName(), &rl.LeaderElectionRecord{
 							HolderIdentity:       identity,
 							LeaseDurationSeconds: 15,
@@ -1251,8 +1167,6 @@ func TestCoordinatedFastPathLeaderElection(t *testing.T) {
 					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
 						updates++
 						lockOps = append(lockOps, "update")
-						// After acquiring (first update), subsequent renewals should be fast path (update only).
-						// Cancel after 3 updates: 1 acquire + 2 renewals.
 						if updates == 3 {
 							cancelFunc()
 						}
@@ -1265,7 +1179,8 @@ func TestCoordinatedFastPathLeaderElection(t *testing.T) {
 			expectedLockOps: []string{"get", "update", "update", "update"},
 		},
 		{
-			name: "Fallback to slow path after coordinated fast path conflict",
+			name:        "Fallback to slow path after coordinated fast path conflict",
+			coordinated: true,
 			reactors: []Reactor{
 				{
 					verb:       "get",
@@ -1292,7 +1207,6 @@ func TestCoordinatedFastPathLeaderElection(t *testing.T) {
 						lockOps = append(lockOps, "update")
 						switch updates {
 						case 2:
-							// First renewal fast path: return conflict to force slow path fallback
 							return true, nil, errors.NewConflict(action.(fakeclient.UpdateAction).GetResource().GroupResource(), "fake conflict", nil)
 						case 4:
 							cancelFunc()
@@ -1333,7 +1247,18 @@ func TestCoordinatedFastPathLeaderElection(t *testing.T) {
 				t.Fatal("resourcelock.New() = ", err)
 			}
 
-			lec.Lock = lock
+			lec := LeaderElectionConfig{
+				Lock:          lock,
+				LeaseDuration: 15 * time.Second,
+				RenewDeadline: 2 * time.Second,
+				RetryPeriod:   1 * time.Second,
+				Coordinated:   test.coordinated,
+				Callbacks: LeaderCallbacks{
+					OnNewLeader:      func(identity string) {},
+					OnStoppedLeading: func() {},
+					OnStartedLeading: func(context.Context) {},
+				},
+			}
 			elector, err := NewLeaderElector(lec)
 			if err != nil {
 				t.Fatal("Failed to create leader elector: ", err)

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -1220,6 +1220,68 @@ func TestFastPathLeaderElection(t *testing.T) {
 			// then renewal 2: update (fast path again)
 			expectedLockOps: []string{"get", "update", "update", "get", "update", "update"},
 		},
+		{
+			name:        "Fast path conflict when server sets PreferredHolder (end of term)",
+			coordinated: true,
+			reactors: []Reactor{
+				{
+					verb:       "get",
+					objectType: objectType,
+					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
+						lockOps = append(lockOps, "get")
+						if lockObj != nil {
+							return true, lockObj.DeepCopyObject(), nil
+						}
+						lockObj = createLockObject(t, objectType, action.GetNamespace(), action.(fakeclient.GetAction).GetName(), &rl.LeaderElectionRecord{
+							HolderIdentity:       identity,
+							LeaseDurationSeconds: 15,
+							RenewTime:            metav1.NewTime(time.Now()),
+							AcquireTime:          metav1.NewTime(time.Now()),
+						})
+						return true, lockObj.DeepCopyObject(), nil
+					},
+				},
+				{
+					verb:       "update",
+					objectType: objectType,
+					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
+						updates++
+						lockOps = append(lockOps, "update")
+						switch updates {
+						case 1:
+							// First update: acquire succeeds.
+							lockObj = action.(fakeclient.UpdateAction).GetObject().DeepCopyObject()
+							return true, lockObj.DeepCopyObject(), nil
+						case 2:
+							// Second update: fast-path renewal succeeds normally.
+							lockObj = action.(fakeclient.UpdateAction).GetObject().DeepCopyObject()
+							// After this write, the CLE server sets PreferredHolder
+							// on the canonical lease (bumping rv in a real apiserver).
+							preferred := "other-candidate"
+							lockObj.(*coordinationv1.Lease).Spec.PreferredHolder = &preferred
+							return true, action.(fakeclient.UpdateAction).GetObject().DeepCopyObject(), nil
+						case 3:
+							// Third update: fast-path conflicts because the server
+							// modified the lease (set PreferredHolder, bumped rv).
+							return true, nil, errors.NewConflict(action.(fakeclient.UpdateAction).GetResource().GroupResource(), "server set PreferredHolder", nil)
+						case 4:
+							cancelFunc()
+							lockObj = action.(fakeclient.UpdateAction).GetObject().DeepCopyObject()
+							return true, lockObj.DeepCopyObject(), nil
+						}
+						lockObj = action.(fakeclient.UpdateAction).GetObject().DeepCopyObject()
+						return true, lockObj.DeepCopyObject(), nil
+					},
+				},
+			},
+			// acquire: get + update
+			// renewal 1: update (fast path succeeds)
+			// renewal 2: update (fast path, rv conflict from server PreferredHolder write)
+			//   → slow path: get (sees PreferredHolder) → returns false
+			// renewal 3-4: fast path skipped (PreferredHolder in observed) → slow path:
+			//   get → PreferredHolder → returns false (retries until RenewDeadline expires)
+			expectedLockOps: []string{"get", "update", "update", "update", "get", "get", "get"},
+		},
 	}
 
 	for i := range tests {

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -1191,6 +1191,163 @@ func TestFastPathLeaderElection(t *testing.T) {
 	}
 }
 
+func TestCoordinatedFastPathLeaderElection(t *testing.T) {
+	objectType := "leases"
+	identity := "baz"
+	var (
+		lockObj    runtime.Object
+		updates    int
+		lockOps    []string
+		cancelFunc func()
+	)
+	resetVars := func() {
+		lockObj = nil
+		updates = 0
+		lockOps = []string{}
+		cancelFunc = nil
+	}
+	lec := LeaderElectionConfig{
+		LeaseDuration: 15 * time.Second,
+		RenewDeadline: 2 * time.Second,
+		RetryPeriod:   1 * time.Second,
+		Coordinated:   true,
+
+		Callbacks: LeaderCallbacks{
+			OnNewLeader:      func(identity string) {},
+			OnStoppedLeading: func() {},
+			OnStartedLeading: func(context.Context) {},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		reactors        []Reactor
+		expectedLockOps []string
+	}{
+		{
+			name: "Exercise fast path after coordinated lock acquired",
+			reactors: []Reactor{
+				{
+					verb:       "get",
+					objectType: objectType,
+					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
+						lockOps = append(lockOps, "get")
+						if lockObj != nil {
+							return true, lockObj, nil
+						}
+						// Pre-existing lease held by this identity (coordinated leases are created externally)
+						lockObj = createLockObject(t, objectType, action.GetNamespace(), action.(fakeclient.GetAction).GetName(), &rl.LeaderElectionRecord{
+							HolderIdentity:       identity,
+							LeaseDurationSeconds: 15,
+							RenewTime:            metav1.NewTime(time.Now()),
+							AcquireTime:          metav1.NewTime(time.Now()),
+						})
+						return true, lockObj, nil
+					},
+				},
+				{
+					verb:       "update",
+					objectType: objectType,
+					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
+						updates++
+						lockOps = append(lockOps, "update")
+						// After acquiring (first update), subsequent renewals should be fast path (update only).
+						// Cancel after 3 updates: 1 acquire + 2 renewals.
+						if updates == 3 {
+							cancelFunc()
+						}
+						lockObj = action.(fakeclient.UpdateAction).GetObject()
+						return true, lockObj, nil
+					},
+				},
+			},
+			// acquire: get + update, then 2 fast-path renewals: update, update (no get)
+			expectedLockOps: []string{"get", "update", "update", "update"},
+		},
+		{
+			name: "Fallback to slow path after coordinated fast path conflict",
+			reactors: []Reactor{
+				{
+					verb:       "get",
+					objectType: objectType,
+					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
+						lockOps = append(lockOps, "get")
+						if lockObj != nil {
+							return true, lockObj, nil
+						}
+						lockObj = createLockObject(t, objectType, action.GetNamespace(), action.(fakeclient.GetAction).GetName(), &rl.LeaderElectionRecord{
+							HolderIdentity:       identity,
+							LeaseDurationSeconds: 15,
+							RenewTime:            metav1.NewTime(time.Now()),
+							AcquireTime:          metav1.NewTime(time.Now()),
+						})
+						return true, lockObj, nil
+					},
+				},
+				{
+					verb:       "update",
+					objectType: objectType,
+					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
+						updates++
+						lockOps = append(lockOps, "update")
+						switch updates {
+						case 2:
+							// First renewal fast path: return conflict to force slow path fallback
+							return true, nil, errors.NewConflict(action.(fakeclient.UpdateAction).GetResource().GroupResource(), "fake conflict", nil)
+						case 4:
+							cancelFunc()
+						}
+						lockObj = action.(fakeclient.UpdateAction).GetObject()
+						return true, lockObj, nil
+					},
+				},
+			},
+			// acquire: get + update, then renewal 1: update(conflict) + get + update (slow path),
+			// then renewal 2: update (fast path again)
+			expectedLockOps: []string{"get", "update", "update", "get", "update", "update"},
+		},
+	}
+
+	for i := range tests {
+		test := &tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+
+			resetVars()
+
+			recorder := record.NewFakeRecorder(100)
+			resourceLockConfig := rl.ResourceLockConfig{
+				Identity:      identity,
+				EventRecorder: recorder,
+			}
+			c := &fake.Clientset{}
+			for _, reactor := range test.reactors {
+				c.AddReactor(reactor.verb, objectType, reactor.reaction)
+			}
+			c.AddReactor("*", "*", func(action fakeclient.Action) (bool, runtime.Object, error) {
+				t.Errorf("unreachable action. testclient called too many times: %+v", action)
+				return true, nil, fmt.Errorf("unreachable action")
+			})
+			lock, err := rl.New("leases", "foo", "bar", c.CoreV1(), c.CoordinationV1(), resourceLockConfig)
+			if err != nil {
+				t.Fatal("resourcelock.New() = ", err)
+			}
+
+			lec.Lock = lock
+			elector, err := NewLeaderElector(lec)
+			if err != nil {
+				t.Fatal("Failed to create leader elector: ", err)
+			}
+
+			ctx, cancel := context.WithCancel(ctx)
+			cancelFunc = cancel
+
+			elector.Run(ctx)
+			assert.Equal(t, test.expectedLockOps, lockOps, "Expected lock ops %q, got %q", test.expectedLockOps, lockOps)
+		})
+	}
+}
+
 func TestCheckMethodRace(t *testing.T) {
 	objectType := "leases"
 	objectMeta := metav1.ObjectMeta{Namespace: "foo", Name: "bar"}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds an optimistic fast path to `tryCoordinatedRenew` so the leader can renew its lease with a single UPDATE (no GET) on the happy path. If the optimistic update fails (e.g., conflict), it falls back to the existing GET+UPDATE slow path. Also refactors the slow path to use the existing `isLeaseValid` helper and simplifies the leader/non-leader branching since only the leader can reach the update step.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This mirrors the existing fast path in `tryAcquireOrRenew`. The non-leader branch that incremented `LeaderTransitions` was removed because non-leaders return false at step 3 before reaching the update step — coordinated acquisition is handled externally.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```