### PR TITLE
client-go: release LeaseCandidate on graceful shutdown

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
@@ -39,7 +39,10 @@ import (
 	coordinationv1beta1listers "k8s.io/client-go/listers/coordination/v1beta1"
 )
 
-const requeueInterval = 5 * time.Minute
+const (
+	requeueInterval = 5 * time.Minute
+	releaseTimeout  = 5 * time.Second
+)
 
 type CacheSyncWaiter interface {
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
@@ -133,6 +136,11 @@ func (c *LeaseCandidate) Run(ctx context.Context) {
 	defer func() {
 		c.queue.ShutDown()
 		wg.Wait()
+		releaseCtx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
+		defer cancel()
+		if err := c.release(releaseCtx); err != nil {
+			logger.Error(err, "Failed to release lease candidate")
+		}
 	}()
 
 	c.informerFactory.Start(ctx.Done())
@@ -200,6 +208,16 @@ func (c *LeaseCandidate) ensureLease(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// release deletes the LeaseCandidate object from the API server to avoid
+// stale candidates interfering with future elections.
+func (c *LeaseCandidate) release(ctx context.Context) error {
+	err := c.leaseClient.Delete(ctx, c.name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 func (c *LeaseCandidate) newLeaseCandidate() *v1beta1.LeaseCandidate {

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate_test.go
@@ -122,6 +122,55 @@ func TestLeaseCandidateAck(t *testing.T) {
 	}
 }
 
+func TestLeaseCandidateReleasedOnShutdown(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	tc := testcase{
+		candidateName:      "foo",
+		candidateNamespace: "default",
+		leaseName:          "lease",
+		binaryVersion:      "1.35.0",
+		emulationVersion:   "1.35.0",
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+
+	client := fake.NewSimpleClientset()
+	candidate, _, err := NewCandidate(
+		client,
+		tc.candidateNamespace,
+		tc.candidateName,
+		tc.leaseName,
+		tc.binaryVersion,
+		tc.emulationVersion,
+		v1.OldestEmulationVersion,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		candidate.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for the LeaseCandidate to be created
+	if err := pollForLease(ctx, tc, client, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancel context to trigger shutdown
+	cancel()
+	<-done
+
+	// Verify the LeaseCandidate was deleted
+	_, err = client.CoordinationV1beta1().LeaseCandidates(tc.candidateNamespace).Get(
+		context.Background(), tc.candidateName, metav1.GetOptions{})
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected NotFound after shutdown, got: %v", err)
+	}
+}
+
 func pollForLease(ctx context.Context, tc testcase, client *fake.Clientset, t *metav1.MicroTime) error {
 	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		lc, err := client.CoordinationV1beta1().LeaseCandidates(tc.candidateNamespace).Get(ctx, tc.candidateName, metav1.GetOptions{})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a LeaseCandidate process shuts down gracefully, it does not delete its LeaseCandidate object. The stale object persists until GC runs (up to 30 minutes), and during that window the server-side controller includes it in elections — pinging it and waiting the full `electionDuration` (5s) for an ack that never comes, delaying leader election.

This adds a `release` method to `LeaseCandidate` that deletes the object from the API server, called automatically from `Run` on shutdown.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This only helps with graceful shutdown. Crashes/SIGKILL still rely on the existing GC controller to clean up stale candidates.

#### Does this PR introduce a user-facing change?

```release-note
LeaseCandidate objects are now deleted on graceful shutdown, reducing election delays caused by stale candidates.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```