### PR TITLE
Migrate HPA CrossVersionObjectReference.Kind and .Name to declarative validation

### DIFF
--- a/pkg/apis/autoscaling/v1/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.validations.go
@@ -40,68 +40,88 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
 	// type HorizontalPodAutoscaler
-	scheme.AddValidationFunc(
-		(*autoscalingv1.HorizontalPodAutoscaler)(nil),
-		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-			switch op.Request.SubresourcePath() {
-			case "/", "/status":
-				return Validate_HorizontalPodAutoscaler(
-					ctx, op, nil, /* fldPath */
-					obj.(*autoscalingv1.HorizontalPodAutoscaler),
-					safe.Cast[*autoscalingv1.HorizontalPodAutoscaler](oldObj))
-			}
-			return field.ErrorList{
-				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
-			}
-		})
+	scheme.AddValidationFunc((*autoscalingv1.HorizontalPodAutoscaler)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_HorizontalPodAutoscaler(ctx, op, nil /* fldPath */, obj.(*autoscalingv1.HorizontalPodAutoscaler), safe.Cast[*autoscalingv1.HorizontalPodAutoscaler](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type Scale
-	scheme.AddValidationFunc(
-		(*autoscalingv1.Scale)(nil),
-		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-			switch op.Request.SubresourcePath() {
-			case "/scale":
-				return Validate_Scale(
-					ctx, op, nil, /* fldPath */
-					obj.(*autoscalingv1.Scale),
-					safe.Cast[*autoscalingv1.Scale](oldObj))
-			}
-			return field.ErrorList{
-				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
-			}
-		})
+	scheme.AddValidationFunc((*autoscalingv1.Scale)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/scale":
+			return Validate_Scale(ctx, op, nil /* fldPath */, obj.(*autoscalingv1.Scale), safe.Cast[*autoscalingv1.Scale](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
+}
+
+// Validate_CrossVersionObjectReference validates an instance of CrossVersionObjectReference according
+// to declarative validation rules in the API schema.
+func Validate_CrossVersionObjectReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.CrossVersionObjectReference) (errs field.ErrorList) {
+	// field autoscalingv1.CrossVersionObjectReference.Kind
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("kind"), &obj.Kind, safe.Field(oldObj, func(oldObj *autoscalingv1.CrossVersionObjectReference) *string { return &oldObj.Kind }), oldObj != nil)...)
+
+	// field autoscalingv1.CrossVersionObjectReference.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *autoscalingv1.CrossVersionObjectReference) *string { return &oldObj.Name }), oldObj != nil)...)
+
+	// field autoscalingv1.CrossVersionObjectReference.APIVersion has no validation
+	return errs
 }
 
 // Validate_HorizontalPodAutoscaler validates an instance of HorizontalPodAutoscaler according
 // to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscaler(
-	ctx context.Context, op operation.Operation, fldPath *field.Path,
-	obj, oldObj *autoscalingv1.HorizontalPodAutoscaler) (errs field.ErrorList) {
-
+func Validate_HorizontalPodAutoscaler(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscaler) (errs field.ErrorList) {
 	// field autoscalingv1.HorizontalPodAutoscaler.TypeMeta has no validation
 	// field autoscalingv1.HorizontalPodAutoscaler.ObjectMeta has no validation
 
-	{ // field autoscalingv1.HorizontalPodAutoscaler.Spec
-		fn := func(
-			fldPath *field.Path,
-			obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec,
-			oldValueCorrelated bool) (errs field.ErrorList) {
+	// field autoscalingv1.HorizontalPodAutoscaler.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec, oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update {
-				if equality.Semantic.DeepEqual(obj, oldObj) {
-					return nil
-				}
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_HorizontalPodAutoscalerSpec(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}
-		oldVal := safe.Field(oldObj,
-			func(oldObj *autoscalingv1.HorizontalPodAutoscaler) *autoscalingv1.HorizontalPodAutoscalerSpec {
-				return &oldObj.Spec
-			})
-		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
-	}
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscaler) *autoscalingv1.HorizontalPodAutoscalerSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
 
 	// field autoscalingv1.HorizontalPodAutoscaler.Status has no validation
 	return errs
@@ -109,83 +129,64 @@ func Validate_HorizontalPodAutoscaler(
 
 // Validate_HorizontalPodAutoscalerSpec validates an instance of HorizontalPodAutoscalerSpec according
 // to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscalerSpec(
-	ctx context.Context, op operation.Operation, fldPath *field.Path,
-	obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) (errs field.ErrorList) {
-
-	// field autoscalingv1.HorizontalPodAutoscalerSpec.ScaleTargetRef has no validation
-
-	{ // field autoscalingv1.HorizontalPodAutoscalerSpec.MinReplicas
-		fn := func(
-			fldPath *field.Path,
-			obj, oldObj *int32,
-			oldValueCorrelated bool) (errs field.ErrorList) {
+func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) (errs field.ErrorList) {
+	// field autoscalingv1.HorizontalPodAutoscalerSpec.ScaleTargetRef
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv1.CrossVersionObjectReference, oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update {
-				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
-					return nil
-				}
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CrossVersionObjectReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("scaleTargetRef"), &obj.ScaleTargetRef, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *autoscalingv1.CrossVersionObjectReference {
+			return &oldObj.ScaleTargetRef
+		}), oldObj != nil)...)
+
+	// field autoscalingv1.HorizontalPodAutoscalerSpec.MinReplicas
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true,
-				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
-				}).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false,
-				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
-				}).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-			}
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
+			}).MarkAlpha()...)
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
+			}).MarkAlpha()...)
 			return
-		}
-		oldVal := safe.Field(oldObj,
-			func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 {
-				return oldObj.MinReplicas
-			})
-		errs = append(errs, fn(fldPath.Child("minReplicas"), obj.MinReplicas, oldVal, oldObj != nil)...)
-	}
+		}(fldPath.Child("minReplicas"), obj.MinReplicas, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 { return oldObj.MinReplicas }), oldObj != nil)...)
 
-	{ // field autoscalingv1.HorizontalPodAutoscalerSpec.MaxReplicas
-		fn := func(
-			fldPath *field.Path,
-			obj, oldObj *int32,
-			oldValueCorrelated bool) (errs field.ErrorList) {
+	// field autoscalingv1.HorizontalPodAutoscalerSpec.MaxReplicas
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update {
-				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
-					return nil
-				}
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-			}
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha()...)
 			return
-		}
-		oldVal := safe.Field(oldObj,
-			func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 {
-				return &oldObj.MaxReplicas
-			})
-		errs = append(errs, fn(fldPath.Child("maxReplicas"), &obj.MaxReplicas, oldVal, oldObj != nil)...)
-	}
+		}(fldPath.Child("maxReplicas"), &obj.MaxReplicas, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 { return &oldObj.MaxReplicas }), oldObj != nil)...)
 
 	// field autoscalingv1.HorizontalPodAutoscalerSpec.TargetCPUUtilizationPercentage has no validation
 	return errs
@@ -193,34 +194,21 @@ func Validate_HorizontalPodAutoscalerSpec(
 
 // Validate_Scale validates an instance of Scale according
 // to declarative validation rules in the API schema.
-func Validate_Scale(
-	ctx context.Context, op operation.Operation, fldPath *field.Path,
-	obj, oldObj *autoscalingv1.Scale) (errs field.ErrorList) {
-
+func Validate_Scale(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.Scale) (errs field.ErrorList) {
 	// field autoscalingv1.Scale.TypeMeta has no validation
 	// field autoscalingv1.Scale.ObjectMeta has no validation
 
-	{ // field autoscalingv1.Scale.Spec
-		fn := func(
-			fldPath *field.Path,
-			obj, oldObj *autoscalingv1.ScaleSpec,
-			oldValueCorrelated bool) (errs field.ErrorList) {
+	// field autoscalingv1.Scale.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv1.ScaleSpec, oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update {
-				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
-					return nil
-				}
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_ScaleSpec(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}
-		oldVal := safe.Field(oldObj,
-			func(oldObj *autoscalingv1.Scale) *autoscalingv1.ScaleSpec {
-				return &oldObj.Spec
-			})
-		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
-	}
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *autoscalingv1.Scale) *autoscalingv1.ScaleSpec { return &oldObj.Spec }), oldObj != nil)...)
 
 	// field autoscalingv1.Scale.Status has no validation
 	return errs
