### PR TITLE
Remove CacheSyncWaiter from LeaseCandidate

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -353,7 +353,7 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 		}
 
 		// Start lease candidate controller for coordinated leader election
-		leaseCandidate, waitForSync, err := leaderelection.NewCandidate(
+		leaseCandidate, err := leaderelection.NewCandidate(
 			c.Client,
 			"kube-system",
 			id,
@@ -365,7 +365,6 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 		if err != nil {
 			return err
 		}
-		healthzHandler.AddHealthChecker(healthz.NewInformerSyncHealthz(waitForSync))
 
 		go leaseCandidate.Run(ctx)
 	}

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -247,7 +247,7 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 		}
 
 		// Start lease candidate controller for coordinated leader election
-		leaseCandidate, waitForSync, err := leaderelection.NewCandidate(
+		leaseCandidate, err := leaderelection.NewCandidate(
 			cc.Client,
 			metav1.NamespaceSystem,
 			cc.LeaderElection.Lock.Identity(),
@@ -259,7 +259,6 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 		if err != nil {
 			return err
 		}
-		readyzChecks = append(readyzChecks, healthz.NewInformerSyncHealthz(waitForSync))
 		go leaseCandidate.Run(ctx)
 	}
 

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
@@ -18,7 +18,6 @@ package leaderelection
 
 import (
 	"context"
-	"reflect"
 	"sync"
 	"time"
 
@@ -40,10 +39,6 @@ import (
 )
 
 const requeueInterval = 5 * time.Minute
-
-type CacheSyncWaiter interface {
-	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
-}
 
 type LeaseCandidate struct {
 	leaseClient            coordinationv1beta1client.LeaseCandidateInterface
@@ -78,7 +73,7 @@ func NewCandidate(clientset kubernetes.Interface,
 	targetLease string,
 	binaryVersion, emulationVersion string,
 	strategy v1.CoordinatedLeaseStrategy,
-) (*LeaseCandidate, CacheSyncWaiter, error) {
+) (*LeaseCandidate, error) {
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", candidateName).String()
 	// A separate informer factory is required because this must start before informerFactories
 	// are started for leader elected components
@@ -117,11 +112,11 @@ func NewCandidate(clientset kubernetes.Interface,
 		},
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	lc.hasSynced = h.HasSynced
 
-	return lc, informerFactory, nil
+	return lc, nil
 }
 
 func (c *LeaseCandidate) Run(ctx context.Context) {

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate_test.go
@@ -48,7 +48,7 @@ func TestLeaseCandidateCreation(t *testing.T) {
 	defer cancel()
 
 	client := fake.NewSimpleClientset()
-	candidate, _, err := NewCandidate(
+	candidate, err := NewCandidate(
 		client,
 		tc.candidateNamespace,
 		tc.candidateName,
@@ -84,7 +84,7 @@ func TestLeaseCandidateAck(t *testing.T) {
 
 	client := fake.NewSimpleClientset()
 
-	candidate, _, err := NewCandidate(
+	candidate, err := NewCandidate(
 		client,
 		tc.candidateNamespace,
 		tc.candidateName,

--- a/test/e2e/apimachinery/coordinatedleaderelection.go
+++ b/test/e2e/apimachinery/coordinatedleaderelection.go
@@ -212,7 +212,7 @@ func (t *cleTest) createAndRunFakeLegacyController(name string, namespace string
 
 }
 func (t *cleTest) createAndRunFakeController(name string, namespace string, targetLease string, binaryVersion string, compatibilityVersion string, preferredStrategy coordinationv1.CoordinatedLeaseStrategy) {
-	identityLease, _, err := leaderelection.NewCandidate(
+	identityLease, err := leaderelection.NewCandidate(
 		t.clientset,
 		namespace,
 		name,

--- a/test/integration/apiserver/coordinatedleaderelection/cle_managed_lease_test.go
+++ b/test/integration/apiserver/coordinatedleaderelection/cle_managed_lease_test.go
@@ -336,7 +336,7 @@ func (t *cleTest) createAndRunFakeLegacyController(name string, namespace string
 
 }
 func (t *cleTest) createAndRunFakeController(name string, namespace string, targetLease string, binaryVersion string, compatibilityVersion string, preferredStrategy v1.CoordinatedLeaseStrategy) {
-	identityLease, _, err := leaderelection.NewCandidate(
+	identityLease, err := leaderelection.NewCandidate(
 		t.clientset,
 		namespace,
 		name,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the `CacheSyncWaiter` interface and external healthz check from `LeaseCandidate`. The `Run()` method already waits for informer sync internally via `cache.WaitForNamedCacheSyncWithContext`, making the external health check redundant and unnecessarily complex.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```