### PR TITLE
events: add AnnotatedEventRecorder interface into internal/events

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -470,6 +470,9 @@ linters:
     forbidigo:
       analyze-types: true
       forbid:
+        - pattern: \.AnnotatedEventf$
+          # https://github.com/kubernetes/kubernetes/pull/137270
+          msg: "Do not use AnnotatedEventf. Events are fire-and-forget and aggressively throttled; do not rely on them to pass state or metadata for programmatic triggers."
         - pattern: md5\.*
           # https://github.com/kubernetes/kubernetes/issues/129652
           msg: md5 is oudated, insecure, prefer a secure hash (such as sha256) or a non-cryptographic hash

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -483,6 +483,9 @@ linters:
     forbidigo:
       analyze-types: true
       forbid:
+        - pattern: \.AnnotatedEventf$
+          # https://github.com/kubernetes/kubernetes/pull/137270
+          msg: "Do not use AnnotatedEventf. Events are fire-and-forget and aggressively throttled; do not rely on them to pass state or metadata for programmatic triggers."
         - pattern: md5\.*
           # https://github.com/kubernetes/kubernetes/issues/129652
           msg: md5 is oudated, insecure, prefer a secure hash (such as sha256) or a non-cryptographic hash

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -229,6 +229,9 @@ linters:
     forbidigo:
       analyze-types: true
       forbid:
