### PR TITLE
Deprecate MultiLock in client-go leader election

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
@@ -25,10 +25,14 @@ import (
 )
 
 const (
+	// Deprecated: UnknownLeader is only used by MultiLock, which is deprecated.
 	UnknownLeader = "leaderelection.k8s.io/unknown"
 )
 
-// MultiLock is used for lock's migration
+// Deprecated: MultiLock was used to facilitate migration from non-lease
+// based leader election to lease-based leader election. Support for
+// non-lease locks was removed in Kubernetes 1.28, making MultiLock
+// non-functional. Use LeaseLock directly instead.
 type MultiLock struct {
 	Primary   Interface
 	Secondary Interface
@@ -99,6 +103,7 @@ func (ml *MultiLock) Identity() string {
 	return ml.Primary.Identity()
 }
 
+// Deprecated: ConcatRawRecord is only used by MultiLock, which is deprecated.
 func ConcatRawRecord(primaryRaw, secondaryRaw []byte) []byte {
 	return bytes.Join([][]byte{primaryRaw, secondaryRaw}, []byte(","))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Adds `// Deprecated:` comments to `MultiLock`, `UnknownLeader`, and `ConcatRawRecord` in `k8s.io/client-go/tools/leaderelection/resourcelock`.

`MultiLock` was used to facilitate migration from ConfigMap/Endpoints-based leader election to Lease-based leader election. Support for non-lease lock types (`endpointsleases`, `configmapsleases`) was removed in Kubernetes 1.28 (commit 2bd42061b6e), making `MultiLock` non-functional — the factory function returns an error for these lock types. There are no internal consumers of `MultiLock`, `UnknownLeader`, or `ConcatRawRecord` anywhere in the Kubernetes codebase.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

External usage is minimal, a few vendored instances of old controller-runtime code. Marking as deprecated so we may be able to remove it in the future.

#### Does this PR introduce a user-facing change?

```release-note
Deprecated MultiLock, UnknownLeader, and ConcatRawRecord in client-go leader election resourcelock package. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```