### PR TITLE
Fix leadership stall when PreferredHolder LeaseCandidate is deleted

### DIFF
--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
@@ -325,6 +325,14 @@ func (c *Controller) reconcileElectionStep(ctx context.Context, leaseNN types.Na
 		}
 	}
 	if len(ackedCandidates) == 0 {
+		// If the lease has a stale PreferredHolder (target LeaseCandidate was
+		// deleted or expired), clear it so the current holder can re-acquire
+		// rather than staying stepped-down for a candidate that no longer exists.
+		if cleared, err := c.clearStalePreferredHolder(ctx, leaseNN, candidates); err != nil {
+			return defaultRequeueInterval, err
+		} else if cleared {
+			return defaultRequeueInterval, nil
+		}
 		return noRequeue, fmt.Errorf("no available candidates")
 	}
 
@@ -422,6 +430,45 @@ func (c *Controller) reconcileElectionStep(ctx context.Context, leaseNN types.Na
 	}
 
 	return defaultRequeueInterval, nil
+}
+
+// clearStalePreferredHolder checks whether the lease's PreferredHolder refers
+// to a candidate that is no longer in the provided candidate list. If so it
+// clears PreferredHolder on the lease so that a subsequent reconciliation can
+// elect from the remaining candidates instead of stalling.
+// It returns true if PreferredHolder was cleared.
+func (c *Controller) clearStalePreferredHolder(ctx context.Context, leaseNN types.NamespacedName, candidates []*v1beta1.LeaseCandidate) (bool, error) {
+	lease, err := c.leaseInformer.Lister().Leases(leaseNN.Namespace).Get(leaseNN.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if lease.Spec.PreferredHolder == nil || *lease.Spec.PreferredHolder == "" {
+		return false, nil
+	}
+
+	preferred := *lease.Spec.PreferredHolder
+	for _, c := range candidates {
+		if c.Name == preferred {
+			return false, nil // preferred holder is still a valid candidate
+		}
+	}
+
+	// PreferredHolder is stale — clear it. We must fetch the live object for
+	// the update to avoid conflicts with a stale ResourceVersion from the cache.
+	klog.Infof("Clearing stale PreferredHolder %q on lease %s (candidate no longer exists)", preferred, leaseNN)
+	live, err := c.leaseClient.Leases(leaseNN.Namespace).Get(ctx, leaseNN.Name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	live.Spec.PreferredHolder = nil
+	_, err = c.leaseClient.Leases(leaseNN.Namespace).Update(ctx, live, metav1.UpdateOptions{})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (c *Controller) listAdmissableCandidates(leaseNN types.NamespacedName) ([]*v1beta1.LeaseCandidate, error) {

--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller_test.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller_test.go
@@ -300,6 +300,125 @@ func TestReconcileElectionStep(t *testing.T) {
 			expectedError:          false,
 		},
 		{
+			name:    "stale PreferredHolder cleared when target deleted, other candidates acked",
+			leaseNN: types.NamespacedName{Namespace: "default", Name: "component-A"},
+			candidates: []*v1beta1.LeaseCandidate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "component-identity-1",
+					},
+					Spec: v1beta1.LeaseCandidateSpec{
+						LeaseName:        "component-A",
+						EmulationVersion: "1.19.0",
+						BinaryVersion:    "1.19.0",
+						PingTime:         ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						RenewTime:        ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						Strategy:         v1.OldestEmulationVersion,
+					},
+				},
+			},
+			existingLease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "component-A",
+				},
+				Spec: v1.LeaseSpec{
+					HolderIdentity:       ptr.To("component-identity-old"),
+					PreferredHolder:      ptr.To("component-identity-deleted"),
+					LeaseDurationSeconds: ptr.To(int32(10)),
+					RenewTime:            ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+				},
+			},
+			// The stale PreferredHolder is cleared; since the current holder is
+			// still active, the controller sets PreferredHolder to the best
+			// candidate rather than directly replacing HolderIdentity.
+			expectLease:             true,
+			expectedHolderIdentity:  ptr.To("component-identity-old"),
+			expectedPreferredHolder: ptr.To("component-identity-1"),
+			expectedStrategy:        ptr.To[v1.CoordinatedLeaseStrategy]("OldestEmulationVersion"),
+			expectedRequeue:         true,
+			expectedError:           false,
+		},
+		{
+			name:    "stale PreferredHolder cleared and new leader elected when lease expired",
+			leaseNN: types.NamespacedName{Namespace: "default", Name: "component-A"},
+			candidates: []*v1beta1.LeaseCandidate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "component-identity-1",
+					},
+					Spec: v1beta1.LeaseCandidateSpec{
+						LeaseName:        "component-A",
+						EmulationVersion: "1.19.0",
+						BinaryVersion:    "1.19.0",
+						PingTime:         ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						RenewTime:        ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						Strategy:         v1.OldestEmulationVersion,
+					},
+				},
+			},
+			existingLease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "component-A",
+				},
+				Spec: v1.LeaseSpec{
+					HolderIdentity:       ptr.To("component-identity-old"),
+					PreferredHolder:      ptr.To("component-identity-deleted"),
+					LeaseDurationSeconds: ptr.To(int32(10)),
+					RenewTime:            ptr.To(metav1.NewMicroTime(fakeClock.Now().Add(-1 * time.Minute))),
+				},
+			},
+			// Lease is expired and PreferredHolder is stale: clear PreferredHolder and
+			// directly elect the best candidate as the new holder.
+			expectLease:             true,
+			expectedHolderIdentity:  ptr.To("component-identity-1"),
+			expectedPreferredHolder: nil,
+			expectedStrategy:        ptr.To[v1.CoordinatedLeaseStrategy]("OldestEmulationVersion"),
+			expectedRequeue:         true,
+			expectedError:           false,
+		},
+		{
+			name:    "stale PreferredHolder cleared when target deleted, no acked candidates requeues",
+			leaseNN: types.NamespacedName{Namespace: "default", Name: "component-A"},
+			candidates: []*v1beta1.LeaseCandidate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "component-identity-1",
+					},
+					Spec: v1beta1.LeaseCandidateSpec{
+						LeaseName:        "component-A",
+						EmulationVersion: "1.19.0",
+						BinaryVersion:    "1.19.0",
+						PingTime:         ptr.To(metav1.NewMicroTime(fakeClock.Now().Add(-1 * time.Minute))),
+						RenewTime:        ptr.To(metav1.NewMicroTime(fakeClock.Now().Add(-2 * time.Minute))),
+						Strategy:         v1.OldestEmulationVersion,
+					},
+				},
+			},
+			existingLease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "component-A",
+				},
+				Spec: v1.LeaseSpec{
+					HolderIdentity:       ptr.To("component-identity-old"),
+					PreferredHolder:      ptr.To("component-identity-deleted"),
+					LeaseDurationSeconds: ptr.To(int32(10)),
+					RenewTime:            ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+				},
+			},
+			// No acked candidates but stale PreferredHolder is cleared, triggering requeue
+			expectLease:             true,
+			expectedHolderIdentity:  ptr.To("component-identity-old"),
+			expectedPreferredHolder: nil,
+			expectedRequeue:         true,
+			expectedError:           false,
+		},
+		{
 			name:    "candidates exist, lease exists, lease expired, 3rdparty strategy",
 			leaseNN: types.NamespacedName{Namespace: "default", Name: "component-A"},
 			candidates: []*v1beta1.LeaseCandidate{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the coordinated leader election controller sets PreferredHolder on a lease but the target LeaseCandidate is deleted or expired, the controller returns "no available candidates" and stalls — nobody becomes leader until an informer event retriggers reconciliation. This PR detects stale PreferredHolder references and clears them immediately, allowing the election to proceed with remaining candidates.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The fix adds a clearStalePreferredHolder method called in two places in reconcileElectionStep: (1) when no acked candidates exist, to avoid stalling, and (2) when acked candidates exist, to ensure a stale PreferredHolder doesn't interfere with election. Three new test cases cover both paths.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```