@@ -228,34 +216,18 @@ func Validate_Scale(
 
 // Validate_ScaleSpec validates an instance of ScaleSpec according
 // to declarative validation rules in the API schema.
-func Validate_ScaleSpec(
-	ctx context.Context, op operation.Operation, fldPath *field.Path,
-	obj, oldObj *autoscalingv1.ScaleSpec) (errs field.ErrorList) {
-
-	{ // field autoscalingv1.ScaleSpec.Replicas
-		fn := func(
-			fldPath *field.Path,
-			obj, oldObj *int32,
-			oldValueCorrelated bool) (errs field.ErrorList) {
-			// optional value-type fields with zero-value defaults are purely documentation
+func Validate_ScaleSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.ScaleSpec) (errs field.ErrorList) {
+	// field autoscalingv1.ScaleSpec.Replicas
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update {
-				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
-					return nil
-				}
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
 			}
 			// call field-attached validations
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-			}
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha()...)
 			return
-		}
-		oldVal := safe.Field(oldObj,
-			func(oldObj *autoscalingv1.ScaleSpec) *int32 {
-				return &oldObj.Replicas
-			})
-		errs = append(errs, fn(fldPath.Child("replicas"), &obj.Replicas, oldVal, oldObj != nil)...)
-	}
+		}(fldPath.Child("replicas"), &obj.Replicas, safe.Field(oldObj, func(oldObj *autoscalingv1.ScaleSpec) *int32 { return &oldObj.Replicas }), oldObj != nil)...)
 
 	return errs
 }

--- a/pkg/apis/autoscaling/v1/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.validations.go
@@ -40,56 +40,58 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
 	// type HorizontalPodAutoscaler
-	scheme.AddValidationFunc((*autoscalingv1.HorizontalPodAutoscaler)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/":
-			return Validate_HorizontalPodAutoscaler(ctx, op, nil /* fldPath */, obj.(*autoscalingv1.HorizontalPodAutoscaler), safe.Cast[*autoscalingv1.HorizontalPodAutoscaler](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
+	scheme.AddValidationFunc(
+		(*autoscalingv1.HorizontalPodAutoscaler)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/", "/status":
+				return Validate_HorizontalPodAutoscaler(
+					ctx, op, nil, /* fldPath */
+					obj.(*autoscalingv1.HorizontalPodAutoscaler),
+					safe.Cast[*autoscalingv1.HorizontalPodAutoscaler](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
 	// type Scale
-	scheme.AddValidationFunc((*autoscalingv1.Scale)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/scale":
-			return Validate_Scale(ctx, op, nil /* fldPath */, obj.(*autoscalingv1.Scale), safe.Cast[*autoscalingv1.Scale](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
+	scheme.AddValidationFunc(
+		(*autoscalingv1.Scale)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/scale":
+				return Validate_Scale(
+					ctx, op, nil, /* fldPath */
+					obj.(*autoscalingv1.Scale),
+					safe.Cast[*autoscalingv1.Scale](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
 	return nil
 }
 
 // Validate_CrossVersionObjectReference validates an instance of CrossVersionObjectReference according
 // to declarative validation rules in the API schema.
-func Validate_CrossVersionObjectReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.CrossVersionObjectReference) (errs field.ErrorList) {
-	// field autoscalingv1.CrossVersionObjectReference.Kind
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
-			return
-		}(fldPath.Child("kind"), &obj.Kind, safe.Field(oldObj, func(oldObj *autoscalingv1.CrossVersionObjectReference) *string { return &oldObj.Kind }), oldObj != nil)...)
+func Validate_CrossVersionObjectReference(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv1.CrossVersionObjectReference) (errs field.ErrorList) {
 
-	// field autoscalingv1.CrossVersionObjectReference.Name
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv1.CrossVersionObjectReference.Kind
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -97,7 +99,42 @@ func Validate_CrossVersionObjectReference(ctx context.Context, op operation.Oper
 				return // do not proceed
 			}
 			return
-		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *autoscalingv1.CrossVersionObjectReference) *string { return &oldObj.Name }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv1.CrossVersionObjectReference) *string {
+				return &oldObj.Kind
+			})
+		errs = append(errs, fn(fldPath.Child("kind"), &obj.Kind, oldVal, oldObj != nil)...)
+	}
+
+	{ // field autoscalingv1.CrossVersionObjectReference.Name
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv1.CrossVersionObjectReference) *string {
+				return &oldObj.Name
+			})
+		errs = append(errs, fn(fldPath.Child("name"), &obj.Name, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv1.CrossVersionObjectReference.APIVersion has no validation
 	return errs
@@ -105,23 +142,34 @@ func Validate_CrossVersionObjectReference(ctx context.Context, op operation.Oper
 
 // Validate_HorizontalPodAutoscaler validates an instance of HorizontalPodAutoscaler according
 // to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscaler(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscaler) (errs field.ErrorList) {
+func Validate_HorizontalPodAutoscaler(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv1.HorizontalPodAutoscaler) (errs field.ErrorList) {
+
 	// field autoscalingv1.HorizontalPodAutoscaler.TypeMeta has no validation
 	// field autoscalingv1.HorizontalPodAutoscaler.ObjectMeta has no validation
 
-	// field autoscalingv1.HorizontalPodAutoscaler.Spec
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv1.HorizontalPodAutoscaler.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_HorizontalPodAutoscalerSpec(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscaler) *autoscalingv1.HorizontalPodAutoscalerSpec {
-			return &oldObj.Spec
-		}), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv1.HorizontalPodAutoscaler) *autoscalingv1.HorizontalPodAutoscalerSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv1.HorizontalPodAutoscaler.Status has no validation
 	return errs
@@ -129,64 +177,103 @@ func Validate_HorizontalPodAutoscaler(ctx context.Context, op operation.Operatio
 
 // Validate_HorizontalPodAutoscalerSpec validates an instance of HorizontalPodAutoscalerSpec according
 // to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) (errs field.ErrorList) {
-	// field autoscalingv1.HorizontalPodAutoscalerSpec.ScaleTargetRef
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv1.CrossVersionObjectReference, oldValueCorrelated bool) (errs field.ErrorList) {
+func Validate_HorizontalPodAutoscalerSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) (errs field.ErrorList) {
+
+	{ // field autoscalingv1.HorizontalPodAutoscalerSpec.ScaleTargetRef
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv1.CrossVersionObjectReference,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_CrossVersionObjectReference(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("scaleTargetRef"), &obj.ScaleTargetRef, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *autoscalingv1.CrossVersionObjectReference {
-			return &oldObj.ScaleTargetRef
-		}), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *autoscalingv1.CrossVersionObjectReference {
+				return &oldObj.ScaleTargetRef
+			})
+		errs = append(errs, fn(fldPath.Child("scaleTargetRef"), &obj.ScaleTargetRef, oldVal, oldObj != nil)...)
+	}
 
-	// field autoscalingv1.HorizontalPodAutoscalerSpec.MinReplicas
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv1.HorizontalPodAutoscalerSpec.MinReplicas
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
-			}).MarkAlpha()...)
-			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
-			}).MarkAlpha()...)
+			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true,
+				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
+				}).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false,
+				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
+				}).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
-		}(fldPath.Child("minReplicas"), obj.MinReplicas, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 { return oldObj.MinReplicas }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 {
+				return oldObj.MinReplicas
+			})
+		errs = append(errs, fn(fldPath.Child("minReplicas"), obj.MinReplicas, oldVal, oldObj != nil)...)
+	}
 
