### PR TITLE
[WIP] e2e_node: stabilize CRI proxy tests under all-alpha

### DIFF
--- a/test/e2e_node/container_restart_test.go
+++ b/test/e2e_node/container_restart_test.go
@@ -46,6 +46,13 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	ginkgo.Context("Container restart backs off", func() {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = map[string]bool{}
+			}
+			initialConfig.FeatureGates["KubeletCrashLoopBackOffMax"] = false
+			initialConfig.FeatureGates["ReduceDefaultCrashLoopBackOffDecay"] = false
+		})
 
 		ginkgo.BeforeEach(func() {
 			if err := resetCRIProxyInjector(e2eCriProxy); err != nil {
@@ -70,6 +77,7 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 				initialConfig.FeatureGates = map[string]bool{}
 			}
 			initialConfig.FeatureGates["KubeletCrashLoopBackOffMax"] = true
+			initialConfig.FeatureGates["ReduceDefaultCrashLoopBackOffDecay"] = false
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -93,6 +101,7 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 			if initialConfig.FeatureGates == nil {
 				initialConfig.FeatureGates = map[string]bool{}
 			}
+			initialConfig.FeatureGates["KubeletCrashLoopBackOffMax"] = false
 			initialConfig.FeatureGates["ReduceDefaultCrashLoopBackOffDecay"] = true
 		})
 
@@ -118,8 +127,8 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 			if initialConfig.FeatureGates == nil {
 				initialConfig.FeatureGates = map[string]bool{}
 			}
-			initialConfig.FeatureGates["ReduceDefaultCrashLoopBackOffDecay"] = true
 			initialConfig.FeatureGates["KubeletCrashLoopBackOffMax"] = true
+			initialConfig.FeatureGates["ReduceDefaultCrashLoopBackOffDecay"] = true
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -183,6 +192,8 @@ func newFailAlwaysPod() *v1.Pod {
 					Name:            containerName,
 					Image:           imageutils.GetE2EImage(imageutils.BusyBox),
 					ImagePullPolicy: v1.PullIfNotPresent,
+					// Exit non-zero immediately so restart timing is deterministic.
+					Command: []string{"sh", "-c", "exit 1"},
 				},
 			},
 		},

--- a/test/e2e_node/pod_conditions_criproxy_linux_test.go
+++ b/test/e2e_node/pod_conditions_criproxy_linux_test.go
@@ -49,6 +49,8 @@ var _ = SIGDescribe("Pod conditions managed by Kubelet", func() {
 			if initialConfig.FeatureGates == nil {
 				initialConfig.FeatureGates = map[string]bool{}
 			}
+			initialConfig.FeatureGates["ContainerRestartRules"] = false
+			initialConfig.FeatureGates["RestartAllContainersOnContainerExits"] = false
 		})
 
 		f.Context("timing with CRI Proxy delays", feature.CriProxy, func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

This PR stabilizes two `test/e2e_node` CRI proxy tests in the all-alpha job.

- In `container_restart_test.go`, it makes the test pod fail deterministically with `exit 1` and explicitly sets the two crash-loop backoff feature gates in each context. This keeps the test aligned with the backoff mode it is asserting instead of inheriting unrelated all-alpha behavior.
- In `pod_conditions_criproxy_linux_test.go`, it disables `ContainerRestartRules` and `RestartAllContainersOnContainerExits` for the timing test so unrelated restart alpha features do not change the expected sequencing.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
