### PR TITLE
Migrate Secret.Type to declarative immutable validation

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -48,6 +48,14 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
+	// type Secret
+	scheme.AddValidationFunc((*corev1.Secret)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_Secret(ctx, op, nil /* fldPath */, obj.(*corev1.Secret), safe.Cast[*corev1.Secret](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
 }
 
@@ -131,5 +139,39 @@ func Validate_ReplicationControllerSpec(ctx context.Context, op operation.Operat
 
 	// field corev1.ReplicationControllerSpec.Selector has no validation
 	// field corev1.ReplicationControllerSpec.Template has no validation
+	return errs
+}
+
+// Validate_Secret validates an instance of Secret according
+// to declarative validation rules in the API schema.
+func Validate_Secret(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *corev1.Secret) (errs field.ErrorList) {
+	// field corev1.Secret.TypeMeta has no validation
+	// field corev1.Secret.ObjectMeta has no validation
+	// field corev1.Secret.Immutable has no validation
+	// field corev1.Secret.Data has no validation
+	// field corev1.Secret.StringData has no validation
+
+	// field corev1.Secret.Type
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *corev1.SecretType, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("type"), &obj.Type, safe.Field(oldObj, func(oldObj *corev1.Secret) *corev1.SecretType { return &oldObj.Type }), oldObj != nil)...)
+
 	return errs
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -7842,7 +7842,7 @@ func ValidateSecret(secret *core.Secret) field.ErrorList {
 func ValidateSecretUpdate(newSecret, oldSecret *core.Secret) field.ErrorList {
 	allErrs := ValidateObjectMetaUpdate(&newSecret.ObjectMeta, &oldSecret.ObjectMeta, field.NewPath("metadata"))
 
-	allErrs = append(allErrs, ValidateImmutableField(newSecret.Type, oldSecret.Type, field.NewPath("type"))...)
+	allErrs = append(allErrs, ValidateImmutableField(newSecret.Type, oldSecret.Type, field.NewPath("type")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	if oldSecret.Immutable != nil && *oldSecret.Immutable {
 		if newSecret.Immutable == nil || !*newSecret.Immutable {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("immutable"), "field is immutable when `immutable` is set"))

--- a/pkg/registry/core/secret/declarative_validation_test.go
+++ b/pkg/registry/core/secret/declarative_validation_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestDeclarativeValidate(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: "v1",
+	})
+	testCases := map[string]struct {
+		input        api.Secret
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidSecret(),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: "v1",
+	})
+	testCases := map[string]struct {
+		oldObj       api.Secret
+		updateObj    api.Secret
+		expectedErrs field.ErrorList
+	}{
+		"valid update": {
+			oldObj:    mkValidSecret(),
+			updateObj: mkValidSecret(),
+		},
+		"immutable type": {
+			oldObj: mkValidSecret(),
+			updateObj: mkValidSecret(func(s *api.Secret) {
+				s.Type = api.SecretTypeTLS
+				s.Data = map[string][]byte{
+					api.TLSCertKey:       []byte("cert"),
+					api.TLSPrivateKeyKey: []byte("key"),
+				}
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("type"), nil, "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.oldObj.ObjectMeta.ResourceVersion = "1"
+			tc.updateObj.ObjectMeta.ResourceVersion = "1"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}
+
+func mkValidSecret(tweaks ...func(*api.Secret)) api.Secret {
+	s := api.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "valid-secret", Namespace: metav1.NamespaceDefault},
+		Type:       api.SecretTypeOpaque,
+	}
+	for _, fn := range tweaks {
+		fn(&s)
+	}
+	return s
+}

--- a/pkg/registry/core/secret/strategy.go
+++ b/pkg/registry/core/secret/strategy.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,7 +59,9 @@ func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 }
 
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateSecret(obj.(*api.Secret))
+	secret := obj.(*api.Secret)
+	allErrs := validation.ValidateSecret(secret)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, secret, nil, allErrs, operation.Create)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -86,7 +89,10 @@ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 }
 
 func (strategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateSecretUpdate(obj.(*api.Secret), old.(*api.Secret))
+	newSecret := obj.(*api.Secret)
+	oldSecret := old.(*api.Secret)
+	allErrs := validation.ValidateSecretUpdate(newSecret, oldSecret)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newSecret, oldSecret, allErrs, operation.Update)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5854,6 +5854,8 @@ message Secret {
   // Used to facilitate programmatic handling of secret data.
   // More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
   // +optional
+  // +k8s:alpha(since: "1.36")=+k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional string type = 3;
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7964,6 +7964,8 @@ type Secret struct {
 	// Used to facilitate programmatic handling of secret data.
 	// More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
 	// +optional
+	// +k8s:alpha(since: "1.36")=+k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	Type SecretType `json:"type,omitempty" protobuf:"bytes,3,opt,name=type,casttype=SecretType"`
 }
 


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

Migrates the `Secret.Type` immutable field validation from imperative to declarative validation using the `+k8s:immutable` tag. This is part of the KEP-5073 effort to migrate imperative validation to declarative validation.

## Which issue(s) this PR is related to

Ref: #136785

## Changes

- Add `+k8s:alpha(since: "1.36")=+k8s:immutable` marker to `Secret.Type` in `core/v1` types
- Mark imperative `ValidateImmutableField` call with `.WithOrigin("immutable").MarkCoveredByDeclarative()`
- Wrap Secret strategy `Validate`/`ValidateUpdate` with `rest.ValidateDeclarativelyWithMigrationChecks`
- Regenerate `zz_generated.validations.go`
- Add declarative validation equivalence tests

## Special notes for your reviewer

This follows the same pattern established by EndpointSlice.AddressType and Deployment/ReplicaSet.Spec.Selector declarative validation migrations.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Additional documentation

N/A

---

## Test Results

<details>
<summary>Declarative Validation Tests (go test ./pkg/registry/core/secret -v -run TestDeclarative)</summary>

```
=== RUN   TestDeclarativeValidate
=== RUN   TestDeclarativeValidate/valid
=== RUN   TestDeclarativeValidate/valid/with_declarative_validation_(Beta_enabled)
    feature_gate.go:170: I0328 19:16:07.604034] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.604234] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
    feature_gate.go:170: I0328 19:16:07.605232] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.605290] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
=== RUN   TestDeclarativeValidate/valid/with_declarative_validation_(Beta_disabled)
    feature_gate.go:170: I0328 19:16:07.605477] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.605523] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":false}
    feature_gate.go:170: I0328 19:16:07.605974] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.606027] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
=== RUN   TestDeclarativeValidate/valid/hand_written_validation
    feature_gate.go:170: I0328 19:16:07.606122] Set feature gate emulation emulationVersion="1.35" minCompatibilityVersion="1.34"
    feature_gate.go:170: I0328 19:16:07.606213] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatusMessage" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606245] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RelaxedServiceNameValidation" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606255] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAResourceClaimGranularStatusAuthorization" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606264] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAConsumableCapacity" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606272] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAExtendedResource" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606308] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutablePodResourcesForSuspendedJobs" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606321] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DeclarativeValidationBeta" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606344] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyJob" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606380] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ExtendWebSocketsToKubelet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606390] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentFlagz" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606397] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentStatusz" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606406] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutableSchedulingDirectivesForSuspendedJobs" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606432] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyDaemonSet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606442] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ConstrainedImpersonation" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606451] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ReloadKubeletClientCAFile" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606460] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyReplicaSet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606482] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="PLEGOnDemandRelist" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606493] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeLogQuery" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606515] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodLevelResourcesVerticalScaling" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606524] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceTaints" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606547] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceBindingConditions" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606575] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CustomCPUCFSQuotaPeriod" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606585] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAPartitionableDevices" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606592] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeDeclaredFeatures" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606600] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="UnknownVersionInteroperabilityProxy" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606622] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyStatefulSet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606637] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CRDObservedGenerationTracking" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606661] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutatingAdmissionPolicy" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606672] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="WatchCacheInitializationPostStartHook" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606695] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ServiceCIDRStatusFieldWiping" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606704] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StrictIPCIDRValidation" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606713] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RestartAllContainersOnContainerExits" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606722] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodVerticalScalingInitContainers" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.606731] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatus" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.607850] Updated featureGates={"DeclarativeValidation":false}
    feature_gate.go:170: I0328 19:16:07.607951] Updated featureGates={"DeclarativeValidation":true}
    feature_gate.go:170: I0328 19:16:07.607989] Set feature gate emulation emulationVersion="1.36" minCompatibilityVersion="1.35"
    feature_gate.go:170: I0328 19:16:07.608085] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAResourceClaimGranularStatusAuthorization" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608107] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatus" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608120] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DeclarativeValidationBeta" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608126] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeDeclaredFeatures" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608133] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAConsumableCapacity" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608141] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutatingAdmissionPolicy" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608152] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceTaints" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608179] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ExtendWebSocketsToKubelet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608208] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAPartitionableDevices" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608222] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutablePodResourcesForSuspendedJobs" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608231] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentFlagz" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608238] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyStatefulSet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608322] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="WatchCacheInitializationPostStartHook" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608359] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ServiceCIDRStatusFieldWiping" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608388] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutableSchedulingDirectivesForSuspendedJobs" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608412] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CustomCPUCFSQuotaPeriod" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608423] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ConstrainedImpersonation" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608431] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyDaemonSet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608439] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodLevelResourcesVerticalScaling" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608447] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatusMessage" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608467] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RestartAllContainersOnContainerExits" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608481] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyJob" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608491] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="PLEGOnDemandRelist" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608500] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceBindingConditions" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608512] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="UnknownVersionInteroperabilityProxy" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608519] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeLogQuery" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608527] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyReplicaSet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608534] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StrictIPCIDRValidation" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608553] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CRDObservedGenerationTracking" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608574] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodVerticalScalingInitContainers" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608586] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentStatusz" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608593] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ReloadKubeletClientCAFile" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608600] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RelaxedServiceNameValidation" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.608607] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAExtendedResource" oldValue=false newValue=true
=== RUN   TestDeclarativeValidate/valid/with_declarative_validation_(All_Rules_Enforced)
    feature_gate.go:170: I0328 19:16:07.611043] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.611112] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
    feature_gate.go:170: I0328 19:16:07.611727] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.611785] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
=== RUN   TestDeclarativeValidate/valid//v1,_Kind=Secret
--- PASS: TestDeclarativeValidate (0.01s)
    --- PASS: TestDeclarativeValidate/valid (0.01s)
        --- PASS: TestDeclarativeValidate/valid/with_declarative_validation_(Beta_enabled) (0.00s)
        --- PASS: TestDeclarativeValidate/valid/with_declarative_validation_(Beta_disabled) (0.00s)
        --- PASS: TestDeclarativeValidate/valid/hand_written_validation (0.00s)
        --- PASS: TestDeclarativeValidate/valid/with_declarative_validation_(All_Rules_Enforced) (0.00s)
        --- PASS: TestDeclarativeValidate/valid//v1,_Kind=Secret (0.00s)
=== RUN   TestDeclarativeValidateUpdate
=== RUN   TestDeclarativeValidateUpdate/valid_update
=== RUN   TestDeclarativeValidateUpdate/valid_update/with_declarative_validation_(Beta_enabled)
    feature_gate.go:170: I0328 19:16:07.612189] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.612238] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
    feature_gate.go:170: I0328 19:16:07.612750] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.612808] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
=== RUN   TestDeclarativeValidateUpdate/valid_update/with_declarative_validation_(Beta_disabled)
    feature_gate.go:170: I0328 19:16:07.612950] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.613001] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":false}
    feature_gate.go:170: I0328 19:16:07.613590] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.613655] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
=== RUN   TestDeclarativeValidateUpdate/valid_update/hand_written_validation
    feature_gate.go:170: I0328 19:16:07.613754] Set feature gate emulation emulationVersion="1.35" minCompatibilityVersion="1.34"
    feature_gate.go:170: I0328 19:16:07.613825] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="UnknownVersionInteroperabilityProxy" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613856] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodLevelResourcesVerticalScaling" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613865] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CustomCPUCFSQuotaPeriod" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613888] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyDaemonSet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613900] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyStatefulSet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613908] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="PLEGOnDemandRelist" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613917] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeDeclaredFeatures" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613938] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAResourceClaimGranularStatusAuthorization" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613947] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatus" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613955] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatusMessage" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613977] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAPartitionableDevices" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613987] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodVerticalScalingInitContainers" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.613995] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RelaxedServiceNameValidation" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614017] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ExtendWebSocketsToKubelet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614027] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ConstrainedImpersonation" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614035] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentStatusz" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614042] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceTaints" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614064] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ReloadKubeletClientCAFile" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614074] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyReplicaSet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614096] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutableSchedulingDirectivesForSuspendedJobs" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614105] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StrictIPCIDRValidation" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614135] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAConsumableCapacity" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614143] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RestartAllContainersOnContainerExits" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614151] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ServiceCIDRStatusFieldWiping" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614171] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceBindingConditions" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614179] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAExtendedResource" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614211] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="WatchCacheInitializationPostStartHook" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614220] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutablePodResourcesForSuspendedJobs" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614227] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentFlagz" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614247] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeLogQuery" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614256] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyJob" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614263] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DeclarativeValidationBeta" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614272] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CRDObservedGenerationTracking" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.614295] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutatingAdmissionPolicy" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.615258] Updated featureGates={"DeclarativeValidation":false}
    feature_gate.go:170: I0328 19:16:07.615353] Updated featureGates={"DeclarativeValidation":true}
    feature_gate.go:170: I0328 19:16:07.615390] Set feature gate emulation emulationVersion="1.36" minCompatibilityVersion="1.35"
    feature_gate.go:170: I0328 19:16:07.615460] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentFlagz" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615484] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatusMessage" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615493] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ConstrainedImpersonation" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615500] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RestartAllContainersOnContainerExits" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615521] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAResourceClaimGranularStatusAuthorization" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615530] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyDaemonSet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615549] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="UnknownVersionInteroperabilityProxy" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615575] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyJob" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615584] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeDeclaredFeatures" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615603] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutablePodResourcesForSuspendedJobs" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615612] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="PLEGOnDemandRelist" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615619] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutatingAdmissionPolicy" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615646] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ReloadKubeletClientCAFile" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615658] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RelaxedServiceNameValidation" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615679] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ExtendWebSocketsToKubelet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615687] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StrictIPCIDRValidation" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615708] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatus" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615717] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CRDObservedGenerationTracking" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615738] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAPartitionableDevices" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615747] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceBindingConditions" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615754] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodVerticalScalingInitContainers" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615760] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ServiceCIDRStatusFieldWiping" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615768] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyReplicaSet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615776] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CustomCPUCFSQuotaPeriod" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615782] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeLogQuery" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615803] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutableSchedulingDirectivesForSuspendedJobs" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615811] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceTaints" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615830] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodLevelResourcesVerticalScaling" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615838] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyStatefulSet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615858] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentStatusz" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615866] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="WatchCacheInitializationPostStartHook" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615874] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAExtendedResource" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615880] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAConsumableCapacity" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.615887] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DeclarativeValidationBeta" oldValue=false newValue=true
=== RUN   TestDeclarativeValidateUpdate/valid_update/with_declarative_validation_(All_Rules_Enforced)
    feature_gate.go:170: I0328 19:16:07.617903] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.617970] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
    feature_gate.go:170: I0328 19:16:07.618456] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.618518] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
=== RUN   TestDeclarativeValidateUpdate/valid_update//v1,_Kind=Secret
=== RUN   TestDeclarativeValidateUpdate/immutable_type
=== RUN   TestDeclarativeValidateUpdate/immutable_type/with_declarative_validation_(Beta_enabled)
    feature_gate.go:170: I0328 19:16:07.618805] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.618849] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
    feature_gate.go:170: I0328 19:16:07.619295] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.619347] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
=== RUN   TestDeclarativeValidateUpdate/immutable_type/with_declarative_validation_(Beta_disabled)
    feature_gate.go:170: I0328 19:16:07.619494] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.619539] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":false}
    feature_gate.go:170: I0328 19:16:07.620001] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.620050] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
=== RUN   TestDeclarativeValidateUpdate/immutable_type/hand_written_validation
    feature_gate.go:170: I0328 19:16:07.620142] Set feature gate emulation emulationVersion="1.35" minCompatibilityVersion="1.34"
    feature_gate.go:170: I0328 19:16:07.620232] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RestartAllContainersOnContainerExits" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620262] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyJob" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620272] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ReloadKubeletClientCAFile" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620280] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutablePodResourcesForSuspendedJobs" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620288] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyDaemonSet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620309] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CRDObservedGenerationTracking" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620318] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAResourceClaimGranularStatusAuthorization" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620339] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="UnknownVersionInteroperabilityProxy" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620348] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceBindingConditions" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620373] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StrictIPCIDRValidation" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620381] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RelaxedServiceNameValidation" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620389] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="PLEGOnDemandRelist" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620396] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeLogQuery" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620418] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyReplicaSet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620426] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatusMessage" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620447] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DeclarativeValidationBeta" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620455] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAConsumableCapacity" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620478] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAPartitionableDevices" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620487] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyStatefulSet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620494] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodVerticalScalingInitContainers" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620515] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentStatusz" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620525] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutableSchedulingDirectivesForSuspendedJobs" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620545] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="WatchCacheInitializationPostStartHook" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620553] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatus" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620562] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAExtendedResource" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620582] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeDeclaredFeatures" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620591] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutatingAdmissionPolicy" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620598] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentFlagz" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620609] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodLevelResourcesVerticalScaling" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620617] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ConstrainedImpersonation" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620625] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CustomCPUCFSQuotaPeriod" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620674] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ExtendWebSocketsToKubelet" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620683] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ServiceCIDRStatusFieldWiping" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.620691] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceTaints" oldValue=true newValue=false
    feature_gate.go:170: I0328 19:16:07.621545] Updated featureGates={"DeclarativeValidation":false}
    feature_gate.go:170: I0328 19:16:07.621668] Updated featureGates={"DeclarativeValidation":true}
    feature_gate.go:170: I0328 19:16:07.621720] Set feature gate emulation emulationVersion="1.36" minCompatibilityVersion="1.35"
    feature_gate.go:170: I0328 19:16:07.621788] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ConstrainedImpersonation" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621811] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ServiceCIDRStatusFieldWiping" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621820] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutableSchedulingDirectivesForSuspendedJobs" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621829] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentFlagz" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621837] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ReloadKubeletClientCAFile" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621852] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAConsumableCapacity" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621874] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeDeclaredFeatures" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621882] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAResourceClaimGranularStatusAuthorization" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621890] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyReplicaSet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621896] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RelaxedServiceNameValidation" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621904] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ComponentStatusz" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621910] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAPartitionableDevices" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621916] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyStatefulSet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621933] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyDaemonSet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621942] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutatingAdmissionPolicy" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621949] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DeclarativeValidationBeta" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621960] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="NodeLogQuery" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621967] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodVerticalScalingInitContainers" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621974] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="InPlacePodLevelResourcesVerticalScaling" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621981] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="WatchCacheInitializationPostStartHook" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621987] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="RestartAllContainersOnContainerExits" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.621994] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="MutablePodResourcesForSuspendedJobs" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622014] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRAExtendedResource" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622022] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatusMessage" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622031] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceBindingConditions" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622039] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ResourceHealthStatus" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622045] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CustomCPUCFSQuotaPeriod" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622051] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="DRADeviceTaints" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622064] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StaleControllerConsistencyJob" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622072] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="ExtendWebSocketsToKubelet" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622079] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="UnknownVersionInteroperabilityProxy" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622086] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="PLEGOnDemandRelist" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622092] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="CRDObservedGenerationTracking" oldValue=false newValue=true
    feature_gate.go:170: I0328 19:16:07.622099] Warning: SetEmulationVersionAndMinCompatibilityVersion will change already queried feature featureGate="StrictIPCIDRValidation" oldValue=false newValue=true
=== RUN   TestDeclarativeValidateUpdate/immutable_type/with_declarative_validation_(All_Rules_Enforced)
    feature_gate.go:170: I0328 19:16:07.624160] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.624228] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
    feature_gate.go:170: I0328 19:16:07.624742] Warning: setting GA feature gate. It will be removed in a future release. featureGate="DeclarativeValidation" value=true
    feature_gate.go:170: I0328 19:16:07.624797] Updated featureGates={"DeclarativeValidation":true,"DeclarativeValidationBeta":true}
=== RUN   TestDeclarativeValidateUpdate/immutable_type//v1,_Kind=Secret
--- PASS: TestDeclarativeValidateUpdate (0.01s)
    --- PASS: TestDeclarativeValidateUpdate/valid_update (0.01s)
        --- PASS: TestDeclarativeValidateUpdate/valid_update/with_declarative_validation_(Beta_enabled) (0.00s)
        --- PASS: TestDeclarativeValidateUpdate/valid_update/with_declarative_validation_(Beta_disabled) (0.00s)
        --- PASS: TestDeclarativeValidateUpdate/valid_update/hand_written_validation (0.00s)
        --- PASS: TestDeclarativeValidateUpdate/valid_update/with_declarative_validation_(All_Rules_Enforced) (0.00s)
        --- PASS: TestDeclarativeValidateUpdate/valid_update//v1,_Kind=Secret (0.00s)
    --- PASS: TestDeclarativeValidateUpdate/immutable_type (0.01s)
        --- PASS: TestDeclarativeValidateUpdate/immutable_type/with_declarative_validation_(Beta_enabled) (0.00s)
        --- PASS: TestDeclarativeValidateUpdate/immutable_type/with_declarative_validation_(Beta_disabled) (0.00s)
        --- PASS: TestDeclarativeValidateUpdate/immutable_type/hand_written_validation (0.00s)
        --- PASS: TestDeclarativeValidateUpdate/immutable_type/with_declarative_validation_(All_Rules_Enforced) (0.00s)
        --- PASS: TestDeclarativeValidateUpdate/immutable_type//v1,_Kind=Secret (0.00s)
PASS
ok  	k8s.io/kubernetes/pkg/registry/core/secret	0.055s
```

</details>

<details>
<summary>Validation Tests (go test ./pkg/apis/core/validation/... -v -run TestValidateSecret)</summary>

```
=== RUN   TestValidateSecret
--- PASS: TestValidateSecret (0.00s)
=== RUN   TestValidateSecretUpdate
=== RUN   TestValidateSecretUpdate/mark_secret_immutable
=== RUN   TestValidateSecretUpdate/revert_immutable_secret
=== RUN   TestValidateSecretUpdate/makr_immutable_secret_mutable
=== RUN   TestValidateSecretUpdate/add_data_in_secret
=== RUN   TestValidateSecretUpdate/add_data_in_immutable_secret
=== RUN   TestValidateSecretUpdate/change_data_in_secret
=== RUN   TestValidateSecretUpdate/change_data_in_immutable_secret
--- PASS: TestValidateSecretUpdate (0.00s)
    --- PASS: TestValidateSecretUpdate/mark_secret_immutable (0.00s)
    --- PASS: TestValidateSecretUpdate/revert_immutable_secret (0.00s)
    --- PASS: TestValidateSecretUpdate/makr_immutable_secret_mutable (0.00s)
    --- PASS: TestValidateSecretUpdate/add_data_in_secret (0.00s)
    --- PASS: TestValidateSecretUpdate/add_data_in_immutable_secret (0.00s)
    --- PASS: TestValidateSecretUpdate/change_data_in_secret (0.00s)
    --- PASS: TestValidateSecretUpdate/change_data_in_immutable_secret (0.00s)
PASS
ok  	k8s.io/kubernetes/pkg/apis/core/validation	0.014s
```

</details>