### PR TITLE
fix kubelet rejecting pods with node affnity error

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -430,6 +430,22 @@ func PreInitRuntimeService(ctx context.Context, kubeCfg *kubeletconfiginternal.K
 	return nil
 }
 
+// newNodeHasSyncedFunc returns an InformerSynced that reports true only once the
+// node object for this kubelet is present in the informer cache.
+func newNodeHasSyncedFunc(nodeLister corelisters.NodeLister, nodeName types.NodeName) cache.InformerSynced {
+	var synced atomic.Bool
+	return func() bool {
+		if synced.Load() {
+			return true
+		}
+		if _, err := nodeLister.Get(string(nodeName)); err == nil {
+			synced.Store(true)
+			return true
+		}
+		return false
+	}
+}
+
 // NewMainKubelet instantiates a new Kubelet object along with all the required internal modules.
 // No initialization of Kubelet and its modules should happen here.
 func NewMainKubelet(ctx context.Context,
@@ -488,9 +504,7 @@ func NewMainKubelet(ctx context.Context,
 		}))
 		nodeInformer = kubeInformers.Core().V1().Nodes()
 		nodeLister = nodeInformer.Lister()
-		nodeHasSynced = func() bool {
-			return kubeInformers.Core().V1().Nodes().Informer().HasSynced()
-		}
+		nodeHasSynced = newNodeHasSyncedFunc(nodeLister, nodeName)
 		kubeInformers.Start(wait.NeverStop)
 		logger.Info("Attempting to sync node with API server")
 	} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Gating the apiserver pod source on `HasSynced()` alone lets the kubelet start admitting pods while the node cache is still empty, so admission falls back to the minimal node built by `initialNode()`. Gate the pod source on the node actually appearing in the informer cache instead, latching the signal so it stays once the node has been observed

#### Which issue(s) this PR is related to:

Fixes: #129463 
Follow up of: https://github.com/kubernetes/kubernetes/issues/129464

#### Special notes for your reviewer:
https://github.com/kubernetes/kubernetes/pull/134445 has a partial fix for the issue. But this should fix the root cause too. 

#### Does this PR introduce a user-facing change?

```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

