### PR TITLE
fix: validate apiserver endpoints in master lease reconciler

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -352,6 +352,12 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	if err := fs.Parse(customFlags); err != nil {
 		return result, err
 	}
+
+	// disable endpoint reconciliation when using a loopback "external" address
+	// unless the user has explicitly overridden the reconciler or advertise address
+	if !fs.Changed("advertise-address") && !fs.Changed("endpoint-reconciler-type") {
+		s.EndpointReconcilerType = "none"
+	}
 	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentFlagz) {
 		s.Flagz = flagz.NamedFlagSetsReader{FlagSets: namedFlagSets}
 	}

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -346,6 +346,11 @@ func (c CompletedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get listener address: %w", err)
 	}
+
+	if err := c.Extra.EndpointReconcilerConfig.Reconciler.ValidateIP(c.ControlPlane.Generic.PublicAddress); err != nil {
+		return nil, fmt.Errorf("cannot use public IP %s with endpoint reconciler: %w", c.ControlPlane.Generic.PublicAddress.String(), err)
+	}
+
 	kubernetesServiceCtrl := kubernetesservice.New(kubernetesservice.Config{
 		PublicIP: c.ControlPlane.Generic.PublicAddress,
 

--- a/pkg/controlplane/reconcilers/instancecount.go
+++ b/pkg/controlplane/reconcilers/instancecount.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	endpointsv1 "k8s.io/kubernetes/pkg/api/v1/endpoints"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
 )
 
 // masterCountEndpointReconciler reconciles endpoints based on a specified expected number of
@@ -45,6 +46,10 @@ func NewMasterCountEndpointReconciler(masterCount int, epAdapter EndpointsAdapte
 		masterCount: masterCount,
 		epAdapter:   epAdapter,
 	}
+}
+
+func (r *masterCountEndpointReconciler) ValidateIP(ip net.IP) error {
+	return validation.ValidateEndpointIP(ip.String(), nil).ToAggregate()
 }
 
 // ReconcileEndpoints sets the endpoints for the given apiserver service (ro or rw).

--- a/pkg/controlplane/reconcilers/lease.go
+++ b/pkg/controlplane/reconcilers/lease.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	storagefactory "k8s.io/apiserver/pkg/storage/storagebackend/factory"
 	endpointsv1 "k8s.io/kubernetes/pkg/api/v1/endpoints"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
 )
 
 // Leases is an interface which assists in managing the set of active masters
@@ -160,6 +161,10 @@ func NewLeaseEndpointReconciler(epAdapter EndpointsAdapter, masterLeases Leases)
 		epAdapter:    epAdapter,
 		masterLeases: masterLeases,
 	}
+}
+
+func (r *leaseEndpointReconciler) ValidateIP(ip net.IP) error {
+	return validation.ValidateEndpointIP(ip.String(), nil).ToAggregate()
 }
 
 // ReconcileEndpoints lists keys in a special etcd directory.

--- a/pkg/controlplane/reconcilers/none.go
+++ b/pkg/controlplane/reconcilers/none.go
@@ -32,6 +32,10 @@ func NewNoneEndpointReconciler() EndpointReconciler {
 	return &noneEndpointReconciler{}
 }
 
+func (r *noneEndpointReconciler) ValidateIP(ip net.IP) error {
+	return nil
+}
+
 // ReconcileEndpoints noop reconcile
 func (r *noneEndpointReconciler) ReconcileEndpoints(serviceName string, ip net.IP, endpointPorts []corev1.EndpointPort, reconcilePorts bool) error {
 	return nil

--- a/pkg/controlplane/reconcilers/reconcilers.go
+++ b/pkg/controlplane/reconcilers/reconcilers.go
@@ -25,6 +25,10 @@ import (
 
 // EndpointReconciler knows how to reconcile the endpoints for the apiserver service.
 type EndpointReconciler interface {
+	// ValidateIP ensures the given IP address meets any requirements to
+	// successfully call ReconcileEndpoints with this reconciler type.
+	ValidateIP(ip net.IP) error
+
 	// ReconcileEndpoints sets the endpoints for the given apiserver service (ro or rw).
 	// ReconcileEndpoints expects that the endpoints objects it manages will all be
 	// managed only by ReconcileEndpoints; therefore, to understand this, you need only


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR adds robust IP validation to the master lease reconciler. 
A misconfigured apiserver (e.g., using --advertise-address=127.0.0.1) could previously poison the master lease pool in etcd. This caused the kubernetes Service endpoint reconciliation to fail for all apiservers because the invalid address was rejected during the final Endpoints object validation.

The fix validates the local IP on startup when using the master-count or lease endpoint reconciler, to prevent invalid addresses (loopback, link-local, unspecified) from being persisted.

#### Which issue(s) this PR is related to:
Fixes #121942

#### Special notes for your reviewer:
The validation logic in pkg/controlplane/reconcilers intentionally mimics pkg/apis/core/validation.ValidateEndpointIP to avoid circular dependencies while maintaining consistent behavior for the kubernetes Service.

#### Does this PR introduce a user-facing change?
```release-note
kube-apiserver now validates the `--advertise-address` IP when using `--endpoint-reconciler-type` `master-count` or `lease` to ensure the specified IP address can be persisted to an `Endpoints` API object successfully.
```