-	// field autoscalingv1.HorizontalPodAutoscalerSpec.MaxReplicas
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv1.HorizontalPodAutoscalerSpec.MaxReplicas
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha()...)
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
-		}(fldPath.Child("maxReplicas"), &obj.MaxReplicas, safe.Field(oldObj, func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 { return &oldObj.MaxReplicas }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv1.HorizontalPodAutoscalerSpec) *int32 {
+				return &oldObj.MaxReplicas
+			})
+		errs = append(errs, fn(fldPath.Child("maxReplicas"), &obj.MaxReplicas, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv1.HorizontalPodAutoscalerSpec.TargetCPUUtilizationPercentage has no validation
 	return errs
@@ -194,21 +281,34 @@ func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Oper
 
 // Validate_Scale validates an instance of Scale according
 // to declarative validation rules in the API schema.
-func Validate_Scale(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.Scale) (errs field.ErrorList) {
+func Validate_Scale(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv1.Scale) (errs field.ErrorList) {
+
 	// field autoscalingv1.Scale.TypeMeta has no validation
 	// field autoscalingv1.Scale.ObjectMeta has no validation
 
-	// field autoscalingv1.Scale.Spec
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv1.ScaleSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv1.Scale.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv1.ScaleSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_ScaleSpec(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *autoscalingv1.Scale) *autoscalingv1.ScaleSpec { return &oldObj.Spec }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv1.Scale) *autoscalingv1.ScaleSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv1.Scale.Status has no validation
 	return errs
@@ -216,18 +316,34 @@ func Validate_Scale(ctx context.Context, op operation.Operation, fldPath *field.
 
 // Validate_ScaleSpec validates an instance of ScaleSpec according
 // to declarative validation rules in the API schema.
-func Validate_ScaleSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv1.ScaleSpec) (errs field.ErrorList) {
-	// field autoscalingv1.ScaleSpec.Replicas
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
+func Validate_ScaleSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv1.ScaleSpec) (errs field.ErrorList) {
+
+	{ // field autoscalingv1.ScaleSpec.Replicas
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// optional value-type fields with zero-value defaults are purely documentation
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha()...)
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
-		}(fldPath.Child("replicas"), &obj.Replicas, safe.Field(oldObj, func(oldObj *autoscalingv1.ScaleSpec) *int32 { return &oldObj.Replicas }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv1.ScaleSpec) *int32 {
+				return &oldObj.Replicas
+			})
+		errs = append(errs, fn(fldPath.Child("replicas"), &obj.Replicas, oldVal, oldObj != nil)...)
+	}
 
 	return errs
 }

--- a/pkg/apis/autoscaling/v2/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v2/zz_generated.validations.go
@@ -40,139 +40,324 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
 	// type HorizontalPodAutoscaler
-	scheme.AddValidationFunc(
-		(*autoscalingv2.HorizontalPodAutoscaler)(nil),
-		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-			switch op.Request.SubresourcePath() {
-			case "/", "/status":
-				return Validate_HorizontalPodAutoscaler(
-					ctx, op, nil, /* fldPath */
-					obj.(*autoscalingv2.HorizontalPodAutoscaler),
-					safe.Cast[*autoscalingv2.HorizontalPodAutoscaler](oldObj))
-			}
-			return field.ErrorList{
-				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
-			}
-		})
+	scheme.AddValidationFunc((*autoscalingv2.HorizontalPodAutoscaler)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_HorizontalPodAutoscaler(ctx, op, nil /* fldPath */, obj.(*autoscalingv2.HorizontalPodAutoscaler), safe.Cast[*autoscalingv2.HorizontalPodAutoscaler](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
+}
+
+// Validate_CrossVersionObjectReference validates an instance of CrossVersionObjectReference according
+// to declarative validation rules in the API schema.
+func Validate_CrossVersionObjectReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.CrossVersionObjectReference) (errs field.ErrorList) {
+	// field autoscalingv2.CrossVersionObjectReference.Kind
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("kind"), &obj.Kind, safe.Field(oldObj, func(oldObj *autoscalingv2.CrossVersionObjectReference) *string { return &oldObj.Kind }), oldObj != nil)...)
+
+	// field autoscalingv2.CrossVersionObjectReference.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *autoscalingv2.CrossVersionObjectReference) *string { return &oldObj.Name }), oldObj != nil)...)
+
+	// field autoscalingv2.CrossVersionObjectReference.APIVersion has no validation
+	return errs
 }
 
 // Validate_HorizontalPodAutoscaler validates an instance of HorizontalPodAutoscaler according
 // to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscaler(
-	ctx context.Context, op operation.Operation, fldPath *field.Path,
-	obj, oldObj *autoscalingv2.HorizontalPodAutoscaler) (errs field.ErrorList) {
-
+func Validate_HorizontalPodAutoscaler(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscaler) (errs field.ErrorList) {
 	// field autoscalingv2.HorizontalPodAutoscaler.TypeMeta has no validation
 	// field autoscalingv2.HorizontalPodAutoscaler.ObjectMeta has no validation
 
-	{ // field autoscalingv2.HorizontalPodAutoscaler.Spec
-		fn := func(
-			fldPath *field.Path,
-			obj, oldObj *autoscalingv2.HorizontalPodAutoscalerSpec,
-			oldValueCorrelated bool) (errs field.ErrorList) {
+	// field autoscalingv2.HorizontalPodAutoscaler.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscalerSpec, oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update {
-				if equality.Semantic.DeepEqual(obj, oldObj) {
-					return nil
-				}
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_HorizontalPodAutoscalerSpec(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}
-		oldVal := safe.Field(oldObj,
-			func(oldObj *autoscalingv2.HorizontalPodAutoscaler) *autoscalingv2.HorizontalPodAutoscalerSpec {
-				return &oldObj.Spec
-			})
-		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
-	}
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscaler) *autoscalingv2.HorizontalPodAutoscalerSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
 
-	// field autoscalingv2.HorizontalPodAutoscaler.Status has no validation
+	// field autoscalingv2.HorizontalPodAutoscaler.Status
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscalerStatus, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_HorizontalPodAutoscalerStatus(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("status"), &obj.Status, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscaler) *autoscalingv2.HorizontalPodAutoscalerStatus {
+			return &oldObj.Status
+		}), oldObj != nil)...)
+
 	return errs
 }
 
 // Validate_HorizontalPodAutoscalerSpec validates an instance of HorizontalPodAutoscalerSpec according
 // to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscalerSpec(
-	ctx context.Context, op operation.Operation, fldPath *field.Path,
-	obj, oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) (errs field.ErrorList) {
-
-	// field autoscalingv2.HorizontalPodAutoscalerSpec.ScaleTargetRef has no validation
-
-	{ // field autoscalingv2.HorizontalPodAutoscalerSpec.MinReplicas
-		fn := func(
-			fldPath *field.Path,
-			obj, oldObj *int32,
-			oldValueCorrelated bool) (errs field.ErrorList) {
+func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) (errs field.ErrorList) {
+	// field autoscalingv2.HorizontalPodAutoscalerSpec.ScaleTargetRef
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv2.CrossVersionObjectReference, oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update {
-				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
-					return nil
-				}
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CrossVersionObjectReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("scaleTargetRef"), &obj.ScaleTargetRef, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *autoscalingv2.CrossVersionObjectReference {
+			return &oldObj.ScaleTargetRef
+		}), oldObj != nil)...)
+
+	// field autoscalingv2.HorizontalPodAutoscalerSpec.MinReplicas
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true,
-				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
-				}).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false,
-				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
-				}).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-			}
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
+			}).MarkAlpha()...)
+			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
+			}).MarkAlpha()...)
 			return
-		}
-		oldVal := safe.Field(oldObj,
-			func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 {
-				return oldObj.MinReplicas
-			})
-		errs = append(errs, fn(fldPath.Child("minReplicas"), obj.MinReplicas, oldVal, oldObj != nil)...)
-	}
+		}(fldPath.Child("minReplicas"), obj.MinReplicas, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 { return oldObj.MinReplicas }), oldObj != nil)...)
 
-	{ // field autoscalingv2.HorizontalPodAutoscalerSpec.MaxReplicas
-		fn := func(
-			fldPath *field.Path,
-			obj, oldObj *int32,
-			oldValueCorrelated bool) (errs field.ErrorList) {
+	// field autoscalingv2.HorizontalPodAutoscalerSpec.MaxReplicas
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update {
-				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
-					return nil
-				}
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-			}
+			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha()...)
 			return
-		}
-		oldVal := safe.Field(oldObj,
-			func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 {
-				return &oldObj.MaxReplicas
-			})
-		errs = append(errs, fn(fldPath.Child("maxReplicas"), &obj.MaxReplicas, oldVal, oldObj != nil)...)
-	}
+		}(fldPath.Child("maxReplicas"), &obj.MaxReplicas, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 { return &oldObj.MaxReplicas }), oldObj != nil)...)
 
-	// field autoscalingv2.HorizontalPodAutoscalerSpec.Metrics has no validation
+	// field autoscalingv2.HorizontalPodAutoscalerSpec.Metrics
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []autoscalingv2.MetricSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_MetricSpec)...)
+			return
+		}(fldPath.Child("metrics"), obj.Metrics, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) []autoscalingv2.MetricSpec {
+			return oldObj.Metrics
+		}), oldObj != nil)...)
+
 	// field autoscalingv2.HorizontalPodAutoscalerSpec.Behavior has no validation
