### PR TITLE
Promote component-base metrics request-related to beta

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -5956,39 +5956,6 @@
     endpoint: /metrics
   - component: kubelet
     endpoint: /metrics
-- name: rest_client_request_duration_seconds
-  help: Request latency in seconds. Broken down by verb, and host.
-  type: Histogram
-  stabilityLevel: ALPHA
-  labels:
-  - host
-  - verb
-  buckets:
-  - 0.005
-  - 0.025
-  - 0.1
-  - 0.25
-  - 0.5
-  - 1
-  - 2
-  - 4
-  - 8
-  - 15
-  - 30
-  - 60
-  componentEndpoints:
-  - component: cloud-controller-manager
-    endpoint: /metrics
-  - component: kube-apiserver
-    endpoint: /metrics
-  - component: kube-controller-manager
-    endpoint: /metrics
-  - component: kube-proxy
-    endpoint: /metrics
-  - component: kube-scheduler
-    endpoint: /metrics
-  - component: kubelet
-    endpoint: /metrics
 - name: rest_client_request_retries_total
   help: Number of request retries, partitioned by status code, verb, and host.
   type: Counter
@@ -6029,27 +5996,6 @@
   - 1.048576e+06
   - 4.194304e+06
   - 1.6777216e+07
-  componentEndpoints:
-  - component: cloud-controller-manager
-    endpoint: /metrics
-  - component: kube-apiserver
-    endpoint: /metrics
-  - component: kube-controller-manager
-    endpoint: /metrics
-  - component: kube-proxy
-    endpoint: /metrics
-  - component: kube-scheduler
-    endpoint: /metrics
-  - component: kubelet
-    endpoint: /metrics
-- name: rest_client_requests_total
-  help: Number of HTTP requests, partitioned by status code, method, and host.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - code
-  - host
-  - method
   componentEndpoints:
   - component: cloud-controller-manager
     endpoint: /metrics
@@ -7721,6 +7667,60 @@
   labels:
   - deprecated_version
   - stability_level
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
+- name: rest_client_request_duration_seconds
+  help: Request latency in seconds. Broken down by verb, and host.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - host
+  - verb
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2
+  - 4
+  - 8
+  - 15
+  - 30
+  - 60
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
+- name: rest_client_requests_total
+  help: Number of HTTP requests, partitioned by status code, method, and host.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - code
+  - host
+  - method
   componentEndpoints:
   - component: cloud-controller-manager
     endpoint: /metrics

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -490,6 +490,34 @@
   labels:
   - deprecated_version
   - stability_level
+- name: rest_client_request_duration_seconds
+  help: Request latency in seconds. Broken down by verb, and host.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - host
+  - verb
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2
+  - 4
+  - 8
+  - 15
+  - 30
+  - 60
+- name: rest_client_requests_total
+  help: Number of HTTP requests, partitioned by status code, method, and host.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - code
+  - host
+  - method
 - name: running_managed_controllers
   help: Indicates where instances of a controller are currently running
   type: Gauge

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -35,7 +35,7 @@ var (
 		&k8smetrics.HistogramOpts{
 			Name:           "rest_client_request_duration_seconds",
 			Help:           "Request latency in seconds. Broken down by verb, and host.",
-			StabilityLevel: k8smetrics.ALPHA,
+			StabilityLevel: k8smetrics.BETA,
 			Buckets:        []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 60.0},
 		},
 		[]string{"verb", "host"},
