### PR TITLE
proxy: clarify BoundedFrequencyRunner minInterval behavior

### DIFF
--- a/pkg/proxy/runner/bounded_frequency_runner.go
+++ b/pkg/proxy/runner/bounded_frequency_runner.go
@@ -49,6 +49,9 @@ type BoundedFrequencyRunner struct {
 //     the *completion* of one execution and the *start* of the next. Calls to
 //     `Run()` during this cooldown period are coalesced and deferred until the
 //     interval expires. This prevents burst executions.
+//     Note: if `fn` takes longer than `minInterval` to complete, any `Run()`
+//     call made during that execution will trigger the next run immediately
+//     after completion, without an additional cooldown wait.
 //  2. Maximum Interval (`maxInterval`): The function `fn` is guaranteed to run
 //     at least once per `maxInterval`, ensuring periodic execution even without
 //     explicit `Run()` calls (e.g., for refreshing state).


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Clarifies the `minInterval` behavior in [BoundedFrequencyRunner](file:///Users/ijasahammed/Documents/open_source/kubernetes/pkg/proxy/runner/bounded_frequency_runner.go#29-43).

The existing comment stated that at least `minInterval` must pass between the *completion* of one execution and the *start* of the next. While this is true in the normal case, it was missing an important edge case: if `fn()` takes longer than `minInterval` to complete, any [Run()](file:///Users/ijasahammed/Documents/open_source/kubernetes/pkg/proxy/runner/bounded_frequency_runner.go#148-159) call made during that execution will trigger the next run immediately after completion, without an additional cooldown wait.

This was reported in #138073 where users observed that `minSyncPeriod` appeared to be measured start-to-start rather than completion-to-start. The code behavior is correct, this is an expected edge case that was simply undocumented.

#### Which issue(s) this PR is related to:

Fixes #138073

#### Special notes for your reviewer:

This is a documentation-only change. No functional code is modified.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```