+	return errs
+}
+
+// Validate_HorizontalPodAutoscalerStatus validates an instance of HorizontalPodAutoscalerStatus according
+// to declarative validation rules in the API schema.
+func Validate_HorizontalPodAutoscalerStatus(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscalerStatus) (errs field.ErrorList) {
+	// field autoscalingv2.HorizontalPodAutoscalerStatus.ObservedGeneration has no validation
+	// field autoscalingv2.HorizontalPodAutoscalerStatus.LastScaleTime has no validation
+	// field autoscalingv2.HorizontalPodAutoscalerStatus.CurrentReplicas has no validation
+	// field autoscalingv2.HorizontalPodAutoscalerStatus.DesiredReplicas has no validation
+
+	// field autoscalingv2.HorizontalPodAutoscalerStatus.CurrentMetrics
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []autoscalingv2.MetricStatus, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_MetricStatus)...)
+			return
+		}(fldPath.Child("currentMetrics"), obj.CurrentMetrics, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerStatus) []autoscalingv2.MetricStatus {
+			return oldObj.CurrentMetrics
+		}), oldObj != nil)...)
+
+	// field autoscalingv2.HorizontalPodAutoscalerStatus.Conditions has no validation
+	return errs
+}
+
+// Validate_MetricSpec validates an instance of MetricSpec according
+// to declarative validation rules in the API schema.
+func Validate_MetricSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.MetricSpec) (errs field.ErrorList) {
+	// field autoscalingv2.MetricSpec.Type has no validation
+
+	// field autoscalingv2.MetricSpec.Object
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv2.ObjectMetricSource, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ObjectMetricSource(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("object"), obj.Object, safe.Field(oldObj, func(oldObj *autoscalingv2.MetricSpec) *autoscalingv2.ObjectMetricSource { return oldObj.Object }), oldObj != nil)...)
+
+	// field autoscalingv2.MetricSpec.Pods has no validation
+	// field autoscalingv2.MetricSpec.Resource has no validation
+	// field autoscalingv2.MetricSpec.ContainerResource has no validation
+	// field autoscalingv2.MetricSpec.External has no validation
+	return errs
+}
+
+// Validate_MetricStatus validates an instance of MetricStatus according
+// to declarative validation rules in the API schema.
+func Validate_MetricStatus(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.MetricStatus) (errs field.ErrorList) {
+	// field autoscalingv2.MetricStatus.Type has no validation
+
+	// field autoscalingv2.MetricStatus.Object
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv2.ObjectMetricStatus, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ObjectMetricStatus(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("object"), obj.Object, safe.Field(oldObj, func(oldObj *autoscalingv2.MetricStatus) *autoscalingv2.ObjectMetricStatus { return oldObj.Object }), oldObj != nil)...)
+
+	// field autoscalingv2.MetricStatus.Pods has no validation
+	// field autoscalingv2.MetricStatus.Resource has no validation
+	// field autoscalingv2.MetricStatus.ContainerResource has no validation
+	// field autoscalingv2.MetricStatus.External has no validation
+	return errs
+}
+
+// Validate_ObjectMetricSource validates an instance of ObjectMetricSource according
+// to declarative validation rules in the API schema.
+func Validate_ObjectMetricSource(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.ObjectMetricSource) (errs field.ErrorList) {
+	// field autoscalingv2.ObjectMetricSource.DescribedObject
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv2.CrossVersionObjectReference, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CrossVersionObjectReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("describedObject"), &obj.DescribedObject, safe.Field(oldObj, func(oldObj *autoscalingv2.ObjectMetricSource) *autoscalingv2.CrossVersionObjectReference {
+			return &oldObj.DescribedObject
+		}), oldObj != nil)...)
+
+	// field autoscalingv2.ObjectMetricSource.Target has no validation
+	// field autoscalingv2.ObjectMetricSource.Metric has no validation
+	return errs
+}
+
+// Validate_ObjectMetricStatus validates an instance of ObjectMetricStatus according
+// to declarative validation rules in the API schema.
+func Validate_ObjectMetricStatus(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.ObjectMetricStatus) (errs field.ErrorList) {
+	// field autoscalingv2.ObjectMetricStatus.Metric has no validation
+	// field autoscalingv2.ObjectMetricStatus.Current has no validation
+
+	// field autoscalingv2.ObjectMetricStatus.DescribedObject
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *autoscalingv2.CrossVersionObjectReference, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CrossVersionObjectReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("describedObject"), &obj.DescribedObject, safe.Field(oldObj, func(oldObj *autoscalingv2.ObjectMetricStatus) *autoscalingv2.CrossVersionObjectReference {
+			return &oldObj.DescribedObject
+		}), oldObj != nil)...)
+
 	return errs
 }

--- a/pkg/apis/autoscaling/v2/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v2/zz_generated.validations.go
@@ -40,48 +40,43 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
 	// type HorizontalPodAutoscaler
-	scheme.AddValidationFunc((*autoscalingv2.HorizontalPodAutoscaler)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		switch op.Request.SubresourcePath() {
-		case "/":
-			return Validate_HorizontalPodAutoscaler(ctx, op, nil /* fldPath */, obj.(*autoscalingv2.HorizontalPodAutoscaler), safe.Cast[*autoscalingv2.HorizontalPodAutoscaler](oldObj))
-		}
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
-	})
+	scheme.AddValidationFunc(
+		(*autoscalingv2.HorizontalPodAutoscaler)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/", "/status":
+				return Validate_HorizontalPodAutoscaler(
+					ctx, op, nil, /* fldPath */
+					obj.(*autoscalingv2.HorizontalPodAutoscaler),
+					safe.Cast[*autoscalingv2.HorizontalPodAutoscaler](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
 	return nil
 }
 
 // Validate_CrossVersionObjectReference validates an instance of CrossVersionObjectReference according
 // to declarative validation rules in the API schema.
-func Validate_CrossVersionObjectReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.CrossVersionObjectReference) (errs field.ErrorList) {
-	// field autoscalingv2.CrossVersionObjectReference.Kind
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
-			return
-		}(fldPath.Child("kind"), &obj.Kind, safe.Field(oldObj, func(oldObj *autoscalingv2.CrossVersionObjectReference) *string { return &oldObj.Kind }), oldObj != nil)...)
+func Validate_CrossVersionObjectReference(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv2.CrossVersionObjectReference) (errs field.ErrorList) {
 
-	// field autoscalingv2.CrossVersionObjectReference.Name
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.CrossVersionObjectReference.Kind
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -89,7 +84,42 @@ func Validate_CrossVersionObjectReference(ctx context.Context, op operation.Oper
 				return // do not proceed
 			}
 			return
-		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *autoscalingv2.CrossVersionObjectReference) *string { return &oldObj.Name }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.CrossVersionObjectReference) *string {
+				return &oldObj.Kind
+			})
+		errs = append(errs, fn(fldPath.Child("kind"), &obj.Kind, oldVal, oldObj != nil)...)
+	}
+
+	{ // field autoscalingv2.CrossVersionObjectReference.Name
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.CrossVersionObjectReference) *string {
+				return &oldObj.Name
+			})
+		errs = append(errs, fn(fldPath.Child("name"), &obj.Name, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv2.CrossVersionObjectReference.APIVersion has no validation
 	return errs
@@ -97,123 +127,191 @@ func Validate_CrossVersionObjectReference(ctx context.Context, op operation.Oper
 
 // Validate_HorizontalPodAutoscaler validates an instance of HorizontalPodAutoscaler according
 // to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscaler(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscaler) (errs field.ErrorList) {
+func Validate_HorizontalPodAutoscaler(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv2.HorizontalPodAutoscaler) (errs field.ErrorList) {
+
 	// field autoscalingv2.HorizontalPodAutoscaler.TypeMeta has no validation
 	// field autoscalingv2.HorizontalPodAutoscaler.ObjectMeta has no validation
 
-	// field autoscalingv2.HorizontalPodAutoscaler.Spec
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscalerSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.HorizontalPodAutoscaler.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv2.HorizontalPodAutoscalerSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_HorizontalPodAutoscalerSpec(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscaler) *autoscalingv2.HorizontalPodAutoscalerSpec {
-			return &oldObj.Spec
-		}), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.HorizontalPodAutoscaler) *autoscalingv2.HorizontalPodAutoscalerSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
 
-	// field autoscalingv2.HorizontalPodAutoscaler.Status
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscalerStatus, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.HorizontalPodAutoscaler.Status
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv2.HorizontalPodAutoscalerStatus,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_HorizontalPodAutoscalerStatus(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("status"), &obj.Status, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscaler) *autoscalingv2.HorizontalPodAutoscalerStatus {
-			return &oldObj.Status
-		}), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.HorizontalPodAutoscaler) *autoscalingv2.HorizontalPodAutoscalerStatus {
+				return &oldObj.Status
+			})
+		errs = append(errs, fn(fldPath.Child("status"), &obj.Status, oldVal, oldObj != nil)...)
+	}
 
 	return errs
 }
 
 // Validate_HorizontalPodAutoscalerSpec validates an instance of HorizontalPodAutoscalerSpec according
 // to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) (errs field.ErrorList) {
-	// field autoscalingv2.HorizontalPodAutoscalerSpec.ScaleTargetRef
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv2.CrossVersionObjectReference, oldValueCorrelated bool) (errs field.ErrorList) {
+func Validate_HorizontalPodAutoscalerSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) (errs field.ErrorList) {
+
+	{ // field autoscalingv2.HorizontalPodAutoscalerSpec.ScaleTargetRef
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv2.CrossVersionObjectReference,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_CrossVersionObjectReference(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("scaleTargetRef"), &obj.ScaleTargetRef, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *autoscalingv2.CrossVersionObjectReference {
-			return &oldObj.ScaleTargetRef
-		}), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *autoscalingv2.CrossVersionObjectReference {
+				return &oldObj.ScaleTargetRef
+			})
+		errs = append(errs, fn(fldPath.Child("scaleTargetRef"), &obj.ScaleTargetRef, oldVal, oldObj != nil)...)
+	}
 
