### PR TITLE
Increase CRD deletion discovery poll timeout to reduce flakiness

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -517,7 +517,7 @@ func DeleteV1CustomResourceDefinition(crd *apiextensionsv1.CustomResourceDefinit
 		return err
 	}
 	for _, version := range servedV1Versions(crd) {
-		err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 			exists, err := existsInDiscoveryV1(crd, apiExtensionsClient, version)
 			return !exists, err
 		})
@@ -539,7 +539,7 @@ func DeleteV1CustomResourceDefinitions(deleteListOpts metav1.ListOptions, apiExt
 	}
 	for _, crd := range list.Items {
 		for _, version := range servedV1Versions(&crd) {
-			err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+			err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 				exists, err := existsInDiscoveryV1(&crd, apiExtensionsClient, version)
 				return !exists, err
 			})


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it:**

Increases the poll timeout in `DeleteV1CustomResourceDefinition` and `DeleteV1CustomResourceDefinitions` from 30 seconds to 60 seconds. These functions wait for a CRD to disappear from discovery after deletion, and on busy CI nodes (especially GCE), CRD finalization can take longer than 30 seconds, causing flaky `context deadline exceeded` failures in Conformance tests.

**Which issue(s) this PR fixes:**

Fixes #138085

**Special notes for your reviewer:**

This is the same root cause as #129989 (closed), which reported the identical `context deadline exceeded` error during CRD deletion. That issue was closed because the flake rate was low at the time, but it has resurfaced.

The fix is minimal: only two timeout values changed in test fixture code. No production code is affected.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```