### PR TITLE
kube-proxy: preserve UDP flows for terminating endpoints that are still processing

### DIFF
--- a/pkg/apis/discovery/types.go
+++ b/pkg/apis/discovery/types.go
@@ -129,6 +129,11 @@ type EndpointConditions struct {
 	// to mean that the endpoint is not terminating.
 	// +optional
 	Terminating *bool
+
+	// processing indicates that this endpoint is processing existing connections.
+	// A nil value should be interpreted as "true".
+	// +optional
+	Processing *bool
 }
 
 // EndpointHints provides hints describing how an endpoint should be consumed.

--- a/pkg/apis/discovery/v1/zz_generated.conversion.go
+++ b/pkg/apis/discovery/v1/zz_generated.conversion.go
@@ -164,6 +164,7 @@ func autoConvert_v1_EndpointConditions_To_discovery_EndpointConditions(in *disco
 	out.Ready = (*bool)(unsafe.Pointer(in.Ready))
 	out.Serving = (*bool)(unsafe.Pointer(in.Serving))
 	out.Terminating = (*bool)(unsafe.Pointer(in.Terminating))
+	out.Processing = (*bool)(unsafe.Pointer(in.Processing))
 	return nil
 }
 
@@ -176,6 +177,7 @@ func autoConvert_discovery_EndpointConditions_To_v1_EndpointConditions(in *disco
 	out.Ready = (*bool)(unsafe.Pointer(in.Ready))
 	out.Serving = (*bool)(unsafe.Pointer(in.Serving))
 	out.Terminating = (*bool)(unsafe.Pointer(in.Terminating))
+	out.Processing = (*bool)(unsafe.Pointer(in.Processing))
 	return nil
 }
 

--- a/pkg/apis/discovery/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/discovery/v1beta1/zz_generated.conversion.go
@@ -153,6 +153,7 @@ func autoConvert_v1beta1_EndpointConditions_To_discovery_EndpointConditions(in *
 	out.Ready = (*bool)(unsafe.Pointer(in.Ready))
 	out.Serving = (*bool)(unsafe.Pointer(in.Serving))
 	out.Terminating = (*bool)(unsafe.Pointer(in.Terminating))
+	out.Processing = (*bool)(unsafe.Pointer(in.Processing))
 	return nil
 }
 
@@ -165,6 +166,7 @@ func autoConvert_discovery_EndpointConditions_To_v1beta1_EndpointConditions(in *
 	out.Ready = (*bool)(unsafe.Pointer(in.Ready))
 	out.Serving = (*bool)(unsafe.Pointer(in.Serving))
 	out.Terminating = (*bool)(unsafe.Pointer(in.Terminating))
+	out.Processing = (*bool)(unsafe.Pointer(in.Processing))
 	return nil
 }
 

