### PR TITLE
e2e_node/testdeviceplugin: retry registration when kubelet socket not yet ready

### DIFF
--- a/test/e2e_node/testdeviceplugin/device-plugin.go
+++ b/test/e2e_node/testdeviceplugin/device-plugin.go
@@ -29,7 +29,10 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	"k8s.io/kubernetes/pkg/cluster/ports"
@@ -202,9 +205,6 @@ func (dp *DevicePlugin) RegisterDevicePlugin(ctx context.Context, uniqueName, re
 		return fmt.Errorf("failed to listen on the unix socket, error: %w", err)
 	}
 
-	ginkgo.By("Wait enough for unix socket to be open")
-	time.Sleep(time.Second)
-
 	ginkgo.By("Create a new gRPC server")
 	dp.server = grpc.NewServer()
 	ginkgo.By("Register the device plugin with the server")
@@ -231,9 +231,6 @@ func (dp *DevicePlugin) RegisterDevicePlugin(ctx context.Context, uniqueName, re
 		gomega.Expect(err).To(gomega.Succeed())
 	}()
 
-	ginkgo.By("Wait enough for gRPC server unix scoket to be open")
-	time.Sleep(time.Second)
-
 	ginkgo.By("Create a client for the kubelet")
 	client := kubeletdevicepluginv1beta1.NewRegistrationClient(conn)
 
@@ -244,11 +241,23 @@ func (dp *DevicePlugin) RegisterDevicePlugin(ctx context.Context, uniqueName, re
 	}
 
 	ginkgo.By("Register the device plugin with the kubelet")
-	_, err = client.Register(ctx, reqt)
-	if err != nil {
-		return err
+	// kubelet's device-plugin socket only listens once
+	// initializeRuntimeDependentModules completes; that can take several seconds
+	// after /healthz is up if container-runtime recovery is slow. Poll for it
+	// rather than sleeping a fixed duration.
+	var registerErr error
+	timeouts := framework.NewTimeoutContext()
+	pollErr := wait.PollUntilContextTimeout(ctx, timeouts.Poll, timeouts.PodStart, true, func(ctx context.Context) (bool, error) {
+		_, registerErr = client.Register(ctx, reqt)
+		if status.Code(registerErr) == codes.Unavailable {
+			return false, nil
+		}
+		return true, nil
+	})
+	if pollErr != nil {
+		return fmt.Errorf("timed out waiting for kubelet device-plugin socket: %w", registerErr)
 	}
-	return nil
+	return registerErr
 }
 
 func (dp *DevicePlugin) Stop() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In https://github.com/kubernetes/kubernetes/pull/137919 I noticed `pull-kubernetes-node-kubelet-serial-device-manager` tests flaking out (example: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/137919/pull-kubernetes-node-kubelet-serial-device-manager/2037551287762948096)

- `testdeviceplugin.RegisterDevicePlugin` attempts to call a `client.Register` RPC
- empirically it seems like sometimes the kubelet socket is not ready (we see a `rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /var/lib/kubelet/device-plugins/kubelet.sock: connect: connection refused"`)
- I found some prior art in the non-test code (`pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go`) that handles kubelet restarts by wrapping the attempt in a retry loop (https://github.com/kubernetes/kubernetes/blob/16c5a6be07bb2eab06b6e7732eb1cb759a7fe61c/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go#L221)

#### Special notes for your reviewer:

I'm kind of low confidence in this change. When I run the e2e tests myself, they pass reliably. This seems like a tricky-to-diagnose ci-only flake.

I'd like to try the ci tests a few times and see what the empirical ci flake rate looks like with this change

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```