### PR TITLE
mount-utils: Fix duplicated args in log string

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -357,7 +357,7 @@ func MakeMountArgsSensitiveWithMountFlags(source, target, fstype string, options
 
 	if len(fstype) > 0 {
 		mountArgs = append(mountArgs, "-t", fstype)
-		mountArgsLogStr += strings.Join(mountArgs, " ")
+		mountArgsLogStr += " -t " + fstype
 	}
 	if len(options) > 0 || len(sensitiveOptions) > 0 {
 		combinedOptions := []string{}

--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -465,6 +465,7 @@ func TestSensitiveMountOptions(t *testing.T) {
 		options          []string
 		sensitiveOptions []string
 		mountFlags       []string
+		expectedLogStr   string
 	}{
 		{
 			source:           "mySrc",
@@ -473,6 +474,7 @@ func TestSensitiveMountOptions(t *testing.T) {
 			options:          []string{"o1", "o2"},
 			sensitiveOptions: []string{"s1", "s2"},
 			mountFlags:       []string{},
+			expectedLogStr:   " -t myFS -o o1,o2,<masked>,<masked> mySrc myTarget",
 		},
 		{
 			source:           "mySrc",
@@ -481,6 +483,7 @@ func TestSensitiveMountOptions(t *testing.T) {
 			options:          []string{},
 			sensitiveOptions: []string{"s1", "s2"},
 			mountFlags:       []string{},
+			expectedLogStr:   " -t myFS -o <masked>,<masked> mySrc myTarget",
 		},
 		{
 			source:           "mySrc",
@@ -489,6 +492,7 @@ func TestSensitiveMountOptions(t *testing.T) {
 			options:          []string{"o1", "o2"},
 			sensitiveOptions: []string{},
 			mountFlags:       []string{},
+			expectedLogStr:   " -t myFS -o o1,o2 mySrc myTarget",
 		},
 		{
 			source:           "mySrc",
@@ -497,6 +501,7 @@ func TestSensitiveMountOptions(t *testing.T) {
 			options:          []string{"o1", "o2"},
 			sensitiveOptions: []string{"s1", "s2"},
 			mountFlags:       []string{"--no-canonicalize"},
+			expectedLogStr:   "--no-canonicalize -t myFS -o o1,o2,<masked>,<masked> mySrc myTarget",
 		},
 	}
 
@@ -529,6 +534,9 @@ func TestSensitiveMountOptions(t *testing.T) {
 			if strings.Contains(mountArgsLogStr, sensitiveOption) {
 				t.Errorf("Expected sensitiveOption (%q) to not exist in returned mountArgsLogStr (%q), but it does", sensitiveOption, mountArgsLogStr)
 			}
+		}
+		if v.expectedLogStr != "" && mountArgsLogStr != v.expectedLogStr {
+			t.Errorf("Expected mountArgsLogStr to be %q, got %q", v.expectedLogStr, mountArgsLogStr)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes duplicated mount arguments in the log string output from
`MakeMountArgsSensitiveWithMountFlags`.

When `fstype` is set, the function builds the log string with
`strings.Join(mountArgs, " ")`, which re-joins the entire
`mountArgs` slice (including any previously appended mount flags)
into `mountArgsLogStr`. This produces confusing duplicated output
like:

    mount_linux.go:270] Mounting cmd (mount) with arguments
    (--no-mtab--no-mtab -t lustre -o noatime,flock ...

This has caused confusion during customer triage — the duplicated
`--no-mtab--no-mtab` makes it look like mount was invoked
incorrectly when the actual mount call is fine.

The fix replaces the `strings.Join(mountArgs, " ")` call with
direct string concatenation of just the `-t` flag and fstype
value, matching how the other branches (options, source, target)
build the log string.

Also adds `expectedLogStr` to the test cases to catch log string
duplication regressions.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This change was developed in cooperation with David Bradley.
GitHub Copilot was used to help prepare the commit and PR.

Previously submitted as kubernetes/mount-utils#21 before
learning that changes must go through the staging directory
in this repo.

/sig storage

#### Does this PR introduce a user-facing change?

```release-note
Fix duplicated mount arguments in log string output from MakeMountArgsSensitiveWithMountFlags
```

#### Additional documentation

```docs
N/A
```