### PR TITLE
leaderelection: optimize server-side election latency

### DIFF
--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
@@ -211,14 +211,30 @@ func (c *Controller) electionNeeded(candidates []*v1beta1.LeaseCandidate, leaseN
 		return true, nil
 	}
 
-	// every 15min enforce an election to update all candidates. Every 30min we garbage collect.
+	// Filter out non-responsive candidates: those that were pinged, the election
+	// window has passed, and they never acknowledged. This prevents dead candidates
+	// whose LeaseCandidate objects persist (up to 30min GC window) from defeating
+	// the fast path and causing no-op election cycles every 5 seconds.
+	now := c.clock.Now()
+	var responsiveCandidates []*v1beta1.LeaseCandidate
 	for _, candidate := range candidates {
-		if candidate.Spec.RenewTime != nil && candidate.Spec.RenewTime.Add(leaseCandidateValidDuration/2).Before(c.clock.Now()) {
+		if candidate.Spec.PingTime != nil &&
+			candidate.Spec.PingTime.Add(electionDuration).Before(now) &&
+			candidate.Spec.RenewTime.Before(candidate.Spec.PingTime) {
+			klog.V(5).Infof("Filtering non-responsive candidate %s (pinged at %v, last renew at %v)", candidate.Name, candidate.Spec.PingTime.Time, candidate.Spec.RenewTime.Time)
+			continue
+		}
+		responsiveCandidates = append(responsiveCandidates, candidate)
+	}
+
+	// every 15min enforce an election to update all candidates. Every 30min we garbage collect.
+	for _, candidate := range responsiveCandidates {
+		if candidate.Spec.RenewTime != nil && candidate.Spec.RenewTime.Add(leaseCandidateValidDuration/2).Before(now) {
 			return true, nil
 		}
 	}
 
-	prelimStrategy, err := pickBestStrategy(candidates)
+	prelimStrategy, err := pickBestStrategy(responsiveCandidates)
 	if err != nil {
 		return false, err
 	}
@@ -227,7 +243,7 @@ func (c *Controller) electionNeeded(candidates []*v1beta1.LeaseCandidate, leaseN
 		return false, nil
 	}
 
-	prelimElectee := pickBestLeaderOldestEmulationVersion(candidates)
+	prelimElectee := pickBestLeaderOldestEmulationVersion(responsiveCandidates)
 	if prelimElectee == nil {
 		return false, nil
 	} else if lease != nil && lease.Spec.HolderIdentity != nil && prelimElectee.Name == *lease.Spec.HolderIdentity {
@@ -266,14 +282,12 @@ func (c *Controller) reconcileElectionStep(ctx context.Context, leaseNN types.Na
 	}
 
 	now := c.clock.Now()
-	canVoteYet := true
+	sendingPings := false
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, candidate := range candidates {
 		if candidate.Spec.PingTime != nil && candidate.Spec.PingTime.Add(electionDuration).After(now) &&
 			candidate.Spec.RenewTime != nil && candidate.Spec.RenewTime.Before(candidate.Spec.PingTime) {
-
-			// continue waiting for the election to timeout
-			canVoteYet = false
+			// Still waiting for this candidate to ack
 			continue
 		}
 		if candidate.Spec.RenewTime != nil && candidate.Spec.RenewTime.Add(electionDuration).After(now) {
@@ -290,42 +304,53 @@ func (c *Controller) reconcileElectionStep(ctx context.Context, leaseNN types.Na
 				_, err := c.leaseCandidateClient.LeaseCandidates(clone.Namespace).Update(gCtx, clone, metav1.UpdateOptions{})
 				return err
 			})
-			canVoteYet = false
+			sendingPings = true
 		}
 	}
 	if err := g.Wait(); err != nil {
 		return defaultRequeueInterval, err
 	}
-	if !canVoteYet {
+	if sendingPings {
+		// We just sent pings; wait for candidates to respond before proceeding.
 		return defaultRequeueInterval, nil
 	}
 
-	// election is ongoing as long as unexpired PingTimes exist
+	// Collect acked candidates and check if we still need to wait for others.
+	var ackedCandidates []*v1beta1.LeaseCandidate
+	waitingForAck := false
 	for _, candidate := range candidates {
+		if candidate.Spec.RenewTime != nil && candidate.Spec.RenewTime.Add(electionDuration).After(now) {
+			ackedCandidates = append(ackedCandidates, candidate)
+			continue
+		}
 		if candidate.Spec.PingTime == nil {
-			continue // shouldn't be the case after the above
+			continue
 		}
-
 		if candidate.Spec.RenewTime != nil && !candidate.Spec.RenewTime.Before(candidate.Spec.PingTime) {
-			continue // this has renewed already
+			continue // already renewed
 		}
-
-		// If a candidate has a PingTime within the election duration, they have not acked
-		// and we should wait until we receive their response
 		if candidate.Spec.PingTime.Add(electionDuration).After(now) {
-			// continue waiting for the election to timeout
+			waitingForAck = true
+		}
+	}
+
+	if len(ackedCandidates) == 0 {
+		if waitingForAck {
 			return noRequeue, nil
 		}
+		return noRequeue, fmt.Errorf("no available candidates")
 	}
 
-	var ackedCandidates []*v1beta1.LeaseCandidate
-	for _, candidate := range candidates {
-		if candidate.Spec.RenewTime.Add(electionDuration).After(now) {
-			ackedCandidates = append(ackedCandidates, candidate)
+	// If we're still waiting for some candidates to ack, check whether the
+	// best overall candidate has already responded. If so, we know the winner
+	// and can skip waiting for worse candidates.
+	if waitingForAck {
+		bestOverall := pickBestLeaderOldestEmulationVersion(candidates)
+		bestAcked := pickBestLeaderOldestEmulationVersion(ackedCandidates)
+		if bestOverall == nil || bestAcked == nil || bestOverall.Name != bestAcked.Name {
+			return noRequeue, nil // best candidate hasn't acked yet, keep waiting
 		}
-	}
-	if len(ackedCandidates) == 0 {
-		return noRequeue, fmt.Errorf("no available candidates")
+		klog.V(4).Infof("Best candidate %s already acked, proceeding with election without waiting for remaining candidates", bestAcked.Name)
 	}
 
 	strategy, err := pickBestStrategy(ackedCandidates)

--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller_test.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller_test.go
@@ -296,7 +296,92 @@ func TestReconcileElectionStep(t *testing.T) {
 			existingLease:          nil,
 			expectLease:            false,
 			expectedHolderIdentity: nil,
+			// No requeue: controller waits for the candidate's ack via informer event
+			// rather than polling on a timer.
+			expectedRequeue: false,
+			expectedError:   false,
+		},
+		{
+			name:    "best candidate acked, worse candidate still pending, should elect immediately",
+			leaseNN: types.NamespacedName{Namespace: "default", Name: "component-A"},
+			candidates: []*v1beta1.LeaseCandidate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "component-best",
+					},
+					Spec: v1beta1.LeaseCandidateSpec{
+						LeaseName:        "component-A",
+						EmulationVersion: "1.19.0",
+						BinaryVersion:    "1.19.0",
+						// Pinged and acked (RenewTime >= PingTime, both within election window)
+						PingTime:  ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						RenewTime: ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						Strategy:  v1.OldestEmulationVersion,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "component-worse",
+					},
+					Spec: v1beta1.LeaseCandidateSpec{
+						LeaseName:        "component-A",
+						EmulationVersion: "1.20.0",
+						BinaryVersion:    "1.20.0",
+						// Pinged but NOT acked (RenewTime < PingTime, PingTime within election window)
+						PingTime:  ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						RenewTime: ptr.To(metav1.NewMicroTime(fakeClock.Now().Add(-1 * time.Minute))),
+						Strategy:  v1.OldestEmulationVersion,
+					},
+				},
+			},
+			existingLease:          nil,
+			expectLease:            true,
+			expectedHolderIdentity: ptr.To("component-best"),
+			expectedStrategy:       ptr.To[v1.CoordinatedLeaseStrategy]("OldestEmulationVersion"),
 			expectedRequeue:        true,
+			expectedError:          false,
+		},
+		{
+			name:    "best candidate NOT acked, worse candidate acked, should wait",
+			leaseNN: types.NamespacedName{Namespace: "default", Name: "component-A"},
+			candidates: []*v1beta1.LeaseCandidate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "component-best",
+					},
+					Spec: v1beta1.LeaseCandidateSpec{
+						LeaseName:        "component-A",
+						EmulationVersion: "1.19.0",
+						BinaryVersion:    "1.19.0",
+						// Pinged but NOT acked
+						PingTime:  ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						RenewTime: ptr.To(metav1.NewMicroTime(fakeClock.Now().Add(-1 * time.Minute))),
+						Strategy:  v1.OldestEmulationVersion,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "component-worse",
+					},
+					Spec: v1beta1.LeaseCandidateSpec{
+						LeaseName:        "component-A",
+						EmulationVersion: "1.20.0",
+						BinaryVersion:    "1.20.0",
+						// Pinged and acked
+						PingTime:  ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						RenewTime: ptr.To(metav1.NewMicroTime(fakeClock.Now())),
+						Strategy:  v1.OldestEmulationVersion,
+					},
+				},
+			},
+			existingLease:          nil,
+			expectLease:            false,
+			expectedHolderIdentity: nil,
+			expectedRequeue:        false,
 			expectedError:          false,
 		},
 		{
@@ -835,6 +920,136 @@ func TestController(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestElectionNeededFiltersNonResponsiveCandidates(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	now := fakeClock.Now()
+
+	leaseNN := types.NamespacedName{Namespace: "default", Name: "component-A"}
+
+	// A valid, non-expired lease held by component-identity-1
+	existingLease := &v1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "component-A",
+		},
+		Spec: v1.LeaseSpec{
+			HolderIdentity:       ptr.To("component-identity-1"),
+			LeaseDurationSeconds: ptr.To(int32(10)),
+			RenewTime:            ptr.To(metav1.NewMicroTime(now)),
+		},
+	}
+
+	// Current leader (responsive)
+	currentLeader := &v1beta1.LeaseCandidate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "component-identity-1",
+		},
+		Spec: v1beta1.LeaseCandidateSpec{
+			LeaseName:        "component-A",
+			EmulationVersion: "1.20.0",
+			BinaryVersion:    "1.20.0",
+			RenewTime:        ptr.To(metav1.NewMicroTime(now)),
+			Strategy:         v1.OldestEmulationVersion,
+		},
+	}
+
+	// Dead candidate: "better" (older emulation version) but pinged and never acked
+	deadCandidate := &v1beta1.LeaseCandidate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "component-identity-2",
+		},
+		Spec: v1beta1.LeaseCandidateSpec{
+			LeaseName:        "component-A",
+			EmulationVersion: "1.19.0",
+			BinaryVersion:    "1.19.0",
+			PingTime:         ptr.To(metav1.NewMicroTime(now.Add(-2 * electionDuration))),
+			RenewTime:        ptr.To(metav1.NewMicroTime(now.Add(-3 * electionDuration))),
+			Strategy:         v1.OldestEmulationVersion,
+		},
+	}
+
+	t.Run("dead candidate does not trigger election", func(t *testing.T) {
+		ctx := context.Background()
+		client := fake.NewSimpleClientset()
+		informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+		controller, err := NewController(
+			informerFactory.Coordination().V1().Leases(),
+			informerFactory.Coordination().V1beta1().LeaseCandidates(),
+			client.CoordinationV1(),
+			client.CoordinationV1beta1(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		controller.clock = fakeClock
+
+		if _, err := client.CoordinationV1().Leases(existingLease.Namespace).Create(ctx, existingLease, metav1.CreateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		for _, c := range []*v1beta1.LeaseCandidate{currentLeader, deadCandidate} {
+			if _, err := client.CoordinationV1beta1().LeaseCandidates(c.Namespace).Create(ctx, c, metav1.CreateOptions{}); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		informerFactory.Start(ctx.Done())
+		informerFactory.WaitForCacheSync(ctx.Done())
+
+		needed, err := controller.electionNeeded([]*v1beta1.LeaseCandidate{currentLeader, deadCandidate}, leaseNN)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if needed {
+			t.Error("electionNeeded() = true, want false: dead candidate should be filtered out")
+		}
+	})
+
+	t.Run("recovered candidate triggers election", func(t *testing.T) {
+		ctx := context.Background()
+		client := fake.NewSimpleClientset()
+		informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+		controller, err := NewController(
+			informerFactory.Coordination().V1().Leases(),
+			informerFactory.Coordination().V1beta1().LeaseCandidates(),
+			client.CoordinationV1(),
+			client.CoordinationV1beta1(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		controller.clock = fakeClock
+
+		if _, err := client.CoordinationV1().Leases(existingLease.Namespace).Create(ctx, existingLease, metav1.CreateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Same candidate but RenewTime is after PingTime (it came back)
+		recoveredCandidate := deadCandidate.DeepCopy()
+		recoveredCandidate.Spec.RenewTime = ptr.To(metav1.NewMicroTime(now))
+
+		for _, c := range []*v1beta1.LeaseCandidate{currentLeader, recoveredCandidate} {
+			if _, err := client.CoordinationV1beta1().LeaseCandidates(c.Namespace).Create(ctx, c, metav1.CreateOptions{}); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		informerFactory.Start(ctx.Done())
+		informerFactory.WaitForCacheSync(ctx.Done())
+
+		needed, err := controller.electionNeeded([]*v1beta1.LeaseCandidate{currentLeader, recoveredCandidate}, leaseNN)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !needed {
+			t.Error("electionNeeded() = false, want true: recovered candidate with better version should trigger election")
+		}
+	})
 }
 
 func strOrNil[T any](s *T) string {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

Two optimizations to the coordinated leader election (CLE) server-side controller that reduce election latency:

1. **Filter non-responsive candidates in `electionNeeded`**: Dead candidates that were pinged but never acked (within the 30min GC window) no longer trigger unnecessary election cycles every 5 seconds. Once filtered, the preliminary pick sees the current leader as optimal and skips the election.

2. **Early elect when best candidate acks**: When multiple candidates are contending, the controller no longer waits for all candidates to ack before electing. If the best overall candidate has already responded, the controller proceeds immediately — skipping the up-to-5s wait for worse candidates that can't win anyway.

#### Which issue(s) this PR is related to:

Related to KEP https://github.com/kubernetes/enhancements/issues/4355

#### Special notes for your reviewer:

The second optimization restructures the `canVoteYet` logic in `reconcileElectionStep`. The old code used a single boolean that conflated "sending new pings" with "waiting for acks", preventing early election. The new code separates these into `sendingPings` (must wait) and `waitingForAck` (can skip if best candidate already responded).

An existing test expectation changed: when a pinged candidate hasn't acked and no new pings are being sent, the controller now returns `noRequeue` (event-driven via informer) instead of `defaultRequeueInterval` (5s timer poll). This is strictly better — the ack triggers an informer event that re-enqueues immediately.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```