### PR TITLE
kubelet: dynamically update NodeDeclaredFeatures when runtime features change

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1091,8 +1091,7 @@ func NewMainKubelet(ctx context.Context,
 		framework := ndf.DefaultFramework
 		klet.version = v
 		klet.nodeDeclaredFeaturesFramework = framework
-		klet.nodeDeclaredFeatures = klet.discoverNodeDeclaredFeatures()
-		klet.nodeDeclaredFeaturesSet = framework.MustMapSorted(klet.nodeDeclaredFeatures)
+		klet.updateNodeDeclaredFeatures()
 	}
 
 	// Safe, allowed sysctls can always be used as unsafe sysctls in the spec.
@@ -1130,7 +1129,7 @@ func NewMainKubelet(ctx context.Context,
 	handlers = append(handlers, lifecycle.NewPodFeaturesAdmitHandler())
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.NodeDeclaredFeatures) {
-		handlers = append(handlers, lifecycle.NewDeclaredFeaturesAdmitHandler(klet.nodeDeclaredFeaturesFramework, klet.nodeDeclaredFeaturesSet, klet.version))
+		handlers = append(handlers, lifecycle.NewDeclaredFeaturesAdmitHandler(klet.nodeDeclaredFeaturesFramework, klet.getNodeDeclaredFeaturesSet, klet.version))
 	}
 
 	leaseDuration := time.Duration(kubeCfg.NodeLeaseDurationSeconds) * time.Second
