### PR TITLE
Add validation-gen to pined tools

### DIFF
--- a/staging/src/k8s.io/code-generator/tools.go
+++ b/staging/src/k8s.io/code-generator/tools.go
@@ -30,5 +30,6 @@ import (
 	_ "k8s.io/code-generator/cmd/informer-gen"
 	_ "k8s.io/code-generator/cmd/lister-gen"
 	_ "k8s.io/code-generator/cmd/register-gen"
+	_ "k8s.io/code-generator/cmd/validation-gen"
 	_ "k8s.io/kube-openapi/cmd/openapi-gen"
 )


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
After we landed https://github.com/kubernetes/kubernetes/pull/131755 in 1.35 I can't properly use `kube_codegen.sh` because it requires `k8s.io/code-generator/cmd/validation-gen` but that is not in the tools, so that when you just pin `k8s.io/code-generator` it should include all the necessary tools. 

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
/assign @jpbetz 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