-	// field autoscalingv2.HorizontalPodAutoscalerSpec.MinReplicas
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.HorizontalPodAutoscalerSpec.MinReplicas
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
-			}).MarkAlpha()...)
-			errs = append(errs, validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-				return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
-			}).MarkAlpha()...)
+			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", true,
+				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 0)
+				}).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "HPAScaleToZero", false,
+				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
+					return validate.Minimum(ctx, op, fldPath, obj, oldObj, 1)
+				}).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
-		}(fldPath.Child("minReplicas"), obj.MinReplicas, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 { return oldObj.MinReplicas }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 {
+				return oldObj.MinReplicas
+			})
+		errs = append(errs, fn(fldPath.Child("minReplicas"), obj.MinReplicas, oldVal, oldObj != nil)...)
+	}
 
-	// field autoscalingv2.HorizontalPodAutoscalerSpec.MaxReplicas
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.HorizontalPodAutoscalerSpec.MaxReplicas
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			errs = append(errs, validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha()...)
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
-		}(fldPath.Child("maxReplicas"), &obj.MaxReplicas, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 { return &oldObj.MaxReplicas }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) *int32 {
+				return &oldObj.MaxReplicas
+			})
+		errs = append(errs, fn(fldPath.Child("maxReplicas"), &obj.MaxReplicas, oldVal, oldObj != nil)...)
+	}
 
-	// field autoscalingv2.HorizontalPodAutoscalerSpec.Metrics
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []autoscalingv2.MetricSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.HorizontalPodAutoscalerSpec.Metrics
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj []autoscalingv2.MetricSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_MetricSpec)...)
+			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_MetricSpec); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
-		}(fldPath.Child("metrics"), obj.Metrics, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) []autoscalingv2.MetricSpec {
-			return oldObj.Metrics
-		}), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.HorizontalPodAutoscalerSpec) []autoscalingv2.MetricSpec {
+				return oldObj.Metrics
+			})
+		errs = append(errs, fn(fldPath.Child("metrics"), obj.Metrics, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv2.HorizontalPodAutoscalerSpec.Behavior has no validation
 	return errs
@@ -221,33 +319,46 @@ func Validate_HorizontalPodAutoscalerSpec(ctx context.Context, op operation.Oper
 
 // Validate_HorizontalPodAutoscalerStatus validates an instance of HorizontalPodAutoscalerStatus according
 // to declarative validation rules in the API schema.
-func Validate_HorizontalPodAutoscalerStatus(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.HorizontalPodAutoscalerStatus) (errs field.ErrorList) {
+func Validate_HorizontalPodAutoscalerStatus(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv2.HorizontalPodAutoscalerStatus) (errs field.ErrorList) {
+
 	// field autoscalingv2.HorizontalPodAutoscalerStatus.ObservedGeneration has no validation
 	// field autoscalingv2.HorizontalPodAutoscalerStatus.LastScaleTime has no validation
 	// field autoscalingv2.HorizontalPodAutoscalerStatus.CurrentReplicas has no validation
 	// field autoscalingv2.HorizontalPodAutoscalerStatus.DesiredReplicas has no validation
 
-	// field autoscalingv2.HorizontalPodAutoscalerStatus.CurrentMetrics
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []autoscalingv2.MetricStatus, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.HorizontalPodAutoscalerStatus.CurrentMetrics
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj []autoscalingv2.MetricStatus,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_MetricStatus)...)
+			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_MetricStatus); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
-		}(fldPath.Child("currentMetrics"), obj.CurrentMetrics, safe.Field(oldObj, func(oldObj *autoscalingv2.HorizontalPodAutoscalerStatus) []autoscalingv2.MetricStatus {
-			return oldObj.CurrentMetrics
-		}), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.HorizontalPodAutoscalerStatus) []autoscalingv2.MetricStatus {
+				return oldObj.CurrentMetrics
+			})
+		errs = append(errs, fn(fldPath.Child("currentMetrics"), obj.CurrentMetrics, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv2.HorizontalPodAutoscalerStatus.Conditions has no validation
 	return errs
@@ -255,28 +366,39 @@ func Validate_HorizontalPodAutoscalerStatus(ctx context.Context, op operation.Op
 
 // Validate_MetricSpec validates an instance of MetricSpec according
 // to declarative validation rules in the API schema.
-func Validate_MetricSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.MetricSpec) (errs field.ErrorList) {
+func Validate_MetricSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv2.MetricSpec) (errs field.ErrorList) {
+
 	// field autoscalingv2.MetricSpec.Type has no validation
 
-	// field autoscalingv2.MetricSpec.Object
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv2.ObjectMetricSource, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.MetricSpec.Object
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv2.ObjectMetricSource,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			// call the type's validation function
-			errs = append(errs, Validate_ObjectMetricSource(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("object"), obj.Object, safe.Field(oldObj, func(oldObj *autoscalingv2.MetricSpec) *autoscalingv2.ObjectMetricSource { return oldObj.Object }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.MetricSpec) *autoscalingv2.ObjectMetricSource {
+				return oldObj.Object
+			})
+		errs = append(errs, fn(fldPath.Child("object"), obj.Object, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv2.MetricSpec.Pods has no validation
 	// field autoscalingv2.MetricSpec.Resource has no validation
@@ -287,28 +409,39 @@ func Validate_MetricSpec(ctx context.Context, op operation.Operation, fldPath *f
 
 // Validate_MetricStatus validates an instance of MetricStatus according
 // to declarative validation rules in the API schema.
-func Validate_MetricStatus(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.MetricStatus) (errs field.ErrorList) {
+func Validate_MetricStatus(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv2.MetricStatus) (errs field.ErrorList) {
+
 	// field autoscalingv2.MetricStatus.Type has no validation
 
-	// field autoscalingv2.MetricStatus.Object
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv2.ObjectMetricStatus, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.MetricStatus.Object
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv2.ObjectMetricStatus,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			// call the type's validation function
-			errs = append(errs, Validate_ObjectMetricStatus(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("object"), obj.Object, safe.Field(oldObj, func(oldObj *autoscalingv2.MetricStatus) *autoscalingv2.ObjectMetricStatus { return oldObj.Object }), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.MetricStatus) *autoscalingv2.ObjectMetricStatus {
+				return oldObj.Object
+			})
+		errs = append(errs, fn(fldPath.Child("object"), obj.Object, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv2.MetricStatus.Pods has no validation
 	// field autoscalingv2.MetricStatus.Resource has no validation
@@ -319,20 +452,31 @@ func Validate_MetricStatus(ctx context.Context, op operation.Operation, fldPath 
 
 // Validate_ObjectMetricSource validates an instance of ObjectMetricSource according
 // to declarative validation rules in the API schema.
-func Validate_ObjectMetricSource(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.ObjectMetricSource) (errs field.ErrorList) {
-	// field autoscalingv2.ObjectMetricSource.DescribedObject
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv2.CrossVersionObjectReference, oldValueCorrelated bool) (errs field.ErrorList) {
+func Validate_ObjectMetricSource(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv2.ObjectMetricSource) (errs field.ErrorList) {
+
+	{ // field autoscalingv2.ObjectMetricSource.DescribedObject
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv2.CrossVersionObjectReference,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_CrossVersionObjectReference(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("describedObject"), &obj.DescribedObject, safe.Field(oldObj, func(oldObj *autoscalingv2.ObjectMetricSource) *autoscalingv2.CrossVersionObjectReference {
-			return &oldObj.DescribedObject
-		}), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.ObjectMetricSource) *autoscalingv2.CrossVersionObjectReference {
+				return &oldObj.DescribedObject
+			})
+		errs = append(errs, fn(fldPath.Child("describedObject"), &obj.DescribedObject, oldVal, oldObj != nil)...)
+	}
 
 	// field autoscalingv2.ObjectMetricSource.Target has no validation
 	// field autoscalingv2.ObjectMetricSource.Metric has no validation
@@ -341,23 +485,34 @@ func Validate_ObjectMetricSource(ctx context.Context, op operation.Operation, fl
 
 // Validate_ObjectMetricStatus validates an instance of ObjectMetricStatus according
 // to declarative validation rules in the API schema.
-func Validate_ObjectMetricStatus(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *autoscalingv2.ObjectMetricStatus) (errs field.ErrorList) {
+func Validate_ObjectMetricStatus(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *autoscalingv2.ObjectMetricStatus) (errs field.ErrorList) {
+
 	// field autoscalingv2.ObjectMetricStatus.Metric has no validation
 	// field autoscalingv2.ObjectMetricStatus.Current has no validation
 
-	// field autoscalingv2.ObjectMetricStatus.DescribedObject
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *autoscalingv2.CrossVersionObjectReference, oldValueCorrelated bool) (errs field.ErrorList) {
+	{ // field autoscalingv2.ObjectMetricStatus.DescribedObject
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *autoscalingv2.CrossVersionObjectReference,
+			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
-			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
-				return nil
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_CrossVersionObjectReference(ctx, op, fldPath, obj, oldObj)...)
 			return
-		}(fldPath.Child("describedObject"), &obj.DescribedObject, safe.Field(oldObj, func(oldObj *autoscalingv2.ObjectMetricStatus) *autoscalingv2.CrossVersionObjectReference {
-			return &oldObj.DescribedObject
-		}), oldObj != nil)...)
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *autoscalingv2.ObjectMetricStatus) *autoscalingv2.CrossVersionObjectReference {
+				return &oldObj.DescribedObject
+			})
+		errs = append(errs, fn(fldPath.Child("describedObject"), &obj.DescribedObject, oldVal, oldObj != nil)...)
+	}
 
 	return errs
 }

--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -84,7 +84,7 @@ func validateHorizontalPodAutoscalerSpec(autoscaler autoscaling.HorizontalPodAut
 func ValidateCrossVersionObjectReference(ref autoscaling.CrossVersionObjectReference, fldPath *field.Path, opts CrossVersionObjectReferenceValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(ref.Kind) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("kind"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("kind"), "").MarkCoveredByDeclarative())
 	} else {
 		for _, msg := range content.IsPathSegmentName(ref.Kind) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), ref.Kind, msg))
@@ -92,7 +92,7 @@ func ValidateCrossVersionObjectReference(ref autoscaling.CrossVersionObjectRefer
 	}
 
 	if len(ref.Name) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "").MarkCoveredByDeclarative())
 	} else {
 		for _, msg := range content.IsPathSegmentName(ref.Name) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ref.Name, msg))

--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -84,7 +84,11 @@ func validateHorizontalPodAutoscalerSpec(autoscaler autoscaling.HorizontalPodAut
 func ValidateCrossVersionObjectReference(ref autoscaling.CrossVersionObjectReference, fldPath *field.Path, opts CrossVersionObjectReferenceValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(ref.Kind) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("kind"), "").MarkCoveredByDeclarative())
+		err := field.Required(fldPath.Child("kind"), "")
+		if opts.RequiredCoveredByDeclarative {
+			err = err.MarkCoveredByDeclarative()
+		}
+		allErrs = append(allErrs, err)
 	} else {
 		for _, msg := range content.IsPathSegmentName(ref.Kind) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), ref.Kind, msg))
@@ -92,7 +96,11 @@ func ValidateCrossVersionObjectReference(ref autoscaling.CrossVersionObjectRefer
 	}
 
 	if len(ref.Name) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "").MarkCoveredByDeclarative())