@@ -1341,6 +1340,9 @@ type Kubelet struct {
 	// a list of node labels to register
 	nodeLabels map[string]string
 
+	// nodeDeclaredFeaturesMux protects nodeDeclaredFeatures and nodeDeclaredFeaturesSet,
+	// which are dynamically updated when container runtime features change.
+	nodeDeclaredFeaturesMux sync.RWMutex
 	// nodeDeclaredFeatures is the ordered static list of features that are determined at startup and declared in node status.
 	nodeDeclaredFeatures []string
 	// nodeDeclaredFeaturesSet provides the same features as nodeDeclaredFeatures, but as a set for faster inference.
@@ -2948,7 +2950,7 @@ func (kl *Kubelet) HandlePodUpdates(ctx context.Context, pods []*v1.Pod) {
 				logger.Error(err, "Failed to infer required features for pod update", "pod", klog.KObj(pod))
 			}
 			if !reqs.IsEmpty() {
-				matchResult, err := kl.nodeDeclaredFeaturesFramework.MatchNodeFeatureSet(reqs, kl.nodeDeclaredFeaturesSet)
+				matchResult, err := kl.nodeDeclaredFeaturesFramework.MatchNodeFeatureSet(reqs, kl.getNodeDeclaredFeaturesSet())
 				if err != nil {
 					logger.Error(err, "Failed to match pod features with the node", "pod", klog.KObj(pod))
 
@@ -3280,6 +3282,11 @@ func (kl *Kubelet) updateRuntimeUp(ctx context.Context) {
 	kl.oneTimeInitializer.Do(func() {
 		kl.initializeRuntimeDependentModules(ctx)
 	})
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.NodeDeclaredFeatures) && kl.nodeDeclaredFeaturesFramework != nil {
+		kl.updateNodeDeclaredFeatures()
+	}
+
 	kl.runtimeState.setRuntimeSync(kl.clock.Now())
 }
 

--- a/pkg/kubelet/kubelet_node_declared_features.go
+++ b/pkg/kubelet/kubelet_node_declared_features.go
@@ -19,7 +19,7 @@ package kubelet
 import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate" // Import for the type conversion
-	"k8s.io/component-helpers/nodedeclaredfeatures"
+	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
 )
 
 // FeatureGateAdapter adapts a component-base FeatureGate to the nodedeclaredfeatures FeatureGate interface.
@@ -38,15 +38,37 @@ func (a FeatureGateAdapter) Enabled(key string) bool {
 func (kl *Kubelet) discoverNodeDeclaredFeatures() []string {
 	adaptedFG := FeatureGateAdapter{FeatureGate: utilfeature.DefaultFeatureGate}
 
-	runtimeFeatures := nodedeclaredfeatures.RuntimeFeatures{}
+	runtimeFeatures := ndf.RuntimeFeatures{}
 	if features := kl.runtimeState.runtimeFeatures(); features != nil {
 		runtimeFeatures.UserNamespacesHostNetwork = features.UserNamespacesHostNetwork
 	}
 
-	cfg := &nodedeclaredfeatures.NodeConfiguration{
+	cfg := &ndf.NodeConfiguration{
 		FeatureGates:    adaptedFG,
 		Version:         kl.version,
 		RuntimeFeatures: runtimeFeatures,
 	}
 	return kl.nodeDeclaredFeaturesFramework.DiscoverNodeFeatures(cfg)
+}
+
+func (kl *Kubelet) getNodeDeclaredFeatures() []string {
+	kl.nodeDeclaredFeaturesMux.RLock()
+	defer kl.nodeDeclaredFeaturesMux.RUnlock()
+	return kl.nodeDeclaredFeatures
+}
+
+func (kl *Kubelet) getNodeDeclaredFeaturesSet() ndf.FeatureSet {
+	kl.nodeDeclaredFeaturesMux.RLock()
+	defer kl.nodeDeclaredFeaturesMux.RUnlock()
+	return kl.nodeDeclaredFeaturesSet
+}
+
+func (kl *Kubelet) updateNodeDeclaredFeatures() {
+	features := kl.discoverNodeDeclaredFeatures()
+	featureSet := kl.nodeDeclaredFeaturesFramework.MustMapSorted(features)
+
+	kl.nodeDeclaredFeaturesMux.Lock()
+	defer kl.nodeDeclaredFeaturesMux.Unlock()
+	kl.nodeDeclaredFeatures = features
+	kl.nodeDeclaredFeaturesSet = featureSet
 }

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -673,8 +673,10 @@ func (kl *Kubelet) setNodeStatus(ctx context.Context, node *v1.Node) {
 			logger.Error(err, "Failed to set some node status fields", "node", klog.KObj(node))
 		}
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.NodeDeclaredFeatures) && kl.nodeDeclaredFeatures != nil {
-		node.Status.DeclaredFeatures = kl.nodeDeclaredFeatures
+	if utilfeature.DefaultFeatureGate.Enabled(features.NodeDeclaredFeatures) {
+		if ndf := kl.getNodeDeclaredFeatures(); ndf != nil {
+			node.Status.DeclaredFeatures = ndf
+		}
 	}
 }
 

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -244,15 +244,15 @@ func (h *podFeaturesAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResul
 // declaredFeaturesAdmitHandler is a PodAdmitHandler that checks a pod's feature requirements.
 type declaredFeaturesAdmitHandler struct {
 	ndfFramework *ndf.Framework
-	ndfSet       ndf.FeatureSet
+	ndfSetFunc   func() ndf.FeatureSet
 	version      *versionutil.Version
 }
 
 // NewDeclaredFeaturesAdmitHandler returns a new features admit handler.
-func NewDeclaredFeaturesAdmitHandler(nodeDeclaredFeaturesHelper *ndf.Framework, nodeDeclaredFeaturesSet ndf.FeatureSet, version *versionutil.Version) PodAdmitHandler {
+func NewDeclaredFeaturesAdmitHandler(nodeDeclaredFeaturesHelper *ndf.Framework, ndfSetFunc func() ndf.FeatureSet, version *versionutil.Version) PodAdmitHandler {
 	return &declaredFeaturesAdmitHandler{
 		ndfFramework: nodeDeclaredFeaturesHelper,
-		ndfSet:       nodeDeclaredFeaturesSet,
+		ndfSetFunc:   ndfSetFunc,
 		version:      version,
 	}
 }
@@ -275,7 +275,7 @@ func (c *declaredFeaturesAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmit
 		return PodAdmitResult{Admit: true}
 	}
 
-	matchResult, err := c.ndfFramework.MatchNodeFeatureSet(reqs, c.ndfSet)
+	matchResult, err := c.ndfFramework.MatchNodeFeatureSet(reqs, c.ndfSetFunc())
 	if err != nil {
 		return PodAdmitResult{
 			Admit:   false,

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -911,7 +911,7 @@ func TestDeclaredFeaturesAdmitHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			framework := ndf.New(tc.registeredFeatures)
 			fs := framework.MustMapSorted(tc.nodeDeclaredFeatures)
-			handler := NewDeclaredFeaturesAdmitHandler(framework, fs, tc.version)
+			handler := NewDeclaredFeaturesAdmitHandler(framework, func() ndf.FeatureSet { return fs }, tc.version)
 			attrs := &PodAdmitAttributes{Pod: pod}
 
 			result := handler.Admit(attrs)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR makes the kubelet dynamically re-discover `NodeDeclaredFeatures` whenever the container runtime reports updated features

Previously, `nodeDeclaredFeatures` and `nodeDeclaredFeaturesSet` were computed once in `NewMainKubelet` and never refreshed. This meant changes to container runtime capabilities (e.g., `UserNamespacesHostNetwork` becoming available after a runtime upgrade) would not be reflected in the `NodeDeclaredFeatures` until the kubelet was restarted.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #138099

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: `NodeDeclaredFeatures` are now dynamically updated when container runtime features change, instead of only being discovered once at startup.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