@@ -88,7 +88,7 @@ var (
 	requestResult = k8smetrics.NewCounterVec(
 		&k8smetrics.CounterOpts{
 			Name:           "rest_client_requests_total",
-			StabilityLevel: k8smetrics.ALPHA,
+			StabilityLevel: k8smetrics.BETA,
 			Help:           "Number of HTTP requests, partitioned by status code, method, and host.",
 		},
 		[]string{"code", "method", "host"},

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
@@ -18,14 +18,21 @@ package restclient
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/metrics"
+	cbmetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/klog/v2/ktesting"
 )
 
 // TestMain ensures the deferred restclient registration callback (installed
@@ -126,31 +133,66 @@ func TestClientGOMetrics(t *testing.T) {
 }
 
 func TestRequestLatencyMetric(t *testing.T) {
-	requestLatency.Reset()
-	u := url.URL{Host: "localhost:6443"}
-	metrics.RequestLatency.Observe(context.TODO(), "GET", u, 100*time.Millisecond)
+	_, ctx := ktesting.NewTestContext(t)
+	registry := cbmetrics.NewKubeRegistry()
+	defer registry.Reset()
+	registry.MustRegister(requestLatency)
 
-	want := `
-		# HELP rest_client_request_duration_seconds [BETA] Request latency in seconds. Broken down by verb, and host.
-		# TYPE rest_client_request_duration_seconds histogram
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.005"} 0
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.025"} 0
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.1"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.25"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.5"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="1"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="2"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="4"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="8"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="15"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="30"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="60"} 1
-		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="+Inf"} 1
-		rest_client_request_duration_seconds_sum{host="localhost:6443",verb="GET"} 0.1
-		rest_client_request_duration_seconds_count{host="localhost:6443",verb="GET"} 1
-	`
-	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "rest_client_request_duration_seconds"); err != nil {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := &rest.Config{
+		Host: srv.URL,
+		ContentConfig: rest.ContentConfig{
+			NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+			GroupVersion:         &schema.GroupVersion{Version: "v1"},
+		},
+	}
+
+	client, err := rest.RESTClientFor(cfg)
+	if err != nil {
+		t.Fatalf("RESTClientFor: %v", err)
+	}
+
+	if _, err := client.Get().AbsPath("/api").DoRaw(ctx); err != nil {
+		t.Fatalf("request: %v", err)
+	}
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse srv.URL: %v", err)
+	}
+
+	// The real request above drives metrics.RequestLatency.Observe via the
+	// registered latencyAdapter. Strip timing-dependent histogram fields so the
+	// comparison only verifies _count (bucket/sum depend on real wall-clock latency).
+	want := fmt.Sprintf(`# HELP rest_client_request_duration_seconds [BETA] Request latency in seconds. Broken down by verb, and host.
+# TYPE rest_client_request_duration_seconds histogram
+rest_client_request_duration_seconds_count{host=%q,verb="GET"} 1
+`, srvURL.Host)
+
+	if err := testutil.GatherAndCompare(gatherWithoutDurations(registry), strings.NewReader(want), "rest_client_request_duration_seconds"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// gatherWithoutDurations wraps a gatherer and strips timing-dependent fields
+// (SampleSum and Bucket) from histograms so tests only verify _count.
+func gatherWithoutDurations(registry cbmetrics.KubeRegistry) testutil.GathererFunc {
+	return func() ([]*testutil.MetricFamily, error) {
+		got, err := registry.Gather()
+		for _, mf := range got {
+			for _, m := range mf.Metric {
+				if m.Histogram == nil {
+					continue
+				}
+				m.Histogram.SampleSum = nil
+				m.Histogram.Bucket = nil
+			}
+		}
+		return got, err
 	}
 }
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
@@ -18,8 +18,10 @@ package restclient
 
 import (
 	"context"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/client-go/tools/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -53,7 +55,7 @@ func TestClientGOMetrics(t *testing.T) {
 				metrics.RequestResult.Increment(context.TODO(), "200", "POST", "www.foo.com")
 			},
 			want: `
-			            # HELP rest_client_requests_total [ALPHA] Number of HTTP requests, partitioned by status code, method, and host.
+			            # HELP rest_client_requests_total [BETA] Number of HTTP requests, partitioned by status code, method, and host.
 			            # TYPE rest_client_requests_total counter
 			            rest_client_requests_total{code="200",host="www.foo.com",method="POST"} 1
 				`,
@@ -120,6 +122,35 @@ func TestClientGOMetrics(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestRequestLatencyMetric(t *testing.T) {
+	requestLatency.Reset()
+	u := url.URL{Host: "localhost:6443"}
+	metrics.RequestLatency.Observe(context.TODO(), "GET", u, 100*time.Millisecond)
+
+	want := `
+		# HELP rest_client_request_duration_seconds [BETA] Request latency in seconds. Broken down by verb, and host.
+		# TYPE rest_client_request_duration_seconds histogram
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.005"} 0
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.025"} 0
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.1"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.25"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="0.5"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="1"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="2"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="4"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="8"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="15"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="30"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="60"} 1
+		rest_client_request_duration_seconds_bucket{host="localhost:6443",verb="GET",le="+Inf"} 1
+		rest_client_request_duration_seconds_sum{host="localhost:6443",verb="GET"} 0.1
+		rest_client_request_duration_seconds_count{host="localhost:6443",verb="GET"} 1
+	`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(want), "rest_client_request_duration_seconds"); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow up #136154
Related #136312

#### Which issue(s) this PR is related to:

Promote `rest_client_requests_total` and `rest_client_request_duration_seconds` to BETA

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Promoted several component-base metrics (`rest_client_requests_total`, `rest_client_request_duration_seconds`) from Alpha to Beta stability
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