+		err := field.Required(fldPath.Child("name"), "")
+		if opts.RequiredCoveredByDeclarative {
+			err = err.MarkCoveredByDeclarative()
+		}
+		allErrs = append(allErrs, err)
 	} else {
 		for _, msg := range content.IsPathSegmentName(ref.Name) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ref.Name, msg))
@@ -150,6 +158,12 @@ type CrossVersionObjectReferenceValidationOptions struct {
 	AllowEmptyAPIGroup bool
 	// AllowInvalidAPIVersion skips APIVersion validation when true.
 	AllowInvalidAPIVersion bool
+	// RequiredCoveredByDeclarative marks the required-value errors for Kind and
+	// Name as covered by declarative validation. Set it only where declarative
+	// validation actually validates the reference (scaleTargetRef); leave it
+	// false for describedObject, which is under the opaque metrics subtree and is
+	// validated only by hand-written validation.
+	RequiredCoveredByDeclarative bool
 }
 
 // HorizontalPodAutoscalerSpecValidationOptions contains the different settings for

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -192,7 +192,7 @@ func (autoscalerStatusStrategy) WarningsOnUpdate(ctx context.Context, obj, old r
 func validationOptionsForHorizontalPodAutoscaler(newHPA, oldHPA *autoscaling.HorizontalPodAutoscaler) validation.HorizontalPodAutoscalerSpecValidationOptions {
 	opts := validation.HorizontalPodAutoscalerSpecValidationOptions{
 		MinReplicasLowerBound:           1,
-		ScaleTargetRefValidationOptions: validation.CrossVersionObjectReferenceValidationOptions{AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false},
+		ScaleTargetRefValidationOptions: validation.CrossVersionObjectReferenceValidationOptions{AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true},
 		ObjectMetricsValidationOptions: validation.CrossVersionObjectReferenceValidationOptions{
 			AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
 		},

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy_test.go
@@ -221,7 +221,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -234,7 +234,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -247,7 +247,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 0,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -260,7 +260,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     true,
 			expectMinReplicasLower: 0,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -274,7 +274,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -287,7 +287,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -300,7 +300,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -313,7 +313,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -326,7 +326,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -340,7 +340,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -353,7 +353,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -366,7 +366,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -379,7 +379,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: true,
@@ -392,7 +392,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
@@ -408,7 +408,7 @@ func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
 			scaleToZeroEnabled:     false,
 			expectMinReplicasLower: 1,
 			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
-				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false, RequiredCoveredByDeclarative: true,
 			},
 			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
 				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -88,11 +88,11 @@ message ContainerResourceMetricStatus {
 // +structType=atomic
 message CrossVersionObjectReference {
   // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional string kind = 1;
 
   // name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional string name = 2;
 
   // apiVersion is the API version of the referent

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -88,9 +88,11 @@ message ContainerResourceMetricStatus {
 // +structType=atomic
 message CrossVersionObjectReference {
   // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string kind = 1;
 
   // name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 2;
 
   // apiVersion is the API version of the referent

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -26,11 +26,11 @@ import (
 // +structType=atomic
 type CrossVersionObjectReference struct {
 	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 
 	// name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
 	// apiVersion is the API version of the referent

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -26,9 +26,11 @@ import (
 // +structType=atomic
 type CrossVersionObjectReference struct {
 	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 
 	// name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
 	// apiVersion is the API version of the referent

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -67,11 +67,11 @@ message ContainerResourceMetricStatus {
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 message CrossVersionObjectReference {
   // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional string kind = 1;
 
   // name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-  // +k8s:alpha(since: "1.36")=+k8s:required
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional string name = 2;
 
   // apiVersion is the API version of the referent
@@ -273,7 +273,8 @@ message HorizontalPodAutoscalerSpec {
   // If not set, the default metric will be set to 80% average CPU utilization.
   // +listType=atomic
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:opaqueType
   repeated MetricSpec metrics = 4;
 
   // behavior configures the scaling behavior of the target
@@ -306,7 +307,8 @@ message HorizontalPodAutoscalerStatus {
   // currentMetrics is the last read state of the metrics used by this autoscaler.
   // +listType=atomic
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:opaqueType
   repeated MetricStatus currentMetrics = 5;
 
   // conditions is the set of conditions required for this autoscaler to scale its target,
@@ -341,7 +343,8 @@ message MetricSpec {
   // object refers to a metric describing a single kubernetes object
   // (for example, hits-per-second on an Ingress object).
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:opaqueType
   optional ObjectMetricSource object = 2;
 
   // pods refers to a metric describing each pod in the current scale target
@@ -384,7 +387,8 @@ message MetricStatus {
   // object refers to a metric describing a single kubernetes object
   // (for example, hits-per-second on an Ingress object).
   // +optional
-  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:opaqueType
   optional ObjectMetricStatus object = 2;
 
   // pods refers to a metric describing each pod in the current scale target

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -67,9 +67,11 @@ message ContainerResourceMetricStatus {
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 message CrossVersionObjectReference {
   // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string kind = 1;
 
   // name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string name = 2;
 
   // apiVersion is the API version of the referent
@@ -271,6 +273,7 @@ message HorizontalPodAutoscalerSpec {
   // If not set, the default metric will be set to 80% average CPU utilization.
   // +listType=atomic
   // +optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated MetricSpec metrics = 4;
 
   // behavior configures the scaling behavior of the target
@@ -303,6 +306,7 @@ message HorizontalPodAutoscalerStatus {
   // currentMetrics is the last read state of the metrics used by this autoscaler.
   // +listType=atomic
   // +optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   repeated MetricStatus currentMetrics = 5;
 
   // conditions is the set of conditions required for this autoscaler to scale its target,
@@ -337,6 +341,7 @@ message MetricSpec {
   // object refers to a metric describing a single kubernetes object
   // (for example, hits-per-second on an Ingress object).
   // +optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional ObjectMetricSource object = 2;
 
   // pods refers to a metric describing each pod in the current scale target
@@ -379,6 +384,7 @@ message MetricStatus {
   // object refers to a metric describing a single kubernetes object
   // (for example, hits-per-second on an Ingress object).
   // +optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
   optional ObjectMetricStatus object = 2;
 
   // pods refers to a metric describing each pod in the current scale target

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -274,7 +274,6 @@ message HorizontalPodAutoscalerSpec {
   // +listType=atomic
   // +optional
   // +k8s:alpha(since: "1.37")=+k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:opaqueType
   repeated MetricSpec metrics = 4;
 
   // behavior configures the scaling behavior of the target
@@ -308,7 +307,6 @@ message HorizontalPodAutoscalerStatus {
   // +listType=atomic
   // +optional
   // +k8s:alpha(since: "1.37")=+k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:opaqueType
   repeated MetricStatus currentMetrics = 5;
 
   // conditions is the set of conditions required for this autoscaler to scale its target,

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -82,6 +82,7 @@ type HorizontalPodAutoscalerSpec struct {
 	// If not set, the default metric will be set to 80% average CPU utilization.
 	// +listType=atomic
 	// +optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Metrics []MetricSpec `json:"metrics,omitempty" protobuf:"bytes,4,rep,name=metrics"`
 
 	// behavior configures the scaling behavior of the target
@@ -94,9 +95,11 @@ type HorizontalPodAutoscalerSpec struct {
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 type CrossVersionObjectReference struct {
 	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 
 	// name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
 	// apiVersion is the API version of the referent
@@ -114,6 +117,7 @@ type MetricSpec struct {
 	// object refers to a metric describing a single kubernetes object
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Object *ObjectMetricSource `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
 
 	// pods refers to a metric describing each pod in the current scale target
@@ -425,6 +429,7 @@ type HorizontalPodAutoscalerStatus struct {
 	// currentMetrics is the last read state of the metrics used by this autoscaler.
 	// +listType=atomic
 	// +optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	CurrentMetrics []MetricStatus `json:"currentMetrics" protobuf:"bytes,5,rep,name=currentMetrics"`
 
 	// conditions is the set of conditions required for this autoscaler to scale its target,
@@ -488,6 +493,7 @@ type MetricStatus struct {
 	// object refers to a metric describing a single kubernetes object
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
 	Object *ObjectMetricStatus `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
 
 	// pods refers to a metric describing each pod in the current scale target

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -82,7 +82,8 @@ type HorizontalPodAutoscalerSpec struct {
 	// If not set, the default metric will be set to 80% average CPU utilization.
 	// +listType=atomic
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:opaqueType
 	Metrics []MetricSpec `json:"metrics,omitempty" protobuf:"bytes,4,rep,name=metrics"`
 
 	// behavior configures the scaling behavior of the target
@@ -95,11 +96,11 @@ type HorizontalPodAutoscalerSpec struct {
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 type CrossVersionObjectReference struct {
 	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 
 	// name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-	// +k8s:alpha(since: "1.36")=+k8s:required
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
 	// apiVersion is the API version of the referent
@@ -117,7 +118,8 @@ type MetricSpec struct {
 	// object refers to a metric describing a single kubernetes object
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:opaqueType
 	Object *ObjectMetricSource `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
 
 	// pods refers to a metric describing each pod in the current scale target
@@ -429,7 +431,8 @@ type HorizontalPodAutoscalerStatus struct {
 	// currentMetrics is the last read state of the metrics used by this autoscaler.
 	// +listType=atomic
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:opaqueType
 	CurrentMetrics []MetricStatus `json:"currentMetrics" protobuf:"bytes,5,rep,name=currentMetrics"`
 
 	// conditions is the set of conditions required for this autoscaler to scale its target,
@@ -493,7 +496,8 @@ type MetricStatus struct {
 	// object refers to a metric describing a single kubernetes object
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
-	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:opaqueType
 	Object *ObjectMetricStatus `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
 
 	// pods refers to a metric describing each pod in the current scale target

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -83,7 +83,6 @@ type HorizontalPodAutoscalerSpec struct {
 	// +listType=atomic
 	// +optional
 	// +k8s:alpha(since: "1.37")=+k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:opaqueType
 	Metrics []MetricSpec `json:"metrics,omitempty" protobuf:"bytes,4,rep,name=metrics"`
 
 	// behavior configures the scaling behavior of the target
@@ -432,7 +431,6 @@ type HorizontalPodAutoscalerStatus struct {
 	// +listType=atomic
 	// +optional
 	// +k8s:alpha(since: "1.37")=+k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:opaqueType
 	CurrentMetrics []MetricStatus `json:"currentMetrics" protobuf:"bytes,5,rep,name=currentMetrics"`
 
 	// conditions is the set of conditions required for this autoscaler to scale its target,

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
@@ -59,6 +59,18 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"valid: minReplicas not set (nil)": {
 			input: makeValidHPA(), // Default, no minReplicas set
 		},
+		"invalid: scaleTargetRef.kind empty (required)": {
+			input: makeValidHPA(tweakScaleTargetRefKind("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "scaleTargetRef", "kind"), "").MarkAlpha(),
+			},
+		},
+		"invalid: scaleTargetRef.name empty (required)": {
+			input: makeValidHPA(tweakScaleTargetRefName("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "scaleTargetRef", "name"), "").MarkAlpha(),
+			},
+		},
 		"invalid: maxReplicas = 0 (required)": {
 			input: makeValidHPA(tweakMaxReplicas(0)),
 			expectedErrs: field.ErrorList{
@@ -113,6 +125,20 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:            makeValidHPA(tweakMinReplicas(1), tweakMetrics(validScaleToZeroMetrics...)),
 			updateObj:         makeValidHPA(tweakMinReplicas(0), tweakMetrics(validScaleToZeroMetrics...)),
 			enableScaleToZero: true,
+		},
+		"invalid update: scaleTargetRef.kind empty (required)": {
+			oldObj:    makeValidHPA(),
+			updateObj: makeValidHPA(tweakScaleTargetRefKind("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "scaleTargetRef", "kind"), "").MarkAlpha(),
+			},
+		},
+		"invalid update: scaleTargetRef.name empty (required)": {
+			oldObj:    makeValidHPA(),
+			updateObj: makeValidHPA(tweakScaleTargetRefName("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "scaleTargetRef", "name"), "").MarkAlpha(),
+			},
 		},
 		"invalid update: maxReplicas = 0 (required)": {
 			oldObj:    makeValidHPA(),
@@ -177,6 +203,18 @@ func makeValidHPA(mutators ...func(*api.HorizontalPodAutoscaler)) api.Horizontal
 		mutate(&hpa)
 	}
 	return hpa
+}
+
+func tweakScaleTargetRefKind(kind string) func(*api.HorizontalPodAutoscaler) {
+	return func(hpa *api.HorizontalPodAutoscaler) {
+		hpa.Spec.ScaleTargetRef.Kind = kind
+	}
+}
+
+func tweakScaleTargetRefName(name string) func(*api.HorizontalPodAutoscaler) {
+	return func(hpa *api.HorizontalPodAutoscaler) {
+		hpa.Spec.ScaleTargetRef.Name = name
+	}
 }
 
 func tweakMinReplicas(replicas int32) func(*api.HorizontalPodAutoscaler) {

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
@@ -38,6 +38,12 @@ func init() {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"spec.scaleTargetRef.kind": {
+				{ErrorType: "FieldValueRequired"},
+			},
+			"spec.scaleTargetRef.name": {
+				{ErrorType: "FieldValueRequired"},
+			},
 		},
 	)
 }

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
@@ -38,6 +38,12 @@ func init() {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"spec.scaleTargetRef.kind": {
+				{ErrorType: "FieldValueRequired"},
+			},
+			"spec.scaleTargetRef.name": {
+				{ErrorType: "FieldValueRequired"},
+			},
 		},
 	)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR migrates the `required` validation for `CrossVersionObjectReference.Kind` and `CrossVersionObjectReference.Name` fields to declarative validation (DV) using `+k8s:alpha(since: "1.36")=+k8s:required` tags. This is part of the broader declarative validation migration effort (KEP-5073).

**Changes:**
1. **`staging/src/k8s.io/api/autoscaling/v1/types.go`** and **`v2/types.go`**: Added `+k8s:alpha(since: "1.36")=+k8s:required` to `CrossVersionObjectReference.Kind` and `.Name` fields
2. **`staging/src/k8s.io/api/autoscaling/v2/types.go`**: Added `+k8s:alpha(since: "1.36")=+k8s:optional` to 4 cascading fields that transitively contain `CrossVersionObjectReference` (`HorizontalPodAutoscalerSpec.Metrics`, `MetricSpec.Object`, `HorizontalPodAutoscalerStatus.CurrentMetrics`, `MetricStatus.Object`)
3. **`pkg/apis/autoscaling/validation/validation.go`**: Marked hand-written `Required` checks with `.MarkCoveredByDeclarative()`
4. **`pkg/registry/autoscaling/horizontalpodautoscaler/declarative_validation_test.go`**: Added equivalence test cases for create and update scenarios
5. Regenerated validation (`zz_generated.validations.go`) and protobuf (`generated.proto`) files via `hack/update-codegen.sh`

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/135752

KEP: https://github.com/kubernetes/enhancements/issues/5073

#### Special notes for your reviewer:

- `CrossVersionObjectReference` is defined separately in both `autoscaling/v1` and `autoscaling/v2` — both are updated.
- Adding `+k8s:required` to `CrossVersionObjectReference` fields triggered cascading DV lint requirements in v2 for fields that transitively contain `CrossVersionObjectReference`. Four already-optional fields needed explicit `+k8s:optional` declarations to satisfy the lint rule.
- The `else` branches of the hand-written validation (which validate `IsPathSegmentName`) are NOT marked as covered by DV, since DV does not yet support that validation. Only the `Required` checks are covered.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5073
```

---

### Test Results

All relevant test suites pass with no regressions. Below are the complete before/after test logs.

<details>
<summary>Before: Declarative Validation Tests (without this PR's changes)</summary>

```
=== RUN   TestDeclarativeValidate
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/hand_written_validation
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/hand_written_validation
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/hand_written_validation
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/hand_written_validation
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/hand_written_validation
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/hand_written_validation
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
--- PASS: TestDeclarativeValidate (0.26s)
=== RUN   TestDeclarativeValidateUpdate
=== RUN   TestDeclarativeValidateUpdate/v1
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/autoscaling/v1,_Kind=HorizontalPodAutoscaler
--- PASS: TestDeclarativeValidateUpdate (0.26s)
PASS
ok  	k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler	0.565s

Note: Before this PR, there are NO test cases for scaleTargetRef.kind or scaleTargetRef.name
in TestDeclarativeValidate or TestDeclarativeValidateUpdate.
```

</details>

<details>
<summary>After: Declarative Validation Tests (with this PR's changes)</summary>

```
=== RUN   TestDeclarativeValidate
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.kind_empty_(required)
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.kind_empty_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.kind_empty_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.kind_empty_(required)/hand_written_validation
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.kind_empty_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.kind_empty_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.kind_empty_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.name_empty_(required)
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.name_empty_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.name_empty_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.name_empty_(required)/hand_written_validation
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.name_empty_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.name_empty_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_scaleTargetRef.name_empty_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/hand_written_validation
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_=_0_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/hand_written_validation
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_maxReplicas_negative/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/hand_written_validation
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/invalid:_minReplicas_=_0_(gate_disabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/hand_written_validation
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_5/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/hand_written_validation
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_=_0_(gate_enabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/hand_written_validation
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidate/valid:_minReplicas_not_set_(nil)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
--- PASS: TestDeclarativeValidate (0.15s)
=== RUN   TestDeclarativeValidateUpdate
=== RUN   TestDeclarativeValidateUpdate/v1
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_minReplicas_1_->_0_(gate_enabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.name_empty_(required)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.name_empty_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.name_empty_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.name_empty_(required)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.name_empty_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.name_empty_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.name_empty_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_minReplicas_1_->_0_(gate_disabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_change_minReplicas/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.kind_empty_(required)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.kind_empty_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.kind_empty_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.kind_empty_(required)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.kind_empty_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.kind_empty_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_scaleTargetRef.kind_empty_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_=_0_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/invalid_update:_maxReplicas_negative/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v1/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_=_0_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_change_minReplicas/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.name_empty_(required)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.name_empty_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.name_empty_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.name_empty_(required)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.name_empty_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.name_empty_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.name_empty_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_maxReplicas_negative/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_minReplicas_1_->_0_(gate_disabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_ratcheting_minReplicas=0_when_gate_disabled/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/valid_update:_minReplicas_1_->_0_(gate_enabled)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.kind_empty_(required)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.kind_empty_(required)/with_declarative_validation_(Beta_enabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.kind_empty_(required)/with_declarative_validation_(Beta_disabled)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.kind_empty_(required)/hand_written_validation
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.kind_empty_(required)/with_declarative_validation_(All_Rules_Enforced)
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.kind_empty_(required)/autoscaling/v2,_Kind=HorizontalPodAutoscaler
=== RUN   TestDeclarativeValidateUpdate/v2/invalid_update:_scaleTargetRef.kind_empty_(required)/autoscaling/v1,_Kind=HorizontalPodAutoscaler
--- PASS: TestDeclarativeValidateUpdate (0.16s)
PASS
ok  	k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler	0.340s

Key difference: 4 NEW test cases added for scaleTargetRef.kind and scaleTargetRef.name
(2 for create, 2 for update), each running with DV Beta enabled/disabled,
hand-written validation, All Rules Enforced, and both v1/v2 API versions.
All pass, confirming DV produces identical errors to hand-written validation.
```

</details>

<details>
<summary>After: Hand-written Validation Tests (no regression)</summary>

```
=== RUN   TestScaleDeclarativeValidation
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_positive_replicas
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_positive_replicas/autoscaling/v1,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_positive_replicas/apps/v1beta2,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_positive_replicas/apps/v1beta1,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_positive_replicas/extensions/v1beta1,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_negative_replicas
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_negative_replicas/autoscaling/v1,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_negative_replicas/apps/v1beta2,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_negative_replicas/apps/v1beta1,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_negative_replicas/extensions/v1beta1,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_0_replicas
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_0_replicas/autoscaling/v1,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_0_replicas/apps/v1beta2,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_0_replicas/apps/v1beta1,_Kind=Scale
=== RUN   TestScaleDeclarativeValidation/spec.replicas:_0_replicas/extensions/v1beta1,_Kind=Scale
--- PASS: TestScaleDeclarativeValidation (0.00s)
    --- PASS: TestScaleDeclarativeValidation/spec.replicas:_positive_replicas (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_positive_replicas/autoscaling/v1,_Kind=Scale (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_positive_replicas/apps/v1beta2,_Kind=Scale (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_positive_replicas/apps/v1beta1,_Kind=Scale (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_positive_replicas/extensions/v1beta1,_Kind=Scale (0.00s)
    --- PASS: TestScaleDeclarativeValidation/spec.replicas:_negative_replicas (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_negative_replicas/autoscaling/v1,_Kind=Scale (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_negative_replicas/apps/v1beta2,_Kind=Scale (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_negative_replicas/apps/v1beta1,_Kind=Scale (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_negative_replicas/extensions/v1beta1,_Kind=Scale (0.00s)
    --- PASS: TestScaleDeclarativeValidation/spec.replicas:_0_replicas (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_0_replicas/autoscaling/v1,_Kind=Scale (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_0_replicas/apps/v1beta2,_Kind=Scale (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_0_replicas/apps/v1beta1,_Kind=Scale (0.00s)
        --- PASS: TestScaleDeclarativeValidation/spec.replicas:_0_replicas/extensions/v1beta1,_Kind=Scale (0.00s)
=== RUN   TestValidateScale
--- PASS: TestValidateScale (0.00s)
=== RUN   TestValidateBehavior
--- PASS: TestValidateBehavior (0.00s)
=== RUN   TestValidateHorizontalPodAutoscaler
--- PASS: TestValidateHorizontalPodAutoscaler (0.00s)
=== RUN   TestValidateHorizontalPodAutoscalerScaleToZeroEnabled
--- PASS: TestValidateHorizontalPodAutoscalerScaleToZeroEnabled (0.00s)
=== RUN   TestValidateHorizontalPodAutoscalerScaleToZeroDisabled
--- PASS: TestValidateHorizontalPodAutoscalerScaleToZeroDisabled (0.00s)
=== RUN   TestValidateHorizontalPodAutoscalerUpdateScaleToZeroEnabled
--- PASS: TestValidateHorizontalPodAutoscalerUpdateScaleToZeroEnabled (0.00s)
=== RUN   TestValidateHorizontalPodAutoscalerScaleToZeroUpdateDisabled
--- PASS: TestValidateHorizontalPodAutoscalerScaleToZeroUpdateDisabled (0.00s)
=== RUN   TestValidateHorizontalPodAutoscalerConfigurableToleranceEnabled
--- PASS: TestValidateHorizontalPodAutoscalerConfigurableToleranceEnabled (0.00s)
=== RUN   TestValidateHorizontalPodAutoscalerConfigurableToleranceDisabled
--- PASS: TestValidateHorizontalPodAutoscalerConfigurableToleranceDisabled (0.00s)
=== RUN   TestValidateHorizontalPodAutoscalerUpdateConfigurableToleranceEnabled
--- PASS: TestValidateHorizontalPodAutoscalerUpdateConfigurableToleranceEnabled (0.00s)
=== RUN   TestValidateHorizontalPodAutoscalerUpdateInvalidHPA
--- PASS: TestValidateHorizontalPodAutoscalerUpdateInvalidHPA (0.00s)
PASS
ok  	k8s.io/kubernetes/pkg/apis/autoscaling/validation	0.025s
```

</details>

<details>
<summary>After: API Round-Trip Tests (no regression)</summary>

```
=== RUN   TestRoundTripTypes
--- PASS: TestRoundTripTypes (1.34s)
PASS
ok  	k8s.io/kubernetes/pkg/api/testing	1.369s
```

</details>