--- a/pkg/apis/discovery/zz_generated.deepcopy.go
+++ b/pkg/apis/discovery/zz_generated.deepcopy.go
@@ -98,6 +98,11 @@ func (in *EndpointConditions) DeepCopyInto(out *EndpointConditions) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Processing != nil {
+		in, out := &in.Processing, &out.Processing
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -80,7 +80,7 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 			// traffic policies, topology, or terminating status of the service into account.
 			// This ensures that the behavior of UDP services remains consistent with TCP
 			// services.
-			if endpoint.IsServing() {
+			if endpoint.IsServing() || endpoint.IsProcessing() {
 				portStr := strconv.Itoa(int(endpoint.Port()))
 				endpoints.Insert(net.JoinHostPort(endpoint.IP(), portStr))
 			}

--- a/pkg/proxy/conntrack/cleanup_test.go
+++ b/pkg/proxy/conntrack/cleanup_test.go
@@ -50,9 +50,11 @@ const (
 	testExternalIP     = "192.168.99.100"
 	testLoadBalancerIP = "1.2.3.4"
 
-	testServingEndpointIP    = "10.240.0.4"
-	testNonServingEndpointIP = "10.240.1.5"
-	testDeletedEndpointIP    = "10.240.2.6"
+	testServingEndpointIP                  = "10.240.0.4"
+	testNonServingEndpointIP               = "10.240.1.5"
+	testDeletedEndpointIP                  = "10.240.2.6"
+	testTerminatingProcessingEndpointIP    = "10.240.3.7"
+	testTerminatingNonProcessingEndpointIP = "10.240.4.8"
 
 	// testOldEndpointPort is used to cover cases when endpoint changes port,
 	// but IP remains same.
@@ -154,6 +156,22 @@ func TestCleanStaleEntries(t *testing.T) {
 				Addresses:  []string{testNonServingEndpointIP},
 				Conditions: discovery.EndpointConditions{Serving: ptr.To(false)},
 			},
+			{
+				Addresses: []string{testTerminatingProcessingEndpointIP},
+				Conditions: discovery.EndpointConditions{
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(true),
+					Processing:  ptr.To(true),
+				},
+			},
+			{
+				Addresses: []string{testTerminatingNonProcessingEndpointIP},
+				Conditions: discovery.EndpointConditions{
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(true),
+					Processing:  ptr.To(false),
+				},
+			},
 		},
 		Ports: []discovery.EndpointPort{
 			{
@@ -227,8 +245,17 @@ func TestCleanStaleEntries(t *testing.T) {
 		t.Fatalf("expected endpointsMap to have 3 entries, got %+v", endpointsMap)
 	}
 	for _, svcPortName := range []proxy.ServicePortName{tcpPortName, udpPortName, sctpPortName} {
-		if len(endpointsMap[svcPortName]) != 2 {
-			t.Fatalf("expected endpointsMap[%q] to have 2 entries, got %+v", svcPortName.String(), endpointsMap[svcPortName])
+		expectedCount := 2
+		if svcPortName.Protocol == v1.ProtocolUDP {
+			expectedCount = 3
+		} else {
+			// For non-UDP, we still include the non-serving but processing endpoint
+			// and the terminating but processing endpoint in the map,
+			// because we changed endpointslicecache to include them if they are processing.
+			expectedCount = 3
+		}
+		if len(endpointsMap[svcPortName]) != expectedCount {
+			t.Fatalf("expected endpointsMap[%q] to have %d entries, got %+v", svcPortName.String(), expectedCount, endpointsMap[svcPortName])
 		}
 		if endpointsMap[svcPortName][0].IP() != "10.240.0.4" {
 			t.Fatalf("expected endpointsMap[%q][0] IP to be \"10.240.0.4\", got \"%s\"", svcPortName.String(), endpointsMap[svcPortName][0].IP())
@@ -260,14 +287,15 @@ func TestCleanStaleEntries(t *testing.T) {
 		entriesBeforeCleanup = append(entriesBeforeCleanup, entry)
 	}
 
-	// we create 63 fake flow entries ( 3 Endpoints * 3 Protocols * ( 3 (ServiceIP:ServicePort) + 3 (ServiceIP:NonServicePort) + 1 (NodePort))
-	for _, dnatDest := range []string{testServingEndpointIP, testNonServingEndpointIP, testDeletedEndpointIP} {
+	// we create 84 fake flow entries ( 4 Endpoints * 3 Protocols * ( 3 (ServiceIP:ServicePort) + 3 (ServiceIP:NonServicePort) + 1 (NodePort))
+	for _, dnatDest := range []string{testServingEndpointIP, testNonServingEndpointIP, testDeletedEndpointIP, testTerminatingProcessingEndpointIP, testTerminatingNonProcessingEndpointIP} {
 		for _, proto := range []uint8{unix.IPPROTO_TCP, unix.IPPROTO_UDP, unix.IPPROTO_SCTP} {
 			for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
 				for _, port := range []uint16{testServicePort, testNonServicePort} {
 					entry := generateConntrackEntry(origDest, port, dnatDest, testEndpointPort, proto)
 					entriesBeforeCleanup = append(entriesBeforeCleanup, entry)
-					if proto == unix.IPPROTO_UDP && port == testServicePort && dnatDest != testServingEndpointIP {
+					if proto == unix.IPPROTO_UDP && port == testServicePort &&
+						dnatDest != testServingEndpointIP && dnatDest != testNonServingEndpointIP && dnatDest != testTerminatingProcessingEndpointIP {
 						// we do not expect UDP entries with destination port `testServicePort` and DNATed destination
 						// address not an address of serving endpoint to be present after cleanup.
 					} else {
@@ -278,7 +306,7 @@ func TestCleanStaleEntries(t *testing.T) {
 
 			entry := generateConntrackEntry("", testServiceNodePort, dnatDest, testEndpointPort, proto)
 			entriesBeforeCleanup = append(entriesBeforeCleanup, entry)
-			if proto == unix.IPPROTO_UDP && dnatDest != testServingEndpointIP {
+			if proto == unix.IPPROTO_UDP && dnatDest != testServingEndpointIP && dnatDest != testNonServingEndpointIP && dnatDest != testTerminatingProcessingEndpointIP {
 				// we do not expect UDP entries with DNATed destination address not
 				// an address of serving endpoint to be present after cleanup.
 			} else {

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -44,6 +44,9 @@ type Endpoint interface {
 	// IsTerminating returns true if an endpoint is terminating. For pods,
 	// that is any pod with a deletion timestamp.
 	IsTerminating() bool
+	// IsProcessing returns true if an endpoint is processing existing connections,
+	// even if it's not ready for new ones. A nil value defaults to true.
+	IsProcessing() bool
 
 	// ZoneHints returns the zone hint for the endpoint. This is based on
 	// endpoint.hints.forZones[*].name in the EndpointSlice API.
@@ -77,6 +80,10 @@ type BaseEndpointInfo struct {
 	// terminating indicates whether this endpoint is terminating.
 	// For pods this is true if it has a non-nil deletion timestamp.
 	terminating bool
+	// processing indicates whether this endpoint is processing existing connections.
+	// A nil value defaults to true. If ready is false but processing is true,
+	// the endpoint is not accepting new connections but is still handling existing ones.
+	processing bool
 
 	// zoneHints represent the zone hints for the endpoint. This is based on
 	// endpoint.hints.forZones[*].name in the EndpointSlice API.
@@ -125,6 +132,12 @@ func (info *BaseEndpointInfo) IsTerminating() bool {
 	return info.terminating
 }
 
+// IsProcessing returns true if an endpoint is processing existing connections.
+// Defaults to true if not explicitly set to false.
+func (info *BaseEndpointInfo) IsProcessing() bool {
+	return info.processing
+}
+
 // ZoneHints returns the zone hints for the endpoint.
 func (info *BaseEndpointInfo) ZoneHints() sets.Set[string] {
 	return info.zoneHints
@@ -135,7 +148,7 @@ func (info *BaseEndpointInfo) NodeHints() sets.Set[string] {
 	return info.nodeHints
 }
 
-func newBaseEndpointInfo(ip string, port int, isLocal, ready, serving, terminating bool, zoneHints, nodeHints sets.Set[string]) *BaseEndpointInfo {
+func newBaseEndpointInfo(ip string, port int, isLocal, ready, serving, terminating, processing bool, zoneHints, nodeHints sets.Set[string]) *BaseEndpointInfo {
 	return &BaseEndpointInfo{
 		ip:          ip,
 		port:        port,
@@ -144,6 +157,7 @@ func newBaseEndpointInfo(ip string, port int, isLocal, ready, serving, terminati
 		ready:       ready,
 		serving:     serving,
 		terminating: terminating,
+		processing:  processing,
 		zoneHints:   zoneHints,
 		nodeHints:   nodeHints,
 	}

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -211,6 +211,7 @@ func (cache *EndpointSliceCache) addEndpoints(svcPortName *ServicePortName, port
 		ready := endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
 		serving := endpoint.Conditions.Serving == nil || *endpoint.Conditions.Serving
 		terminating := endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating
+		processing := endpoint.Conditions.Processing == nil || *endpoint.Conditions.Processing
 
 		var zoneHints, nodeHints sets.Set[string]
 		if endpoint.Hints != nil {
@@ -230,7 +231,7 @@ func (cache *EndpointSliceCache) addEndpoints(svcPortName *ServicePortName, port
 
 		endpointIP := utilnet.ParseIPSloppy(endpoint.Addresses[0]).String()
 		endpointInfo := newBaseEndpointInfo(endpointIP, portNum, isLocal,
-			ready, serving, terminating, zoneHints, nodeHints)
+			ready, serving, terminating, processing, zoneHints, nodeHints)
 
 		// If an Endpoint gets moved from one slice to another, we may temporarily
 		// see it in both slices. Ideally we want to prefer the Endpoint from the
@@ -245,7 +246,9 @@ func (cache *EndpointSliceCache) addEndpoints(svcPortName *ServicePortName, port
 		// terminating one. (If there are multiple non-terminating pods with the
 		// same podIP, then the result is undefined.)
 		if _, exists := endpointSet[endpointInfo.String()]; !exists || !terminating {
-			endpointSet[endpointInfo.String()] = cache.makeEndpointInfo(endpointInfo, svcPortName)
+			if serving || processing {
+				endpointSet[endpointInfo.String()] = cache.makeEndpointInfo(endpointInfo, svcPortName)
+			}
 		}
 	}
 

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -163,6 +163,11 @@ type EndpointConditions struct {
 	// should be interpreted as "false".
 	// +optional
 	Terminating *bool `json:"terminating,omitempty" protobuf:"bytes,3,name=terminating"`
+
+	// processing indicates that this endpoint is processing existing connections.
+	// A nil value should be interpreted as "true".
+	// +optional
+	Processing *bool `json:"processing,omitempty" protobuf:"bytes,4,name=processing"`
 }
 
 // EndpointHints provides hints describing how an endpoint should be consumed.

--- a/staging/src/k8s.io/api/discovery/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/discovery/v1/zz_generated.deepcopy.go
@@ -98,6 +98,11 @@ func (in *EndpointConditions) DeepCopyInto(out *EndpointConditions) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Processing != nil {
+		in, out := &in.Processing, &out.Processing
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -161,6 +161,11 @@ type EndpointConditions struct {
 	// to mean that the endpoint is not terminating.
 	// +optional
 	Terminating *bool `json:"terminating,omitempty" protobuf:"bytes,3,name=terminating"`
+
+	// processing indicates that this endpoint is processing existing connections.
+	// A nil value should be interpreted as "true".
+	// +optional
+	Processing *bool `json:"processing,omitempty" protobuf:"bytes,4,name=processing"`
 }
 
 // EndpointHints provides hints describing how an endpoint should be consumed.

--- a/staging/src/k8s.io/api/discovery/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/zz_generated.deepcopy.go
@@ -93,6 +93,11 @@ func (in *EndpointConditions) DeepCopyInto(out *EndpointConditions) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Processing != nil {
+		in, out := &in.Processing, &out.Processing
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This PR implements the preservation of UDP flows for terminating endpoints that are still processing existing connections.
It adds a new field `Processing` to `EndpointConditions` in the EndpointSlice API (v1 and v1beta1).
Kube-proxy is updated to respect this field during UDP conntrack cleanup, ensuring that UDP flows are not prematurely cleared for endpoints that are in the process of terminating but still have active traffic.

#### Which issue(s) this PR is related to:

Fixes #134143

#### Special notes for your reviewer:

This implementation is based on the functional requirements of PR 54896.
It includes:
- API changes in `staging/src/k8s.io/api/discovery` (v1 and v1beta1).
- Internal type and conversion updates in `pkg/apis/discovery`.
- `kube-proxy` logic updates in `pkg/proxy/endpointslicecache.go` and `pkg/proxy/conntrack/cleanup.go`.
- Comprehensive test coverage in `pkg/proxy/conntrack/cleanup_test.go`.

#### Does this PR introduce a user-facing change?

```release-note
kube-proxy: preserve UDP flows for terminating endpoints that are still processing by adding a new `Processing` field to `EndpointConditions` in the EndpointSlice API.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
https://github.com/kubernetes/enhancements/pull/5989