+        - pattern: \.AnnotatedEventf$
+          # https://github.com/kubernetes/kubernetes/pull/137270
+          msg: "Do not use AnnotatedEventf. Events are fire-and-forget and aggressively throttled; do not rely on them to pass state or metadata for programmatic triggers."
         - pattern: md5\.*
           # https://github.com/kubernetes/kubernetes/issues/129652
           msg: md5 is oudated, insecure, prefer a secure hash (such as sha256) or a non-cryptographic hash

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -325,6 +325,7 @@ func (irecorder *innerEventRecorder) Eventf(object runtime.Object, eventtype, re
 
 func (irecorder *innerEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
 	if ref, ok := irecorder.shouldRecordEvent(object); ok {
+		//nolint:forbidigo // Legacy usage
 		irecorder.recorder.AnnotatedEventf(ref, annotations, eventtype, reason, messageFmt, args...)
 	}
 

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -1204,12 +1204,14 @@ func TestFilterEventRecorder(t *testing.T) {
 	obj := &v1.ObjectReference{FieldPath: "foo"}
 	filtered.Event(obj, "Normal", "Reason", "Message")
 	filtered.Eventf(obj, "Normal", "Reason", "MessageFmt")
+	//nolint:forbidigo // Legacy usage
 	filtered.AnnotatedEventf(obj, map[string]string{"a": "b"}, "Normal", "Reason", "MessageFmt")
 
 	// don't record events for implicit container
 	implicit := &v1.ObjectReference{FieldPath: "implicitly required container foo"}
 	filtered.Event(implicit, "Normal", "Reason", "Message")
 	filtered.Eventf(implicit, "Normal", "Reason", "MessageFmt")
+	//nolint:forbidigo // Legacy usage
 	filtered.AnnotatedEventf(implicit, map[string]string{"a": "b"}, "Normal", "Reason", "MessageFmt")
 
 	assert.Len(t, recorder.events, 1, "Expected only one event of each type to be recorded, got events: %v", recorder.events)

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -635,6 +635,7 @@ func (m *managerImpl) evictPod(logger klog.Logger, pod *v1.Pod, gracePeriodOverr
 		return false
 	}
 	// record that we are evicting the pod
+	//nolint:forbidigo // Legacy usage
 	m.recorder.AnnotatedEventf(pod, annotations, v1.EventTypeWarning, Reason, "%s", evictMsg)
 	// this is a blocking call and should only return when the pod and its containers are killed.
 	logger.V(3).Info("Evicting pod", "pod", klog.KObj(pod), "podUID", pod.UID, "message", evictMsg)

--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -41,9 +41,14 @@ type recorderImpl struct {
 }
 
 var _ EventRecorder = &recorderImpl{}
+var _ AnnotatedEventRecorder = &recorderImpl{}
 
 func (recorder *recorderImpl) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
-	recorder.eventf(klog.Background(), regarding, related, eventtype, reason, action, note, args...)
+	recorder.eventf(klog.Background(), regarding, related, nil, eventtype, reason, action, note, args...)
+}
+
+func (recorder *recorderImpl) AnnotatedEventf(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
+	recorder.eventf(klog.Background(), regarding, related, annotations, eventtype, reason, action, note, args...)
 }
 
 type recorderImplLogger struct {
@@ -54,14 +59,18 @@ type recorderImplLogger struct {
 var _ EventRecorderLogger = &recorderImplLogger{}
 
 func (recorder *recorderImplLogger) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
-	recorder.eventf(recorder.logger, regarding, related, eventtype, reason, action, note, args...)
+	recorder.eventf(recorder.logger, regarding, related, nil, eventtype, reason, action, note, args...)
+}
+
+func (recorder *recorderImplLogger) AnnotatedEventf(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
+	recorder.eventf(recorder.logger, regarding, related, annotations, eventtype, reason, action, note, args...)
 }
 
 func (recorder *recorderImplLogger) WithLogger(logger klog.Logger) EventRecorderLogger {
 	return &recorderImplLogger{recorderImpl: recorder.recorderImpl, logger: logger}
 }
 
-func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
 	timestamp := metav1.MicroTime{Time: time.Now()}
 	message := fmt.Sprintf(note, args...)
 	refRegarding, err := reference.GetReference(recorder.scheme, regarding)
@@ -81,14 +90,14 @@ func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Objec
 		logger.Error(nil, "Unsupported event type", "eventType", eventtype)
 		return
 	}
-	event := recorder.makeEvent(refRegarding, refRelated, timestamp, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
+	event := recorder.makeEvent(refRegarding, refRelated, timestamp, annotations, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
 	go func() {
 		defer utilruntime.HandleCrash()
 		recorder.Action(watch.Added, event)
 	}()
 }
 
-func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRelated *v1.ObjectReference, timestamp metav1.MicroTime, eventtype, reason, message string, reportingController string, reportingInstance string, action string) *eventsv1.Event {
+func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRelated *v1.ObjectReference, timestamp metav1.MicroTime, annotations map[string]string, eventtype, reason, message string, reportingController string, reportingInstance string, action string) *eventsv1.Event {
 	t := metav1.Time{Time: recorder.clock.Now()}
 	namespace := refRegarding.Namespace
 	if namespace == "" {
@@ -96,8 +105,9 @@ func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRel
 	}
 	return &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.GenerateEventName(refRegarding.Name, t.UnixNano()),
-			Namespace: namespace,
+			Name:        util.GenerateEventName(refRegarding.Name, t.UnixNano()),
+			Namespace:   namespace,
+			Annotations: annotations,
 		},
 		EventTime:           timestamp,
 		Series:              nil,

--- a/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
@@ -299,7 +299,7 @@ func TestFinishSeries(t *testing.T) {
 	cache := map[eventKey]*eventsv1.Event{}
 	eventBroadcaster := newBroadcaster(&testEvents, 0, cache).(*eventBroadcasterImpl)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, "k8s.io/kube-foo").(*recorderImplLogger)
-	cachedEvent := recorder.makeEvent(regarding, related, metav1.MicroTime{Time: time.Now()}, v1.EventTypeNormal, "test", "some verbose message: 1", "eventTest", "eventTest-"+hostname, "started")
+	cachedEvent := recorder.makeEvent(regarding, related, metav1.MicroTime{Time: time.Now()}, nil, v1.EventTypeNormal, "test", "some verbose message: 1", "eventTest", "eventTest-"+hostname, "started")
 	nonFinishedEvent := cachedEvent.DeepCopy()
 	nonFinishedEvent.ReportingController = "nonFinished-controller"
 	cachedEvent.Series = &eventsv1.EventSeries{
@@ -386,7 +386,7 @@ func TestRefreshExistingEventSeries(t *testing.T) {
 		cache := map[eventKey]*eventsv1.Event{}
 		eventBroadcaster := newBroadcaster(&testEvents, 0, cache).(*eventBroadcasterImpl)
 		recorder := eventBroadcaster.NewRecorder(scheme.Scheme, "k8s.io/kube-foo").(*recorderImplLogger)
-		cachedEvent := recorder.makeEvent(regarding, related, metav1.MicroTime{Time: time.Now()}, v1.EventTypeNormal, "test", "some verbose message: 1", "eventTest", "eventTest-"+hostname, "started")
+		cachedEvent := recorder.makeEvent(regarding, related, metav1.MicroTime{Time: time.Now()}, nil, v1.EventTypeNormal, "test", "some verbose message: 1", "eventTest", "eventTest-"+hostname, "started")
 		cachedEvent.Series = &eventsv1.EventSeries{
 			Count:            10,
 			LastObservedTime: LastObservedTime,

--- a/staging/src/k8s.io/client-go/tools/events/fake.go
+++ b/staging/src/k8s.io/client-go/tools/events/fake.go
@@ -27,26 +27,71 @@ import (
 // when created manually and not by NewFakeRecorder, however all events may be
 // thrown away in this case.
 type FakeRecorder struct {
-	Events chan string
+	Events  chan string
+	Verbose bool
 }
 
 var _ EventRecorderLogger = &FakeRecorder{}
+var _ AnnotatedEventRecorder = &FakeRecorder{}
 
 // Eventf emits an event
 func (f *FakeRecorder) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
-	if f.Events != nil {
-		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+note, args...)
-	}
+	f.writeEvent(regarding, related, nil, eventtype, reason, action, note, args...)
+}
+
+// AnnotatedEventf emits an event like Eventf, but with annotations attached
+func (f *FakeRecorder) AnnotatedEventf(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
+	f.writeEvent(regarding, related, annotations, eventtype, reason, action, note, args...)
 }
 
 func (f *FakeRecorder) WithLogger(logger klog.Logger) EventRecorderLogger {
 	return f
 }
 
+// writeEvent constructs a string from the event parameters and sends
+// it to the Events channel
+func (f *FakeRecorder) writeEvent(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
+	if f.Events != nil {
+		msg := fmt.Sprintf(eventtype+" "+reason+" "+note, args...)
+		if f.Verbose {
+			msg = eventtype + " " + reason + " " + action + " " + fmt.Sprintf(note, args...) +
+				objectString(regarding) + objectString(related) + annotationsString(annotations)
+		}
+		f.Events <- msg
+	}
+}
+
+// annotationsString returns a formatted string of the annotations map,
+// or empty string if none
+func annotationsString(annotations map[string]string) string {
+	annotationString := ""
+	if len(annotations) > 0 {
+		annotationString = " " + fmt.Sprint(annotations)
+	}
+	return annotationString
+}
+
+// objectString returns a formatted string with the object's kind and
+// apiVersion
+func objectString(object runtime.Object) string {
+	objectString := ""
+	if object != nil {
+		gvk := object.GetObjectKind().GroupVersionKind()
+		if !gvk.Empty() {
+			objectString = fmt.Sprintf(" {kind=%s,apiVersion=%s}",
+				gvk.Kind,
+				gvk.GroupVersion(),
+			)
+		}
+	}
+	return objectString
+}
+
 // NewFakeRecorder creates new fake event recorder with event channel with
 // buffer of given size.
 func NewFakeRecorder(bufferSize int) *FakeRecorder {
 	return &FakeRecorder{
-		Events: make(chan string, bufferSize),
+		Events:  make(chan string, bufferSize),
+		Verbose: false,
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/events/interfaces.go
+++ b/staging/src/k8s.io/client-go/tools/events/interfaces.go
@@ -28,6 +28,7 @@ import (
 
 type EventRecorder = internalevents.EventRecorder
 type EventRecorderLogger = internalevents.EventRecorderLogger
+type AnnotatedEventRecorder = internalevents.AnnotatedEventRecorder
 
 // EventBroadcaster knows how to receive events and send them to any EventSink, watcher, or log.
 type EventBroadcaster interface {

--- a/staging/src/k8s.io/client-go/tools/internal/events/interfaces.go
+++ b/staging/src/k8s.io/client-go/tools/internal/events/interfaces.go
@@ -43,6 +43,15 @@ type EventRecorder interface {
 	Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{})
 }
 
+// AnnotatedEventRecorder is an optional extension of EventRecorder that
+// supports attaching annotations to events at creation time.
+// Annotations are intended for low-frequency correlation metadata, not as a general purpose structured-data channel.
+// Kubernetes events are best-effort, supplemental observability data and may be dropped, deduped or aggregated at any
+// point in pipeline. Do not rely on annotations for event-driven control flow.
+type AnnotatedEventRecorder interface {
+	AnnotatedEventf(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{})
+}
+
 // EventRecorderLogger extends EventRecorder such that a logger can
 // be set for methods in EventRecorder. Normally, those methods
 // uses the global default logger to record errors and debug messages.

--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -176,6 +176,12 @@ func (a *EventRecorderAdapter) Eventf(regarding, _ runtime.Object, eventtype, re
 	a.recorder.Eventf(regarding, eventtype, reason, note, args...)
 }
 
+// AnnotatedEventf is a wrapper around v1 AnnotatedEventf
+func (a *EventRecorderAdapter) AnnotatedEventf(regarding, _ runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
+	//nolint:forbidigo // Legacy usage
+	a.recorder.AnnotatedEventf(regarding, annotations, eventtype, reason, note, args...)
+}
+
 func (a *EventRecorderAdapter) WithLogger(logger klog.Logger) internalevents.EventRecorderLogger {
 	return &EventRecorderAdapter{
 		recorder: a.recorder.WithLogger(logger),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds an AnnotatedEventf method to the EventRecorder and EventRecorderLogger interfaces in `client-go/tools/events`, allowing callers to attach custom map[string]string annotations to events at creation time.

Changes:
- Added AnnotatedEventf to the EventRecorder interface in tools/internal/events/interfaces.go
- Implemented AnnotatedEventf on recorderImpl and recorderImplLogger
- Threaded the annotations parameter through the internal eventf and makeEvent methods, setting `ObjectMeta.Annotations` on the resulting eventsv1.Event
- Added AnnotatedEventf to FakeRecorder (delegates to Eventf)
- Added AnnotatedEventf to EventRecorderAdapter (wraps the v1 AnnotatedEventf)
- Updated existing test call sites for the new makeEvent signature

This mirrors the pattern already established by the v1 EventRecorder interface (tools/record), which has AnnotatedEventf for attaching annotations. The new events API (tools/events) was missing this capability, forcing callers to either post-process events or fall back to the legacy API when annotations were needed.
#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
- The FakeRecorder.AnnotatedEventf implementation intentionally drops annotations and delegates to Eventf, consistent with how FakeRecorder works (it only captures the formatted message string).
- The EventRecorderAdapter.AnnotatedEventf drops the related object and action parameters when forwarding to the v1 recorder, matching the existing Eventf adapter behavior.
- Existing Eventf callers are unaffected — they pass nil for annotations internally.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `AnnotatedEventf` method to the new events API (`EventRecorder` and `EventRecorderLogger` interfaces in `client-go/tools/events`), enabling callers to attach custom annotations to events at creation time.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
