### PR TITLE
leaderelection: remove unnecessary 15min forced election cycle

### DIFF
--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
@@ -211,13 +211,6 @@ func (c *Controller) electionNeeded(candidates []*v1beta1.LeaseCandidate, leaseN
 		return true, nil
 	}
 
-	// every 15min enforce an election to update all candidates. Every 30min we garbage collect.
-	for _, candidate := range candidates {
-		if candidate.Spec.RenewTime != nil && candidate.Spec.RenewTime.Add(leaseCandidateValidDuration/2).Before(c.clock.Now()) {
-			return true, nil
-		}
-	}
-
 	prelimStrategy, err := pickBestStrategy(candidates)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Removes the 15-minute forced election cycle in `electionNeeded`. Currently, if any candidate's `RenewTime` is older than 15 minutes, the controller triggers a full ping/ack/elect round even if the current leader is still optimal and nothing has changed. This was added in https://github.com/kubernetes/kubernetes/pull/124012 alongside the GC mechanism, but it turns out to be unnecessary:

- **Candidates keep themselves alive.** The client-side `ensureLease` updates `RenewTime` every 5 minutes. GC deletes candidates based on `RenewTime` being >30min stale. So candidates never get GC'd as long as the client is running. No server-side ping needed to keep them alive.

- **Leader optimality is already checked on every lease renewal.** The leader renews every few seconds which triggers the informer to check for optimality.

- **New candidates trigger elections immediately via informer.** When a LeaseCandidate is created, the informer fires and we re-evaluate.

- **Candidate versions are immutable.** The current leader can't become non-optimal on its own. It takes a new candidate or a leader crash, both of which are caught by the above.

Net effect: we avoid a full ping/ack/elect write storm for every CLE-managed lease every 15 minutes, with no change in correctness.

#### Which issue(s) this PR is related to:

Related to KEP https://github.com/kubernetes/enhancements/issues/4355

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```